### PR TITLE
[Device 2.0] Add LocalL1 endpoint for local-core L1 NoC ops

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/endpoints.h
+++ b/tt_metal/hw/inc/api/dataflow/endpoints.h
@@ -41,6 +41,15 @@ struct AllocatorBank {
     }
 };
 
+/**
+ * @brief Wrapper for a fixed L1 address on the local core (e.g. MEM_ZEROS_BASE). Used as a source for
+ * noc self-reads (read from local L1 routed through the NoC) and for noc writes whose source is a
+ * local L1 region. Has no destination form — local L1 is never a NoC destination in current callers.
+ */
+struct LocalL1 {
+    uint64_t get_noc_local_addr(uint32_t addr, uint8_t noc) const { return ::get_noc_addr(addr, noc); }
+};
+
 template <>
 struct noc_traits_t<UnicastEndpoint> {
     struct src_args_type {
@@ -112,5 +121,21 @@ struct noc_traits_t<AllocatorBank<bank_type>> {
         static_assert(address_type == Noc::AddressType::NOC);
         uint64_t noc_addr = dst.template get_noc_addr_from_bank_id(args.bank_id, args.addr, noc.get_noc_id());
         return noc_addr;
+    }
+};
+
+template <>
+struct noc_traits_t<LocalL1> {
+    struct src_args_type {
+        uint32_t addr{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const LocalL1& src, const Noc& noc, const src_args_type& args) {
+        if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
+            return args.addr;
+        } else {
+            uint64_t noc_addr = src.get_noc_local_addr(args.addr, noc.get_noc_id());
+            return noc_addr;
+        }
     }
 };


### PR DESCRIPTION
Adds a typed endpoint for fixed L1 addresses on the local core (e.g. MEM_ZEROS_BASE), letting kernels express self-reads and writes-from-local-L1 through Noc::async_read / Noc::async_write instead of falling back to the legacy noc_async_* free functions.

Mirrors the UnicastEndpoint pattern: tag-like struct plus noc_traits_t<>
specialization. Source-only — no caller treats local L1 as a NoC destination.

No callers migrated in this commit; the CCL kernels that currently retain the legacy primitives around MEM_ZEROS_BASE (#45003 item 4) will be swept in a follow-up.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-device2-local-l1-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-device2-local-l1-endpoint)