### PR TITLE
[ttnn] Relax to_layout ROW_MAJOR dtype assert: allow BFLOAT8_B -> BFLOAT16

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -106,6 +106,44 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
 
 @pytest.mark.parametrize(
     "shape",
+    # (30, 62) forces the padding-change branch (untilize_with_unpadding).
+    # (32, 64) and (1, 32, 128) are tile-aligned so the no-padding-change branch
+    # (untilize) handles them. Both branches must accept the BFLOAT8_B->BFLOAT16
+    # dtype change after the assert relaxation.
+    [(30, 62), (32, 64), (1, 32, 128)],
+)
+def test_to_layout_bfloat8_b_to_bfloat16(device, shape):
+    """Verify the relaxed dtype assert on ttnn::to_layout(ROW_MAJOR, dtype=bfloat16).
+
+    The underlying untilize / untilize_with_unpadding kernel converts BFLOAT8_B input
+    to BFLOAT16 output natively as part of de-tiling (see
+    untilize_device_operation.cpp). Before the assert relaxation this call would
+    TT_FATAL on dtype mismatch even though the kernel supports the conversion.
+    """
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    assert input_tensor.layout == ttnn.TILE_LAYOUT
+    assert input_tensor.dtype == ttnn.bfloat8_b
+
+    output_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+    assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert output_tensor.dtype == ttnn.bfloat16
+
+    torch_output_tensor = ttnn.to_torch(output_tensor)
+    # BFLOAT8_B roundtrip introduces ~1% quantization error; 0.99 PCC is the
+    # standard tolerance used elsewhere in the test suite for bfp8 paths.
+    assert_with_pcc(torch_input_tensor, torch_output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize(
+    "shape",
     [(1, 1, 32, 128 * 1024), (1, 1, 128, 5120), (1, 1, 512, 5120), (1, 1, 128, 128 * 1024)],
 )
 @pytest.mark.parametrize("on_device", [True])

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -6,6 +6,7 @@
 
 #include <bit>
 #include <limits>
+#include <string_view>
 
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
@@ -33,6 +34,18 @@ bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout) {
         tt::tt_metal::TensorLayout(tensor.dtype(), tt::tt_metal::PageConfig(layout, tile), tensor.memory_config()));
     return tensor.padded_shape() != padded_spec.padded_shape();
 }
+
+bool is_allowed_row_major_dtype(ttnn::DataType tensor_dtype, std::optional<ttnn::DataType> requested_dtype) {
+    if (!requested_dtype.has_value() || requested_dtype.value() == tensor_dtype) {
+        return true;
+    }
+    // untilize / untilize_with_unpadding convert BFLOAT8_B -> BFLOAT16 natively as part of de-tiling.
+    return tensor_dtype == ttnn::DataType::BFLOAT8_B && requested_dtype.value() == ttnn::DataType::BFLOAT16;
+}
+
+constexpr std::string_view kRowMajorDtypeErrorMessage =
+    "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device "
+    "(allowed exception: BFLOAT8_B -> BFLOAT16, which untilize handles natively)!";
 
 Tensor to_layout_impl(
     const ttnn::Tensor& tensor_arg,
@@ -103,7 +116,7 @@ Tensor to_layout_impl(
 
         if (not requires_padding_change(tensor, layout)) {
             if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-                TT_ASSERT(not dtype.has_value(), "dtype cannot be specified when converting to ROW_MAJOR_LAYOUT!");
+                TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
                 return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
             }
             if (layout == ttnn::TILE_LAYOUT) {
@@ -138,9 +151,7 @@ Tensor to_layout_impl(
             throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
         }
         if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            TT_FATAL(
-                !dtype.has_value() || dtype.value() == tensor_arg.dtype(),
-                "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device!");
+            TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
 
             if (tensor.is_sharded()) {
                 output_memory_config =


### PR DESCRIPTION
### PR Category
Cleanup: Relax to_layout ROW_MAJOR dtype assert: allow BFLOAT8_B -> BFLOAT16

### Summary
The underlying untilize / untilize_with_unpadding kernels called in to_layout op accept BFLOAT8_B input and produce BFLOAT16 output natively as part of de-tiling, so the strict dtype-equality assert in to_layout's ROW_MAJOR_LAYOUT branch is overly conservative. 
###Change
- Relax both the no-padding-change TT_ASSERT and the padding-change TT_FATAL to allow the BFLOAT8_B -> BFLOAT16 case in addition to the no-op case; all other dtype mismatches still fail.
- Add a unit test in test_to_layout.py exercising both branches (tile-aligned shapes for the no-padding-change path, sub-tile shapes for the padding-change path).
- Register a dedicated merge_gate entry in tests/pipeline_reorg/ttnn-tests.yaml so the new test runs on every PR (via merge-gate.yaml -> ttnn-post-commit with merge-gate-call=true) on WH N300 + BH P100/P150, in addition to the nightly sanity run where it was already picked up by the "core ttnn unit test group" entry.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgolubovic/relax-to-layout-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgolubovic/relax-to-layout-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgolubovic/relax-to-layout-assert)