### PR TITLE
#42357 [Descriptor Migration] eltwise/unary

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -38,14 +38,10 @@ struct UnaryDeviceOperation {
         std::optional<Tensor> output_tensor;
     };
 
-    struct ProgramFactory {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& output);
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -87,7 +87,7 @@ namespace ttnn::operations::unary {
 
 using namespace utils;
 
-tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_descriptor(
+tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
@@ -411,10 +411,8 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
             uint32_t o_tiles = out_shard_pages(core);
             uint32_t out_start_id = ((i / num_shards_per_width) * (out_shard_height * oWt)) +
                                     ((i % num_shards_per_width) * out_shard_width);
-            reader_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{input.buffer()->address(), in_tiles, out_start_id});
-            writer_desc.runtime_args.emplace_back(
-                core, KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), o_tiles, out_start_id});
+            reader_desc.emplace_runtime_args(core, {input.buffer(), in_tiles, out_start_id});
+            writer_desc.emplace_runtime_args(core, {output.buffer(), o_tiles, out_start_id});
             compute_desc.runtime_args.emplace_back(
                 core, KernelDescriptor::CoreRuntimeArgs{o_tiles, packed_scalar1, packed_scalar2});
         }
@@ -455,39 +453,31 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::ProgramFactory::create_des
             }
 
             if (rm_interleaved) {
-                reader_desc.runtime_args.emplace_back(
+                reader_desc.emplace_runtime_args(
                     core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input.buffer()->address(),
-                        npc,
-                        start_tile_id,
-                        chunks_per_row,
-                        input_chunk_size,
-                        input_last_chunk_size,
-                        rows_per_tile,
-                        total_rows});
-                writer_desc.runtime_args.emplace_back(
+                    {input.buffer(),
+                     npc,
+                     start_tile_id,
+                     chunks_per_row,
+                     input_chunk_size,
+                     input_last_chunk_size,
+                     rows_per_tile,
+                     total_rows});
+                writer_desc.emplace_runtime_args(
                     core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        output.buffer()->address(),
-                        npc,
-                        start_tile_id,
-                        chunks_per_row,
-                        output_chunk_size,
-                        output_last_chunk_size,
-                        rows_per_tile,
-                        total_rows});
+                    {output.buffer(),
+                     npc,
+                     start_tile_id,
+                     chunks_per_row,
+                     output_chunk_size,
+                     output_last_chunk_size,
+                     rows_per_tile,
+                     total_rows});
                 compute_desc.runtime_args.emplace_back(
                     core, KernelDescriptor::CoreRuntimeArgs{npc * chunks_per_row, packed_scalar1, packed_scalar2});
             } else {
-                reader_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        input.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
-                writer_desc.runtime_args.emplace_back(
-                    core,
-                    KernelDescriptor::CoreRuntimeArgs{
-                        output.buffer()->address(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
+                reader_desc.emplace_runtime_args(core, {input.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
+                writer_desc.emplace_runtime_args(core, {output.buffer(), npc, start_tile_id, 0u, 0u, 0u, 0u, 0u});
                 compute_desc.runtime_args.emplace_back(
                     core, KernelDescriptor::CoreRuntimeArgs{npc, packed_scalar1, packed_scalar2});
             }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -411,6 +411,7 @@ tt::tt_metal::ProgramDescriptor UnaryDeviceOperation::create_descriptor(
             uint32_t o_tiles = out_shard_pages(core);
             uint32_t out_start_id = ((i / num_shards_per_width) * (out_shard_height * oWt)) +
                                     ((i % num_shards_per_width) * out_shard_width);
+            // Compute args are scalar-only — no buffer resolution needed
             reader_desc.emplace_runtime_args(core, {input.buffer(), in_tiles, out_start_id});
             writer_desc.emplace_runtime_args(core, {output.buffer(), o_tiles, out_start_id});
             compute_desc.runtime_args.emplace_back(


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/migrate-eltwise_unary-to-program-descriptor)