### PR TITLE
 Make Unpacker Strides Operation-Restorable

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_top32_rm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_A_top32_rm.h
@@ -135,7 +135,7 @@ inline void _llk_unpack_A_top32_rm_(
 
     if (unpack_to_dest) {
         if (is_32bit_input(unpack_src_format, unpack_dst_format)) {
-            unpack_to_dest_tile_done(unp_cfg_context);
+            unpack_to_dest_tile_done(unp_cfg_context, unpack_dst_format);
         }
     }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -41,7 +41,7 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
  */
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t num_faces = get_operand_num_faces(operand);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -391,6 +391,5 @@ llk_unpack_tilizeA_B_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -43,7 +43,8 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_(
+        (std::uint32_t)unpack_dst_format[operand_id], ckernel::tensor_shape_from_num_faces(num_faces, face_r_dim));
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_tilize.h"
 
@@ -30,12 +31,19 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
+ * Face count and face row dimension are derived from the operand's CB metadata (mirroring
+ * llk_unpack_tilize_init) so the canonical Tile_x_dim / SrcA stride restore matches the operand's
+ * tile geometry. Deriving face_r_dim (rather than defaulting it to FACE_R_DIM) is what lets the
+ * tiny-tile (face_r_dim < 16) restore reach the Compute API, whose tilize_uninit /
+ * tilize_uninit_with_dt call this with the operand only.
+ *
  * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const uint num_faces = get_operand_num_faces(operand);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    const std::uint32_t num_faces = get_operand_num_faces(operand);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
 /**
@@ -391,5 +399,5 @@ llk_unpack_tilizeA_B_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
+    _llk_unpack_tilizeA_B_uninit_((std::uint32_t)unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -32,10 +32,10 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
  *
  * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
     std::uint32_t operand_id = get_operand_id(operand);
     const uint num_faces = get_operand_num_faces(operand);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces);
+    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
 /**
@@ -391,5 +391,6 @@ llk_unpack_tilizeA_B_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -24,12 +24,8 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
-inline void llk_unpack_untilize_uninit(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    // Derive face_r_dim from operand metadata so the canonical baseline restored here matches
-    // what configure_unpack_AB / the srcA reconfig programmed for this operand. A default
-    // (e.g. FACE_R_DIM) would silently restore the wrong strides for non-default operands.
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+    std::uint32_t operand_id = get_operand_id(operand);
     WAYPOINT("UPUW");
     _llk_unpack_untilize_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
     WAYPOINT("UPUD");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -24,8 +24,12 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
-inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
-    std::uint32_t operand_id = get_operand_id(operand);
+inline void llk_unpack_untilize_uninit(const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    // Derive face_r_dim from operand metadata so the canonical baseline restored here matches
+    // what configure_unpack_AB / the srcA reconfig programmed for this operand. A default
+    // (e.g. FACE_R_DIM) would silently restore the wrong strides for non-default operands.
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     WAYPOINT("UPUW");
     _llk_unpack_untilize_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
     WAYPOINT("UPUD");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_tilize.h"
 #include "llk_unpack_common_api.h"
 
@@ -31,12 +32,19 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
+ * Face count and face row dimension are derived from the operand's CB metadata (mirroring
+ * llk_unpack_tilize_init) so the canonical Tile_x_dim / SrcA stride restore matches the operand's
+ * tile geometry. Deriving face_r_dim (rather than defaulting it to FACE_R_DIM) is what lets the
+ * tiny-tile (face_r_dim < 16) restore reach the Compute API, whose tilize_uninit /
+ * tilize_uninit_with_dt call this with the operand only.
+ *
  * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
 /**
@@ -457,5 +465,5 @@ inline void llk_unpack_fast_tilize_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
+    _llk_unpack_tilizeA_B_uninit_((std::uint32_t)unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -33,9 +33,10 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
  *
  * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
     std::uint32_t operand_id = get_operand_id(operand);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id]);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -44,7 +44,8 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_(
+        (std::uint32_t)unpack_dst_format[operand_id], ckernel::tensor_shape_from_num_faces(num_faces, face_r_dim));
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -24,9 +24,10 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
-inline void llk_unpack_untilize_uninit() {
+inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+    std::uint32_t operand_id = get_operand_id(operand);
     WAYPOINT("UPUW");
-    _llk_unpack_untilize_uninit_();
+    _llk_unpack_untilize_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
     WAYPOINT("UPUD");
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -24,8 +24,12 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
-inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
-    std::uint32_t operand_id = get_operand_id(operand);
+inline void llk_unpack_untilize_uninit(const std::uint32_t operand) {
+    const std::uint32_t operand_id = get_operand_id(operand);
+    // Derive face_r_dim from operand metadata so the canonical baseline restored here matches
+    // what configure_unpack_AB / the srcA reconfig programmed for this operand. A default
+    // (e.g. FACE_R_DIM) would silently restore the wrong strides for non-default operands.
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     WAYPOINT("UPUW");
     _llk_unpack_untilize_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
     WAYPOINT("UPUD");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -24,14 +24,9 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
-inline void llk_unpack_untilize_uninit(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    // Derive face_r_dim from operand metadata so the canonical baseline restored here matches
-    // what configure_unpack_AB / the srcA reconfig programmed for this operand. A default
-    // (e.g. FACE_R_DIM) would silently restore the wrong strides for non-default operands.
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+inline void llk_unpack_untilize_uninit() {
     WAYPOINT("UPUW");
-    _llk_unpack_untilize_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+    _llk_unpack_untilize_uninit_();
     WAYPOINT("UPUD");
 }
 

--- a/tt_metal/tt-llk/.pre-commit-config.yaml
+++ b/tt_metal/tt-llk/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   hooks:
     - id: isort
       language: python
-      args: ["--settings-path=pyproject.toml"]
+      args: ["--settings-path=tt_metal/tt-llk/pyproject.toml"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 25.9.0
   hooks:

--- a/tt_metal/tt-llk/common/tensor_shape.h
+++ b/tt_metal/tt-llk/common/tensor_shape.h
@@ -78,6 +78,24 @@ static_assert(sizeof(TensorShape) == 4, "TensorShape must be 4 bytes");
 constexpr TensorShape DEFAULT_TENSOR_SHAPE = {MAX_FACE_R_DIM, MAX_FACE_C_DIM, MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM};
 
 /**
+ * @brief Build a TensorShape from a flat face count and face row dimension.
+ *
+ * Bridges legacy APIs that still carry a flat num_faces / face_r_dim (e.g. CB metadata) into a
+ * TensorShape. Uses the canonical face-grid decomposition for tile-dependent ops, which are
+ * constrained to num_faces in {1, 2, 4}: 1 -> 1x1, 2 -> 1x2, 4 -> 2x2. The face column dimension
+ * is always 16 in hardware.
+ *
+ * @param num_faces: Total number of faces in the tile (1, 2, or 4).
+ * @param face_r_dim: Row dimension of each face (defaults to the full 16-row face).
+ */
+constexpr TensorShape tensor_shape_from_num_faces(const std::uint32_t num_faces, const std::uint32_t face_r_dim = MAX_FACE_R_DIM)
+{
+    const std::uint8_t num_faces_r_dim = (num_faces == 4) ? 2 : 1;
+    const std::uint8_t num_faces_c_dim = (num_faces == 4) ? 2 : static_cast<std::uint8_t>(num_faces);
+    return TensorShape {static_cast<std::uint8_t>(face_r_dim), MAX_FACE_C_DIM, num_faces_r_dim, num_faces_c_dim};
+}
+
+/**
  * @brief Validates tensor shape for operations that depend on face positioning within a tile.
  * Will start relaxing this constraint once we test larger tensor shapes.
  *

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -59,7 +59,7 @@ inline void _llk_unpack_tilize_wrapper_(
 inline void _llk_unpack_tilize_uninit_wrapper_(
     const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
-    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_(unpack_dst_format, ckernel::tensor_shape_from_num_faces(num_faces, face_r_dim));
 }
 
 #elif defined(ARCH_BLACKHOLE)
@@ -108,7 +108,7 @@ inline void _llk_unpack_tilize_wrapper_(
 
 inline void _llk_unpack_tilize_uninit_wrapper_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4)
 {
-    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces);
+    _llk_unpack_tilize_uninit_(unpack_dst_format, ckernel::tensor_shape_from_num_faces(num_faces));
 }
 
 #else

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -56,9 +56,10 @@ inline void _llk_unpack_tilize_wrapper_(
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, block_ct_dim, face_r_dim, num_faces, narrow_tile);
 }
 
-inline void _llk_unpack_tilize_uninit_wrapper_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t num_faces = 4)
+inline void _llk_unpack_tilize_uninit_wrapper_(
+    const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
-    _llk_unpack_tilize_uninit_(unpack_dst_format);
+    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces, face_r_dim);
 }
 
 #elif defined(ARCH_BLACKHOLE)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
@@ -101,6 +101,10 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tile_shape = compute_unit.src_a.tile_shape
 
-        return f"    _llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces});\n"
+        return (
+            f"    _llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, "
+            f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, "
+            f"{tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}});\n"
+        )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -104,4 +104,7 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format});\n\n"
+        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
+        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+
+        return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces}, {face_r_dim});\n\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -57,10 +57,11 @@ class UnpackerTilizeA(Unpacker):
             compute_unit.src_a.dimensions,
             compute_unit.src_a.data_format,
             compute_unit.src_a.tile_shape.total_num_faces(),
-            tile_dimensions=(
+            tile_dimensions=[
                 compute_unit.src_a.tile_shape.total_row_dim(),
                 compute_unit.src_a.tile_shape.total_col_dim(),
-            ),
+            ],
+            face_r_dim=compute_unit.src_a.tile_shape.face_r_dim,
         )
 
         return tilized_a, None

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -105,7 +105,10 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tile_shape = compute_unit.src_a.tile_shape
 
-        return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces}, {face_r_dim});\n\n"
+        return (
+            f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, "
+            f"ckernel::TensorShape{{{tile_shape.face_r_dim}, {tile_shape.face_c_dim}, "
+            f"{tile_shape.num_faces_r_dim}, {tile_shape.num_faces_c_dim}}});\n\n"
+        )

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -22,9 +22,13 @@ leaks its strides into the matmul, corrupting the result.
 
 The `do_restore` toggle makes this a controlled experiment:
     do_restore=True  -> transition restores the baseline; matmul must match golden.
-    do_restore=False -> no restore; on a correct (PR) build this is expected to expose
-                        the leak for tiny G0 (regular G0 is the control and may pass
-                        even without restore since its strides already match).
+    do_restore=False -> no restore; on a correct (PR) build this always exposes the leak
+                        and corrupts the matmul, for every polluter geometry including the
+                        regular G0 (face_r_dim=16). Even when the regular polluter's
+                        Y-stride already matches, `unpack_tilize` leaves `tilize_mode` set
+                        and `Tile_x_dim` covering the whole tile row, which
+                        `_llk_unpack_AB_matmul_init_` does not reset — so divergence is
+                        guaranteed and (16, False) is a valid negative-control point.
 """
 
 from dataclasses import dataclass

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -30,6 +30,7 @@ The `do_restore` toggle makes this a controlled experiment:
 from dataclasses import dataclass
 
 import torch
+from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import MatmulGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, MathFidelity, format_dict
@@ -46,8 +47,6 @@ from helpers.test_variant_parameters import (
 )
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
-
-from conftest import skip_for_blackhole
 
 # The matmul victim is always a regular 32x32 (4-face) tile.
 MATMUL_NUM_FACES = 4

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -30,7 +30,6 @@ The `do_restore` toggle makes this a controlled experiment:
 from dataclasses import dataclass
 
 import torch
-from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import MatmulGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, MathFidelity, format_dict
@@ -47,6 +46,8 @@ from helpers.test_variant_parameters import (
 )
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
+
+from conftest import skip_for_blackhole
 
 # The matmul victim is always a regular 32x32 (4-face) tile.
 MATMUL_NUM_FACES = 4
@@ -76,11 +77,17 @@ class DO_RESTORE(TemplateParameter):
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
+            DataFormat.Float32,
         ],
-        same=True,
+        same=False,
     ),
-    dest_acc=[DestAccumulation.No],
-    math_fidelity=[MathFidelity.HiFi4],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
     # Polluter (run-0) tilize face row count: 16 == regular (control), <16 == tiny.
     polluter_face_r_dim=[16, 4, 1],
     do_restore=[True, False],
@@ -186,6 +193,10 @@ def test_tilize_polluter_matmul(
         res_tensor,
         formats.output_format,
         L1_to_L1_iterations=L1_to_L1_iterations,
+        # do_restore=False is a negative control that *expects* a mismatch, so
+        # suppress the (otherwise alarming) ERROR-level diff dump for it. The
+        # do_restore=True path keeps it on so an unexpected divergence is shown.
+        print_errors=do_restore,
     )
 
     if do_restore:

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -9,8 +9,9 @@ cannot mix tile geometries, so this uses a **state-leak** design instead:
 
     run 0: `unpack_tilize` at geometry G0 (the polluter; output discarded to scratch).
            G0 = tiny when face_r_dim < 16, regular when face_r_dim == 16.
-    transition (only when do_restore=True): `_llk_unpack_tilize_uninit_` +
-           `_llk_unpack_reconfig_data_format_srca_impl_<.. FACE_ROW_MAJOR>`.
+    transition (only when do_restore=True): `_llk_unpack_tilize_uninit_` (PR C1) +
+           `_llk_unpack_hw_configure_` re-establishing the regular 32x32 operand baseline
+           (a tiny->regular geometry change needs a full reconfigure, not a stride-only one).
     run 1: a REGULAR 32x32 `_llk_unpack_AB_matmul_` on independent, pre-tilized
            operands read directly from buffer_A[0] / buffer_B[0].
 
@@ -55,10 +56,11 @@ REGULAR_FACE_R_DIM = 16
 
 @dataclass
 class DO_RESTORE(TemplateParameter):
-    """Whether the run-0 -> run-1 transition restores the tilize-mutated SrcA baseline.
+    """Whether the run-0 -> run-1 transition restores the tilize-mutated operand baseline.
 
-    True  -> `_llk_unpack_tilize_uninit_` + reconfig<FACE_ROW_MAJOR> before the matmul.
-    False -> nothing; the (possibly tiny) tilize strides leak straight into the matmul.
+    True  -> `_llk_unpack_tilize_uninit_` + `_llk_unpack_hw_configure_` (regular baseline)
+             before the matmul, so it reads correct operands.
+    False -> nothing; the (possibly tiny) tilize state leaks straight into the matmul.
     """
 
     do_restore: bool = True
@@ -180,9 +182,25 @@ def test_tilize_polluter_matmul(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    assert passed_test(
+    result_matches = passed_test(
         golden_tensor,
         res_tensor,
         formats.output_format,
         L1_to_L1_iterations=L1_to_L1_iterations,
-    ), "Assert against golden failed"
+    )
+
+    if do_restore:
+        # Correct path: uninit + FACE_ROW_MAJOR reconfig on BOTH operands re-establishes
+        # the regular 32x32 baseline, so the matmul reads its operands correctly.
+        assert (
+            result_matches
+        ), "restore (uninit + reconfig) failed: matmul diverged from golden"
+    else:
+        # Negative control: run-1 performs NO hw_configure and relies entirely on the
+        # restore that we skipped here, so the polluter tilize state (tilize_mode, mutated
+        # Tile_x_dim / Y-stride, and — for tiny polluters — a <4-face descriptor) leaks into
+        # the regular matmul and MUST corrupt the result. This proves the restore is
+        # load-bearing (and that _llk_unpack_AB_matmul_init_ does not reset that state).
+        assert (
+            not result_matches
+        ), "expected a state leak without restore, but the matmul matched golden"

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_matmul.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-op tile-geometry transition test: `unpack_tilize` (polluter) -> regular matmul.
+
+This is the "tiny tile unpack tilize + regular matmul" case from the unpacker-stride
+coverage roadmap (Phase 3b). A coupled pipeline (tilize output feeding the matmul)
+cannot mix tile geometries, so this uses a **state-leak** design instead:
+
+    run 0: `unpack_tilize` at geometry G0 (the polluter; output discarded to scratch).
+           G0 = tiny when face_r_dim < 16, regular when face_r_dim == 16.
+    transition (only when do_restore=True): `_llk_unpack_tilize_uninit_` +
+           `_llk_unpack_reconfig_data_format_srca_impl_<.. FACE_ROW_MAJOR>`.
+    run 1: a REGULAR 32x32 `_llk_unpack_AB_matmul_` on independent, pre-tilized
+           operands read directly from buffer_A[0] / buffer_B[0].
+
+`_llk_unpack_AB_matmul_init_` only reprograms x-end and the ZW *counter*; it does NOT
+reset the SrcA Y-stride / Z-stride / Tile_x_dim that `unpack_tilize` mutates (those are
+restored by `_llk_unpack_tilize_uninit_`). So a tiny tilize that is not properly uninit'd
+leaks its strides into the matmul, corrupting the result.
+
+The `do_restore` toggle makes this a controlled experiment:
+    do_restore=True  -> transition restores the baseline; matmul must match golden.
+    do_restore=False -> no restore; on a correct (PR) build this is expected to expose
+                        the leak for tiny G0 (regular G0 is the control and may pass
+                        even without restore since its strides already match).
+"""
+
+from dataclasses import dataclass
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import MatmulGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, MathFidelity, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import convert_to_l1_view, generate_face_matmul_data
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    MATH_FIDELITY,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TemplateParameter,
+    generate_input_dim,
+)
+from helpers.tilize_untilize import tilize_block
+from helpers.utils import passed_test
+
+from conftest import skip_for_blackhole
+
+# The matmul victim is always a regular 32x32 (4-face) tile.
+MATMUL_NUM_FACES = 4
+REGULAR_FACE_R_DIM = 16
+
+
+@dataclass
+class DO_RESTORE(TemplateParameter):
+    """Whether the run-0 -> run-1 transition restores the tilize-mutated SrcA baseline.
+
+    True  -> `_llk_unpack_tilize_uninit_` + reconfig<FACE_ROW_MAJOR> before the matmul.
+    False -> nothing; the (possibly tiny) tilize strides leak straight into the matmul.
+    """
+
+    do_restore: bool = True
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool DO_RESTORE = {str(self.do_restore).lower()};"
+
+
+@skip_for_blackhole
+@parametrize(
+    # Same format for both runs so skipping the restore (do_restore=False) does not
+    # introduce a data-format mismatch — isolating the unpacker-stride leak.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No],
+    math_fidelity=[MathFidelity.HiFi4],
+    # Polluter (run-0) tilize face row count: 16 == regular (control), <16 == tiny.
+    polluter_face_r_dim=[16, 4, 1],
+    do_restore=[True, False],
+)
+def test_tilize_polluter_matmul(
+    formats,
+    dest_acc,
+    math_fidelity,
+    polluter_face_r_dim,
+    do_restore,
+):
+    torch_format = format_dict[formats.output_format]
+    mm_dimensions = [32, 32]
+
+    # Independent, regular 32x32 matmul operands (run 1 reads these tilized).
+    in0 = generate_face_matmul_data(
+        num_faces=MATMUL_NUM_FACES,
+        stimuli_format=formats.input_format,
+        input_dimensions=mm_dimensions,
+        is_matrix_A=True,
+        face_r_dim=REGULAR_FACE_R_DIM,
+    )
+    in1 = generate_face_matmul_data(
+        num_faces=MATMUL_NUM_FACES,
+        stimuli_format=formats.input_format,
+        input_dimensions=mm_dimensions,
+        is_matrix_A=False,
+    )
+
+    generate_golden = get_golden_generator(MatmulGolden)
+    golden_tensor = generate_golden(
+        in0,
+        in1,
+        formats.output_format,
+        math_fidelity,
+        input_A_dimensions=mm_dimensions,
+        input_B_dimensions=mm_dimensions,
+        tilize=True,
+        input_A_format=formats.input_format,
+        input_B_format=formats.input_format,
+    )
+    golden_tensor = convert_to_l1_view(
+        golden_tensor,
+        (mm_dimensions[0], mm_dimensions[1]),
+        tile_dimensions=mm_dimensions,
+    )
+
+    # Pre-tilize the operands and lay them out exactly as L1 expects them; run-1's
+    # matmul reads them directly, run-0's tilize reads the same bytes as raw row-major
+    # input (its output is discarded, so the garbage does not matter).
+    tilized_in0 = tilize_block(
+        in0, dimensions=mm_dimensions, stimuli_format=formats.input_format
+    )
+    tilized_in1 = tilize_block(
+        in1, dimensions=mm_dimensions, stimuli_format=formats.input_format
+    )
+    tilized_in0_l1_view = convert_to_l1_view(
+        tilized_in0, mm_dimensions, tile_dimensions=mm_dimensions
+    )
+    tilized_in1_l1_view = convert_to_l1_view(
+        tilized_in1, mm_dimensions, tile_dimensions=mm_dimensions
+    )
+
+    polluter_num_faces = 4 if polluter_face_r_dim == REGULAR_FACE_R_DIM else 2
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/tilize_polluter_matmul_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(mm_dimensions, mm_dimensions),
+            MATH_FIDELITY(math_fidelity),
+            DO_RESTORE(do_restore=do_restore),
+        ],
+        runtimes=[
+            NUM_FACES(polluter_num_faces),
+            TEST_FACE_DIMS(face_r_dim=polluter_face_r_dim, face_c_dim=16),
+        ],
+        variant_stimuli=StimuliConfig(
+            tilized_in0_l1_view.flatten(),
+            formats.input_format,
+            tilized_in1_l1_view.flatten(),
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=1,
+            tile_count_B=1,
+            tile_count_res=1,
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
@@ -22,6 +22,7 @@ correct result; `do_restore=False` is the negative control.
 from dataclasses import dataclass
 
 import torch
+from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import MatmulGolden, get_golden_generator
 from helpers.llk_params import (
@@ -56,8 +57,6 @@ from helpers.test_variant_parameters import (
 )
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
-
-from conftest import skip_for_blackhole
 
 # Tiny in0 (SrcB) is 2 horizontal faces; in1 (SrcA) is a regular 4-face 32x32 tile.
 TINY_NUM_FACES_IN0 = 2

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
@@ -22,7 +22,6 @@ correct result; `do_restore=False` is the negative control.
 from dataclasses import dataclass
 
 import torch
-from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import MatmulGolden, get_golden_generator
 from helpers.llk_params import (
@@ -57,6 +56,8 @@ from helpers.test_variant_parameters import (
 )
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
+
+from conftest import skip_for_blackhole
 
 # Tiny in0 (SrcB) is 2 horizontal faces; in1 (SrcA) is a regular 4-face 32x32 tile.
 TINY_NUM_FACES_IN0 = 2
@@ -105,12 +106,18 @@ def _tiny_matmul_layout(in0_tile_r_dim: int):
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
+            DataFormat.Float32,
         ],
-        same=True,
+        same=False,
     ),
-    dest_acc=[DestAccumulation.No],
-    math_fidelity=[MathFidelity.HiFi4],
-    in0_tile_r_dim=[8, 4],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
+    in0_tile_r_dim=[8, 4, 2, 1],
     do_restore=[True, False],
 )
 def test_tilize_polluter_tiny_matmul(

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_polluter_tiny_matmul.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-op tile-geometry transition test: REGULAR `unpack_tilize` -> TINY matmul.
+
+Phase 3b Direction B. `test_matmul_unpack_tilize` only exercises the tilize->matmul
+transition with `num_faces == 4`; this closes the `num_faces < 4` (tiny / partial-face
+matmul) corner of that cell.
+
+A coupled pipeline cannot mix tile geometries, so the tiny matmul reads its own
+independent, pre-tilized operands (in0 = tiny [face_r,32] SrcB, in1 = regular 32x32
+SrcA), exactly as `test_unpack_matmul`'s tiny path does. Run 0 is a regular 32x32
+`unpack_tilize` polluter (output discarded to scratch) that leaves the unpacker in a
+regular-tilize state; `_llk_unpack_tilize_uninit_` then restores the baseline (gated by
+`do_restore`) before the tiny matmul.
+
+Because the tiny-matmul run re-runs `_llk_unpack_hw_configure_` for its operands, this
+primarily validates that the regular-tilize -> uninit -> tiny-matmul SEQUENCE produces a
+correct result; `do_restore=False` is the negative control.
+"""
+
+from dataclasses import dataclass
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import MatmulGolden, get_golden_generator
+from helpers.llk_params import (
+    DestAccumulation,
+    MathFidelity,
+    StochasticRounding,
+    Transpose,
+    format_dict,
+)
+from helpers.matmul_sweep import (
+    FaceLayoutConfig,
+    calculate_matmul_output_faces,
+    generate_tile_dims,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import convert_to_l1_view, generate_face_matmul_data
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    CRK_TILE_DIMM,
+    DEST_INDEX,
+    IN_TILE_DIMS,
+    MATH_FIDELITY,
+    NUM_FACES,
+    PARTIAL_FACE,
+    STOCHASTIC_ROUNDING,
+    THROTTLE_LEVEL,
+    TILE_COUNT,
+    UNPACK_TRANS_FACES,
+    UNPACK_TRANS_WITHIN_FACE,
+    TemplateParameter,
+)
+from helpers.tilize_untilize import tilize_block
+from helpers.utils import passed_test
+
+from conftest import skip_for_blackhole
+
+# Tiny in0 (SrcB) is 2 horizontal faces; in1 (SrcA) is a regular 4-face 32x32 tile.
+TINY_NUM_FACES_IN0 = 2
+REGULAR_NUM_FACES_IN1 = 4
+
+
+@dataclass
+class DO_RESTORE(TemplateParameter):
+    """Whether `_llk_unpack_tilize_uninit_` runs between the polluter and the matmul."""
+
+    do_restore: bool = True
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool DO_RESTORE = {str(self.do_restore).lower()};"
+
+
+def _tiny_matmul_layout(in0_tile_r_dim: int):
+    """Build (tile_dims, face_layout) for a single-output-tile tiny matmul:
+    in0 = [in0_tile_r_dim, 32] (SrcB), in1 = [32, 32] (SrcA)."""
+    input1_dims = [32, 32]
+    tile_dims = generate_tile_dims(
+        ([32, 32], input1_dims), in0_tile_r_dim=in0_tile_r_dim
+    )
+    output_num_faces = calculate_matmul_output_faces(
+        num_faces_in0=TINY_NUM_FACES_IN0,
+        num_faces_in1=REGULAR_NUM_FACES_IN1,
+        is_in0_horizontal=True,
+    )
+    face = FaceLayoutConfig(
+        num_faces_in0=TINY_NUM_FACES_IN0,
+        num_faces_in1=REGULAR_NUM_FACES_IN1,
+        num_faces=output_num_faces,
+        unpack_transpose_faces=Transpose.No,
+        unpack_transpose_within_face=Transpose.No,
+        partial_face_in0=True,  # SrcB
+        partial_face_in1=False,  # SrcA
+        partial_face_math=in0_tile_r_dim < 16,
+        partial_face_pack=True,
+    )
+    return tile_dims, face
+
+
+@skip_for_blackhole
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No],
+    math_fidelity=[MathFidelity.HiFi4],
+    in0_tile_r_dim=[8, 4],
+    do_restore=[True, False],
+)
+def test_tilize_polluter_tiny_matmul(
+    formats,
+    dest_acc,
+    math_fidelity,
+    in0_tile_r_dim,
+    do_restore,
+):
+    tile_dims, face = _tiny_matmul_layout(in0_tile_r_dim)
+    in0_dimensions = tile_dims.in0_dimensions
+    in1_dimensions = tile_dims.in1_dimensions
+
+    # Independent tiny/regular matmul operands (run 1 reads these tilized).
+    in0 = generate_face_matmul_data(
+        num_faces=face.num_faces_in0,
+        stimuli_format=formats.input_format,
+        input_dimensions=in0_dimensions,
+        is_matrix_A=True,  # SrcB uses f0,f1
+        face_r_dim=(in0_tile_r_dim if in0_tile_r_dim < 16 else 16),
+    )
+    in1 = generate_face_matmul_data(
+        num_faces=face.num_faces_in1,
+        stimuli_format=formats.input_format,
+        input_dimensions=in1_dimensions,
+        is_matrix_A=False,  # SrcA uses f0,f2
+    )
+
+    generate_golden = get_golden_generator(MatmulGolden)
+    golden_tensor = generate_golden(
+        in0,
+        in1,
+        formats.output_format,
+        math_fidelity,
+        input_A_dimensions=in0_dimensions,
+        input_B_dimensions=in1_dimensions,
+        tilize=True,
+        input_A_format=formats.input_format,
+        input_B_format=formats.input_format,
+    )
+    golden_tensor = convert_to_l1_view(
+        golden_tensor,
+        (in0_dimensions[0], in1_dimensions[1]),
+        tile_dimensions=[tile_dims.in0_tile_r_dim, tile_dims.in1_tile_c_dim],
+    )
+
+    tilized_in0 = tilize_block(
+        in0, dimensions=in0_dimensions, stimuli_format=formats.input_format
+    )
+    tilized_in1 = tilize_block(
+        in1, dimensions=in1_dimensions, stimuli_format=formats.input_format
+    )
+    tilized_in0_l1_view = convert_to_l1_view(
+        tilized_in0,
+        in0_dimensions,
+        tile_dimensions=[tile_dims.in0_tile_r_dim, tile_dims.in0_tile_c_dim],
+    )
+    tilized_in1_l1_view = convert_to_l1_view(
+        tilized_in1,
+        in1_dimensions,
+        tile_dimensions=[tile_dims.in1_tile_r_dim, tile_dims.in1_tile_c_dim],
+    )
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/tilize_polluter_tiny_matmul_test.cpp",
+        formats,
+        templates=[
+            STOCHASTIC_ROUNDING(StochasticRounding.No),
+            MATH_FIDELITY(math_fidelity),
+            THROTTLE_LEVEL(0),
+            DO_RESTORE(do_restore=do_restore),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_dims.tile_cnt),
+            NUM_FACES(face.num_faces, face.num_faces_in0, face.num_faces_in1),
+            UNPACK_TRANS_FACES(Transpose.No),
+            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+            PARTIAL_FACE(
+                partial_a=face.partial_face_in0,
+                partial_face_pack=face.partial_face_pack,
+                partial_b=face.partial_face_in1,
+                partial_face_math=face.partial_face_math,
+            ),
+            CRK_TILE_DIMM(tile_dims.ct_dim, tile_dims.rt_dim, tile_dims.kt_dim),
+            IN_TILE_DIMS(
+                tile_dims.in0_tile_r_dim,
+                tile_dims.in0_tile_c_dim,
+                tile_dims.in1_tile_r_dim,
+                tile_dims.in1_tile_c_dim,
+            ),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            tilized_in0_l1_view.flatten(),
+            formats.input_format,
+            tilized_in1_l1_view.flatten(),
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_dims.tile_cnt_in0,
+            tile_count_B=tile_dims.tile_cnt_in1,
+            tile_count_res=tile_dims.tile_cnt,
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    # num_faces < 4: compare only the active faces of each output tile.
+    num_elements_per_tile = tile_dims.in0_tile_r_dim * tile_dims.in1_tile_c_dim
+    TILE_R_DIM, TILE_C_DIM = 32, 32
+    for i in range(tile_dims.output_tile_cnt):
+        start = i * (TILE_R_DIM * TILE_C_DIM)
+        assert passed_test(
+            golden_tensor[start : start + num_elements_per_tile],
+            res_tensor[start : start + num_elements_per_tile],
+            formats.output_format,
+        ), f"Assert on tile {i}/{tile_dims.output_tile_cnt} against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
@@ -13,15 +13,15 @@ only restore path that both re-commits the canonical SrcA Y-stride AND retargets
 the geometry (Tile_x_dim_cntx0 from G1.face_r_dim, descriptor Z-dim from
 G1.num_faces).
 
-The kernel reads the four canonical SrcA registers back and DEVICE_PRINTs the
-(expected G1 baseline, actual) pairs. Because a SrcA datacopy victim's
+The kernel reads the four canonical SrcA registers back and LLK_ASSERTs them
+against the expected G1 baseline on-device. Because a SrcA datacopy victim's
 correctness is *entirely* a function of these registers — and Phases 1/2 already
-prove "correct registers => correct data" behaviourally — reading them directly
+prove "correct registers => correct data" behaviourally — checking them directly
 verifies the transition for BOTH directions without needing a second operand /
 golden (a single-geometry stimuli harness can't lay out two tile shapes cleanly).
 
 `do_restore=False` is the negative control: with no transition the registers stay
-in the G0 tilize state, so the host sees the G1 baseline is NOT reproduced
+in the G0 tilize state, so the kernel asserts the G1 baseline is NOT reproduced
 (Tile_x_dim / Z-dim differ), proving the transition is load-bearing.
 
 WH-only: exercises the 3-arg `_llk_unpack_tilize_uninit_(dst, num_faces,
@@ -29,7 +29,6 @@ face_r_dim)` and tiny `face_r_dim < 16` geometry, which BH's 2-arg uninit cannot
 express (matches `test_unpack_tilize_uninit_restore_tiny`).
 """
 
-import re
 from dataclasses import dataclass
 
 from helpers.format_config import DataFormat
@@ -51,18 +50,6 @@ pytestmark = skip_for_coverage
 REGULAR_FACE_R_DIM = 16
 REGULAR_NUM_FACES = 4
 TINY_NUM_FACES = 2
-
-# "[RISC|UNPACK|...] T1 txdim exp=256 act=64" -> ("txdim", 256, 64)
-_T1_LINE_RE = re.compile(r"T1\s+(\w+)\s+exp=(-?\d+)\s+act=(-?\d+)")
-
-
-def _parse_t1(lines: list[str]) -> dict[str, tuple[int, int]]:
-    out: dict[str, tuple[int, int]] = {}
-    for line in lines:
-        m = _T1_LINE_RE.search(line)
-        if m:
-            out[m.group(1)] = (int(m.group(2)), int(m.group(3)))
-    return out
 
 
 @dataclass
@@ -95,10 +82,11 @@ class VICTIM_GEOMETRY(TemplateParameter):
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
+            DataFormat.Float32,
         ],
-        same=True,
+        same=False,
     ),
-    dest_acc=[DestAccumulation.No],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     direction=["normal_to_tiny", "tiny_to_normal"],
     # The tiny side's face row count (the normal side is always 16 / 4 faces).
     tiny_face_r_dim=[8, 4, 2, 1],
@@ -173,31 +161,10 @@ def test_tilize_transition_reconfig(
         ),
         dest_acc=dest_acc,
         L1_to_L1_iterations=2,
-        requires_device_print=True,
     )
 
-    parsed = _parse_t1(configuration.run().device_print_lines)
-
-    keys = ("ystride", "zstride", "txdim", "zdim")
-    for key in keys:
-        assert key in parsed, f"missing T1 {key} device print; parsed={parsed}"
-
-    if do_restore:
-        # The transition must reproduce the canonical G1 SrcA baseline exactly.
-        for key in keys:
-            exp, act = parsed[key]
-            assert exp == act, (
-                f"transition (uninit + reconfig) failed to retarget {key} to G1: "
-                f"expected(G1)={exp}, actual(register)={act} "
-                f"(direction={direction}, tiny_face_r_dim={tiny_face_r_dim})"
-            )
-    else:
-        # Negative control: without the transition the SrcA baseline is the G0
-        # tilize state, so the full G1 baseline must NOT be reproduced (the
-        # geometry-bearing Tile_x_dim / Z-dim differ between G0 and G1).
-        all_match = all(parsed[key][0] == parsed[key][1] for key in keys)
-        assert not all_match, (
-            "expected a state leak without the transition, but the SrcA registers "
-            f"already matched the G1 baseline: parsed={parsed} "
-            f"(direction={direction}, tiny_face_r_dim={tiny_face_r_dim})"
-        )
+    # All verification is on-device: the kernel LLK_ASSERTs that the SrcA baseline
+    # matches the canonical G1 state when do_restore=True, and that it does NOT
+    # match (a load-bearing leak) when do_restore=False. A failed assert surfaces
+    # here as a test failure.
+    configuration.run()

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
@@ -24,9 +24,11 @@ golden (a single-geometry stimuli harness can't lay out two tile shapes cleanly)
 in the G0 tilize state, so the kernel asserts the G1 baseline is NOT reproduced
 (Tile_x_dim / Z-dim differ), proving the transition is load-bearing.
 
-WH-only: exercises the 3-arg `_llk_unpack_tilize_uninit_(dst, num_faces,
-face_r_dim)` and tiny `face_r_dim < 16` geometry, which BH's 2-arg uninit cannot
-express (matches `test_unpack_tilize_uninit_restore_tiny`).
+WH-only: exercises the 3-arg WH test wrapper `_llk_unpack_tilize_uninit_wrapper_(dst,
+num_faces, face_r_dim)` and tiny `face_r_dim < 16` geometry. The BH library uninit does
+honor `face_r_dim` (via its `TensorShape` param), but the BH wrapper is 2-arg and drops
+it, so this branch cannot be expressed on BH without extending that wrapper (matches
+`test_unpack_tilize_uninit_restore_tiny`).
 """
 
 from dataclasses import dataclass

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
@@ -31,6 +31,7 @@ express (matches `test_unpack_tilize_uninit_restore_tiny`).
 
 from dataclasses import dataclass
 
+from conftest import skip_for_blackhole, skip_for_coverage
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation
 from helpers.param_config import input_output_formats, parametrize
@@ -42,8 +43,6 @@ from helpers.test_variant_parameters import (
     TEST_FACE_DIMS,
     TemplateParameter,
 )
-
-from conftest import skip_for_blackhole, skip_for_coverage
 
 pytestmark = skip_for_coverage
 

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_transition_reconfig.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mixed-tile transition test for `tilize_uninit` + the C2 reconfig retarget.
+
+Closes the last open `tilize_uninit` (C1) cell: "normal->tiny / tiny->normal with
+reconfig" (axis F = tile-size transition, axis E = with-reconfig). A real
+`unpack_tilize` at geometry G0 leaves the SrcA baseline in the G0 tilize state;
+the transition under test re-establishes a DIFFERENT geometry G1 using
+`_llk_unpack_tilize_uninit_(G0)` (PR C1) followed by
+`_llk_unpack_reconfig_data_format_srca_impl_<FACE_ROW_MAJOR>(G1)` (PR C2) — the
+only restore path that both re-commits the canonical SrcA Y-stride AND retargets
+the geometry (Tile_x_dim_cntx0 from G1.face_r_dim, descriptor Z-dim from
+G1.num_faces).
+
+The kernel reads the four canonical SrcA registers back and DEVICE_PRINTs the
+(expected G1 baseline, actual) pairs. Because a SrcA datacopy victim's
+correctness is *entirely* a function of these registers — and Phases 1/2 already
+prove "correct registers => correct data" behaviourally — reading them directly
+verifies the transition for BOTH directions without needing a second operand /
+golden (a single-geometry stimuli harness can't lay out two tile shapes cleanly).
+
+`do_restore=False` is the negative control: with no transition the registers stay
+in the G0 tilize state, so the host sees the G1 baseline is NOT reproduced
+(Tile_x_dim / Z-dim differ), proving the transition is load-bearing.
+
+WH-only: exercises the 3-arg `_llk_unpack_tilize_uninit_(dst, num_faces,
+face_r_dim)` and tiny `face_r_dim < 16` geometry, which BH's 2-arg uninit cannot
+express (matches `test_unpack_tilize_uninit_restore_tiny`).
+"""
+
+import re
+from dataclasses import dataclass
+
+from helpers.format_config import DataFormat
+from helpers.llk_params import DestAccumulation
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TemplateParameter,
+)
+
+from conftest import skip_for_blackhole, skip_for_coverage
+
+pytestmark = skip_for_coverage
+
+REGULAR_FACE_R_DIM = 16
+REGULAR_NUM_FACES = 4
+TINY_NUM_FACES = 2
+
+# "[RISC|UNPACK|...] T1 txdim exp=256 act=64" -> ("txdim", 256, 64)
+_T1_LINE_RE = re.compile(r"T1\s+(\w+)\s+exp=(-?\d+)\s+act=(-?\d+)")
+
+
+def _parse_t1(lines: list[str]) -> dict[str, tuple[int, int]]:
+    out: dict[str, tuple[int, int]] = {}
+    for line in lines:
+        m = _T1_LINE_RE.search(line)
+        if m:
+            out[m.group(1)] = (int(m.group(2)), int(m.group(3)))
+    return out
+
+
+@dataclass
+class DO_RESTORE(TemplateParameter):
+    """Whether the G0->G1 transition (uninit + reconfig) runs before the readback."""
+
+    do_restore: bool = True
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool DO_RESTORE = {str(self.do_restore).lower()};"
+
+
+@dataclass
+class VICTIM_GEOMETRY(TemplateParameter):
+    """Target (G1) tile geometry the transition must re-establish."""
+
+    victim_num_faces: int = REGULAR_NUM_FACES
+    victim_face_r_dim: int = REGULAR_FACE_R_DIM
+
+    def convert_to_cpp(self) -> str:
+        return (
+            f"constexpr std::uint32_t VICTIM_NUM_FACES = {self.victim_num_faces};\n"
+            f"constexpr std::uint32_t VICTIM_FACE_R_DIM = {self.victim_face_r_dim};"
+        )
+
+
+@skip_for_blackhole
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No],
+    direction=["normal_to_tiny", "tiny_to_normal"],
+    # The tiny side's face row count (the normal side is always 16 / 4 faces).
+    tiny_face_r_dim=[8, 4, 2, 1],
+    do_restore=[True, False],
+)
+def test_tilize_transition_reconfig(
+    formats,
+    dest_acc,
+    direction,
+    tiny_face_r_dim,
+    do_restore,
+):
+    # G0 = polluter tilize geometry (run-0); G1 = target geometry the transition
+    # must re-establish.
+    if direction == "normal_to_tiny":
+        g0_face_r_dim, g0_num_faces = REGULAR_FACE_R_DIM, REGULAR_NUM_FACES
+        g1_face_r_dim, g1_num_faces = tiny_face_r_dim, TINY_NUM_FACES
+    else:  # tiny_to_normal
+        g0_face_r_dim, g0_num_faces = tiny_face_r_dim, TINY_NUM_FACES
+        g1_face_r_dim, g1_num_faces = REGULAR_FACE_R_DIM, REGULAR_NUM_FACES
+
+    # Stimuli are sized for the run-0 (G0) tilize input; the run-0 output is
+    # discarded to scratch and the test validates registers, so the exact data
+    # does not matter (no golden).
+    g0_is_tiny = g0_face_r_dim < REGULAR_FACE_R_DIM
+    g0_dims = [g0_face_r_dim, 32] if g0_is_tiny else [32, 32]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=g0_dims,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=g0_dims,
+        face_r_dim=g0_face_r_dim,
+        num_faces=g0_num_faces,
+    )
+
+    stimuli_kwargs = dict(
+        tile_count_A=tile_cnt_A,
+        tile_count_B=tile_cnt_B,
+        tile_count_res=tile_cnt_A,
+        num_faces=g0_num_faces,
+        face_r_dim=g0_face_r_dim,
+    )
+    if g0_is_tiny:
+        # Tiny tile is dense (num_faces * face_r_dim * 16 row-major elements);
+        # do NOT pad to a full 32x32 tile (matches the tiny restore test).
+        pass
+    else:
+        # Full 32x32 tiles needed in L1 for the regular tilize input.
+        stimuli_kwargs["write_full_tiles"] = True
+
+    configuration = TestConfig(
+        "sources/tilize_transition_reconfig_test.cpp",
+        formats,
+        templates=[
+            DO_RESTORE(do_restore=do_restore),
+            VICTIM_GEOMETRY(
+                victim_num_faces=g1_num_faces, victim_face_r_dim=g1_face_r_dim
+            ),
+        ],
+        runtimes=[
+            NUM_FACES(g0_num_faces),
+            TEST_FACE_DIMS(face_r_dim=g0_face_r_dim, face_c_dim=16),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            **stimuli_kwargs,
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=2,
+        requires_device_print=True,
+    )
+
+    parsed = _parse_t1(configuration.run().device_print_lines)
+
+    keys = ("ystride", "zstride", "txdim", "zdim")
+    for key in keys:
+        assert key in parsed, f"missing T1 {key} device print; parsed={parsed}"
+
+    if do_restore:
+        # The transition must reproduce the canonical G1 SrcA baseline exactly.
+        for key in keys:
+            exp, act = parsed[key]
+            assert exp == act, (
+                f"transition (uninit + reconfig) failed to retarget {key} to G1: "
+                f"expected(G1)={exp}, actual(register)={act} "
+                f"(direction={direction}, tiny_face_r_dim={tiny_face_r_dim})"
+            )
+    else:
+        # Negative control: without the transition the SrcA baseline is the G0
+        # tilize state, so the full G1 baseline must NOT be reproduced (the
+        # geometry-bearing Tile_x_dim / Z-dim differ between G0 and G1).
+        all_match = all(parsed[key][0] == parsed[key][1] for key in keys)
+        assert not all_match, (
+            "expected a state leak without the transition, but the SrcA registers "
+            f"already matched the G1 baseline: parsed={parsed} "
+            f"(direction={direction}, tiny_face_r_dim={tiny_face_r_dim})"
+        )

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_bcastA_B_uninit_restore.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_bcastA_B_uninit_restore.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-op SrcA Y-stride restore test for the SDPA `_llk_unpack_bcastA_B_` path.
+
+This is Phase 3 + Phase 4 of the unpacker-stride coverage roadmap, covering the
+two PR #45127 changes that touch the SrcA **Y-stride**:
+
+* **C1 / Phase 4** — `_llk_unpack_bcastA_B_uninit_` now restores the canonical
+  Y-stride (`canonical_unpA_y_stride(dst)` = 16 for bf16) instead of the hardcoded
+  bcast value 32. NO existing test calls this function at all.
+* **C2 / Phase 3** — `_llk_unpack_reconfig_data_format_srca_impl_` (FACE_ROW_MAJOR
+  branch) now also (re)writes that canonical Y-stride. The matmul-tilize test only
+  ever calls the reconfig with `p_dim_stride_target::IGNORE`, so the new write is
+  otherwise unexercised.
+
+`_llk_unpack_bcastA_B_init_` mutates the SrcA Y-stride to 32. The kernel runs a
+bcast op (run 0), restores via the method under test (uninit OR reconfig), then
+does a plain `_llk_unpack_A_` datacopy of the ORIGINAL operand-A tile (run 1) with
+no other state reset. If the restore leaves Y-stride at 32 instead of the canonical
+16, run 1 reads SrcA with the wrong row stride and diverges from the datacopy golden.
+
+Only 16-bit formats (Float16_b / Float16) expose the bug: for those the canonical
+Y-stride is 16, whereas the old hardcoded value was 32. (Float32's canonical stride
+is already 32, so it would not reveal the regression.)
+"""
+
+from dataclasses import dataclass
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import DataCopyGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, MathOperation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    MATH_OP,
+    SRCA_REUSE_COUNT,
+    TemplateParameter,
+)
+from helpers.utils import passed_test
+
+from conftest import skip_for_blackhole
+
+# 1 SrcA tile reused for 1 SrcB tile — the minimal bcast that still sets Y-stride=32.
+BCAST_SRCA_REUSE = 1
+NUM_FACES = 4
+
+
+@dataclass
+class RESTORE_VIA_RECONFIG(TemplateParameter):
+    """Selects the run-0 -> run-1 SrcA restore path in the C++ kernel.
+
+    False -> `_llk_unpack_bcastA_B_uninit_` (C1, Phase 4)
+    True  -> `_llk_unpack_reconfig_data_format_srca_impl_<.., FACE_ROW_MAJOR>` (C2, Phase 3)
+    """
+
+    via_reconfig: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return (
+            f"constexpr bool RESTORE_VIA_RECONFIG = {str(self.via_reconfig).lower()};"
+        )
+
+
+@skip_for_blackhole
+@parametrize(
+    # Same format for both ops so the run-1 datacopy needs no data-format reconfig —
+    # isolating the Y-stride restore as the only state change that matters.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No],
+    # "uninit" -> Phase 4 (C1); "reconfig" -> Phase 3 (C2).
+    restore_via_reconfig=[False, True],
+)
+def test_unpack_bcastA_B_uninit_restore(
+    formats,
+    dest_acc,
+    restore_via_reconfig,
+):
+    torch_format = format_dict[formats.output_format]
+    input_dimensions = [32, 32]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    # Golden is the run-1 plain datacopy of the original operand-A tile; the run-0
+    # bcast only pollutes the SrcA Y-stride. A correct restore yields an identity
+    # copy of src_A in face layout.
+    generate_golden = get_golden_generator(DataCopyGolden)
+    golden_tensor = generate_golden(
+        src_A,
+        formats.output_format,
+        NUM_FACES,
+        input_dimensions,
+        16,  # face_r_dim
+    ).to(torch_format)
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/unpack_bcastA_B_uninit_restore_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.Elwadd),
+            RESTORE_VIA_RECONFIG(via_reconfig=restore_via_reconfig),
+        ],
+        runtimes=[
+            SRCA_REUSE_COUNT(BCAST_SRCA_REUSE),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_bcastA_B_uninit_restore.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_bcastA_B_uninit_restore.py
@@ -28,6 +28,7 @@ is already 32, so it would not reveal the regression.)
 from dataclasses import dataclass
 
 import torch
+from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import DataCopyGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, MathOperation, format_dict
@@ -41,8 +42,6 @@ from helpers.test_variant_parameters import (
     TemplateParameter,
 )
 from helpers.utils import passed_test
-
-from conftest import skip_for_blackhole
 
 # 1 SrcA tile reused for 1 SrcB tile — the minimal bcast that still sets Y-stride=32.
 BCAST_SRCA_REUSE = 1

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
@@ -14,18 +14,15 @@ num_faces). Every restore test exercises the helpers transitively; this test
 pins them down directly across the full (format × num_faces × face_r_dim) grid.
 
 The kernel (`unpack_canonical_baseline_check_test.cpp`) runs `hw_configure`,
-reads back the four canonical SrcA registers, asserts each equals the helper
-value on-device (LLK_ASSERT), and DEVICE_PRINTs the (expected, actual) pairs.
-This test parses those prints and re-asserts the equality on the host, so a
-helper drift is caught both ways and is diagnosable from the dumped values.
+reads back the four canonical SrcA registers, and LLK_ASSERTs each equals the
+helper value on-device. A helper drift fails the assert, which surfaces here as
+a test failure.
 
 `configure_unpack_AB` computes the Z-stride and Tile_x_dim_cntx0 with its OWN
 inline formulas (not via the helpers — cunpack_common.h:807/928), so the
 expected/actual agreement is a genuine cross-check of two independent code
 paths, not a tautology.
 """
-
-import re
 
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation
@@ -37,23 +34,12 @@ from conftest import skip_for_coverage
 
 pytestmark = skip_for_coverage
 
-# "[RISC|UNPACK|...] C4 ystride exp=16 act=16" -> ("ystride", 16, 16)
-_C4_LINE_RE = re.compile(r"C4\s+(\w+)\s+exp=(-?\d+)\s+act=(-?\d+)")
-
-
-def _parse_c4(lines: list[str]) -> dict[str, tuple[int, int]]:
-    out: dict[str, tuple[int, int]] = {}
-    for line in lines:
-        m = _C4_LINE_RE.search(line)
-        if m:
-            out[m.group(1)] = (int(m.group(2)), int(m.group(3)))
-    return out
-
 
 @parametrize(
-    # `same=True` so the inferred SrcA dst register format is well-defined. The
-    # formats span all canonical x-stride buckets: Float16->2, Float32->4, and
-    # the "else->1" bucket (Float16_b and Bfp8_b). Bfp8_b is applicable here even
+    # `same=False` sweeps mismatched input/output format pairs too; the canonical
+    # SrcA baseline keys off `unpack_A_dst` either way. The formats span all
+    # canonical x-stride buckets: Float16->2, Float32->4, and the "else->1" bucket
+    # (Float16_b and Bfp8_b). Bfp8_b is applicable here even
     # though the tilize unpacker can't read Bfp8_b input: this test only
     # `configure_unpack_AB`s the unpacker and reads the descriptor/stride
     # registers back (no actual tilize), so it directly checks the helper buckets
@@ -65,9 +51,9 @@ def _parse_c4(lines: list[str]) -> dict[str, tuple[int, int]]:
             DataFormat.Float32,
             DataFormat.Bfp8_b,
         ],
-        same=True,
+        same=False,
     ),
-    dest_acc=[DestAccumulation.No],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     # Tile-descriptor Z-dim restore axis.
     num_faces=[4, 2, 1],
     # Stride / Tile_x_dim axis: 16 = normal, <16 = tiny.
@@ -79,7 +65,10 @@ def test_unpack_canonical_baseline(
     num_faces,
     face_r_dim,
 ):
-    outcome = TestConfig(
+    # All verification is on-device: the kernel LLK_ASSERTs each canonical SrcA
+    # register against its helper value. A failed assert surfaces here as a test
+    # failure.
+    TestConfig(
         "sources/unpack_canonical_baseline_check_test.cpp",
         formats,
         runtimes=[
@@ -87,19 +76,4 @@ def test_unpack_canonical_baseline(
             TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=16),
         ],
         dest_acc=dest_acc,
-        requires_device_print=True,  # the readback values are surfaced via DEVICE_PRINT
     ).run()
-
-    parsed = _parse_c4(outcome.device_print_lines)
-
-    for key in ("ystride", "zstride", "txdim", "zdim"):
-        assert key in parsed, (
-            f"missing C4 {key} device print; "
-            f"got lines: {outcome.device_print_lines}"
-        )
-        exp, act = parsed[key]
-        assert exp == act, (
-            f"canonical helper vs configure_unpack_AB mismatch for {key}: "
-            f"expected(helper)={exp}, actual(register)={act} "
-            f"(num_faces={num_faces}, face_r_dim={face_r_dim})"
-        )

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
@@ -51,14 +51,19 @@ def _parse_c4(lines: list[str]) -> dict[str, tuple[int, int]]:
 
 
 @parametrize(
-    # `same=True` so the inferred SrcA dst register format is well-defined; the
-    # three formats span all canonical x-stride cases (Float16_b->1, Float16->2,
-    # Float32->4). dest_acc auto-upgrades for the Float32 outlier.
+    # `same=True` so the inferred SrcA dst register format is well-defined. The
+    # formats span all canonical x-stride buckets: Float16->2, Float32->4, and
+    # the "else->1" bucket (Float16_b and Bfp8_b). Bfp8_b is applicable here even
+    # though the tilize unpacker can't read Bfp8_b input: this test only
+    # `configure_unpack_AB`s the unpacker and reads the descriptor/stride
+    # registers back (no actual tilize), so it directly checks the helper buckets
+    # the Bfp8_b dst-format code into the 1-byte x-stride like configure does.
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
             DataFormat.Float16,
             DataFormat.Float32,
+            DataFormat.Bfp8_b,
         ],
         same=True,
     ),

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
@@ -24,13 +24,12 @@ expected/actual agreement is a genuine cross-check of two independent code
 paths, not a tautology.
 """
 
+from conftest import skip_for_coverage
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation
 from helpers.param_config import input_output_formats, parametrize
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
-
-from conftest import skip_for_coverage
 
 pytestmark = skip_for_coverage
 

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_canonical_baseline.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct helper-correctness check for the PR #45127 canonical-baseline helpers (C4).
+
+`canonical_unpA_y_stride`, `canonical_unpA_z_stride`, and
+`canonical_unpA_tile_x_dim_cntx` are the single source of truth that the three
+restore paths (`_llk_unpack_tilize_uninit_`, `_llk_unpack_bcastA_B_uninit_`,
+`_llk_unpack_reconfig_data_format_srca_impl_<FACE_ROW_MAJOR>`) write back. The
+whole "recompute-canonical" restore design is only correct if those helpers
+reproduce the EXACT register values that `configure_unpack_AB`
+(`_llk_unpack_hw_configure_`) programs for a given (dst_format, face_r_dim,
+num_faces). Every restore test exercises the helpers transitively; this test
+pins them down directly across the full (format × num_faces × face_r_dim) grid.
+
+The kernel (`unpack_canonical_baseline_check_test.cpp`) runs `hw_configure`,
+reads back the four canonical SrcA registers, asserts each equals the helper
+value on-device (LLK_ASSERT), and DEVICE_PRINTs the (expected, actual) pairs.
+This test parses those prints and re-asserts the equality on the host, so a
+helper drift is caught both ways and is diagnosable from the dumped values.
+
+`configure_unpack_AB` computes the Z-stride and Tile_x_dim_cntx0 with its OWN
+inline formulas (not via the helpers — cunpack_common.h:807/928), so the
+expected/actual agreement is a genuine cross-check of two independent code
+paths, not a tautology.
+"""
+
+import re
+
+from helpers.format_config import DataFormat
+from helpers.llk_params import DestAccumulation
+from helpers.param_config import input_output_formats, parametrize
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
+
+from conftest import skip_for_coverage
+
+pytestmark = skip_for_coverage
+
+# "[RISC|UNPACK|...] C4 ystride exp=16 act=16" -> ("ystride", 16, 16)
+_C4_LINE_RE = re.compile(r"C4\s+(\w+)\s+exp=(-?\d+)\s+act=(-?\d+)")
+
+
+def _parse_c4(lines: list[str]) -> dict[str, tuple[int, int]]:
+    out: dict[str, tuple[int, int]] = {}
+    for line in lines:
+        m = _C4_LINE_RE.search(line)
+        if m:
+            out[m.group(1)] = (int(m.group(2)), int(m.group(3)))
+    return out
+
+
+@parametrize(
+    # `same=True` so the inferred SrcA dst register format is well-defined; the
+    # three formats span all canonical x-stride cases (Float16_b->1, Float16->2,
+    # Float32->4). dest_acc auto-upgrades for the Float32 outlier.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No],
+    # Tile-descriptor Z-dim restore axis.
+    num_faces=[4, 2, 1],
+    # Stride / Tile_x_dim axis: 16 = normal, <16 = tiny.
+    face_r_dim=[16, 8, 4, 2, 1],
+)
+def test_unpack_canonical_baseline(
+    formats,
+    dest_acc,
+    num_faces,
+    face_r_dim,
+):
+    outcome = TestConfig(
+        "sources/unpack_canonical_baseline_check_test.cpp",
+        formats,
+        runtimes=[
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=16),
+        ],
+        dest_acc=dest_acc,
+        requires_device_print=True,  # the readback values are surfaced via DEVICE_PRINT
+    ).run()
+
+    parsed = _parse_c4(outcome.device_print_lines)
+
+    for key in ("ystride", "zstride", "txdim", "zdim"):
+        assert key in parsed, (
+            f"missing C4 {key} device print; "
+            f"got lines: {outcome.device_print_lines}"
+        )
+        exp, act = parsed[key]
+        assert exp == act, (
+            f"canonical helper vs configure_unpack_AB mismatch for {key}: "
+            f"expected(helper)={exp}, actual(register)={act} "
+            f"(num_faces={num_faces}, face_r_dim={face_r_dim})"
+        )

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-op unpacker-state restore test for `_llk_unpack_tilize_uninit_`.
+
+This exercises a gap left by the existing tilize tests: every other call site of
+`_llk_unpack_tilize_uninit_` (matmul_unpack_tilize, the fuser tilize node, the
+C++ sweep) restores with ``num_faces=4`` / ``face_r_dim=16``. The PR threads the
+operand's ``num_faces``/``face_r_dim`` through uninit so it restores the SrcA
+tile-descriptor + ``Tile_x_dim_cntx0`` back to the *operand* baseline programmed
+by ``configure_unpack_AB`` (not a hardcoded 16x16, 4-face baseline).
+
+The C++ source runs two ops back-to-back on the SAME operand format:
+    1. ``unpack_tilize`` of operand A (with the parameterized ``num_faces``)
+    2. ``_llk_unpack_tilize_uninit_`` (the restore under test)
+    3. a plain ``_llk_unpack_A_`` datacopy of the tilized tile, with NO
+       data-format reconfig in between.
+
+Because there is no reconfig, the uninit restore is the only thing that resets
+the unpacker state between the two ops. If it leaves the tile-descriptor Z-dim
+(num_faces), the Y-dim, ``tilize_mode``, or ``Tile_x_dim_cntx0`` in a
+tilize-specific / wrong-faces state, the second datacopy reads corrupted data
+and the result diverges from ``TilizeGolden(src_A, num_faces)``.
+
+``num_faces ∈ {1, 2}`` specifically covers the tile-descriptor Z-dim restore
+that no existing tilize test reaches.
+"""
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import TilizeGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
+from helpers.utils import passed_test
+
+
+@parametrize(
+    # Same input/output format for both ops so the second op needs NO data-format
+    # reconfig — isolating the uninit restore as the only state reset.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    # num_faces=1,2 are the new coverage; 4 is the existing-baseline control.
+    num_faces=[4, 2, 1],
+)
+def test_unpack_tilize_uninit_restore(
+    formats,
+    dest_acc,
+    num_faces,
+):
+    torch_format = format_dict[formats.output_format]
+    input_dimensions = [32, 32]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    # Golden: the run-1 datacopy is an identity copy of the run-0 tilized tile,
+    # so a correct restore yields exactly the tilized operand A.
+    tilize_function = get_golden_generator(TilizeGolden)
+    golden_tensor = tilize_function(
+        src_A,
+        input_dimensions,
+        formats.output_format,
+        num_faces,
+    ).to(torch_format)
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/unpack_tilize_uninit_restore_test.cpp",
+        formats,
+        templates=[],
+        runtimes=[
+            NUM_FACES(num_faces),
+            # Normal (non-tiny) tile: face_r_dim=16. The tiny-tile face_r_dim<16
+            # coverage lives in test_unpack_tilize_uninit_restore_tiny.py.
+            TEST_FACE_DIMS(face_r_dim=16, face_c_dim=16),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            write_full_tiles=True,  # tilize input needs full tiles in L1
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_block.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_block.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-tile-block cross-op restore test for `_llk_unpack_tilize_uninit_` (Phase 6).
+
+Same restore design as `test_unpack_tilize_uninit_restore` (tilize ->
+`_llk_unpack_tilize_uninit_` -> plain datacopy, NO data-format reconfig in
+between so uninit is the only state reset), but run 0 tilizes a BLOCK of
+``BLOCK_CT_DIM > 1`` column tiles in one init/execute sweep.
+
+`_llk_unpack_tilize_init_(ct_dim=BLOCK_CT_DIM)` programs the tilize
+``shift_amount`` / per-column addressing from the block width, so the op leaves
+SrcA in a block-tilize state. This pins that the PR's uninit still restores the
+canonical single-tile operand baseline: run 1 datacopies EACH tilized tile of
+the block back, and the full block must equal ``TilizeGolden(src_A_block)``. A
+residual block-tilize state that uninit fails to clear corrupts the run-1
+datacopy and diverges from the golden.
+"""
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import TilizeGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    generate_input_dim,
+)
+from helpers.utils import passed_test
+
+
+@parametrize(
+    # Same input/output format for both ops so the second op needs NO data-format
+    # reconfig — isolating the uninit restore as the only state reset.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    num_faces=[4, 2],
+    # The new axis: tilize a block of >1 column tiles before uninit.
+    block_ct_dim=[2, 4],
+)
+def test_unpack_tilize_uninit_restore_block(
+    formats,
+    dest_acc,
+    num_faces,
+    block_ct_dim,
+):
+    torch_format = format_dict[formats.output_format]
+    # A horizontal block of `block_ct_dim` 32x32 tiles.
+    input_dimensions = [32, 32 * block_ct_dim]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    # Golden: the run-1 datacopy is an identity copy of the run-0 tilized block,
+    # so a correct restore yields exactly the tilized operand-A block.
+    tilize_function = get_golden_generator(TilizeGolden)
+    golden_tensor = tilize_function(
+        src_A,
+        input_dimensions,
+        formats.output_format,
+        num_faces,
+    ).to(torch_format)
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/unpack_tilize_uninit_restore_block_test.cpp",
+        formats,
+        templates=[],
+        runtimes=[
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(face_r_dim=16, face_c_dim=16),
+            TILE_COUNT(tile_cnt_A),
+            generate_input_dim(
+                input_dimensions,
+                input_dimensions,
+                block_ct_dim=block_ct_dim,
+                block_rt_dim=1,
+            ),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            write_full_tiles=True,  # tilize input needs full tiles in L1
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tiny-tile (face_r_dim < 16) cross-op restore test for `_llk_unpack_tilize_uninit_`.
+
+This is the Phase 2 companion to ``test_unpack_tilize_uninit_restore.py``. Phase 1
+covers the ``num_faces`` (tile-descriptor Z-dim) restore for full 16-row faces.
+Phase 2 covers the orthogonal axis the PR actually changed on Wormhole: the
+``Tile_x_dim_cntx0`` restore, which is computed as
+``canonical_unpA_tile_x_dim_cntx(face_r_dim)`` and therefore only differs from the
+old hardcoded ``16 | (16 << 16)`` value when ``face_r_dim < 16``.
+
+No existing tilize test runs ``unpack_tilize`` with ``face_r_dim < 16``, so this
+also serves as the first end-to-end exercise of the tiny-tile tilize path.
+
+Flow (same C++ source as Phase 1, ``face_r_dim`` is threaded through every call):
+    1. ``unpack_tilize`` of a tiny [face_r_dim, 32] operand A (num_faces=2).
+    2. ``_llk_unpack_tilize_uninit_(dst, num_faces, face_r_dim)`` (restore under test).
+    3. a plain ``_llk_unpack_A_`` datacopy of the tilized tile, with NO data-format
+       reconfig in between.
+
+Because there is no reconfig, the uninit is the only thing that restores
+``Tile_x_dim_cntx0`` back to the tiny-tile baseline programmed by
+``configure_unpack_AB``. If uninit restored the old ``16|16`` value instead of
+``canonical_unpA_tile_x_dim_cntx(face_r_dim)``, the second datacopy reads the
+operand with the wrong per-row datum count and the result diverges from the
+tilized golden.
+"""
+
+import torch
+from helpers.format_config import DataFormat
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
+from helpers.tilize_untilize import tilize
+from helpers.utils import passed_test
+
+# Tiny tiles are always 2 horizontal faces ([face_r_dim, 32] => f0 | f1).
+TINY_NUM_FACES = 2
+
+
+@parametrize(
+    # Same input/output format for both ops so the second op needs NO data-format
+    # reconfig — isolating the uninit restore as the only state reset.
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    # All sub-16 face row counts. face_r_dim=16 is the Phase 1 baseline and is
+    # covered by test_unpack_tilize_uninit_restore.py.
+    face_r_dim=[8, 4, 2, 1],
+)
+def test_unpack_tilize_uninit_restore_tiny(
+    formats,
+    dest_acc,
+    face_r_dim,
+):
+    torch_format = format_dict[formats.output_format]
+    # Tiny tile: a single [face_r_dim, 32] tile (2 horizontal faces).
+    input_dimensions = [face_r_dim, 32]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        face_r_dim=face_r_dim,
+        num_faces=TINY_NUM_FACES,
+    )
+
+    # Golden: the run-1 datacopy is an identity copy of the run-0 tilized tile,
+    # so a correct restore yields exactly the tilized tiny operand A. tile_dimensions
+    # drives the horizontal 2-face (Nx32) tilize layout for face_r_dim < 16.
+    golden_tensor = tilize(
+        src_A,
+        stimuli_format=formats.output_format,
+        tile_dimensions=input_dimensions,
+    ).to(torch_format)
+
+    L1_to_L1_iterations = 2
+    configuration = TestConfig(
+        "sources/unpack_tilize_uninit_restore_test.cpp",
+        formats,
+        templates=[],
+        runtimes=[
+            NUM_FACES(TINY_NUM_FACES),
+            TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=16),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=TINY_NUM_FACES,
+            face_r_dim=face_r_dim,
+            # Tiny tile is dense (num_faces * face_r_dim * 16 == face_r_dim * 32
+            # row-major elements), so do NOT pad to a full 32x32 tile.
+        ),
+        dest_acc=dest_acc,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert passed_test(
+        golden_tensor,
+        res_tensor,
+        formats.output_format,
+        L1_to_L1_iterations=L1_to_L1_iterations,
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
@@ -43,9 +43,11 @@ from helpers.utils import passed_test
 TINY_NUM_FACES = 2
 
 
-# Blackhole's `_llk_unpack_tilize_uninit_` has no `face_r_dim` argument (2-arg
-# signature), so the tiny-tile (face_r_dim < 16) restore branch under test here
-# cannot be expressed on BH. The num_faces axis (face_r_dim=16) still runs on BH
+# Blackhole's `_llk_unpack_tilize_uninit_` does honor `face_r_dim` (via its
+# `TensorShape` param), but the BH test wrapper `_llk_unpack_tilize_uninit_wrapper_`
+# is 2-arg (`dst, num_faces`) and drops `face_r_dim` (WH's wrapper is 3-arg), so the
+# tiny-tile (face_r_dim < 16) restore branch under test here cannot be expressed on BH
+# without extending that wrapper. The num_faces axis (face_r_dim=16) still runs on BH
 # via test_unpack_tilize_uninit_restore.py.
 @skip_for_blackhole
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
@@ -28,6 +28,7 @@ tilized golden.
 """
 
 import torch
+from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation, format_dict
 from helpers.param_config import input_output_formats, parametrize
@@ -37,8 +38,6 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
 from helpers.tilize_untilize import tilize
 from helpers.utils import passed_test
-
-from conftest import skip_for_blackhole
 
 # Tiny tiles are always 2 horizontal faces ([face_r_dim, 32] => f0 | f1).
 TINY_NUM_FACES = 2

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore_tiny.py
@@ -38,10 +38,17 @@ from helpers.test_variant_parameters import NUM_FACES, TEST_FACE_DIMS
 from helpers.tilize_untilize import tilize
 from helpers.utils import passed_test
 
+from conftest import skip_for_blackhole
+
 # Tiny tiles are always 2 horizontal faces ([face_r_dim, 32] => f0 | f1).
 TINY_NUM_FACES = 2
 
 
+# Blackhole's `_llk_unpack_tilize_uninit_` has no `face_r_dim` argument (2-arg
+# signature), so the tiny-tile (face_r_dim < 16) restore branch under test here
+# cannot be expressed on BH. The num_faces axis (face_r_dim=16) still runs on BH
+# via test_unpack_tilize_uninit_restore.py.
+@skip_for_blackhole
 @parametrize(
     # Same input/output format for both ops so the second op needs NO data-format
     # reconfig — isolating the uninit restore as the only state reset.

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
@@ -114,7 +114,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             ZONE_SCOPED("INIT")
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                formats.unpack_A_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
         }
         {
@@ -124,13 +131,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
                 {
                     _llk_unpack_tilize_dispatch_(
-                        _llk_unpack_tilize_, L1_ADDRESS(buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4 /* num_faces */, false /* narrow_tile */);
+                        _llk_unpack_tilize_,
+                        L1_ADDRESS(buffer_A[0]),
+                        0,
+                        formats.unpack_A_src,
+                        formats.unpack_A_dst,
+                        FACE_R_DIM,
+                        4 /* num_faces */,
+                        false /* narrow_tile */);
                 }
             }
         }
         {
             ZONE_SCOPED("UNINIT")
-            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, 4 /* num_faces */);
+            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, ckernel::tensor_shape_from_num_faces(4 /* num_faces */));
         }
         return;
     }
@@ -144,13 +158,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             const std::uint32_t compat_dst = ckernel::to_underlying(DataFormat::Float16_b);
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, compat_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                compat_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(compat_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         else
         {
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                formats.unpack_A_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(formats.unpack_A_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         // Base address is programmed per-call inside _llk_unpack_fast_tilize_block_
@@ -224,14 +252,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             ZONE_SCOPED("INIT")
             _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(4 /* num_faces */, formats.math);
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(
+                4 /* num_faces */, formats.math);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* dst_index */, formats.math, formats.math, 4 /* num_faces */);
+                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(
+                    0 /* dst_index */, formats.math, formats.math, 4 /* num_faces */);
                 _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
@@ -358,7 +388,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
-            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
+            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(
+                0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
         }
         {
             ZONE_SCOPED("TILE_LOOP")

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Cross-op tile-geometry transition test (state-leak design): a `unpack_tilize`
+// at one geometry (the "polluter") followed by a REGULAR `unpack_AB_matmul` on
+// independent operands.
+//
+// This covers the user-requested "tiny tile unpack tilize + regular matmul"
+// transition. Because a coupled pipeline (tilize output feeding the matmul) cannot
+// mix geometries, the matmul reads its own independent, pre-tilized 32x32 operands
+// from `buffer_A[0]` / `buffer_B[0]`; the run-0 tilize only exists to leave the
+// unpacker in a (possibly tiny `face_r_dim`) state. The run-1 transition is:
+//   `_llk_unpack_tilize_uninit_` (restores the tilize-mutated SrcA baseline) +
+//   `_llk_unpack_reconfig_data_format_src{a,b}_impl_<.. FACE_ROW_MAJOR>`
+//   (re-establishes the canonical regular strides / Tile_x_dim / Z-dim).
+//
+// If that transition fails to fully reset the unpacker (e.g. leaves a tiny
+// `Tile_x_dim_cntx0`, a tilize-specific Z-dim, or a stale Y-stride), the regular
+// matmul reads its operands with the wrong layout and the result diverges from
+// `tilize(MatmulGolden(A, B))`.
+//
+// NOTE: run-0 tilize reads `buffer_A[0]` (which holds the tilized matmul operand)
+// as raw row-major input; its packed output goes to a scratch buffer and is
+// discarded. Only the run-1 matmul result is validated.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+std::uint32_t tile_size                = 128;
+
+// Scratch L1 address for the discarded run-0 (polluter) tilize output.
+constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_lib_unpack_wrappers.h"
+#include "llk_unpack_AB_matmul.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    // Polluter (run-0) tilize geometry: face_r_dim=16 -> regular, <16 -> tiny.
+    const std::uint32_t pol_face_r_dim                    = params.TEST_FACE_R_DIM;
+    const std::uint32_t pol_num_faces                     = params.num_faces;
+    [[maybe_unused]] constexpr std::uint32_t mm_num_faces = 4; // regular matmul operands
+
+    // ---- Run 0: tilize "polluter" (output discarded) ----
+    int run                              = 0;
+    const std::uint32_t pol_block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
+    const std::uint32_t pol_tilize_nf    = _llk_unpack_tilize_num_faces_wrapper_(pol_num_faces);
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_A_dst,
+        formats_array[run].unpack_B_dst,
+        pol_face_r_dim,
+        pol_face_r_dim,
+        pol_num_faces,
+        pol_num_faces);
+    _llk_unpack_tilize_init_wrapper_(
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, pol_face_r_dim, false /* narrow_tile */, pol_tilize_nf);
+    _llk_unpack_tilize_wrapper_(
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst,
+        pol_block_ct_dim,
+        pol_face_r_dim,
+        pol_tilize_nf,
+        false /* narrow_tile */);
+
+    // Wait until the run-0 packer has drained before touching unpacker state.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: REGULAR matmul on independent pre-tilized operands ----
+    run = 1;
+    if constexpr (DO_RESTORE)
+    {
+        // Restore the canonical SrcA baseline mutated by the (tiny) tilize, then re-commit
+        // the regular SrcA strides. `_llk_unpack_AB_matmul_init_` only reprograms x-end and
+        // the ZW counter (see its uninit doc) -- it does NOT reset the SrcA Y/Z strides or
+        // Tile_x_dim, so without this restore the tilize-polluted strides leak into the matmul.
+        // SrcB is untouched by tilize, so its reconfig uses the proven IGNORE form.
+#ifdef ARCH_WORMHOLE
+        _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, pol_num_faces, pol_face_r_dim);
+#else
+        _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, pol_num_faces);
+#endif
+        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, false>(
+            formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, tile_size, FACE_R_DIM, mm_num_faces);
+        _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
+            formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
+    }
+    _llk_unpack_AB_matmul_init_<>();
+    _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, tile_size, tile_size);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_matmul.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const bool is_int_fpu_en          = false;
+    const std::uint32_t pol_num_faces = params.num_faces;
+    const std::uint32_t res_dst_idx   = 0;
+
+    // ---- Run 0: datacopy consuming the polluter tilize ----
+    int run                      = 0;
+    static constexpr bool TILIZE = true;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, TILIZE>>(pol_num_faces, formats_array[run].math);
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+        res_dst_idx, formats_array[run].math, formats_array[run].math);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // ---- Run 1: regular matmul ----
+    run = 1;
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(formats_array[run].math);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, false>(formats_array[run].math);
+    _llk_math_matmul_init_<MATH_FIDELITY>();
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_matmul_<MATH_FIDELITY>(res_dst_idx);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t pol_face_r_dim = params.TEST_FACE_R_DIM;
+    const std::uint32_t pol_num_faces  = params.num_faces;
+    const std::uint32_t res_dst_idx    = 0;
+    static constexpr bool UNTILIZE     = false;
+    static constexpr bool TILIZE       = true;
+
+    // ---- Run 0: pack the (discarded) polluter tilize result to scratch ----
+    int run = 0;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        formats_array[run].pack_src,
+        formats_array[run].pack_dst,
+        pol_face_r_dim * params.TEST_FACE_C_DIM * pol_num_faces /* tile_size */,
+        pol_face_r_dim,
+        TILE_C_DIM,
+        pol_num_faces);
+    _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
+        formats_array[run].pack_dst, pol_face_r_dim, TILE_C_DIM, pol_num_faces);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(res_dst_idx, L1_ADDRESS(buffer_polluter_scratch));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that run-0 has fully drained.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the matmul result to the output buffer ----
+    run = 1;
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(formats_array[run].pack_src, formats_array[run].pack_dst, tile_size);
+
+#ifdef ARCH_BLACKHOLE
+    _llk_pack_init_<ckernel::PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
+        formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_idx, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
@@ -53,9 +53,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
     // Polluter (run-0) tilize geometry: face_r_dim=16 -> regular, <16 -> tiny.
-    const std::uint32_t pol_face_r_dim                    = params.TEST_FACE_R_DIM;
-    const std::uint32_t pol_num_faces                     = params.num_faces;
-    [[maybe_unused]] constexpr std::uint32_t mm_num_faces = 4; // regular matmul operands
+    const std::uint32_t pol_face_r_dim   = params.TEST_FACE_R_DIM;
+    const std::uint32_t pol_num_faces    = params.num_faces;
+    constexpr std::uint32_t mm_num_faces = 4; // regular matmul operands
 
     // ---- Run 0: tilize "polluter" (output discarded) ----
     int run                              = 0;
@@ -91,20 +91,37 @@ void run_kernel(RUNTIME_PARAMETERS params)
     run = 1;
     if constexpr (DO_RESTORE)
     {
-        // Restore the canonical SrcA baseline mutated by the (tiny) tilize, then re-commit
-        // the regular SrcA strides. `_llk_unpack_AB_matmul_init_` only reprograms x-end and
-        // the ZW counter (see its uninit doc) -- it does NOT reset the SrcA Y/Z strides or
-        // Tile_x_dim, so without this restore the tilize-polluted strides leak into the matmul.
-        // SrcB is untouched by tilize, so its reconfig uses the proven IGNORE form.
+        // Tear down the tilize-mutated SrcA state (PR C1) and then re-establish the regular
+        // 32x32 operand baseline for BOTH operands before the matmul.
+        //
+        // `_llk_unpack_AB_matmul_init_` only reprograms x-end and the ZW counter (see its
+        // uninit doc) -- it does NOT reset the SrcA Y/Z strides, Tile_x_dim, or the operand
+        // tile descriptors, so without an explicit restore the polluter tilize state leaks
+        // into the matmul.
+        //
+        // A *geometry change* (tiny polluter -> regular matmul) cannot be undone by
+        // uninit + a stride-only reconfig alone: `_llk_unpack_reconfig_data_format_srca_impl_`
+        // re-commits the SrcA Z-stride / Y-stride / Tile_x_dim_cntx0 and descriptor Z-dim, but
+        // not the SrcA tile-descriptor X/Y-dim, which uninit left at the tiny geometry. The
+        // idiomatic full reconfigure for a geometry change is `_llk_unpack_hw_configure_`
+        // (configure_unpack_AB), which reprograms both descriptors to the regular baseline.
+        // (For a geometry-matched polluter, face_r_dim==16, uninit alone already suffices.)
 #ifdef ARCH_WORMHOLE
         _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, pol_num_faces, pol_face_r_dim);
 #else
         _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, pol_num_faces);
 #endif
-        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, false>(
-            formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, tile_size, FACE_R_DIM, mm_num_faces);
-        _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
-            formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
+        _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+            formats_array[run].unpack_A_src,
+            formats_array[run].unpack_B_src,
+            formats_array[run].unpack_A_dst,
+            formats_array[run].unpack_B_dst,
+            FACE_R_DIM,
+            FACE_R_DIM,
+            mm_num_faces,
+            mm_num_faces,
+            tile_size,
+            tile_size);
     }
     _llk_unpack_AB_matmul_init_<>();
     _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, tile_size, tile_size);
@@ -195,13 +212,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     t6_semaphore_post<>(semaphore::PACK_DONE);
 
     // ---- Run 1: pack the matmul result to the output buffer ----
-    run = 1;
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(formats_array[run].pack_src, formats_array[run].pack_dst, tile_size);
-
-#ifdef ARCH_BLACKHOLE
-    _llk_pack_init_<ckernel::PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
-        formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
-#endif
+    // The matmul output is a regular 32x32 (4-face) tile. Run-0 configured the packer for the
+    // (possibly tiny) polluter geometry (pol_num_faces / pol_face_r_dim), so a data-format-only
+    // reconfig would pack the regular result with a tiny face layout. Re-run the full pack
+    // hw_configure + init for the regular geometry (Default mode). NOTE: deliberately NO
+    // `_llk_pack_dest_init_` here -- the SyncHalf dest-bank counter is initialised once in run-0.
+    run                                   = 1;
+    constexpr std::uint32_t mm_num_faces  = 4;
+    const std::uint32_t mm_pack_tile_size = FACE_R_DIM * TILE_C_DIM * mm_num_faces;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
+        formats_array[run].pack_src, formats_array[run].pack_dst, mm_pack_tile_size, FACE_R_DIM, TILE_C_DIM, mm_num_faces);
+    _llk_pack_init_wrapper_<ckernel::PackMode::Default, false /* zero_output */>(formats_array[run].pack_dst, FACE_R_DIM, TILE_C_DIM, mm_num_faces);
 
     _llk_packer_wait_for_math_done_();
     _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_idx, L1_ADDRESS(params.buffer_Res[0]));

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
@@ -35,7 +35,8 @@
 std::uint32_t unp_cfg_context          = 0;
 std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
-std::uint32_t tile_size                = 128;
+// Regular 32x32 (4-face) matmul-operand tile size used by the run-1 matmul.
+std::uint32_t tile_size = ckernel::FACE_R_DIM * ckernel::FACE_C_DIM * 4 / 8;
 
 // Scratch L1 address for the discarded run-0 (polluter) tilize output.
 constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Cross-op tile-geometry transition test (Phase 3b Direction B): a REGULAR
+// `unpack_tilize` (the polluter) followed by a TINY `unpack_AB_matmul`
+// (num_faces < 4 / partial-face operand).
+//
+// This closes the "matmul with num_faces < 4 after a tilize" gap left by
+// `test_matmul_unpack_tilize` (which only ever runs num_faces=4). As with
+// Direction A, a coupled pipeline cannot mix tile geometries, so the tiny matmul
+// reads its own independent, pre-tilized operands from buffer_A[0] / buffer_B[0];
+// run-0's regular tilize only exists to leave the unpacker in a regular-tilize
+// state (its packed output goes to scratch and is discarded). Between the two,
+// `_llk_unpack_tilize_uninit_` restores the SrcA baseline (gated by DO_RESTORE).
+//
+// run-1 is the proven tiny-matmul sequence (verbatim from unpack_matmul_test.cpp,
+// retargeted at formats_array[1]); it re-runs `_llk_unpack_hw_configure_` for the
+// tiny operands, so this primarily validates that a regular tilize -> uninit ->
+// tiny matmul SEQUENCE produces correct results. NOTE: because run-1 self-configures,
+// DO_RESTORE=false is expected to behave the same on a correct build; the toggle is
+// kept to probe whether an un-uninit'd tilize can corrupt the subsequent matmul.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Scratch L1 address for the discarded run-0 (polluter) tilize output.
+constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
+
+// run-0 polluter is always a regular 32x32 tilize.
+constexpr std::uint32_t POLLUTER_FACE_R_DIM = 16;
+constexpr std::uint32_t POLLUTER_NUM_FACES  = 4;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_lib_unpack_wrappers.h"
+#include "llk_unpack_AB_matmul.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+
+    // ---- Run 0: regular tilize "polluter" (output discarded to scratch) ----
+    int run                              = 0;
+    const std::uint32_t pol_block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
+    const std::uint32_t pol_tilize_nf    = _llk_unpack_tilize_num_faces_wrapper_(POLLUTER_NUM_FACES);
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_A_dst,
+        formats_array[run].unpack_B_dst,
+        POLLUTER_FACE_R_DIM,
+        POLLUTER_FACE_R_DIM,
+        POLLUTER_NUM_FACES,
+        POLLUTER_NUM_FACES);
+    _llk_unpack_tilize_init_wrapper_(
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, POLLUTER_FACE_R_DIM, false /* narrow_tile */, pol_tilize_nf);
+    // Read the regular operand B buffer (full 32x32 tile) as raw row-major input.
+    _llk_unpack_tilize_wrapper_(
+        L1_ADDRESS(params.buffer_B[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst,
+        pol_block_ct_dim,
+        POLLUTER_FACE_R_DIM,
+        pol_tilize_nf,
+        false /* narrow_tile */);
+
+    // Wait until the run-0 packer has drained before touching unpacker state.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    if constexpr (DO_RESTORE)
+    {
+        // Restore the canonical SrcA baseline mutated by the regular tilize.
+#ifdef ARCH_WORMHOLE
+        _llk_unpack_tilize_uninit_wrapper_(formats_array[1].unpack_A_dst, POLLUTER_NUM_FACES, POLLUTER_FACE_R_DIM);
+#else
+        _llk_unpack_tilize_uninit_wrapper_(formats_array[1].unpack_A_dst, POLLUTER_NUM_FACES);
+#endif
+    }
+
+    // ---- Run 1: TINY matmul on independent pre-tilized operands (verbatim) ----
+    run = 1;
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_A_dst,
+        formats_array[run].unpack_B_dst,
+        params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM,
+        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
+        params.num_faces_B, // in1
+        params.num_faces_A, // in0
+        params.TILE_SIZE_UNPACK_B,
+        params.TILE_SIZE_UNPACK_A);
+    _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
+    _llk_unpack_AB_matmul_init_<>(
+        params.UNPACK_TRANSPOSE_FACES,
+        params.CT_DIM,
+        params.RT_DIM,
+        params.KT_DIM,
+        params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM,
+        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
+        params.num_faces_B,     // in1
+        params.num_faces_A,     // in0
+        params.PARTIAL_FACE_B,  // in1
+        params.PARTIAL_FACE_A); // in0
+    for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+    {
+        _llk_unpack_AB_matmul_<>(
+            L1_ADDRESS(params.buffer_A[0]),
+            L1_ADDRESS(params.buffer_B[0]),
+            j,
+            j * params.CT_DIM,
+            params.TILE_SIZE_UNPACK_B,
+            params.TILE_SIZE_UNPACK_A,
+            params.PARTIAL_FACE_B, // in1
+            params.PARTIAL_FACE_A, // in0
+            params.CT_DIM,
+            params.RT_DIM,
+            params.KT_DIM);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_common.h"
+#include "llk_math_matmul.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const bool is_int_fpu_en = false;
+
+    // ---- Run 0: datacopy consuming the regular tilize polluter ----
+    int run                      = 0;
+    static constexpr bool TILIZE = true;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, TILIZE>>(POLLUTER_NUM_FACES, formats_array[run].math);
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+        0 /* dst */, formats_array[run].math, formats_array[run].math);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // ---- Run 1: tiny matmul ----
+    run = 1;
+    _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(formats_array[run].math);
+    _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, false>(formats_array[run].math);
+    _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(
+        params.in0_tile_r_dim,
+        params.in0_tile_c_dim,
+        params.in1_tile_r_dim,
+        params.in1_tile_c_dim,
+        params.PARTIAL_FACE_MATH,
+        params.UNPACK_TRANSPOSE_FACES,
+        params.CT_DIM,
+        params.RT_DIM);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+    {
+        _llk_math_matmul_<MATH_FIDELITY, THROTTLE_LEVEL>(params.DST_INDEX, params.CT_DIM, params.RT_DIM);
+    }
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    static constexpr bool UNTILIZE = false;
+    static constexpr bool TILIZE   = true;
+
+    // ---- Run 0: pack the (discarded) regular tilize result to scratch ----
+    int run = 0;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        formats_array[run].pack_src,
+        formats_array[run].pack_dst,
+        POLLUTER_FACE_R_DIM * TILE_C_DIM * POLLUTER_NUM_FACES /* tile_size */,
+        POLLUTER_FACE_R_DIM,
+        TILE_C_DIM,
+        POLLUTER_NUM_FACES);
+    _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
+        formats_array[run].pack_dst, POLLUTER_FACE_R_DIM, TILE_C_DIM, POLLUTER_NUM_FACES);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(0 /* dst */, L1_ADDRESS(buffer_polluter_scratch));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that run-0 has fully drained.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the tiny matmul result to the output buffer (verbatim) ----
+    run = 1;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats_array[run].pack_src,
+        formats_array[run].pack_dst,
+        params.TILE_SIZE_PACK,
+        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
+        TILE_C_DIM,
+        params.num_faces,
+        params.PARTIAL_FACE_PACK);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats_array[run].pack_dst, params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_packer_wait_for_math_done_();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    {
+        LLK_ASSERT((i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "i exceeds max dest tiles");
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(params.DST_INDEX + i, L1_ADDRESS(params.buffer_Res[i]));
+    }
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
@@ -239,7 +239,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.PARTIAL_FACE_PACK);
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
         formats_array[run].pack_dst, params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    // NOTE: do NOT re-run `_llk_pack_dest_init_` here. In a two-run SyncHalf kernel the
+    // dest-bank counter is initialised once (run-0); re-initialising it in run-1 resets
+    // the counter to bank-0 while the math side has already toggled to bank-1, so the
+    // packer would drain an unwritten bank (all-zeros result).
     _llk_packer_wait_for_math_done_();
     for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
     {

--- a/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
@@ -28,12 +28,13 @@
 //           output discarded to scratch) — leaves SrcA in the G0 tilize state.
 //   Transition (only when DO_RESTORE): `_llk_unpack_tilize_uninit_(G0)` +
 //           `_llk_unpack_reconfig_data_format_srca_impl_<.. FACE_ROW_MAJOR>(G1)`.
-//   Readback: UNP0 Y-stride / Z-stride, Tile_x_dim_cntx0, tile-descriptor Z-dim.
-//           DEVICE_PRINT (expected G1 baseline, actual); LLK_ASSERT when DO_RESTORE.
+//   Readback: UNP0 Y-stride / Z-stride, Tile_x_dim_cntx0, tile-descriptor Z-dim,
+//           compared against the canonical G1 baseline on-device via LLK_ASSERT.
 //
 // DO_RESTORE=false is the negative control: with no transition the registers stay in
-// the G0 tilize state, so the host sees actual != G1-expected (the Tile_x_dim / Z-dim
-// differ between G0 and G1), proving the transition is load-bearing.
+// the G0 tilize state, so actual != G1-expected (the Tile_x_dim / Z-dim differ between
+// G0 and G1) — the kernel LLK_ASSERTs that the G1 baseline is NOT reproduced, proving
+// the transition is load-bearing.
 
 #include <algorithm>
 #include <cstdint>
@@ -52,7 +53,6 @@ constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
 
 #ifdef LLK_TRISC_UNPACK
 
-#include "dprint.h"
 #include "llk_lib_unpack_wrappers.h"
 #include "llk_unpack_A.h"
 #include "llk_unpack_common.h"
@@ -136,17 +136,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t exp_tile_x_dim = canonical_unpA_tile_x_dim_cntx(g1_face_r_dim);
     const std::uint32_t exp_z_dim      = g1_num_faces;
 
-    DEVICE_PRINT("T1 ystride exp={} act={}", exp_y_stride, act_y_stride);
-    DEVICE_PRINT("T1 zstride exp={} act={}", exp_z_stride, act_z_stride);
-    DEVICE_PRINT("T1 txdim exp={} act={}", exp_tile_x_dim, act_tile_x_dim);
-    DEVICE_PRINT("T1 zdim exp={} act={}", exp_z_dim, act_z_dim);
-
     if constexpr (DO_RESTORE)
     {
+        // The transition must reproduce the canonical G1 SrcA baseline exactly.
         LLK_ASSERT(act_y_stride == exp_y_stride, "transition: SrcA Y-stride not the canonical G1 baseline");
         LLK_ASSERT(act_z_stride == exp_z_stride, "transition: SrcA Z-stride not the canonical G1 baseline");
         LLK_ASSERT(act_tile_x_dim == exp_tile_x_dim, "transition: Tile_x_dim_cntx0 not retargeted to G1 face_r_dim");
         LLK_ASSERT(act_z_dim == exp_z_dim, "transition: tile-descriptor Z-dim not retargeted to G1 num_faces");
+    }
+    else
+    {
+        // Negative control: without the transition the SrcA baseline stays in the G0
+        // tilize state, so the full G1 baseline must NOT be reproduced (the
+        // geometry-bearing Tile_x_dim / Z-dim differ between G0 and G1).
+        const bool all_match =
+            (act_y_stride == exp_y_stride) && (act_z_stride == exp_z_stride) && (act_tile_x_dim == exp_tile_x_dim) && (act_z_dim == exp_z_dim);
+        LLK_ASSERT(!all_match, "negative control: SrcA already matches the G1 baseline without the transition");
     }
 }
 

--- a/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Cross-op MIXED-TILE transition test (register-state design): a real `unpack_tilize`
+// at one tile geometry G0 (the "polluter") followed by the transition under test —
+// `_llk_unpack_tilize_uninit_` (PR C1) + `_llk_unpack_reconfig_data_format_srca_impl_`
+// `<.. FACE_ROW_MAJOR>` (PR C2) — that retargets the SrcA baseline to a DIFFERENT
+// geometry G1. The test then reads the SrcA config registers back and verifies they
+// are the canonical G1 baseline.
+//
+// This closes the last open `tilize_uninit` cell: "normal->tiny / tiny->normal with
+// reconfig" (axis F = tile-size transition, axis E = with-reconfig). Phase 3b covers
+// tilize->matmul geometry changes via a full `_llk_unpack_hw_configure_`; here the
+// re-establishment uses the lightweight C2 reconfig path, the ONLY mechanism that both
+// (a) re-commits the canonical SrcA Y-stride (the PR's new write) and (b) RETARGETS the
+// geometry — it rewrites `Tile_x_dim_cntx0 = canonical_unpA_tile_x_dim_cntx(G1.face_r_dim)`
+// and the tile-descriptor Z-dim = G1.num_faces (llk_unpack_common.h:170-174).
+//
+// Why a register-state check (not a 2nd data op): the run-1 victim of such a transition
+// is a SrcA datacopy whose correctness is *entirely* a function of these four SrcA
+// registers, and Phases 1/2 already prove "correct registers => correct data". Reading
+// the registers directly verifies the transition for BOTH directions with no second
+// operand / golden (which a single-geometry stimuli harness can't lay out cleanly for
+// two different tile shapes).
+//
+//   Run 0 : real `unpack_tilize` of a G0 tile (full unpack->math->pack pipeline,
+//           output discarded to scratch) — leaves SrcA in the G0 tilize state.
+//   Transition (only when DO_RESTORE): `_llk_unpack_tilize_uninit_(G0)` +
+//           `_llk_unpack_reconfig_data_format_srca_impl_<.. FACE_ROW_MAJOR>(G1)`.
+//   Readback: UNP0 Y-stride / Z-stride, Tile_x_dim_cntx0, tile-descriptor Z-dim.
+//           DEVICE_PRINT (expected G1 baseline, actual); LLK_ASSERT when DO_RESTORE.
+//
+// DO_RESTORE=false is the negative control: with no transition the registers stay in
+// the G0 tilize state, so the host sees actual != G1-expected (the Tile_x_dim / Z-dim
+// differ between G0 and G1), proving the transition is load-bearing.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Scratch L1 address for the discarded run-0 (polluter) tilize output.
+constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "dprint.h"
+#include "llk_lib_unpack_wrappers.h"
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    // Polluter (run-0) tilize geometry.
+    const std::uint32_t g0_face_r_dim = params.TEST_FACE_R_DIM;
+    const std::uint32_t g0_num_faces  = params.num_faces;
+    // Victim (run-1) target geometry (compile-time).
+    constexpr std::uint32_t g1_face_r_dim = VICTIM_FACE_R_DIM;
+    constexpr std::uint32_t g1_num_faces  = VICTIM_NUM_FACES;
+    constexpr std::uint32_t g1_tile_size  = g1_face_r_dim * FACE_C_DIM * g1_num_faces;
+
+    // ---- Run 0: real tilize "polluter" (output discarded) ----
+    const std::uint32_t g0_block_ct  = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
+    const std::uint32_t g0_tilize_nf = _llk_unpack_tilize_num_faces_wrapper_(g0_num_faces);
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[0].unpack_A_src,
+        formats_array[0].unpack_B_src,
+        formats_array[0].unpack_A_dst,
+        formats_array[0].unpack_B_dst,
+        g0_face_r_dim,
+        g0_face_r_dim,
+        g0_num_faces,
+        g0_num_faces);
+    _llk_unpack_tilize_init_wrapper_(
+        formats_array[0].unpack_A_src, formats_array[0].unpack_A_dst, 1 /* ct_dim */, g0_face_r_dim, false /* narrow_tile */, g0_tilize_nf);
+    _llk_unpack_tilize_wrapper_(
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats_array[0].unpack_A_src,
+        formats_array[0].unpack_A_dst,
+        g0_block_ct,
+        g0_face_r_dim,
+        g0_tilize_nf,
+        false /* narrow_tile */);
+
+    // Wait until the run-0 packer has drained before touching unpacker state.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Transition under test: uninit (C1) + reconfig (C2) retarget G0 -> G1 ----
+    if constexpr (DO_RESTORE)
+    {
+        // C1: tear down the tilize-mutated SrcA baseline at the G0 geometry (WH 3-arg
+        // uninit threads face_r_dim so it restores the G0 operand baseline exactly).
+        _llk_unpack_tilize_uninit_wrapper_(formats_array[0].unpack_A_dst, g0_num_faces, g0_face_r_dim);
+        // C2: the FACE_ROW_MAJOR reconfig re-commits the canonical SrcA Y/Z-stride AND
+        // retargets the geometry to G1 (Tile_x_dim_cntx0 from g1_face_r_dim, descriptor
+        // Z-dim from g1_num_faces). Same format both runs, so this is purely the
+        // geometry/stride retarget (no data-format change).
+        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, false>(
+            formats_array[1].unpack_A_src, formats_array[1].unpack_A_dst, g1_tile_size, g1_face_r_dim, g1_num_faces);
+    }
+
+    // ---- Read back the SrcA baseline and compare against the canonical G1 state ----
+    tensix_sync();
+    for (std::uint32_t i = 0; i < 10; i++)
+    {
+        asm volatile("nop");
+    }
+
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer();
+
+    const std::uint32_t act_y_stride =
+        (cfg[UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32] & UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK) >> UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT;
+    const std::uint32_t act_z_stride =
+        (cfg[UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] & UNP0_ADDR_CTRL_ZW_REG_1_Zstride_MASK) >> UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT;
+    const std::uint32_t act_tile_x_dim = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
+    const std::uint32_t act_z_dim      = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1] >> 16;
+
+    const std::uint32_t dst_format     = formats_array[1].unpack_A_dst;
+    const std::uint32_t exp_y_stride   = canonical_unpA_y_stride(dst_format);
+    const std::uint32_t exp_z_stride   = canonical_unpA_z_stride(dst_format);
+    const std::uint32_t exp_tile_x_dim = canonical_unpA_tile_x_dim_cntx(g1_face_r_dim);
+    const std::uint32_t exp_z_dim      = g1_num_faces;
+
+    DEVICE_PRINT("T1 ystride exp={} act={}", exp_y_stride, act_y_stride);
+    DEVICE_PRINT("T1 zstride exp={} act={}", exp_z_stride, act_z_stride);
+    DEVICE_PRINT("T1 txdim exp={} act={}", exp_tile_x_dim, act_tile_x_dim);
+    DEVICE_PRINT("T1 zdim exp={} act={}", exp_z_dim, act_z_dim);
+
+    if constexpr (DO_RESTORE)
+    {
+        LLK_ASSERT(act_y_stride == exp_y_stride, "transition: SrcA Y-stride not the canonical G1 baseline");
+        LLK_ASSERT(act_z_stride == exp_z_stride, "transition: SrcA Z-stride not the canonical G1 baseline");
+        LLK_ASSERT(act_tile_x_dim == exp_tile_x_dim, "transition: Tile_x_dim_cntx0 not retargeted to G1 face_r_dim");
+        LLK_ASSERT(act_z_dim == exp_z_dim, "transition: tile-descriptor Z-dim not retargeted to G1 num_faces");
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t g0_num_faces = params.num_faces;
+    const bool is_int_fpu_en         = false;
+    const std::uint32_t res_dst_idx  = 0;
+
+    // ---- Run 0: datacopy consuming the polluter tilize ----
+    static constexpr bool TILIZE = true;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, TILIZE>>(g0_num_faces, formats_array[0].math);
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[0].math, formats_array[0].math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        res_dst_idx, formats_array[0].math, formats_array[0].math, g0_num_faces);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t g0_face_r_dim = params.TEST_FACE_R_DIM;
+    const std::uint32_t g0_num_faces  = params.num_faces;
+    const std::uint32_t res_dst_idx   = 0;
+    static constexpr bool UNTILIZE    = false;
+    static constexpr bool TILIZE      = true;
+
+    // ---- Run 0: pack the (discarded) polluter tilize result to scratch ----
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        formats_array[0].pack_src,
+        formats_array[0].pack_dst,
+        g0_face_r_dim * params.TEST_FACE_C_DIM * g0_num_faces /* tile_size */,
+        g0_face_r_dim,
+        TILE_C_DIM,
+        g0_num_faces);
+    _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
+        formats_array[0].pack_dst, g0_face_r_dim, TILE_C_DIM, g0_num_faces);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(res_dst_idx, L1_ADDRESS(buffer_polluter_scratch));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that run-0 has fully drained.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/unpack_bcastA_B_uninit_restore_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_bcastA_B_uninit_restore_test.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Cross-op unpacker-state restore test for the SDPA `_llk_unpack_bcastA_B_` path.
+//
+// PR #45127 changed `_llk_unpack_bcastA_B_uninit_` so its SrcA Y-stride restore
+// went from a hardcoded `FACE_R_DIM*2` (=32) to `canonical_unpA_y_stride(dst_format)`
+// (=16 for bf16), and it added the matching Y-stride (re)write to
+// `_llk_unpack_reconfig_data_format_srca_impl_` (the FACE_ROW_MAJOR branch).
+// NO existing C++ test calls `_llk_unpack_bcastA_B_uninit_` at all, and the matmul
+// tilize test only ever calls the reconfig with `p_dim_stride_target::IGNORE`, so
+// the new Y-stride write is unexercised.
+//
+// `_llk_unpack_bcastA_B_init_` mutates the SrcA Y-stride to 32. This test runs:
+//   Run 0: `_llk_unpack_bcastA_B_` (which leaves Y-stride = 32) + an eltwise-binary
+//          math op to drain the pipeline.
+//   Restore under test (selected by `RESTORE_VIA_RECONFIG`):
+//     * false -> `_llk_unpack_bcastA_B_uninit_(dst)`            (C1, Phase 4)
+//     * true  -> `_llk_unpack_reconfig_data_format_srca_impl_<.., FACE_ROW_MAJOR>` (C2, Phase 3)
+//   Run 1: a plain `_llk_unpack_A_` datacopy of the ORIGINAL operand-A tile
+//          (`buffer_A[0]`), with NO other state reset in between.
+//
+// If the restore leaves the SrcA Y-stride at the bcast-specific value (32) instead
+// of the canonical baseline (16 for bf16), the run-1 datacopy reads SrcA with the
+// wrong row stride and the result diverges from `DataCopyGolden(src_A)`.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Scratch L1 address that holds the run-0 (bcast) result. Run 1 does NOT read it;
+// it exists only so the run-0 packer has a destination and the pipeline drains.
+constexpr std::uint32_t buffer_bcast_scratch = 0xA0000;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_AB.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    constexpr std::uint32_t num_faces = 4;
+    // Datum count for one 32x32 tile; only used to seed the tile-size GPR (the
+    // single-tile run-1 datacopy reads tile index 0, so the exact value is moot).
+    constexpr std::uint32_t tile_size_datums = num_faces * FACE_R_DIM * FACE_C_DIM;
+
+    // ---- Run 0: SDPA row-broadcast of operand A against operand B ----
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[0].unpack_A_src,
+        formats_array[0].unpack_B_src,
+        formats_array[0].unpack_A_dst,
+        formats_array[0].unpack_B_dst,
+        FACE_R_DIM,
+        FACE_R_DIM,
+        num_faces,
+        num_faces);
+    _llk_unpack_bcastA_B_init_();
+    _llk_unpack_bcastA_B_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), params.SRCA_REUSE_COUNT);
+
+    // Wait until the run-0 packer has drained before touching unpacker state.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Restore under test ----
+    if constexpr (RESTORE_VIA_RECONFIG)
+    {
+        // C2 (Phase 3): the reconfig FACE_ROW_MAJOR branch re-commits the canonical
+        // SrcA Y-stride (and Z-stride / Tile_x_dim / Z-dim). This is the only place
+        // the new Y-stride write is exercised; the matmul tilize test uses IGNORE.
+        _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::FACE_ROW_MAJOR, false>(
+            formats_array[1].unpack_A_src, formats_array[1].unpack_A_dst, tile_size_datums, FACE_R_DIM, num_faces);
+    }
+    else
+    {
+        // C1 (Phase 4): the bcast-specific uninit restores the canonical Y-stride
+        // from the dst format. NOTE: intentionally NO reconfig here, so this uninit
+        // is the sole reset of the unpacker state before the next op.
+        _llk_unpack_bcastA_B_uninit_(formats_array[1].unpack_A_dst);
+    }
+
+    // ---- Run 1: plain datacopy of the ORIGINAL operand-A tile (no reconfig) ----
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0, 0, FACE_R_DIM, num_faces, formats_array[1].unpack_A_src, formats_array[1].unpack_A_dst);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        L1_ADDRESS(params.buffer_A[0]), formats_array[1].unpack_A_src, formats_array[1].unpack_A_dst);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_binary.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    constexpr std::uint32_t num_faces = 4;
+    const bool is_int_fpu_en          = false;
+    const std::uint32_t res_dst_idx   = 0;
+
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[0].math, formats_array[0].math);
+
+    // ---- Run 0: eltwise-binary consuming the broadcast operands ----
+    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, ckernel::MathFidelity::LoFi>(params.SRCA_REUSE_COUNT);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_binary_(res_dst_idx);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // ---- Run 1: plain datacopy ----
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en, ckernel::PackMode::Default>(
+        num_faces, formats_array[1].math);
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        res_dst_idx, formats_array[1].math, formats_array[1].math, num_faces);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    constexpr std::uint32_t num_faces = 4;
+    const std::uint32_t res_dst_idx   = 0;
+
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats_array[0].pack_src, formats_array[0].pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces /* tile_size */);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats_array[0].pack_dst);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
+
+    // ---- Run 0: pack the bcast result to scratch (drains the pipeline) ----
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_idx, L1_ADDRESS(buffer_bcast_scratch));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that run-0 has fully drained.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the datacopy result to the output buffer ----
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_idx, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/unpack_canonical_baseline_check_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_canonical_baseline_check_test.cpp
@@ -21,13 +21,12 @@
 //        - UNP0 ch1 Z-stride   (UNP0_ADDR_CTRL_ZW_REG_1_Zstride)
 //        - Tile_x_dim_cntx0     (THCON_SEC0_REG5_Tile_x_dim_cntx0)
 //        - tile-descriptor Z-dim (THCON_SEC0_REG0_TileDescriptor word 1, bits 31:16)
-//   3. LLK_ASSERT each equals the helper value (Z-dim equals num_faces), and
-//      DEVICE_PRINT the (expected, actual) pair so the host can re-verify + diagnose.
+//   3. LLK_ASSERT each equals the helper value (Z-dim equals num_faces) on-device.
 //
 // If a helper ever drifts from `configure_unpack_AB`'s inline programming, the
-// readback diverges from the helper and BOTH the on-device assert and the host
-// comparison fail. There is no actual unpack/datacopy here — the registers are the
-// deliverable, so no stimuli / golden are needed.
+// readback diverges from the helper and the on-device assert fails. There is no
+// actual unpack/datacopy here — the registers are the deliverable, so no stimuli /
+// golden are needed.
 
 #include <cstdint>
 
@@ -41,7 +40,6 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
-#include "dprint.h"
 #include "llk_unpack_common.h"
 #include "params.h"
 
@@ -79,11 +77,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t exp_z_stride   = canonical_unpA_z_stride(dst_format);
     const std::uint32_t exp_tile_x_dim = canonical_unpA_tile_x_dim_cntx(face_r_dim);
     const std::uint32_t exp_z_dim      = num_faces;
-
-    DEVICE_PRINT("C4 ystride exp={} act={}", exp_y_stride, act_y_stride);
-    DEVICE_PRINT("C4 zstride exp={} act={}", exp_z_stride, act_z_stride);
-    DEVICE_PRINT("C4 txdim exp={} act={}", exp_tile_x_dim, act_tile_x_dim);
-    DEVICE_PRINT("C4 zdim exp={} act={}", exp_z_dim, act_z_dim);
 
     LLK_ASSERT(act_y_stride == exp_y_stride, "canonical_unpA_y_stride mismatch vs configure_unpack_AB");
     LLK_ASSERT(act_z_stride == exp_z_stride, "canonical_unpA_z_stride mismatch vs configure_unpack_AB");

--- a/tt_metal/tt-llk/tests/sources/unpack_canonical_baseline_check_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_canonical_baseline_check_test.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Direct helper-correctness check for the PR #45127 canonical-baseline helpers (C4):
+//   `canonical_unpA_y_stride`, `canonical_unpA_z_stride`, `canonical_unpA_tile_x_dim_cntx`.
+//
+// These helpers are the single source of truth that `_llk_unpack_tilize_uninit_`,
+// `_llk_unpack_bcastA_B_uninit_`, and `_llk_unpack_reconfig_data_format_srca_impl_`
+// restore to. The whole restore design is only correct if the helpers reproduce the
+// EXACT register state that `configure_unpack_AB` (`_llk_unpack_hw_configure_`)
+// programs for a given (dst_format, face_r_dim, num_faces). Every restore test
+// exercises the helpers transitively; this test pins them down DIRECTLY.
+//
+// Flow (unpack thread only):
+//   1. `_llk_unpack_hw_configure_(dst, face_r_dim, num_faces)` programs the SrcA
+//      tile descriptor + stride registers from its OWN inline formulas (which are
+//      written independently of the helpers — see cunpack_common.h:807/928).
+//   2. Read back the four canonical SrcA registers:
+//        - UNP0 ch1 Y-stride   (UNP0_ADDR_CTRL_XY_REG_1_Ystride)
+//        - UNP0 ch1 Z-stride   (UNP0_ADDR_CTRL_ZW_REG_1_Zstride)
+//        - Tile_x_dim_cntx0     (THCON_SEC0_REG5_Tile_x_dim_cntx0)
+//        - tile-descriptor Z-dim (THCON_SEC0_REG0_TileDescriptor word 1, bits 31:16)
+//   3. LLK_ASSERT each equals the helper value (Z-dim equals num_faces), and
+//      DEVICE_PRINT the (expected, actual) pair so the host can re-verify + diagnose.
+//
+// If a helper ever drifts from `configure_unpack_AB`'s inline programming, the
+// readback diverges from the helper and BOTH the on-device assert and the host
+// comparison fail. There is no actual unpack/datacopy here — the registers are the
+// deliverable, so no stimuli / golden are needed.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals referenced by the LLK config helpers (configure_unpack_AB / sync_regfile_write).
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "dprint.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t num_faces  = params.num_faces;
+    const std::uint32_t face_r_dim = params.TEST_FACE_R_DIM;
+    const std::uint32_t dst_format = formats.unpack_A_dst;
+
+    // Program the canonical SrcA baseline for this (dst_format, face_r_dim, num_faces).
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, face_r_dim, face_r_dim, num_faces, num_faces);
+
+    // Drain config writes before reading them back (mirrors are_unpackers_AB_configured_correctly).
+    tensix_sync();
+    for (std::uint32_t i = 0; i < 10; i++)
+    {
+        asm volatile("nop");
+    }
+
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer();
+
+    const std::uint32_t act_y_stride =
+        (cfg[UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32] & UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK) >> UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT;
+    const std::uint32_t act_z_stride =
+        (cfg[UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] & UNP0_ADDR_CTRL_ZW_REG_1_Zstride_MASK) >> UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT;
+    const std::uint32_t act_tile_x_dim = cfg[THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32];
+    // tile_descriptor word 1: z_dim at bits [31:16].
+    const std::uint32_t act_z_dim = cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1] >> 16;
+
+    const std::uint32_t exp_y_stride   = canonical_unpA_y_stride(dst_format);
+    const std::uint32_t exp_z_stride   = canonical_unpA_z_stride(dst_format);
+    const std::uint32_t exp_tile_x_dim = canonical_unpA_tile_x_dim_cntx(face_r_dim);
+    const std::uint32_t exp_z_dim      = num_faces;
+
+    DEVICE_PRINT("C4 ystride exp={} act={}", exp_y_stride, act_y_stride);
+    DEVICE_PRINT("C4 zstride exp={} act={}", exp_z_stride, act_z_stride);
+    DEVICE_PRINT("C4 txdim exp={} act={}", exp_tile_x_dim, act_tile_x_dim);
+    DEVICE_PRINT("C4 zdim exp={} act={}", exp_z_dim, act_z_dim);
+
+    LLK_ASSERT(act_y_stride == exp_y_stride, "canonical_unpA_y_stride mismatch vs configure_unpack_AB");
+    LLK_ASSERT(act_z_stride == exp_z_stride, "canonical_unpA_z_stride mismatch vs configure_unpack_AB");
+    LLK_ASSERT(act_tile_x_dim == exp_tile_x_dim, "canonical_unpA_tile_x_dim_cntx mismatch vs configure_unpack_AB");
+    LLK_ASSERT(act_z_dim == exp_z_dim, "tile-descriptor Z-dim (num_faces) mismatch vs configure_unpack_AB");
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS)
+{
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS)
+{
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_block_test.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Multi-tile-block variant of unpack_tilize_uninit_restore_test.cpp (Phase 6).
+//
+// Same cross-op restore design (tilize -> `_llk_unpack_tilize_uninit_` -> plain
+// datacopy, NO data-format reconfig in between, so uninit is the SOLE state
+// reset), but run 0 tilizes a BLOCK of `BLOCK_CT_DIM > 1` column tiles in one
+// init/execute sweep instead of a single tile.
+//
+// Why this is a distinct case: `_llk_unpack_tilize_init_(ct_dim=BLOCK_CT_DIM)`
+// programs the tilize `shift_amount` (config word-0) and per-column addressing
+// from the block width, and the op leaves SrcA in that block-tilize state. The
+// PR's `_llk_unpack_tilize_uninit_` must still restore the canonical single-tile
+// operand baseline so the following plain datacopy of EACH tilized tile reads
+// correctly. If the block tilize leaves residual state that uninit doesn't
+// clear, the run-1 datacopy of the block diverges from the tilized golden.
+//
+// Run 0: tilize the `BLOCK_CT_DIM` column tiles of operand A -> packed to
+//         `BLOCK_CT_DIM` scratch L1 slots.
+// Run 1: plain `_llk_unpack_A_` datacopy of each scratch tilized tile -> result.
+//         On a correct restore this is an identity copy, so the result equals
+//         `TilizeGolden(src_A_block, num_faces)`.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Scratch L1 base for the tilized block; each tilized tile gets a generous
+// fixed slot (>= the largest 4-face fp32 tile = 4 KiB) well above the
+// stimuli/result buffers (which start at 0x21000).
+constexpr std::uint32_t buffer_block_scratch = 0xA0000;
+constexpr std::uint32_t scratch_tile_stride  = 0x4000;
+
+constexpr std::uint32_t scratch_tile_addr(std::uint32_t i)
+{
+    return buffer_block_scratch + i * scratch_tile_stride;
+}
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_lib_unpack_wrappers.h"
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces  = params.num_faces;
+    const std::uint32_t face_r_dim = params.TEST_FACE_R_DIM;
+
+    // ---- Run 0: tilize the BLOCK_CT_DIM column tiles of operand A into scratch ----
+    int run = 0;
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_A_dst,
+        formats_array[run].unpack_B_dst,
+        face_r_dim,
+        face_r_dim,
+        num_faces,
+        num_faces);
+
+    const std::uint32_t tilize_num_faces = _llk_unpack_tilize_num_faces_wrapper_(num_faces);
+    const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(params.BLOCK_CT_DIM);
+
+    _llk_unpack_tilize_init_wrapper_(
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, params.BLOCK_CT_DIM, face_r_dim, false /* narrow_tile */, tilize_num_faces);
+    for (std::uint32_t col = 0; col < params.BLOCK_CT_DIM; ++col)
+    {
+        _llk_unpack_tilize_wrapper_(
+            L1_ADDRESS(params.buffer_A[0]),
+            col,
+            formats_array[run].unpack_A_src,
+            formats_array[run].unpack_A_dst,
+            block_ct_dim,
+            face_r_dim,
+            tilize_num_faces,
+            false /* narrow_tile */);
+    }
+
+    // Wait until the packer has written all BLOCK_CT_DIM tilized tiles to scratch.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Restore under test (NO reconfig — uninit is the sole reset) ----
+#ifdef ARCH_WORMHOLE
+    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, num_faces, face_r_dim);
+#else
+    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, num_faces);
+#endif
+
+    // ---- Run 1: plain datacopy of each tilized tile (same format, no reconfig) ----
+    run = 1;
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0, 0, face_r_dim, num_faces, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+            L1_ADDRESS(scratch_tile_addr(i)), formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces = params.num_faces;
+    const bool is_int_fpu_en      = false;
+
+    // ---- Run 0: block datacopy with tilize ----
+    int run                      = 0;
+    static constexpr bool TILIZE = true;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, TILIZE>>(num_faces, formats_array[run].math);
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        LLK_ASSERT(
+            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
+        _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+            i, formats_array[run].math, formats_array[run].math, num_faces);
+    }
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // ---- Run 1: plain block datacopy (no tilize) ----
+    run                             = 1;
+    static constexpr bool NO_TILIZE = false;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, NO_TILIZE>>(num_faces, formats_array[run].math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+            i, formats_array[run].math, formats_array[run].math, num_faces);
+    }
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces  = params.num_faces;
+    const std::uint32_t face_r_dim = params.TEST_FACE_R_DIM;
+    const std::uint32_t tile_size  = face_r_dim * params.TEST_FACE_C_DIM * num_faces;
+    static constexpr bool UNTILIZE = false;
+    static constexpr bool TILIZE   = true;
+
+    // ---- Run 0: pack the BLOCK_CT_DIM tilized tiles to scratch ----
+    int run = 0;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        formats_array[run].pack_src, formats_array[run].pack_dst, tile_size, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
+        formats_array[run].pack_dst, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+    _llk_packer_wait_for_math_done_();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(i, L1_ADDRESS(scratch_tile_addr(i)));
+    }
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that the tilized block is ready in L1.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the datacopy results to the output buffers ----
+    run = 1;
+#ifdef ARCH_BLACKHOLE
+    // Blackhole run-0 used PackMode::Tilize; re-establish a Default-mode packer
+    // for the plain datacopy result (Wormhole tilize pack cfg mode is Default).
+    _llk_pack_reconfig_data_format_wrapper_<is_fp32_dest_acc_en>(
+        formats_array[run].pack_src, formats_array[run].pack_dst, tile_size, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_init_wrapper_<ckernel::PackMode::Default, false /* zero_output */>(formats_array[run].pack_dst, face_r_dim, TILE_C_DIM, num_faces);
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+    }
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_test.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Cross-op unpacker-state restore test for `_llk_unpack_tilize_uninit_`.
+//
+// Goal: prove that after a `unpack_tilize` op, `_llk_unpack_tilize_uninit_`
+// restores the SrcA tile-descriptor (num_faces / Y-dim), the unpack config
+// word-0 (tilize_mode etc.), and `Tile_x_dim_cntx0` back to the canonical
+// operand baseline programmed by `configure_unpack_AB` — so that a *following*
+// op that uses the SAME operand baseline (and therefore performs NO data-format
+// reconfig) reads correct data.
+//
+// To isolate the uninit restore as the *only* state reset between the two ops,
+// this test deliberately:
+//   * uses the SAME data format for both runs (see python `same=True`), and
+//   * does NOT call `_llk_unpack_reconfig_data_format_srca_impl_` before the
+//     second op (a reconfig would re-establish the strides and mask a broken
+//     uninit).
+//
+// Run 0: tilize operand A (parameterized num_faces) -> packed to a scratch L1
+//         buffer (`buffer_A_tilized`).
+// Run 1: plain `_llk_unpack_A_` datacopy of that tilized tile -> packed to the
+//         result buffer. On a correct build this is an identity copy of the
+//         tilized tile, so the result equals `TilizeGolden(src_A, num_faces)`.
+//         If uninit fails to restore the operand baseline (e.g. leaves the
+//         tile-descriptor Z-dim at a tilize-specific value, or leaves
+//         tilize_mode set), this datacopy is corrupted and the test fails.
+//
+// The `num_faces ∈ {1, 2}` cases specifically exercise the tile-descriptor
+// Z-dim restore (`_llk_unpack_tilize_uninit_` line restoring num_faces) that no
+// existing tilize test covers — every other uninit call site uses num_faces=4.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// Scratch L1 address that holds the tilized tile written by the run-0 packer
+// and read back by the run-1 unpacker. Sits well above the stimuli/result
+// buffers (which start at 0x21000), matching matmul_unpack_tilize_test.cpp.
+constexpr std::uint32_t buffer_A_tilized = 0xA0000;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_lib_unpack_wrappers.h"
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces = params.num_faces;
+    // face_r_dim = 16 → normal tile (Phase 1); face_r_dim < 16 → tiny tile (Phase 2),
+    // which exercises the `canonical_unpA_tile_x_dim_cntx(face_r_dim)` restore branch.
+    const std::uint32_t face_r_dim = params.TEST_FACE_R_DIM;
+
+    // ---- Run 0: tilize operand A into the scratch buffer ----
+    int run = 0;
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_B_src,
+        formats_array[run].unpack_A_dst,
+        formats_array[run].unpack_B_dst,
+        face_r_dim,
+        face_r_dim,
+        num_faces,
+        num_faces);
+
+    const std::uint32_t tilize_num_faces = _llk_unpack_tilize_num_faces_wrapper_(num_faces);
+    const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
+
+    _llk_unpack_tilize_init_wrapper_(
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, face_r_dim, false /* narrow_tile */, tilize_num_faces);
+    _llk_unpack_tilize_wrapper_(
+        L1_ADDRESS(params.buffer_A[0]),
+        0 /* tile_index */,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst,
+        block_ct_dim,
+        face_r_dim,
+        tilize_num_faces,
+        false /* narrow_tile */);
+
+    // Wait until the packer has written the tilized tile to the scratch buffer.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Restore under test ----
+    // Restore the SrcA operand baseline this op mutated. NOTE: intentionally NO
+    // `_llk_unpack_reconfig_data_format_srca_impl_` here, so this uninit is the
+    // sole reset of the unpacker state before the next op.
+#ifdef ARCH_WORMHOLE
+    // Wormhole threads face_r_dim so the restore matches a tiny-tile operand baseline.
+    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, num_faces, face_r_dim);
+#else
+    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, num_faces);
+#endif
+
+    // ---- Run 1: plain datacopy of the tilized tile (same format, no reconfig) ----
+    run = 1;
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0, 0, face_r_dim, num_faces, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        L1_ADDRESS(buffer_A_tilized), formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+#include "params.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces   = params.num_faces;
+    const bool is_int_fpu_en        = false;
+    const std::uint32_t res_dst_idx = 0;
+
+    // ---- Run 0: datacopy with tilize ----
+    int run                      = 0;
+    static constexpr bool TILIZE = true;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, TILIZE>>(num_faces, formats_array[run].math);
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        res_dst_idx, formats_array[run].math, formats_array[run].math, num_faces);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // ---- Run 1: plain datacopy (no tilize) ----
+    run                             = 1;
+    static constexpr bool NO_TILIZE = false;
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        is_int_fpu_en,
+        llk_test_pack_mode_v<false, NO_TILIZE>>(num_faces, formats_array[run].math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+        res_dst_idx, formats_array[run].math, formats_array[run].math, num_faces);
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig(&formats_array)[2] = params.formats;
+#endif
+    const std::uint32_t num_faces   = params.num_faces;
+    const std::uint32_t face_r_dim  = params.TEST_FACE_R_DIM;
+    const std::uint32_t res_dst_idx = 0;
+    // Tilized datum count for the (possibly tiny) tile being packed.
+    const std::uint32_t tile_size  = face_r_dim * params.TEST_FACE_C_DIM * num_faces;
+    static constexpr bool UNTILIZE = false;
+    static constexpr bool TILIZE   = true;
+
+    // ---- Run 0: pack the tilized tile to the scratch buffer ----
+    int run = 0;
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+        formats_array[run].pack_src, formats_array[run].pack_dst, tile_size, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
+        formats_array[run].pack_dst, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(res_dst_idx, L1_ADDRESS(buffer_A_tilized));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    // Signal the unpacker that the tilized tile is ready in L1.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the datacopy result to the output buffer ----
+    run = 1;
+#ifdef ARCH_BLACKHOLE
+    // Blackhole run-0 used PackMode::Tilize; re-establish a Default-mode packer
+    // for the plain datacopy result. Wormhole's tilize pack cfg mode is already
+    // Default, so it needs no reconfig here.
+    _llk_pack_reconfig_data_format_wrapper_<is_fp32_dest_acc_en>(
+        formats_array[run].pack_src, formats_array[run].pack_dst, tile_size, face_r_dim, TILE_C_DIM, num_faces);
+    _llk_pack_init_wrapper_<ckernel::PackMode::Default, false /* zero_output */>(formats_array[run].pack_dst, face_r_dim, TILE_C_DIM, num_faces);
+#endif
+
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_idx, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
@@ -22,35 +22,37 @@ struct p_gpr
 // Unpack GPR thread
 struct p_gpr_unpack
 {
-    constexpr static std::uint32_t OPERAND_BASE_ADDR       = 4;      // Operand base address used by zero buffer function
-    constexpr static std::uint32_t OPERAND_OFFSET_ADDR     = 5;      // Operand offset address used by zero buffer function
-    constexpr static std::uint32_t ZERO_0                  = 8;      // Zero data
-    constexpr static std::uint32_t ZERO_1                  = 9;      // Zero data
-    constexpr static std::uint32_t ZERO_2                  = 10;     // Zero data
-    constexpr static std::uint32_t ZERO_3                  = 11;     // Zero data
-    constexpr static std::uint32_t TMP0                    = 12;     // Temp data
-    constexpr static std::uint32_t TMP1                    = 13;     // Temp data
-    constexpr static std::uint32_t TILE_SIZE               = 14;     // Tile size
-    constexpr static std::uint32_t TILE_OFFSET             = 15;     // Tile offset
-    constexpr static std::uint32_t L1_BUFFER_ADDR          = 17;     // Holds address of fixed l1 buffer used for reduce in1
-    constexpr static std::uint32_t TMP_LO                  = 18;     // Temp data. Upper 16-bits always 0
-    constexpr static std::uint32_t TMP_HI                  = 19;     // Temp data. Lower 16-bits always 0
-    constexpr static std::uint32_t PERF_FIRST_UNP_LO       = 32;     // timestamp for first-unpack-instruction (low 32b)
-    constexpr static std::uint32_t PERF_FIRST_UNP_HI       = 33;     // timestamp for first-unpack-instruction (high 32b)
-    constexpr static std::uint32_t TILE_SIZE_A             = 36;     // Holds tile size for unpacker 0
-    constexpr static std::uint32_t TILE_SIZE_B             = 37;     // Holds tile size for unpacker 1
-    constexpr static std::uint32_t KT_DIM                  = 38;     // Holds matmul kt_dim
-    constexpr static std::uint32_t FACE_DIM_16x16          = 40;     // Holds face dimension (16x16)
-    constexpr static std::uint32_t FACE_DIM_8x16           = 41;     // Holds face dimension (8x16)
-    constexpr static std::uint32_t FACE_DIM_4x16           = 42;     // Holds face dimension (4x16)
-    constexpr static std::uint32_t FACE_DIM_2x16           = 43;     // Holds face dimension (2x16)
-    constexpr static std::uint32_t FACE_DIM_1x16           = 44;     // Holds face dimension (1x16)
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_0 = 45;     // num tiles for input operands 0-1
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_1 = 46;     // num tiles for input operands 2-3
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_2 = 47;     // num tiles for input operands 4-5
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48;     // num tiles for input operands 6-7
-    constexpr static std::uint32_t UNPACK_STRIDE           = 52;     // Used to save/restore unpack A stride (UNP0_ADDR_CTRL_ZW_REG_1_Zstride register)
-                                                                     // before/after unpacking directly to dest
+    constexpr static std::uint32_t OPERAND_BASE_ADDR       = 4;  // Operand base address used by zero buffer function
+    constexpr static std::uint32_t OPERAND_OFFSET_ADDR     = 5;  // Operand offset address used by zero buffer function
+    constexpr static std::uint32_t ZERO_0                  = 8;  // Zero data
+    constexpr static std::uint32_t ZERO_1                  = 9;  // Zero data
+    constexpr static std::uint32_t ZERO_2                  = 10; // Zero data
+    constexpr static std::uint32_t ZERO_3                  = 11; // Zero data
+    constexpr static std::uint32_t TMP0                    = 12; // Temp data
+    constexpr static std::uint32_t TMP1                    = 13; // Temp data
+    constexpr static std::uint32_t TILE_SIZE               = 14; // Tile size
+    constexpr static std::uint32_t TILE_OFFSET             = 15; // Tile offset
+    constexpr static std::uint32_t L1_BUFFER_ADDR          = 17; // Holds address of fixed l1 buffer used for reduce in1
+    constexpr static std::uint32_t TMP_LO                  = 18; // Temp data. Upper 16-bits always 0
+    constexpr static std::uint32_t TMP_HI                  = 19; // Temp data. Lower 16-bits always 0
+    constexpr static std::uint32_t PERF_FIRST_UNP_LO       = 32; // timestamp for first-unpack-instruction (low 32b)
+    constexpr static std::uint32_t PERF_FIRST_UNP_HI       = 33; // timestamp for first-unpack-instruction (high 32b)
+    constexpr static std::uint32_t TILE_SIZE_A             = 36; // Holds tile size for unpacker 0
+    constexpr static std::uint32_t TILE_SIZE_B             = 37; // Holds tile size for unpacker 1
+    constexpr static std::uint32_t KT_DIM                  = 38; // Holds matmul kt_dim
+    constexpr static std::uint32_t FACE_DIM_16x16          = 40; // Holds face dimension (16x16)
+    constexpr static std::uint32_t FACE_DIM_8x16           = 41; // Holds face dimension (8x16)
+    constexpr static std::uint32_t FACE_DIM_4x16           = 42; // Holds face dimension (4x16)
+    constexpr static std::uint32_t FACE_DIM_2x16           = 43; // Holds face dimension (2x16)
+    constexpr static std::uint32_t FACE_DIM_1x16           = 44; // Holds face dimension (1x16)
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_0 = 45; // num tiles for input operands 0-1
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_1 = 46; // num tiles for input operands 2-3
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_2 = 47; // num tiles for input operands 4-5
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48; // num tiles for input operands 6-7
+    // Slot 52 was the legacy UNPACK_STRIDE GPR used to snapshot/restore the channel-1 Z-stride
+    // around unpack-to-dest. Removed in favor of canonical_unpA_z_stride() in the bracket pair
+    // (set_dst_write_addr / unpack_to_dest_tile_done). See tt-llk#1015. Slot is reserved as
+    // free until the next unpacker GPR consolidation.
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_0   = 54; // Save unpack state before tilizer is enabled for quick restore
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_1   = 55;
     constexpr static std::uint32_t SR_UNPACK_UNTILIZER_STATE_0 = 56; // Save unpack state before tilizer is enabled for quick restore

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_gpr_map.h
@@ -51,8 +51,8 @@ struct p_gpr_unpack
     constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48; // num tiles for input operands 6-7
     // Slot 52 was the legacy UNPACK_STRIDE GPR used to snapshot/restore the channel-1 Z-stride
     // around unpack-to-dest. Removed in favor of canonical_unpA_z_stride() in the bracket pair
-    // (set_dst_write_addr / unpack_to_dest_tile_done). See tt-llk#1015. Slot is reserved as
-    // free until the next unpacker GPR consolidation.
+    // (set_dst_write_addr / unpack_to_dest_tile_done), which recomputes the baseline instead of
+    // preserving caller-side state. Slot is reserved as free until the next unpacker GPR consolidation.
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_0   = 54; // Save unpack state before tilizer is enabled for quick restore
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_1   = 55;
     constexpr static std::uint32_t SR_UNPACK_UNTILIZER_STATE_0 = 56; // Save unpack state before tilizer is enabled for quick restore

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -983,9 +983,9 @@ inline void wait_for_dest_available()
 }
 
 // Restore srcA channel-1 Z-stride to the canonical baseline derived from unpack_dst_format.
-// This pairs with set_dst_write_addr to bracket the unpack-to-dest section without snapshotting
-// the prior register value into a GPR (per tt-llk#1015: each op restores to a documented
-// baseline rather than preserving caller-side state).
+// This pairs with set_dst_write_addr to bracket the unpack-to-dest section: rather than
+// snapshotting the prior register value into a GPR, we recompute the canonical baseline so the
+// restore is deterministic and order-independent.
 inline void unpack_to_dest_tile_done(std::uint32_t &context_id, const std::uint32_t unpack_dst_format)
 {
     t6_semaphore_post<p_stall::UNPACK0>(semaphore::UNPACK_TO_DEST);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -273,6 +273,9 @@ inline constexpr std::uint32_t canonical_unpA_z_stride(const std::uint32_t unpac
 constexpr std::uint32_t CANONICAL_UNPA_TILE_Y_DIM = 1;
 constexpr std::uint32_t CANONICAL_UNPA_TILE_X_DIM = 0;
 
+// Mask for the upper halfword of a TileDescriptor config word, where the X/Y/Z dim fields live.
+constexpr std::uint32_t TILE_DESC_UPPER_HALFWORD_MASK = 0xffff0000;
+
 // Canonical Tile_x_dim_cntx0 word: face_dim packed into both cntx0 (low 16) and cntx1 (high 16),
 // where face_dim = face_r_dim * FACE_C_DIM. configure_unpack_AB programs this value.
 inline constexpr std::uint32_t canonical_unpA_tile_x_dim_cntx(const std::uint32_t face_r_dim)

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -251,6 +251,24 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
 {
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
+
+// Canonical srcA tile-descriptor baseline programmed by configure_unpack_AB.
+// Per-op uninits restore the tile descriptor to this state.
+//
+// Y-dim (lower 16 bits of TileDescriptor word 1): always 1.
+// X-dim (upper 16 bits of TileDescriptor word 0): 0 for srcA because Tile_x_dim_cntx0 overrides it.
+// Z-dim (upper 16 bits of TileDescriptor word 1): equals the operand's num_faces (used directly at call sites).
+constexpr std::uint32_t CANONICAL_UNPA_TILE_Y_DIM = 1;
+constexpr std::uint32_t CANONICAL_UNPA_TILE_X_DIM = 0;
+
+// Canonical Tile_x_dim_cntx0 word: face_dim packed into both cntx0 (low 16) and cntx1 (high 16),
+// where face_dim = face_r_dim * FACE_C_DIM. configure_unpack_AB programs this value.
+inline constexpr std::uint32_t canonical_unpA_tile_x_dim_cntx(const std::uint32_t face_r_dim)
+{
+    const std::uint32_t face_dim = face_r_dim * FACE_C_DIM;
+    return face_dim | (face_dim << 16);
+}
+
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -213,6 +213,13 @@ inline void enable_int8_fpu_math()
  * \param unpack_dst_format Unpacker output (register) data format.
  * \return true if both formats are Int32 or Float32; false otherwise.
  */
+inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
+    const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
+    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
+}
+
 // Canonical srcA channel-1 X stride in bytes, derived from the unpacker dst format.
 // Used to compute the canonical Y/Z strides programmed into UNP0_ADDR_CTRL_*.
 inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpack_dst_format)
@@ -230,13 +237,6 @@ inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpac
     return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
 }
 
-inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
-{
-    const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
-    const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
-    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
-}
-
 /*
  * Single source of truth for whether _llk_unpack_A_ takes the "unpack to dest" (SrcA -> DEST) path.
  * It is only taken for genuinely 32-bit input; otherwise the MOP falls through to the normal/broadcast
@@ -251,7 +251,6 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
 {
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
-
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -227,14 +227,15 @@ inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpac
     return (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float32) ? 4 : (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float16) ? 2 : 1;
 }
 
-// Canonical srcA channel-1 Y stride: full-tile sequential row step.
+// Canonical srcA channel-1 Y stride: face row step (one face row = FACE_R_DIM datums).
 //
 // This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
 // so it serves as the documented baseline that operations which mutate Y-stride
-// (e.g. tilizeA_B) must restore on uninit.
-inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+// (e.g. tilizeA_B) must restore on uninit. It does not depend on the operand's face_r_dim;
+// FACE_R_DIM is the constant face row count (matches set_packer_strides and unpack_untilize).
+inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format)
 {
-    return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
+    return FACE_R_DIM * canonical_unpA_x_stride(unpack_dst_format);
 }
 
 /*
@@ -823,7 +824,7 @@ inline void configure_unpack_AB(
     // mutate Y-stride (e.g. tilizeA_B) can deterministically restore this baseline on uninit
     // rather than snapshotting the previous register value into a GPR.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-        canonical_unpA_y_stride(unpA_dst_format_masked, unpA_face_r_dim));
+        canonical_unpA_y_stride(unpA_dst_format_masked));
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -252,6 +252,17 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
 
+// Canonical srcA channel-1 Z stride: face-sized row step.
+//
+// Programmed by configure_unpack_AB and the srca data-format reconfig, and re-asserted by
+// unpack-to-dest brackets. Z-stride does not depend on operand face_r_dim; FACE_R_DIM is
+// the constant face row count because data is not stored densely in src/dest registers
+// (matches the explicit comment in _llk_unpack_reconfig_data_format_srca_impl_).
+inline constexpr std::uint32_t canonical_unpA_z_stride(const std::uint32_t unpack_dst_format)
+{
+    return FACE_C_DIM * FACE_R_DIM * canonical_unpA_x_stride(unpack_dst_format);
+}
+
 // Canonical srcA tile-descriptor baseline programmed by configure_unpack_AB.
 // Per-op uninits restore the tile descriptor to this state.
 //
@@ -971,10 +982,15 @@ inline void wait_for_dest_available()
     t6_semaphore_wait_on_max<p_stall::STALL_UNPACK>(semaphore::UNPACK_TO_DEST);
 }
 
-inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
+// Restore srcA channel-1 Z-stride to the canonical baseline derived from unpack_dst_format.
+// This pairs with set_dst_write_addr to bracket the unpack-to-dest section without snapshotting
+// the prior register value into a GPR (per tt-llk#1015: each op restores to a documented
+// baseline rather than preserving caller-side state).
+inline void unpack_to_dest_tile_done(std::uint32_t &context_id, const std::uint32_t unpack_dst_format)
 {
     t6_semaphore_post<p_stall::UNPACK0>(semaphore::UNPACK_TO_DEST);
-    TTI_WRCFG(p_gpr_unpack::UNPACK_STRIDE, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Restore unpack stride
+    TT_SETDMAREG(0, LOWER_HALFWORD(canonical_unpA_z_stride(unpack_dst_format) << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Restore canonical Z-stride
     // Restore config context
     if (context_id == 0)
     {
@@ -991,13 +1007,12 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
 
 inline void set_dst_write_addr(const std::uint32_t &context_id, const std::uint32_t &unpack_dst_format)
 {
-    std::uint32_t dst_byte_addr = 16 * (4 + mailbox_read(ThreadId::MathThreadId));  // Apply fixed offset of 4*16 to dest address
-    TTI_SETC16(SRCA_SET_Base_ADDR32, 0x0);                                          // Disable address bit swizzle
-    TTI_RDCFG(p_gpr_unpack::UNPACK_STRIDE, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Save current stride
-    std::uint32_t unpA_ch1_x_stride = datum_size_in_bytes(unpack_dst_format);
-    std::uint32_t unpA_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpA_ch1_x_stride;
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_ch1_z_stride << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
-    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Set unpack stride
+    std::uint32_t dst_byte_addr = 16 * (4 + mailbox_read(ThreadId::MathThreadId)); // Apply fixed offset of 4*16 to dest address
+    TTI_SETC16(SRCA_SET_Base_ADDR32, 0x0);                                         // Disable address bit swizzle
+    // Set unpacker Z-stride to the canonical baseline for unpack_dst_format. Paired with
+    // unpack_to_dest_tile_done's canonical restore; no GPR snapshot of the prior value.
+    TT_SETDMAREG(0, LOWER_HALFWORD(canonical_unpA_z_stride(unpack_dst_format) << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32);
     if (context_id == 0)
     {
         cfg_reg_rmw_tensix<THCON_SEC0_REG2_Unpack_if_sel_cntx0_RMW>(1);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -213,6 +213,23 @@ inline void enable_int8_fpu_math()
  * \param unpack_dst_format Unpacker output (register) data format.
  * \return true if both formats are Int32 or Float32; false otherwise.
  */
+// Canonical srcA channel-1 X stride in bytes, derived from the unpacker dst format.
+// Used to compute the canonical Y/Z strides programmed into UNP0_ADDR_CTRL_*.
+inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpack_dst_format)
+{
+    return (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float32) ? 4 : (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float16) ? 2 : 1;
+}
+
+// Canonical srcA channel-1 Y stride: full-tile sequential row step.
+//
+// This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
+// so it serves as the documented baseline that operations which mutate Y-stride
+// (untilize, tilizeA_B) restore on uninit. See tt-llk#1015.
+inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+{
+    return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
+}
+
 inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
 {
     const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
@@ -773,6 +790,12 @@ inline void configure_unpack_AB(
     cfg[UNP1_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] =
         (0 << UNP1_ADDR_CTRL_ZW_REG_1_Wstride_SHAMT) |
         (unpB_ch1_z_stride << UNP1_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT); // Z and W(not used) stride for dest address (ch1)
+
+    // Canonical Y-stride for srcA (ch1). Programmed here so per-op inits that mutate Y-stride
+    // (untilize, tilizeA_B) can deterministically restore this baseline on uninit instead of
+    // snapshotting the previous value. See tt-llk#1015.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+        canonical_unpA_y_stride(unpA_dst_format_masked, unpA_face_r_dim));
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -231,7 +231,7 @@ inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpac
 //
 // This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
 // so it serves as the documented baseline that operations which mutate Y-stride
-// (untilize, tilizeA_B) restore on uninit. See tt-llk#1015.
+// (e.g. tilizeA_B) must restore on uninit.
 inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
 {
     return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
@@ -790,9 +790,9 @@ inline void configure_unpack_AB(
         (0 << UNP1_ADDR_CTRL_ZW_REG_1_Wstride_SHAMT) |
         (unpB_ch1_z_stride << UNP1_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT); // Z and W(not used) stride for dest address (ch1)
 
-    // Canonical Y-stride for srcA (ch1). Programmed here so per-op inits that mutate Y-stride
-    // (untilize, tilizeA_B) can deterministically restore this baseline on uninit instead of
-    // snapshotting the previous value. See tt-llk#1015.
+    // Establish the canonical Y-stride baseline for srcA (ch1) here, so per-op inits that
+    // mutate Y-stride (e.g. tilizeA_B) can deterministically restore this baseline on uninit
+    // rather than snapshotting the previous register value into a GPR.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
         canonical_unpA_y_stride(unpA_dst_format_masked, unpA_face_r_dim));
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_topk_xl_copy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_A_topk_xl_copy.h
@@ -91,7 +91,7 @@ inline void _llk_unpack_topk_xl_copy_(
 
     if (is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        unpack_to_dest_tile_done(unp_cfg_context);
+        unpack_to_dest_tile_done(unp_cfg_context, unpack_dst_format);
     }
 
     switch_config_context(unp_cfg_context);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -430,7 +430,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     {
         if (is_32bit_input(unpack_src_format, unpack_dst_format))
         {
-            unpack_to_dest_tile_done(unp_cfg_context);
+            unpack_to_dest_tile_done(unp_cfg_context, unpack_dst_format);
         }
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -183,9 +183,9 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
-        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits (untilize, tilizeA_B)
-        // mutate this register; configure_unpack_AB and this reconfig are the only places that
-        // commit the canonical value. See tt-llk#1015.
+        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits that mutate
+        // this register (e.g. tilizeA_B) restore back to this baseline on uninit, so the
+        // baseline must be re-committed whenever the dst format changes.
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
             canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -194,7 +194,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
 
         // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (unpack_num_faces << 16));
     }
 }
 
@@ -261,10 +261,10 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         cfg_reg_rmw_tensix<UNP1_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Set X-dim to face_r_dim * FACE_C_DIM
-        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>((unpack_face_r_dim * FACE_C_DIM) << 16);
+        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, TILE_DESC_UPPER_HALFWORD_MASK>((unpack_face_r_dim * FACE_C_DIM) << 16);
 
         // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (unpack_num_faces << 16));
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -177,11 +177,10 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        std::uint32_t unpack_ch1_x_stride = canonical_unpA_x_stride(unpack_dst_format);
-        // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
-        // so we want to keep standard stride for one face
-        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
-        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
+        // Re-establish the canonical Z-stride baseline for srcA. Per-op brackets that mutate
+        // this register (unpack-to-dest in unpack_A / unpack_tilize) restore to this baseline,
+        // so it must be re-committed whenever the dst format changes.
+        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(canonical_unpA_z_stride(unpack_dst_format));
 
         // Re-establish the canonical Y-stride baseline for srcA. Per-op inits that mutate
         // this register (e.g. tilizeA_B) restore back to this baseline on uninit, so the

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -177,11 +177,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        std::uint32_t unpack_ch1_x_stride = datum_size_in_bytes(unpack_dst_format);
+        std::uint32_t unpack_ch1_x_stride = canonical_unpA_x_stride(unpack_dst_format);
         // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
         // so we want to keep standard stride for one face
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
+
+        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits (untilize, tilizeA_B)
+        // mutate this register; configure_unpack_AB and this reconfig are the only places that
+        // commit the canonical value. See tt-llk#1015.
+        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+            canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -186,7 +186,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // this register (e.g. tilizeA_B) restore back to this baseline on uninit, so the
         // baseline must be re-committed whenever the dst format changes.
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-            canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
+            canonical_unpA_y_stride(unpack_dst_format));
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -555,9 +555,9 @@ inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
     TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32);
     // GPR preloaded with  16 | (16 << 16)}
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
-    // Restore canonical srcA Y-stride. _llk_unpack_tilizeA_B_init_ mutates it to a per-op value
-    // (SCALE_DATUM_SIZE(unpack_dst_format, FACE_C_DIM)); restore to the baseline programmed by
-    // configure_unpack_AB so this op does not leak state to the next op. See tt-llk#1015.
+    // Restore canonical srcA Y-stride. _llk_unpack_tilizeA_B_init_ mutates it to a per-op
+    // value (SCALE_DATUM_SIZE(unpack_dst_format, FACE_C_DIM)); restoring the baseline
+    // programmed by configure_unpack_AB keeps this op from leaking Y-stride to the next op.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
         canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
     TTI_NOP;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -295,11 +296,15 @@ inline void _llk_unpack_tilize_(
  * reprogrammed by the next operation's init (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @param num_faces: Number of faces, used to restore the Z dimension, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tile geometry; total_num_faces() restores the Z dimension (valid values
+ *                      = <1, 2, 4>) and face_r_dim restores the canonical Tile_x_dim.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
+    const std::uint32_t num_faces  = tensor_shape.total_num_faces();
+    const std::uint32_t face_r_dim = tensor_shape.face_r_dim;
+
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -134,9 +134,9 @@ inline void _llk_unpack_tilize_init_(
         const std::uint32_t Tile_z_dim = 1;
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(Tile_x_dim | (Tile_x_dim << 16));
         // Set x-dim to cover entire tile (face_r_dim * num_faces * FACE_C_DIM)
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>(0 | (Tile_x_dim << 16));
+        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (Tile_x_dim << 16));
         // Set z-dim to 1 as X dim is set to cover the entire tile, so no need to iterate over faces.
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (Tile_z_dim << 16));
+        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (Tile_z_dim << 16));
 
         // Set x-end for Unpackers to (face_r_dim * num_faces * FACE_C_DIM - 1)
         TT_SETADCXX(p_setadc::UNP0, Tile_x_dim - 1, 0x0);
@@ -308,8 +308,8 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
     // per-context override in Tile_x_dim_cntx0 (set below) is what the unpacker actually
     // consumes for srcA. The non-8-bit init path mutates X-dim (to face_r_dim*num_faces*FACE_C_DIM)
     // so it must be reverted here too to keep the operand operation-restorable.
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 16, 0xffff0000>(CANONICAL_UNPA_TILE_X_DIM);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, TILE_DESC_UPPER_HALFWORD_MASK>(num_faces);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 16, TILE_DESC_UPPER_HALFWORD_MASK>(CANONICAL_UNPA_TILE_X_DIM);
 
     // The unpack-config[0] write below also clears tileize_mode, haloize_mode, and the
     // other word-0 fields back to 0, mirroring what the zero-initialised config struct

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -277,7 +277,9 @@ inline void _llk_unpack_tilize_(
 
         if (unpack_to_dest)
         {
-            unpack_to_dest_tile_done(unp_cfg_context);
+            // Pair with set_dst_write_addr above (both keyed on unpack_src_format), so the
+            // canonical Z-stride restore matches the value programmed on entry.
+            unpack_to_dest_tile_done(unp_cfg_context, unpack_src_format);
         }
 
         // Switch unpacker config context

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -555,5 +555,10 @@ inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
     TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32);
     // GPR preloaded with  16 | (16 << 16)}
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
+    // Restore canonical srcA Y-stride. _llk_unpack_tilizeA_B_init_ mutates it to a per-op value
+    // (SCALE_DATUM_SIZE(unpack_dst_format, FACE_C_DIM)); restore to the baseline programmed by
+    // configure_unpack_AB so this op does not leak state to the next op. See tt-llk#1015.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+        canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
     TTI_NOP;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -298,7 +298,7 @@ inline void _llk_unpack_tilize_(
  * @param num_faces: Number of faces, used to restore the Z dimension, valid values = <1, 2, 4>.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
@@ -548,7 +548,7 @@ inline void _llk_unpack_tilizeA_B_(
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -301,10 +301,17 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
 
-    // Revert Z dim value back to default.
-    const std::uint32_t Tile_z_dim = num_faces;
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(Tile_z_dim);
+    // Restore tile-descriptor Z and X dim to the canonical baseline programmed by
+    // configure_unpack_AB. Z-dim equals the operand's num_faces; X-dim is 0 because the
+    // per-context override in Tile_x_dim_cntx0 (set below) is what the unpacker actually
+    // consumes for srcA. The non-8-bit init path mutates X-dim (to face_r_dim*num_faces*FACE_C_DIM)
+    // so it must be reverted here too to keep the operand operation-restorable.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 16, 0xffff0000>(CANONICAL_UNPA_TILE_X_DIM);
 
+    // The unpack-config[0] write below also clears tileize_mode, haloize_mode, and the
+    // other word-0 fields back to 0, mirroring what the zero-initialised config struct
+    // produces in configure_unpack_AB.
     unpack_config_u config = {0};
 
     config.f.out_data_format = unpack_dst_format;
@@ -314,8 +321,10 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     // Load unpack config[0]
     TTI_WRCFG(p_gpr_unpack::TMP0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32);
-    // GPR preloaded with  16 | (16 << 16)}
-    TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
+    // Restore Tile_x_dim_cntx0 to the canonical face_dim-derived value. The previous
+    // FACE_DIM_16x16 GPR was correct only for face_r_dim=16; tiny tiles need a
+    // face_r_dim-aware value to match the baseline programmed by configure_unpack_AB.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(canonical_unpA_tile_x_dim_cntx(face_r_dim));
     TTI_NOP;
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -548,7 +548,7 @@ inline void _llk_unpack_tilizeA_B_(
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 
@@ -570,6 +570,6 @@ inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format,
     // value (SCALE_DATUM_SIZE(unpack_dst_format, FACE_C_DIM)); restoring the baseline
     // programmed by configure_unpack_AB keeps this op from leaking Y-stride to the next op.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-        canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
+        canonical_unpA_y_stride(unpack_dst_format));
     TTI_NOP;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -147,6 +147,10 @@ inline void _llk_unpack_untilize_init_(const std::uint32_t unpack_dst_format, co
  */
 inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
 {
+    const DataFormat dst_format           = static_cast<DataFormat>(unpack_dst_format & 0x3);
+    const std::uint32_t unpA_ch1_x_stride = dst_format == DataFormat::Float32 ? 4 : dst_format == DataFormat::Float16 ? 2 : 1;
+    const std::uint32_t unpA_ch1_y_stride = FACE_C_DIM * face_r_dim * unpA_ch1_x_stride;
+
     // Check that unpacker is done (all contexts freed up) before starting hw configuration
     wait_for_idle();
 
@@ -159,9 +163,7 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);
-    // Restore canonical srcA Y-stride established by configure_unpack_AB. See tt-llk#1015.
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-        canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
 
     TTI_NOP;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -147,12 +147,6 @@ inline void _llk_unpack_untilize_init_(const std::uint32_t unpack_dst_format, co
  */
 inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
 {
-    llk::san::operation_uninit<llk::san::Operation::UnpackUntilize>();
-
-    const DataFormat dst_format           = static_cast<DataFormat>(unpack_dst_format & 0x3);
-    const std::uint32_t unpA_ch1_x_stride = dst_format == DataFormat::Float32 ? 4 : dst_format == DataFormat::Float16 ? 2 : 1;
-    const std::uint32_t unpA_ch1_y_stride = FACE_C_DIM * face_r_dim * unpA_ch1_x_stride;
-
     // Check that unpacker is done (all contexts freed up) before starting hw configuration
     wait_for_idle();
 
@@ -165,7 +159,9 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
+    // Restore canonical srcA Y-stride established by configure_unpack_AB. See tt-llk#1015.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+        canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
 
     TTI_NOP;
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
@@ -22,35 +22,37 @@ struct p_gpr
 // Unpack GPR thread
 struct p_gpr_unpack
 {
-    constexpr static std::uint32_t OPERAND_BASE_ADDR       = 4;      // Operand base address used by zero buffer function
-    constexpr static std::uint32_t OPERAND_OFFSET_ADDR     = 5;      // Operand offset address used by zero buffer function
-    constexpr static std::uint32_t ZERO_0                  = 8;      // Zero data
-    constexpr static std::uint32_t ZERO_1                  = 9;      // Zero data
-    constexpr static std::uint32_t ZERO_2                  = 10;     // Zero data
-    constexpr static std::uint32_t ZERO_3                  = 11;     // Zero data
-    constexpr static std::uint32_t TMP0                    = 12;     // Temp data
-    constexpr static std::uint32_t TMP1                    = 13;     // Temp data
-    constexpr static std::uint32_t TILE_SIZE               = 14;     // Tile size
-    constexpr static std::uint32_t TILE_OFFSET             = 15;     // Tile offset
-    constexpr static std::uint32_t L1_BUFFER_ADDR          = 17;     // Holds address of fixed l1 buffer used for reduce in1
-    constexpr static std::uint32_t TMP_LO                  = 18;     // Temp data. Upper 16-bits always 0
-    constexpr static std::uint32_t TMP_HI                  = 19;     // Temp data. Lower 16-bits always 0
-    constexpr static std::uint32_t PERF_FIRST_UNP_LO       = 32;     // timestamp for first-unpack-instruction (low 32b)
-    constexpr static std::uint32_t PERF_FIRST_UNP_HI       = 33;     // timestamp for first-unpack-instruction (high 32b)
-    constexpr static std::uint32_t TILE_SIZE_A             = 36;     // Holds tile size for unpacker 0
-    constexpr static std::uint32_t TILE_SIZE_B             = 37;     // Holds tile size for unpacker 1
-    constexpr static std::uint32_t KT_DIM                  = 38;     // Holds matmul kt_dim
-    constexpr static std::uint32_t FACE_DIM_16x16          = 40;     // Holds face dimension (16x16)
-    constexpr static std::uint32_t FACE_DIM_8x16           = 41;     // Holds face dimension (8x16)
-    constexpr static std::uint32_t FACE_DIM_4x16           = 42;     // Holds face dimension (4x16)
-    constexpr static std::uint32_t FACE_DIM_2x16           = 43;     // Holds face dimension (2x16)
-    constexpr static std::uint32_t FACE_DIM_1x16           = 44;     // Holds face dimension (1x16)
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_0 = 45;     // num tiles for input operands 0-1
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_1 = 46;     // num tiles for input operands 2-3
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_2 = 47;     // num tiles for input operands 4-5
-    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48;     // num tiles for input operands 6-7
-    constexpr static std::uint32_t UNPACK_STRIDE           = 52;     // Used to save/restore unpack A stride (UNP0_ADDR_CTRL_ZW_REG_1_Zstride register)
-                                                                     // before/after unpacking directly to dest
+    constexpr static std::uint32_t OPERAND_BASE_ADDR       = 4;  // Operand base address used by zero buffer function
+    constexpr static std::uint32_t OPERAND_OFFSET_ADDR     = 5;  // Operand offset address used by zero buffer function
+    constexpr static std::uint32_t ZERO_0                  = 8;  // Zero data
+    constexpr static std::uint32_t ZERO_1                  = 9;  // Zero data
+    constexpr static std::uint32_t ZERO_2                  = 10; // Zero data
+    constexpr static std::uint32_t ZERO_3                  = 11; // Zero data
+    constexpr static std::uint32_t TMP0                    = 12; // Temp data
+    constexpr static std::uint32_t TMP1                    = 13; // Temp data
+    constexpr static std::uint32_t TILE_SIZE               = 14; // Tile size
+    constexpr static std::uint32_t TILE_OFFSET             = 15; // Tile offset
+    constexpr static std::uint32_t L1_BUFFER_ADDR          = 17; // Holds address of fixed l1 buffer used for reduce in1
+    constexpr static std::uint32_t TMP_LO                  = 18; // Temp data. Upper 16-bits always 0
+    constexpr static std::uint32_t TMP_HI                  = 19; // Temp data. Lower 16-bits always 0
+    constexpr static std::uint32_t PERF_FIRST_UNP_LO       = 32; // timestamp for first-unpack-instruction (low 32b)
+    constexpr static std::uint32_t PERF_FIRST_UNP_HI       = 33; // timestamp for first-unpack-instruction (high 32b)
+    constexpr static std::uint32_t TILE_SIZE_A             = 36; // Holds tile size for unpacker 0
+    constexpr static std::uint32_t TILE_SIZE_B             = 37; // Holds tile size for unpacker 1
+    constexpr static std::uint32_t KT_DIM                  = 38; // Holds matmul kt_dim
+    constexpr static std::uint32_t FACE_DIM_16x16          = 40; // Holds face dimension (16x16)
+    constexpr static std::uint32_t FACE_DIM_8x16           = 41; // Holds face dimension (8x16)
+    constexpr static std::uint32_t FACE_DIM_4x16           = 42; // Holds face dimension (4x16)
+    constexpr static std::uint32_t FACE_DIM_2x16           = 43; // Holds face dimension (2x16)
+    constexpr static std::uint32_t FACE_DIM_1x16           = 44; // Holds face dimension (1x16)
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_0 = 45; // num tiles for input operands 0-1
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_1 = 46; // num tiles for input operands 2-3
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_2 = 47; // num tiles for input operands 4-5
+    constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48; // num tiles for input operands 6-7
+    // Slot 52 was the legacy UNPACK_STRIDE GPR used to snapshot/restore the channel-1 Z-stride
+    // around unpack-to-dest. Removed in favor of canonical_unpA_z_stride() in the bracket pair
+    // (set_dst_write_addr / unpack_to_dest_tile_done). See tt-llk#1015. Slot is reserved as
+    // free until the next unpacker GPR consolidation.
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_0   = 54; // Save unpack state before tilizer is enabled for quick restore
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_1   = 55;
     constexpr static std::uint32_t SR_UNPACK_UNTILIZER_STATE_0 = 56; // Save unpack state before tilizer is enabled for quick restore

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_gpr_map.h
@@ -51,8 +51,8 @@ struct p_gpr_unpack
     constexpr static std::uint32_t PERF_UNPACK_NUM_TILES_3 = 48; // num tiles for input operands 6-7
     // Slot 52 was the legacy UNPACK_STRIDE GPR used to snapshot/restore the channel-1 Z-stride
     // around unpack-to-dest. Removed in favor of canonical_unpA_z_stride() in the bracket pair
-    // (set_dst_write_addr / unpack_to_dest_tile_done). See tt-llk#1015. Slot is reserved as
-    // free until the next unpacker GPR consolidation.
+    // (set_dst_write_addr / unpack_to_dest_tile_done), which recomputes the baseline instead of
+    // preserving caller-side state. Slot is reserved as free until the next unpacker GPR consolidation.
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_0   = 54; // Save unpack state before tilizer is enabled for quick restore
     constexpr static std::uint32_t SR_UNPACK_TILIZER_STATE_1   = 55;
     constexpr static std::uint32_t SR_UNPACK_UNTILIZER_STATE_0 = 56; // Save unpack state before tilizer is enabled for quick restore

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -214,6 +214,13 @@ inline void enable_int8_fpu_math()
  * \param unpack_dst_format Unpacker output (register) data format.
  * \return true if both formats are Int32 or Float32; false otherwise.
  */
+inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
+    const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
+    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
+}
+
 // Canonical srcA channel-1 X stride in bytes, derived from the unpacker dst format.
 // Used to compute the canonical Y/Z strides programmed into UNP0_ADDR_CTRL_*.
 inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpack_dst_format)
@@ -231,13 +238,6 @@ inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpac
     return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
 }
 
-inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
-{
-    const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
-    const DataFormat output_df = static_cast<DataFormat>(masked_data_format(unpack_dst_format));
-    return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
-}
-
 /*
  * Single source of truth for whether _llk_unpack_A_ takes the "unpack to dest" (SrcA -> DEST) path.
  * It is only taken for genuinely 32-bit input; otherwise the MOP falls through to the normal/broadcast
@@ -252,7 +252,6 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
 {
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
-
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -274,6 +274,9 @@ inline constexpr std::uint32_t canonical_unpA_z_stride(const std::uint32_t unpac
 constexpr std::uint32_t CANONICAL_UNPA_TILE_Y_DIM = 1;
 constexpr std::uint32_t CANONICAL_UNPA_TILE_X_DIM = 0;
 
+// Mask for the upper halfword of a TileDescriptor config word, where the X/Y/Z dim fields live.
+constexpr std::uint32_t TILE_DESC_UPPER_HALFWORD_MASK = 0xffff0000;
+
 // Canonical Tile_x_dim_cntx0 word: face_dim packed into both cntx0 (low 16) and cntx1 (high 16),
 // where face_dim = face_r_dim * FACE_C_DIM. configure_unpack_AB programs this value.
 inline constexpr std::uint32_t canonical_unpA_tile_x_dim_cntx(const std::uint32_t face_r_dim)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -228,14 +228,15 @@ inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpac
     return (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float32) ? 4 : (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float16) ? 2 : 1;
 }
 
-// Canonical srcA channel-1 Y stride: full-tile sequential row step.
+// Canonical srcA channel-1 Y stride: face row step (one face row = FACE_R_DIM datums).
 //
 // This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
 // so it serves as the documented baseline that operations which mutate Y-stride
-// (e.g. bcastA_B) must restore on uninit.
-inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+// (e.g. bcastA_B) must restore on uninit. It does not depend on the operand's face_r_dim;
+// FACE_R_DIM is the constant face row count (matches set_packer_strides and unpack_untilize).
+inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format)
 {
-    return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
+    return FACE_R_DIM * canonical_unpA_x_stride(unpack_dst_format);
 }
 
 /*
@@ -813,7 +814,7 @@ inline void configure_unpack_AB(
     // mutate Y-stride (e.g. bcastA_B) can deterministically restore this baseline on uninit
     // rather than snapshotting the previous register value into a GPR.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-        canonical_unpA_y_stride(unpA_dst_format, unpA_face_r_dim));
+        canonical_unpA_y_stride(unpA_dst_format));
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -252,6 +252,24 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
 {
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
+
+// Canonical srcA tile-descriptor baseline programmed by configure_unpack_AB.
+// Per-op uninits restore the tile descriptor to this state.
+//
+// Y-dim (lower 16 bits of TileDescriptor word 1): always 1.
+// X-dim (upper 16 bits of TileDescriptor word 0): 0 for srcA because Tile_x_dim_cntx0 overrides it.
+// Z-dim (upper 16 bits of TileDescriptor word 1): equals the operand's num_faces (used directly at call sites).
+constexpr std::uint32_t CANONICAL_UNPA_TILE_Y_DIM = 1;
+constexpr std::uint32_t CANONICAL_UNPA_TILE_X_DIM = 0;
+
+// Canonical Tile_x_dim_cntx0 word: face_dim packed into both cntx0 (low 16) and cntx1 (high 16),
+// where face_dim = face_r_dim * FACE_C_DIM. configure_unpack_AB programs this value.
+inline constexpr std::uint32_t canonical_unpA_tile_x_dim_cntx(const std::uint32_t face_r_dim)
+{
+    const std::uint32_t face_dim = face_r_dim * FACE_C_DIM;
+    return face_dim | (face_dim << 16);
+}
+
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -971,9 +971,9 @@ inline void wait_for_dest_available()
 }
 
 // Restore srcA channel-1 Z-stride to the canonical baseline derived from unpack_dst_format.
-// This pairs with set_dst_write_addr to bracket the unpack-to-dest section without snapshotting
-// the prior register value into a GPR (per tt-llk#1015: each op restores to a documented
-// baseline rather than preserving caller-side state).
+// This pairs with set_dst_write_addr to bracket the unpack-to-dest section: rather than
+// snapshotting the prior register value into a GPR, we recompute the canonical baseline so the
+// restore is deterministic and order-independent.
 inline void unpack_to_dest_tile_done(std::uint32_t &context_id, const std::uint32_t unpack_dst_format)
 {
     t6_semaphore_post<p_stall::UNPACK0>(semaphore::UNPACK_TO_DEST);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -253,6 +253,17 @@ inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std
     return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
 }
 
+// Canonical srcA channel-1 Z stride: face-sized row step.
+//
+// Programmed by configure_unpack_AB and the srca data-format reconfig, and re-asserted by
+// unpack-to-dest brackets. Z-stride does not depend on operand face_r_dim; FACE_R_DIM is
+// the constant face row count because data is not stored densely in src/dest registers
+// (matches the explicit comment in _llk_unpack_reconfig_data_format_srca_impl_).
+inline constexpr std::uint32_t canonical_unpA_z_stride(const std::uint32_t unpack_dst_format)
+{
+    return FACE_C_DIM * FACE_R_DIM * canonical_unpA_x_stride(unpack_dst_format);
+}
+
 // Canonical srcA tile-descriptor baseline programmed by configure_unpack_AB.
 // Per-op uninits restore the tile descriptor to this state.
 //
@@ -959,10 +970,15 @@ inline void wait_for_dest_available()
     t6_semaphore_wait_on_max<p_stall::STALL_UNPACK>(semaphore::UNPACK_TO_DEST);
 }
 
-inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
+// Restore srcA channel-1 Z-stride to the canonical baseline derived from unpack_dst_format.
+// This pairs with set_dst_write_addr to bracket the unpack-to-dest section without snapshotting
+// the prior register value into a GPR (per tt-llk#1015: each op restores to a documented
+// baseline rather than preserving caller-side state).
+inline void unpack_to_dest_tile_done(std::uint32_t &context_id, const std::uint32_t unpack_dst_format)
 {
     t6_semaphore_post<p_stall::UNPACK0>(semaphore::UNPACK_TO_DEST);
-    TTI_WRCFG(p_gpr_unpack::UNPACK_STRIDE, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Restore unpack stride
+    TT_SETDMAREG(0, LOWER_HALFWORD(canonical_unpA_z_stride(unpack_dst_format) << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Restore canonical Z-stride
     // Restore config context
     if (context_id == 0)
     {
@@ -984,13 +1000,12 @@ inline void unpack_to_dest_tile_done(std::uint32_t &context_id)
 
 inline void set_dst_write_addr(const std::uint32_t &context_id, const std::uint32_t &unpack_dst_format)
 {
-    std::uint32_t dst_byte_addr = 16 * (4 + mailbox_read(ThreadId::MathThreadId));  // Apply fixed offset of 4*16 to dest address
-    TTI_SETC16(SRCA_SET_Base_ADDR32, 0x0);                                          // Disable address bit swizzle
-    TTI_RDCFG(p_gpr_unpack::UNPACK_STRIDE, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Save current stride
-    std::uint32_t unpA_ch1_x_stride = datum_size_in_bytes(unpack_dst_format);
-    std::uint32_t unpA_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpA_ch1_x_stride;
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_ch1_z_stride << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
-    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32); // Set unpack stride
+    std::uint32_t dst_byte_addr = 16 * (4 + mailbox_read(ThreadId::MathThreadId)); // Apply fixed offset of 4*16 to dest address
+    TTI_SETC16(SRCA_SET_Base_ADDR32, 0x0);                                         // Disable address bit swizzle
+    // Set unpacker Z-stride to the canonical baseline for unpack_dst_format. Paired with
+    // unpack_to_dest_tile_done's canonical restore; no GPR snapshot of the prior value.
+    TT_SETDMAREG(0, LOWER_HALFWORD(canonical_unpA_z_stride(unpack_dst_format) << UNP0_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT), 0, LO_16(p_gpr_unpack::TMP_LO));
+    TTI_WRCFG(p_gpr_unpack::TMP_LO, p_cfg::WRCFG_32b, UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32);
     if (context_id == 0)
     {
         cfg_reg_rmw_tensix<THCON_SEC0_REG2_Unpack_if_sel_cntx0_RMW>(1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -232,7 +232,7 @@ inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpac
 //
 // This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
 // so it serves as the documented baseline that operations which mutate Y-stride
-// (untilize, bcastA_B) restore on uninit. See tt-llk#1015.
+// (e.g. bcastA_B) must restore on uninit.
 inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
 {
     return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
@@ -780,9 +780,9 @@ inline void configure_unpack_AB(
         (0 << UNP1_ADDR_CTRL_ZW_REG_1_Wstride_SHAMT) |
         (unpB_ch1_z_stride << UNP1_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT); // Z and W(not used) stride for dest address (ch1)
 
-    // Canonical Y-stride for srcA (ch1). Programmed here so per-op inits that mutate Y-stride
-    // (untilize, bcastA_B) can deterministically restore this baseline on uninit instead of
-    // snapshotting the previous value. See tt-llk#1015.
+    // Establish the canonical Y-stride baseline for srcA (ch1) here, so per-op inits that
+    // mutate Y-stride (e.g. bcastA_B) can deterministically restore this baseline on uninit
+    // rather than snapshotting the previous register value into a GPR.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
         canonical_unpA_y_stride(unpA_dst_format, unpA_face_r_dim));
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -214,6 +214,23 @@ inline void enable_int8_fpu_math()
  * \param unpack_dst_format Unpacker output (register) data format.
  * \return true if both formats are Int32 or Float32; false otherwise.
  */
+// Canonical srcA channel-1 X stride in bytes, derived from the unpacker dst format.
+// Used to compute the canonical Y/Z strides programmed into UNP0_ADDR_CTRL_*.
+inline constexpr std::uint32_t canonical_unpA_x_stride(const std::uint32_t unpack_dst_format)
+{
+    return (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float32) ? 4 : (unpack_dst_format & 0x3) == to_underlying(DataFormat::Float16) ? 2 : 1;
+}
+
+// Canonical srcA channel-1 Y stride: full-tile sequential row step.
+//
+// This is the value programmed by configure_unpack_AB and the srca data-format reconfig,
+// so it serves as the documented baseline that operations which mutate Y-stride
+// (untilize, bcastA_B) restore on uninit. See tt-llk#1015.
+inline constexpr std::uint32_t canonical_unpA_y_stride(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+{
+    return FACE_C_DIM * face_r_dim * canonical_unpA_x_stride(unpack_dst_format);
+}
+
 inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
 {
     const DataFormat input_df  = static_cast<DataFormat>(masked_data_format(unpack_src_format));
@@ -763,6 +780,12 @@ inline void configure_unpack_AB(
     cfg[UNP1_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] =
         (0 << UNP1_ADDR_CTRL_ZW_REG_1_Wstride_SHAMT) |
         (unpB_ch1_z_stride << UNP1_ADDR_CTRL_ZW_REG_1_Zstride_SHAMT); // Z and W(not used) stride for dest address (ch1)
+
+    // Canonical Y-stride for srcA (ch1). Programmed here so per-op inits that mutate Y-stride
+    // (untilize, bcastA_B) can deterministically restore this baseline on uninit instead of
+    // snapshotting the previous value. See tt-llk#1015.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+        canonical_unpA_y_stride(unpA_dst_format, unpA_face_r_dim));
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -415,7 +415,7 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     {
         if (is_32bit_input(unpack_src_format, unpack_dst_format))
         {
-            unpack_to_dest_tile_done(unp_cfg_context);
+            unpack_to_dest_tile_done(unp_cfg_context, unpack_dst_format);
         }
     }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -396,9 +396,10 @@ inline void _llk_unpack_bcastA_B_init_()
 
 inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
-    // Restore canonical srcA Y-stride established by configure_unpack_AB. _llk_unpack_bcastA_B_init_
-    // mutates Y-stride to the bcast-specific value (32); the restore here is order-independent
-    // because the canonical value is derivable from format + face_r_dim. See tt-llk#1015.
+    // Restore canonical srcA Y-stride established by configure_unpack_AB.
+    // _llk_unpack_bcastA_B_init_ mutates Y-stride to the bcast-specific value (32); the
+    // restore here is order-independent because the canonical value is derivable from
+    // format + face_r_dim, so we do not need to snapshot the previous register value.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
     TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -399,8 +399,8 @@ inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, 
     // Restore canonical srcA Y-stride established by configure_unpack_AB.
     // _llk_unpack_bcastA_B_init_ mutates Y-stride to the bcast-specific value (32); the
     // restore here is order-independent because the canonical value is derivable from
-    // format + face_r_dim, so we do not need to snapshot the previous register value.
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
+    // the dst format, so we do not need to snapshot the previous register value.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(canonical_unpA_y_stride(unpack_dst_format));
     TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -394,19 +394,13 @@ inline void _llk_unpack_bcastA_B_init_()
     _llk_unpack_bcastA_B_mop_config_();
 }
 
-/**
- * @brief Uninitialize the unpacker after the SDPA sub_bcast_row variant.
- *
- * Restores the SrcA Y stride. x-start/x-end is transient and reprogrammed by each operation's init
- * (see tt-llk#1036), so it is not restored here.
- *
- * @param y_stride: SrcA Y stride to restore.
- * @note Call @ref _llk_unpack_bcastA_B_init_ before this function.
- */
-inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2)
+inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
-    // Revisit default stride value in tt-llk#1015
-    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(y_stride);
+    // Restore canonical srcA Y-stride established by configure_unpack_AB. _llk_unpack_bcastA_B_init_
+    // mutates Y-stride to the bcast-specific value (32); the restore here is order-independent
+    // because the canonical value is derivable from format + face_r_dim. See tt-llk#1015.
+    cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(canonical_unpA_y_stride(unpack_dst_format, face_r_dim));
+    TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -394,8 +394,26 @@ inline void _llk_unpack_bcastA_B_init_()
     _llk_unpack_bcastA_B_mop_config_();
 }
 
+/**
+ * @brief Restore unpacker state after an SDPA sub_bcast_row operation.
+ *
+ * Drains the unpacker, then restores the canonical srcA Y-stride established by
+ * configure_unpack_AB (_llk_unpack_bcastA_B_init_ mutates it to the bcast-specific value 32). The
+ * restore is order-independent because the canonical value is derivable from the dst format, so no
+ * register snapshot is needed. The per-unpacker x-end datum counts are also reset to the canonical
+ * face layout; x-start/x-end is transient and reprogrammed by the next operation's init (see
+ * tt-llk#1036), so this is a deterministic safety reset rather than a required restore.
+ *
+ * @param unpack_dst_format: Destination data format used to recompute the canonical srcA Y-stride.
+ * @param tensor_shape: Tile geometry; face_r_dim sizes the canonical x-end datum count.
+ * @note Call @ref _llk_unpack_bcastA_B_init_ before this function.
+ */
 inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
+    // Drain the unpacker before touching config so an in-flight UNPACR does not read a
+    // half-updated Y-stride, mirroring the other unpack uninit paths.
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
+
     // Restore canonical srcA Y-stride established by configure_unpack_AB.
     // _llk_unpack_bcastA_B_init_ mutates Y-stride to the bcast-specific value (32); the
     // restore here is order-independent because the canonical value is derivable from

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -394,14 +394,14 @@ inline void _llk_unpack_bcastA_B_init_()
     _llk_unpack_bcastA_B_mop_config_();
 }
 
-inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t unpack_dst_format, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // Restore canonical srcA Y-stride established by configure_unpack_AB.
     // _llk_unpack_bcastA_B_init_ mutates Y-stride to the bcast-specific value (32); the
     // restore here is order-independent because the canonical value is derivable from
     // the dst format, so we do not need to snapshot the previous register value.
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(canonical_unpA_y_stride(unpack_dst_format));
-    TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
+    TT_SETADCXX(p_setadc::UNP_AB, tensor_shape.face_r_dim * FACE_C_DIM - 1, 0x0);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -179,11 +179,10 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        std::uint32_t unpack_ch1_x_stride = canonical_unpA_x_stride(unpack_dst_format);
-        // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
-        // so we want to keep standard stride for one face
-        std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
-        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
+        // Re-establish the canonical Z-stride baseline for srcA. Per-op brackets that mutate
+        // this register (unpack-to-dest in unpack_A / unpack_tilize) restore to this baseline,
+        // so it must be re-committed whenever the dst format changes.
+        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(canonical_unpA_z_stride(unpack_dst_format));
 
         // Re-establish the canonical Y-stride baseline for srcA. Per-op inits that mutate
         // this register (e.g. bcastA_B) restore back to this baseline on uninit, so the

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -185,9 +185,9 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
-        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits (untilize, bcastA_B)
-        // mutate this register; configure_unpack_AB and this reconfig are the only places that
-        // commit the canonical value. See tt-llk#1015.
+        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits that mutate
+        // this register (e.g. bcastA_B) restore back to this baseline on uninit, so the
+        // baseline must be re-committed whenever the dst format changes.
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
             canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -196,7 +196,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(face_dim | (face_dim << 16));
 
         // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+        cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (unpack_num_faces << 16));
     }
 }
 
@@ -260,10 +260,10 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         cfg_reg_rmw_tensix<UNP1_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
 
         // Set X-dim to face_r_dim * FACE_C_DIM
-        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>((unpack_face_r_dim * FACE_C_DIM) << 16);
+        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, TILE_DESC_UPPER_HALFWORD_MASK>((unpack_face_r_dim * FACE_C_DIM) << 16);
 
         // Set Z-dim to number of faces
-        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
+        cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, TILE_DESC_UPPER_HALFWORD_MASK>(0 | (unpack_num_faces << 16));
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -188,7 +188,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // this register (e.g. bcastA_B) restore back to this baseline on uninit, so the
         // baseline must be re-committed whenever the dst format changes.
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
-            canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
+            canonical_unpA_y_stride(unpack_dst_format));
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -179,11 +179,17 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
-        std::uint32_t unpack_ch1_x_stride = datum_size_in_bytes(unpack_dst_format);
+        std::uint32_t unpack_ch1_x_stride = canonical_unpA_x_stride(unpack_dst_format);
         // FACE_R_DIM constant is used here because data is not stored densely in src/dest registers
         // so we want to keep standard stride for one face
         std::uint32_t unpack_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpack_ch1_x_stride;
         cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_ZW_REG_1_Zstride_RMW>(unpack_ch1_z_stride);
+
+        // Re-establish the canonical Y-stride baseline for srcA. Per-op inits (untilize, bcastA_B)
+        // mutate this register; configure_unpack_AB and this reconfig are the only places that
+        // commit the canonical value. See tt-llk#1015.
+        cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(
+            canonical_unpA_y_stride(unpack_dst_format, unpack_face_r_dim));
 
         // Program unpacker0 per context x_dim (face size in l1)
         // Overrides value set by tile descriptor when thread override bit is set in unpack instruction

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -225,7 +225,9 @@ inline void unpack_tilize_to_dest_impl(
 
     // T6::SEMGET for context release
     t6_semaphore_get(semaphore::UNPACK_SYNC);
-    unpack_to_dest_tile_done(unp_cfg_context);
+    // Pair unpack_to_dest_tile_done with set_dst_write_addr above (both keyed on unpack_src_format),
+    // so the canonical Z-stride restore matches the value programmed on entry.
+    unpack_to_dest_tile_done(unp_cfg_context, unpack_src_format);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -532,6 +532,20 @@ inline void _llk_unpack_tilizeA_B_(
     }
 }
 
+/**
+ * @brief Restore unpacker state after a tilize operation.
+ *
+ * Drains the unpacker, reverts the tile-descriptor Y/Z dimensions to the canonical operand
+ * baseline programmed by configure_unpack_AB, rewrites the unpack config (clearing tilize mode)
+ * and restores the face_r_dim-aware canonical Tile_x_dim so subsequent ops see a normal tile
+ * layout. x-start/x-end is transient and reprogrammed by the next operation's init (see
+ * tt-llk#1036), so it is not restored here.
+ *
+ * @param unpack_dst_format: Destination data format to restore in the unpack config.
+ * @param tensor_shape: Tile geometry; total_num_faces() restores the descriptor Z dimension
+ *                      (valid values = <1, 2, 4>) and face_r_dim restores the canonical Tile_x_dim.
+ * @note Call @ref _llk_unpack_tilize_init_ before this function.
+ */
 inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     const std::uint32_t num_faces  = tensor_shape.total_num_faces();

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -529,29 +529,19 @@ inline void _llk_unpack_tilizeA_B_(
     }
 }
 
-/**
- * @brief Restore unpacker state after a tilize operation.
- *
- * Reverts the tile descriptor Y and Z dimensions to defaults and rewrites the unpack config
- * (clearing tilize mode) so subsequent ops see a normal tile layout. x-start/x-end is transient
- * and reprogrammed by each operation's init (see tt-llk#1036), so it is not restored here.
- *
- * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @note Call @ref _llk_unpack_tilize_init_ before this function.
- */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim)
 {
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 
-    // Revert Z and Y dim value back to default:
-    // THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1 - word 1 of the same-named register
-    // y-dim sits in lower 16 bits and is set to 1 by default
-    // z-dim sits in upper 16 bits and is set to unpA_num_faces which is 4 by default
-    // TODO NC: Make this configurable and restored to a default operand state under tt-llk#1161
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(4);
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0x0000ffff>(1);
+    // Restore tile-descriptor Y/Z dim to the canonical operand baseline programmed by
+    // configure_unpack_AB. Y-dim is always 1, Z-dim equals the operand's num_faces.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0x0000ffff>(CANONICAL_UNPA_TILE_Y_DIM);
 
+    // The unpack-config[0] write below also clears tileize_mode, haloize_mode, and the
+    // other word-0 fields back to 0, mirroring what the zero-initialised config struct
+    // produces in configure_unpack_AB.
     unpack_config_u config   = {0};
     config.f.out_data_format = unpack_dst_format;
     config.f.throttle_mode   = 2;
@@ -559,13 +549,14 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format)
     TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(p_gpr_unpack::TMP0));
     TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG2_Out_data_format_ADDR32 + 0 - THCON_CFGREG_BASE_ADDR32,
                  p_gpr_unpack::TMP0); // Load unpack config[0]
-    TTI_REG2FLOP(
-        1,
-        0,
-        0,
-        0,
-        THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32,
-        p_gpr_unpack::FACE_DIM_16x16); // GPR preloaded with  16 | (16 << 16)}
+
+    // Restore Tile_x_dim_cntx0 to the canonical face_dim-derived value. The previous
+    // FACE_DIM_16x16 GPR was correct only for face_r_dim=16; tiny tiles need a
+    // face_r_dim-aware value to match the baseline programmed by configure_unpack_AB.
+    const std::uint32_t canonical_x_dim_cntx = canonical_unpA_tile_x_dim_cntx(face_r_dim);
+    TT_SETDMAREG(0, LOWER_HALFWORD(canonical_x_dim_cntx), 0, LO_16(p_gpr_unpack::TMP0));
+    TT_SETDMAREG(0, UPPER_HALFWORD(canonical_x_dim_cntx), 0, HI_16(p_gpr_unpack::TMP0));
+    TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_unpack::TMP0);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -531,7 +531,7 @@ inline void _llk_unpack_tilizeA_B_(
     }
 }
 
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -531,8 +532,11 @@ inline void _llk_unpack_tilizeA_B_(
     }
 }
 
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
+    const std::uint32_t num_faces  = tensor_shape.total_num_faces();
+    const std::uint32_t face_r_dim = tensor_shape.face_r_dim;
+
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -538,7 +538,7 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 
     // Restore tile-descriptor Y/Z dim to the canonical operand baseline programmed by
     // configure_unpack_AB. Y-dim is always 1, Z-dim equals the operand's num_faces.
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, TILE_DESC_UPPER_HALFWORD_MASK>(num_faces);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0x0000ffff>(CANONICAL_UNPA_TILE_Y_DIM);
 
     // The unpack-config[0] write below also clears tileize_mode, haloize_mode, and the


### PR DESCRIPTION
### PR Category
Solution for https://github.com/tenstorrent/tt-llk/issues/1015

### Summary
unified untilize init and uninit calls accross BH and WH devices
configure_unpack_AB now sets strides to their canonical values at the beginning regarding data formats passed
Uninits then revert strides when the op is finished

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/unpacker_strides)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/unpacker_strides)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/unpacker_strides)