### PR TITLE
[Bugfix] Use modular int16 comparison for DFB implicit-sync uint16 counters

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -217,7 +217,10 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
     //   completed      → tack == 0, tiles >  0   ← break here
     // Also exits early if the ISR fires (collective batch done).
     WAYPOINT("WTP1");
-    while (read_actual_slot0() < expected_slot0) {
+    // Modular comparison: read_actual_slot0() and expected_slot0 are both
+    // uint16; their wrapped difference interpreted as int16 is negative when
+    // actual is "behind" expected. See prepare_implicit_read for rationale.
+    while (static_cast<int16_t>(read_actual_slot0() - expected_slot0) < 0) {
         uint64_t tack, tiles;
         if constexpr (is_producer) {
             tack  = CMDBUF_TR_ACK_TRID(OVERLAY_RD_CMD_BUF, tail_txn_id);
@@ -239,8 +242,8 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
     // contributions of all producers / consumers for this collective batch.
     sync_threads();
 
-    // ISR already handled the collective batch
-    if (read_actual_slot0() >= expected_slot0) {
+    // ISR already handled the collective batch — modular check (see WTP1).
+    if (static_cast<int16_t>(read_actual_slot0() - expected_slot0) >= 0) {
         return;
     }
 
@@ -249,7 +252,7 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
     // never post credits for it, so we fall through to the manual posting below.
     uint16_t global_threshold = local_dfb_interface_.threshold;
     WAYPOINT("WTP2");
-    while (read_actual_slot0() < expected_slot0) {
+    while (static_cast<int16_t>(read_actual_slot0() - expected_slot0) < 0) {
         uint64_t tiles;
         if constexpr (is_producer) {
             tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
@@ -262,22 +265,28 @@ inline void DataflowBuffer::handle_final_credits(uint16_t transactions_issued, u
     }
 
     // Manually post missing credits if ISR did not fire.
+    // Modular: int16(actual - expected) < 0 means actual is behind expected,
+    // and the unsigned difference (expected - actual) is the number of missing
+    // increments — correct across the uint16 wrap because both operands wrap.
     uint16_t actual_slot0 = read_actual_slot0();
-    if (actual_slot0 < expected_slot0) {
+    if (static_cast<int16_t>(actual_slot0 - expected_slot0) < 0) {
         for (uint8_t i = 0; i < N; i++) {
             dfb::PackedTileCounter ptc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
             uint8_t tensix_id = dfb::get_tensix_id(ptc);
             uint8_t tc_id     = dfb::get_counter_id(ptc);
             uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
             if constexpr (is_producer) {
+                // Modular int16 comparison: posted (16-bit HW) wraps at 65 536, so
+                // `actual < expected` is wrong at wrap; cast the difference to int16_t
+                // to get a signed modular distance. Negative = behind, ≥0 = caught up.
                 uint16_t actual = static_cast<uint16_t>(overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
-                if (actual < expected) {
-                    overlay::fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
+                if (static_cast<int16_t>(actual - expected) < 0) {
+                    overlay::fast_llk_intf_inc_posted(tensix_id, tc_id, static_cast<uint16_t>(expected - actual));
                 }
             } else {
                 uint16_t actual = static_cast<uint16_t>(overlay::fast_llk_intf_read_acked(tensix_id, tc_id));
-                if (actual < expected) {
-                    overlay::fast_llk_intf_inc_acked(tensix_id, tc_id, expected - actual);
+                if (static_cast<int16_t>(actual - expected) < 0) {
+                    overlay::fast_llk_intf_inc_acked(tensix_id, tc_id, static_cast<uint16_t>(expected - actual));
                 }
             }
         }
@@ -306,7 +315,16 @@ inline uint32_t DataflowBuffer::prepare_implicit_read() {
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
     const uint32_t txn_id = local_dfb_interface_.txn_ids[ptxn_id_index_];
     WAYPOINT("PIRW");
-    while (overlay::fast_llk_intf_read_posted(tensix_id, tc_id) < (ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    // Modular comparison: posted (16-bit HW) wraps at 65 536, and so does the
+    // kernel-side expectation `ptxn_id_loop_cnt_ * per_tc` if both operands are
+    // reduced to uint16 before subtracting. Interpreting the wrapped difference
+    // as int16 gives a signed modular distance — negative means posted is behind
+    // expected, non-negative means it has caught up. Safe as long as the gap
+    // never exceeds half the wrap range (~32K), which is guaranteed by the
+    // bounded txn-id ring depth.
+    while (static_cast<int16_t>(
+        static_cast<uint16_t>(overlay::fast_llk_intf_read_posted(tensix_id, tc_id)) -
+        static_cast<uint16_t>(ptxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc)) < 0);
     while (overlay::fast_llk_intf_get_free_space(tensix_id, tc_id) < 1);
     WAYPOINT("PIRD");
     return txn_id;
@@ -336,7 +354,11 @@ inline uint32_t DataflowBuffer::prepare_implicit_write() {
     uint8_t tc_id = dfb::get_counter_id(packed_tc);
     const uint32_t txn_id = local_dfb_interface_.txn_ids[ctxn_id_index_];
     WAYPOINT("PIWW");
-    while (overlay::fast_llk_intf_read_acked(tensix_id, tc_id) < (ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc));
+    // Modular comparison — see prepare_implicit_read for the rationale. Same
+    // trick applied to the acked side.
+    while (static_cast<int16_t>(
+        static_cast<uint16_t>(overlay::fast_llk_intf_read_acked(tensix_id, tc_id)) -
+        static_cast<uint16_t>(ctxn_id_loop_cnt_ * local_dfb_interface_.num_entries_per_txn_id_per_tc)) < 0);
     while (overlay::fast_llk_intf_get_occupancy(tensix_id, tc_id) < 1);
     WAYPOINT("PIWD");
     return txn_id;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix Quasar DFB implicit-sync counter wrap handling for uint16 HW credit counters.

The implicit-sync subsystem compares uint16 posted/acked counters using `<` checks. These counters wrap at 65536, so comparisons break across wrap boundaries and can cause loops to exit early or never exit.

This PR replaces those comparisons with modular signed-distance checks:
`static_cast<int16_t>(actual - expected) < 0`

Correctness-only change. No API or perf impact.

### Notes for reviewers
Touched call sites are in:
- `handle_final_credits`
- `prepare_implicit_read`
- `prepare_implicit_write`

This is safe as long as the gap between posted and acked remains below half the wrap range, which is enforced by the bounded txn-id ring.

### Validation
Validated using new tests found in `[Test Only] Add 193 Metal 2.0 DFB tests on Quasar`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/fix-dfb-counter-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/fix-dfb-counter-wrap)