### PR TITLE
[Bugfix] Make DFB PACK finish_impl wait for UNPACK drain on INTRA self-loop

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -145,10 +145,17 @@ inline void DataflowBuffer::finish_impl() {
         for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
             dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
             uint8_t tc_id = dfb::get_counter_id(packed_tc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+#if defined(COMPILE_FOR_TRISC) && (defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK))
+            // TRISC drain: finish() must not return until this TC is empty (posted == 0) -
+            // covers the consumer (UNPACK), the Tensix->DM producer (PACK), and both sides of
+            // an INTRA self-loop. The consumer also skips TCs this TRISC doesn't own via
+            // tensix_trisc_mask, which exists only in the UNPACK-side LocalDFBInterface, so the
+            // gate sits under an inner UNPACK guard (the PACK struct has no such member).
+#ifdef UCK_CHLKC_UNPACK
             if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
                 continue;
             }
+#endif
             all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
 #elif !defined(COMPILE_FOR_TRISC)
             uint8_t tensix_id = dfb::get_tensix_id(packed_tc);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix PACK `finish_impl` behavior for INTRA-tensix DFB self-loops on Quasar.

For INTRA-tensix DFBs where the same DFB is bound as both PRODUCER and CONSUMER, PACK returned from `finish_impl` once everything was pushed, without waiting for UNPACK to finish popping and mutating tiles in place.

This allowed downstream code to observe output as ready before UNPACK had fully completed.

The fix adds a PACK-specific drain wait inside `finish_impl`'s waypoint loop and waits for `posted == 0`.

Correctness-only change. No API change.

### Notes for reviewers
The new branch is guarded behind PACK/TRISC-specific compile macros and is intended only for the INTRA self-loop case.

### Validation
Validated using new tests found in `[Test Only] Add 193 Metal 2.0 DFB tests on Quasar`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/fix-dfb-pack-finish-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/fix-dfb-pack-finish-drain)