### PR TITLE
emule: define TRISC_UNPACK/MATH/PACK for non-Quasar compute kernels (fixes tt-emule#24)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1100,6 +1100,37 @@ static void collect_kernels(
             auto* qck = dynamic_cast<experimental::quasar::QuasarComputeKernel*>(kernel.get());
             bool is_quasar_compute = is_tensix && (qck != nullptr);
 
+            // Issue tenstorrent/tt-emule#24: emule runs all three TRISC code paths
+            // in a single unified compute thread (no separate UNPACK/MATH/PACK
+            // RISC cores). tt-mlir-generated D2M kernels guard hardware code
+            // paths with `#ifdef TRISC_UNPACK|MATH|PACK`; without these defines
+            // helpers like `experimental::write_row_mask_tile` compile to empty
+            // bodies and the downstream `where_tile` reads stale data. Define
+            // all three so the kernel's `#ifdef TRISC_*` blocks execute exactly
+            // once on the unified thread.
+            //
+            // EXCEPT for tilize kernels: emule's host-side
+            // `tilize_with_val_padding` already produces tiled data, so an
+            // additional kernel-side tilize would re-tilize and corrupt the
+            // layout. Skip TRISC defines when the kernel source mentions
+            // `llk_unpack_tilize` (the tilize compute path).
+            bool is_tilize_kernel = false;
+            if (is_tensix && !is_quasar_compute) {
+                std::ifstream kscan(src_path);
+                if (kscan) {
+                    std::string content((std::istreambuf_iterator<char>(kscan)), std::istreambuf_iterator<char>());
+                    is_tilize_kernel = content.find("llk_unpack_tilize") != std::string::npos;
+                }
+            }
+            if (is_tensix && !is_quasar_compute && !is_tilize_kernel) {
+                auto defines_with_trisc = build_kernel_defines(
+                    *kernel, impl, num_dram_channels, worker_col_map_str, worker_row_map_str, emule_sem_base);
+                defines_with_trisc["TRISC_UNPACK"] = "1";
+                defines_with_trisc["TRISC_MATH"] = "1";
+                defines_with_trisc["TRISC_PACK"] = "1";
+                defines = std::move(defines_with_trisc);
+            }
+
             // Metal 2.0 bindings — same across this Kernel's TRISC variants, so
             // capture the cache-key suffix once and append it to every variant key.
             Metal2BindingsSnapshot bindings = build_metal2_snapshot(*kernel);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1117,18 +1117,17 @@ static void collect_kernels(
             bool is_tilize_kernel = false;
             if (is_tensix && !is_quasar_compute) {
                 std::ifstream kscan(src_path);
-                if (kscan) {
-                    std::string content((std::istreambuf_iterator<char>(kscan)), std::istreambuf_iterator<char>());
-                    is_tilize_kernel = content.find("llk_unpack_tilize") != std::string::npos;
+                if (!kscan) {
+                    throw std::runtime_error(
+                        "collect_kernels: cannot read kernel source for TRISC-define gating: " + src_path);
                 }
+                std::string content((std::istreambuf_iterator<char>(kscan)), std::istreambuf_iterator<char>());
+                is_tilize_kernel = content.find("llk_unpack_tilize") != std::string::npos;
             }
             if (is_tensix && !is_quasar_compute && !is_tilize_kernel) {
-                auto defines_with_trisc = build_kernel_defines(
-                    *kernel, impl, num_dram_channels, worker_col_map_str, worker_row_map_str, emule_sem_base);
-                defines_with_trisc["TRISC_UNPACK"] = "1";
-                defines_with_trisc["TRISC_MATH"] = "1";
-                defines_with_trisc["TRISC_PACK"] = "1";
-                defines = std::move(defines_with_trisc);
+                defines["TRISC_UNPACK"] = "1";
+                defines["TRISC_MATH"] = "1";
+                defines["TRISC_PACK"] = "1";
             }
 
             // Metal 2.0 bindings — same across this Kernel's TRISC variants, so


### PR DESCRIPTION
## Summary

Fixes [tenstorrent/tt-emule#24](https://github.com/tenstorrent/tt-emule/issues/24) — `test_reduce_2d_unaligned[(129, 65)-1-min-f32-keep1]` flake at ~50%.

emule runs all three TRISC code paths in a single unified compute thread (no separate UNPACK/MATH/PACK RISC cores). tt-mlir-generated D2M kernels guard hardware-specific code paths with `#ifdef TRISC_UNPACK|MATH|PACK`. On silicon each TRISC compiles separately so exactly one guard is active per object; in emule we need all three defined so the generated kernel's `#ifdef TRISC_*` blocks execute exactly once on the unified thread.

Without the defines, `experimental::write_row_mask_tile` / `write_col_mask_tile` in compute_kernel7 (the `fill_implicit_tile_padding` kernel) compile to empty bodies, leaving the mask CBs with stale data. The downstream `where_tile` then reads that stale data as the partial-tile mask — flaky.

### Tilize exclusion

Skip the defines for tilize kernels (kernel source contains `llk_unpack_tilize`): emule's host-side `tilize_with_val_padding` already emits tiled data, so an additional kernel-side tilize would re-tilize and corrupt the layout. This exclusion is a surgical fix — a cleaner long-term solution is to have either the host-side tilize emit row-major output or the kernel-side tilize detect already-tiled input and pass through, at which point this exclusion can go away.

### Companion PR

emule-side plumbing (real `get_local_cb_interface` reading `__emule_cbs[cb_id]`, and an `api/compute/cb_api.h` shim) lives in the companion tt-emule PR. Without those pieces this PR on its own moves the kernel from "silently broken (mask write skipped)" to "writes mask to address 0 (segfault or worse)."

### Verification

Verified at tt-metal `d5a16537336` + companion tt-emule changes on top of pinned SHA `67266c75`:

- 20/20 PASS on `test_reduce_2d_unaligned[ttmetal-(129, 65)-1-min-f32-keep1]` (cold cache, rm `/tmp/tt_emule_jit_cache_*` between every iteration)
- 20/20 PASS on `test_reduce_2d_unaligned[ttmetal-(50, 100)-0-min-f32-keep1]` (cold cache)
- 15/15 PASS on the other `test_reduce_2d_unaligned` parametrizations (no regression)

Re-verification against current main HEAD (`81a9c888`) was attempted but blocked by pre-existing API drift between tt-mlir's prebuilt runtime and the new tt-metal API (undefined symbols `tt::tt_metal::MeshTensor::is_initialized`, `ttnn::prim::selective_reduce_combine` in `libTTMLIRRuntime.so`) — unrelated to this fix. The patch is localized to `collect_kernels` in `emulated_program_runner.cpp`; nothing in the 50 commits between `d5a16537336` and main touches that file.

## Test plan

- [x] 20× cold-cache run of `(129, 65)-1-min-f32-keep1` → 20/20 PASS
- [x] 20× cold-cache run of `(50, 100)-0-min-f32-keep1` → 20/20 PASS
- [x] Smoke test broader `test_reduce_2d_unaligned` suite → 15/15 PASS

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/fix-issue-24-trisc-defines)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/fix-issue-24-trisc-defines)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/fix-issue-24-trisc-defines)