### PR TITLE
moreh_mean_backward: register output_grad as BufferBinding to fix stale-address cache hits

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -242,17 +242,27 @@ ProgramDescriptor MorehMeanBackwardOperation::create_descriptor(
             TT_THROW("Core not in specified core ranges.");
         }
 
-        // Build reader runtime args: addr, num_tiles, offset, num_dim, then dim vectors
-        KernelDescriptor::CoreRuntimeArgs reader_rt_args;
-        reader_rt_args.push_back(output_grad.buffer()->address());
+        // Build reader runtime args: addr, num_tiles, offset, num_dim, then dim vectors.
+        // output_grad goes in via the Buffer* overload so the framework registers a
+        // BufferBinding and re-patches the address on every cache hit; otherwise the
+        // reader keeps reading the first-call address even when callers (e.g. AdamW
+        // training loops) pass a freshly-allocated output_grad each step.
+        KernelDescriptor::RTArgList reader_rt_args;
+        reader_rt_args.push_back(output_grad.buffer());
         reader_rt_args.push_back(num_tiles_per_core);
         reader_rt_args.push_back(tile_offset);
         reader_rt_args.push_back(num_dim);
-        reader_rt_args.insert(reader_rt_args.end(), output_grad_dim.begin(), output_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), input_grad_dim.begin(), input_grad_dim.end());
-        reader_rt_args.insert(reader_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+        for (uint32_t v : output_grad_dim) {
+            reader_rt_args.push_back(v);
+        }
+        for (uint32_t v : input_grad_dim) {
+            reader_rt_args.push_back(v);
+        }
+        for (uint32_t v : need_bcast_dim) {
+            reader_rt_args.push_back(v);
+        }
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+        reader_desc.emplace_runtime_args(core, reader_rt_args);
 
         writer_desc.emplace_runtime_args(core, {input_grad.buffer(), num_tiles_per_core, tile_offset});
 


### PR DESCRIPTION
## Summary

Fixes #44730 — `tt-train` `AdamWCompositeFullTest.AdamWCompositeTest` failing on Blackhole P150b after my migration in #42481.

## Root cause

In the post-migration factory, the **writer** kernel's `input_grad` was correctly converted to a `BufferBinding` via `emplace_runtime_args(core, {input_grad.buffer(), ...})`. The **reader** kernel still wrote `output_grad.buffer()->address()` as a raw `uint32_t` into its runtime arg list (because of its variable-length arg layout), with no corresponding `BufferBinding`.

The descriptor framework only re-patches addresses that are registered as `BufferBindings` on cache hits. So on every cache-hit invocation, the reader kept reading from whatever address was set on the first call, regardless of what `output_grad` the caller passed in.

## Why CI didn't catch it pre-merge

Same reason Pavle's same-class SDPA bug (8635db0bafe / #45121) was caught only by a downstream consumer test:
- Cache-miss path uses the address directly → correct on first call.
- Single-shot unit tests never exercise cache-hit, so they pass.
- The device allocator typically reuses the same slot for a freshly-allocated gradient tensor on N150, so even the cache-hit tests happen to land on the right address.
- Blackhole P150b's allocation pattern in the AdamW training loop *does* hand out a fresh address each step, so the reader points at stale memory → garbage gradient → AdamW fails to converge: `losses.back() = 0.0224 vs < 1e-3`.

## The fix

Switch the reader to `KernelDescriptor::RTArgList` and pass `output_grad.buffer()` (Buffer\*) instead of `.buffer()->address()` (uint32_t). The framework auto-registers the BufferBinding at the right arg position and re-patches the address on every cache hit. Variable-length dim vectors remain raw uint32 args.

## Test plan

- [x] Full `tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py` — 76 passed, 72 skipped on N150 (no regression).
- [x] `test_moreh_mean_backward_callback` (2-iteration cache-hit test) passes — confirms the new arg-list shape is correct; it doesn't independently reproduce the BH allocator pattern.
- [ ] tt-train `AdamWCompositeFullTest.AdamWCompositeTest` on Blackhole P150b — needs the BH lab to confirm convergence is restored. This is what nightly will catch.

## Audit follow-up

`moreh_sum_backward_program_factory.cpp:250` has the exact same pattern (reader's `output_grad.buffer()->address()` raw-pushed in a `create_descriptor`-based factory with no override callback). Not fixed in this PR per scope. If a downstream test starts failing for sum_backward in a training loop, that's where to look.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-moreh-mean-backward-buffer-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-moreh-mean-backward-buffer-binding)