### PR TITLE
Improve unary SFPU golden generation

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1957,6 +1957,10 @@ class UnarySFPUGolden:
             return math.nan
 
     def _torch_unary(self, x, torch_fn) -> float:
+        """Apply torch_fn to scalar x in fp32, then enforce the
+        format-aware NaN rule: convert +/-inf to NaN when the dest is
+        A-exponent (Float16).
+        """
         result = torch_fn(torch.tensor(x, dtype=torch.float32)).item()
         if math.isinf(result) and not self.data_format.is_exponent_B():
             return math.nan

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1961,34 +1961,34 @@ class UnarySFPUGolden:
         return abs(x)
 
     def _atanh(self, x):
-        if x < -1.0 or x > 1.0:
+        result = torch.atanh(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
             return math.nan
-        if x == -1.0:
-            return self.handle_infinite_numbers(-math.inf)
-        if x == 1.0:
-            return self.handle_infinite_numbers(math.inf)
-        return math.atanh(x)
+        return result
 
     def _asinh(self, x):
         return math.asinh(x)
 
     def _acosh(self, x):
-        if x < 1.0:
+        result = torch.acosh(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
             return math.nan
-        return math.acosh(x)
+        return result
 
     def _cos(self, x):
         return math.cos(x)
 
     def _log(self, x):
-        if x == 0.0:
-            return self.handle_infinite_numbers(-math.inf)
-        return math.log(x)
+        result = torch.log(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
+            return math.nan
+        return result
 
     def _log1p(self, x):
-        if x == -1.0:
-            return self.handle_infinite_numbers(-math.inf)
-        return math.log1p(x)
+        result = torch.log1p(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
+            return math.nan
+        return result
 
     def _reciprocal(self, x):
         if x == 0.0:
@@ -2003,16 +2003,16 @@ class UnarySFPUGolden:
         return max(0.0, x)
 
     def _rsqrt(self, x):
-        if x < 0.0:
-            return self.handle_infinite_numbers(float("nan"))
-        if x == 0.0:
-            return self.handle_infinite_numbers(float("inf"))
-        return 1 / math.sqrt(x)
+        result = torch.rsqrt(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
+            return math.nan
+        return result
 
     def _sqrt(self, x):
-        if x < 0.0:
+        result = torch.sqrt(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
             return math.nan
-        return math.sqrt(x)
+        return result
 
     def _tanh(self, x):
         return math.tanh(x)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1956,45 +1956,36 @@ class UnarySFPUGolden:
         else:  # self.data_format == DataFormat.Float16:
             return math.nan
 
+    def _torch_unary(self, x, torch_fn) -> float:
+        result = torch_fn(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
+            return math.nan
+        return result
+
     # Operation methods
     def _abs(self, x):
         return abs(x)
 
     def _atanh(self, x):
-        result = torch.atanh(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.atanh)
 
     def _asinh(self, x):
         return math.asinh(x)
 
     def _acosh(self, x):
-        result = torch.acosh(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.acosh)
 
     def _cos(self, x):
         return math.cos(x)
 
     def _log(self, x):
-        result = torch.log(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.log)
 
     def _log1p(self, x):
-        result = torch.log1p(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.log1p)
 
     def _reciprocal(self, x):
-        result = torch.reciprocal(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.reciprocal)
 
     def _sin(self, x):
         # Never not finite, values range from [-1, 1]
@@ -2004,16 +1995,10 @@ class UnarySFPUGolden:
         return max(0.0, x)
 
     def _rsqrt(self, x):
-        result = torch.rsqrt(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.rsqrt)
 
     def _sqrt(self, x):
-        result = torch.sqrt(torch.tensor(x, dtype=torch.float32)).item()
-        if math.isinf(result) and not self.data_format.is_exponent_B():
-            return math.nan
-        return result
+        return self._torch_unary(x, torch.sqrt)
 
     def _tanh(self, x):
         return math.tanh(x)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1991,9 +1991,10 @@ class UnarySFPUGolden:
         return result
 
     def _reciprocal(self, x):
-        if x == 0.0:
-            return self.handle_infinite_numbers(float("inf"))
-        return 1 / x
+        result = torch.reciprocal(torch.tensor(x, dtype=torch.float32)).item()
+        if math.isinf(result) and not self.data_format.is_exponent_B():
+            return math.nan
+        return result
 
     def _sin(self, x):
         # Never not finite, values range from [-1, 1]

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -35,9 +35,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         if constexpr (RECIPROCAL)
         {
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = y * t;
             }
@@ -76,9 +77,10 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         {
             sfpi::vFloat half_y              = sfpi::addexp(y, -1);
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
+            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
+            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
             {
                 y = one_minus_xyy * half_y + y;
             }
@@ -102,7 +104,16 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
     }
     if constexpr (!FAST_APPROX)
     {
-        v_if (x < 0.0F)
+        sfpi::vInt x_abs_bits = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
+        if constexpr (!RECIPROCAL)
+        {
+            v_if (x_abs_bits == 0)
+            {
+                y = x;
+            }
+            v_endif;
+        }
+        v_if (x < 0.0F && x_abs_bits != 0)
         {
             y = std::numeric_limits<float>::quiet_NaN(); // returns nan for fp32 and inf for bf16
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_sqrt.h
@@ -35,10 +35,9 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         if constexpr (RECIPROCAL)
         {
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
-            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
+            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
             {
                 y = y * t;
             }
@@ -77,10 +76,9 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
         {
             sfpi::vFloat half_y              = sfpi::addexp(y, -1);
             sfpi::vInt x_bits                = sfpi::reinterpret<sfpi::vInt>(x);
-            sfpi::vInt x_abs_bits            = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
             sfpi::vInt infinity_minus_x_bits = infinity_bits - x_bits;
             // If x != inf and x != 0.
-            v_if (x_abs_bits != infinity_bits && x_abs_bits != 0)
+            v_if (infinity_minus_x_bits != 0 && x_bits != 0)
             {
                 y = one_minus_xyy * half_y + y;
             }
@@ -104,16 +102,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x)
     }
     if constexpr (!FAST_APPROX)
     {
-        sfpi::vInt x_abs_bits = sfpi::reinterpret<sfpi::vInt>(sfpi::setsgn(x, 0));
-        if constexpr (!RECIPROCAL)
-        {
-            v_if (x_abs_bits == 0)
-            {
-                y = x;
-            }
-            v_endif;
-        }
-        v_if (x < 0.0F && x_abs_bits != 0)
+        v_if (x < 0.0F)
         {
             y = std::numeric_limits<float>::quiet_NaN(); // returns nan for fp32 and inf for bf16
         }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This PR updates unary SFPU golden generation for a group of math ops by switching selected golden paths from Python math.* calls to torch-based generation and by aligning special-value (`inf`, `-inf`, `nan`, `-0.0`, `0.0`) handling more consistently across formats.

Updated ops:
- `log`
- `log1p`
- `sqrt`
- `rsqrt`
- `reciprocal`
- `atanh`
- `acosh`

This change makes golden generation handle special inputs better and prevents failures before we can compare results with hardware. For example, the old log golden could crash with a domain error on invalid inputs, while the new version lets the test run and shows the actual hardware vs. golden mismatch.

### Notes for reviewers
Main places to look at:
- `helpers/golden_generators.py`
- `python_tests/test_sfpu_plot_special_values.py`

FYI: @pmilenkovicTT @fvranicTT

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/unary-sfpu-golden-torch-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/unary-sfpu-golden-torch-migration)