### PR TITLE
[tt-train] Use fused SDPA in DeepSeek MLA

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/__init__.py
@@ -88,15 +88,17 @@ class DeepSeek(AbstractModuleBase):
 
         Args:
             tokens: Token IDs [B, 1, 1, S]
-            mask: Causal attention mask [1, 1, S, S]
+            mask: Unused. DeepSeek attention is causal-only; the fused SDPA
+                generates the causal mask on chip. Kept for the shared
+                forward(input, mask) model interface.
 
         Returns:
             Logits [B, 1, S, vocab_size]
         """
 
-        if mask is None:
-            raise ValueError("Mask is required for DeepSeek model")
-
+        # `mask` is unused: MLA is causal-only and generates its causal mask on chip
+        # (see mla.py). It is still threaded to blocks to keep the shared
+        # block(input, mask) / memory_efficient_runner call form intact.
         x = self.tok_emb(tokens)
 
         for block in self.blocks:

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -114,7 +114,9 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
 
         # ── Attention ──
-        attn = ttml.ops.attention.scaled_dot_product_attention(q_full, k_full, v, mask)
+        # MLA uses a causal mask; passing None lets the fused SDPA kernels generate it on chip
+        # and select their causal/balanced path instead of loading a materialized arbitrary mask.
+        attn = ttml.ops.attention.scaled_dot_product_attention(q_full, k_full, v, None)
 
         # ── Output ──
         attn = ttml.ops.multi_head_utils.heads_fusion(attn)  # [B, 1, S, n_heads * v_dim]

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -113,8 +113,8 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         q_full = autograd_concat([q_nope, q_pe], dim=3)  # [B, H, S, qk_head]
         k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
 
-        # ── Attention (composite path supports v_dim != qk_head) ──
-        attn = ttml.ops.attention.scaled_dot_product_attention_composite(q_full, k_full, v, mask)
+        # ── Attention ──
+        attn = ttml.ops.attention.scaled_dot_product_attention(q_full, k_full, v, mask)
 
         # ── Output ──
         attn = ttml.ops.multi_head_utils.heads_fusion(attn)  # [B, 1, S, n_heads * v_dim]

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -31,7 +31,11 @@ class MultiHeadLatentAttention(AbstractModuleBase):
       Both: -> [q_nope, q_pe] -> RoPE(q_pe) -> cat
       KV: x -> wkv_a -> [kv_latent, k_pe] -> norm(kv_latent) -> wkv_b -> split_heads
           -> [k_nope, v] + RoPE(k_pe) broadcast -> cat(k_nope, k_pe)
-      Attention: composite_SDPA(Q, K, V, mask) -> fuse_heads -> wo
+      Attention: fused causal SDPA(Q, K, V) -> fuse_heads -> wo
+
+    Causal-only: the fused SDPA generates the causal mask on chip, so this layer
+    takes no mask argument. A non-causal/custom mask would only matter for
+    sequence packing or padding, which the DeepSeek training path does not use.
     """
 
     def __init__(self, config, rope_params) -> None:
@@ -70,7 +74,7 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         # Output projection
         self.wo = LinearLayer(config.n_heads * config.v_head_dim, config.dim, has_bias=False)
 
-    def forward(self, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         B, _, S, _ = list(x.get_value().shape)
         n_heads = self.n_heads
         qk_nope = self.qk_nope_head_dim
@@ -113,9 +117,10 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         q_full = autograd_concat([q_nope, q_pe], dim=3)  # [B, H, S, qk_head]
         k_full = autograd_concat([k_nope, k_pe], dim=3)  # [B, H, S, qk_head]
 
-        # ── Attention ──
-        # MLA uses a causal mask; passing None lets the fused SDPA kernels generate it on chip
-        # and select their causal/balanced path instead of loading a materialized arbitrary mask.
+        # ── Attention (causal-only) ──
+        # None -> fused SDPA generates the causal mask on chip and takes the faster
+        # causal/balanced path (vs a materialized arbitrary mask). MLA is causal-only,
+        # so there is deliberately no mask argument; see the class docstring.
         attn = ttml.ops.attention.scaled_dot_product_attention(q_full, k_full, v, None)
 
         # ── Output ──

--- a/tt-train/sources/ttml/ttml/models/deepseek/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/transformer.py
@@ -60,7 +60,10 @@ class DeepSeekBlock(AbstractModuleBase):
         self.attn_norm = RMSNormLayer(config.dim)
         self.ffn_norm = RMSNormLayer(config.dim)
 
-    def forward(self, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
-        x = ttml.ops.binary.add(x, self.attn(self.attn_norm(x), mask))
+    def forward(self, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor = None) -> ttml.autograd.Tensor:
+        # `mask` is accepted (and unused) only to satisfy the shared block(input, mask)
+        # contract used by memory_efficient_runner. MLA is causal-only and generates its
+        # causal mask on chip, so nothing is forwarded to attention.
+        x = ttml.ops.binary.add(x, self.attn(self.attn_norm(x)))
         x = ttml.ops.binary.add(x, self.ffn(self.ffn_norm(x)))
         return x

--- a/tt-train/tests/python/test_deepseek_mla_sdpa.py
+++ b/tt-train/tests/python/test_deepseek_mla_sdpa.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused parity coverage for DeepSeek MLA fused SDPA.
+
+This intentionally avoids the full DeepSeek model path so unrelated MoE test
+failures do not mask whether MLA can use the fused SDPA op directly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import ttnn
+import ttml
+from ttml.models.deepseek import DeepSeekConfig
+from ttml.models.deepseek.autograd_ops import autograd_concat, autograd_slice, split_heads
+from ttml.models.deepseek.mla import MultiHeadLatentAttention
+
+
+SEED = 2026
+
+
+def _make_config(seq_len: int = 64) -> DeepSeekConfig:
+    return DeepSeekConfig(
+        vocab_size=64,
+        dim=64,
+        inter_dim=64,
+        moe_inter_dim=64,
+        n_layers=1,
+        n_dense_layers=1,
+        n_heads=2,
+        q_lora_rank=32,
+        kv_lora_rank=32,
+        qk_nope_head_dim=32,
+        qk_rope_head_dim=32,
+        v_head_dim=32,
+        max_seq_len=seq_len,
+        rope_theta=10000.0,
+    )
+
+
+def _make_inputs(batch_size: int = 2, seq_len: int = 64, dim: int = 64):
+    rng = np.random.default_rng(SEED)
+    x_np = rng.standard_normal((batch_size, 1, seq_len, dim), dtype=np.float32)
+    mask_np = np.tril(np.ones((seq_len, seq_len), dtype=np.float32)).reshape(1, 1, seq_len, seq_len)
+    x = ttml.autograd.Tensor.from_numpy(x_np, layout=ttnn.Layout.TILE, new_type=ttnn.DataType.BFLOAT16)
+    mask = ttml.autograd.Tensor.from_numpy(mask_np, layout=ttnn.Layout.TILE, new_type=ttnn.DataType.BFLOAT16)
+    return x, mask
+
+
+def _old_composite_forward(module: MultiHeadLatentAttention, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor):
+    B, _, S, _ = list(x.get_value().shape)
+    n_heads = module.n_heads
+    qk_nope = module.qk_nope_head_dim
+    qk_head = module.qk_head_dim
+    kv_lora = module.kv_lora_rank
+
+    if module.q_lora_rank == 0:
+        q = module.wq(x)
+    else:
+        q = module.wq_b(module.q_norm(module.wq_a(x)))
+    q = split_heads(q, n_heads)
+
+    q_nope = autograd_slice(q, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
+    q_pe = autograd_slice(q, [0, 0, 0, qk_nope], [B, n_heads, S, qk_head])
+    q_pe = ttml.ops.rope.rope(q_pe, module.rope_params)
+
+    kv_full = module.wkv_a(x)
+    kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
+    k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + module.qk_rope_head_dim])
+    k_pe = ttml.ops.rope.rope(k_pe, module.rope_params)
+    k_pe = autograd_concat([k_pe] * n_heads, dim=1)
+
+    kv_up = module.wkv_b(module.kv_norm(kv))
+    kv_up = split_heads(kv_up, n_heads)
+    k_nope = autograd_slice(kv_up, [0, 0, 0, 0], [B, n_heads, S, qk_nope])
+    v = autograd_slice(kv_up, [0, 0, 0, qk_nope], [B, n_heads, S, qk_nope + module.v_head_dim])
+
+    q_full = autograd_concat([q_nope, q_pe], dim=3)
+    k_full = autograd_concat([k_nope, k_pe], dim=3)
+    attn = ttml.ops.attention.scaled_dot_product_attention_composite(q_full, k_full, v, mask)
+    attn = ttml.ops.multi_head_utils.heads_fusion(attn)
+    return module.wo(attn)
+
+
+def _to_numpy(tensor: ttml.autograd.Tensor) -> np.ndarray:
+    return np.asarray(tensor.to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
+
+
+def _compare_arrays(a: np.ndarray, b: np.ndarray) -> dict[str, float]:
+    af = np.asarray(a, dtype=np.float32).reshape(-1)
+    bf = np.asarray(b, dtype=np.float32).reshape(-1)
+    diff = np.abs(af - bf)
+    norm_a = float(np.linalg.norm(af))
+    norm_b = float(np.linalg.norm(bf))
+    denom = norm_a * norm_b + 1e-8
+    return {
+        "abs_max": float(diff.max()),
+        "abs_mean": float(diff.mean()),
+        "cos_sim": float(np.dot(af, bf) / denom),
+        "norm_a": norm_a,
+        "norm_b": norm_b,
+    }
+
+
+def _assert_close(name: str, metrics: dict[str, float], abs_mean_limit: float = 5e-3) -> None:
+    assert metrics["abs_mean"] < abs_mean_limit, f"{name} mean abs diff too high: {metrics}"
+    assert metrics["abs_max"] < 5e-2, f"{name} max abs diff too high: {metrics}"
+
+    # Very small gradients can have unstable cosine despite BF16-sized absolute
+    # differences, so treat sub-1e-5 mean error as already close enough.
+    if metrics["abs_mean"] >= 1e-5:
+        assert metrics["cos_sim"] > 0.995, f"{name} cosine similarity too low: {metrics}"
+
+
+@pytest.fixture(autouse=True)
+def reset_graph():
+    yield
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def test_mla_fused_sdpa_matches_composite_forward_and_backward():
+    ctx = ttml.autograd.AutoContext.get_instance()
+    ctx.open_device()
+
+    try:
+        device = ctx.get_device()
+        cfg = _make_config()
+        rope_params = ttml.ops.rope.build_rope_params(cfg.max_seq_len, cfg.qk_rope_head_dim, cfg.rope_theta)
+        module = MultiHeadLatentAttention(cfg, rope_params)
+
+        ctx.set_gradient_mode(ttml.autograd.GradMode.DISABLED)
+        x, mask = _make_inputs()
+        out_composite = _old_composite_forward(module, x, mask)
+        ttnn.synchronize_device(device)
+        out_composite_np = _to_numpy(out_composite)
+        ctx.reset_graph()
+
+        x, mask = _make_inputs()
+        out_fused = module(x, mask)
+        ttnn.synchronize_device(device)
+        out_fused_np = _to_numpy(out_fused)
+        ctx.reset_graph()
+
+        _assert_close("forward", _compare_arrays(out_composite_np, out_fused_np))
+
+        ctx.set_gradient_mode(ttml.autograd.GradMode.ENABLED)
+        opt_cfg = ttml.optimizers.SGDConfig.make(0.0, 0.0, 0.0, 0.0, False)
+        zero_grad = ttml.optimizers.SGD(module.parameters(), opt_cfg)
+
+        zero_grad.zero_grad()
+        x, mask = _make_inputs()
+        loss = ttml.ops.unary.mean(_old_composite_forward(module, x, mask))
+        loss.backward(False)
+        ttnn.synchronize_device(device)
+        composite_grads = {
+            name: np.asarray(param.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
+            for name, param in module.parameters().items()
+            if param.is_grad_initialized()
+        }
+        ctx.reset_graph()
+
+        zero_grad.zero_grad()
+        x, mask = _make_inputs()
+        loss = ttml.ops.unary.mean(module(x, mask))
+        loss.backward(False)
+        ttnn.synchronize_device(device)
+        fused_grads = {
+            name: np.asarray(param.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
+            for name, param in module.parameters().items()
+            if param.is_grad_initialized()
+        }
+        ctx.reset_graph()
+
+        assert set(composite_grads) == set(fused_grads)
+        for name in sorted(composite_grads):
+            _assert_close(f"grad {name}", _compare_arrays(composite_grads[name], fused_grads[name]))
+    finally:
+        ctx.close_device()

--- a/tt-train/tests/python/test_deepseek_mla_sdpa.py
+++ b/tt-train/tests/python/test_deepseek_mla_sdpa.py
@@ -24,6 +24,7 @@ SEED = 2026
 
 
 def _make_config(seq_len: int = 64) -> DeepSeekConfig:
+    """Build a minimal DeepSeek config that exercises MLA's fused SDPA shape path."""
     return DeepSeekConfig(
         vocab_size=64,
         dim=64,
@@ -43,6 +44,7 @@ def _make_config(seq_len: int = 64) -> DeepSeekConfig:
 
 
 def _make_inputs(batch_size: int = 2, seq_len: int = 64, dim: int = 64):
+    """Create deterministic MLA activations plus the explicit mask used by the old composite path."""
     rng = np.random.default_rng(SEED)
     x_np = rng.standard_normal((batch_size, 1, seq_len, dim), dtype=np.float32)
     mask_np = np.tril(np.ones((seq_len, seq_len), dtype=np.float32)).reshape(1, 1, seq_len, seq_len)
@@ -52,6 +54,7 @@ def _make_inputs(batch_size: int = 2, seq_len: int = 64, dim: int = 64):
 
 
 def _old_composite_forward(module: MultiHeadLatentAttention, x: ttml.autograd.Tensor, mask: ttml.autograd.Tensor):
+    """Run the pre-fused MLA attention path as the reference implementation."""
     B, _, S, _ = list(x.get_value().shape)
     n_heads = module.n_heads
     qk_nope = module.qk_nope_head_dim
@@ -87,10 +90,17 @@ def _old_composite_forward(module: MultiHeadLatentAttention, x: ttml.autograd.Te
 
 
 def _to_numpy(tensor: ttml.autograd.Tensor) -> np.ndarray:
+    """Convert a TTML tensor to an fp32 numpy array for host-side comparison."""
     return np.asarray(tensor.to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
 
 
+def _grad_to_numpy(param) -> np.ndarray:
+    """Convert an initialized TTML parameter gradient to an fp32 numpy array."""
+    return np.asarray(param.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
+
+
 def _compare_arrays(a: np.ndarray, b: np.ndarray) -> dict[str, float]:
+    """Return absolute-error and cosine-similarity metrics for two arrays."""
     af = np.asarray(a, dtype=np.float32).reshape(-1)
     bf = np.asarray(b, dtype=np.float32).reshape(-1)
     diff = np.abs(af - bf)
@@ -107,6 +117,7 @@ def _compare_arrays(a: np.ndarray, b: np.ndarray) -> dict[str, float]:
 
 
 def _assert_close(name: str, metrics: dict[str, float], abs_mean_limit: float = 5e-3) -> None:
+    """Assert BF16-tolerant closeness from the metrics produced by `_compare_arrays`."""
     assert metrics["abs_mean"] < abs_mean_limit, f"{name} mean abs diff too high: {metrics}"
     assert metrics["abs_max"] < 5e-2, f"{name} max abs diff too high: {metrics}"
 
@@ -118,11 +129,13 @@ def _assert_close(name: str, metrics: dict[str, float], abs_mean_limit: float = 
 
 @pytest.fixture(autouse=True)
 def reset_graph():
+    """Clear the TTML autograd graph after each test case."""
     yield
     ttml.autograd.AutoContext.get_instance().reset_graph()
 
 
 def test_mla_fused_sdpa_matches_composite_forward_and_backward():
+    """Compare fused-SDPA MLA against the old composite path for output and parameter gradients."""
     ctx = ttml.autograd.AutoContext.get_instance()
     ctx.open_device()
 
@@ -157,9 +170,7 @@ def test_mla_fused_sdpa_matches_composite_forward_and_backward():
         loss.backward(False)
         ttnn.synchronize_device(device)
         composite_grads = {
-            name: np.asarray(param.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
-            for name, param in module.parameters().items()
-            if param.is_grad_initialized()
+            name: _grad_to_numpy(param) for name, param in module.parameters().items() if param.is_grad_initialized()
         }
         ctx.reset_graph()
 
@@ -169,9 +180,7 @@ def test_mla_fused_sdpa_matches_composite_forward_and_backward():
         loss.backward(False)
         ttnn.synchronize_device(device)
         fused_grads = {
-            name: np.asarray(param.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32), dtype=np.float32)
-            for name, param in module.parameters().items()
-            if param.is_grad_initialized()
+            name: _grad_to_numpy(param) for name, param in module.parameters().items() if param.is_grad_initialized()
         }
         ctx.reset_graph()
 

--- a/tt-train/tests/python/test_deepseek_mla_sdpa.py
+++ b/tt-train/tests/python/test_deepseek_mla_sdpa.py
@@ -153,8 +153,8 @@ def test_mla_fused_sdpa_matches_composite_forward_and_backward():
         out_composite_np = _to_numpy(out_composite)
         ctx.reset_graph()
 
-        x, mask = _make_inputs()
-        out_fused = module(x, mask)
+        x, _ = _make_inputs()
+        out_fused = module(x)  # MLA is causal-only: no mask argument
         ttnn.synchronize_device(device)
         out_fused_np = _to_numpy(out_fused)
         ctx.reset_graph()
@@ -176,8 +176,8 @@ def test_mla_fused_sdpa_matches_composite_forward_and_backward():
         ctx.reset_graph()
 
         zero_grad.zero_grad()
-        x, mask = _make_inputs()
-        loss = ttml.ops.unary.mean(module(x, mask))
+        x, _ = _make_inputs()
+        loss = ttml.ops.unary.mean(module(x))  # MLA is causal-only: no mask argument
         loss.backward(False)
         ttnn.synchronize_device(device)
         fused_grads = {

--- a/tt-train/tests/python/test_deepseek_mla_sdpa.py
+++ b/tt-train/tests/python/test_deepseek_mla_sdpa.py
@@ -134,6 +134,7 @@ def reset_graph():
     ttml.autograd.AutoContext.get_instance().reset_graph()
 
 
+@pytest.mark.requires_device
 def test_mla_fused_sdpa_matches_composite_forward_and_backward():
     """Compare fused-SDPA MLA against the old composite path for output and parameter gradients."""
     ctx = ttml.autograd.AutoContext.get_instance()


### PR DESCRIPTION
## Summary

This PR plugs fused `scaled_dot_product_attention` into TTML DeepSeek MLA, replacing the current composite SDPA path in `MultiHeadLatentAttention`.

The intent is to validate whether the fused SDPA op is ready for the MLA training path, including autograd and `qk_head_dim != v_head_dim`. MLA uses causal attention, so the fused path passes `None` for the mask and lets the kernel generate the causal mask on chip. This avoids materializing/loading the mask and enables the causal balanced-parallelism path when the shape qualifies.

## Why Add A Focused Test?

The full DeepSeek model tests can fail for unrelated MoE/model issues, which makes it hard to tell whether MLA SDPA itself is correct. This PR adds an MLA-only parity test that compares:

- old composite SDPA MLA path
- new fused SDPA MLA path
- forward output
- backward gradients

## Smoke Training Check

Ran 100-step DeepSeek nano Shakespeare training smoke on N300.

Config:

- `tt-train/configs/training_configs/training_shakespeare_nano_deepseek_char.yaml`
- batch sizes `16`, `32`
- sequence lengths `64`, `128`, `256`
- timing excludes first 15 steps
- timing is full training step time: forward + loss + backward + optimizer
- TFLOPS/MFU are the full training-step estimates printed by `train_nanogpt.py`
- fused SDPA uses on-chip causal mask generation, not a materialized mask tensor

| B | S | composite final loss | fused final loss | composite avg step | fused avg step | composite TFLOPS / MFU | fused TFLOPS / MFU | result |
|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 16 | 64 | 2.343750 | 2.359375 | 341.81 ms | 328.15 ms | 0.34 / 0.6% | 0.36 / 0.6% | fused 4.0% faster |
| 16 | 128 | 2.281250 | 2.265625 | 355.41 ms | 342.82 ms | 0.68 / 1.2% | 0.71 / 1.3% | fused 3.5% faster |
| 16 | 256 | 2.312500 | 2.312500 | 385.33 ms | 374.88 ms | 1.34 / 2.4% | 1.38 / 2.5% | fused 2.7% faster |
| 32 | 64 | 2.187500 | 2.171875 | 369.71 ms | 351.41 ms | 0.64 / 1.1% | 0.67 / 1.2% | fused 4.9% faster |
| 32 | 128 | 2.156250 | 2.187500 | 375.13 ms | 373.79 ms | 1.29 / 2.3% | 1.30 / 2.3% | about equal |
| 32 | 256 | 2.109375 | 2.109375 | 545.60 ms | 540.73 ms | 1.89 / 3.4% | 1.91 / 3.4% | about equal |

Loss deltas across the 100 steps were small:

- `B=16, S=64`: max abs delta `0.046875`, mean abs delta `0.011250`
- `B=16, S=128`: max abs delta `0.031250`, mean abs delta `0.010156`
- `B=16, S=256`: max abs delta `0.062500`, mean abs delta `0.009531`
- `B=32, S=64`: max abs delta `0.031250`, mean abs delta `0.009062`
- `B=32, S=128`: max abs delta `0.031250`, mean abs delta `0.007188`
- `B=32, S=256`: max abs delta `0.046875`, mean abs delta `0.008750`

For the attached plots, I also reran the largest smoke shape for 200 steps:

| B | S | steps | composite final loss | fused final loss | composite avg step | fused avg step | composite TFLOPS / MFU | fused TFLOPS / MFU | result |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 32 | 256 | 200 | 1.601562 | 1.617188 | 553.56 ms | 536.20 ms | 1.87 / 3.3% | 1.92 / 3.4% | fused 3.1% faster |

200-step loss delta: max abs `0.046876`, mean abs `0.012734`, final delta `+0.015626`.

### Plot: Loss Curve

<img width="1500" height="750" alt="loss_curve_200_b32_s256_causal" src="https://github.com/user-attachments/assets/7e524abc-425f-416b-8887-c23791b32965" />

### Plot: Loss Delta

<img width="1500" height="750" alt="loss_delta_200_b32_s256_causal" src="https://github.com/user-attachments/assets/be420407-9528-4699-9c0c-351310632fc8" />

### Plot: Step Time

<img width="1500" height="750" alt="step_time_200_b32_s256_causal" src="https://github.com/user-attachments/assets/c5e7a0be-399c-4385-9a00-ef157ffea297" />

## Notes

Correctness looks reasonable from the focused parity test and training smoke. Performance is non-regressing in this full-step smoke: fused SDPA is faster for the smaller cases and about equal for `B=32, S=128/256`.

I am leaving this for review/decision because the remaining question is whether reviewers want additional isolated MLA/SDPA forward/backward timing before merging the fused path.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/mla_sdpa_plug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/mla_sdpa_plug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/mla_sdpa_plug)
