### PR TITLE
[API Cleanup] Move DFB disable_implicit_sync to Gen2DMConfig in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -68,15 +68,16 @@ inline TensorSpec make_alias_l1_tensor_spec(uint32_t entry_size, uint32_t num_en
 // producer = DM RISC 0, consumer = DM RISC 1 (valid on WH/BH and Quasar).
 inline dfb::DataflowBufferConfig make_1sx1s_config(uint32_t entry_size, uint32_t num_entries) {
     return dfb::DataflowBufferConfig{
-        .entry_size         = entry_size,
-        .num_entries        = num_entries,
+        .entry_size = entry_size,
+        .num_entries = num_entries,
         .producer_risc_mask = 0x1,
-        .num_producers      = 1,
-        .pap                = dfb::AccessPattern::STRIDED,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
         .consumer_risc_mask = 0x2,
-        .num_consumers      = 1,
-        .cap                = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false,
     };
 }
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -114,31 +114,33 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
 
     // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
     const DataMovementConfiguration producer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1_data_movement_config =
+            DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
+        .gen2_data_movement_config =
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync = {{"dfb_a", true}, {"dfb_b", true}}},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1_data_movement_config =
+            DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
+        .gen2_data_movement_config =
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync = {{"dfb_a", true}, {"dfb_b", true}}},
     };
 
     DataflowBufferSpec dfb_a{
-        .unique_id        = "dfb_a",
-        .entry_size       = entry_size_a,
-        .num_entries      = num_entries_a,
+        .unique_id = "dfb_a",
+        .entry_size = entry_size_a,
+        .num_entries = num_entries_a,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .alias_with       = {"dfb_b"},
-        .disable_implicit_sync = true,
+        .alias_with = {"dfb_b"},
     };
     DataflowBufferSpec dfb_b{
-        .unique_id        = "dfb_b",
-        .entry_size       = entry_size_b,
-        .num_entries      = num_entries_b,
+        .unique_id = "dfb_b",
+        .entry_size = entry_size_b,
+        .num_entries = num_entries_b,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .alias_with       = {"dfb_a"},
-        .disable_implicit_sync = true,
+        .alias_with = {"dfb_a"},
     };
 
     KernelSpec producer{
@@ -315,34 +317,36 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         *mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries), TensorTopology{});
 
     const DataMovementConfiguration producer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1_data_movement_config =
+            DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
+        .gen2_data_movement_config =
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync = {{"dfb_borrowed", true}, {"dfb_alias", true}}},
     };
     const DataMovementConfiguration consumer_cfg{
-        .gen1_data_movement_config = DataMovementConfiguration::Gen1DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1},
-        .gen2_data_movement_config = DataMovementConfiguration::Gen2DataMovementConfig{},
+        .gen1_data_movement_config =
+            DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
+        .gen2_data_movement_config =
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync = {{"dfb_borrowed", true}, {"dfb_alias", true}}},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)
     DataflowBufferSpec dfb_borrowed{
-        .unique_id             = "dfb_borrowed",
-        .entry_size            = entry_size,
-        .num_entries           = num_entries,
-        .data_format_metadata  = tt::DataFormat::Float16_b,
-        .borrowed_from         = "ring_tensor",
-        .alias_with            = {"dfb_alias"},
-        .disable_implicit_sync = true,
+        .unique_id = "dfb_borrowed",
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .borrowed_from = "ring_tensor",
+        .alias_with = {"dfb_alias"},
     };
     DataflowBufferSpec dfb_alias_spec{
-        .unique_id             = "dfb_alias",
-        .entry_size            = entry_size,
-        .num_entries           = num_entries,
-        .data_format_metadata  = tt::DataFormat::Float16_b,
-        .borrowed_from         = "ring_tensor",
-        .alias_with            = {"dfb_borrowed"},
-        .disable_implicit_sync = true,
+        .unique_id = "dfb_alias",
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .borrowed_from = "ring_tensor",
+        .alias_with = {"dfb_borrowed"},
     };
 
     KernelSpec producer{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -117,15 +117,13 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{
-                .disable_implicit_sync = {{"dfb_a", true}, {"dfb_b", true}}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_a", "dfb_b"}},
     };
     const DataMovementConfiguration consumer_cfg{
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{
-                .disable_implicit_sync = {{"dfb_a", true}, {"dfb_b", true}}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_a", "dfb_b"}},
     };
 
     DataflowBufferSpec dfb_a{
@@ -320,15 +318,13 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{
-                .disable_implicit_sync = {{"dfb_borrowed", true}, {"dfb_alias", true}}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_borrowed", "dfb_alias"}},
     };
     const DataMovementConfiguration consumer_cfg{
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{
-                .disable_implicit_sync = {{"dfb_borrowed", true}, {"dfb_alias", true}}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_borrowed", "dfb_alias"}},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -117,13 +117,13 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_a", "dfb_b"}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync_for = {"dfb_a", "dfb_b"}},
     };
     const DataMovementConfiguration consumer_cfg{
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_a", "dfb_b"}},
+            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync_for = {"dfb_a", "dfb_b"}},
     };
 
     DataflowBufferSpec dfb_a{
@@ -318,13 +318,15 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_0},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_borrowed", "dfb_alias"}},
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync_for = {"dfb_borrowed", "dfb_alias"}},
     };
     const DataMovementConfiguration consumer_cfg{
         .gen1_data_movement_config =
             DataMovementConfiguration::Gen1DataMovementConfig{.processor = DataMovementProcessor::RISCV_1},
         .gen2_data_movement_config =
-            DataMovementConfiguration::Gen2DataMovementConfig{.disable_implicit_sync = {"dfb_borrowed", "dfb_alias"}},
+            DataMovementConfiguration::Gen2DataMovementConfig{
+                .disable_implicit_sync_for = {"dfb_borrowed", "dfb_alias"}},
     };
 
     // dfb_borrowed: backed by ring_tensor (L1)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -162,10 +162,10 @@ void run_borrowed_memory_dfb_program(
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
         std::get<DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back("borrowed_dfb");
         if (!cfg.tensix_consumer) {
             std::get<DataMovementConfiguration>(consumer_spec.config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back("borrowed_dfb");
         }
     }
 
@@ -311,9 +311,9 @@ void run_update_address_test(
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
         std::get<DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back("borrowed_dfb");
         std::get<DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back("borrowed_dfb");
     }
 
     DataflowBufferSpec dfb_spec{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -158,14 +158,24 @@ void run_borrowed_memory_dfb_program(
     BindDFBToKernel(consumer_spec, "borrowed_dfb", "in",
                     KernelSpec::DFBEndpointType::CONSUMER, cfg.cap);
 
+    // Disable implicit sync on the borrowed DFB for every DM endpoint (Gen2 only;
+    // Gen1 has no ISR-based implicit sync to opt out of).
+    if (arch == ARCH::QUASAR) {
+        std::get<DataMovementConfiguration>(producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+        if (!cfg.tensix_consumer) {
+            std::get<DataMovementConfiguration>(consumer_spec.config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+        }
+    }
+
     // --- Borrowed DFB spec ---
     DataflowBufferSpec dfb_spec{
-        .unique_id             = "borrowed_dfb",
-        .entry_size            = cfg.entry_size,
-        .num_entries           = cfg.num_entries,
-        .data_format_metadata  = tt::DataFormat::Float16_b,
-        .borrowed_from         = "dfb_ring_tensor",
-        .disable_implicit_sync = true,
+        .unique_id = "borrowed_dfb",
+        .entry_size = cfg.entry_size,
+        .num_entries = cfg.num_entries,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .borrowed_from = "dfb_ring_tensor",
     };
 
     // --- TensorParameters ---
@@ -297,13 +307,21 @@ void run_update_address_test(
     }};
     BindDFBToKernel(consumer_spec, "borrowed_dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
 
+    // Disable implicit sync on the borrowed DFB for both DM endpoints (Gen2 only;
+    // Gen1 has no ISR-based implicit sync to opt out of).
+    if (arch == ARCH::QUASAR) {
+        std::get<DataMovementConfiguration>(producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+        std::get<DataMovementConfiguration>(consumer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+    }
+
     DataflowBufferSpec dfb_spec{
-        .unique_id             = "borrowed_dfb",
-        .entry_size            = entry_size,
-        .num_entries           = num_entries,
-        .data_format_metadata  = tt::DataFormat::Float16_b,
-        .borrowed_from         = "dfb_ring_tensor",
-        .disable_implicit_sync = true,
+        .unique_id = "borrowed_dfb",
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = tt::DataFormat::Float16_b,
+        .borrowed_from = "dfb_ring_tensor",
     };
 
     const TensorSpec src_spec  = make_flat_dram_tensor_spec(entry_size, num_entries);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -162,10 +162,10 @@ void run_borrowed_memory_dfb_program(
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
         std::get<DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
         if (!cfg.tensix_consumer) {
             std::get<DataMovementConfiguration>(consumer_spec.config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+                .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
         }
     }
 
@@ -311,9 +311,9 @@ void run_update_address_test(
     // Gen1 has no ISR-based implicit sync to opt out of).
     if (arch == ARCH::QUASAR) {
         std::get<DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
         std::get<DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({"borrowed_dfb", true});
+            .gen2_data_movement_config->disable_implicit_sync.push_back("borrowed_dfb");
     }
 
     DataflowBufferSpec dfb_spec{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -212,14 +212,14 @@ void run_single_dfb_program(
     const auto consumer_pattern = is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
                                          : experimental::metal2_host_api::DFBAccessPattern::STRIDED;
 
-    // enable_implicit_sync: true  -> default disable_implicit_sync = false (implicit sync ON)
-    // enable_implicit_sync: false -> disable_implicit_sync = true
+    // Per-DM-kernel disable_implicit_sync entries below mirror the boolean derived from
+    // dfb_config.enable_implicit_sync (the lower-level legacy config still drives the value;
+    // each DM endpoint votes per-DFB on the spec side).
     experimental::metal2_host_api::DataflowBufferSpec dfb_spec{
         .unique_id = DFB_NAME,
         .entry_size = entry_size,
         .num_entries = dfb_config.num_entries,
         .data_format_metadata = dfb_config.data_format,
-        .disable_implicit_sync = !dfb_config.enable_implicit_sync,
     };
 
     // DM kernel configs supply both Gen1 (BRISC for producer / NCRISC for consumer) and
@@ -326,6 +326,17 @@ void run_single_dfb_program(
             .compile_time_arg_bindings = {{"num_entries_per_consumer", num_entries_per_consumer}},
             .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
         };
+    }
+
+    // Each DM endpoint votes per-DFB on opting out of implicit sync.
+    const bool disable_isync = !dfb_config.enable_implicit_sync;
+    if (producer_type == DFBPorCType::DM) {
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({DFB_NAME, disable_isync});
+    }
+    if (consumer_type == DFBPorCType::DM) {
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({DFB_NAME, disable_isync});
     }
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -639,8 +650,9 @@ void run_concurrent_dfbs_program(
             .entry_size = entry_size,
             .num_entries = entries_per_dfb,
             .data_format_metadata = dfb_config.data_format,
-            .disable_implicit_sync = !dfb_config.enable_implicit_sync,
         });
+
+        const bool disable_isync = !dfb_config.enable_implicit_sync;
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = producer_name,
@@ -667,7 +679,8 @@ void run_concurrent_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                            .disable_implicit_sync = {{dfb_name, disable_isync}}}},
         });
         kernel_names.push_back(producer_name);
 
@@ -696,7 +709,8 @@ void run_concurrent_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                            .disable_implicit_sync = {{dfb_name, disable_isync}}}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -835,7 +849,6 @@ void run_concurrent_tensix_dm_dfbs_program(
             .entry_size = entry_size,
             .num_entries = entries_per_dfb,
             .data_format_metadata = dfb_config.data_format,
-            .disable_implicit_sync = !dfb_config.enable_implicit_sync,
         });
 
         tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
@@ -867,7 +880,8 @@ void run_concurrent_tensix_dm_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                            .disable_implicit_sync = {{dfb_name, !dfb_config.enable_implicit_sync}}}},
         });
         kernel_names.push_back(consumer_name);
     }
@@ -1072,8 +1086,12 @@ void run_sequential_dfbs_program(
             .entry_size = entry_size,
             .num_entries = num_entries,
             .data_format_metadata = configs[i].data_format,
-            .disable_implicit_sync = !configs[i].enable_implicit_sync,
         });
+        const bool disable_isync = !configs[i].enable_implicit_sync;
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({dfb_name, disable_isync});
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back({dfb_name, disable_isync});
         tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
             .unique_id = in_tensor_name,
             .spec = in_tensors[i].tensor_spec(),
@@ -1206,14 +1224,12 @@ void run_in_dfb_out_dfb_program(
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = dm2tensix_config.data_format,
-        .disable_implicit_sync = !dm2tensix_config.enable_implicit_sync,
     };
     experimental::metal2_host_api::DataflowBufferSpec out_dfb_spec{
         .unique_id = OUT_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = tensix2dm_config.data_format,
-        .disable_implicit_sync = !tensix2dm_config.enable_implicit_sync,
     };
 
     experimental::metal2_host_api::KernelSpec producer_spec{
@@ -1242,7 +1258,8 @@ void run_in_dfb_out_dfb_program(
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{IN_DFB, !dm2tensix_config.enable_implicit_sync}}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{
@@ -1299,7 +1316,8 @@ void run_in_dfb_out_dfb_program(
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{OUT_DFB, !tensix2dm_config.enable_implicit_sync}}}},
     };
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -1898,7 +1916,6 @@ static void run_intra_tensix_dfb_program(
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = dfb_config.data_format,
-        .disable_implicit_sync = !dfb_config.enable_implicit_sync,
     };
 
     // Self-looped: register both PRODUCER and CONSUMER bindings on the same kernel.
@@ -2038,14 +2055,12 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = remapper_dfb_config.data_format,
-        .disable_implicit_sync = !remapper_dfb_config.enable_implicit_sync,
     };
     experimental::metal2_host_api::DataflowBufferSpec intra_dfb_spec{
         .unique_id = INTRA_DFB,
         .entry_size = entry_size,
         .num_entries = num_entries,
         .data_format_metadata = intra_dfb_config.data_format,
-        .disable_implicit_sync = !intra_dfb_config.enable_implicit_sync,
     };
 
     experimental::metal2_host_api::KernelSpec dm_producer_spec{
@@ -2074,7 +2089,8 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{REMAPPER_DFB, !remapper_dfb_config.enable_implicit_sync}}}},
     };
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -145,7 +145,8 @@ void run_single_dfb_program(
         // Implicit sync (Noc::TxnIdMode::ENABLED) is declared only under #ifdef ARCH_QUASAR
         // in api/dataflow/noc.h. Force it off so the device-side kernel's
         // `if constexpr (implicit_sync)` branch is dead code on WH/BH.
-        dfb_config.enable_implicit_sync = false;
+        dfb_config.enable_producer_implicit_sync = false;
+        dfb_config.enable_consumer_implicit_sync = false;
     }
 
     const uint32_t num_cores = core_range_set.num_cores();
@@ -213,7 +214,7 @@ void run_single_dfb_program(
                                          : experimental::metal2_host_api::DFBAccessPattern::STRIDED;
 
     // Per-DM-kernel disable_implicit_sync_for entries below mirror the boolean derived from
-    // dfb_config.enable_implicit_sync (the lower-level legacy config still drives the value;
+    // dfb_config.enable_producer_implicit_sync (the lower-level legacy config still drives the value;
     // each DM endpoint votes per-DFB on the spec side).
     experimental::metal2_host_api::DataflowBufferSpec dfb_spec{
         .unique_id = DFB_NAME,
@@ -258,7 +259,7 @@ void run_single_dfb_program(
             .compile_time_arg_bindings =
                 {
                     {"num_entries_per_producer", num_entries_per_producer},
-                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
+                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_producer_implicit_sync ? 1u : 0u)},
                     {"num_producers", dfb_config.num_producers},
                 },
             .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
@@ -304,7 +305,7 @@ void run_single_dfb_program(
                 {
                     {"num_entries_per_consumer", num_entries_per_consumer},
                     {"blocked_consumer", static_cast<uint32_t>(is_all ? 1u : 0u)},
-                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
+                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_producer_implicit_sync ? 1u : 0u)},
                     {"num_consumers", dfb_config.num_consumers},
                 },
             .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
@@ -329,7 +330,7 @@ void run_single_dfb_program(
     }
 
     // Each DM endpoint votes per-DFB on opting out of implicit sync.
-    const bool disable_isync = !dfb_config.enable_implicit_sync;
+    const bool disable_isync = !dfb_config.enable_producer_implicit_sync;
     if (producer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
             .gen2_data_movement_config->disable_implicit_sync_for.push_back(DFB_NAME);
@@ -652,7 +653,7 @@ void run_concurrent_dfbs_program(
             .data_format_metadata = dfb_config.data_format,
         });
 
-        const bool disable_isync = !dfb_config.enable_implicit_sync;
+        const bool disable_isync = !dfb_config.enable_producer_implicit_sync;
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = producer_name,
@@ -673,7 +674,7 @@ void run_concurrent_dfbs_program(
             .compile_time_arg_bindings =
                 {
                     {"num_entries_per_producer", entries_per_dfb},
-                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
+                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_producer_implicit_sync ? 1u : 0u)},
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
@@ -706,7 +707,7 @@ void run_concurrent_dfbs_program(
             .compile_time_arg_bindings =
                 {
                     {"num_entries_per_consumer", entries_per_dfb},
-                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
+                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_producer_implicit_sync ? 1u : 0u)},
                     {"chunk_offset", chunk_offset},
                 },
             .config_spec =
@@ -881,14 +882,14 @@ void run_concurrent_tensix_dm_dfbs_program(
             .compile_time_arg_bindings =
                 {
                     {"num_entries_per_consumer", num_entries_per_consumer},
-                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_implicit_sync ? 1u : 0u)},
+                    {"implicit_sync", static_cast<uint32_t>(dfb_config.enable_producer_implicit_sync ? 1u : 0u)},
                 },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
                         experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
         });
-        if (!dfb_config.enable_implicit_sync) {
+        if (!dfb_config.enable_producer_implicit_sync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
                 .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
         }
@@ -1046,7 +1047,7 @@ void run_sequential_dfbs_program(
         .compile_time_arg_bindings =
             {
                 {"num_entries_per_producer", num_entries_per_producer},
-                {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
+                {"implicit_sync", static_cast<uint32_t>(configs[0].enable_producer_implicit_sync ? 1u : 0u)},
                 {"num_producers", num_producers},
             },
         .config_spec =
@@ -1066,7 +1067,7 @@ void run_sequential_dfbs_program(
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings =
             {
-                {"implicit_sync", static_cast<uint32_t>(configs[0].enable_implicit_sync ? 1u : 0u)},
+                {"implicit_sync", static_cast<uint32_t>(configs[0].enable_producer_implicit_sync ? 1u : 0u)},
                 {"num_consumers", num_consumers},
             },
         .config_spec =
@@ -1096,7 +1097,7 @@ void run_sequential_dfbs_program(
             .num_entries = num_entries,
             .data_format_metadata = configs[i].data_format,
         });
-        const bool disable_isync = !configs[i].enable_implicit_sync;
+        const bool disable_isync = !configs[i].enable_producer_implicit_sync;
         if (disable_isync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
                 .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
@@ -1262,7 +1263,7 @@ void run_in_dfb_out_dfb_program(
         .compile_time_arg_bindings =
             {
                 {"num_entries_per_producer", num_entries_per_producer},
-                {"implicit_sync", static_cast<uint32_t>(dm2tensix_config.enable_implicit_sync ? 1u : 0u)},
+                {"implicit_sync", static_cast<uint32_t>(dm2tensix_config.enable_producer_implicit_sync ? 1u : 0u)},
                 {"num_producers", dm2tensix_config.num_producers},
             },
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
@@ -1271,7 +1272,7 @@ void run_in_dfb_out_dfb_program(
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
-    if (!dm2tensix_config.enable_implicit_sync) {
+    if (!dm2tensix_config.enable_producer_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
             .gen2_data_movement_config->disable_implicit_sync_for.push_back(IN_DFB);
     }
@@ -1323,7 +1324,7 @@ void run_in_dfb_out_dfb_program(
             {
                 {"num_entries_per_consumer", num_entries_per_consumer},
                 {"blocked_consumer", static_cast<uint32_t>(out_is_all ? 1u : 0u)},
-                {"implicit_sync", static_cast<uint32_t>(tensix2dm_config.enable_implicit_sync ? 1u : 0u)},
+                {"implicit_sync", static_cast<uint32_t>(tensix2dm_config.enable_producer_implicit_sync ? 1u : 0u)},
                 {"num_consumers", tensix2dm_config.num_consumers},
             },
         .runtime_arguments_schema = {.named_runtime_args = {"chunk_offset", "entries_per_core"}},
@@ -1332,7 +1333,7 @@ void run_in_dfb_out_dfb_program(
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
-    if (!tensix2dm_config.enable_implicit_sync) {
+    if (!tensix2dm_config.enable_producer_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
             .gen2_data_movement_config->disable_implicit_sync_for.push_back(OUT_DFB);
     }
@@ -1427,27 +1428,29 @@ constexpr uint32_t dfb_default_num_entries(uint32_t num_p, uint32_t num_c) {
             .pap = dfb::AccessPattern::pap_kind,                                                        \
             .num_consumers = (num_c),                                                                   \
             .cap = dfb::AccessPattern::cap_kind,                                                        \
-            .enable_implicit_sync = GetParam()};                                                        \
-        run_single_dfb_program(                                                                         \
-            this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind);                    \
+            .enable_producer_implicit_sync = GetParam(),                                                \
+            .enable_consumer_implicit_sync = GetParam()};                                               \
+        run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind); \
     }
 
 // Variant for DM->DM tests that pass an explicit num_entries_in_buffer (forces wraparound
 // when the requested total exceeds the ring size).
-#define DFB_TEST_BUF(prefix, suffix, p_kind, c_kind, num_p, pap_kind, num_c, cap_kind, extra_skip, n_buf) \
-    TEST_P(DFBImplicitSyncParamFixture, prefix##Test1xDFB##suffix) {                                    \
-        DFB_SKIP_IF_UNSUPPORTED((num_p), (num_c));                                                      \
-        extra_skip;                                                                                     \
-        experimental::dfb::DataflowBufferConfig config{                                                 \
-            .entry_size = 1024,                                                                         \
-            .num_entries = dfb_default_num_entries((num_p), (num_c)),                                   \
-            .num_producers = (num_p), .pap = dfb::AccessPattern::pap_kind,                              \
-            .num_consumers = (num_c), .cap = dfb::AccessPattern::cap_kind,                              \
-            .enable_implicit_sync = GetParam()};                                                        \
-        CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));                       \
-        run_single_dfb_program(                                                                         \
-            this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind,                     \
-            core_range_set, (n_buf));                                                                   \
+#define DFB_TEST_BUF(prefix, suffix, p_kind, c_kind, num_p, pap_kind, num_c, cap_kind, extra_skip, n_buf)     \
+    TEST_P(DFBImplicitSyncParamFixture, prefix##Test1xDFB##suffix) {                                          \
+        DFB_SKIP_IF_UNSUPPORTED((num_p), (num_c));                                                            \
+        extra_skip;                                                                                           \
+        experimental::dfb::DataflowBufferConfig config{                                                       \
+            .entry_size = 1024,                                                                               \
+            .num_entries = dfb_default_num_entries((num_p), (num_c)),                                         \
+            .num_producers = (num_p),                                                                         \
+            .pap = dfb::AccessPattern::pap_kind,                                                              \
+            .num_consumers = (num_c),                                                                         \
+            .cap = dfb::AccessPattern::cap_kind,                                                              \
+            .enable_producer_implicit_sync = GetParam(),                                                      \
+            .enable_consumer_implicit_sync = GetParam()};                                                     \
+        CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));                             \
+        run_single_dfb_program(                                                                               \
+            this->devices_.at(0), config, DFBPorCType::p_kind, DFBPorCType::c_kind, core_range_set, (n_buf)); \
     }
 
 // =====================================================================================
@@ -1470,7 +1473,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 1,
 //         .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     experimental::dfb::DataflowBufferConfig tensix2dm_config{
 //         .entry_size = 1024,
@@ -1479,7 +1483,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 1,
 //             .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
 // }
@@ -1495,7 +1500,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 1,
 //         .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     experimental::dfb::DataflowBufferConfig tensix2dm_config{
 //         .entry_size = 1024,
@@ -1504,7 +1510,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 2,
 //         .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
 // }
@@ -1520,7 +1527,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 1,
 //         .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     experimental::dfb::DataflowBufferConfig tensix2dm_config{
 //         .entry_size = 1024,
@@ -1529,7 +1537,8 @@ DFB_TEST    (TensixDM, 1Sx1S, TENSIX, DM,     1, STRIDED, 1, STRIDED, DFB_NO_EXT
 //         .pap = dfb::AccessPattern::STRIDED,
 //         .num_consumers = 4,
 //         .cap = dfb::AccessPattern::STRIDED,
-//         .enable_implicit_sync = false};
+//         .enable_producer_implicit_sync = false,
+//         .enable_consumer_implicit_sync = false};
 
 //     run_in_dfb_out_dfb_program(this->devices_.at(0), dm2tensix_config, tensix2dm_config);
 // }
@@ -1659,7 +1668,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_RingPressure_1Sx1S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_single_dfb_program(
         this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM,
         CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
@@ -1679,7 +1689,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_RingPressure_3Sx3S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 3,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_single_dfb_program(
         this->devices_.at(0),
         config,
@@ -1704,7 +1715,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTensixTest1xDFB_RingPressure_4Sx4A) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_single_dfb_program(
         this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::TENSIX,
         CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
@@ -1725,7 +1737,8 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest1xDFB_RingPressure_2Sx4S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_single_dfb_program(
         this->devices_.at(0), config, DFBPorCType::TENSIX, DFBPorCType::DM,
         CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0))), /*num_entries_in_buffer=*/64);
@@ -1742,7 +1755,8 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx1S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
 
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
@@ -1759,7 +1773,8 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_2Sx2S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 2,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
 
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
@@ -1779,7 +1794,8 @@ TEST_P(DFBImplicitSyncParamFixture, MultiCoreDMTest2Core_1Sx4A) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
 
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     run_single_dfb_program(this->devices_.at(0), config, DFBPorCType::DM, DFBPorCType::DM, core_range_set);
@@ -1812,13 +1828,14 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest3xDFB_1Sx1S) {
         GTEST_SKIP() << "Skipping: concurrent DFB test requires Quasar multi-threaded DM";
     }
     experimental::dfb::DataflowBufferConfig config{
-        .entry_size    = 1024,
-        .num_entries   = 16,
+        .entry_size = 1024,
+        .num_entries = 16,
         .num_producers = 1,
-        .pap           = dfb::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap           = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_concurrent_dfbs_program(this->devices_.at(0), /*num_dfbs=*/3, config);
 }
 
@@ -1830,13 +1847,14 @@ TEST_P(DFBImplicitSyncParamFixture, TensixDMTest4xDFB_1Sx1S) {
         GTEST_SKIP() << "Skipping: Tensix concurrent DFB test requires Quasar";
     }
     experimental::dfb::DataflowBufferConfig config{
-        .entry_size    = 1024,
-        .num_entries   = 16,
+        .entry_size = 1024,
+        .num_entries = 16,
         .num_producers = 1,
-        .pap           = dfb::AccessPattern::STRIDED,
+        .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
-        .cap           = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_concurrent_tensix_dm_dfbs_program(this->devices_.at(0), /*num_dfbs=*/4, config);
 }
 
@@ -1855,7 +1873,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest4xDFB_3Sx3S) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 3,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_sequential_dfbs_program(this->devices_.at(0), {config, config, config, config});
 }
 
@@ -1877,7 +1896,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest4xDFB_Mixed) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 3,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     experimental::dfb::DataflowBufferConfig all_cfg{
         .entry_size = 1024,
         .num_entries = 18,
@@ -1885,7 +1905,8 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest4xDFB_Mixed) {
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 3,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = GetParam()};
+        .enable_producer_implicit_sync = GetParam(),
+        .enable_consumer_implicit_sync = GetParam()};
     run_sequential_dfbs_program(
         this->devices_.at(0), {strided_cfg, strided_cfg, all_cfg, all_cfg});
 }
@@ -1911,7 +1932,8 @@ static void run_intra_tensix_dfb_program(
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = num_threads,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false,
         .tensix_scope = experimental::dfb::TensixScope::INTRA};
 
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -2039,24 +2061,26 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
 
     // dfb(0): DM->Tensix, 1Sx4A with remapper, implicit sync enabled.
     experimental::dfb::DataflowBufferConfig remapper_dfb_config{
-        .entry_size           = entry_size,
-        .num_entries          = num_entries,
-        .num_producers        = 1,
-        .pap                  = dfb::AccessPattern::STRIDED,
-        .num_consumers        = num_neos,
-        .cap                  = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = true};
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = num_neos,
+        .cap = dfb::AccessPattern::ALL,
+        .enable_producer_implicit_sync = true,
+        .enable_consumer_implicit_sync = true};
 
     // dfb(1): intra-tensix, 4 packer->unpacker pairs, hidden TCs.
     experimental::dfb::DataflowBufferConfig intra_dfb_config{
-        .entry_size           = entry_size,
-        .num_entries          = num_entries,
-        .num_producers        = num_neos,
-        .pap                  = dfb::AccessPattern::STRIDED,
-        .num_consumers        = num_neos,
-        .cap                  = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false,
-        .tensix_scope         = experimental::dfb::TensixScope::INTRA};
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .num_producers = num_neos,
+        .pap = dfb::AccessPattern::STRIDED,
+        .num_consumers = num_neos,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false,
+        .tensix_scope = experimental::dfb::TensixScope::INTRA};
 
     auto in_tensor = MeshTensor::allocate_on_device(
         *this->devices_.at(0), make_flat_dram_tensor_spec(entry_size, num_entries), TensorTopology{});
@@ -2108,7 +2132,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
-    if (!remapper_dfb_config.enable_implicit_sync) {
+    if (!remapper_dfb_config.enable_producer_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(dm_producer_spec.config_spec)
             .gen2_data_movement_config->disable_implicit_sync_for.push_back(REMAPPER_DFB);
     }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -212,7 +212,7 @@ void run_single_dfb_program(
     const auto consumer_pattern = is_all ? experimental::metal2_host_api::DFBAccessPattern::ALL
                                          : experimental::metal2_host_api::DFBAccessPattern::STRIDED;
 
-    // Per-DM-kernel disable_implicit_sync entries below mirror the boolean derived from
+    // Per-DM-kernel disable_implicit_sync_for entries below mirror the boolean derived from
     // dfb_config.enable_implicit_sync (the lower-level legacy config still drives the value;
     // each DM endpoint votes per-DFB on the spec side).
     experimental::metal2_host_api::DataflowBufferSpec dfb_spec{
@@ -332,11 +332,11 @@ void run_single_dfb_program(
     const bool disable_isync = !dfb_config.enable_implicit_sync;
     if (producer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back(DFB_NAME);
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back(DFB_NAME);
     }
     if (consumer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back(DFB_NAME);
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back(DFB_NAME);
     }
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -683,7 +683,7 @@ void run_concurrent_dfbs_program(
         });
         if (disable_isync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
         }
         kernel_names.push_back(producer_name);
 
@@ -716,7 +716,7 @@ void run_concurrent_dfbs_program(
         });
         if (disable_isync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
         }
         kernel_names.push_back(consumer_name);
     }
@@ -890,7 +890,7 @@ void run_concurrent_tensix_dm_dfbs_program(
         });
         if (!dfb_config.enable_implicit_sync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
         }
         kernel_names.push_back(consumer_name);
     }
@@ -1099,9 +1099,9 @@ void run_sequential_dfbs_program(
         const bool disable_isync = !configs[i].enable_implicit_sync;
         if (disable_isync) {
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
             std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
-                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+                .gen2_data_movement_config->disable_implicit_sync_for.push_back(dfb_name);
         }
         tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
             .unique_id = in_tensor_name,
@@ -1273,7 +1273,7 @@ void run_in_dfb_out_dfb_program(
     };
     if (!dm2tensix_config.enable_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back(IN_DFB);
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back(IN_DFB);
     }
 
     experimental::metal2_host_api::KernelSpec compute_spec{
@@ -1334,7 +1334,7 @@ void run_in_dfb_out_dfb_program(
     };
     if (!tensix2dm_config.enable_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back(OUT_DFB);
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back(OUT_DFB);
     }
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -2110,7 +2110,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     };
     if (!remapper_dfb_config.enable_implicit_sync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(dm_producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back(REMAPPER_DFB);
+            .gen2_data_movement_config->disable_implicit_sync_for.push_back(REMAPPER_DFB);
     }
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -330,13 +330,13 @@ void run_single_dfb_program(
 
     // Each DM endpoint votes per-DFB on opting out of implicit sync.
     const bool disable_isync = !dfb_config.enable_implicit_sync;
-    if (producer_type == DFBPorCType::DM) {
+    if (producer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({DFB_NAME, disable_isync});
+            .gen2_data_movement_config->disable_implicit_sync.push_back(DFB_NAME);
     }
-    if (consumer_type == DFBPorCType::DM) {
+    if (consumer_type == DFBPorCType::DM && disable_isync) {
         std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({DFB_NAME, disable_isync});
+            .gen2_data_movement_config->disable_implicit_sync.push_back(DFB_NAME);
     }
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -679,9 +679,12 @@ void run_concurrent_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                            .disable_implicit_sync = {{dfb_name, disable_isync}}}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
         });
+        if (disable_isync) {
+            std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+        }
         kernel_names.push_back(producer_name);
 
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
@@ -709,9 +712,12 @@ void run_concurrent_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                            .disable_implicit_sync = {{dfb_name, disable_isync}}}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
         });
+        if (disable_isync) {
+            std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+        }
         kernel_names.push_back(consumer_name);
     }
 
@@ -880,9 +886,12 @@ void run_concurrent_tensix_dm_dfbs_program(
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
-                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                            .disable_implicit_sync = {{dfb_name, !dfb_config.enable_implicit_sync}}}},
+                        experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
         });
+        if (!dfb_config.enable_implicit_sync) {
+            std::get<experimental::metal2_host_api::DataMovementConfiguration>(kernel_specs.back().config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+        }
         kernel_names.push_back(consumer_name);
     }
 
@@ -1088,10 +1097,12 @@ void run_sequential_dfbs_program(
             .data_format_metadata = configs[i].data_format,
         });
         const bool disable_isync = !configs[i].enable_implicit_sync;
-        std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({dfb_name, disable_isync});
-        std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
-            .gen2_data_movement_config->disable_implicit_sync.push_back({dfb_name, disable_isync});
+        if (disable_isync) {
+            std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+            std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
+                .gen2_data_movement_config->disable_implicit_sync.push_back(dfb_name);
+        }
         tensor_parameters.push_back(experimental::metal2_host_api::TensorParameter{
             .unique_id = in_tensor_name,
             .spec = in_tensors[i].tensor_spec(),
@@ -1258,9 +1269,12 @@ void run_in_dfb_out_dfb_program(
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{IN_DFB, !dm2tensix_config.enable_implicit_sync}}}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
+    if (!dm2tensix_config.enable_implicit_sync) {
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back(IN_DFB);
+    }
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
@@ -1316,9 +1330,12 @@ void run_in_dfb_out_dfb_program(
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{OUT_DFB, !tensix2dm_config.enable_implicit_sync}}}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
+    if (!tensix2dm_config.enable_implicit_sync) {
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(consumer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back(OUT_DFB);
+    }
 
     experimental::metal2_host_api::WorkUnitSpec wu{
         .unique_id = "main",
@@ -2089,9 +2106,12 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{REMAPPER_DFB, !remapper_dfb_config.enable_implicit_sync}}}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
     };
+    if (!remapper_dfb_config.enable_implicit_sync) {
+        std::get<experimental::metal2_host_api::DataMovementConfiguration>(dm_producer_spec.config_spec)
+            .gen2_data_movement_config->disable_implicit_sync.push_back(REMAPPER_DFB);
+    }
 
     // Combined compute kernel: BLOCKED consumer of remapper DFB ("remapper_in"),
     // self-looped on intra DFB (PRODUCER "intra_out" + CONSUMER "intra_in"; the

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -227,7 +227,8 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1SConfig) {
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -256,7 +257,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4SConfig) {
         .consumer_risc_mask = 0x1E,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -290,7 +292,8 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1SConfig) {
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -322,7 +325,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1SConfig) {
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -354,7 +358,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4SConfig) {
         .consumer_risc_mask = 0xF0,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -386,7 +391,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4SConfig) {
         .consumer_risc_mask = 0x3C,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -424,7 +430,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2SConfig) {
         .consumer_risc_mask = 0x30,
         .num_consumers = 2,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -456,7 +463,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1BConfig) {
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -485,7 +493,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4BConfig) {
         .consumer_risc_mask = 0x1E,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -519,7 +528,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1BConfig) {
         .consumer_risc_mask = 0x10,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -551,7 +561,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4BConfig) {
         .consumer_risc_mask = 0xF0,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -607,7 +618,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2BConfig) {
         .consumer_risc_mask = 0x30,
         .num_consumers = 2,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -658,7 +670,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4BConfig) {
         .consumer_risc_mask = 0x3C,
         .num_consumers = 4,
         .cap = dfb::AccessPattern::ALL,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreCoord logical_core = CoreCoord(0, 0);
@@ -746,7 +759,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));  // 2 cores: (0,0) and (1,0)
@@ -807,7 +821,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync) {
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = true};
+        .enable_producer_implicit_sync = true,
+        .enable_consumer_implicit_sync = true};
 
     Program program = CreateProgram();
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));  // 2 cores
@@ -844,7 +859,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
         .consumer_risc_mask = 0x2,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     Program program = CreateProgram();
     // 4 cores in a 2x2 grid — all identical config → should produce 1 DfbGroup.
@@ -920,7 +936,8 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig) {
         .consumer_risc_mask = 0x100,  // bit 8 = Neo0 (same as producer — intentional for INTRA)
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false,
         .tensix_scope = experimental::dfb::TensixScope::INTRA};
 
     Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -582,7 +582,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     // INTRA-tensix self-loop DFBs have no DM endpoint; the spec-to-impl translation produces
-    // enable_implicit_sync=false automatically (no DM kernel to vote for it).
+    // enable_{producer,consumer}_implicit_sync=false automatically (no DM kernel to vote for it).
 
     BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1686,7 +1686,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
     // INTRA-tensix self-loop: no DM endpoint, so the spec-to-impl translation produces
-    // enable_implicit_sync=false at the lower DFB layer automatically.
+    // enable_{producer,consumer}_implicit_sync=false at the lower DFB layer automatically.
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -706,7 +706,11 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
             "KernelSpec 'kernel' has too many threads. The architecture supports up to 4 for compute kernels")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
+TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigSucceeds) {
+    // Gen2 config is fully optional even on Quasar: absence is treated as "use defaults"
+    // (empty disable_implicit_sync_for). A Gen1-only DM kernel building on Quasar is
+    // permitted at the spec layer (whether such a kernel actually does anything useful on
+    // Gen2 hardware is a separate question, outside the validator's scope).
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -727,10 +731,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigFails) {
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("KernelSpec 'kernel' must specify a Gen2 DM config when targeting Quasar")));
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -581,10 +581,8 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) 
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    // INTRA-tensix self-loop DFBs require implicit_sync disabled (a lower-layer constraint
-    // enforced in dataflow_buffer.cpp). This matches the pattern real self-loop DFBs use
-    // (e.g. ACC_DFB / INEG_DFB in the reduction op factory's negate path).
-    dfb.disable_implicit_sync = true;
+    // INTRA-tensix self-loop DFBs have no DM endpoint; the spec-to-impl translation produces
+    // enable_implicit_sync=false automatically (no DM kernel to vote for it).
 
     BindDFBToKernel(self_loop_1, "dfb", "p", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(self_loop_1, "dfb", "c", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1536,7 +1534,6 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    dfb.disable_implicit_sync = true;
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1589,7 +1586,6 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    dfb.disable_implicit_sync = true;
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1645,7 +1641,6 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSelfLoopScopeEntriesFails) {
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    dfb.disable_implicit_sync = true;
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1689,8 +1684,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelImplicitIntraSucceeds) {
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    // INTRA requires implicit-sync OFF at the lower DFB layer.
-    dfb.disable_implicit_sync = true;
+    // INTRA-tensix self-loop: no DM endpoint, so the spec-to-impl translation produces
+    // enable_implicit_sync=false at the lower DFB layer automatically.
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -1717,7 +1712,6 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
-    dfb.disable_implicit_sync = true;
 
     BindDFBToKernel(compute, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
     BindDFBToKernel(compute, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
@@ -2335,11 +2329,9 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
         .entry_size = 1024,
         .num_entries = 8,
         .borrowed_from = "input_tensor",
-        .disable_implicit_sync = true,
     };
 
     EXPECT_EQ(borrowed_dfb.borrowed_from, std::optional<TensorParameterName>{"input_tensor"});
-    EXPECT_TRUE(borrowed_dfb.disable_implicit_sync);
 }
 
 TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -415,6 +415,9 @@ bool reader_datacopy_writer(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
+    // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
+    // via Gen2DataMovementConfig::disable_implicit_sync). The program-level
+    // reservation flag set below is independent of per-DFB sync mode.
     experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -416,7 +416,7 @@ bool reader_datacopy_writer(
     constexpr const char* COMPUTE = "compute";
 
     // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
-    // via Gen2DataMovementConfig::disable_implicit_sync). The program-level
+    // via Gen2DataMovementConfig::disable_implicit_sync_for). The program-level
     // reservation flag set below is independent of per-DFB sync mode.
     experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -74,8 +74,6 @@ void RunTest(
         .entry_size = TILE_SIZE,
         .num_entries = NUM_ENTRIES_PER_DFB,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        // Legacy enable_implicit_sync = false -> disable_implicit_sync = true.
-        .disable_implicit_sync = true,
     };
 
     const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_tile_counters.cpp";
@@ -95,7 +93,8 @@ void RunTest(
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{TILE_COUNTER_DFB, true}}}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -94,7 +94,7 @@ void RunTest(
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {TILE_COUNTER_DFB}}},
+                        .disable_implicit_sync_for = {TILE_COUNTER_DFB}}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -94,7 +94,7 @@ void RunTest(
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{TILE_COUNTER_DFB, true}}}},
+                        .disable_implicit_sync = {TILE_COUNTER_DFB}}},
     };
 
     // NEO compute consumer kernel (4 threads = 4 Neo clusters)

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -155,7 +155,8 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
         .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false,
         .data_format = tt::DataFormat::Float16_b};
 
     std::vector<uint32_t> dfb_ids(total_dfbs);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -1081,7 +1081,8 @@ DFBConfigReaderProgram create_dfb_config_reader_program(uint32_t entry_size, uin
         .pap = dfb::AccessPattern::STRIDED,
         .num_consumers = 1,
         .cap = dfb::AccessPattern::STRIDED,
-        .enable_implicit_sync = false};
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
 
     auto dfb_id = experimental::dfb::CreateDataflowBuffer(program, core_range, dfb_config);
     experimental::dfb::BindDataflowBufferToProducerConsumerKernels(program, dfb_id, producer_kernel, consumer_kernel);

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -237,21 +237,18 @@ static void matmul_tile_block(
         .entry_size = ctx.single_tile_size_bfp16b,
         .num_entries = ctx.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec src1_dfb_spec{
         .unique_id = SRC1_DFB,
         .entry_size = ctx.single_tile_size_bfp16b,
         .num_entries = ctx.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = ctx.single_tile_size_out0,
         .num_entries = ctx.num_tiles,
         .data_format_metadata = cfg.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{
@@ -288,7 +285,8 @@ static void matmul_tile_block(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{SRC0_DFB, true}, {SRC1_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -310,7 +308,8 @@ static void matmul_tile_block(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{DST_DFB, true}}}},
     };
 
     // matmul_block.cpp uses named CTAs. Map cfg.compute_kernel_args (positional) to the

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -286,7 +286,7 @@ static void matmul_tile_block(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {SRC0_DFB, SRC1_DFB}}},
+                        .disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -309,7 +309,7 @@ static void matmul_tile_block(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {DST_DFB}}},
+                        .disable_implicit_sync_for = {DST_DFB}}},
     };
 
     // matmul_block.cpp uses named CTAs. Map cfg.compute_kernel_args (positional) to the

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -286,7 +286,7 @@ static void matmul_tile_block(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{SRC0_DFB, true}, {SRC1_DFB, true}}}},
+                        .disable_implicit_sync = {SRC0_DFB, SRC1_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -309,7 +309,7 @@ static void matmul_tile_block(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{DST_DFB, true}}}},
+                        .disable_implicit_sync = {DST_DFB}}},
     };
 
     // matmul_block.cpp uses named CTAs. Map cfg.compute_kernel_args (positional) to the

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -306,7 +306,6 @@ void run_single_core_broadcast(
             .num_entries = k_num_tiles_broadcast_test,
             .data_format_metadata = tt::DataFormat::Float16_b,
             .tile_format_metadata = tile_dims,
-            .disable_implicit_sync = true,
         };
     };
 
@@ -341,7 +340,8 @@ void run_single_core_broadcast(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -363,7 +363,8 @@ void run_single_core_broadcast(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync_for = {OUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -133,7 +133,7 @@ void run_single_core_copy_block_matmul_partials(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {SRC0_DFB}}},
+                        .disable_implicit_sync_for = {SRC0_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -157,7 +157,7 @@ void run_single_core_copy_block_matmul_partials(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {DST_DFB}}},
+                        .disable_implicit_sync_for = {DST_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -104,16 +104,12 @@ void run_single_core_copy_block_matmul_partials(
         .entry_size = single_tile_size,
         .num_entries = num_input_tiles,
         .data_format_metadata = data_format,
-        // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false.
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = single_tile_size,
         .num_entries = num_output_tiles,
         .data_format_metadata = data_format,
-        // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false.
-        .disable_implicit_sync = true,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{
@@ -136,7 +132,8 @@ void run_single_core_copy_block_matmul_partials(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{SRC0_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -159,7 +156,8 @@ void run_single_core_copy_block_matmul_partials(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{DST_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -133,7 +133,7 @@ void run_single_core_copy_block_matmul_partials(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{SRC0_DFB, true}}}},
+                        .disable_implicit_sync = {SRC0_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -157,7 +157,7 @@ void run_single_core_copy_block_matmul_partials(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{DST_DFB, true}}}},
+                        .disable_implicit_sync = {DST_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -465,7 +465,7 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {INP0_DFB, INP1_DFB, INP2_DFB, INP3_DFB, INP4_DFB, INP5_DFB}}},
+                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB, INP2_DFB, INP3_DFB, INP4_DFB, INP5_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -484,7 +484,7 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {OUT_DFB}}},
+                        .disable_implicit_sync_for = {OUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -399,7 +399,6 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             .entry_size = f16_tile_size,
             .num_entries = 1,
             .data_format_metadata = tt::DataFormat::Float16_b,
-            .disable_implicit_sync = true,
         };
     };
     auto make_f32_input_dfb = [&](const std::string& name) {
@@ -408,7 +407,6 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             .entry_size = f32_tile_size,
             .num_entries = 1,
             .data_format_metadata = tt::DataFormat::Float32,
-            .disable_implicit_sync = true,
         };
     };
     experimental::metal2_host_api::DataflowBufferSpec inp0_dfb_spec = make_f16_input_dfb(INP0_DFB);
@@ -422,7 +420,6 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
         .entry_size = f16_tile_size,
         .num_entries = kNumOps,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
 
     using DFBEndpoint = experimental::metal2_host_api::KernelSpec::DFBEndpointType;
@@ -467,7 +464,14 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync =
+                            {{INP0_DFB, true},
+                             {INP1_DFB, true},
+                             {INP2_DFB, true},
+                             {INP3_DFB, true},
+                             {INP4_DFB, true},
+                             {INP5_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -485,7 +489,8 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{OUT_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -465,13 +465,7 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync =
-                            {{INP0_DFB, true},
-                             {INP1_DFB, true},
-                             {INP2_DFB, true},
-                             {INP3_DFB, true},
-                             {INP4_DFB, true},
-                             {INP5_DFB, true}}}},
+                        .disable_implicit_sync = {INP0_DFB, INP1_DFB, INP2_DFB, INP3_DFB, INP4_DFB, INP5_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -490,7 +484,7 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{OUT_DFB, true}}}},
+                        .disable_implicit_sync = {OUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -388,7 +388,7 @@ void run_single_core_reduce_program(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {SRC0_DFB, SRC1_DFB}}},
+                        .disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -412,7 +412,7 @@ void run_single_core_reduce_program(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {DST_DFB}}},
+                        .disable_implicit_sync_for = {DST_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -388,7 +388,7 @@ void run_single_core_reduce_program(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{SRC0_DFB, true}, {SRC1_DFB, true}}}},
+                        .disable_implicit_sync = {SRC0_DFB, SRC1_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -412,7 +412,7 @@ void run_single_core_reduce_program(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{DST_DFB, true}}}},
+                        .disable_implicit_sync = {DST_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -319,14 +319,12 @@ void run_single_core_reduce_program(
     constexpr const char* IN_TENSOR = "in_tensor";
     constexpr const char* OUT_TENSOR = "out_tensor";
 
-    // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false on all 3 DFBs.
     experimental::metal2_host_api::DataflowBufferSpec src0_dfb_spec{
         .unique_id = SRC0_DFB,
         .entry_size = dims.single_tile_bytes,
         .num_entries = num_buffer_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .tile_format_metadata = test_config.tile_shape,
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec src1_dfb_spec{
         .unique_id = SRC1_DFB,
@@ -334,7 +332,6 @@ void run_single_core_reduce_program(
         .num_entries = 2,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .tile_format_metadata = tt_metal::Tile({32, 32}),
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
@@ -342,7 +339,6 @@ void run_single_core_reduce_program(
         .num_entries = num_output_buffer_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .tile_format_metadata = test_config.tile_shape,
-        .disable_implicit_sync = true,
     };
 
     // Build reader spec depending on reduce dim
@@ -391,7 +387,8 @@ void run_single_core_reduce_program(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{SRC0_DFB, true}, {SRC1_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -414,7 +411,8 @@ void run_single_core_reduce_program(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{DST_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -216,21 +216,17 @@ bool run_sfpu_all_same_buffer(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
-    // Legacy DataflowBufferConfig set enable_implicit_sync = false on both DFBs;
-    // mirror that with disable_implicit_sync = true.
     experimental::metal2_host_api::DataflowBufferSpec in_dfb_spec{
         .unique_id = IN_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_input_data_format,
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec out_dfb_spec{
         .unique_id = OUT_DFB,
         .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_output_data_format,
-        .disable_implicit_sync = true,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -290,8 +290,6 @@ bool single_core_binary(
             .num_entries = static_cast<uint32_t>(test_config.num_tiles),
             .data_format_metadata = test_config.l1_input_data_format,
             .tile_format_metadata = test_config.tile,
-            // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false.
-            .disable_implicit_sync = true,
         };
     };
 
@@ -304,8 +302,6 @@ bool single_core_binary(
         .num_entries = static_cast<uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_output_data_format,
         .tile_format_metadata = test_config.tile,
-        // Match pre-migration behavior: legacy DataflowBufferConfig set enable_implicit_sync=false.
-        .disable_implicit_sync = true,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{
@@ -343,7 +339,8 @@ bool single_core_binary(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{INP0_DFB, true}, {INP1_DFB, true}, {INP2_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -365,7 +362,8 @@ bool single_core_binary(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{OUT_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -340,7 +340,7 @@ bool single_core_binary(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {INP0_DFB, INP1_DFB, INP2_DFB}}},
+                        .disable_implicit_sync_for = {INP0_DFB, INP1_DFB, INP2_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -363,7 +363,7 @@ bool single_core_binary(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {OUT_DFB}}},
+                        .disable_implicit_sync_for = {OUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -340,7 +340,7 @@ bool single_core_binary(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{INP0_DFB, true}, {INP1_DFB, true}, {INP2_DFB, true}}}},
+                        .disable_implicit_sync = {INP0_DFB, INP1_DFB, INP2_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -363,7 +363,7 @@ bool single_core_binary(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{OUT_DFB, true}}}},
+                        .disable_implicit_sync = {OUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec compute_spec{

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -571,7 +571,8 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                     .consumer_risc_mask = consumer_mask,
                     .num_consumers = 1,
                     .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-                    .enable_implicit_sync = false,
+                    .enable_producer_implicit_sync = false,
+                    .enable_consumer_implicit_sync = false,
                     .data_format = tt::DataFormat::Float16_b});
         };
         in0_id = make_dfb(cb_page_size, M * K, 0x1, 0x100);
@@ -587,7 +588,8 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .pap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
                 .num_consumers = 1,
                 .cap = tt_metal::experimental::dfb::AccessPattern::STRIDED,
-                .enable_implicit_sync = false,
+                .enable_producer_implicit_sync = false,
+                .enable_consumer_implicit_sync = false,
                 .data_format = tt::DataFormat::Float16_b,
                 .tensix_scope = tt_metal::experimental::dfb::TensixScope::INTRA});
     } else {

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -213,7 +213,7 @@ void run_single_core_transpose(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {INPUT_DFB}}},
+                        .disable_implicit_sync_for = {INPUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -237,7 +237,7 @@ void run_single_core_transpose(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {OUTPUT_DFB}}},
+                        .disable_implicit_sync_for = {OUTPUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -184,14 +184,12 @@ void run_single_core_transpose(
         .entry_size = test_config.single_tile_size,
         .num_entries = num_buffer_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
     experimental::metal2_host_api::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
         .entry_size = test_config.single_tile_size,
         .num_entries = num_output_buffer_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = true,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{
@@ -214,7 +212,8 @@ void run_single_core_transpose(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{INPUT_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -237,7 +236,8 @@ void run_single_core_transpose(
                     experimental::metal2_host_api::DataMovementConfiguration::Gen1DataMovementConfig{
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
-                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+                    experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
+                        .disable_implicit_sync = {{OUTPUT_DFB, true}}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -213,7 +213,7 @@ void run_single_core_transpose(
                         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{INPUT_DFB, true}}}},
+                        .disable_implicit_sync = {INPUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec writer_spec{
@@ -237,7 +237,7 @@ void run_single_core_transpose(
                         .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{
-                        .disable_implicit_sync = {{OUTPUT_DFB, true}}}},
+                        .disable_implicit_sync = {OUTPUT_DFB}}},
     };
 
     experimental::metal2_host_api::KernelSpec::CompilerOptions::Defines compute_defines;

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -98,27 +98,28 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default},
         .gen2_data_movement_config =
             experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}};
+    if (!use_implicit_sync) {
+        reader_config.gen2_data_movement_config->disable_implicit_sync_for = {SRC0_DFB, SRC1_DFB};
+        writer_config.gen2_data_movement_config->disable_implicit_sync_for = {DST_DFB};
+    }
 
     experimental::metal2_host_api::DataflowBufferSpec src0_dfb_spec{
         .unique_id = SRC0_DFB,
         .entry_size = p.single_tile_size,
         .num_entries = p.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = !use_implicit_sync,
     };
     experimental::metal2_host_api::DataflowBufferSpec src1_dfb_spec{
         .unique_id = SRC1_DFB,
         .entry_size = p.single_tile_size,
         .num_entries = p.num_input_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = !use_implicit_sync,
     };
     experimental::metal2_host_api::DataflowBufferSpec dst_dfb_spec{
         .unique_id = DST_DFB,
         .entry_size = p.single_tile_size,
         .num_entries = p.num_output_tiles,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .disable_implicit_sync = !use_implicit_sync,
     };
 
     experimental::metal2_host_api::KernelSpec reader_spec{

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -63,9 +63,9 @@ static void run_pack_relu_test(
     constexpr const char* WRITER = "writer";
     constexpr const char* COMPUTE = "compute";
 
-    // Legacy DataflowBufferConfig used enable_implicit_sync = true on both DFBs;
-    // keep DataflowBufferSpec::disable_implicit_sync at its default (false) and
-    // set the program-level reservation flag below.
+    // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
+    // via Gen2DataMovementConfig::disable_implicit_sync). The program-level
+    // reservation flag set below is independent of per-DFB sync mode.
     experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,
         .entry_size = single_tile_size,

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -64,7 +64,7 @@ static void run_pack_relu_test(
     constexpr const char* COMPUTE = "compute";
 
     // Implicit sync is enabled by default for both DFBs (no DM kernel opts out
-    // via Gen2DataMovementConfig::disable_implicit_sync). The program-level
+    // via Gen2DataMovementConfig::disable_implicit_sync_for). The program-level
     // reservation flag set below is independent of per-DFB sync mode.
     experimental::metal2_host_api::DataflowBufferSpec input_dfb_spec{
         .unique_id = INPUT_DFB,

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -49,7 +49,7 @@ struct DataflowBufferConfig {
     // By default, the producer and consumer sides share the same implicit sync setting
     // However, you can "flip" the behavior of the consumer side to create
     //  - explicit producer + implicit consumer
-    //  - implicit producer + explicit consumer)
+    //  - implicit producer + explicit consumer
     // This is rarely (if ever) useful, hence why it's a std::optional rather than plain bool.
     // The option exists primarily to simplify legality check coupling in Metal 2.0.
     std::optional<bool> override_consumer_implicit_sync = std::nullopt;

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -41,18 +41,12 @@ struct DataflowBufferConfig {
     uint8_t num_consumers = 1;
     AccessPattern cap = AccessPattern::STRIDED;
 
-    // Implicit sync:
-    // When true, both producer and consumer kernels use the streamlined implicit sync syntax
-    // (This ONLY applies to DM riscs; Tensix riscs always require explicit sync.)
-    bool enable_implicit_sync = false;
-
-    // By default, the producer and consumer sides share the same implicit sync setting
-    // However, you can "flip" the behavior of the consumer side to create
-    //  - explicit producer + implicit consumer
-    //  - implicit producer + explicit consumer
-    // This is rarely (if ever) useful, hence why it's a std::optional rather than plain bool.
-    // The option exists primarily to simplify legality check coupling in Metal 2.0.
-    std::optional<bool> override_consumer_implicit_sync = std::nullopt;
+    // Implicit sync — per-side opt-in to the streamlined ISR-driven credit posting.
+    // (Only applies to DM riscs; Tensix riscs always require explicit sync.)
+    // Setting the two sides asymmetrically is a niche debug knob for isolating sync bugs;
+    // typical usage sets both to the same value.
+    bool enable_producer_implicit_sync = false;
+    bool enable_consumer_implicit_sync = false;
 
     // Data format and tile formats for LLKs
     DataFormat data_format = tt::DataFormat::Float16_b;
@@ -64,12 +58,6 @@ struct DataflowBufferConfig {
     // supplied before launch via DataflowBufferImpl::set_borrowed_memory_base_addr.
     bool borrows_memory = false;
 };
-
-inline bool producer_implicit_sync_active(const DataflowBufferConfig& config) { return config.enable_implicit_sync; }
-
-inline bool consumer_implicit_sync_active(const DataflowBufferConfig& config) {
-    return config.override_consumer_implicit_sync.value_or(config.enable_implicit_sync);
-}
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with
 // host API redesign. Returns logical DFB id

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -40,16 +40,21 @@ struct DataflowBufferConfig {
     uint16_t consumer_risc_mask = 0x0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
     uint8_t num_consumers = 1;
     AccessPattern cap = AccessPattern::STRIDED;
+
+    // Implicit sync:
+    // When true, both producer and consumer kernels use the streamlined implicit sync syntax
+    // (This ONLY applies to DM riscs; Tensix riscs always require explicit sync.)
     bool enable_implicit_sync = false;
-    // Per-endpoint override for implicit sync. When std::nullopt, the consumer side follows
-    // enable_implicit_sync. When set, the consumer side follows this value; the producer
-    // side still follows enable_implicit_sync. This is the per-endpoint override that the
-    // Metal 2.0 spec-layer translation uses to express asymmetric setups.
-    //
-    // For per-endpoint queries, prefer the producer_implicit_sync_active(config) /
-    // consumer_implicit_sync_active(config) free functions below; read this field directly
-    // only at the host-side translation site.
+
+    // By default, the producer and consumer sides share the same implicit sync setting
+    // However, you can "flip" the behavior of the consumer side to create
+    //  - explicit producer + implicit consumer
+    //  - implicit producer + explicit consumer)
+    // This is rarely (if ever) useful, hence why it's a std::optional rather than plain bool.
+    // The option exists primarily to simplify legality check coupling in Metal 2.0.
     std::optional<bool> override_consumer_implicit_sync = std::nullopt;
+
+    // Data format and tile formats for LLKs
     DataFormat data_format = tt::DataFormat::Float16_b;
     std::optional<Tile> tile = std::nullopt;
     // Set only when both producer and consumer are the same compute kernel

--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -41,6 +41,15 @@ struct DataflowBufferConfig {
     uint8_t num_consumers = 1;
     AccessPattern cap = AccessPattern::STRIDED;
     bool enable_implicit_sync = false;
+    // Per-endpoint override for implicit sync. When std::nullopt, the consumer side follows
+    // enable_implicit_sync. When set, the consumer side follows this value; the producer
+    // side still follows enable_implicit_sync. This is the per-endpoint override that the
+    // Metal 2.0 spec-layer translation uses to express asymmetric setups.
+    //
+    // For per-endpoint queries, prefer the producer_implicit_sync_active(config) /
+    // consumer_implicit_sync_active(config) free functions below; read this field directly
+    // only at the host-side translation site.
+    std::optional<bool> override_consumer_implicit_sync = std::nullopt;
     DataFormat data_format = tt::DataFormat::Float16_b;
     std::optional<Tile> tile = std::nullopt;
     // Set only when both producer and consumer are the same compute kernel
@@ -50,6 +59,12 @@ struct DataflowBufferConfig {
     // supplied before launch via DataflowBufferImpl::set_borrowed_memory_base_addr.
     bool borrows_memory = false;
 };
+
+inline bool producer_implicit_sync_active(const DataflowBufferConfig& config) { return config.enable_implicit_sync; }
+
+inline bool consumer_implicit_sync_active(const DataflowBufferConfig& config) {
+    return config.override_consumer_implicit_sync.value_or(config.enable_implicit_sync);
+}
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with
 // host API redesign. Returns logical DFB id

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -105,11 +105,6 @@ struct DataflowBufferSpec {
     //     (derived from their bound kernels' WorkUnitSpecs).
     using DFBIdentifiers = std::vector<DFBSpecName>;
     DFBIdentifiers alias_with;  // empty vector means no aliasing
-
-    // Disable implicit sync
-    // Implicit sync is handled via ISR (available on Gen2 only)
-    // Disabling may be useful in niche cases for fine tuning performance or performance debug.
-    bool disable_implicit_sync = false;
 };
 
 // NOTE: Remote DataflowBuffer is not yet supported!

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -79,31 +79,12 @@ struct DataMovementConfiguration {
     std::optional<Gen1DataMovementConfig> gen1_data_movement_config = std::nullopt;
 
     struct Gen2DataMovementConfig {
-        // Per-DFB-binding opt-out from ISR-based implicit sync.
-        //
-        // Implicit sync collapses the four-line DM-kernel dance
-        // (`reserve_back` → `noc.async_read` → `async_read_barrier` → `push_back`) into a
-        // single tagged call by tying NoC transaction completion to credit posting via an
-        // ISR. It is a Gen2-only mechanism (the per-NoC-transaction-ID interrupt-enable
-        // registers and ROCC ISR machinery do not exist on Gen1) and applies only to DM
-        // endpoints (the ISR fires on NoC-transaction completion; compute kernels have no
-        // NoC traffic).
-        //
-        // Default is implicit sync ENABLED on Gen2 for any DFB this kernel binds. List a
-        // DFB's name here to opt this kernel out of implicit sync for that DFB; the opt-out
-        // applies to whichever side(s) of the DFB this kernel binds (producer, consumer,
-        // or both for a self-loop).
-        //
-        // Use cases for opting out:
-        //   - Performance tuning: ISR dispatch overhead in a tight inner loop.
-        //   - Debug bisect: disable on one endpoint to isolate a sync bug.
-        //   - Mixed kernel styles during porting.
-        //
-        // Validation: if multiple DM kernels are bound as producers (or as consumers) of
-        // the same DFB, they MUST agree on this setting — either all list the DFB here, or
-        // none do. Mismatch is a spec error. Producer-side and consumer-side are checked
-        // independently.
-        std::vector<DFBSpecName> disable_implicit_sync;
+        // Opt-out of DFB implicit sync (on a per-DFB basis)
+        // Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
+        // You may revert to the legacy explicit sync APIs for specific bound DFBs by
+        // listing their DFBSpecNames here. (This feature is mainly for debug purposes.)
+        // Any bound DFB not listed here will use implicit sync by default.
+        std::vector<DFBSpecName> disable_implicit_sync_for;
     };
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -89,10 +89,10 @@ struct DataMovementConfiguration {
         // endpoints (the ISR fires on NoC-transaction completion; compute kernels have no
         // NoC traffic).
         //
-        // Default (no entry, or entry false) is to use implicit sync on Gen2 hardware for
-        // this kernel's role on the named DFB. An entry with value `true` opts this kernel
-        // out for that DFB. Each entry's bool applies to whichever side(s) of the DFB this
-        // kernel binds (producer, consumer, or both for a self-loop).
+        // Default is implicit sync ENABLED on Gen2 for any DFB this kernel binds. List a
+        // DFB's name here to opt this kernel out of implicit sync for that DFB; the opt-out
+        // applies to whichever side(s) of the DFB this kernel binds (producer, consumer,
+        // or both for a self-loop).
         //
         // Use cases for opting out:
         //   - Performance tuning: ISR dispatch overhead in a tight inner loop.
@@ -100,10 +100,10 @@ struct DataMovementConfiguration {
         //   - Mixed kernel styles during porting.
         //
         // Validation: if multiple DM kernels are bound as producers (or as consumers) of
-        // the same DFB, they MUST agree on this setting for that DFB. Mismatch is a spec
-        // error. Producer-side and consumer-side are checked independently.
-        using DisableImplicitSyncEntry = std::pair<DFBSpecName, bool>;
-        std::vector<DisableImplicitSyncEntry> disable_implicit_sync;
+        // the same DFB, they MUST agree on this setting — either all list the DFB here, or
+        // none do. Mismatch is a spec error. Producer-side and consumer-side are checked
+        // independently.
+        std::vector<DFBSpecName> disable_implicit_sync;
     };
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -68,8 +68,6 @@ struct ComputeConfiguration {
 
 struct DataMovementConfiguration {
     // The DM configuration is different for Gen1 and Gen2.
-    // You can provide either a Gen1 config, a Gen2 config, or both.
-    // If your host code is intended to be architecture-agnostic, provide both.
 
     struct Gen1DataMovementConfig {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -79,8 +79,31 @@ struct DataMovementConfiguration {
     std::optional<Gen1DataMovementConfig> gen1_data_movement_config = std::nullopt;
 
     struct Gen2DataMovementConfig {
-        // Currently, no configuration is needed for Gen2!
-        // The empty struct is still used to express a Gen2 DM kernel.
+        // Per-DFB-binding opt-out from ISR-based implicit sync.
+        //
+        // Implicit sync collapses the four-line DM-kernel dance
+        // (`reserve_back` → `noc.async_read` → `async_read_barrier` → `push_back`) into a
+        // single tagged call by tying NoC transaction completion to credit posting via an
+        // ISR. It is a Gen2-only mechanism (the per-NoC-transaction-ID interrupt-enable
+        // registers and ROCC ISR machinery do not exist on Gen1) and applies only to DM
+        // endpoints (the ISR fires on NoC-transaction completion; compute kernels have no
+        // NoC traffic).
+        //
+        // Default (no entry, or entry false) is to use implicit sync on Gen2 hardware for
+        // this kernel's role on the named DFB. An entry with value `true` opts this kernel
+        // out for that DFB. Each entry's bool applies to whichever side(s) of the DFB this
+        // kernel binds (producer, consumer, or both for a self-loop).
+        //
+        // Use cases for opting out:
+        //   - Performance tuning: ISR dispatch overhead in a tight inner loop.
+        //   - Debug bisect: disable on one endpoint to isolate a sync bug.
+        //   - Mixed kernel styles during porting.
+        //
+        // Validation: if multiple DM kernels are bound as producers (or as consumers) of
+        // the same DFB, they MUST agree on this setting for that DFB. Mismatch is a spec
+        // error. Producer-side and consumer-side are checked independently.
+        using DisableImplicitSyncEntry = std::pair<DFBSpecName, bool>;
+        std::vector<DisableImplicitSyncEntry> disable_implicit_sync;
     };
     std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -80,9 +80,9 @@ struct DataMovementConfiguration {
 
     struct Gen2DataMovementConfig {
         // Opt-out of DFB implicit sync (on a per-DFB basis)
-        // Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
-        // You may revert to the legacy explicit sync APIs for specific bound DFBs by
-        // listing their DFBSpecNames here. (This feature is mainly for debug purposes.)
+        //  - Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
+        //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
+        //  - This feature is mainly for debug purposes, or for backwards-compatible code style.
         // Any bound DFB not listed here will use implicit sync by default.
         std::vector<DFBSpecName> disable_implicit_sync_for;
     };

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -634,7 +634,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
             config.pap == dfb::AccessPattern::STRIDED && config.cap == dfb::AccessPattern::STRIDED,
             "Intra-tensix DFBs require STRIDED access for both producer (packer) and consumer (unpacker)");
         TT_FATAL(
-            !config.enable_implicit_sync,
+            !producer_implicit_sync_active(config) && !consumer_implicit_sync_active(config),
             "Intra-tensix DFBs do not support implicit sync (ISR-based credits)");
     }
 
@@ -1277,9 +1277,13 @@ void ProgramImpl::finalize_single_dfb_config(
     }
 
     // Allocate transaction IDs and compute ISR descriptor fields when implicit sync is enabled.
-    // Only done on the first core processed for this DFB because txn IDs are core-invariant
-    if (config.enable_implicit_sync && dfb->groups.empty()) {
-        if (!producer_is_tensix_only) {
+    // Only done on the first core processed for this DFB because txn IDs are core-invariant.
+    // Producer and consumer sides are checked independently — the underlying hardware mechanism
+    // is per-side (separate IE_1/IE_2 masks driving separate ISR handlers).
+    if (dfb->groups.empty()) {
+        const bool producer_implicit_sync = producer_implicit_sync_active(config);
+        const bool consumer_implicit_sync = consumer_implicit_sync_active(config);
+        if (producer_implicit_sync && !producer_is_tensix_only) {
             uint8_t num_prod_txn_ids = compute_optimal_txn_id_count(
                 config.num_entries, config.num_producers, num_producer_tcs,
                 /*consumes_all=*/false);
@@ -1302,7 +1306,7 @@ void ProgramImpl::finalize_single_dfb_config(
                 dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
         }
 
-        if (!consumer_is_tensix_only) {
+        if (consumer_implicit_sync && !consumer_is_tensix_only) {
             const bool consumes_all = (config.cap == ::dfb::AccessPattern::ALL);
             uint8_t num_cons_txn_ids = compute_optimal_txn_id_count(
                 config.num_entries, config.num_consumers, num_consumer_tcs,

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -634,7 +634,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
             config.pap == dfb::AccessPattern::STRIDED && config.cap == dfb::AccessPattern::STRIDED,
             "Intra-tensix DFBs require STRIDED access for both producer (packer) and consumer (unpacker)");
         TT_FATAL(
-            !producer_implicit_sync_active(config) && !consumer_implicit_sync_active(config),
+            !config.enable_producer_implicit_sync && !config.enable_consumer_implicit_sync,
             "Intra-tensix DFBs do not support implicit sync (ISR-based credits)");
     }
 
@@ -1281,9 +1281,7 @@ void ProgramImpl::finalize_single_dfb_config(
     // Producer and consumer sides are checked independently — the underlying hardware mechanism
     // is per-side (separate IE_1/IE_2 masks driving separate ISR handlers).
     if (dfb->groups.empty()) {
-        const bool producer_implicit_sync = producer_implicit_sync_active(config);
-        const bool consumer_implicit_sync = consumer_implicit_sync_active(config);
-        if (producer_implicit_sync && !producer_is_tensix_only) {
+        if (config.enable_producer_implicit_sync && !producer_is_tensix_only) {
             uint8_t num_prod_txn_ids = compute_optimal_txn_id_count(
                 config.num_entries, config.num_producers, num_producer_tcs,
                 /*consumes_all=*/false);
@@ -1306,7 +1304,7 @@ void ProgramImpl::finalize_single_dfb_config(
                 dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
         }
 
-        if (consumer_implicit_sync && !consumer_is_tensix_only) {
+        if (config.enable_consumer_implicit_sync && !consumer_is_tensix_only) {
             const bool consumes_all = (config.cap == ::dfb::AccessPattern::ALL);
             uint8_t num_cons_txn_ids = compute_optimal_txn_id_count(
                 config.num_entries, config.num_consumers, num_consumer_tcs,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -842,11 +842,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.unique_id);
     }
 
-    // Validate DM kernel disable_implicit_sync entries.
+    // Validate DM kernel disable_implicit_sync_for entries.
     //
     // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
     // transaction completion). Each DM kernel can opt out per-DFB by listing the DFB's name
-    // in its Gen2DataMovementConfig::disable_implicit_sync vector. The opt-out applies to
+    // in its Gen2DataMovementConfig::disable_implicit_sync_for vector. The opt-out applies to
     // the side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
     //
     // Per-kernel rules:
@@ -873,15 +873,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 bound_dfbs.insert(binding.dfb_spec_name);
             }
             std::unordered_set<DFBSpecName> entries_seen;
-            for (const auto& dfb_name : dm_config.gen2_data_movement_config->disable_implicit_sync) {
+            for (const auto& dfb_name : dm_config.gen2_data_movement_config->disable_implicit_sync_for) {
                 TT_FATAL(
                     bound_dfbs.contains(dfb_name),
-                    "Kernel '{}' disable_implicit_sync entry references DFB '{}', which the kernel does not bind",
+                    "Kernel '{}' disable_implicit_sync_for entry references DFB '{}', which the kernel does not bind",
                     kernel.unique_id,
                     dfb_name);
                 TT_FATAL(
                     entries_seen.insert(dfb_name).second,
-                    "Kernel '{}' has duplicate disable_implicit_sync entries for DFB '{}'",
+                    "Kernel '{}' has duplicate disable_implicit_sync_for entries for DFB '{}'",
                     kernel.unique_id,
                     dfb_name);
             }
@@ -893,7 +893,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (!dm_config.gen2_data_movement_config.has_value()) {
                 return false;
             }
-            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync;
+            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
             return std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
         };
         auto check_side_agreement =
@@ -914,7 +914,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     }
                     TT_FATAL(
                         vote == canonical_vote,
-                        "DFB '{}' has disagreeing disable_implicit_sync state on the {} side: "
+                        "DFB '{}' has disagreeing disable_implicit_sync_for state on the {} side: "
                         "kernel '{}' {} list the DFB, kernel '{}' {}. All DM {} kernels of a DFB "
                         "must agree (the hardware programs a single mask per side).",
                         dfb_name,
@@ -2039,7 +2039,7 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
             if (!dm_config.gen2_data_movement_config.has_value()) {
                 continue;
             }
-            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync;
+            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
             if (std::find(vec.begin(), vec.end(), dfb_spec->unique_id) != vec.end()) {
                 disabled = true;
             }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -892,11 +892,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                         continue;
                     }
                     const auto& dm_config = std::get<DataMovementConfiguration>(ep.kernel->config_spec);
-                    bool lists_dfb = false;
-                    if (dm_config.gen2_data_movement_config.has_value()) {
-                        const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
-                        lists_dfb = std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
+                    if (!dm_config.gen2_data_movement_config.has_value()) {
+                        // Gen1-only DM kernel — can't physically participate in Gen2 implicit sync; abstains.
+                        continue;
                     }
+                    const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
+                    const bool lists_dfb = std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
                     if (canonical == nullptr) {
                         canonical = ep.kernel;
                         canonical_lists_dfb = lists_dfb;
@@ -904,15 +905,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     }
                     TT_FATAL(
                         lists_dfb == canonical_lists_dfb,
-                        "DFB '{}' has disagreeing disable_implicit_sync_for state on the {} side: "
-                        "kernel '{}' {} list the DFB, kernel '{}' {}. All DM {} kernels of a DFB "
-                        "must agree (the hardware programs a single mask per side).",
+                        "DFB '{}' has disagreeing disable_implicit_sync_for state on the {} side",
                         dfb_name,
-                        side_label,
-                        canonical->unique_id,
-                        canonical_lists_dfb ? "does" : "does not",
-                        ep.kernel->unique_id,
-                        lists_dfb ? "does" : "does not",
                         side_label);
                 }
             };

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2025,11 +2025,6 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         }
         return any_dm && !disabled;
     };
-    const bool producer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.producers);
-    const bool consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers);
-    const std::optional<bool> override_consumer_implicit_sync =
-        (consumer_implicit_sync != producer_implicit_sync) ? std::make_optional(consumer_implicit_sync) : std::nullopt;
-
     return experimental::dfb::DataflowBufferConfig{
         .entry_size = dfb_spec->entry_size,
         .num_entries = dfb_spec->num_entries,
@@ -2039,8 +2034,8 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .consumer_risc_mask = consumer_risc_mask,
         .num_consumers = consumer->num_threads,
         .cap = consumer_access_pattern,
-        .enable_implicit_sync = producer_implicit_sync,
-        .override_consumer_implicit_sync = override_consumer_implicit_sync,
+        .enable_producer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.producers),
+        .enable_consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers),
         .data_format = dfb_spec->data_format_metadata.value_or(tt::DataFormat::Invalid),
         .tile = dfb_spec->tile_format_metadata,
         .tensix_scope = tensix_scope,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <bit>
 #include <functional>
 #include <limits>
@@ -844,23 +845,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate DM kernel disable_implicit_sync entries.
     //
     // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
-    // transaction completion). Each DM kernel can opt out per-DFB via its
-    // Gen2DataMovementConfig::disable_implicit_sync vector. The entry's bool applies to the
-    // side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
+    // transaction completion). Each DM kernel can opt out per-DFB by listing the DFB's name
+    // in its Gen2DataMovementConfig::disable_implicit_sync vector. The opt-out applies to
+    // the side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
     //
     // Per-kernel rules:
-    //   - Every entry references a DFB the kernel binds.
-    //   - No duplicate entries for the same DFB on a single kernel.
+    //   - Every listed name references a DFB the kernel binds.
+    //   - No duplicate names in a single kernel's vector.
     //
     // Cross-kernel rules (per DFB):
-    //   - All DM producers must agree on the disable value for this DFB.
-    //   - All DM consumers must agree on the disable value for this DFB.
+    //   - All DM producers must agree: either all list the DFB, or none do.
+    //   - All DM consumers must agree the same way.
     //   - Producer-side and consumer-side are checked independently — the underlying hardware
     //     mechanism is per-side.
-    //
-    // Default (no entry, or entry false) is "implicit sync enabled" for this kernel's role on
-    // the DFB. So a kernel with no entry implicitly votes false; the validator treats this as
-    // a vote for false and checks all DM kernels on each side agree.
     {
         // Per-kernel pass: typo guards + duplicate guards.
         for (const auto& kernel : spec.kernels) {
@@ -876,7 +873,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 bound_dfbs.insert(binding.dfb_spec_name);
             }
             std::unordered_set<DFBSpecName> entries_seen;
-            for (const auto& [dfb_name, _value] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
+            for (const auto& dfb_name : dm_config.gen2_data_movement_config->disable_implicit_sync) {
                 TT_FATAL(
                     bound_dfbs.contains(dfb_name),
                     "Kernel '{}' disable_implicit_sync entry references DFB '{}', which the kernel does not bind",
@@ -896,12 +893,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (!dm_config.gen2_data_movement_config.has_value()) {
                 return false;
             }
-            for (const auto& [name, val] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
-                if (name == dfb_name) {
-                    return val;
-                }
-            }
-            return false;
+            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync;
+            return std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
         };
         auto check_side_agreement =
             [&](const std::vector<CollectedSpecData::DFBEndpointInfo::EndpointRecord>& endpoints,
@@ -921,15 +914,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     }
                     TT_FATAL(
                         vote == canonical_vote,
-                        "DFB '{}' has disagreeing disable_implicit_sync votes on the {} side: "
-                        "kernel '{}' votes {}, kernel '{}' votes {}. All DM {} kernels of a DFB must "
-                        "agree (the hardware programs a single mask per side).",
+                        "DFB '{}' has disagreeing disable_implicit_sync state on the {} side: "
+                        "kernel '{}' {} list the DFB, kernel '{}' {}. All DM {} kernels of a DFB "
+                        "must agree (the hardware programs a single mask per side).",
                         dfb_name,
                         side_label,
                         canonical->unique_id,
-                        canonical_vote,
+                        canonical_vote ? "does" : "does not",
                         ep.kernel->unique_id,
-                        vote,
+                        vote ? "does" : "does not",
                         side_label);
                 }
             };
@@ -2046,11 +2039,9 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
             if (!dm_config.gen2_data_movement_config.has_value()) {
                 continue;
             }
-            for (const auto& [name, val] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
-                if (name == dfb_spec->unique_id) {
-                    disabled = val;
-                    break;
-                }
+            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync;
+            if (std::find(vec.begin(), vec.end(), dfb_spec->unique_id) != vec.end()) {
+                disabled = true;
             }
         }
         return any_dm && !disabled;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -849,17 +849,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // in its Gen2DataMovementConfig::disable_implicit_sync_for vector. The opt-out applies to
     // the side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
     //
-    // Per-kernel rules:
-    //   - Every listed name references a DFB the kernel binds.
-    //   - No duplicate names in a single kernel's vector.
+    // Per-kernel rule: every listed name references a DFB the kernel binds (typo guard).
     //
-    // Cross-kernel rules (per DFB):
-    //   - All DM producers must agree: either all list the DFB, or none do.
-    //   - All DM consumers must agree the same way.
-    //   - Producer-side and consumer-side are checked independently — the underlying hardware
-    //     mechanism is per-side.
+    // Cross-kernel rule (per DFB): on each side independently, all DM kernels must agree —
+    // either all list the DFB, or none do. (Producer-side and consumer-side are checked
+    // separately; the underlying hardware mechanism is per-side, with one mask per side.)
     {
-        // Per-kernel pass: typo guards + duplicate guards.
+        // Per-kernel pass: typo guard.
         for (const auto& kernel : spec.kernels) {
             if (!kernel.is_dm_kernel()) {
                 continue;
@@ -872,57 +868,51 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             for (const auto& binding : kernel.dfb_bindings) {
                 bound_dfbs.insert(binding.dfb_spec_name);
             }
-            std::unordered_set<DFBSpecName> entries_seen;
             for (const auto& dfb_name : dm_config.gen2_data_movement_config->disable_implicit_sync_for) {
                 TT_FATAL(
                     bound_dfbs.contains(dfb_name),
                     "Kernel '{}' disable_implicit_sync_for entry references DFB '{}', which the kernel does not bind",
                     kernel.unique_id,
                     dfb_name);
-                TT_FATAL(
-                    entries_seen.insert(dfb_name).second,
-                    "Kernel '{}' has duplicate disable_implicit_sync_for entries for DFB '{}'",
-                    kernel.unique_id,
-                    dfb_name);
             }
         }
 
         // Cross-kernel pass: per-DFB producer-side and consumer-side agreement.
-        auto resolve_vote = [](const KernelSpec* kernel, const DFBSpecName& dfb_name) -> bool {
-            const auto& dm_config = std::get<DataMovementConfiguration>(kernel->config_spec);
-            if (!dm_config.gen2_data_movement_config.has_value()) {
-                return false;
-            }
-            const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
-            return std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
-        };
+        // Note: a single DFB can be bound by multiple producer KernelSpecs and multiple
+        // consumer KernelSpecs — ops sometimes specialize the same kernel source by CTAs,
+        // producing several KernelSpecs that share a DFB.
         auto check_side_agreement =
             [&](const std::vector<CollectedSpecData::DFBEndpointInfo::EndpointRecord>& endpoints,
                 const DFBSpecName& dfb_name,
                 std::string_view side_label) {
                 const KernelSpec* canonical = nullptr;
-                bool canonical_vote = false;
+                bool canonical_lists_dfb = false;
                 for (const auto& ep : endpoints) {
                     if (!ep.kernel->is_dm_kernel()) {
                         continue;
                     }
-                    const bool vote = resolve_vote(ep.kernel, dfb_name);
+                    const auto& dm_config = std::get<DataMovementConfiguration>(ep.kernel->config_spec);
+                    bool lists_dfb = false;
+                    if (dm_config.gen2_data_movement_config.has_value()) {
+                        const auto& vec = dm_config.gen2_data_movement_config->disable_implicit_sync_for;
+                        lists_dfb = std::find(vec.begin(), vec.end(), dfb_name) != vec.end();
+                    }
                     if (canonical == nullptr) {
                         canonical = ep.kernel;
-                        canonical_vote = vote;
+                        canonical_lists_dfb = lists_dfb;
                         continue;
                     }
                     TT_FATAL(
-                        vote == canonical_vote,
+                        lists_dfb == canonical_lists_dfb,
                         "DFB '{}' has disagreeing disable_implicit_sync_for state on the {} side: "
                         "kernel '{}' {} list the DFB, kernel '{}' {}. All DM {} kernels of a DFB "
                         "must agree (the hardware programs a single mask per side).",
                         dfb_name,
                         side_label,
                         canonical->unique_id,
-                        canonical_vote ? "does" : "does not",
+                        canonical_lists_dfb ? "does" : "does not",
                         ep.kernel->unique_id,
-                        vote ? "does" : "does not",
+                        lists_dfb ? "does" : "does not",
                         side_label);
                 }
             };

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -841,6 +841,104 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.unique_id);
     }
 
+    // Validate DM kernel disable_implicit_sync entries.
+    //
+    // Implicit sync is a Gen2-only, DM-only mechanism (ISR-based credit posting from NoC
+    // transaction completion). Each DM kernel can opt out per-DFB via its
+    // Gen2DataMovementConfig::disable_implicit_sync vector. The entry's bool applies to the
+    // side(s) of the DFB this kernel binds (producer, consumer, or both for a self-loop).
+    //
+    // Per-kernel rules:
+    //   - Every entry references a DFB the kernel binds.
+    //   - No duplicate entries for the same DFB on a single kernel.
+    //
+    // Cross-kernel rules (per DFB):
+    //   - All DM producers must agree on the disable value for this DFB.
+    //   - All DM consumers must agree on the disable value for this DFB.
+    //   - Producer-side and consumer-side are checked independently — the underlying hardware
+    //     mechanism is per-side.
+    //
+    // Default (no entry, or entry false) is "implicit sync enabled" for this kernel's role on
+    // the DFB. So a kernel with no entry implicitly votes false; the validator treats this as
+    // a vote for false and checks all DM kernels on each side agree.
+    {
+        // Per-kernel pass: typo guards + duplicate guards.
+        for (const auto& kernel : spec.kernels) {
+            if (!kernel.is_dm_kernel()) {
+                continue;
+            }
+            const auto& dm_config = std::get<DataMovementConfiguration>(kernel.config_spec);
+            if (!dm_config.gen2_data_movement_config.has_value()) {
+                continue;
+            }
+            std::unordered_set<DFBSpecName> bound_dfbs;
+            for (const auto& binding : kernel.dfb_bindings) {
+                bound_dfbs.insert(binding.dfb_spec_name);
+            }
+            std::unordered_set<DFBSpecName> entries_seen;
+            for (const auto& [dfb_name, _value] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
+                TT_FATAL(
+                    bound_dfbs.contains(dfb_name),
+                    "Kernel '{}' disable_implicit_sync entry references DFB '{}', which the kernel does not bind",
+                    kernel.unique_id,
+                    dfb_name);
+                TT_FATAL(
+                    entries_seen.insert(dfb_name).second,
+                    "Kernel '{}' has duplicate disable_implicit_sync entries for DFB '{}'",
+                    kernel.unique_id,
+                    dfb_name);
+            }
+        }
+
+        // Cross-kernel pass: per-DFB producer-side and consumer-side agreement.
+        auto resolve_vote = [](const KernelSpec* kernel, const DFBSpecName& dfb_name) -> bool {
+            const auto& dm_config = std::get<DataMovementConfiguration>(kernel->config_spec);
+            if (!dm_config.gen2_data_movement_config.has_value()) {
+                return false;
+            }
+            for (const auto& [name, val] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
+                if (name == dfb_name) {
+                    return val;
+                }
+            }
+            return false;
+        };
+        auto check_side_agreement =
+            [&](const std::vector<CollectedSpecData::DFBEndpointInfo::EndpointRecord>& endpoints,
+                const DFBSpecName& dfb_name,
+                std::string_view side_label) {
+                const KernelSpec* canonical = nullptr;
+                bool canonical_vote = false;
+                for (const auto& ep : endpoints) {
+                    if (!ep.kernel->is_dm_kernel()) {
+                        continue;
+                    }
+                    const bool vote = resolve_vote(ep.kernel, dfb_name);
+                    if (canonical == nullptr) {
+                        canonical = ep.kernel;
+                        canonical_vote = vote;
+                        continue;
+                    }
+                    TT_FATAL(
+                        vote == canonical_vote,
+                        "DFB '{}' has disagreeing disable_implicit_sync votes on the {} side: "
+                        "kernel '{}' votes {}, kernel '{}' votes {}. All DM {} kernels of a DFB must "
+                        "agree (the hardware programs a single mask per side).",
+                        dfb_name,
+                        side_label,
+                        canonical->unique_id,
+                        canonical_vote,
+                        ep.kernel->unique_id,
+                        vote,
+                        side_label);
+                }
+            };
+        for (const auto& [dfb_name, endpoint_info] : collected.dfb_endpoints) {
+            check_side_agreement(endpoint_info.producers, dfb_name, "producer");
+            check_side_agreement(endpoint_info.consumers, dfb_name, "consumer");
+        }
+    }
+
     //////////////////////////////////
     // Validate DataflowBufferSpecs
     //////////////////////////////////
@@ -1932,6 +2030,36 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
                            : experimental::dfb::TensixScope::INTER;  // currently blocked in validation
     }
 
+    // Compute the per-side implicit-sync value by polling the bound DM kernels' Gen2 votes.
+    // Sides with no DM endpoints get implicit_sync=false (no DM endpoint to enable it for).
+    // Validator guarantees per-side agreement among DM kernels, so any DM kernel's vote works.
+    auto side_implicit_sync_enabled =
+        [&](const std::vector<CollectedSpecData::DFBEndpointInfo::EndpointRecord>& endpoints) -> bool {
+        bool any_dm = false;
+        bool disabled = false;
+        for (const auto& ep : endpoints) {
+            if (!ep.kernel->is_dm_kernel()) {
+                continue;
+            }
+            any_dm = true;
+            const auto& dm_config = std::get<DataMovementConfiguration>(ep.kernel->config_spec);
+            if (!dm_config.gen2_data_movement_config.has_value()) {
+                continue;
+            }
+            for (const auto& [name, val] : dm_config.gen2_data_movement_config->disable_implicit_sync) {
+                if (name == dfb_spec->unique_id) {
+                    disabled = val;
+                    break;
+                }
+            }
+        }
+        return any_dm && !disabled;
+    };
+    const bool producer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.producers);
+    const bool consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers);
+    const std::optional<bool> override_consumer_implicit_sync =
+        (consumer_implicit_sync != producer_implicit_sync) ? std::make_optional(consumer_implicit_sync) : std::nullopt;
+
     return experimental::dfb::DataflowBufferConfig{
         .entry_size = dfb_spec->entry_size,
         .num_entries = dfb_spec->num_entries,
@@ -1941,7 +2069,8 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .consumer_risc_mask = consumer_risc_mask,
         .num_consumers = consumer->num_threads,
         .cap = consumer_access_pattern,
-        .enable_implicit_sync = !dfb_spec->disable_implicit_sync,
+        .enable_implicit_sync = producer_implicit_sync,
+        .override_consumer_implicit_sync = override_consumer_implicit_sync,
         .data_format = dfb_spec->data_format_metadata.value_or(tt::DataFormat::Invalid),
         .tile = dfb_spec->tile_format_metadata,
         .tensix_scope = tensix_scope,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -677,19 +677,14 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 "KernelSpec '{}' must specify a DM config for Gen1, Gen2, or both.",
                 kernel.unique_id);
 
-            // The config for the current target architecture must be specified.
-            if (is_gen2_arch()) {
-                TT_FATAL(
-                    data_movement_config.gen2_data_movement_config.has_value(),
-                    "KernelSpec '{}' must specify a Gen2 DM config when targeting Quasar.",
-                    kernel.unique_id);
-            } else if (is_gen1_arch()) {
+            // Gen1 builds still require an explicit Gen1 config (its fields — processor, NOC,
+            // NOC mode — have no universally-safe defaults). Gen2 is fully optional even on
+            // Gen2 builds: absence is treated as "use defaults" (empty disable_implicit_sync_for).
+            if (is_gen1_arch()) {
                 TT_FATAL(
                     data_movement_config.gen1_data_movement_config.has_value(),
                     "KernelSpec '{}' must specify a Gen1 DM config when targeting WH or BH.",
                     kernel.unique_id);
-            } else {
-                TT_FATAL(false, "Unknown architecture");
             }
         }
     }


### PR DESCRIPTION
## PR Category
Cleanup (user API cleanup)

## Summary
This PR moves the Metal 2.0 `disable_implicit_sync` option from the `DataflowBufferSpec` to the Gen2-specific DMConfig. For a DM-to-DM DFB, it also enables both endpoints to independently control implicit sync.

Implicit sync is default-enabled on a Gen2 DM kernel. The user can selectively disable implicit sync on select DFBs by doing:
```cpp
Gen2DataMovementConfig gen2dm{.disable_implicit_sync_for = {"my_dfb"}};
```

### Why the old location was wrong
 - `DataflowBufferSpec` is arch-agnostic. This flag means nothing on Gen1, but had to be set.
 - The flag is kernel type dependent. Only DM kernels can use implicit sync on Gen2. 
 - The Gen2-default (implicit sync enabled) triggers an error on a self-loop compute DFB. This caused confusion in AI op porting.

### Why the new location is correct
The new API location suits the semantics of the feature:
 - Architecture-specific (Gen2 only)
 - DM kernel-specific (compute kernels can't use implicit sync)
 - DFB endpoint-specific (implicit sync syntax is a kernel-local concern)

As an added bonus, our Gen2 DM config is no longer sheepishly empty.

## Notes for reviewers
The most important part of this change is the public API surface:
 - kernel_spec.hpp
 - dataflow_buffer_spec.hpp

(Note that dataflow_buffer.hpp is actually _not_ part of the public API surface; it's about to get moved into `impl`. The API I added there prioritize code stability over intuitiveness.)

The backend implementation is almost trivial.

The bulk of the change is just propagating this across to the tests... many of which disable implicit sync.

(I have another PR coming up that improves the syntax around gen2 DM config... kinda verbose right now.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-disable-implicit-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-disable-implicit-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-disable-implicit-sync)