### PR TITLE
Fix fusion clang-tidy missing MeshCoordinateRange include

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.cpp
@@ -11,6 +11,7 @@
 
 #include "device/fusion_dispatch_op_device_operation.hpp"
 #include "device/fusion_dispatch_op_helpers.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
 namespace nb = nanobind;


### PR DESCRIPTION
## Summary
- Add a direct `ttnn/distributed/types.hpp` include for `ttnn::MeshCoordinateRange` in `fusion_dispatch_op_nanobind.cpp`.
- This fixes the clang-tidy no-PCH build used by merge queue, which is currently stuck on this failure.
- The immediate failing merge-queue run is: https://github.com/tenstorrent/tt-metal/actions/runs/26393340408/attempts/1

## Regression
- The `ttnn::MeshCoordinateRange` use was introduced by `4c1c3447c82` / #42660.
- It regressed when `5f92add5298` / #44405 removed the transitive include path through `FusionDispatchOpProgramFactory`, causing clang-tidy to fail with `no member named MeshCoordinateRange in namespace ttnn`.
- `tt_metal` clang-tidy passed, but `TTNN`, `tt-train`, and `catchall` fail because they build/scan the `ttnn` target.
