### PR TITLE
[Bug fix] test_bcast.cpp: qualify ELW* enumerators with EltwiseBinaryType::

### DIFF
--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -60,7 +60,8 @@ const char* get_compute_name(BcastDim::Enum bcast_dim) {
 
 const char* bdim_to_log_string[] = {"", "BCAST_H", "BCAST_W", "", "BCAST_HW"};
 const char* op_id_to_op_define[] = {"add_tiles_bcast", "sub_tiles_bcast", "mul_tiles_bcast"};
-const char* op_id_to_llkop_define[] = {"ELWADD", "ELWSUB", "ELWMUL"};
+const char* op_id_to_llkop_define[] = {
+    "EltwiseBinaryType::ELWADD", "EltwiseBinaryType::ELWSUB", "EltwiseBinaryType::ELWMUL"};
 const char* bdim_to_llkdim_define[] = {"", "BroadcastType::ROW", "BroadcastType::COL", "", "BroadcastType::SCALAR"};
 const char* op_id_to_op_name[] = {"ADD", "SUB", "MUL"};
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
PR #44619 converted `EltwiseBinaryType` to a scoped `enum class` on Wormhole and Blackhole, but `tests/tt_metal/tt_metal/test_bcast.cpp` was missed: it still emitted bare `"ELWADD"`, `"ELWSUB"`, `"ELWMUL"` strings as the host-side `BCAST_LLKOP` kernel define. With the scoped enum, the generated `init_bcast<BCAST_LLKOP, ...>` instantiation in `tests/tt_metal/tt_metal/test_kernels/compute/bcast_{h,w,hw}.cpp` fails to compile with:

```
'ELWMUL' was not declared in this scope; did you mean 'ckernel::EltwiseBinaryType::ELWMUL'?
```

The kernel-side build error is then mishandled and `unit_tests_legacy` SIGSEGVs, which is exactly what we saw on all four `runtime_sd_legacy` jobs in [(Runtime) Unit Tests #155](https://github.com/tenstorrent/tt-metal/actions/runs/26352899880) (`wh_n150_civ2`, `wh_n300_civ2`, `bh_p150b_civ2`, `bh_p100a_civ2_viommu` — all exit 139 in `MeshDeviceSingleCardFixture.BcastHWMul`).

This change qualifies the strings to `"EltwiseBinaryType::ELWADD/SUB/MUL"`, matching the sibling LLK test (`tests/tt_metal/tt_metal/llk/test_broadcast.cpp:71-73`) and the production define map (`ttnn/cpp/ttnn/operations/data_movement/bcast/bcast_types.cpp:13`), both of which were already updated in #44619.

### Notes for reviewers
- One-line behavior change: only the strings emitted into the kernel build's `defines_generated.h` change.
- Verified locally on a Blackhole P150: `unit_tests_legacy --gtest_filter='MeshDeviceSingleCardFixture.Bcast*'` now passes 9/9 (including `BcastHWMul`, the one that was crashing).
- Pre-commit hooks (clang-format, etc.) all pass.
- Sibling files were already correct; only this test was missed in #44619.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-test-bcast-eltwise-binary-type-scoping)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-test-bcast-eltwise-binary-type-scoping)