### PR TITLE
Remove dependency on debug bit 11 for typecast from uint16 to uint32/fp32

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -56,7 +56,8 @@ inline void calculate_typecast_uint_to_uint8() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
-            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+            TTI_SFPAND(0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
         } else {
             TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         }
@@ -179,6 +180,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
+    sfpi::vConstIntPrgm1 = 0x0000FFFF;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -57,7 +57,8 @@ inline void calculate_typecast_uint_to_uint8() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
-            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+            TTI_SFPAND(0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
         } else {
             TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         }
@@ -180,6 +181,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
+    sfpi::vConstIntPrgm1 = 0x0000FFFF;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -270,35 +270,15 @@ inline void _calculate_typecast_fp32_to_fp16b_()
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_typecast_uint16_to_fp32_()
 {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round | Store   |
-    // - | ---- | ----------------- | --- | ----- | ------- |
-    // 0 | [v]  |                   |     |       |         |
-    // 0 | ...  | [v] L16 = cast(v) |     |       |         |
-    // 0 | ...  |                   |     |       | [v] L16 |
-
-    constexpr int v = p_sfpu::LREG0;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -477,30 +457,14 @@ inline void _calculate_typecast_uint32_to_fp32_()
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_typecast_uint16_to_uint32_()
 {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple | MAD | Round | Store |
-    // - | ---- | ------ | --- | ----- | ----- |
-    // 0 | [v]  |        |     |       |       |
-    // 0 | ...  |        |     |       | [v]   |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
-    }
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -645,25 +609,7 @@ inline void _init_typecast_fp32_to_fp16b_()
 template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint16_to_uint32_()
 {
-#ifndef DISABLE_SFPLOADMACRO
-    {
-        constexpr std::uint32_t simple_bits = 0;
-        constexpr std::uint32_t mad_bits    = 0;
-        constexpr std::uint32_t round_bits  = 0;
-        constexpr std::uint32_t store_bits  = 0x00 | 0x00 | (0 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: INT32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -806,29 +752,7 @@ inline void _init_typecast_int32_to_fp16b_()
 template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint16_to_fp32_()
 {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits    = 0;
-        constexpr std::uint32_t round_bits  = 0;
-        constexpr std::uint32_t store_bits  = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -50,11 +50,7 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
 
     // Workaround for HW bugs:
     // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
-    // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest = is_fp32_dest_acc_en && ((srca_data_format == ckernel::to_underlying(DataFormat::UInt16)) ||
-                                                         (srcb_data_format == ckernel::to_underlying(DataFormat::UInt16)));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
+    if (int8_math_enabled)
     {
         _llk_math_dbg_feature_disable_();
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -306,9 +306,17 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }
+        else if (is_fp32_dest_acc_en && (dst_format == to_underlying(DataFormat::UInt16)))
+        {
+            // Typecasting uint16 to 32bit data, need data to be written to lower 16 bits without modification
+            // to be consumed by SFPU easily.
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
+            tmp.program();
+        }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_NORM, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_typecast.h
@@ -269,35 +269,15 @@ inline void _calculate_typecast_fp32_to_fp16b_()
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_typecast_uint16_to_fp32_()
 {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round | Store   |
-    // - | ---- | ----------------- | --- | ----- | ------- |
-    // 0 | [v]  |                   |     |       |         |
-    // 0 | ...  | [v] L16 = cast(v) |     |       |         |
-    // 0 | ...  |                   |     |       | [v] L16 |
-
-    constexpr int v = p_sfpu::LREG0;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -476,30 +456,14 @@ inline void _calculate_typecast_uint32_to_fp32_()
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_typecast_uint16_to_uint32_()
 {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple | MAD | Round | Store |
-    // - | ---- | ------ | --- | ----- | ----- |
-    // 0 | [v]  |        |     |       |       |
-    // 0 | ...  |        |     |       | [v]   |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
-    }
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -666,25 +630,7 @@ inline void _init_typecast_fp32_to_fp16b_()
 template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint16_to_uint32_()
 {
-#ifndef DISABLE_SFPLOADMACRO
-    {
-        constexpr std::uint32_t simple_bits = 0;
-        constexpr std::uint32_t mad_bits    = 0;
-        constexpr std::uint32_t round_bits  = 0;
-        constexpr std::uint32_t store_bits  = 0x00 | 0x00 | (0 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: INT32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -827,29 +773,7 @@ inline void _init_typecast_int32_to_fp16b_()
 template <bool APPROXIMATION_MODE>
 inline void _init_typecast_uint16_to_fp32_()
 {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits    = 0;
-        constexpr std::uint32_t round_bits  = 0;
-        constexpr std::uint32_t store_bits  = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -50,11 +50,7 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
 
     // Workaround for HW bugs:
     // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
-    // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest =
-        is_fp32_dest_acc_en && ((srca_data_format == to_underlying(DataFormat::UInt16)) || (srcb_data_format == to_underlying(DataFormat::UInt16)));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
+    if (int8_math_enabled)
     {
         _llk_math_dbg_feature_disable_();
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -278,9 +278,17 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }
+        else if (is_fp32_dest_acc_en && (dst_format == to_underlying(DataFormat::UInt16)))
+        {
+            // Typecasting uint16 to 32bit data, need data to be written to lower 16 bits without modification
+            // to be consumed by SFPU easily.
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
+            tmp.program();
+        }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_NORM, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/41163


### PR Category
For typecast to uint32/fp32 from uint16, the data was written to the high bits of 32 bit dest, and using debug bit hack, the high bits were read into low bits for typecast to uint32. The PR writes uint16 into low bits of 32 bit dest, then reads the low bits and clears garbage data read in high bits and then does the typecast.

### Summary
We want to get rid of debug bit 11 usage. It is causing many issues. 

### Notes for reviewers
Not removing setting of debug bit 11 totally due to SFPU reduce depending on it. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/dbg_bit_11_sfpu_typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/dbg_bit_11_sfpu_typecast)