### PR TITLE
[Bugfix] Cap DFB HW configure loops at NUM_DFBS and skip non-participating slots

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -20,8 +20,17 @@
 inline void llk_pack_hw_configure(const std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);
 
-    // Program buffer descriptors for all 32 dataflow buffers, i is the logical dfb id
-    for (std::uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; ++i) {
+    // Program buffer descriptors for all 32 dataflow buffers, i is the logical dfb id.
+    // Skip non-participating DFBs (gate matched the state in which A2 implicit-sync
+    // passes; reverting to a plain unfiltered loop caused the implicit-sync 3-DFB
+    // runtime to hang at credit-ack handshake). Loop bound is dfb::NUM_DFBS because
+    // g_dfb_logical_to_compact[] is sized NUM_DFBS (=32) and NUM_CIRCULAR_BUFFERS
+    // resolves to 64 on Quasar — GCC -Werror=aggressive-loop-optimizations rejects
+    // the direct OOB array access at the gate.
+    for (std::uint32_t i = 0; i < dfb::NUM_DFBS; ++i) {
+        if (g_dfb_logical_to_compact[i] == 0xFF) {
+            continue;
+        }
         const DataFormat l1_data_format = static_cast<DataFormat>(pack_dst_format[i]);
 
         if (l1_data_format == DataFormat::Invalid) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -30,8 +30,15 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const std::uint32_t unpA_operand_id = get_operand_id(unpA_operand);
     const std::uint32_t unpB_operand_id = get_operand_id(unpB_operand);
 
-    // Program buffer descriptors for all 32 dataflow buffers, i is the logical dfb id
-    for (std::uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; ++i) {
+    // Program buffer descriptors for all 32 dataflow buffers, i is the logical dfb id.
+    // Skip non-participating DFBs via entry_size==0 (g_dfb_interface[] is zero-init,
+    // so non-populated entries naturally fall out). Loop bound is dfb::NUM_DFBS because
+    // g_dfb_interface[] is sized NUM_DFBS (=32) and NUM_CIRCULAR_BUFFERS resolves to 64
+    // on Quasar — GCC -Werror=aggressive-loop-optimizations rejects the OOB.
+    for (std::uint32_t i = 0; i < dfb::NUM_DFBS; ++i) {
+        if (g_dfb_interface[i].entry_size == 0) {
+            continue;
+        }
         const DataFormat l1_data_format = static_cast<DataFormat>(unpack_src_format[i]);
 
         if (l1_data_format == DataFormat::Invalid) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix out-of-bounds iteration in Quasar DFB HW configure loops for PACK and UNPACK.

`llk_pack_hw_configure` and `llk_unpack_hw_configure` iterate over the 32 logical DFB slots, but PACK accesses `g_dfb_interface[]` (sized `MAX_ACTIVE_DFBS_PACK` = 16) via an indirection that returns `0xFF` for non-active slots, causing OOB on the PACK side.

This is caught by `-Werror=aggressive-loop-optimizations` at compile time. If the warning is silenced instead of fixing the bug, the runtime can hang at the credit-ack handshake in 3-DFB implicit-sync programs.

The fix:
- caps both loops at `dfb::NUM_DFBS`
- skips non-participating slots:
  - PACK: `g_dfb_logical_to_compact[i] == 0xFF`
  - UNPACK: `g_dfb_interface[i].entry_size == 0`

Correctness-only change. No API or perf impact.

### Notes for reviewers
Root cause is that `NUM_CIRCULAR_BUFFERS` is a legacy CB-era alias and does not match the underlying DFB array dimensions on Quasar.

### Validation
Validated using new tests found in `[Test Only] Add 193 Metal 2.0 DFB tests on Quasar`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/fix-pack-unpack-dfb-loop-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/fix-pack-unpack-dfb-loop-oob)