### PR TITLE
[Quasar] Add 9x4 DM-only emulation support

### DIFF
--- a/docs/superpowers/plans/2026-06-01-noc-write-latency.md
+++ b/docs/superpowers/plans/2026-06-01-noc-write-latency.md
@@ -1,0 +1,408 @@
+# NOC Write Round-Trip Latency Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two Quasar-only tests to the `data_movement` suite that measure round-trip NOC write latency (far-corner and adjacent cores) using `rdcycles` + `DEVICE_PRINT`.
+
+**Architecture:** Sender kernel issues a 32-byte `noc_async_write`, times the barrier with `rdcycles`, then sends a plain-write flag to the receiver. Receiver kernel spins on that flag via an uncached volatile pointer and prints confirmation. Both kernels use compile-time args only and run in a single `Program` via two `experimental::quasar::CreateKernel` calls.
+
+**Tech Stack:** C++20, tt-metal `experimental::quasar` API, `noc_async_write` / `noc_async_write_barrier`, `DEVICE_PRINT`, inline `rdcycle` RISC-V CSR, `GenericMeshDeviceFixture`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp` | Issues timed write + flag signal |
+| Create | `tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp` | Spins on flag, prints confirmation |
+| Create | `tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp` | Host test: config, program setup, two GTest cases |
+| Modify | `tests/tt_metal/tt_metal/data_movement/sources.cmake` | Register new test file |
+
+---
+
+## Task 1: Sender kernel
+
+**Files:**
+- Create: `tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp`
+
+- [ ] **Step 1: Create the sender kernel**
+
+```cpp
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/device_print.h"
+#include "dev_mem_map.h"
+
+static inline uint32_t rdcycles() {
+    uint32_t c;
+    asm volatile("rdcycle %0" : "=r"(c));
+    return c;
+}
+
+void kernel_main() {
+    // Compile-time args
+    constexpr uint32_t src_l1_addr              = get_compile_time_arg_val(0);
+    constexpr uint32_t flag_local_addr           = get_compile_time_arg_val(1);
+    constexpr uint32_t dst_l1_data_addr          = get_compile_time_arg_val(2);
+    constexpr uint32_t dst_l1_flag_addr          = get_compile_time_arg_val(3);
+    constexpr uint32_t dst_noc_x                 = get_compile_time_arg_val(4);
+    constexpr uint32_t dst_noc_y                 = get_compile_time_arg_val(5);
+    constexpr uint32_t num_iterations            = get_compile_time_arg_val(6);
+    constexpr uint32_t transaction_size_bytes    = get_compile_time_arg_val(7);
+
+    uint64_t dst_data_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_data_addr);
+    uint64_t dst_flag_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_flag_addr);
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        // Write payload to local L1 bypassing cache
+        *(volatile tt_l1_ptr uint32_t*)(src_l1_addr + MEM_L1_UNCACHED_BASE) = 0xDEADBEEF;
+
+        // Issue the data write
+        noc_async_write(src_l1_addr, dst_data_noc, transaction_size_bytes);
+
+        // Time the barrier (= round-trip until write ACK received)
+        uint32_t t0 = rdcycles();
+        noc_async_write_barrier();
+        uint32_t t1 = rdcycles();
+
+        DEVICE_PRINT("[sender] iter %u: %u cycles\n", i, t1 - t0);
+
+        // Signal receiver with a flag write
+        *(volatile tt_l1_ptr uint32_t*)(flag_local_addr + MEM_L1_UNCACHED_BASE) = i + 1;
+        noc_async_write(flag_local_addr, dst_flag_noc, sizeof(uint32_t));
+        noc_async_write_barrier();
+    }
+}
+```
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
+```
+Expected: file listed with no error.
+
+---
+
+## Task 2: Receiver kernel
+
+**Files:**
+- Create: `tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp`
+
+- [ ] **Step 1: Create the receiver kernel**
+
+```cpp
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/device_print.h"
+#include "dev_mem_map.h"
+
+void kernel_main() {
+    // Compile-time args
+    constexpr uint32_t flag_l1_addr   = get_compile_time_arg_val(0);
+    constexpr uint32_t num_iterations = get_compile_time_arg_val(1);
+    constexpr uint32_t my_noc_x       = get_compile_time_arg_val(2);
+    constexpr uint32_t my_noc_y       = get_compile_time_arg_val(3);
+
+    volatile tt_l1_ptr uint32_t* flag_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(flag_l1_addr + MEM_L1_UNCACHED_BASE);
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        // Spin until sender writes flag value i+1
+        while (*flag_ptr != i + 1) {}
+    }
+
+    DEVICE_PRINT("[receiver] core (%u,%u) received all %u writes\n", my_noc_x, my_noc_y, num_iterations);
+}
+```
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+```
+Expected: file listed with no error.
+
+---
+
+## Task 3: Host test file
+
+**Files:**
+- Create: `tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp`
+
+- [ ] **Step 1: Create the host test**
+
+```cpp
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include "impl/context/metal_context.hpp"
+#include "impl/host_api/temp_quasar_api.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+
+namespace unit_tests::dm::noc_write_latency {
+
+struct NocWriteLatencyConfig {
+    CoreCoord src_core;
+    CoreCoord dst_core;
+    uint32_t num_iterations       = 100;
+    uint32_t transaction_size_bytes = 32;
+};
+
+bool run_noc_write_latency(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    const NocWriteLatencyConfig& cfg) {
+
+    IDevice* device = mesh_device->get_device(0);
+
+    // Skip on non-Quasar or grids smaller than 9x4
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        log_info(LogTest, "Skipping: not a Quasar device");
+        return true;
+    }
+    auto grid = device->compute_with_storage_grid_size();
+    if (grid.x < 9 || grid.y < 4) {
+        log_info(LogTest, "Skipping: grid {}x{} smaller than 9x4", grid.x, grid.y);
+        return true;
+    }
+
+    // Physical NOC coordinates for source and destination
+    CoreCoord phys_src = device->worker_core_from_logical_core(cfg.src_core);
+    CoreCoord phys_dst = device->worker_core_from_logical_core(cfg.dst_core);
+
+    // L1 address layout (sender core)
+    L1AddressInfo src_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.src_core);
+    uint32_t src_l1_addr    = src_l1.base_address;          // payload source
+    uint32_t flag_local_addr = src_l1.base_address + 64;    // outgoing flag (64B past payload)
+
+    // L1 address layout (receiver core)
+    L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.dst_core);
+    uint32_t dst_l1_data_addr = dst_l1.base_address;        // incoming payload
+    uint32_t dst_l1_flag_addr = dst_l1.base_address + 64;   // incoming flag
+
+    // Zero the receiver flag in device L1 before starting
+    vector<uint32_t> zero{0};
+    detail::WriteToDeviceL1(device, cfg.dst_core, dst_l1_flag_addr, zero);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    Program program = CreateProgram();
+
+    // Sender kernel
+    experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp",
+        cfg.src_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {
+                src_l1_addr,
+                flag_local_addr,
+                dst_l1_data_addr,
+                dst_l1_flag_addr,
+                (uint32_t)phys_dst.x,
+                (uint32_t)phys_dst.y,
+                cfg.num_iterations,
+                cfg.transaction_size_bytes,
+            }});
+
+    // Receiver kernel
+    experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp",
+        cfg.dst_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {
+                dst_l1_flag_addr,
+                cfg.num_iterations,
+                (uint32_t)phys_dst.x,
+                (uint32_t)phys_dst.y,
+            }});
+
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    return true;
+}
+
+}  // namespace unit_tests::dm::noc_write_latency
+
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyFarCorners) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {8, 3},
+        .num_iterations = 100,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+}
+
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyAdjacentCores) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {1, 0},
+        .num_iterations = 100,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+}
+
+}  // namespace tt::tt_metal
+```
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+```
+Expected: file listed with no error.
+
+---
+
+## Task 4: Register in sources.cmake
+
+**Files:**
+- Modify: `tests/tt_metal/tt_metal/data_movement/sources.cmake`
+
+- [ ] **Step 1: Add the new test file**
+
+In `tests/tt_metal/tt_metal/data_movement/sources.cmake`, append before the closing `)`:
+
+```cmake
+    noc_write_latency/test_noc_write_latency.cpp
+```
+
+The end of the file should look like:
+
+```cmake
+    quasar_examples/quasar_idma/test_idma_example.cpp
+    noc_write_latency/test_noc_write_latency.cpp
+)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add \
+  tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp \
+  tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp \
+  tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp \
+  tests/tt_metal/tt_metal/data_movement/sources.cmake
+git commit -m "Add NOC write round-trip latency tests for Quasar 9x4"
+```
+
+---
+
+## Task 5: Build and verify compilation
+
+**Files:** (no changes — build only)
+
+- [ ] **Step 1: Activate python env and build**
+
+```bash
+source /proj_sw/user_dev/vvukomanovic/tt-metal/python_env/bin/activate && \
+./build_metal.sh --build-tests 2>&1 | tail -40
+```
+Expected: build completes with `[N/N] Install the project...` at the end, no errors.
+
+- [ ] **Step 2: If compilation fails due to `rdcycle` not recognized**
+
+Replace the `rdcycles()` helper in `sender.cpp` with a `csrrw`-based read on CSR 0xC00 (the standard `mcycle` register):
+
+```cpp
+static inline uint32_t rdcycles() {
+    uint32_t c;
+    asm volatile("csrr %0, 0xC00" : "=r"(c));
+    return c;
+}
+```
+
+Rebuild after the change.
+
+- [ ] **Step 3: If compilation fails due to `DEVICE_PRINT` not found**
+
+Add `#include "api/debug/dprint.h"` instead of `api/debug/device_print.h` — `dprint.h` includes `device_print.h` and defines `DEVICE_PRINT` via the same header. Rebuild.
+
+---
+
+## Task 6: Run the tests
+
+**Files:** (no changes — run only)
+
+- [ ] **Step 1: Set emulator path and run far-corners test**
+
+```bash
+export TT_METAL_SIMULATOR=/proj_sw/user_dev/vvukomanovic/tt-umd-simulators/build/emu-quasar-9x4_DM && \
+./build_Release/test/tt_metal/unit_tests_data_movement \
+  --gtest_filter="*NocWriteLatencyFarCorners*" \
+  --gtest_color=yes
+```
+
+Expected output contains lines like:
+```
+[sender] iter 0: NNNN cycles
+[sender] iter 1: NNNN cycles
+...
+[receiver] core (X,Y) received all 100 writes
+[ PASSED ] NocWriteLatencyFarCorners
+```
+
+- [ ] **Step 2: Run adjacent-cores test**
+
+```bash
+export TT_METAL_SIMULATOR=/proj_sw/user_dev/vvukomanovic/tt-umd-simulators/build/emu-quasar-9x4_DM && \
+./build_Release/test/tt_metal/unit_tests_data_movement \
+  --gtest_filter="*NocWriteLatencyAdjacentCores*" \
+  --gtest_color=yes
+```
+
+Expected output same pattern, with `[receiver] core (X,Y) received all 100 writes` and `[ PASSED ]`.
+
+- [ ] **Step 3: Commit**
+
+If both tests pass:
+
+```bash
+git add -p  # nothing new to stage; all files already committed in Task 4
+# Only commit if any fixup changes were made during build/run
+```
+
+If fixup changes were made during Tasks 5–6, stage and commit:
+```bash
+git add tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp \
+        tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+git commit -m "Fix rdcycles/DEVICE_PRINT after build verification"
+```
+
+---
+
+## Self-review checklist (already applied)
+
+- Spec coverage: sender kernel ✓, receiver kernel ✓, two GTests ✓, sources.cmake ✓, uncached L1 pattern ✓, rdcycles ✓, DEVICE_PRINT ✓
+- No TBDs or placeholders — every step has exact code or exact commands
+- Type/name consistency: `NocWriteLatencyConfig`, `run_noc_write_latency`, `src_l1_addr`, `flag_local_addr`, `dst_l1_data_addr`, `dst_l1_flag_addr` consistent across Tasks 3, 1, and 2

--- a/docs/superpowers/specs/2026-06-01-noc-write-latency-design.md
+++ b/docs/superpowers/specs/2026-06-01-noc-write-latency-design.md
@@ -1,0 +1,156 @@
+# NOC Write Round-Trip Latency Test — Design Spec
+
+**Date:** 2026-06-01
+**Branch:** vvukomanovic/quasar-9x4-dm-emu
+**Target device:** Quasar 9x4 DM-only emulator
+
+---
+
+## Goal
+
+Add two latency tests to the `data_movement` test suite that measure the round-trip time of a single non-posted NOC write (i.e. time from issuing the write to the barrier completing). A second kernel on the receiver confirms the data arrived on the correct core.
+
+---
+
+## Tests
+
+| Test name | Source core | Dest core | Purpose |
+|---|---|---|---|
+| `NocWriteLatencyFarCorners` | `(0,0)` | `(8,3)` | Far-corner latency on 9x4 grid |
+| `NocWriteLatencyAdjacentCores` | `(0,0)` | `(1,0)` | Adjacent-core latency baseline |
+
+Both tests run on the Quasar 9x4 emulator only and are skipped on all other targets.
+
+---
+
+## Measurement
+
+- **Iterations:** 100 per test
+- **Transaction size:** 32 bytes
+- **Timing:** `rdcycles()` sampled immediately before and after `noc_async_write_barrier()`
+- **Output:** `DEVICE_PRINT` per iteration from sender; one confirmation print from receiver
+
+```
+[sender] iter 0: 1234 cycles
+[sender] iter 1: 1230 cycles
+...
+[receiver] core (8,3) received
+```
+
+---
+
+## File Layout
+
+```
+tests/tt_metal/tt_metal/data_movement/
+└── noc_write_latency/
+    ├── kernels/
+    │   ├── sender.cpp
+    │   └── receiver.cpp
+    └── test_noc_write_latency.cpp
+```
+
+`sources.cmake` gets one new entry:
+```cmake
+noc_write_latency/test_noc_write_latency.cpp
+```
+
+---
+
+## Kernel Design
+
+### sender.cpp
+
+Compile-time args (in order):
+| Index | Name | Notes |
+|---|---|---|
+| 0 | `src_l1_addr` | Physical L1 address for payload |
+| 1 | `flag_local_addr` | Physical L1 address for outgoing flag |
+| 2 | `dst_l1_data_addr` | Physical L1 address on receiver for payload |
+| 3 | `dst_l1_flag_addr` | Physical L1 address on receiver for flag |
+| 4 | `dst_noc_x` | NOC X of destination (physical) |
+| 5 | `dst_noc_y` | NOC Y of destination (physical) |
+| 6 | `num_iterations` | 100 |
+| 7 | `transaction_size_bytes` | 32 |
+
+Logic per iteration:
+1. Write payload to `src_l1_addr + MEM_L1_UNCACHED_BASE` (bypass cache)
+2. Build `dst_data_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_data_addr)`
+3. `noc_async_write(src_l1_addr, dst_data_noc, transaction_size_bytes)`
+4. `t0 = rdcycles()`
+5. `noc_async_write_barrier()`
+6. `t1 = rdcycles()`
+7. `DEVICE_PRINT("[sender] iter %u: %u cycles\n", i, t1 - t0)`
+8. Write `i + 1` to `flag_local_addr + MEM_L1_UNCACHED_BASE`
+9. `noc_async_write(flag_local_addr, dst_flag_noc, sizeof(uint32_t))`
+10. `noc_async_write_barrier()`
+
+### receiver.cpp
+
+Compile-time args (in order):
+| Index | Name | Notes |
+|---|---|---|
+| 0 | `flag_l1_addr` | Physical L1 address where flag arrives |
+| 1 | `num_iterations` | Must match sender |
+| 2 | `my_noc_x` | For the print |
+| 3 | `my_noc_y` | For the print |
+
+Logic:
+1. Create `volatile tt_l1_ptr uint32_t* flag_ptr = (volatile tt_l1_ptr uint32_t*)(flag_l1_addr + MEM_L1_UNCACHED_BASE)`
+2. For each iteration `i`: spin until `*flag_ptr == i + 1`
+3. After final iteration: `DEVICE_PRINT("[receiver] core (%u,%u) received\n", my_noc_x, my_noc_y)`
+
+---
+
+## Host Test Design
+
+### Config struct
+```cpp
+struct NocWriteLatencyConfig {
+    CoreCoord src_core;
+    CoreCoord dst_core;
+    uint32_t num_iterations;
+    uint32_t transaction_size_bytes;
+};
+```
+
+### Helper `run_noc_write_latency(mesh_device, config)`
+1. Skip if not Quasar or grid < 9×4
+2. Get physical NOC coords for src and dst via `device->worker_core_from_logical_core()`
+3. Compute L1 addresses via `get_l1_address_and_size()` from `dm_common`; pick non-overlapping offsets for payload and flag on both cores
+4. Create `Program`, add sender kernel on `src_core` and receiver kernel on `dst_core`
+5. Wrap in `MeshWorkload`, enqueue, `Finish(cq)`
+6. Return `true`
+
+### Tests
+```cpp
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyFarCorners) {
+    NocWriteLatencyConfig cfg{.src_core={0,0}, .dst_core={8,3},
+                               .num_iterations=100, .transaction_size_bytes=32};
+    EXPECT_TRUE(run_noc_write_latency(this->mesh_device_, cfg));
+}
+
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyAdjacentCores) {
+    NocWriteLatencyConfig cfg{.src_core={0,0}, .dst_core={1,0},
+                               .num_iterations=100, .transaction_size_bytes=32};
+    EXPECT_TRUE(run_noc_write_latency(this->mesh_device_, cfg));
+}
+```
+
+---
+
+## Key Quasar L1 Rules (from codebase)
+
+- `MEM_L1_UNCACHED_BASE` is defined in `dev_mem_map.h` as `MEM_L1_BASE + MEM_L1_SIZE`
+- **Local writes**: use `addr + MEM_L1_UNCACHED_BASE` to bypass cache
+- **NOC source/dest addresses**: pass physical `addr` (no uncached offset) to `get_noc_addr()` and `noc_async_write()`
+- **Receiver polling**: cast to `volatile tt_l1_ptr uint32_t*` at `addr + MEM_L1_UNCACHED_BASE`
+- Atomics (LR/SC, AMO) do not work on uncached addresses — plain loads/stores only
+
+---
+
+## Out of scope
+
+- Bandwidth sweep (different transaction sizes)
+- Multi-iteration flag reset from receiver
+- Non-Quasar architectures

--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -3,7 +3,7 @@
 # Structure:
 #   <group>:            Binary name under build/test/tt_metal/
 #     - filter: <glob>  GTest filter pattern
-#       config: <config>   Simulator grid config (maps to emu-quasar-<config>). Supports 1x3 and 2x3 and 2x3_DISPATCH
+#       config: <config>   Simulator grid config (maps to emu-quasar-<config>). Supports 1x3, 2x3, 2x3_DISPATCH, and 9x4
 #       env:            (optional) Extra environment variables as key: value pairs
 #       gtest_repeat:   (optional) Run each matched test N times (--gtest_repeat=N)
 #

--- a/tests/scripts/quasar/quasar_sim_regresion_tests.yaml
+++ b/tests/scripts/quasar/quasar_sim_regresion_tests.yaml
@@ -3,7 +3,7 @@
 # Structure:
 #   <group>:            Binary name under build/test/tt_metal/
 #     - filter: <glob>  GTest filter pattern
-#       config: <NxM>   Simulator grid config (maps to emu-quasar-<config>). Supports 1x3 and 2x3 and 2x3_DISPATCH
+#       config: <NxM>   Simulator grid config (maps to emu-quasar-<config>). Supports 1x3, 2x3, 2x3_DISPATCH, and 9x4
 #       env:            (optional) Extra environment variables as key: value pairs
 #
 # Example test entry

--- a/tests/scripts/quasar/run_quasar_regression.sh
+++ b/tests/scripts/quasar/run_quasar_regression.sh
@@ -26,7 +26,7 @@ Run Quasar emulator regression tests defined in a YAML file.
 Required environment variables:
   TT_METAL_SIMULATOR_BASE   Base path containing simulator build directories
                            (e.g. the parent of emu-quasar-1x3/, emu-quasar-2x3/,
-                           emu-quasar-2x3_DISPATCH/)
+                           emu-quasar-2x3_DISPATCH/, emu-quasar-9x4/)
                            The script sets TT_METAL_SIMULATOR per test automatically.
                            If TT_METAL_SIMULATOR is already set, the base is
                            derived automatically (one directory up).
@@ -35,7 +35,7 @@ Required environment variables:
 
 Options:
   --build                          Run build_metal.sh --build-tests before testing
-  --config <1x3|2x3|2x3_DISPATCH>  Only run tests for the specified configuration
+  --config <1x3|2x3|2x3_DISPATCH|9x4>  Only run tests for the specified configuration
   --group <name>                   Only run tests from the specified test group
   --tests <path>                   Path to YAML test file (default: quasar_regression_tests.yaml)
   --build-dir <path>               Path to build directory (default: $BUILD_DIR)
@@ -61,8 +61,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -n "$FILTER_CONFIG" && "$FILTER_CONFIG" != "1x3" && "$FILTER_CONFIG" != "2x3" && "$FILTER_CONFIG" != "2x3_DISPATCH" ]]; then
-    echo "ERROR: invalid --config value '$FILTER_CONFIG'. Supported: 1x3, 2x3, 2x3_DISPATCH"
+if [[ -n "$FILTER_CONFIG" && "$FILTER_CONFIG" != "1x3" && "$FILTER_CONFIG" != "2x3" && "$FILTER_CONFIG" != "2x3_DISPATCH" && "$FILTER_CONFIG" != "9x4" ]]; then
+    echo "ERROR: invalid --config value '$FILTER_CONFIG'. Supported: 1x3, 2x3, 2x3_DISPATCH, 9x4"
     exit 1
 fi
 
@@ -134,7 +134,7 @@ skipped=0
 declare -a results=()
 
 # Load tests from YAML into an array (single-pass read via yq)
-VALID_CONFIGS=("1x3" "2x3" "2x3_DISPATCH")
+VALID_CONFIGS=("1x3" "2x3" "2x3_DISPATCH" "9x4")
 
 is_valid_config() {
     local cfg="$1"

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/noise.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/noise.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "dev_mem_map.h"
+
+// Background "noise" kernel: continuously blasts posted writes (no ACK wait, so maximum
+// injection rate) toward a scratch L1 region on the destination core. Placed on the cores
+// along the measured route so the traffic contends for the same NOC links. Silent (no
+// DEVICE_PRINT) to avoid slowing the cores or flooding the print stream.
+void kernel_main() {
+    constexpr uint32_t src_l1_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_l1_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t dst_noc_x = get_compile_time_arg_val(2);
+    constexpr uint32_t dst_noc_y = get_compile_time_arg_val(3);
+    constexpr uint32_t num_writes = get_compile_time_arg_val(4);
+    constexpr uint32_t transaction_size_bytes = get_compile_time_arg_val(5);
+
+    // Seed a payload in local L1 (uncached alias) so the NOC reads valid data.
+    *(volatile tt_l1_ptr uint32_t*)(src_l1_addr + MEM_L1_UNCACHED_BASE) = 0x00C0FFEE;
+
+    uint64_t dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_addr);
+
+    for (uint32_t i = 0; i < num_writes; i++) {
+        noc_async_write<NOC_MAX_BURST_SIZE + 1, true, /*posted=*/true>(
+            src_l1_addr, dst_noc_addr, transaction_size_bytes);
+    }
+    noc_async_posted_writes_flushed();
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
@@ -9,8 +9,8 @@
 void kernel_main() {
     constexpr uint32_t flag_l1_addr = get_compile_time_arg_val(0);
     constexpr uint32_t num_iterations = get_compile_time_arg_val(1);
-    constexpr uint32_t my_noc_x = get_compile_time_arg_val(2);
-    constexpr uint32_t my_noc_y = get_compile_time_arg_val(3);
+    constexpr uint32_t my_noc_x = get_compile_time_arg_val(2);  // used only for diagnostic print
+    constexpr uint32_t my_noc_y = get_compile_time_arg_val(3);  // used only for diagnostic print
 
     volatile tt_l1_ptr uint32_t* flag_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(flag_l1_addr + MEM_L1_UNCACHED_BASE);

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
@@ -12,12 +12,15 @@ void kernel_main() {
     constexpr uint32_t my_noc_x = get_compile_time_arg_val(2);  // used only for diagnostic print
     constexpr uint32_t my_noc_y = get_compile_time_arg_val(3);  // used only for diagnostic print
 
+    DEVICE_PRINT("[receiver] running on core ({},{}), waiting for {} writes\n", my_noc_x, my_noc_y, num_iterations);
+
     volatile tt_l1_ptr uint32_t* flag_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(flag_l1_addr + MEM_L1_UNCACHED_BASE);
 
     for (uint32_t i = 0; i < num_iterations; i++) {
         while (*flag_ptr != i + 1) {
         }
+        DEVICE_PRINT("[receiver] ({},{}) got write {}\n", my_noc_x, my_noc_y, i + 1);
     }
 
     DEVICE_PRINT("[receiver] core ({},{}) received all {} writes\n", my_noc_x, my_noc_y, num_iterations);

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/device_print.h"
+#include "dev_mem_map.h"
+
+void kernel_main() {
+    constexpr uint32_t flag_l1_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_iterations = get_compile_time_arg_val(1);
+    constexpr uint32_t my_noc_x = get_compile_time_arg_val(2);
+    constexpr uint32_t my_noc_y = get_compile_time_arg_val(3);
+
+    volatile tt_l1_ptr uint32_t* flag_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(flag_l1_addr + MEM_L1_UNCACHED_BASE);
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        while (*flag_ptr != i + 1) {
+        }
+    }
+
+    DEVICE_PRINT("[receiver] core (%u,%u) received all %u writes\n", my_noc_x, my_noc_y, num_iterations);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp
@@ -20,5 +20,5 @@ void kernel_main() {
         }
     }
 
-    DEVICE_PRINT("[receiver] core (%u,%u) received all %u writes\n", my_noc_x, my_noc_y, num_iterations);
+    DEVICE_PRINT("[receiver] core ({},{}) received all {} writes\n", my_noc_x, my_noc_y, num_iterations);
 }

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver_bh.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver_bh.cpp
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Blackhole variant of the latency receiver. Same protocol as the Quasar receiver.cpp, but
+// L1 is accessed directly (no MEM_L1_UNCACHED_BASE alias) and the poll loop invalidates the
+// L1 cache each spin so incoming NOC writes become visible. Compile-time argument order is
+// identical to receiver.cpp.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/device_print.h"
-#include "dev_mem_map.h"
 
 void kernel_main() {
     constexpr uint32_t data_l1_addr = get_compile_time_arg_val(0);
@@ -14,13 +18,11 @@ void kernel_main() {
 
     DEVICE_PRINT("[receiver] running on core ({},{}), waiting for {} writes\n", my_noc_x, my_noc_y, num_iterations);
 
-    // The sender writes the iteration count (i+1) as the first word of the payload, so we poll
-    // the data location itself — no separate flag needed.
-    volatile tt_l1_ptr uint32_t* data_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(data_l1_addr + MEM_L1_UNCACHED_BASE);
+    volatile tt_l1_ptr uint32_t* data_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(data_l1_addr);
 
     for (uint32_t i = 0; i < num_iterations; i++) {
         while (*data_ptr != i + 1) {
+            invalidate_l1_cache();
         }
         DEVICE_PRINT("[receiver] ({},{}) got write {}\n", my_noc_x, my_noc_y, i + 1);
     }

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/device_print.h"
+#include "dev_mem_map.h"
+
+static inline uint32_t rdcycles() {
+    uint32_t c;
+    asm volatile("rdcycle %0" : "=r"(c));
+    return c;
+}
+
+void kernel_main() {
+    constexpr uint32_t src_l1_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t flag_local_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t dst_l1_data_addr = get_compile_time_arg_val(2);
+    constexpr uint32_t dst_l1_flag_addr = get_compile_time_arg_val(3);
+    constexpr uint32_t dst_noc_x = get_compile_time_arg_val(4);
+    constexpr uint32_t dst_noc_y = get_compile_time_arg_val(5);
+    constexpr uint32_t num_iterations = get_compile_time_arg_val(6);
+    constexpr uint32_t transaction_size_bytes = get_compile_time_arg_val(7);
+
+    uint64_t dst_data_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_data_addr);
+    uint64_t dst_flag_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_flag_addr);
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        *(volatile tt_l1_ptr uint32_t*)(src_l1_addr + MEM_L1_UNCACHED_BASE) = 0xDEADBEEF;
+
+        noc_async_write(src_l1_addr, dst_data_noc, transaction_size_bytes);
+
+        uint32_t t0 = rdcycles();
+        noc_async_write_barrier();
+        uint32_t t1 = rdcycles();
+
+        DEVICE_PRINT("[sender] iter %u: %u cycles\n", i, t1 - t0);
+
+        *(volatile tt_l1_ptr uint32_t*)(flag_local_addr + MEM_L1_UNCACHED_BASE) = i + 1;
+        noc_async_write(flag_local_addr, dst_flag_noc, sizeof(uint32_t));
+        noc_async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
@@ -6,6 +6,8 @@
 #include "api/debug/device_print.h"
 #include "dev_mem_map.h"
 
+// DeviceTimestampedData/DeviceZoneScopedN are not available on Quasar emulator;
+// use inline rdcycle CSR read instead.
 static inline uint32_t rdcycles() {
     uint32_t c;
     asm volatile("rdcycle %0" : "=r"(c));
@@ -30,6 +32,8 @@ void kernel_main() {
 
         noc_async_write(src_l1_addr, dst_data_noc, transaction_size_bytes);
 
+        // Measures time for the write to retire on the sender side (write ACK received).
+        // t0 is placed after noc_async_write() — the write may already be in-flight.
         uint32_t t0 = rdcycles();
         noc_async_write_barrier();
         uint32_t t1 = rdcycles();

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
@@ -23,6 +23,17 @@ void kernel_main() {
     constexpr uint32_t dst_noc_y = get_compile_time_arg_val(5);
     constexpr uint32_t num_iterations = get_compile_time_arg_val(6);
     constexpr uint32_t transaction_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t src_noc_x = get_compile_time_arg_val(8);
+    constexpr uint32_t src_noc_y = get_compile_time_arg_val(9);
+
+    DEVICE_PRINT(
+        "[sender] running on core ({},{}), writing {} bytes to core ({},{}) for {} iterations\n",
+        src_noc_x,
+        src_noc_y,
+        transaction_size_bytes,
+        dst_noc_x,
+        dst_noc_y,
+        num_iterations);
 
     uint64_t dst_data_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_data_addr);
     uint64_t dst_flag_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_flag_addr);
@@ -38,7 +49,8 @@ void kernel_main() {
         noc_async_write_barrier();
         uint32_t t1 = rdcycles();
 
-        DEVICE_PRINT("[sender] iter {}: {} cycles\n", i, t1 - t0);
+        DEVICE_PRINT(
+            "[sender] ({},{}) -> ({},{}) iter {}: {} cycles\n", src_noc_x, src_noc_y, dst_noc_x, dst_noc_y, i, t1 - t0);
 
         *(volatile tt_l1_ptr uint32_t*)(flag_local_addr + MEM_L1_UNCACHED_BASE) = i + 1;
         noc_async_write(flag_local_addr, dst_flag_noc, sizeof(uint32_t));

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
         noc_async_write_barrier();
         uint32_t t1 = rdcycles();
 
-        DEVICE_PRINT("[sender] iter %u: %u cycles\n", i, t1 - t0);
+        DEVICE_PRINT("[sender] iter {}: {} cycles\n", i, t1 - t0);
 
         *(volatile tt_l1_ptr uint32_t*)(flag_local_addr + MEM_L1_UNCACHED_BASE) = i + 1;
         noc_async_write(flag_local_addr, dst_flag_noc, sizeof(uint32_t));

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender_bh.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender_bh.cpp
@@ -2,16 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Blackhole variant of the latency sender. Same protocol as the Quasar sender.cpp, but:
+//   - timing uses the memory-mapped wall-clock register instead of the rdcycle CSR
+//   - L1 is accessed directly (no MEM_L1_UNCACHED_BASE alias)
+// Compile-time argument order is identical to sender.cpp so the host can share the layout.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/device_print.h"
-#include "dev_mem_map.h"
+#include "risc_common.h"
 
-// DeviceTimestampedData/DeviceZoneScopedN are not available on Quasar emulator;
-// use inline rdcycle CSR read instead.
-static inline uint32_t rdcycles() {
-    uint32_t c;
-    asm volatile("rdcycle %0" : "=r"(c));
-    return c;
+// Blackhole free-running wall-clock low word (core-cycle counter). A single volatile
+// register read, matching what the on-device profiler uses.
+static inline uint32_t read_timer() {
+    return *reinterpret_cast<volatile tt_reg_ptr uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
 }
 
 void kernel_main() {
@@ -36,18 +39,17 @@ void kernel_main() {
     uint64_t dst_data_noc = get_noc_addr(dst_noc_x, dst_noc_y, dst_l1_data_addr);
 
     for (uint32_t i = 0; i < num_iterations; i++) {
-        // The first word of the payload carries the iteration count, which doubles as the
-        // signal the receiver polls for. Written via the uncached alias so the NOC read picks
-        // up the new value.
-        *(volatile tt_l1_ptr uint32_t*)(src_l1_addr + MEM_L1_UNCACHED_BASE) = i + 1;
+        // First word of the payload carries the iteration count, which doubles as the signal
+        // the receiver polls for.
+        *(volatile tt_l1_ptr uint32_t*)(src_l1_addr) = i + 1;
 
         noc_async_write(src_l1_addr, dst_data_noc, transaction_size_bytes);
 
         // Measures time for the write to retire on the sender side (write ACK received).
         // t0 is placed after noc_async_write() — the write may already be in-flight.
-        uint32_t t0 = rdcycles();
+        uint32_t t0 = read_timer();
         noc_async_write_barrier();
-        uint32_t t1 = rdcycles();
+        uint32_t t1 = read_timer();
 
         DEVICE_PRINT(
             "[sender] ({},{}) -> ({},{}) iter {}: {} cycles\n", src_noc_x, src_noc_y, dst_noc_x, dst_noc_y, i, t1 - t0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
@@ -35,7 +35,6 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
         return true;
     }
 
-    CoreCoord phys_src = device->worker_core_from_logical_core(cfg.src_core);
     CoreCoord phys_dst = device->worker_core_from_logical_core(cfg.dst_core);
 
     L1AddressInfo src_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.src_core);
@@ -45,6 +44,16 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
     L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.dst_core);
     uint32_t dst_l1_data_addr = dst_l1.base_address;
     uint32_t dst_l1_flag_addr = dst_l1.base_address + 64;
+
+    if (src_l1.size < cfg.transaction_size_bytes || dst_l1.size < cfg.transaction_size_bytes) {
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    TT_FATAL(
+        cfg.transaction_size_bytes <= 64,
+        "transaction_size_bytes {} exceeds 64 bytes; data and flag buffers would overlap",
+        cfg.transaction_size_bytes);
 
     vector<uint32_t> zero{0};
     detail::WriteToDeviceL1(device, cfg.dst_core, dst_l1_flag_addr, zero);

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
@@ -18,6 +18,8 @@ namespace unit_tests::dm::noc_write_latency {
 struct NocWriteLatencyConfig {
     CoreCoord src_core;
     CoreCoord dst_core;
+    // When true, dst_core is ignored and the bottom-right compute core is used instead.
+    bool dst_far_corner = false;
     uint32_t num_iterations = 100;
     uint32_t transaction_size_bytes = 32;
 };
@@ -30,18 +32,33 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
         return true;
     }
     auto grid = device->compute_with_storage_grid_size();
-    if (grid.x < 9 || grid.y < 4) {
-        log_info(LogTest, "Skipping: grid {}x{} smaller than 9x4", grid.x, grid.y);
+    log_info(LogTest, "Compute grid: {}x{}", grid.x, grid.y);
+
+    // The bottom-right compute core is (grid.x - 1, grid.y - 1).
+    CoreCoord dst_core = cfg.dst_far_corner ? CoreCoord{grid.x - 1, grid.y - 1} : cfg.dst_core;
+
+    if (cfg.src_core.x >= grid.x || cfg.src_core.y >= grid.y || dst_core.x >= grid.x || dst_core.y >= grid.y) {
+        log_info(
+            LogTest,
+            "Skipping: src ({},{}) or dst ({},{}) outside compute grid {}x{}",
+            cfg.src_core.x,
+            cfg.src_core.y,
+            dst_core.x,
+            dst_core.y,
+            grid.x,
+            grid.y);
         return true;
     }
+    log_info(LogTest, "src ({},{}) -> dst ({},{})", cfg.src_core.x, cfg.src_core.y, dst_core.x, dst_core.y);
 
-    CoreCoord phys_dst = device->worker_core_from_logical_core(cfg.dst_core);
+    CoreCoord phys_src = device->worker_core_from_logical_core(cfg.src_core);
+    CoreCoord phys_dst = device->worker_core_from_logical_core(dst_core);
 
     L1AddressInfo src_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.src_core);
     uint32_t src_l1_addr = src_l1.base_address;
     uint32_t flag_local_addr = src_l1.base_address + 64;
 
-    L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.dst_core);
+    L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, dst_core);
     uint32_t dst_l1_data_addr = dst_l1.base_address;
     uint32_t dst_l1_flag_addr = dst_l1.base_address + 64;
 
@@ -56,7 +73,7 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
         cfg.transaction_size_bytes);
 
     vector<uint32_t> zero{0};
-    detail::WriteToDeviceL1(device, cfg.dst_core, dst_l1_flag_addr, zero);
+    detail::WriteToDeviceL1(device, dst_core, dst_l1_flag_addr, zero);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     Program program = CreateProgram();
@@ -76,12 +93,14 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
                 (uint32_t)phys_dst.y,
                 cfg.num_iterations,
                 cfg.transaction_size_bytes,
+                (uint32_t)phys_src.x,
+                (uint32_t)phys_src.y,
             }});
 
     experimental::quasar::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp",
-        cfg.dst_core,
+        dst_core,
         experimental::quasar::QuasarDataMovementConfig{
             .num_threads_per_cluster = 1,
             .compile_args = {
@@ -116,7 +135,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyFarCorners) {
     }
     unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
         .src_core = {0, 0},
-        .dst_core = {8, 3},
+        .dst_core = {0, 0},
+        .dst_far_corner = true,
         .num_iterations = 100,
         .transaction_size_bytes = 32,
     };
@@ -131,6 +151,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyAdjacentCores) {
     unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
         .src_core = {0, 0},
         .dst_core = {1, 0},
+        .dst_far_corner = false,
         .num_iterations = 100,
         .transaction_size_bytes = 32,
     };

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
@@ -20,15 +20,21 @@ struct NocWriteLatencyConfig {
     CoreCoord dst_core;
     // When true, dst_core is ignored and the bottom-right compute core is used instead.
     bool dst_far_corner = false;
+    // When true, every core on the X-first route (except sender and dst) blasts posted writes
+    // toward the dst to saturate the path and measure latency under congestion.
+    bool enable_congestion = false;
     uint32_t num_iterations = 100;
     uint32_t transaction_size_bytes = 32;
+    uint32_t noise_writes_per_core = 100000;
 };
 
 bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocWriteLatencyConfig& cfg) {
     IDevice* device = mesh_device->get_device(0);
 
-    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
-        log_info(LogTest, "Skipping: not a Quasar device");
+    const ARCH arch = MetalContext::instance().get_cluster().arch();
+    const bool is_quasar = (arch == ARCH::QUASAR);
+    if (arch != ARCH::QUASAR && arch != ARCH::BLACKHOLE) {
+        log_info(LogTest, "Skipping: unsupported arch (only Quasar and Blackhole)");
         return true;
     }
     auto grid = device->compute_with_storage_grid_size();
@@ -56,59 +62,106 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
 
     L1AddressInfo src_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.src_core);
     uint32_t src_l1_addr = src_l1.base_address;
-    uint32_t flag_local_addr = src_l1.base_address + 64;
 
     L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, dst_core);
     uint32_t dst_l1_data_addr = dst_l1.base_address;
-    uint32_t dst_l1_flag_addr = dst_l1.base_address + 64;
 
     if (src_l1.size < cfg.transaction_size_bytes || dst_l1.size < cfg.transaction_size_bytes) {
         log_error(LogTest, "Insufficient L1 size for the test configuration");
         return false;
     }
 
-    TT_FATAL(
-        cfg.transaction_size_bytes <= 64,
-        "transaction_size_bytes {} exceeds 64 bytes; data and flag buffers would overlap",
-        cfg.transaction_size_bytes);
-
+    // The payload's first word doubles as the receiver's poll signal; zero it before starting.
     vector<uint32_t> zero{0};
-    detail::WriteToDeviceL1(device, dst_core, dst_l1_flag_addr, zero);
+    detail::WriteToDeviceL1(device, dst_core, dst_l1_data_addr, zero);
     MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     Program program = CreateProgram();
 
-    experimental::quasar::CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp",
-        cfg.src_core,
-        experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1,
-            .compile_args = {
-                src_l1_addr,
-                flag_local_addr,
-                dst_l1_data_addr,
-                dst_l1_flag_addr,
-                (uint32_t)phys_dst.x,
-                (uint32_t)phys_dst.y,
-                cfg.num_iterations,
-                cfg.transaction_size_bytes,
-                (uint32_t)phys_src.x,
-                (uint32_t)phys_src.y,
-            }});
+    // Quasar and Blackhole use different kernel-creation APIs and different kernel sources
+    // (the _bh variants read the wall-clock register and skip the uncached-L1 alias). The
+    // compile-arg layouts are identical, so only the create call and source path differ.
+    const std::string kdir = "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/";
+    const std::string sender_kernel = kdir + (is_quasar ? "sender.cpp" : "sender_bh.cpp");
+    const std::string receiver_kernel = kdir + (is_quasar ? "receiver.cpp" : "receiver_bh.cpp");
 
-    experimental::quasar::CreateKernel(
-        program,
-        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp",
+    auto create_dm_kernel = [&](const std::string& path, const CoreCoord& core, const std::vector<uint32_t>& args) {
+        if (is_quasar) {
+            experimental::quasar::CreateKernel(
+                program,
+                path,
+                core,
+                experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1, .compile_args = args});
+        } else {
+            CreateKernel(
+                program,
+                path,
+                core,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = args});
+        }
+    };
+
+    create_dm_kernel(
+        sender_kernel,
+        cfg.src_core,
+        {
+            src_l1_addr,
+            dst_l1_data_addr,
+            (uint32_t)phys_dst.x,
+            (uint32_t)phys_dst.y,
+            cfg.num_iterations,
+            cfg.transaction_size_bytes,
+            (uint32_t)phys_src.x,
+            (uint32_t)phys_src.y,
+        });
+
+    create_dm_kernel(
+        receiver_kernel,
         dst_core,
-        experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 1,
-            .compile_args = {
-                dst_l1_flag_addr,
-                cfg.num_iterations,
-                (uint32_t)phys_dst.x,
-                (uint32_t)phys_dst.y,
-            }});
+        {
+            dst_l1_data_addr,
+            cfg.num_iterations,
+            (uint32_t)phys_dst.x,
+            (uint32_t)phys_dst.y,
+        });
+
+    // Optional background traffic: place noise kernels on every core along the X-first route
+    // (row 0 east leg, then dst column south leg), excluding the sender and dst. They blast
+    // posted writes to a scratch L1 region on dst, contending for the same NOC links.
+    if (cfg.enable_congestion && !is_quasar) {
+        log_warning(LogTest, "Congestion mode is only implemented for Quasar; running without noise");
+    }
+    if (cfg.enable_congestion && is_quasar) {
+        const uint32_t noise_dst_addr = dst_l1_data_addr + 1024;  // clear of the measured payload/poll word
+
+        std::vector<CoreCoord> noise_cores;
+        for (uint32_t x = 1; x <= dst_core.x; ++x) {
+            noise_cores.push_back(CoreCoord{x, 0});  // east leg along row 0, including (dst.x, 0)
+        }
+        for (uint32_t y = 1; y < dst_core.y; ++y) {
+            noise_cores.push_back(CoreCoord{dst_core.x, y});  // south leg down dst column, excluding dst
+        }
+
+        for (const auto& nc : noise_cores) {
+            L1AddressInfo nc_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, nc);
+            experimental::quasar::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/noise.cpp",
+                nc,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 1,
+                    .compile_args = {
+                        (uint32_t)nc_l1.base_address,
+                        noise_dst_addr,
+                        (uint32_t)phys_dst.x,
+                        (uint32_t)phys_dst.y,
+                        cfg.noise_writes_per_core,
+                        cfg.transaction_size_bytes,
+                    }});
+        }
+        log_info(LogTest, "Congestion enabled: {} noise cores blasting toward dst", noise_cores.size());
+    }
 
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
@@ -137,7 +190,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyFarCorners) {
         .src_core = {0, 0},
         .dst_core = {0, 0},
         .dst_far_corner = true,
-        .num_iterations = 100,
+        .num_iterations = 10,
         .transaction_size_bytes = 32,
     };
     EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
@@ -152,7 +205,46 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyAdjacentCores) {
         .src_core = {0, 0},
         .dst_core = {1, 0},
         .dst_far_corner = false,
-        .num_iterations = 100,
+        .num_iterations = 10,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyFarCornersCongested) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {0, 0},
+        .dst_far_corner = true,
+        .enable_congestion = true,
+        .num_iterations = 10,
+        .transaction_size_bytes = 32,
+        .noise_writes_per_core = 100000,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
+}
+
+TEST_F(BlackholeSingleCardFixture, NocWriteLatencyFarCornersBH) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {0, 0},
+        .dst_far_corner = true,
+        .num_iterations = 10,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
+}
+
+TEST_F(BlackholeSingleCardFixture, NocWriteLatencyAdjacentCoresBH) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {1, 0},
+        .dst_far_corner = false,
+        .num_iterations = 10,
         .transaction_size_bytes = 32,
     };
     EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "multi_device_fixture.hpp"
+#include "device_fixture.hpp"
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
@@ -109,24 +109,32 @@ bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_devic
 
 }  // namespace unit_tests::dm::noc_write_latency
 
-TEST_F(GenericMeshDeviceFixture, NocWriteLatencyFarCorners) {
+TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyFarCorners) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
     unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
         .src_core = {0, 0},
         .dst_core = {8, 3},
         .num_iterations = 100,
         .transaction_size_bytes = 32,
     };
-    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
 }
 
-TEST_F(GenericMeshDeviceFixture, NocWriteLatencyAdjacentCores) {
+TEST_F(QuasarMeshDeviceSingleCardFixture, NocWriteLatencyAdjacentCores) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
     unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
         .src_core = {0, 0},
         .dst_core = {1, 0},
         .num_iterations = 100,
         .transaction_size_bytes = 32,
     };
-    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->devices_[0], cfg));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_write_latency/test_noc_write_latency.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include "impl/context/metal_context.hpp"
+#include "impl/host_api/temp_quasar_api.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+
+namespace unit_tests::dm::noc_write_latency {
+
+struct NocWriteLatencyConfig {
+    CoreCoord src_core;
+    CoreCoord dst_core;
+    uint32_t num_iterations = 100;
+    uint32_t transaction_size_bytes = 32;
+};
+
+bool run_noc_write_latency(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocWriteLatencyConfig& cfg) {
+    IDevice* device = mesh_device->get_device(0);
+
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        log_info(LogTest, "Skipping: not a Quasar device");
+        return true;
+    }
+    auto grid = device->compute_with_storage_grid_size();
+    if (grid.x < 9 || grid.y < 4) {
+        log_info(LogTest, "Skipping: grid {}x{} smaller than 9x4", grid.x, grid.y);
+        return true;
+    }
+
+    CoreCoord phys_src = device->worker_core_from_logical_core(cfg.src_core);
+    CoreCoord phys_dst = device->worker_core_from_logical_core(cfg.dst_core);
+
+    L1AddressInfo src_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.src_core);
+    uint32_t src_l1_addr = src_l1.base_address;
+    uint32_t flag_local_addr = src_l1.base_address + 64;
+
+    L1AddressInfo dst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, cfg.dst_core);
+    uint32_t dst_l1_data_addr = dst_l1.base_address;
+    uint32_t dst_l1_flag_addr = dst_l1.base_address + 64;
+
+    vector<uint32_t> zero{0};
+    detail::WriteToDeviceL1(device, cfg.dst_core, dst_l1_flag_addr, zero);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    Program program = CreateProgram();
+
+    experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/sender.cpp",
+        cfg.src_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {
+                src_l1_addr,
+                flag_local_addr,
+                dst_l1_data_addr,
+                dst_l1_flag_addr,
+                (uint32_t)phys_dst.x,
+                (uint32_t)phys_dst.y,
+                cfg.num_iterations,
+                cfg.transaction_size_bytes,
+            }});
+
+    experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/noc_write_latency/kernels/receiver.cpp",
+        cfg.dst_core,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 1,
+            .compile_args = {
+                dst_l1_flag_addr,
+                cfg.num_iterations,
+                (uint32_t)phys_dst.x,
+                (uint32_t)phys_dst.y,
+            }});
+
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    return true;
+}
+
+}  // namespace unit_tests::dm::noc_write_latency
+
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyFarCorners) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {8, 3},
+        .num_iterations = 100,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+}
+
+TEST_F(GenericMeshDeviceFixture, NocWriteLatencyAdjacentCores) {
+    unit_tests::dm::noc_write_latency::NocWriteLatencyConfig cfg{
+        .src_core = {0, 0},
+        .dst_core = {1, 0},
+        .num_iterations = 100,
+        .transaction_size_bytes = 32,
+    };
+    EXPECT_TRUE(unit_tests::dm::noc_write_latency::run_noc_write_latency(this->mesh_device_, cfg));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -38,4 +38,5 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     quasar_examples/quasar_addrgen/test_addrgen_example.cpp
     quasar_examples/quasar_im2col/test_im2col_example.cpp
     quasar_examples/quasar_idma/test_idma_example.cpp
+    noc_write_latency/test_noc_write_latency.cpp
 )

--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -26,6 +26,7 @@ set(UNIT_TESTS_LEGACY_SRC
     test_multiple_programs.cpp
     test_pack_relu.cpp
     test_quasar_compute_kernels.cpp
+    test_quasar_9x4_sanity.cpp
     test_quasar_events.cpp
     test_quasar_mesh_buffers.cpp
     test_quasar_mesh_workloads.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
@@ -17,14 +17,14 @@ void kernel_main() {
     uint32_t sem_addr = get_arg(args::sem_addr);
 
     if (is_leader) {
-        DPRINT << "[leader] (" << my_x << "," << my_y << ") waiting for " << expected_acks << " acks\n";
+        DPRINT("[leader] (%u,%u) waiting for %u acks\n", my_x, my_y, expected_acks);
         // Use uncached address for local polling so NOC writes are immediately visible.
         volatile tt_l1_ptr uint32_t* sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr + MEM_L1_UNCACHED_BASE);
         noc_semaphore_wait(sem_ptr, expected_acks);
-        DPRINT << "[leader] got " << *sem_ptr << " acks\n";
+        DPRINT("[leader] got %u acks\n", *sem_ptr);
     } else {
-        DPRINT << "[worker] hello from (" << my_x << "," << my_y << ")\n";
+        DPRINT("[worker] hello from (%u,%u)\n", my_x, my_y);
         Noc noc;
         // sem_addr is the physical L1 offset (no uncached base) for the NOC address.
         uint64_t noc_addr = get_noc_addr(leader_noc_x, leader_noc_y, sem_addr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
@@ -17,14 +17,14 @@ void kernel_main() {
     uint32_t sem_addr = get_arg(args::sem_addr);
 
     if (is_leader) {
-        DEVICE_PRINT("[leader] (%u,%u) waiting for %u acks\n", my_x, my_y, expected_acks);
+        DEVICE_PRINT("[leader] ({},{}) waiting for {} acks\n", my_x, my_y, expected_acks);
         // Use uncached address for local polling so NOC writes are immediately visible.
         volatile tt_l1_ptr uint32_t* sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr + MEM_L1_UNCACHED_BASE);
         noc_semaphore_wait(sem_ptr, expected_acks);
-        DEVICE_PRINT("[leader] got %u acks\n", *sem_ptr);
+        DEVICE_PRINT("[leader] got {} acks\n", *sem_ptr);
     } else {
-        DEVICE_PRINT("[worker] hello from (%u,%u)\n", my_x, my_y);
+        DEVICE_PRINT("[worker] hello from ({},{})\n", my_x, my_y);
         Noc noc;
         // sem_addr is the physical L1 offset (no uncached base) for the NOC address.
         uint64_t noc_addr = get_noc_addr(leader_noc_x, leader_noc_y, sem_addr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/debug/dprint.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t is_leader = get_arg(args::is_leader);
+    uint32_t my_x = get_arg(args::my_x);
+    uint32_t my_y = get_arg(args::my_y);
+    uint32_t leader_noc_x = get_arg(args::leader_noc_x);
+    uint32_t leader_noc_y = get_arg(args::leader_noc_y);
+    uint32_t expected_acks = get_arg(args::expected_acks);
+    uint32_t sem_addr = get_arg(args::sem_addr);
+
+    if (is_leader) {
+        DPRINT << "[leader] (" << my_x << "," << my_y << ") waiting for " << expected_acks << " acks\n";
+        // Use uncached address for local polling so NOC writes are immediately visible.
+        volatile tt_l1_ptr uint32_t* sem_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr + MEM_L1_UNCACHED_BASE);
+        noc_semaphore_wait(sem_ptr, expected_acks);
+        DPRINT << "[leader] got " << *sem_ptr << " acks\n";
+    } else {
+        DPRINT << "[worker] hello from (" << my_x << "," << my_y << ")\n";
+        Noc noc;
+        // sem_addr is the physical L1 offset (no uncached base) for the NOC address.
+        uint64_t noc_addr = get_noc_addr(leader_noc_x, leader_noc_y, sem_addr);
+        noc_semaphore_inc(noc_addr, 1, noc.get_noc_id());
+        noc.async_atomic_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp
@@ -4,7 +4,7 @@
 
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
@@ -17,14 +17,14 @@ void kernel_main() {
     uint32_t sem_addr = get_arg(args::sem_addr);
 
     if (is_leader) {
-        DPRINT("[leader] (%u,%u) waiting for %u acks\n", my_x, my_y, expected_acks);
+        DEVICE_PRINT("[leader] (%u,%u) waiting for %u acks\n", my_x, my_y, expected_acks);
         // Use uncached address for local polling so NOC writes are immediately visible.
         volatile tt_l1_ptr uint32_t* sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr + MEM_L1_UNCACHED_BASE);
         noc_semaphore_wait(sem_ptr, expected_acks);
-        DPRINT("[leader] got %u acks\n", *sem_ptr);
+        DEVICE_PRINT("[leader] got %u acks\n", *sem_ptr);
     } else {
-        DPRINT("[worker] hello from (%u,%u)\n", my_x, my_y);
+        DEVICE_PRINT("[worker] hello from (%u,%u)\n", my_x, my_y);
         Noc noc;
         // sem_addr is the physical L1 offset (no uncached base) for the NOC address.
         uint64_t noc_addr = get_noc_addr(leader_noc_x, leader_noc_y, sem_addr);

--- a/tests/tt_metal/tt_metal/test_quasar_9x4_sanity.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_9x4_sanity.cpp
@@ -43,9 +43,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, Quasar9x4SanityAllCoresAck) {
     constexpr const char* ACK_KERNEL = "ack_kernel";
     experimental::metal2_host_api::KernelSpec ack_kernel_spec{
         .unique_id = ACK_KERNEL,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp"},
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {

--- a/tests/tt_metal/tt_metal/test_quasar_9x4_sanity.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_9x4_sanity.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/device_fixture.hpp"
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include "impl/context/metal_context.hpp"
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, Quasar9x4SanityAllCoresAck) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
+                        "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
+    }
+
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    auto grid = dev->compute_with_storage_grid_size();
+    log_info(LogTest, "Compute grid: {}x{}", grid.x, grid.y);
+
+    constexpr uint32_t SEM_L1_ADDR = 100 * 1024;
+    const uint32_t total_cores = grid.x * grid.y;
+    const uint32_t expected_acks = total_cores - 1;
+
+    const experimental::metal2_host_api::NodeCoord leader{0, 0};
+    std::vector<uint32_t> zero{0};
+    tt_metal::detail::WriteToDeviceL1(dev, leader, SEM_L1_ADDR, zero);
+    MetalContext::instance().get_cluster().l1_barrier(dev->id());
+
+    const CoreCoord leader_phys = mesh_device->worker_core_from_logical_core(leader);
+
+    constexpr const char* ACK_KERNEL = "ack_kernel";
+    experimental::metal2_host_api::KernelSpec ack_kernel_spec{
+        .unique_id = ACK_KERNEL,
+        .source =
+            experimental::metal2_host_api::KernelSpec::SourceFilePath{
+                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/quasar_9x4_ack.cpp"},
+        .num_threads = 1,
+        .runtime_arguments_schema =
+            {
+                .named_runtime_args =
+                    {"is_leader", "my_x", "my_y", "leader_noc_x", "leader_noc_y", "expected_acks", "sem_addr"},
+            },
+        .config_spec =
+            experimental::metal2_host_api::DataMovementConfiguration{
+                .gen2_data_movement_config =
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+    };
+
+    experimental::metal2_host_api::NodeRange all_cores{
+        experimental::metal2_host_api::NodeCoord{0, 0},
+        experimental::metal2_host_api::NodeCoord{grid.x - 1, grid.y - 1}};
+
+    experimental::metal2_host_api::WorkUnitSpec wu{
+        .unique_id = "all_cores",
+        .kernels = {ACK_KERNEL},
+        .target_nodes = all_cores,
+    };
+
+    experimental::metal2_host_api::ProgramSpec spec{
+        .program_id = "quasar_9x4_sanity",
+        .kernels = {ack_kernel_spec},
+        .work_units = {wu},
+    };
+    Program program = experimental::metal2_host_api::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::metal2_host_api::ProgramRunParams params;
+    experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp;
+    krp.kernel_spec_name = ACK_KERNEL;
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            uint32_t is_leader = (x == 0 && y == 0) ? 1u : 0u;
+            krp.named_runtime_args.push_back({
+                .node = experimental::metal2_host_api::NodeCoord{x, y},
+                .args =
+                    {
+                        {"is_leader", is_leader},
+                        {"my_x", x},
+                        {"my_y", y},
+                        {"leader_noc_x", static_cast<uint32_t>(leader_phys.x)},
+                        {"leader_noc_y", static_cast<uint32_t>(leader_phys.y)},
+                        {"expected_acks", expected_acks},
+                        {"sem_addr", SEM_L1_ADDR},
+                    },
+            });
+        }
+    }
+    params.kernel_run_params.push_back(std::move(krp));
+    experimental::metal2_host_api::SetProgramRunParameters(program, params);
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> sem_value(1, 0);
+    tt_metal::detail::ReadFromDeviceL1(dev, leader, SEM_L1_ADDR, sizeof(uint32_t), sem_value);
+    log_info(LogTest, "Leader semaphore final value: {} (expected {})", sem_value[0], expected_acks);
+    ASSERT_EQ(sem_value[0], expected_acks);
+}

--- a/tt_metal/core_descriptors/quasar_simulation_9x4_arch.yaml
+++ b/tt_metal/core_descriptors/quasar_simulation_9x4_arch.yaml
@@ -1,0 +1,32 @@
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+
+# product name:
+#   num of HW command queues:
+#     core descriptor config
+
+unharvested:
+  row:
+    1:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 3]
+
+
+      dispatch_cores:
+        []
+
+      dispatch_core_type:
+        "tensix"
+
+    2:
+      compute_with_storage_grid_range: # Logical only start and end [x, y]
+        start: [0, 0]
+        end: [7, 3]
+
+
+      dispatch_cores:
+        []
+
+      dispatch_core_type:
+        "tensix"

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -70,6 +70,7 @@ inline void invalidate_kernel_binary_l2_cache(uintptr_t kernel_lma, launch_msg_t
 }
 
 void set_deassert_addresses() {
+#ifndef QUASAR_DM_ONLY
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC0_RESET_PC_REG_ADDR, MEM_TRISC0_FIRMWARE_BASE);
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC1_RESET_PC_REG_ADDR, MEM_TRISC1_FIRMWARE_BASE);
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC2_RESET_PC_REG_ADDR, MEM_TRISC2_FIRMWARE_BASE);
@@ -90,25 +91,31 @@ void set_deassert_addresses() {
     WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_TRISC2_RESET_PC_REG_ADDR, MEM_TRISC2_FIRMWARE_BASE);
     WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_TRISC3_RESET_PC_REG_ADDR, MEM_TRISC3_FIRMWARE_BASE);
     WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_TRISC_RESET_PC_OVERRIDE_REG_ADDR, 0b1111);
+#endif
 }
 
 void invalidate_trisc_instruction_cache() {
-    // invalidate TRISCs
+#ifndef QUASAR_DM_ONLY
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_RISCV_IC_INVALIDATE_REG_ADDR, RISCV_IC_TRISC_ALL_MASK);
     WRITE_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_RISCV_IC_INVALIDATE_REG_ADDR, RISCV_IC_TRISC_ALL_MASK);
     WRITE_REG(NEO_REGS_2__LOCAL_REGS_DEBUG_REGS_RISCV_IC_INVALIDATE_REG_ADDR, RISCV_IC_TRISC_ALL_MASK);
     WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_RISCV_IC_INVALIDATE_REG_ADDR, RISCV_IC_TRISC_ALL_MASK);
+#endif
 }
 
 void deassert_trisc() {
+#ifndef QUASAR_DM_ONLY
     // Temporary workaround due to race vs. host deasserting TRISC reset.
     // https://github.com/tenstorrent/tt-metal/issues/48064
     assert_trisc_reset();
+    // allNeo slots are already 0 (= RUN_SYNC_MSG_ALL_SUBORDINATES_DONE) in DM-only mode;
+    // only set them to INIT (and release TRISC reset) when TRISC hardware is present.
     subordinate_sync->allNeo0 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo2 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo3 = RUN_SYNC_MSG_ALL_INIT;
     deassert_trisc_reset();
+#endif
 }
 
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
@@ -132,7 +139,8 @@ inline __attribute__((always_inline)) void signal_subordinate_completion() {
     *((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) = RUN_SYNC_MSG_DONE;
 }
 
-inline void run_triscs(uint32_t enables) {
+inline void run_triscs([[maybe_unused]] uint32_t enables) {
+#ifndef QUASAR_DM_ONLY
     // Wait for init_sync_registers to complete. Should always be done by the time we get here.
     DPRINT("DM-FW: waiting for TRISCs to complete\n");
     while (subordinate_sync->allNeo0 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
@@ -170,6 +178,7 @@ inline void run_triscs(uint32_t enables) {
         subordinate_sync->neo3_trisc2 = RUN_SYNC_MSG_GO;
         subordinate_sync->neo3_trisc3 = RUN_SYNC_MSG_GO;
     }
+#endif
 }
 
 inline void start_subordinate_kernel_run_early(uint32_t enables) {
@@ -184,15 +193,26 @@ inline void wait_subordinates() {
     WAYPOINT("NTW");
     // Set subordinate_sync->padding to 0 to make checks against subordinate_sync->allDMs correct.
     subordinate_sync->padding = 0;
+#ifdef QUASAR_DM_ONLY
+    while (subordinate_sync->allDMs != RUN_SYNC_MSG_ALL_SUBORDINATES_DMS_DONE);
+#else
     while (subordinate_sync->allDMs != RUN_SYNC_MSG_ALL_SUBORDINATES_DMS_DONE ||
            subordinate_sync->allNeo0 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo1 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo2 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo3 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE);
+#endif
     WAYPOINT("NTD");
 }
 
-inline void trigger_sync_register_init() { subordinate_sync->neo0_trisc0 = RUN_SYNC_MSG_INIT_SYNC_REGISTERS; }
+inline void trigger_sync_register_init() {
+#ifndef QUASAR_DM_ONLY
+    // Signals NEO0's TRISC0 to initialize sync registers.  In DM-only mode there
+    // are no TRISCs, so writing this would leave neo0_trisc0 (= byte 0 of allNeo0)
+    // permanently non-zero, causing wait_subordinates() to spin forever.
+    subordinate_sync->neo0_trisc0 = RUN_SYNC_MSG_INIT_SYNC_REGISTERS;
+#endif
+}
 
 extern "C" uint32_t _start1() {
     configure_csr();

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -158,6 +158,10 @@ std::map<std::string, std::string> initialize_device_kernel_defines(const JitDev
     device_kernel_defines.emplace("PCIE_NOC_X", std::to_string(config.pcie_core.x));
     device_kernel_defines.emplace("PCIE_NOC_Y", std::to_string(config.pcie_core.y));
 
+    if (config.quasar_dm_only) {
+        device_kernel_defines.emplace("QUASAR_DM_ONLY", "1");
+    }
+
     return device_kernel_defines;
 }
 
@@ -179,6 +183,7 @@ uint64_t compute_build_key(const JitDeviceConfig& config, const llrt::RunTimeOpt
     }
 
     hasher.update(rtoptions.get_compile_hash_string());
+    hasher.update(static_cast<uint32_t>(config.quasar_dm_only));
 
     return hasher.digest();
 }

--- a/tt_metal/jit_build/jit_device_config.cpp
+++ b/tt_metal/jit_build/jit_device_config.cpp
@@ -47,6 +47,9 @@ JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs, C
     auto pcie_cores = soc_d.get_cores(CoreType::PCIE, CoordSystem::TRANSLATED);
     CoreCoord pcie_core = pcie_cores.empty() ? soc_d.grid_size : pcie_cores[0];
 
+    const bool quasar_dm_only =
+        (cluster.arch() == tt::ARCH::QUASAR) && (soc_d.grid_size.x == 9 && soc_d.grid_size.y == 4);
+
     return {
         .hal = &hal,
         .arch = cluster.arch(),
@@ -61,6 +64,7 @@ JitDeviceConfig create_jit_device_config(ChipId device_id, uint8_t num_hw_cqs, C
         .max_cbs = hal.get_arch_num_circular_buffers(),
         .num_hw_cqs = num_hw_cqs,
         .routing_fw_enabled = cluster.is_base_routing_fw_enabled(),
+        .quasar_dm_only = quasar_dm_only,
         .profiler_dram_bank_size_per_risc_bytes = get_profiler_dram_bank_size_per_risc_bytes(ctx.rtoptions())};
 }
 

--- a/tt_metal/jit_build/jit_device_config.hpp
+++ b/tt_metal/jit_build/jit_device_config.hpp
@@ -50,6 +50,12 @@ struct JitDeviceConfig {
 
     bool routing_fw_enabled = false;
 
+    // True when the device is a DM-only Quasar configuration (e.g. 9x4 sim) that has
+    // no TRISC compute hardware.  Causes QUASAR_DM_ONLY to be defined for all firmware
+    // and kernel JIT compilations so that dm.cc can skip TRISC register accesses that
+    // do not exist on such devices.
+    bool quasar_dm_only = false;
+
     // Pre-computed in the factory so that JitBuildEnv::init can consume it without
     // calling get_profiler_dram_bank_size_per_risc_bytes(), which has a side-effect
     // of mutating rtoptions (set_profiler_program_support_count). The build module

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -56,6 +56,9 @@ inline std::string get_core_descriptor_file(
         auto soc_desc = tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(
             env.get_rtoptions().get_simulator_path());
         tt_xy_pair grid_size = tt::umd::SocDescriptor::get_grid_size_from_soc_descriptor_path(soc_desc);
+        if (arch == tt::ARCH::QUASAR && grid_size.x == 9 && grid_size.y == 4) {
+            return core_desc_dir + "quasar_simulation_9x4_arch.yaml";
+        }
         if (grid_size.y <= 2 || grid_size.x <= 2) {  // small simulation grids (any dimension <= 2)
             switch (arch) {
                 default:

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -70,6 +70,7 @@ install(
         ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
         ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/quasar_simulation_1x3_arch.yaml
         ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/quasar_simulation_8x4_arch.yaml
+        ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/quasar_simulation_9x4_arch.yaml
         ${PROJECT_SOURCE_DIR}/tt_metal/core_descriptors/wormhole_b0_versim_1x1_arch.yaml
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/core_descriptors
     COMPONENT metalium-validation


### PR DESCRIPTION
## Summary

Adds a Quasar 9x4 DM-only emulation target (8x4 worker grid, no TRISC compute hardware) and wires it through the full Metal stack.

### Changes
- Add `quasar_simulation_9x4_arch.yaml` core descriptor and register it in `core_descriptor.cpp` and `tt_metal/test/CMakeLists.txt`
- Add `QUASAR_DM_ONLY` compile-time define injected by JIT build system (`jit_device_config.hpp/cpp`, `build_env_manager.cpp`) when grid is 9x4 Quasar; include the flag in the build-cache key to avoid collisions with full-Quasar builds
- Guard all TRISC-specific hardware register accesses in `dm.cc` (NEO_REGS writes, trisc IC invalidation, allNeo sync init) with `#ifndef QUASAR_DM_ONLY`; make `wait_subordinates()` skip allNeo checks in DM-only mode to prevent spurious hangs
- Add `Quasar9x4SanityAllCoresAck` test: 32-core all-cores-ack over NOC semaphore using the Metal 2.0 host API; kernel uses uncached L1 address (`MEM_L1_UNCACHED_BASE`) for local semaphore polling so NOC writes are immediately visible on Quasar
- Register the new test in `sources.cmake` and update quasar regression script/yaml comments to document the new `9x4` config value

## Test plan
- [ ] Build `unit_tests_legacy` against the 9x4 simulator target
- [ ] Run `QuasarMeshDeviceSingleCardFixture.Quasar9x4SanityAllCoresAck` against `emu-quasar-9x4` and confirm all 32 cores ack
- [ ] Verify existing `1x3` / `2x3` / `2x3_DISPATCH` regression configs still pass (no regressions from the `QUASAR_DM_ONLY` guards or build-cache key change)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-9x4-dm-emu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-9x4-dm-emu)