### PR TITLE
Move remaining CCL ops to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include <cstdint>
 
 using address_t = uint32_t;
@@ -30,21 +34,28 @@ void kernel_main() {
 
     auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0);
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     for (uint32_t page_id = input_page_id_start; page_id < input_page_id_end;) {
-        cb_reserve_back(cb0_id, 1);
-        uint32_t l1_write_addr = get_write_ptr(cb0_id);
+        cb0.reserve_back(1);
+        uint32_t l1_write_addr = cb0.get_write_ptr();
 
         // fill CB page
         for (uint32_t input = 0; input < inputs_per_cb_page; input++) {
             if (page_id + input >= input_page_id_end) [[unlikely]] {
                 break;
             }
-            auto tensor_src_addr = tensor0_addrgen.get_noc_addr(page_id + input, 0);
             auto cb_input_page = l1_write_addr + input * input_page_size;
-            noc_async_read(tensor_src_addr, cb_input_page, input_page_size);
+            noc_obj.async_read(
+                tensor0_addrgen,
+                CoreLocalMem<uint8_t>(cb_input_page),
+                input_page_size,
+                {.page_id = page_id + input},
+                {});
         }
         page_id += inputs_per_cb_page;
-        noc_async_read_barrier();
-        cb_push_back(cb0_id, 1);
+        noc_obj.async_read_barrier();
+        cb0.push_back(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_reader.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/core_local_mem.h"
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <array>
 #include <type_traits>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/broadcast_rm_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
@@ -57,12 +61,12 @@ public:
             fabric_connection, unicast_route_id, starts.data(), ranges.data(), nullptr, packet_size);
     }
 
-    void send(uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
+    void send(Noc& noc, uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
         auto packet_read_addr = cb_out_page_start;
         auto dest_addr = tensor_page_addr;
         constexpr uint32_t packets_per_outpage = out_page_size / packet_size;
         for (uint32_t packet = 0; packet < packets_per_outpage; packet++) {
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             fabric_multicast_noc_unicast_write_with_state<UnicastWriteUpdateMask::DstAddr>(
                 fabric_connection,
                 unicast_route_id,
@@ -110,7 +114,7 @@ public:
             fabric_connection, scatter_route_id, starts.data(), ranges.data(), default_scatter_header, packet_size);
     }
 
-    void send(uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
+    void send(Noc& noc, uint32_t cb_out_page_start, uint64_t tensor_page_addr) {
         if (scatter_header.chunk_count == 0) {
             // save the address of the first chunk in packet
             // write function will start reading here
@@ -119,7 +123,7 @@ public:
         scatter_header.noc_address[scatter_header.chunk_count++] = tensor_page_addr;
 
         if (scatter_header.chunk_count == num_out_pages_per_packet) {
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             fabric_multicast_noc_scatter_write_with_state<UnicastScatterWriteUpdateMask::DstAddrs>(
                 fabric_connection,
                 scatter_route_id,
@@ -146,7 +150,11 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const address_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_page_id_start = get_arg_val<uint32_t>(arg_idx++);
     uint32_t output_page_id_end = get_arg_val<uint32_t>(arg_idx++);
@@ -191,8 +199,15 @@ void kernel_main() {
         sem_route_id,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t num_total_targets = num_targets_forward_direction + num_targets_backward_direction;
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), num_total_targets);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
 
     // 1. mcast via fabric to remote tensor addresses
@@ -201,24 +216,28 @@ void kernel_main() {
     FabricWriter writer(fabric_connection, starts, ranges, num_connections);
 
     for (uint32_t page_id = output_page_id_start; page_id < output_page_id_end;) {
-        cb_wait_front(cb0_id, 1);
-        auto l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(1);
+        auto l1_read_addr = cb0.get_read_ptr();
 
         for (uint32_t output = 0u; output < outputs_per_cb_page; output++) {
             if (page_id + output >= output_page_id_end) [[unlikely]] {
                 break;
             };
             auto out_page_start = l1_read_addr + output * out_page_size;
-            auto local_tensor_page_addr = tensor0_addrgen.get_noc_addr(page_id + output, 0);
             auto fabric_tensor_page_addr =
                 tt::tt_fabric::linear::addrgen_detail::get_noc_address(tensor0_addrgen, page_id + output, 0);
-            writer.send(out_page_start, fabric_tensor_page_addr);
-            noc_async_write(out_page_start, local_tensor_page_addr, out_page_size);
+            writer.send(noc_obj, out_page_start, fabric_tensor_page_addr);
+            noc_obj.async_write(
+                CoreLocalMem<uint8_t>(out_page_start),
+                tensor0_addrgen,
+                out_page_size,
+                {},
+                {.page_id = page_id + output});
         }
         page_id += outputs_per_cb_page;
 
-        noc_async_writes_flushed();
-        cb_pop_front(cb0_id, 1);
+        noc_obj.async_writes_flushed();
+        cb0.pop_front(1);
     }
 
     // 2. mcast output ready semaphore
@@ -232,20 +251,27 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
         volatile tt_l1_ptr uint32_t* sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait(sem_ptr, out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
     close_connections(fabric_connection);
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_reader.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
@@ -40,21 +45,28 @@ void kernel_main() {
 
     // interleaved addrgen
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
     uint32_t core_id = 0;
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
-        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
-        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        cb0.reserve_back(num_tiles_to_read_this_core);
+        const uint32_t l1_write_addr = cb0.get_write_ptr();
+        const uint32_t shard_addr = tensor_address0 + shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
-        noc_async_read_barrier();
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id], .noc_y = core_noc_y[core_id], .addr = shard_addr},
+            {});
+        noc_obj.async_read_barrier();
 
-        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        cb0.push_back(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id = 0;
         core_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -46,6 +49,8 @@ void kernel_main() {
     size_t arg_idx = 0;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
@@ -56,6 +61,8 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -69,16 +76,20 @@ void kernel_main() {
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -114,7 +125,13 @@ void kernel_main() {
                 packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
         }
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
@@ -125,8 +142,8 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
         uint64_t noc0_dest_noc_addr =
             get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
@@ -141,7 +158,7 @@ void kernel_main() {
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
 
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
         if (shard_tile_id >= num_tiles_per_core) {
@@ -173,18 +190,25 @@ void kernel_main() {
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
     // 3. wait for mcast output ready semaphore
     if (wait_output_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait_min(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
     }
 
     // 4. global semaphore reset
     if (reset_global_semaphore) {
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), 0);
     }
 
-    noc_async_full_barrier();
+    noc_obj.async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -43,6 +47,8 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);  // 0 is forward, 1 is backward
     const auto input_tile_id_start = get_arg_val<uint32_t>(arg_idx++);
@@ -100,10 +106,13 @@ void kernel_main() {
     const auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address);
 #endif
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     OpSignaler op_signaler;
-    uint32_t self_write_done_semaphore_addr;
+    uint32_t self_write_done_sem_id = 0;
     if constexpr (fuse_op) {
-        self_write_done_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+        self_write_done_sem_id = get_arg_val<uint32_t>(arg_idx++);
         op_signaler = OpSignaler(arg_idx);
     }
 
@@ -116,19 +125,19 @@ void kernel_main() {
             uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
             uint32_t num_tiles_to_read = std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-            cb_reserve_back(cb_output_id, num_tiles_to_write_per_packet);
-            size_t l1_write_addr = get_write_ptr(cb_output_id);
+            cb_output.reserve_back(num_tiles_to_write_per_packet);
+            size_t l1_write_addr = cb_output.get_write_ptr();
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                noc_obj.async_read(
+                    input_tensor_addrgen, CoreLocalMem<uint8_t>(l1_write_addr), page_size, {.page_id = tile_id}, {});
 
                 l1_write_addr += page_size;
                 tiles_read++;
             }
 
-            noc_async_read_barrier();
-            cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
+            noc_obj.async_read_barrier();
+            cb_output.push_back(num_tiles_to_write_per_packet);
         }
         tiles_read = input_tile_id_start;
         tiles_to_read = input_tile_id_end;
@@ -289,6 +298,9 @@ void kernel_main() {
                 while (sem_iter_pos < input_tile_id_end) {
                     // Wait for semaphore (sender's full slice pattern)
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+                        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+                        // GlobalSemaphore. #45003 item 4.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -305,13 +317,17 @@ void kernel_main() {
 
                         // Check if all tiles for this CB entry are ready
                         if (cb_tiles_pushed + num_tiles_to_read <= sem_iter_pos) {
-                            cb_reserve_back(cb_output_id, num_tiles_to_write_per_packet);
-                            size_t l1_write_addr = get_write_ptr(cb_output_id);
+                            cb_output.reserve_back(num_tiles_to_write_per_packet);
+                            size_t l1_write_addr = cb_output.get_write_ptr();
 
                             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                                 uint32_t tile_id = output_tile_id_start + cb_row_offset + cb_pages_read_in_row;
-                                uint64_t noc_read_addr = get_noc_addr(tile_id, output_tensor_addrgen);
-                                noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                                noc_obj.async_read(
+                                    output_tensor_addrgen,
+                                    CoreLocalMem<uint8_t>(l1_write_addr),
+                                    page_size,
+                                    {.page_id = tile_id},
+                                    {});
 
                                 l1_write_addr += page_size;
                                 cb_pages_read_in_row++;
@@ -321,8 +337,8 @@ void kernel_main() {
                                 }
                             }
 
-                            noc_async_read_barrier();
-                            cb_push_back(cb_output_id, num_tiles_to_write_per_packet);
+                            noc_obj.async_read_barrier();
+                            cb_output.push_back(num_tiles_to_write_per_packet);
                             cb_tiles_pushed += num_tiles_to_read;
                         } else {
                             // Need more semaphores before we can push this CB entry
@@ -365,6 +381,9 @@ void kernel_main() {
 
                 while (tiles_read < tiles_to_read) {
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+                        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+                        // GlobalSemaphore. #45003 item 4.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                         sem_target++;
@@ -381,13 +400,15 @@ void kernel_main() {
         if constexpr (fuse_op) {
             // Signal matmul to go
             if (direction == 1 && slices_received == 1) {
-                noc_semaphore_wait_min(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 1);
-                noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(self_write_done_semaphore_addr), 0);
+                Semaphore<> self_write_done_sem(self_write_done_sem_id);
+                self_write_done_sem.wait_min(1);
+                self_write_done_sem.set(0);
             }
             op_signaler.synchronize_workers_and_signal_op(actual_sender_chip_id);
         }
     }
 
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -104,9 +108,13 @@ void kernel_main() {
     address_t output_address = get_arg_val<address_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
 
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -129,6 +137,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
+    // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id);
+    // #45003 item 4.
     uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -195,6 +205,9 @@ void kernel_main() {
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 #endif
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     /* Args for overlapped all gather */
     OpSignaler op_signaler_sender;
     uint32_t self_write_done_semaphore_addr;
@@ -268,7 +281,13 @@ void kernel_main() {
                 ASSERT(false);
             }
         }
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
@@ -343,23 +362,23 @@ void kernel_main() {
                 uint32_t tiles_to_put_in_current_packet =
                     std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-            cb_wait_front(cb_output_id, num_tiles_to_write_per_packet);
-            size_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(num_tiles_to_write_per_packet);
+                size_t l1_read_addr = cb_output.get_read_ptr();
 
-            uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
-            uint64_t noc_addrs[4] = {0, 0, 0, 0};
-            uint64_t local_noc_addrs[4] = {0, 0, 0, 0};
-            for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-                pages_read_in_row++;
-                if (pages_read_in_row >= input_tensor_Wt) {
-                    row_offset += output_tensor_Wt;
-                    pages_read_in_row = 0;
+                uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
+                uint64_t noc_addrs[4] = {0, 0, 0, 0};
+                uint32_t local_tile_ids[4] = {0, 0, 0, 0};
+                for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
+                    uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
+                    pages_read_in_row++;
+                    if (pages_read_in_row >= input_tensor_Wt) {
+                        row_offset += output_tensor_Wt;
+                        pages_read_in_row = 0;
+                    }
+
+                    noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
+                    local_tile_ids[i] = tile_id;
                 }
-
-                noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
-                local_noc_addrs[i] = get_noc_addr(tile_id, output_addrgen);
-            }
 
             if (direction == 1) {
                 if constexpr (num_targets_backward_direction) {
@@ -382,9 +401,14 @@ void kernel_main() {
                 }
 
                 for (uint32_t i = 0; i < tiles_to_put_in_current_packet; i++) {
-                    noc_async_write(l1_read_addr + i * page_size, local_noc_addrs[i], page_size);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr + i * page_size),
+                        output_addrgen,
+                        page_size,
+                        {},
+                        {.page_id = local_tile_ids[i]});
                 }
-                noc_async_write_barrier();
+                noc_obj.async_write_barrier();
             } else {
                 if constexpr (num_targets_forward_direction) {
                     if (tiles_to_put_in_current_packet > 1) {
@@ -407,9 +431,9 @@ void kernel_main() {
             }
             tiles_read += tiles_to_put_in_current_packet;
 
-                noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
 
-                cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
+            cb_output.pop_front(num_tiles_to_write_per_packet);
 
             chunk_count++;
             if (chunk_count % chunks_per_sync == 0) {
@@ -421,7 +445,7 @@ void kernel_main() {
                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
                 }
             }
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         }
 
         if (chunk_count % chunks_per_sync != 0) {
@@ -458,6 +482,7 @@ void kernel_main() {
             op_signaler_sender.synchronize_workers_and_signal_op(my_chip_id);
             uint64_t self_write_done_semaphore_noc_addr =
                 safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, self_write_done_semaphore_addr, 0);
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
             noc_semaphore_inc(self_write_done_semaphore_noc_addr, 1);
         }
     }
@@ -560,8 +585,8 @@ void kernel_main() {
                 uint32_t tiles_to_put_in_current_packet =
                     std::min(tiles_remaining_to_read, num_tiles_to_write_per_packet);
 
-                cb_wait_front(cb_output_id, num_tiles_to_write_per_packet);
-                size_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(num_tiles_to_write_per_packet);
+                size_t l1_read_addr = cb_output.get_read_ptr();
 
                 uint16_t chunk_sizes[3] = {page_size, page_size, page_size};
                 uint64_t noc_addrs[4] = {0, 0, 0, 0};
@@ -593,9 +618,9 @@ void kernel_main() {
 
                 tiles_read += tiles_to_put_in_current_packet;
 
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
 
-                cb_pop_front(cb_output_id, num_tiles_to_write_per_packet);
+                cb_output.pop_front(num_tiles_to_write_per_packet);
 
                 chunk_count++;
                 if (chunk_count % chunks_per_sync == 0) {
@@ -605,7 +630,7 @@ void kernel_main() {
                         pkt_hdr_sem_inc,
                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
                 }
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
             }
 
             if (chunk_count % chunks_per_sync != 0) {
@@ -657,21 +682,25 @@ void kernel_main() {
         slice_writes++;
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 #ifdef USE_WORKER_MUX
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*fabric_direction_connection);
 
         if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program
+            // id); #45003 item 4.
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+            // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program
+            // id); #45003 item 4.
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 #else
@@ -679,5 +708,5 @@ void kernel_main() {
         fabric_connection.close();
     }
 #endif
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <utility>
 #include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/compute.cpp
@@ -13,26 +13,27 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 
-void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    copy_tile_to_dst_init_short(in_cb);
-    reconfig_data_format_srca(in_cb);
-    pack_reconfig_data_format(out_cb);
+void copy_block(CircularBuffer& in_cb, CircularBuffer& out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+    copy_tile_to_dst_init_short(in_cb.get_cb_id());
+    reconfig_data_format_srca(in_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             acquire_dst();
-            copy_tile(in_cb, tile_id, fused_act_dst_id /*dst*/);
+            copy_tile(in_cb.get_cb_id(), tile_id, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
-            pack_tile(fused_act_dst_id, out_cb);
+            pack_tile(fused_act_dst_id, out_cb.get_cb_id());
             release_dst();
             tile_id++;
         }
-        cb_push_back(out_cb, N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 }
 
@@ -45,35 +46,41 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
  *   - true: Pushes tiles one row at a time (for intermediate output to next stage)
  *   - false: Pushes all tiles at end (for final output)
  */
-void add_bias_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
-    add_bcast_rows_init_short(in_cb, bias_cb);
-    reconfig_data_format(in_cb, bias_cb);
-    pack_reconfig_data_format(out_cb);
+void add_bias_block(
+    CircularBuffer& in_cb,
+    CircularBuffer& bias_cb,
+    CircularBuffer& out_cb,
+    uint32_t M_block_tiles,
+    uint32_t N_block_tiles) {
+    add_bcast_rows_init_short(in_cb.get_cb_id(), bias_cb.get_cb_id());
+    reconfig_data_format(in_cb.get_cb_id(), bias_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
     uint32_t fused_act_dst_id = 0;
 
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             acquire_dst();
-            add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, tile_id, n, fused_act_dst_id /*dst*/);
+            add_tiles_bcast<BroadcastType::ROW>(
+                in_cb.get_cb_id(), bias_cb.get_cb_id(), tile_id, n, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
-            pack_tile(fused_act_dst_id, out_cb);
+            pack_tile(fused_act_dst_id, out_cb.get_cb_id());
             release_dst();
             tile_id++;
         }
-        cb_push_back(out_cb, N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 }
 
 void add_bias_and_addcmul_block(
-    uint32_t intermediate_cb,
-    uint32_t bias_cb,
-    uint32_t ternary_a_cb,
-    uint32_t ternary_b_cb,
+    CircularBuffer& intermediate_cb,
+    CircularBuffer& bias_cb,
+    CircularBuffer& ternary_a_cb,
+    CircularBuffer& ternary_b_cb,
     uint32_t scalar_value,
-    uint32_t out_cb,
+    CircularBuffer& out_cb,
     uint32_t M_block_tiles,
     uint32_t N_block_tiles,
     uint32_t broadcast_ternary_b) {
@@ -89,41 +96,41 @@ void add_bias_and_addcmul_block(
     // Read from intermediate_cb and write back to intermediate_cb
     // ============================================
 
-    add_bcast_rows_init_short(intermediate_cb, bias_cb);
-    reconfig_data_format(intermediate_cb, bias_cb);
-    pack_reconfig_data_format(intermediate_cb);
+    add_bcast_rows_init_short(intermediate_cb.get_cb_id(), bias_cb.get_cb_id());
+    reconfig_data_format(intermediate_cb.get_cb_id(), bias_cb.get_cb_id());
+    pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
     // Wait for ALL input data ONCE at the beginning
-    cb_wait_front(bias_cb, N_block_tiles);
+    bias_cb.wait_front(N_block_tiles);
 
     // Unpacker waits for intermediate_cb to be ready
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             uint32_t tile_id = m * N_block_tiles + n;
 
             tile_regs_acquire();
-            add_tiles_bcast<BroadcastType::ROW>(intermediate_cb, bias_cb, tile_id, n, DST_ID);
+            add_tiles_bcast<BroadcastType::ROW>(intermediate_cb.get_cb_id(), bias_cb.get_cb_id(), tile_id, n, DST_ID);
 
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(DST_ID, intermediate_cb);
+            pack_tile(DST_ID, intermediate_cb.get_cb_id());
             tile_regs_release();
         }
     }
 
     // Pop input and push output ONCE at the end
-    // cb_wait_front(intermediate_cb, out_block_num_tiles); // Unpacker-Packer sync
-    // cb_pop_front(intermediate_cb, out_block_num_tiles);
-    cb_pop_front(bias_cb, N_block_tiles);
+    // intermediate_cb.wait_front(out_block_num_tiles); // Unpacker-Packer sync
+    // intermediate_cb.pop_front(out_block_num_tiles);
+    bias_cb.pop_front(N_block_tiles);
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 
     // Restore intermediate_cb to ready (+ sync packer/unpacker)
-    cb_reserve_back(intermediate_cb, out_block_num_tiles);
-    cb_push_back(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.reserve_back(out_block_num_tiles);
+    intermediate_cb.push_back(out_block_num_tiles);
 #endif  // FUSE_BIAS
 
     // ============================================
@@ -132,23 +139,23 @@ void add_bias_and_addcmul_block(
     // broadcast_ternary_b: 1 = single row broadcast, 0 = row-by-row streaming
     // ============================================
 
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
     uint32_t tile_id = 0;
 
     if (broadcast_ternary_b) {
         // === BROADCAST: single row, wait/pop once ===
-        cb_wait_front(ternary_b_cb, N_block_tiles);
+        ternary_b_cb.wait_front(N_block_tiles);
 
 #ifndef TERNARY_B_IS_FLOAT32
-        mul_bcast_rows_init_short(intermediate_cb, ternary_b_cb);
+        mul_bcast_rows_init_short(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
 #else
-        unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+        unary_bcast_init<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), intermediate_cb.get_cb_id());
 #endif  // TERNARY_B_IS_FLOAT32
 
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
+        reconfig_data_format(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
+        pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
@@ -163,14 +170,15 @@ void add_bias_and_addcmul_block(
                 // - mul_tiles_bcast for bfloat16 (LLK bug workaround).
 
                 // ternary_b_cb is [1, N], broadcast across M rows
-                mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+                mul_tiles_bcast<BroadcastType::ROW>(
+                    intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id(), tile_id, n, DST_ID);
 #else
                 constexpr uint32_t TERNARY_B_DST_ID = 1;
-                unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
-                unary_bcast<BroadcastType::ROW>(ternary_b_cb, n, TERNARY_B_DST_ID);
+                unary_bcast_init<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), intermediate_cb.get_cb_id());
+                unary_bcast<BroadcastType::ROW>(ternary_b_cb.get_cb_id(), n, TERNARY_B_DST_ID);
 
-                copy_tile_to_dst_init_short(intermediate_cb);
-                copy_tile(intermediate_cb, tile_id, DST_ID);
+                copy_tile_to_dst_init_short(intermediate_cb.get_cb_id());
+                copy_tile(intermediate_cb.get_cb_id(), tile_id, DST_ID);
 
                 mul_binary_tile_init();
                 mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
@@ -180,37 +188,37 @@ void add_bias_and_addcmul_block(
 
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(DST_ID, intermediate_cb);
+                pack_tile(DST_ID, intermediate_cb.get_cb_id());
                 tile_regs_release();
                 tile_id++;
             }
         }
 
-        cb_pop_front(ternary_b_cb, N_block_tiles);
+        ternary_b_cb.pop_front(N_block_tiles);
     } else {
         // === NO BROADCAST: row-by-row, wait/pop per M row ===
 #ifndef TERNARY_B_IS_FLOAT32
-        mul_tiles_init(intermediate_cb, ternary_b_cb);
+        mul_tiles_init(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
 #endif
         binop_with_scalar_tile_init();
-        reconfig_data_format(intermediate_cb, ternary_b_cb);
-        pack_reconfig_data_format(intermediate_cb);
+        reconfig_data_format(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id());
+        pack_reconfig_data_format(intermediate_cb.get_cb_id());
 
         tile_id = 0;
         for (uint32_t m = 0; m < M_block_tiles; m++) {
-            cb_wait_front(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.wait_front(N_block_tiles);
             for (uint32_t n = 0; n < N_block_tiles; n++) {
                 tile_regs_acquire();
 
 #ifndef TERNARY_B_IS_FLOAT32
-                mul_tiles(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+                mul_tiles(intermediate_cb.get_cb_id(), ternary_b_cb.get_cb_id(), tile_id, n, DST_ID);
 #else
                 constexpr uint32_t TERNARY_B_DST_ID = 1;
-                copy_tile_to_dst_init_short(ternary_b_cb);
-                copy_tile(ternary_b_cb, n, TERNARY_B_DST_ID);
+                copy_tile_to_dst_init_short(ternary_b_cb.get_cb_id());
+                copy_tile(ternary_b_cb.get_cb_id(), n, TERNARY_B_DST_ID);
 
-                copy_tile_to_dst_init_short(intermediate_cb);
-                copy_tile(intermediate_cb, tile_id, DST_ID);
+                copy_tile_to_dst_init_short(intermediate_cb.get_cb_id());
+                copy_tile(intermediate_cb.get_cb_id(), tile_id, DST_ID);
 
                 mul_binary_tile_init();
                 mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
@@ -220,57 +228,57 @@ void add_bias_and_addcmul_block(
 
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(DST_ID, intermediate_cb);
+                pack_tile(DST_ID, intermediate_cb.get_cb_id());
                 tile_regs_release();
                 tile_id++;
             }
-            cb_pop_front(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.pop_front(N_block_tiles);
         }
     }
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 
     // 'refill' intermediate_cb (also synchronize packer/unpacker)
-    cb_reserve_back(intermediate_cb, out_block_num_tiles);
-    cb_push_back(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.reserve_back(out_block_num_tiles);
+    intermediate_cb.push_back(out_block_num_tiles);
 
-    cb_wait_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.wait_front(out_block_num_tiles);
 
-    add_tiles_init(intermediate_cb, ternary_a_cb);
-    reconfig_data_format(intermediate_cb, ternary_a_cb);
-    pack_reconfig_data_format(out_cb);
+    add_tiles_init(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id());
+    reconfig_data_format(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id());
+    pack_reconfig_data_format(out_cb.get_cb_id());
 
     tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         // Wait for one row of ternary_a tiles
-        cb_wait_front(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.wait_front(N_block_tiles);
 
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             tile_regs_acquire();
 
             // ternary_a_cb is pushed one row at a time, so use column index n
-            add_tiles(intermediate_cb, ternary_a_cb, tile_id, n, DST_ID);
+            add_tiles(intermediate_cb.get_cb_id(), ternary_a_cb.get_cb_id(), tile_id, n, DST_ID);
 
             tile_regs_commit();
 
             tile_regs_wait();
-            pack_tile(DST_ID, out_cb);
+            pack_tile(DST_ID, out_cb.get_cb_id());
             tile_regs_release();
             tile_id++;
         }
 
-        cb_pop_front(ternary_a_cb, N_block_tiles);
-        cb_push_back(out_cb, N_block_tiles);
+        ternary_a_cb.pop_front(N_block_tiles);
+        out_cb.push_back(N_block_tiles);
     }
 
-    cb_pop_front(intermediate_cb, out_block_num_tiles);
+    intermediate_cb.pop_front(out_block_num_tiles);
 }
 
 // Slightly modified from compute_common.hpp
 void matmul_blocks(
-    const uint32_t in0_cb,
-    const uint32_t in1_cb,
-    const uint32_t out_cb,
+    CircularBuffer& in0_cb,
+    CircularBuffer& in1_cb,
+    CircularBuffer& out_cb,
     const uint32_t M_block_tiles,
     const uint32_t N_block_tiles,
     const uint32_t full_N_block_tiles,
@@ -290,8 +298,8 @@ void matmul_blocks(
 
             for (uint32_t inner_dim = 0; inner_dim < K_block_tiles; inner_dim++) {
                 matmul_block(
-                    in0_cb,
-                    in1_cb,
+                    in0_cb.get_cb_id(),
+                    in1_cb.get_cb_id(),
                     in0_index,
                     in1_index,
                     dst_index,
@@ -311,7 +319,7 @@ void matmul_blocks(
                 for (uint32_t w = 0; w < subblock_w; w++) {
                     uint32_t w_tile_id = N_start + w;
                     uint32_t out_tile_id = h_tile_id * full_N_block_tiles + w_tile_id;
-                    pack_tile<true>(write_dst_index, out_cb, out_tile_id);
+                    pack_tile<true>(write_dst_index, out_cb.get_cb_id(), out_tile_id);
                     write_dst_index++;
                     dst_index++;
                 }
@@ -349,19 +357,27 @@ void kernel_main() {
     constexpr uint32_t broadcast_ternary_b = 1;
 #endif
 
-    constexpr uint32_t in0_cb = tt::CBIndex::c_0;
-    constexpr uint32_t in1_cb = tt::CBIndex::c_1;
-    constexpr uint32_t out_cb = tt::CBIndex::c_2;
-    constexpr uint32_t intermediate_cb = tt::CBIndex::c_3;
-    constexpr uint32_t in2_cb = tt::CBIndex::c_4;
-    constexpr uint32_t ternary_a_cb = tt::CBIndex::c_5;
-    constexpr uint32_t ternary_b_cb = tt::CBIndex::c_6;
+    constexpr uint32_t in0_cb_id = tt::CBIndex::c_0;
+    constexpr uint32_t in1_cb_id = tt::CBIndex::c_1;
+    constexpr uint32_t out_cb_id = tt::CBIndex::c_2;
+    constexpr uint32_t intermediate_cb_id = tt::CBIndex::c_3;
+    constexpr uint32_t in2_cb_id = tt::CBIndex::c_4;
+    constexpr uint32_t ternary_a_cb_id = tt::CBIndex::c_5;
+    constexpr uint32_t ternary_b_cb_id = tt::CBIndex::c_6;
+
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    CircularBuffer intermediate_cb(intermediate_cb_id);
+    CircularBuffer in2_cb(in2_cb_id);
+    CircularBuffer ternary_a_cb(ternary_a_cb_id);
+    CircularBuffer ternary_b_cb(ternary_b_cb_id);
 
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
 
-    mm_init(in0_cb, in1_cb, intermediate_cb);
+    mm_init(in0_cb_id, in1_cb_id, intermediate_cb_id);
 
     constexpr uint32_t in0_block_num_tiles = M_block_tiles * K_block_tiles;
     constexpr uint32_t in1_block_num_tiles = K_block_tiles * N_block_tiles;
@@ -390,19 +406,19 @@ void kernel_main() {
             current_subblock_w = std::min(current_N_block_tiles, subblock_w);
 
             mm_block_init_short(
-                in0_cb,
-                in1_cb,
+                in0_cb_id,
+                in1_cb_id,
                 false /*transpose*/,
                 current_subblock_w /*ct_dim*/,
                 current_subblock_h /*rt_dim*/,
                 K_block_tiles /*kt_dim*/);
-            reconfig_data_format(in1_cb, in0_cb);
-            pack_reconfig_data_format(intermediate_cb);
+            reconfig_data_format(in1_cb_id, in0_cb_id);
+            pack_reconfig_data_format(intermediate_cb_id);
             // Accumulation buffer
-            cb_reserve_back(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.reserve_back(out_block_num_tiles);
             for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {
-                cb_wait_front(in0_cb, in0_block_num_tiles);
-                cb_wait_front(in1_cb, in1_block_num_tiles);
+                in0_cb.wait_front(in0_block_num_tiles);
+                in1_cb.wait_front(in1_block_num_tiles);
 
                 matmul_blocks(
                     in0_cb,
@@ -426,29 +442,29 @@ void kernel_main() {
                     }
                 }
                 if (!reuse_in0_block) {
-                    cb_pop_front(in0_cb, in0_block_num_tiles);
+                    in0_cb.pop_front(in0_block_num_tiles);
                 }
-                cb_pop_front(in1_cb, in1_block_num_tiles);
+                in1_cb.pop_front(in1_block_num_tiles);
                 reuse_in0_block = false;
                 if (k_block == 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
                 }
             }
 
-            cb_push_back(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.push_back(out_block_num_tiles);
             PACK((llk_pack_reconfig_l1_acc(0)));
 
-            cb_reserve_back(out_cb, out_block_num_tiles);
+            out_cb.reserve_back(out_block_num_tiles);
 #ifndef FUSE_TERNARY
-            cb_wait_front(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
             copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
 #else
-            cb_wait_front(in2_cb, N_block_tiles);
+            in2_cb.wait_front(N_block_tiles);
             add_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);
-            cb_pop_front(in2_cb, N_block_tiles);
+            in2_cb.pop_front(N_block_tiles);
 #endif  // FUSE_BIAS
-            cb_pop_front(intermediate_cb, out_block_num_tiles);
+            intermediate_cb.pop_front(out_block_num_tiles);
 
 #else   // FUSE_TERNARY is set
             add_bias_and_addcmul_block(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "matmul_dataflow_common.hpp"
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
@@ -115,9 +119,16 @@ void kernel_main() {
     const uint32_t in0_dest_noc_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_sender_noc_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t in0_sender_noc_y = get_arg_val<uint32_t>(argidx++);
-    uint32_t in0_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in0_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in0_valid_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
+    const uint32_t in0_sender_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_receiver_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in0_valid_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    Semaphore<> in0_sender_sem(in0_sender_semaphore_id);
+    Semaphore<> in0_receiver_sem(in0_receiver_semaphore_id);
+    Semaphore<> in0_valid_sem(in0_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    uint32_t in0_valid_semaphore_addr = get_semaphore(in0_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    uint32_t in0_receiver_semaphore_addr = get_semaphore(in0_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -178,6 +189,13 @@ void kernel_main() {
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_4;
 #endif
 
+    Noc noc_obj;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_out(cb_id_out);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_id_in2);
+#endif
+
 #ifdef READ_FROM_LOCAL_INPUT
 #ifdef FUSE_BIAS
     constexpr auto in3_args = TensorAccessorArgs<in2_args.next_compile_time_args_offset()>();
@@ -211,18 +229,17 @@ void kernel_main() {
 
     const auto ternary_a_reader = TensorAccessor(ternary_a_args, ternary_a_addr);
     const auto ternary_b_reader = TensorAccessor(ternary_b_args, ternary_b_addr);
+
+    CircularBuffer cb_ternary_a(cb_id_ternary_a);
+    CircularBuffer cb_ternary_b(cb_id_ternary_b);
 #endif
 
-    volatile tt_l1_ptr uint32_t* in0_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_valid_semaphore_addr);
-    *(in0_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in0_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_sender_semaphore_addr);
+    in0_valid_sem.set(VALID);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);
+        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, get_semaphore(in0_sender_semaphore_id));
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     const uint64_t in0_receiver_semaphore_noc_addr =
         get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
     // all gather
@@ -283,13 +300,14 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
-                        cb_wait_front(cb_id_out, out_block_num_tiles);
-                        uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = cb_out.get_read_ptr();
 
                         // write_block_sync_split is more generic (support multiple output tensors)
                         // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
+                                noc_obj,
                                 std::get<0>(outputs_tuple),
                                 out_shape,
                                 out_read_ptr,
@@ -300,6 +318,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         } else {
                             write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                noc_obj,
                                 outputs_tuple,
                                 out0_shape,
                                 out_read_ptr,
@@ -309,7 +328,7 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         }
-                        cb_pop_front(cb_id_out, out_block_num_tiles);
+                        cb_out.pop_front(out_block_num_tiles);
                     }
                 }
                 if (reuse_block && k_block_iter == 0) {
@@ -317,9 +336,9 @@ void kernel_main() {
                     reuse_block = false;
                     continue;
                 }
-                cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                cb_in0.reserve_back(in0_block_num_tiles);
 
-                uint32_t in0_start_address = get_write_ptr(cb_id_in0);
+                uint32_t in0_start_address = cb_in0.get_write_ptr();
 
                 uint32_t k_block_left_tile = 0;
                 uint32_t k_block_right_tile = 0;
@@ -347,6 +366,7 @@ void kernel_main() {
                     k_block_right_tile);
                 if (is_injector_core) {
                     read_in0_block_sync<M_block_tiles, K_block_tiles>(
+                        noc_obj,
                         in0_reader,
                         in0_shape,
                         in0_start_address,
@@ -367,17 +387,18 @@ void kernel_main() {
                         k_right_tiles);
                 } else {
                     // Get from previous device
-                    noc_semaphore_set(in0_receiver_semaphore_addr_ptr, INVALID);
+                    in0_receiver_sem.set(INVALID);
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, VALID);
+                    in0_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
                 // This frees sender to start next read earlier
-                cb_push_back(cb_id_in0, in0_block_num_tiles);
+                cb_in0.push_back(in0_block_num_tiles);
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in0_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in0_sender_semaphore_addr_ptr, 0);
+                    in0_sender_sem.wait(1);
+                    in0_sender_sem.set(0);
 
                     uint64_t in0_unicast_data_addr = get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
 
@@ -385,12 +406,14 @@ void kernel_main() {
                      * in0 is M_block_tiles x K_block_tiles. When M block is partial, we don't need to write the
                      * padded tiles. Use `current_block_bytes`.
                      */
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
 
 #ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 #endif
 
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
                 }
 #ifdef USE_MUX
@@ -404,6 +427,7 @@ void kernel_main() {
                         if (in0_core_order_index >= forward_in0_core_order_index) {
                             // If forward, send backward
                             forward_half_block_to_fabric_neighbor(
+                                noc_obj,
                                 m_tile,
                                 k_block_left_tile,
                                 current_M_block_tiles,
@@ -423,6 +447,7 @@ void kernel_main() {
                         } else if (in0_core_order_index >= backward_in0_core_order_index) {
                             // If backward, send forward
                             forward_half_block_to_fabric_neighbor(
+                                noc_obj,
                                 m_tile,
                                 k_block_right_tile,
                                 current_M_block_tiles,
@@ -446,27 +471,33 @@ void kernel_main() {
             }
 #ifdef FUSE_BIAS
             if constexpr (!is_output_writer) {
-                cb_reserve_back(cb_id_in2, N_block_tiles);
+                cb_in2.reserve_back(N_block_tiles);
 
-                uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
+                uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_obj.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint8_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
                     l1_write_addr_in2 += in2_tile_size;
                 }
-                noc_async_read_barrier();
+                noc_obj.async_read_barrier();
 
-                cb_push_back(cb_id_in2, N_block_tiles);
+                cb_in2.push_back(N_block_tiles);
             }
 #endif
 
 #ifdef FUSE_TERNARY
             if constexpr (!is_output_writer) {
                 read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    noc_obj,
                     ternary_a_reader,
                     ternary_b_reader,
                     out_shape,
-                    cb_id_ternary_a,
-                    cb_id_ternary_b,
+                    cb_ternary_a,
+                    cb_ternary_b,
                     ternary_a_tile_size,
                     ternary_b_tile_size,
                     broadcast_ternary_b,
@@ -498,9 +529,10 @@ void kernel_main() {
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
                         write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            noc_obj,
                             std::get<0>(outputs_tuple),
                             out_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -508,9 +540,10 @@ void kernel_main() {
                             n_tile_end);
                     } else {
                         write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            noc_obj,
                             outputs_tuple,
                             out0_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -522,12 +555,13 @@ void kernel_main() {
         }
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
 #ifdef USE_MUX
     if (mux_backward.connection_valid) {
         close_mux(
+            noc_obj,
             mux_connection_handle_backward,
             mux_backward.is_termination_master,
             mux_backward.termination_sync_address,
@@ -540,6 +574,7 @@ void kernel_main() {
     }
     if (mux_forward.connection_valid) {
         close_mux(
+            noc_obj,
             mux_connection_handle_forward,
             mux_forward.is_termination_master,
             mux_forward.termination_sync_address,
@@ -552,8 +587,12 @@ void kernel_main() {
     }
 #endif
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_backward/forward are GlobalSemaphore
+    // addresses (common runtime args), not per-program ids; Semaphore<> cannot wrap them. #45003 item 4.
     noc_semaphore_set(out_ready_sem_backward_addr_ptr, 0);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_backward/forward are GlobalSemaphore
+    // addresses (common runtime args), not per-program ids; Semaphore<> cannot wrap them. #45003 item 4.
     noc_semaphore_set(out_ready_sem_forward_addr_ptr, 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -14,6 +14,7 @@
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "api/tensor/noc_traits.h"
 
 using ttnn::ccl::Topology;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -10,6 +10,7 @@
 #include "api/core_local_mem.h"
 #include "matmul_dataflow_common.hpp"
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     constexpr uint32_t M_tiles = get_compile_time_arg_val(0);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "matmul_dataflow_common.hpp"
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/fused_receiver_utils.hpp"
 
@@ -50,9 +54,16 @@ void kernel_main() {
     const uint32_t in1_dest_noc_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t in1_sender_noc_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t in1_sender_noc_y = get_arg_val<uint32_t>(argidx++);
-    uint32_t in1_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in1_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
-    uint32_t in1_valid_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
+    const uint32_t in1_sender_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_receiver_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t in1_valid_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    Semaphore<> in1_sender_sem(in1_sender_semaphore_id);
+    Semaphore<> in1_receiver_sem(in1_receiver_semaphore_id);
+    Semaphore<> in1_valid_sem(in1_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    uint32_t in1_valid_semaphore_addr = get_semaphore(in1_valid_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    uint32_t in1_receiver_semaphore_addr = get_semaphore(in1_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -110,16 +121,23 @@ void kernel_main() {
     constexpr uint32_t cb_id_in2 = tt::CBIndex::c_4;
 #endif
 
-    volatile tt_l1_ptr uint32_t* in1_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_valid_semaphore_addr);
-    *(in1_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in1_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in1_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_sender_semaphore_addr);
-    const uint64_t in1_sender_semaphore_noc_addr =
-        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);
+    Noc noc_obj;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_out(cb_id_out);
+#ifdef FUSE_BIAS
+    CircularBuffer cb_in2(cb_id_in2);
+#endif
+#ifdef FUSE_TERNARY
+    CircularBuffer cb_ternary_a(cb_id_ternary_a);
+    CircularBuffer cb_ternary_b(cb_id_ternary_b);
+#endif
 
+    in1_valid_sem.set(VALID);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    const uint64_t in1_sender_semaphore_noc_addr =
+        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, get_semaphore(in1_sender_semaphore_id));
+
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     const uint64_t in1_receiver_semaphore_noc_addr =
         get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
 
@@ -150,12 +168,13 @@ void kernel_main() {
             for (uint32_t k_block_iter = 0; k_block_iter < K_num_blocks; k_block_iter++) {
                 if (defer_write && k_block_iter == defer_write_k_block) {
                     if constexpr (is_output_writer) {
-                        cb_wait_front(cb_id_out, out_block_num_tiles);
-                        uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+                        cb_out.wait_front(out_block_num_tiles);
+                        uint32_t out_read_ptr = cb_out.get_read_ptr();
                         // write_block_sync_split is more generic (support multiple output tensors)
                         // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync should be faster
                         if constexpr (N_chunks == 1) {
                             write_block_sync<M_block_tiles, N_block_tiles>(
+                                noc_obj,
                                 std::get<0>(outputs_tuple),
                                 out_shape,
                                 out_read_ptr,
@@ -166,6 +185,7 @@ void kernel_main() {
                                 defer_write_n_tile_end);
                         } else {
                             write_block_sync_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                                noc_obj,
                                 outputs_tuple,
                                 out0_shape,
                                 out_read_ptr,
@@ -175,13 +195,13 @@ void kernel_main() {
                                 defer_write_n_tile,
                                 defer_write_n_tile_end);
                         }
-                        cb_pop_front(cb_id_out, out_block_num_tiles);
+                        cb_out.pop_front(out_block_num_tiles);
                     }
                 }
 
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.reserve_back(in1_block_num_tiles);
 
-                uint32_t in1_start_address = get_write_ptr(cb_id_in1);
+                uint32_t in1_start_address = cb_in1.get_write_ptr();
                 if constexpr (is_injector_core) {
                     uint32_t k_block_left_tile = 0;
                     uint32_t k_block_right_tile = 0;
@@ -201,6 +221,7 @@ void kernel_main() {
                         k_block_left_tile,
                         k_block_right_tile);
                     read_in1_block_sync<K_block_tiles, N_block_tiles>(
+                        noc_obj,
                         in1_reader,
                         in1_shape,
                         in1_start_address,
@@ -212,18 +233,19 @@ void kernel_main() {
                         n_tile,
                         n_tile_end);
                 } else {
-                    noc_semaphore_set(in1_receiver_semaphore_addr_ptr, INVALID);
+                    in1_receiver_sem.set(INVALID);
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     noc_semaphore_inc(in1_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in1_receiver_semaphore_addr_ptr, VALID);
+                    in1_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
                 // This frees sender to start next read earlier
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.push_back(in1_block_num_tiles);
 
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in1_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in1_sender_semaphore_addr_ptr, 0);
+                    in1_sender_sem.wait(1);
+                    in1_sender_sem.set(0);
 
                     /**
                      * in1 is K_block_tiles x N_block_tiles. When N block is partial, we don't need to write the
@@ -232,40 +254,49 @@ void kernel_main() {
                      */
                     for (uint32_t i = 0; i < K_block_tiles; i++) {
                         uint64_t in1_unicast_data_addr = in1_unicast_data_base_addr | in1_start_address;
+                        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address;
+                        // #45003 item 4.
                         noc_async_write(in1_start_address, in1_unicast_data_addr, current_N_tiles_bytes);
                         in1_start_address += full_N_tiles_bytes;
                     }
 
 #ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 #endif
 
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
                 }
             }
 #ifdef FUSE_BIAS
             if constexpr (!is_output_writer) {
-                cb_reserve_back(cb_id_in2, N_block_tiles);
+                cb_in2.reserve_back(N_block_tiles);
 
-                uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
+                uint32_t l1_write_addr_in2 = cb_in2.get_write_ptr();
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_obj.async_read(
+                        in2_reader,
+                        CoreLocalMem<uint8_t>(l1_write_addr_in2),
+                        in2_tile_size,
+                        {.page_id = n_tile_id},
+                        {});
                     l1_write_addr_in2 += in2_tile_size;
                 }
-                noc_async_read_barrier();
+                noc_obj.async_read_barrier();
 
-                cb_push_back(cb_id_in2, N_block_tiles);
+                cb_in2.push_back(N_block_tiles);
             }
 #endif
 
 #ifdef FUSE_TERNARY
             if constexpr (!is_output_writer) {
                 read_ternary_blocks_sync<M_block_tiles, N_block_tiles>(
+                    noc_obj,
                     ternary_a_reader,
                     ternary_b_reader,
                     out_shape,
-                    cb_id_ternary_a,
-                    cb_id_ternary_b,
+                    cb_ternary_a,
+                    cb_ternary_b,
                     ternary_a_tile_size,
                     ternary_b_tile_size,
                     broadcast_ternary_b,
@@ -296,9 +327,10 @@ void kernel_main() {
                     // But for N_chunks == 1 (non-split minimal_matmul), write_block_sync_granular should be faster
                     if constexpr (N_chunks == 1) {
                         write_block_sync_granular<M_block_tiles, N_block_tiles>(
+                            noc_obj,
                             std::get<0>(outputs_tuple),
                             out_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -306,9 +338,10 @@ void kernel_main() {
                             n_tile_end);
                     } else {
                         write_block_sync_granular_split<M_block_tiles, N_block_tiles, N_chunks, N_tiles_per_chunk>(
+                            noc_obj,
                             outputs_tuple,
                             out0_shape,
-                            cb_id_out,
+                            cb_out,
                             out_tile_size,
                             m_tile,
                             m_tile_end,
@@ -319,6 +352,6 @@ void kernel_main() {
             }
         }
     }
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
@@ -7,6 +7,10 @@
 #include <tuple>
 #include <utility>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 
 namespace detail {
 template <typename... Args, uint32_t... Indexes>
@@ -134,8 +138,14 @@ void compute_actual_k_block(
     if (device_iter > 0 && is_first_n_block) {
         // When we are not reading from local, and we are in the first forward pass through n, wait for data to arrive
         if (is_injector_core) {
+            // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward/backward are
+            // GlobalSemaphore addresses. Semaphore<> binds to per-program ids via get_semaphore<>(id), so it
+            // cannot wrap a GlobalSemaphore. #45003 item 4.
             noc_semaphore_wait_min(out_ready_semaphore_forward, sem_target_forward + in0_core_order_size);
             sem_target_forward += in0_core_order_size;
+            // Device 2.0 migration: legacy primitive retained: out_ready_semaphore_forward/backward are
+            // GlobalSemaphore addresses. Semaphore<> binds to per-program ids via get_semaphore<>(id), so it
+            // cannot wrap a GlobalSemaphore. #45003 item 4.
             noc_semaphore_wait_min(out_ready_semaphore_backward, sem_target_backward + in0_core_order_size);
             sem_target_backward += in0_core_order_size;
         }
@@ -152,6 +162,7 @@ struct PacketHeaders {
 
 template <typename TensorAccessorType, typename ConnectionHandleType>
 FORCE_INLINE void forward_half_block_to_fabric_neighbor(
+    Noc& noc,
     uint32_t m_tile_start,
     uint32_t k_tile_start,  // this is the k_tile_index in the output
     uint32_t m_block_tiles,
@@ -217,7 +228,7 @@ FORCE_INLINE void forward_half_block_to_fabric_neighbor(
                     mux_connection_handle, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_addrs[0]});
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
             tiles_read += tiles_to_put_in_current_packet;
             l1_read_addr += (tiles_to_put_in_current_packet * page_size);
             if (reached_half_block_end) {
@@ -232,7 +243,7 @@ FORCE_INLINE void forward_half_block_to_fabric_neighbor(
         pkt_hdr_sem_inc,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 #endif
 
@@ -244,11 +255,15 @@ bool is_backward_k_block_iter(uint32_t k_block_iter, uint32_t k_blocks_per_devic
 
 void fill_zeros_async(uint32_t write_addr, uint32_t tile_bytes) {
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+    // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE source (local L1); no LocalL1 source
+    // endpoint on main. #45003 item 4.
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     // Fill tile with zeros
     uint32_t bytes_left = tile_bytes;
     for (;;) {
         uint32_t read_size = bytes_left > MEM_ZEROS_SIZE ? MEM_ZEROS_SIZE : bytes_left;
+        // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE source (local L1); no LocalL1 source
+        // endpoint on main. #45003 item 4.
         noc_async_read(zeros_noc_addr, write_addr, read_size);
         write_addr += read_size;
         bytes_left -= read_size;
@@ -288,6 +303,7 @@ template <
 #endif
     >
 void read_in0_block_sync(
+    Noc& noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
     uint32_t write_ptr,
@@ -320,11 +336,13 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_tile(tile_id, in3_accessor, write_ptr);
+                    noc.async_read(
+                        in3_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                    noc.async_read(
+                        tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -341,11 +359,13 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_tile(tile_id, in3_accessor, write_ptr);
+                    noc.async_read(
+                        in3_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                    noc.async_read(
+                        tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -357,7 +377,7 @@ void read_in0_block_sync(
         // finish up incrementing write_ptr if (d1_end - d1_start) < K_block_tiles
         write_ptr += (d1_tiles_right - (d1_end_right - d1_start_right)) * tile_size_bytes;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 /**
@@ -367,6 +387,7 @@ void read_in0_block_sync(
  */
 template <uint32_t K_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void read_in1_block_sync(
+    Noc& noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
     uint32_t write_ptr,
@@ -388,7 +409,8 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                noc.async_read(
+                    tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
             } else {
                 fill_zeros_async(write_ptr, tile_size_bytes);
             }
@@ -405,7 +427,8 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                noc.async_read(
+                    tensor_accessor, CoreLocalMem<uint8_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
             } else {
                 fill_zeros_async(write_ptr, tile_size_bytes);
             }
@@ -414,7 +437,7 @@ void read_in1_block_sync(
         // finish up incrementing write_ptr if (d1_end - d1_start) < N_block_tiles
         write_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
 /**
@@ -423,6 +446,7 @@ void read_in1_block_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void write_block_sync(
+    Noc& noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
     uint32_t read_ptr,
@@ -444,13 +468,14 @@ void write_block_sync(
                 continue;
             }
             uint32_t tile_id = i * shape.logical_d1 + j;
-            noc_async_write_tile(tile_id, tensor_accessor, read_ptr);
+            noc.async_write(
+                CoreLocalMem<uint8_t>(read_ptr), tensor_accessor, tile_size_bytes, {}, {.page_id = tile_id});
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
         read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
@@ -468,11 +493,12 @@ void write_block_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void read_ternary_blocks_sync(
+    Noc& noc,
     const TensorAccessorType& ternary_a_accessor,
     const TensorAccessorType& ternary_b_accessor,
     const TensorShape2D& shape,
-    uint32_t ternary_a_cb,
-    uint32_t ternary_b_cb,
+    CircularBuffer& ternary_a_cb,
+    CircularBuffer& ternary_b_cb,
     uint32_t a_tile_size_bytes,
     uint32_t b_tile_size_bytes,
     uint32_t broadcast_ternary_b,
@@ -485,49 +511,59 @@ void read_ternary_blocks_sync(
 
     if (broadcast_ternary_b) {
         // Broadcast: read single row, push all at once
-        cb_reserve_back(ternary_b_cb, N_block_tiles);
-        uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+        ternary_b_cb.reserve_back(N_block_tiles);
+        uint32_t ternary_b_write_ptr = ternary_b_cb.get_write_ptr();
         for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
             if (n_tile_id >= shape.logical_d1) {
                 break;
             }
-            noc_async_read_tile(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
+            noc.async_read(
+                ternary_b_accessor,
+                CoreLocalMem<uint8_t>(ternary_b_write_ptr),
+                b_tile_size_bytes,
+                {.page_id = n_tile_id},
+                {});
             ternary_b_write_ptr += b_tile_size_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(ternary_b_cb, N_block_tiles);
+        noc.async_read_barrier();
+        ternary_b_cb.push_back(N_block_tiles);
     } else {
         // No broadcast: read row-by-row (matches ternary_a pattern)
         uint32_t b_m_id = 0;
         uint32_t b_i = d0_start;
         for (; b_i < d0_end; b_i++, b_m_id++) {
-            cb_reserve_back(ternary_b_cb, N_block_tiles);
-            uint32_t ternary_b_write_ptr = get_write_ptr(ternary_b_cb);
+            ternary_b_cb.reserve_back(N_block_tiles);
+            uint32_t ternary_b_write_ptr = ternary_b_cb.get_write_ptr();
             for (uint32_t j = d1_start; j < d1_end; j++) {
                 if (j >= shape.logical_d1) {
                     break;
                 }
                 if (b_i < shape.logical_d0) {
                     uint32_t tile_id = b_i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, ternary_b_accessor, ternary_b_write_ptr);
+                    noc.async_read(
+                        ternary_b_accessor,
+                        CoreLocalMem<uint8_t>(ternary_b_write_ptr),
+                        b_tile_size_bytes,
+                        {.page_id = tile_id},
+                        {});
                 }
                 ternary_b_write_ptr += b_tile_size_bytes;
             }
-            noc_async_read_barrier();
-            cb_push_back(ternary_b_cb, N_block_tiles);
+            noc.async_read_barrier();
+            ternary_b_cb.push_back(N_block_tiles);
         }
         for (; b_m_id < M_block_tiles; b_m_id++) {
-            cb_reserve_back(ternary_b_cb, N_block_tiles);
-            cb_push_back(ternary_b_cb, N_block_tiles);
+            ternary_b_cb.reserve_back(N_block_tiles);
+            ternary_b_cb.push_back(N_block_tiles);
         }
     }
 
     uint32_t m_id = 0;
     uint32_t i = d0_start;
     for (; i < d0_end; i++, m_id++) {
-        cb_reserve_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.reserve_back(N_block_tiles);
 
-        uint32_t ternary_a_write_ptr = get_write_ptr(ternary_a_cb);
+        uint32_t ternary_a_write_ptr = ternary_a_cb.get_write_ptr();
         for (uint32_t j = d1_start; j < d1_end; j++) {
             if (j >= shape.logical_d1) {
                 // Do not move tile data into CB if tile is outside ternary/output tensor.
@@ -538,17 +574,22 @@ void read_ternary_blocks_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, ternary_a_accessor, ternary_a_write_ptr);
+                noc.async_read(
+                    ternary_a_accessor,
+                    CoreLocalMem<uint8_t>(ternary_a_write_ptr),
+                    a_tile_size_bytes,
+                    {.page_id = tile_id},
+                    {});
             }
             ternary_a_write_ptr += a_tile_size_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
-        cb_push_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.push_back(N_block_tiles);
     }
     for (; m_id < M_block_tiles; m_id++) {
-        cb_reserve_back(ternary_a_cb, N_block_tiles);
-        cb_push_back(ternary_a_cb, N_block_tiles);
+        ternary_a_cb.reserve_back(N_block_tiles);
+        ternary_a_cb.push_back(N_block_tiles);
     }
 }
 
@@ -558,31 +599,33 @@ void read_ternary_blocks_sync(
  */
 template <uint32_t M_block_tiles, uint32_t N_block_tiles, typename TensorAccessorType>
 void write_block_sync_granular(
+    Noc& noc,
     const TensorAccessorType& tensor_accessor,
     const TensorShape2D& shape,
-    uint32_t cb_id_out,
+    CircularBuffer& cb_out,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
     uint32_t d0_end,
     uint32_t d1_start,
     uint32_t d1_end) {
     for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
-        cb_wait_front(cb_id_out, N_block_tiles);
+        cb_out.wait_front(N_block_tiles);
         uint32_t m_tile = d0_start + m_id;
         if (m_tile < d0_end && m_tile < shape.logical_d0) {
-            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            uint32_t out_read_ptr = cb_out.get_read_ptr();
             for (uint32_t n_tile_id = d1_start; n_tile_id < d1_end; n_tile_id++) {
                 if (n_tile_id >= shape.logical_d1) {
                     break;
                 }
                 uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
-                noc_async_write_tile(tile_id, tensor_accessor, out_read_ptr);
+                noc.async_write(
+                    CoreLocalMem<uint8_t>(out_read_ptr), tensor_accessor, tile_size_bytes, {}, {.page_id = tile_id});
                 out_read_ptr += tile_size_bytes;
             }
         }
-        cb_pop_front(cb_id_out, N_block_tiles);
+        cb_out.pop_front(N_block_tiles);
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
@@ -591,10 +634,21 @@ void write_block_sync_granular(
  */
 template <typename Tuple, size_t... Is>
 FORCE_INLINE void write_tile_to_chunk(
-    const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
+    Noc& noc,
+    const Tuple& accessors,
+    uint32_t chunk_idx,
+    uint32_t tile_id,
+    uint32_t read_ptr,
+    uint32_t tile_size_bytes,
+    std::index_sequence<Is...>) {
     // Fold expression: expands to if/else chain at compile time
-    // Each branch calls noc_async_write_tile with the concrete type
-    ((chunk_idx == Is ? (noc_async_write_tile(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
+    // Each branch calls noc.async_write with the concrete TensorAccessor type
+    ((chunk_idx == Is
+          ? (noc.async_write(
+                 CoreLocalMem<uint8_t>(read_ptr), std::get<Is>(accessors), tile_size_bytes, {}, {.page_id = tile_id}),
+             void())
+          : void()),
+     ...);
 }
 
 /**
@@ -610,6 +664,7 @@ template <
     uint32_t N_tiles_per_chunk,
     typename... Accessors>
 void write_block_sync_split(
+    Noc& noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
     uint32_t read_ptr,
@@ -650,13 +705,19 @@ void write_block_sync_split(
 
             // Compile-time dispatch preserving concrete types
             write_tile_to_chunk(
-                accessors, chunk_idx, tile_id_in_chunk, read_ptr, std::index_sequence_for<Accessors...>{});
+                noc,
+                accessors,
+                chunk_idx,
+                tile_id_in_chunk,
+                read_ptr,
+                tile_size_bytes,
+                std::index_sequence_for<Accessors...>{});
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
         read_ptr += (N_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 /**
@@ -670,9 +731,10 @@ template <
     uint32_t N_tiles_per_chunk,
     typename... Accessors>
 void write_block_sync_granular_split(
+    Noc& noc,
     const std::tuple<Accessors...>& accessors,
     const TensorShape2D& chunk_shape,
-    uint32_t cb_id_out,
+    CircularBuffer& cb_out,
     uint32_t tile_size_bytes,
     uint32_t d0_start,
     uint32_t d0_end,
@@ -682,10 +744,10 @@ void write_block_sync_granular_split(
     const uint32_t tile_idx_in_chunk_start = d1_start % N_tiles_per_chunk;
 
     for (uint32_t m_id = 0; m_id < M_block_tiles; m_id++) {
-        cb_wait_front(cb_id_out, N_block_tiles);
+        cb_out.wait_front(N_block_tiles);
         uint32_t m_tile = d0_start + m_id;
         if (m_tile < d0_end && m_tile < chunk_shape.logical_d0) {
-            uint32_t out_read_ptr = get_read_ptr(cb_id_out);
+            uint32_t out_read_ptr = cb_out.get_read_ptr();
 
             uint32_t chunk_idx = chunk_idx_start;
             uint32_t tile_idx_in_chunk = tile_idx_in_chunk_start;
@@ -704,14 +766,20 @@ void write_block_sync_granular_split(
                 uint32_t tile_id = m_tile * chunk_shape.logical_d1 + tile_idx_in_chunk;
                 // Compile-time dispatch preserving concrete types
                 write_tile_to_chunk(
-                    accessors, chunk_idx, tile_id, out_read_ptr, std::index_sequence_for<Accessors...>{});
+                    noc,
+                    accessors,
+                    chunk_idx,
+                    tile_id,
+                    out_read_ptr,
+                    tile_size_bytes,
+                    std::index_sequence_for<Accessors...>{});
 
                 out_read_ptr += tile_size_bytes;
             }
         }
-        cb_pop_front(cb_id_out, N_block_tiles);
+        cb_out.pop_front(N_block_tiles);
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 #ifdef USE_MUX
@@ -842,6 +910,7 @@ FORCE_INLINE PacketHeaders allocate_and_init_packet_headers(
 
 template <typename ConnectionHandleType>
 FORCE_INLINE void close_mux(
+    Noc& noc,
     ConnectionHandleType mux_connection_handle,
     bool is_termination_master,
     uint32_t termination_sync_address,
@@ -854,13 +923,17 @@ FORCE_INLINE void close_mux(
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
     if (is_termination_master) {
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id);
+        // #45003 item 4.
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =
             safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+        // Device 2.0 migration: legacy primitive retained: fabric-mux sync address (raw L1 pointer, not a program id);
+        // #45003 item 4.
         noc_semaphore_inc(dest_addr, 1);
-        noc_async_atomic_barrier();
+        noc.async_atomic_barrier();
     }
 }
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <cstdint>
 #include <utility>
 
@@ -39,6 +41,9 @@ void kernel_main() {
     constexpr auto tensor0_args = TensorAccessorArgs<7>();
     auto tensor0_addrgen = TensorAccessor(tensor0_args, tensor_address0);
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     bool cur_is_forward = num_targets_forward_direction > num_targets_backward_direction;
     uint32_t forward_hops = 1;
     uint32_t backward_hops = 1;
@@ -69,19 +74,21 @@ void kernel_main() {
             for (uint32_t col_tile_id = shard_col_start_id; col_tile_id < shard_col_end_id;
                  col_tile_id += packet_size_in_pages) {
                 uint32_t tile_id = row_tile_id * in_col_tiles + col_tile_id;
-                cb_reserve_back(cb0_id, packet_size_in_pages);
-                const uint32_t l1_write_addr_base = get_write_ptr(cb0_id);
-                uint32_t l1_write_addr = l1_write_addr_base;
+                cb0.reserve_back(packet_size_in_pages);
 
                 uint32_t num_pages_to_read = std::min(shard_col_end_id - col_tile_id, packet_size_in_pages);
                 for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                    noc_async_read_tile(tile_id, tensor0_addrgen, l1_write_addr);
-                    l1_write_addr += tensor0_page_size;
+                    noc_obj.async_read(
+                        tensor0_addrgen,
+                        cb0,
+                        tensor0_page_size,
+                        {.page_id = tile_id},
+                        {.offset_bytes = j * tensor0_page_size});
                     tile_id++;
                 }
 
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, packet_size_in_pages);
+                noc_obj.async_read_barrier();
+                cb0.push_back(packet_size_in_pages);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 using address_t = uint32_t;
 
@@ -50,6 +52,9 @@ void kernel_main() {
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_buffer_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb(cb_id);
+
     if (my_ring_id == remote_device_ring_id) {
         // Follows same logic as sender reader for local copy.
         uint32_t shard_row_start_id = my_ring_id * input_row_device_stride;
@@ -61,19 +66,17 @@ void kernel_main() {
             for (uint32_t col_tile_id = shard_col_start_id; col_tile_id < shard_col_end_id;
                  col_tile_id += num_pages_per_packet) {
                 uint32_t tile_id = row_tile_id * in_col_tiles + col_tile_id;
-                cb_reserve_back(cb_id, num_pages_per_packet);
-                const uint32_t l1_write_addr_base = get_write_ptr(cb_id);
-                uint32_t l1_write_addr = l1_write_addr_base;
+                cb.reserve_back(num_pages_per_packet);
 
                 uint32_t num_pages_to_read = std::min(shard_col_end_id - col_tile_id, num_pages_per_packet);
                 for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                    noc_async_read_tile(tile_id, input_tensor_addrgen, l1_write_addr);
-                    l1_write_addr += page_size;
+                    noc_obj.async_read(
+                        input_tensor_addrgen, cb, page_size, {.page_id = tile_id}, {.offset_bytes = j * page_size});
                     tile_id++;
                 }
 
-                noc_async_read_barrier();
-                cb_push_back(cb_id, num_pages_per_packet);
+                noc_obj.async_read_barrier();
+                cb.push_back(num_pages_per_packet);
             }
         }
     } else {
@@ -90,8 +93,8 @@ void kernel_main() {
 
         for (uint32_t out_row_id = out_row_start; out_row_id < out_row_end; out_row_id++) {
             for (uint32_t out_col_id = out_col_start; out_col_id < out_col_end; out_col_id += num_pages_per_packet) {
-                cb_reserve_back(cb_id, num_pages_per_packet);
-                size_t l1_write_addr = get_write_ptr(cb_id);
+                cb.reserve_back(num_pages_per_packet);
+                size_t l1_write_addr = cb.get_write_ptr();
                 uint32_t num_pages_to_read = std::min(out_col_end - out_col_id, num_pages_per_packet);
 
                 constexpr uint32_t payload_size_bytes = contig_pages_advanced * page_size;
@@ -100,11 +103,16 @@ void kernel_main() {
                 uint32_t current_chunk_id = packet_id / chunk_granularity;
                 uint32_t wait_chunk_id = current_chunk_id + 1;  // Chunks are 1-based
                 // Ensure that current chunk has been sent
+                // Device 2.0 migration: legacy primitive retained: global_semaphore_addr is a GlobalSemaphore address.
+                // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+                // #45003 item 4.
                 noc_semaphore_wait_min(global_semaphore_ptr, wait_chunk_id);
 
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t global_id = sender_relative_ring_id + packet_id * NUM_SENDERS;
                     uint32_t first_id = (global_id % N_DRAM_BANKS) + 2 * N_DRAM_BANKS * (global_id / N_DRAM_BANKS);
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address;
+                    // #45003 item 4.
                     uint64_t packet_addr =
                         get_noc_addr(first_id, intermediate_tensor_addrgen, 0 /*offset*/, 0 /*noc_id*/);
 
@@ -112,13 +120,16 @@ void kernel_main() {
                     l1_write_addr += payload_size_bytes;
                     packet_id++;
                 }
-                noc_async_read_barrier();
+                noc_obj.async_read_barrier();
 
-                cb_push_back(cb_id, num_pages_per_packet);
+                cb.push_back(num_pages_per_packet);
             }
         }
     }
 
     // Reset global semaphore
+    // Device 2.0 migration: legacy primitive retained: global_semaphore_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+    // #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 using address_t = uint32_t;
 
@@ -42,12 +44,14 @@ void kernel_main() {
     constexpr auto output_tensor_args = TensorAccessorArgs<8>();
     auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_buffer_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb(cb_id);
+
     if (my_ring_id == remote_device_ring_id) {
         // Follows same logic as sender reader for local copy.
         for (uint32_t out_row_id = out_row_start; out_row_id < out_row_end; out_row_id++) {
             for (uint32_t out_col_id = out_col_start; out_col_id < out_col_end; out_col_id += num_pages_per_packet) {
-                cb_wait_front(cb_id, num_pages_per_packet);
-                size_t l1_read_addr = get_read_ptr(cb_id);
+                cb.wait_front(num_pages_per_packet);
                 uint32_t num_pages_to_read = std::min(out_col_end - out_col_id, num_pages_per_packet);
 
                 constexpr uint32_t contig_pages_advanced = 1;  // always 1 for interleaved
@@ -55,12 +59,15 @@ void kernel_main() {
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t col_tile = out_col_id + j;
                     uint32_t tile_id = out_row_id * out_col_tiles + col_tile;
-                    noc_async_write_tile(tile_id, output_tensor_addrgen, l1_read_addr);
-
-                    l1_read_addr += payload_size_bytes;
+                    noc_obj.async_write(
+                        cb,
+                        output_tensor_addrgen,
+                        payload_size_bytes,
+                        {.offset_bytes = j * payload_size_bytes},
+                        {.page_id = tile_id});
                 }
-                noc_async_writes_flushed();
-                cb_pop_front(cb_id, num_pages_per_packet);
+                noc_obj.async_writes_flushed();
+                cb.pop_front(num_pages_per_packet);
             }
         }
 
@@ -71,22 +78,21 @@ void kernel_main() {
 
         for (uint32_t out_row_id = out_row_start; out_row_id < out_row_end; out_row_id++) {
             for (uint32_t out_col_id = out_col_start; out_col_id < out_col_end; out_col_id += num_pages_per_packet) {
-                cb_wait_front(cb_id, num_pages_per_packet);
-                size_t l1_read_addr = get_read_ptr(cb_id);
+                cb.wait_front(num_pages_per_packet);
                 uint32_t num_pages_to_read = std::min(out_col_end - out_col_id, num_pages_per_packet);
 
                 constexpr uint32_t contig_pages_advanced = 1;  // always write 1 tile at a time to output
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t col_tile = out_col_id + j;
                     uint32_t tile_id = out_row_id * out_col_tiles + col_tile;
-                    noc_async_write_tile(tile_id, output_tensor_addrgen, l1_read_addr);
-                    l1_read_addr += page_size;
+                    noc_obj.async_write(
+                        cb, output_tensor_addrgen, page_size, {.offset_bytes = j * page_size}, {.page_id = tile_id});
                 }
-                noc_async_writes_flushed();
+                noc_obj.async_writes_flushed();
 
-                cb_pop_front(cb_id, num_pages_per_packet);
+                cb.pop_front(num_pages_per_packet);
             }
         }
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -62,19 +64,23 @@ void kernel_main() {
     auto fabric_connection = FabricConnectionManager::build_from_args<
         FabricConnectionManager::BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION_START_ONLY>(arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     uint32_t out_row_end = out_row_start + input_shard_row_tiles;
     uint32_t out_col_end = out_col_start + input_shard_col_tiles;
 
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -127,8 +133,8 @@ void kernel_main() {
 
         for (uint32_t out_row_id = out_row_start; out_row_id < out_row_end; out_row_id++) {
             for (uint32_t out_col_id = out_col_start; out_col_id < out_col_end; out_col_id += packet_size_in_pages) {
-                cb_wait_front(cb0_id, packet_size_in_pages);
-                size_t l1_read_addr = get_read_ptr(cb0_id);
+                cb0.wait_front(packet_size_in_pages);
+                size_t l1_read_addr = cb0.get_read_ptr();
                 uint32_t num_pages_to_read = std::min(out_col_end - out_col_id, packet_size_in_pages);
 
                 constexpr uint32_t payload_size_bytes = contig_pages_advanced * tensor0_page_size;
@@ -163,13 +169,13 @@ void kernel_main() {
                         perform_payload_send(cur_connection, l1_read_addr, payload_size_bytes, cur_pkt_header);
                     }
 
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 
                     // Advance local read address
                     l1_read_addr += payload_size_bytes;
                 }
 
-                cb_pop_front(cb0_id, packet_size_in_pages);
+                cb0.pop_front(packet_size_in_pages);
             }
         }
 
@@ -188,5 +194,5 @@ void kernel_main() {
         fabric_connection.close();
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_writer.cpp
@@ -11,6 +11,7 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 
@@ -91,6 +95,13 @@ void kernel_main() {
     const auto mapping_addr_gen = TensorAccessor(mapping_args, mapping_tensor_address, mapping_page_size);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
 
+    Noc noc_obj;
+    CircularBuffer cb_input(input_tensor_cb_id);
+    CircularBuffer cb_indices(indices_tensor_cb_id);
+    CircularBuffer cb_scores(scores_tensor_cb_id);
+    CircularBuffer cb_mapping(mapping_tensor_cb_id);
+    CircularBuffer cb_metadata(metadata_buffer_id);
+
     if (token_start_idx == token_end_idx) {
         return;
     }
@@ -99,25 +110,25 @@ void kernel_main() {
     // Each page is one device's view of the mapping. Read only the source device's page.
     // Page index = linearized_mesh_coord (source device index)
     constexpr uint32_t mapping_pages_to_read = 1;
-    cb_reserve_back(mapping_tensor_cb_id, mapping_pages_to_read);
-    uint32_t base_mapping_addr = get_write_ptr(mapping_tensor_cb_id);
-    noc_async_read_page(linearized_mesh_coord, mapping_addr_gen, base_mapping_addr);
+    cb_mapping.reserve_back(mapping_pages_to_read);
+    uint32_t base_mapping_addr = cb_mapping.get_write_ptr();
+    noc_obj.async_read(mapping_addr_gen, cb_mapping, mapping_page_size, {.page_id = linearized_mesh_coord}, {});
 
     ASSERT(indices_pages == input_pages);
     ASSERT(scores_pages == indices_pages);
     // read the input tokens, selected experts, and scores for each token
-    uint32_t base_indices_addr = get_write_ptr(indices_tensor_cb_id);
-    uint32_t base_scores_addr = get_write_ptr(scores_tensor_cb_id);
-    noc_async_read_barrier();
-    cb_push_back(mapping_tensor_cb_id, mapping_pages_to_read);
+    uint32_t base_indices_addr = cb_indices.get_write_ptr();
+    uint32_t base_scores_addr = cb_scores.get_write_ptr();
+    noc_obj.async_read_barrier();
+    cb_mapping.push_back(mapping_pages_to_read);
 
     for (uint32_t i = token_start_idx; i < token_end_idx; i++) {
-        cb_reserve_back(indices_tensor_cb_id, 1);
-        cb_reserve_back(input_tensor_cb_id, 1);
+        cb_indices.reserve_back(1);
+        cb_input.reserve_back(1);
 
         // All workers read indices (needed for routing decisions)
-        uint32_t l1_write_addr = get_write_ptr(indices_tensor_cb_id);
-        noc_async_read_page(i, indices_addr_gen, l1_write_addr);
+        uint32_t l1_write_addr = cb_indices.get_write_ptr();
+        noc_obj.async_read(indices_addr_gen, cb_indices, indices_page_size, {.page_id = i}, {});
 
         // manually fill in shared expert IDs to the metadata
         if constexpr (num_shared_experts > 0) {
@@ -128,9 +139,9 @@ void kernel_main() {
 
         // Only primary worker reads scores (only primary sends metadata)
         if (is_primary_payload_worker) {
-            cb_reserve_back(scores_tensor_cb_id, 1);
-            l1_write_addr = get_write_ptr(scores_tensor_cb_id);
-            noc_async_read_page(i, scores_addr_gen, l1_write_addr);
+            cb_scores.reserve_back(1);
+            l1_write_addr = cb_scores.get_write_ptr();
+            noc_obj.async_read(scores_addr_gen, cb_scores, scores_page_size, {.page_id = i}, {});
 
             if constexpr (num_shared_experts > 0) {
                 auto* l1_scores_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
@@ -143,37 +154,42 @@ void kernel_main() {
         // Read input token (or portion of it in payload split mode)
         // In non-split mode: payload_offset=0, payload_size=input_page_size (reads full page)
         // In split mode: reads only this worker's portion
-        uint64_t input_page_noc_addr = get_noc_addr(i, input_addr_gen);
-        l1_write_addr = get_write_ptr(input_tensor_cb_id);
-        noc_async_read(input_page_noc_addr + payload_offset, l1_write_addr, payload_size);
+        noc_obj.async_read(input_addr_gen, cb_input, payload_size, {.page_id = i, .offset_bytes = payload_offset}, {});
 
-        noc_async_read_barrier();
-        cb_push_back(indices_tensor_cb_id, 1);
+        noc_obj.async_read_barrier();
+        cb_indices.push_back(1);
         if (is_primary_payload_worker) {
-            cb_push_back(scores_tensor_cb_id, 1);
+            cb_scores.push_back(1);
         }
-        cb_push_back(input_tensor_cb_id, 1);
+        cb_input.push_back(1);
     }
 
     // Only primary worker copies indices and scores to metadata buffer (only primary sends metadata)
     if (is_primary_payload_worker) {
-        cb_reserve_back(metadata_buffer_id, tokens_per_device);
-        const uint32_t metadata_buffer_addr = get_write_ptr(metadata_buffer_id);
+        cb_metadata.reserve_back(tokens_per_device);
+        const uint32_t metadata_buffer_addr = cb_metadata.get_write_ptr();
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(
             get_noc_addr(base_indices_addr),
             metadata_buffer_addr,
             (token_end_idx - token_start_idx) * aligned_metadata_page_size);
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(
             get_noc_addr(base_scores_addr),
-            get_write_ptr(metadata_buffer_id) + (token_end_idx - token_start_idx) * aligned_metadata_page_size,
+            cb_metadata.get_write_ptr() + (token_end_idx - token_start_idx) * aligned_metadata_page_size,
             (token_end_idx - token_start_idx) * aligned_output_scores_page_size);
 
-        noc_async_read_barrier();
-        cb_push_back(metadata_buffer_id, tokens_per_device);
+        noc_obj.async_read_barrier();
+        cb_metadata.push_back(tokens_per_device);
 
         // Wait for all other devices to finish dispatching their input tokens and metadata.
         // The writer now writes metadata directly to the sharded output tensor on the drain sync tilizer core,
         // so we no longer need to copy from the intermediate buffer to the final output here.
+        // Device 2.0 migration: legacy primitive retained: global_semaphore_address is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait((uint32_t*)global_semaphore_address, dispatch_devices);
         noc_semaphore_set((uint32_t*)global_semaphore_address, 0);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -10,6 +10,7 @@
 #include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/tensor/noc_traits.h"
 
 using namespace ttnn::operations::ccl::common;
 using tt::data_movement::common::tt_memmove;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -14,6 +14,7 @@
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "api/tensor/noc_traits.h"
 
 namespace detail {
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -13,26 +18,33 @@
 namespace detail {
 
 inline void dispatch_input_local_device_flushed(
-    uint32_t input_token_read_addr, uint64_t output_token_write_addr, uint32_t output_page_size) {
+    const Noc& noc, uint32_t input_token_read_addr, uint64_t output_token_write_addr, uint32_t output_page_size) {
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 // Insert helper that handles the local-device metadata path
 inline void dispatch_metadata_local_device(
+    const Noc& noc,
     uint32_t token_indices_address,
     uint64_t metadata_write_addr,
     uint32_t metadata_page_size,
     uint64_t global_noc_semaphore_address) {
     // send metadata to local device output buffer
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_write(token_indices_address, metadata_write_addr, metadata_page_size);
-    noc_async_write_barrier();
+    noc.async_write_barrier();
+    // Device 2.0 migration: legacy primitive retained: global_noc_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_inc(global_noc_semaphore_address, 1);
     noc_async_atomic_barrier();
 }
 
 void zero_buffer_async(uint32_t write_addr, int bytes) {
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE self-read; no LocalL1 endpoint on main. #45003
+    // item 4.
     while (bytes > 0) {
         uint32_t curr_bytes = std::min(bytes, MEM_ZEROS_SIZE);
         noc_async_read(zeros_noc_addr, write_addr, curr_bytes);
@@ -41,7 +53,7 @@ void zero_buffer_async(uint32_t write_addr, int bytes) {
     }
 }
 
-void zero_buffer_barrier() { noc_async_read_barrier(); }
+void zero_buffer_barrier(const Noc& noc) { noc.async_read_barrier(); }
 
 // Bidirectional fabric multicast atomic increment - sends to both positive and negative directions
 // For a 1D ring with even number of devices, we multicast in both directions to cover all devices
@@ -110,6 +122,7 @@ template <
     uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* packet_header_pos,
     volatile PACKET_HEADER_TYPE* packet_header_neg,
@@ -176,12 +189,13 @@ FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
         // Wait for header DMAs to complete before modifying headers in next iteration
         // The fabric API uses non-blocking header sends, so we need to ensure the
         // header memory is no longer being read before we overwrite it
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
     }
 
     // Also write to local device (use original addresses and total size)
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_write(original_src_addr, original_noc_addr, total_size);
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 // Fabric multicast metadata write helper - handles scatter writes in both directions along a 1D ring
@@ -194,6 +208,7 @@ template <
     uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* packet_header_pos,
     volatile PACKET_HEADER_TYPE* packet_header_neg,
@@ -244,9 +259,11 @@ FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
     // Also write to local device - scatter means contiguous src, separate destinations
     // First chunk: src_addr -> noc_addresses[0], chunk_sizes[0] bytes
     // Second chunk: src_addr + chunk_sizes[0] -> noc_addresses[1], chunk_sizes[1] bytes
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_write(src_addr, noc_addresses[0], chunk_sizes[0]);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_write(src_addr + chunk_sizes[0], noc_addresses[1], chunk_sizes[1]);
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 }
 
 // ============================================================================
@@ -282,6 +299,7 @@ template <
     typename OutputAddrGenT,
     typename FabricConnectionsType>
 FORCE_INLINE bool dispatch_token_point_to_point_unicast(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* unicast_packet_header,
     const OutputAddrGenT& output_addr_gen,
@@ -313,6 +331,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, we dispatch the input token to it
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
                 needs_barrier = true;
             } else if (is_configured_target<LinearizedSrcMeshCoord, MeshRows, MeshCols, Axis>(target_device)) {
@@ -338,7 +357,7 @@ FORCE_INLINE bool dispatch_token_point_to_point_unicast(
         }
     }
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
     return needs_barrier;
 }
 
@@ -375,6 +394,7 @@ template <
     typename OutputAddrGenT,
     typename FabricConnectionsType>
 FORCE_INLINE bool dispatch_token_sparse_multicast(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* unicast_packet_header,
     const OutputAddrGenT& output_addr_gen,
@@ -409,6 +429,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
 
             if (target_device == LinearizedSrcMeshCoord) {
                 // If the expert lives on the current device, dispatch locally
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
                 needs_barrier = true;
             } else if (is_configured_target<LinearizedSrcMeshCoord, MeshRows, MeshCols, Axis>(target_device)) {
@@ -438,7 +459,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
             alignment,
             payload_offset);
     }
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
     return needs_barrier;
 }
 
@@ -481,6 +502,7 @@ template <
     typename OutputAddrGenT,
     typename FabricConnectionsType>
 FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* packet_header_pos,
     volatile PACKET_HEADER_TYPE* packet_header_neg,
@@ -517,6 +539,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
         if (target_device == LinearizedSrcMeshCoord) {
             // Local device - dispatch once
             if (!sent_local) {
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
                 needs_barrier = true;
                 sent_local = true;
@@ -594,7 +617,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
             payload_offset);
     }
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
     return needs_barrier;
 }
 
@@ -636,6 +659,7 @@ template <
     typename OutputAddrGenT,
     typename FabricConnectionsType>
 FORCE_INLINE bool dispatch_token_split_bandwidth(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* packet_header_pos,
     volatile PACKET_HEADER_TYPE* packet_header_neg,
@@ -679,6 +703,7 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
         if (target_device == LinearizedSrcMeshCoord) {
             // Local device - dispatch once
             if (!sent_local) {
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_write(input_token_read_addr, output_token_write_addr, input_page_size);
                 needs_barrier = true;
                 sent_local = true;
@@ -752,7 +777,7 @@ FORCE_INLINE bool dispatch_token_split_bandwidth(
         (int)half_size,
         alignment,
         neg_offset);
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
     return needs_barrier;
 }
 
@@ -782,6 +807,7 @@ template <
     uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void dispatch_token_bidirectional_multicast(
+    const Noc& noc,
     FabricConnectionsType& fabric_connections,
     volatile PACKET_HEADER_TYPE* packet_header_pos,
     volatile PACKET_HEADER_TYPE* packet_header_neg,
@@ -796,6 +822,7 @@ FORCE_INLINE void dispatch_token_bidirectional_multicast(
         MeshCols,
         Axis,
         DispatchDevices>(
+        noc,
         fabric_connections,
         packet_header_pos,
         packet_header_neg,
@@ -916,6 +943,15 @@ void kernel_main() {
         return;
     }
 
+    Noc noc_obj;
+    CircularBuffer cb_input(input_tensor_cb_id);
+    CircularBuffer cb_indices(indices_tensor_cb_id);
+    CircularBuffer cb_scores(scores_tensor_cb_id);
+    CircularBuffer cb_mapping(mapping_tensor_cb_id);
+    CircularBuffer cb_packet_header(packet_header_cb_id);
+    CircularBuffer cb_send_preparation_buffer(send_preparation_buffer_cb_id);
+    CircularBuffer cb_metadata(metadata_buffer_id);
+
 #ifdef USE_MUX
     // ========================================================================
     // MUX PATH: Use WorkerToFabricMuxSender connections via fabric mux
@@ -995,7 +1031,7 @@ void kernel_main() {
     open_direction_connections_async(directions, fabric_connections, rt_args_idx);
 #endif
 
-    uint32_t send_preparation_buffer_address = get_write_ptr(send_preparation_buffer_cb_id);
+    uint32_t send_preparation_buffer_address = cb_send_preparation_buffer.get_write_ptr();
     detail::zero_buffer_async(
         send_preparation_buffer_address, (token_end_idx - token_start_idx) * num_devices * sizeof(uint8_t));
 
@@ -1021,7 +1057,7 @@ void kernel_main() {
     const auto output_scores_addr_gen =
         TensorAccessor(scores_out_args, scores_out_tensor_address, output_scores_page_size);
 
-    uint32_t packet_header_buffer_address = get_read_ptr(packet_header_cb_id);
+    uint32_t packet_header_buffer_address = cb_packet_header.get_read_ptr();
     auto* unicast_packet_header_pos = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
     auto* unicast_packet_header_neg =
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
@@ -1035,10 +1071,10 @@ void kernel_main() {
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + 5 * sizeof(PACKET_HEADER_TYPE));
     // packet headers at +6 and +7 are currently unused (reserved for future split sends)
 
-    uint32_t base_indices_addr = get_read_ptr(indices_tensor_cb_id);
-    uint32_t base_scores_addr = get_read_ptr(scores_tensor_cb_id);
+    uint32_t base_indices_addr = cb_indices.get_read_ptr();
+    uint32_t base_scores_addr = cb_scores.get_read_ptr();
 
-    detail::zero_buffer_barrier();
+    detail::zero_buffer_barrier(noc_obj);
 
 #ifdef USE_MUX
     // Wait for mux to be ready and connect
@@ -1062,6 +1098,8 @@ void kernel_main() {
     // - All output buffers are persistent, so remote writes won't corrupt data being used
     // - The cross_device_semaphore is double-buffered externally to avoid races between iterations
 #ifndef SKIP_INIT_SEMAPHORE
+    // Device 2.0 migration: legacy primitive retained: init_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
     detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
         linearized_mesh_coord,
@@ -1070,16 +1108,18 @@ void kernel_main() {
         axis,
         dispatch_devices>(
         fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
-    noc_async_writes_flushed();
+    noc_obj.async_writes_flushed();
 
     // Wait for all devices to complete initialization synchronization
+    // Device 2.0 migration: legacy primitive retained: init_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_wait((uint32_t*)init_semaphore_address, dispatch_devices - 1);
     noc_semaphore_set((uint32_t*)init_semaphore_address, 0);
 #endif
     bool needs_barrier = false;
     // Based on the selected experts, we dispatch the input tokens to the corresponding devices
-    cb_wait_front(mapping_tensor_cb_id, 1);
-    uint16_t* expert_mapping = (uint16_t*)(get_read_ptr(mapping_tensor_cb_id));
+    cb_mapping.wait_front(1);
+    uint16_t* expert_mapping = (uint16_t*)(cb_mapping.get_read_ptr());
     uint8_t* send_preparation_buffer = (uint8_t*)send_preparation_buffer_address;
 
     // ============================================================================
@@ -1111,13 +1151,13 @@ void kernel_main() {
         uint64_t output_token_write_addr = get_noc_addr(global_token, output_addr_gen);
         // All workers read indices (needed for routing decisions)
         // Only primary worker reads scores (only primary sends metadata)
-        cb_wait_front(indices_tensor_cb_id, 1);
+        cb_indices.wait_front(1);
         if (is_primary_payload_worker) {
-            cb_wait_front(scores_tensor_cb_id, 1);
+            cb_scores.wait_front(1);
         }
-        cb_wait_front(input_tensor_cb_id, 1);
-        uint32_t input_token_read_addr = get_read_ptr(input_tensor_cb_id);
-        uint16_t* token_indices = (uint16_t*)(get_read_ptr(indices_tensor_cb_id));
+        cb_input.wait_front(1);
+        uint32_t input_token_read_addr = cb_input.get_read_ptr();
+        uint16_t* token_indices = (uint16_t*)(cb_indices.get_read_ptr());
 
         // In payload split mode: reader already reads only this worker's portion into CB
         // In non-split mode: reader reads full page, payload_offset=0
@@ -1135,6 +1175,7 @@ void kernel_main() {
                 mesh_cols,
                 axis,
                 dispatch_devices>(
+                noc_obj,
                 fabric_connections,
                 unicast_packet_header_pos,
                 unicast_packet_header_neg,
@@ -1153,6 +1194,7 @@ void kernel_main() {
                 fabric_max_packet_size,
                 num_devices,
                 shared_and_selected_experts>(
+                noc_obj,
                 fabric_connections,
                 unicast_packet_header_neg,
                 output_addr_gen,
@@ -1178,6 +1220,7 @@ void kernel_main() {
                 fabric_max_packet_size,
                 num_devices,
                 shared_and_selected_experts>(
+                noc_obj,
                 fabric_connections,
                 unicast_packet_header_neg,
                 output_addr_gen,
@@ -1204,6 +1247,7 @@ void kernel_main() {
                 fabric_max_packet_size,
                 dispatch_devices,
                 shared_and_selected_experts>(
+                noc_obj,
                 fabric_connections,
                 unicast_packet_header_pos,
                 unicast_packet_header_neg,
@@ -1232,6 +1276,7 @@ void kernel_main() {
                 fabric_max_packet_size,
                 dispatch_devices,
                 shared_and_selected_experts>(
+                noc_obj,
                 fabric_connections,
                 unicast_packet_header_pos,
                 unicast_packet_header_neg,
@@ -1248,20 +1293,20 @@ void kernel_main() {
 
         // All workers pop indices (all read them for routing)
         // Only primary pops scores (only primary reads them)
-        cb_pop_front(indices_tensor_cb_id, 1);
+        cb_indices.pop_front(1);
         if (is_primary_payload_worker) {
-            cb_pop_front(scores_tensor_cb_id, 1);
+            cb_scores.pop_front(1);
         }
-        cb_pop_front(input_tensor_cb_id, 1);
+        cb_input.pop_front(1);
     }
     if (needs_barrier) {
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
 
 #ifdef PAYLOAD_SPLIT_MODE
     // In payload split mode, all workers must barrier before the primary sends atomic_inc
     // This ensures all payload portions have been sent before signaling completion
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 #endif
 
     // Only the primary worker (or all workers in non-payload-split mode) sends metadata and atomic_inc
@@ -1269,6 +1314,9 @@ void kernel_main() {
     if (is_primary_payload_worker) {
         // Send our selected experts tensor to all other devices and signal that we are done dispatching the input
         // tokens with a semaphore. Write directly to the output metadata tensor on the drain sync tilizer core.
+        // Device 2.0 migration: legacy primitive retained: global_semaphore_address is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         uint64_t global_noc_semaphore_address = get_noc_addr(global_semaphore_address);
 
         // IMPORTANT: Use aligned_metadata_page_size for OUTPUT metadata tensor offsets.
@@ -1296,21 +1344,22 @@ void kernel_main() {
                                                      dispatch_index * metadata_size_per_device +
                                                      token_start_idx * aligned_output_scores_page_size;
 
-        cb_wait_front(metadata_buffer_id, tokens_per_device);
-        uint32_t base_metadata_addr = get_read_ptr(metadata_buffer_id);
+        cb_metadata.wait_front(tokens_per_device);
+        uint32_t base_metadata_addr = cb_metadata.get_read_ptr();
         detail::fabric_multicast_bidirectional_scatter_write_ring_1d_async<
             linearized_mesh_coord,
             mesh_rows,
             mesh_cols,
             axis,
             dispatch_devices>(
+            noc_obj,
             fabric_connections,
             metadata_packet_header_pos,
             metadata_packet_header_neg,
             base_metadata_addr,
             {noc_core_offset_md_write_addr, noc_core_offset_scores_write_addr},
             {static_cast<uint16_t>(metadata_size_per_core), static_cast<uint16_t>(metadata_size_per_core)});
-        cb_pop_front(metadata_buffer_id, tokens_per_device);
+        cb_metadata.pop_front(tokens_per_device);
         // Use DoubleAntipodalAtomicInc=true to increment semaphore on all devices including twice on the antipodal
         // device
         detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
@@ -1326,13 +1375,13 @@ void kernel_main() {
             global_noc_semaphore_address);
     }
 
-    cb_pop_front(mapping_tensor_cb_id, mapping_pages);
+    cb_mapping.pop_front(mapping_pages);
 
 #ifdef USE_MUX
     // MUX teardown for Phase 2: Multiple workers per link share the same mux cores
     // Each link has a termination master that waits for all other workers to disconnect
     // before terminating the mux cores.
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
     noc_async_atomic_barrier();
 
     // Step 1: All workers disconnect from their mux connections
@@ -1365,6 +1414,8 @@ void kernel_main() {
             if (num_mux_clients > 1) {
                 volatile uint32_t* termination_semaphore =
                     reinterpret_cast<volatile uint32_t*>(termination_sync_address_arr[coord_dir]);
+                // Device 2.0 migration: legacy primitive retained: termination_sync_address_arr is a fabric-mux sync
+                // address (not a get_semaphore<>(id) address); #45003 item 4.
                 noc_semaphore_wait(termination_semaphore, num_mux_clients - 1);
             }
 
@@ -1381,14 +1432,16 @@ void kernel_main() {
                 termination_master_noc_x_arr[coord_dir],
                 termination_master_noc_y_arr[coord_dir],
                 termination_sync_address_arr[coord_dir]);
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address_arr is a fabric-mux sync
+            // address (not a get_semaphore<>(id) address); #45003 item 4.
             noc_semaphore_inc(termination_master_semaphore_noc_addr, 1);
             noc_async_atomic_barrier();
         }
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 #else
     close_direction_connections(directions, fabric_connections);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/pack_untilize.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
 #include "internal/mod_div_lib.h"
 
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
@@ -17,21 +18,22 @@ enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 FORCE_INLINE void reload_from_cb_to_dst(
     uint32_t in0_cb_id,
     uint32_t in1_cb_id,
-    uint32_t mm_partials_cb_id,
+    CircularBuffer& cb_mm_partials,
     bool in1_transpose_tile,
     uint32_t out_subblock_num_tiles,
     uint32_t out_subblock_w,
     uint32_t out_subblock_h,
     uint32_t in0_block_w) {
+    const uint32_t mm_partials_cb_id = cb_mm_partials.get_cb_id();
     // Reconfigure input
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
-    cb_wait_front(mm_partials_cb_id, out_subblock_num_tiles);
+    cb_mm_partials.wait_front(out_subblock_num_tiles);
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
     copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
-    cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
+    cb_mm_partials.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
     mm_block_init_short_with_dt(
         in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
@@ -178,6 +180,11 @@ void kernel_main() {
     const uint32_t* unpadded_in0_shard_widths_in_tiles = (uint32_t*)get_arg_addr(rt_args_idx);
     rt_args_idx += ring_size;
 
+    CircularBuffer cb_in0(in0_cb_id);
+    CircularBuffer cb_in1(in1_cb_id);
+    CircularBuffer cb_sync(sync_cb);
+    CircularBuffer cb_sync2(sync_cb2);
+
     constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
 
 #ifdef SFPU_OP_INIT_ACTIVATION
@@ -211,6 +218,8 @@ void kernel_main() {
 #endif
         const uint32_t mm_out_cb_id = mm_out_cb_ids[b];
         const uint32_t mm_partials_cb_id = mm_partials_cb_ids[b];
+        CircularBuffer cb_mm_out(mm_out_cb_id);
+        CircularBuffer cb_mm_partials(mm_partials_cb_id);
 
         bool enable_reload = false;
         uint32_t out_num_tiles_to_wait = out_subblock_num_tiles;
@@ -227,8 +236,8 @@ void kernel_main() {
         }
 
         // Wait to receive in1
-        cb_wait_front(sync_cb2, 1);
-        cb_pop_front(sync_cb2, 1);
+        cb_sync2.wait_front(1);
+        cb_sync2.pop_front(1);
 
         for (uint32_t block = 0; block < num_blocks; block++) {
             const uint32_t curr_ring_idx = (ring_idx - block + ring_size) % ring_size;
@@ -237,7 +246,7 @@ void kernel_main() {
 
             // Wait for in1 block
             if constexpr (in1_is_dram) {
-                cb_wait_front(in1_cb_id, in1_block_num_tiles);
+                cb_in1.wait_front(in1_block_num_tiles);
             }
 
             // const uint32_t input0_cb_id = block == 0 ? in0_cb_id : in2_cb_id;
@@ -252,7 +261,8 @@ void kernel_main() {
 #endif
 
             // Wait to receive in0 block
-            cb_wait_front(input0_cb_id, in0_block_num_tiles);
+            // input0_cb_id == in0_cb_id (see assignment above).
+            cb_in0.wait_front(in0_block_num_tiles);
 
 #ifdef ENABLE_GLOBAL_CB
             UNPACK((calculate_next_block_index_and_update_rd_ptr(
@@ -281,7 +291,7 @@ void kernel_main() {
                         reload_from_cb_to_dst(
                             input0_cb_id,
                             in1_cb_id,
-                            mm_partials_cb_id,
+                            cb_mm_partials,
                             in1_transpose_tile,
                             out_subblock_num_tiles,
                             out_subblock_w,
@@ -328,7 +338,7 @@ void kernel_main() {
                         }
                         tile_regs_commit();
                         // Pack out to output buffer
-                        cb_reserve_back(mm_out_cb_id, out_subblock_num_tiles);
+                        cb_mm_out.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
@@ -351,12 +361,12 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_uninit(mm_out_cb_id);
                         }
-                        cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
+                        cb_mm_out.push_back(out_subblock_num_tiles);
 
                     } else if (spill) {
                         tile_regs_commit();
                         // Move partial result to interm buffer
-                        cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        cb_mm_partials.reserve_back(out_subblock_num_tiles);
                         tile_regs_wait();
 
 #ifdef PACKER_L1_ACC
@@ -371,7 +381,7 @@ void kernel_main() {
                         pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
-                        cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        cb_mm_partials.push_back(out_subblock_num_tiles);
                     }
 
                     in1_index_subblock_offset += out_subblock_w;
@@ -383,8 +393,8 @@ void kernel_main() {
 
             // Last iteration does spill and reload to output buffer
             if (block < num_blocks - 2 && spill) {
-                cb_wait_front(mm_partials_cb_id, out_block_num_tiles);
-                cb_pop_front(mm_partials_cb_id, out_block_num_tiles);
+                cb_mm_partials.wait_front(out_block_num_tiles);
+                cb_mm_partials.pop_front(out_block_num_tiles);
             }
             if (block == num_blocks - 2 && spill) {
                 enable_reload = true;
@@ -395,9 +405,10 @@ void kernel_main() {
             }
 #endif
 
-            cb_pop_front(input0_cb_id, in0_block_num_tiles);
+            // input0_cb_id == in0_cb_id (see assignment above).
+            cb_in0.pop_front(in0_block_num_tiles);
             if constexpr (in1_is_dram) {
-                cb_pop_front(in1_cb_id, in1_block_num_tiles);
+                cb_in1.pop_front(in1_block_num_tiles);
             }
 #ifdef ENABLE_GLOBAL_CB
             curr_in1_block_index = next_in1_block_index;
@@ -407,8 +418,8 @@ void kernel_main() {
 
 #ifdef ENABLE_GLOBAL_CB
         // Release in1
-        cb_reserve_back(sync_cb, 1);
-        cb_push_back(sync_cb, 1);
+        cb_sync.reserve_back(1);
+        cb_sync.push_back(1);
         UNPACK((update_local_cb_rd_ptr(in1_cb_id, in1_rd_ptr_start_addr)));  // reset rd_ptr back to the initial addr
         UNPACK((update_rd_ptr_to_ring_index(
             in1_cb_id, in1_block_size_bytes, ring_size, in1_tensor_split)));  // update to next tensor addr

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/debug/dprint.h"
 
@@ -56,14 +58,19 @@ void kernel_main() {
     constexpr uint32_t multicast_chunk_size_in_tiles = multicast_chunk_width_in_tiles * shard_height_in_tiles;
     constexpr uint32_t multicast_chunk_size_bytes = multicast_chunk_size_in_tiles * in0_single_tile_size_bytes;
 
-    cb_reserve_back(cb_id_in0, multicast_chunk_size_in_tiles * num_multicast_steps);
+    CircularBuffer cb_in0(cb_id_in0);
+
+    cb_in0.reserve_back(multicast_chunk_size_in_tiles * num_multicast_steps);
     for (uint32_t istep = 0; istep < num_multicast_steps; istep++) {
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+        // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
+        // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
         volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
                 fused_op_receiver_signal_semaphore_addr[chunk_indices[istep]]);
 
         noc_semaphore_wait_min(fused_op_receiver_signal_semaphore_addr_ptr, 1);
         noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, 0);
-        cb_push_back(cb_id_in0, multicast_chunk_size_in_tiles);
+        cb_in0.push_back(multicast_chunk_size_in_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -5,6 +5,10 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 #include "api/remote_circular_buffer.h"
 #include "api/debug/dprint.h"
@@ -14,7 +18,8 @@ enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 
 template <typename TensorAccessorType>
 void read_block_from_dram(
-    uint32_t cb_id,
+    Noc& noc,
+    CircularBuffer& cb,
     const TensorAccessorType& s1,
     uint32_t tensor_width_in_tiles,
     uint32_t block_w_idx,
@@ -22,25 +27,26 @@ void read_block_from_dram(
     uint32_t block_w_t,
     uint32_t block_h_t,
     uint32_t tile_size_bytes) {
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t l1_write_addr = cb.get_write_ptr();
 
     // Horizontal idx + vertical idx * width = row major index
     uint32_t block_tile_id = block_w_idx * block_w_t + (block_h_idx * block_h_t) * tensor_width_in_tiles;
     for (uint32_t h = 0; h < block_h_t; ++h) {
         uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
         for (uint32_t w = 0; w < block_w_t; ++w) {
-            noc_async_read_tile(tile_id + w, s1, l1_write_addr);
+            noc.async_read(s1, CoreLocalMem<uint8_t>(l1_write_addr), tile_size_bytes, {.page_id = tile_id + w}, {});
             l1_write_addr += tile_size_bytes;
         }
     }
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 }
 
-void do_signaling(uint32_t& rt_args_idx) {
+void do_signaling(Noc& noc, uint32_t& rt_args_idx) {
     const uint32_t pv_core_x = get_arg_val<uint32_t>(rt_args_idx++);
     const uint32_t pv_core_y = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t pv_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-    volatile tt_l1_ptr uint32_t* pv_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pv_semaphore);
+    const uint32_t pv_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t pv_semaphore = get_semaphore(pv_semaphore_id);
+    Semaphore<> pv_sem(pv_semaphore_id);
     const bool is_privilaged = get_arg_val<uint32_t>(rt_args_idx++) == 1;
     if (is_privilaged) {
         const uint32_t target_sem_value = get_arg_val<uint32_t>(rt_args_idx++);
@@ -50,13 +56,17 @@ void do_signaling(uint32_t& rt_args_idx) {
         const uint32_t multicast_end_y = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t num_signalling_semaphores = get_arg_val<uint32_t>(rt_args_idx++);
         const uint32_t signalling_semaphore = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
         const uint64_t signalling_semaphore_address =
             get_noc_multicast_addr(multicast_start_x, multicast_start_y, multicast_end_x, multicast_end_y, 0) |
             signalling_semaphore;
-        noc_semaphore_wait(pv_semaphore_ptr, target_sem_value);
-        noc_semaphore_set(pv_semaphore_ptr, 1);
+        pv_sem.wait(target_sem_value);
+        pv_sem.set(1);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+        // (noc_semaphore_set_multicast has no Device 2.0 wrapper equivalent.)
         noc_semaphore_set_multicast(pv_semaphore, signalling_semaphore_address, num_signalling_semaphores);
     } else {
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
         const uint64_t sem_addr = get_noc_addr(pv_core_x, pv_core_y, pv_semaphore);
         noc_semaphore_inc(sem_addr, 1);
     }
@@ -81,8 +91,9 @@ void kernel_main() {
     uint32_t core_type = get_arg_val<uint32_t>(rt_args_idx++);
     if (core_type == (uint32_t)CORE_TYPE::IDLE_CORE || core_type == (uint32_t)CORE_TYPE::HOP_CORE) {
         if constexpr (needs_signaler) {
-            do_signaling(rt_args_idx);
-            noc_async_write_barrier();
+            Noc noc_obj_early;
+            do_signaling(noc_obj_early, rt_args_idx);
+            noc_obj_early.async_write_barrier();
         }
         return;
     }
@@ -102,6 +113,11 @@ void kernel_main() {
     constexpr uint32_t sync_cb = get_compile_time_arg_val(12);
     constexpr uint32_t sync_cb2 = get_compile_time_arg_val(13);
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(14);
+
+    Noc noc_obj;
+    CircularBuffer cb_in1(cb_id_in1);
+    CircularBuffer cb_sync(sync_cb);
+    CircularBuffer cb_sync2(sync_cb2);
 
     constexpr auto src_args = TensorAccessorArgs<16>();
 
@@ -126,20 +142,21 @@ void kernel_main() {
     }
 
     for (uint32_t b = 0; b < batch; ++b) {
-        cb_reserve_back(sync_cb2, 1);
+        cb_sync2.reserve_back(1);
 #ifdef ENABLE_GLOBAL_CB
         experimental::remote_cb_wait_front(remote_cb_id, num_blocks);
 #endif
 
-        cb_push_back(sync_cb2, 1);
+        cb_sync2.push_back(1);
 
         if constexpr (in1_is_dram_interleaved) {
             for (uint32_t block = 0; block < num_blocks; ++block) {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
 
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.reserve_back(in1_block_num_tiles);
                 read_block_from_dram(
-                    cb_id_in1,
+                    noc_obj,
+                    cb_in1,
                     s1,
                     in1_tensor_width_in_tiles,
                     ring_idx,
@@ -147,7 +164,7 @@ void kernel_main() {
                     in1_block_width_in_tiles,
                     in1_block_height_in_tiles,
                     in1_single_tile_size_bytes);
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                cb_in1.push_back(in1_block_num_tiles);
             }
         } else if constexpr (in1_is_dram_sharded) {  // when in1 is sharded in DRAM, each core reads from its own bank,
                                                      // two cores on the same row share one bank.
@@ -155,9 +172,11 @@ void kernel_main() {
                 uint32_t block_idx = (ring_idx + block) % num_blocks;
                 l1_read_addr_in1 = block_idx * in1_dram_shard_block_size_bytes + dram_read_offset_bytes;
                 // Operand 1
-                cb_reserve_back(cb_id_in1, in1_block_num_tiles);
-                l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                cb_in1.reserve_back(in1_block_num_tiles);
+                l1_write_addr_in1 = cb_in1.get_write_ptr();
 
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+                // (noc_async_read_one_packet_set_state / with_state state-machine has no Device 2.0 wrapper.)
                 for (uint32_t h = 0; h < in1_block_height_in_tiles; ++h) {
                     uint32_t curr_l1_read_addr_in1 = l1_read_addr_in1;
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
@@ -173,27 +192,27 @@ void kernel_main() {
                     l1_read_addr_in1 += in1_shard_width_offset_bytes;
                 }
 
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                noc_obj.async_read_barrier();
+                cb_in1.push_back(in1_block_num_tiles);
             }
         }
 
 #ifdef ENABLE_GLOBAL_CB
-        cb_wait_front(sync_cb, 1);
+        cb_sync.wait_front(1);
         experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
-        cb_pop_front(sync_cb, 1);
+        cb_sync.pop_front(1);
 #endif
         // Signal Here
         if constexpr (needs_signaler) {
             if (b == 0) {
-                do_signaling(rt_args_idx);
+                do_signaling(noc_obj, rt_args_idx);
             }
         }
     }
 
 #ifdef ENABLE_GLOBAL_CB
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
-    noc_async_atomic_barrier();
+    noc_obj.async_atomic_barrier();
 #endif
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -13,6 +13,7 @@
 #include "api/remote_circular_buffer.h"
 #include "api/debug/dprint.h"
 #include "api/debug/dprint_tile.h"
+#include "api/tensor/noc_traits.h"
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_reader.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include <cstdint>
@@ -37,6 +42,8 @@ void kernel_main() {
     uint32_t intermediate_first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
     uint32_t ring_index = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
@@ -52,20 +59,27 @@ void kernel_main() {
 
     // interleaved addrgen
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     uint32_t tiles_read = 0;
     uint32_t shard_tile_id = first_core_tile_start_offset;
     uint32_t core_id = 0;
-    cb_reserve_back(cb0_id, num_tiles_to_read);
-    uint32_t l1_write_addr = get_write_ptr(cb0_id);
+    cb0.reserve_back(num_tiles_to_read);
+    uint32_t l1_write_addr = cb0.get_write_ptr();
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core =
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
         // cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
         // const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        const uint32_t shard_addr = tensor_address0 + shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id], .noc_y = core_noc_y[core_id], .addr = shard_addr},
+            {});
         // noc_async_read_barrier();
 
         // cb_push_back(cb0_id, num_tiles_to_read_this_core);
@@ -74,21 +88,27 @@ void kernel_main() {
         shard_tile_id = 0;
         core_id++;
     }
-    noc_async_read_barrier();
-    cb_push_back(cb0_id, num_tiles_to_read);
+    noc_obj.async_read_barrier();
+    cb0.push_back(num_tiles_to_read);
     core_id = 0;
-    uint64_t noc0_dest_noc_addr = get_noc_addr(
-        core_noc_x_to_write_to[core_id], core_noc_y_to_write_to[core_id], intermediate_tensor_address0, 0 /*noc_id*/);
-    uint32_t l1_read_addr = get_read_ptr(cb0_id);
-    noc_async_write(
-        l1_read_addr,
-        noc0_dest_noc_addr + intermediate_first_core_tile_start_offset * tensor0_page_size,
-        num_tiles_to_read * tensor0_page_size);
+    const uint32_t intermediate_dest_addr =
+        intermediate_tensor_address0 + intermediate_first_core_tile_start_offset * tensor0_page_size;
+    uint32_t l1_read_addr = cb0.get_read_ptr();
+    noc_obj.async_write(
+        CoreLocalMem<uint8_t>(l1_read_addr),
+        UnicastEndpoint{},
+        num_tiles_to_read * tensor0_page_size,
+        {},
+        {.noc_x = core_noc_x_to_write_to[core_id],
+         .noc_y = core_noc_y_to_write_to[core_id],
+         .addr = intermediate_dest_addr});
 
     // notify local receiver core
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 #include "ckernel.h"
 
@@ -38,14 +41,23 @@ void kernel_main() {
     const uint32_t next_core_id_to_left = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t next_core_id_to_right = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_inter(inter_cb_index);
+
+    // Device 2.0 migration: legacy primitive retained: signal_semaphore_addr is a precomposed L1 semaphore
+    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap); #45003 item 4.
     volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
 
     // Set up for mcasting to mm workers
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    // (fused_op_receiver_signal_semaphore_addr[] is a runtime-indexed array of L1 semaphore addresses
+    // already resolved via get_semaphore(id); Semaphore<> wraps a single id, not an array of addresses.)
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[core_id]);
     noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, VALID);
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr_next_core_right =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[next_core_id_to_right]);
 
@@ -63,17 +75,21 @@ void kernel_main() {
         noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr_next_core_right, 0);
     }
 
-    size_t l1_read_addr = get_read_ptr(inter_cb_index);
+    size_t l1_read_addr = cb_inter.get_read_ptr();
     const uint64_t multicast_addr_noc = get_noc_multicast_addr(bbox_start_x, bbox_start_y, bbox_end_x, bbox_end_y, 0);
     uint64_t aggregated_tensor_addr_this_core =
         (uint64_t)aggregated_tensor_addr + mm_core_offset * intermediate_tensor_shard_num_pages * tensor0_page_size;
     const uint64_t multicast_addr = multicast_addr_noc | aggregated_tensor_addr_this_core;
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    // (noc_async_write_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_async_write_multicast_loopback_src(
         l1_read_addr, multicast_addr, intermediate_tensor_shard_num_pages * tensor0_page_size, bbox_size, true);
 
     uint64_t multicast_sema_addr = multicast_addr_noc | (uint64_t)fused_op_receiver_signal_semaphore_addr[core_id];
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+    // (noc_semaphore_set_multicast_loopback_src has no Device 2.0 wrapper equivalent.)
     noc_semaphore_set_multicast_loopback_src(
         fused_op_receiver_signal_semaphore_addr[core_id], multicast_sema_addr, bbox_size, false);
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_writer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -12,6 +14,7 @@
 
 using address_t = uint32_t;
 FORCE_INLINE void advance_local_read_address_for_fabric_write(
+    Noc& noc,
     uint64_t noc0_dest_noc_addr,
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward,
     volatile PACKET_HEADER_TYPE* pkt_hdr_backward,
@@ -44,7 +47,7 @@ FORCE_INLINE void advance_local_read_address_for_fabric_write(
             (uint32_t)pkt_hdr_backward, sizeof(PACKET_HEADER_TYPE));
     }
 
-    noc_async_writes_flushed();
+    noc.async_writes_flushed();
 
     l1_read_addr += payload_size_bytes;
 }
@@ -96,16 +99,20 @@ void kernel_main() {
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_pkt_hdr(reserved_packet_header_cb_id);
+    CircularBuffer cb0(cb0_id);
+
     // packet header cb
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
-    cb_reserve_back(reserved_packet_header_cb_id, 1);
-    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_addr_forward = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_addr_backward = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
+    cb_pkt_hdr.reserve_back(1);
+    auto packet_header_buffer_seminc = cb_pkt_hdr.get_write_ptr();
+    cb_pkt_hdr.push_back(1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -126,15 +133,17 @@ void kernel_main() {
     while (tiles_read < num_tiles_to_read) {
         uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
         num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
-        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb0_id);
+        cb0.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb0.get_read_ptr();
 
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
         uint64_t noc0_dest_noc_addr =
             get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0 /*noc_id*/);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
 
         // This issues a flush barrier
         advance_local_read_address_for_fabric_write(
+            noc_obj,
             noc0_dest_noc_addr,
             pkt_hdr_forward,
             pkt_hdr_backward,
@@ -147,7 +156,7 @@ void kernel_main() {
             std::swap(pkt_hdr_forward, pkt_hdr_backward);
         }
 
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        cb0.pop_front(num_tiles_to_read_this_core);
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
         if (shard_tile_id >= num_tiles_per_core) {
@@ -181,5 +190,5 @@ void kernel_main() {
     }
 
     fabric_connection.close();
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/compute/reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -17,15 +18,18 @@ void kernel_main() {
     constexpr uint32_t total_pages = num_devices * num_pages_per_packet;
     constexpr uint32_t num_device_pairs = num_devices / 2;  // num_devices is always even
 
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(fabric_receiver_cb_id, fabric_receiver_cb_id, accumulator_cb_id);
     add_tiles_init(fabric_receiver_cb_id, fabric_receiver_cb_id, true);
 
     // Wait for input data once before beginning processing
-    cb_wait_front(fabric_receiver_cb_id, total_pages);
+    cb_fabric_receiver.wait_front(total_pages);
 
     // Reserve output space once before processing
-    cb_reserve_back(accumulator_cb_id, num_pages_per_packet);
+    cb_accumulator.reserve_back(num_pages_per_packet);
 
     // Process tiles in pairs for efficient addition
     tile_regs_acquire();
@@ -54,6 +58,6 @@ void kernel_main() {
     }
     tile_regs_release();
 
-    cb_pop_front(fabric_receiver_cb_id, total_pages);
-    cb_push_back(accumulator_cb_id, num_pages_per_packet);
+    cb_fabric_receiver.pop_front(total_pages);
+    cb_accumulator.push_back(num_pages_per_packet);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -62,8 +67,10 @@ void kernel_main() {
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t local_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+    Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_output_page_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -76,10 +83,16 @@ void kernel_main() {
     uint32_t k_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t v_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
 
-    // Bank base addresses (compute once)
-    const uint32_t bank_base_address = get_write_ptr(input_tensor_cb_id);
+    Noc noc_obj;
+    CircularBuffer cb_input_tensor(input_tensor_cb_id);
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
 
-    uint32_t sender_read_addr = get_write_ptr(fabric_sender_cb_id);
+    // Bank base addresses (compute once)
+    const uint32_t bank_base_address = cb_input_tensor.get_write_ptr();
+
+    uint32_t sender_read_addr = cb_fabric_sender.get_write_ptr();
 
     if (sender_core) {
         for (uint32_t target_device_id : device_order) {
@@ -106,12 +119,13 @@ void kernel_main() {
                 const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
-                cb_reserve_back(fabric_sender_cb_id, num_pages_reserve_push);
+                cb_fabric_sender.reserve_back(num_pages_reserve_push);
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
-                    noc_async_read_barrier();
-                    cb_push_back(fabric_sender_cb_id, num_pages_reserve_push);
+                    noc_obj.async_read_barrier();
+                    cb_fabric_sender.push_back(num_pages_reserve_push);
                     num_pages_reserve_push = 0;
                 }
 
@@ -122,8 +136,8 @@ void kernel_main() {
         }
     } else if (worker_core) {
         // Calculate base addresses once
-        const uint32_t base_input_tensor_addr = get_read_ptr(input_tensor_cb_id);
-        const uint32_t base_receiver_l1_addresses = get_read_ptr(fabric_receiver_cb_id) + chip_id_offset;
+        const uint32_t base_input_tensor_addr = cb_input_tensor.get_read_ptr();
+        const uint32_t base_receiver_l1_addresses = cb_fabric_receiver.get_read_ptr() + chip_id_offset;
 
         for (uint32_t i = 0; i < num_pages_per_packet; i++) {
             const uint32_t rem = linear_input_packet_start_idx + i;
@@ -141,52 +155,67 @@ void kernel_main() {
             const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
             noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
         }
 
+        // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);
 
-        noc_async_read_barrier();
-        cb_push_back(fabric_receiver_cb_id, num_pages_per_packet * num_devices);
+        noc_obj.async_read_barrier();
+        cb_fabric_receiver.push_back(num_pages_per_packet * num_devices);
 
         uint32_t head_idx = linear_output_page_start_idx / 2;  // each head has 2 pages/blocks
-        cb_wait_front(accumulator_cb_id, num_pages_per_packet);
-        auto accumulator_l1_addr = get_read_ptr(accumulator_cb_id);
+        cb_accumulator.wait_front(num_pages_per_packet);
+        auto accumulator_l1_addr = cb_accumulator.get_read_ptr();
         if (head_idx < q_heads) {  // write q heads
             for (uint32_t iblock = 1; iblock < num_pages_per_packet;
                  iblock += 2) {  // increment by 2 so that we can handle 1 head each time.
                 for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                    uint64_t noc_address = get_noc_addr(
-                        q_output_core_xy[istick][x_index],
-                        q_output_core_xy[istick][y_index],
-                        q_base_addr + head_idx * head_dim_bytes + stick_size_byte);
                     uint32_t l1_read_addr = accumulator_l1_addr + iblock * page_size_bytes + istick * stick_size_byte;
-                    noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr),
+                        UnicastEndpoint{},
+                        stick_size_byte,
+                        {},
+                        {.noc_x = q_output_core_xy[istick][x_index],
+                         .noc_y = q_output_core_xy[istick][y_index],
+                         .addr = q_base_addr + head_idx * head_dim_bytes + stick_size_byte});
                 }
                 head_idx++;  // next head as each packet has 2 heads = 4 blocks
             }
         } else {  // write kv heads
             uint32_t iblock1 = 1, iblock2 = 3;
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address = get_noc_addr(
-                    k_output_core_xy[istick][x_index],
-                    k_output_core_xy[istick][y_index],
-                    k_base_addr + stick_size_byte);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock1 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = k_output_core_xy[istick][x_index],
+                     .noc_y = k_output_core_xy[istick][y_index],
+                     .addr = k_base_addr + stick_size_byte});
             }
 
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address = get_noc_addr(
-                    v_output_core_xy[istick][x_index],
-                    v_output_core_xy[istick][y_index],
-                    v_base_addr + stick_size_byte);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock2 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = v_output_core_xy[istick][x_index],
+                     .noc_y = v_output_core_xy[istick][y_index],
+                     .addr = v_base_addr + stick_size_byte});
             }
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
-    noc_semaphore_set((uint32_t*)local_semaphore_address, INVALID);
+    local_sem.set(INVALID);
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -59,8 +64,10 @@ void kernel_main() {
     constexpr uint32_t other_devices = num_devices - 1;
 
     // Runtime arguments
+    // Device 2.0 migration: legacy primitive retained: receiver_semaphore_address is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     uint32_t receiver_semaphore_address = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t local_semaphore_address = get_semaphore(get_arg_val<uint32_t>(rt_arg_idx++));
+    Semaphore<> local_sem(get_arg_val<uint32_t>(rt_arg_idx++));
     bool sender_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_output_page_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
@@ -71,6 +78,12 @@ void kernel_main() {
     uint32_t k_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t v_base_addr = get_arg_val<uint32_t>(rt_arg_idx++);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_sender(fabric_sender_cb_id);
+    CircularBuffer cb_packet_header(packet_header_cb_id);
+    CircularBuffer cb_fabric_receiver(fabric_receiver_cb_id);
+    CircularBuffer cb_accumulator(accumulator_cb_id);
+
     if (sender_core) {
         auto fabric_connection =
             FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
@@ -79,8 +92,8 @@ void kernel_main() {
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
-        cb_reserve_back(packet_header_cb_id, buffering_factor * num_packet_headers_storable);
-        const auto packet_header_buffer_addr = get_read_ptr(packet_header_cb_id);
+        cb_packet_header.reserve_back(buffering_factor * num_packet_headers_storable);
+        const auto packet_header_buffer_addr = cb_packet_header.get_read_ptr();
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
         auto* sem_inc_packet_header =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr + packet_header_size);
@@ -89,7 +102,7 @@ void kernel_main() {
         sem_inc_packet_header->to_noc_unicast_atomic_inc(
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_noc_addr, static_cast<uint32_t>(1)});  // increment 1
 
-        const uint32_t base_receiver_l1_addr = get_read_ptr(fabric_receiver_cb_id);
+        const uint32_t base_receiver_l1_addr = cb_fabric_receiver.get_read_ptr();
 
         // Precompute the packet offset once
         const uint32_t packet_offset = base_receiver_l1_addr + chip_id_offset;
@@ -129,8 +142,8 @@ void kernel_main() {
                 const uint32_t receiver_core_y = packet_worker_cores[packet][y_index];
                 const uint64_t noc0_dest_noc_addr = get_noc_addr(receiver_core_x, receiver_core_y, packet_offset, 0);
 
-                cb_wait_front(fabric_sender_cb_id, curr_packet_num_pages);
-                const auto sender_l1_addr = get_read_ptr(fabric_sender_cb_id);
+                cb_fabric_sender.wait_front(curr_packet_num_pages);
+                const auto sender_l1_addr = cb_fabric_sender.get_read_ptr();
 
                 const uint64_t sem_noc_addr =
                     get_noc_addr(receiver_core_x, receiver_core_y, receiver_semaphore_address, 0);
@@ -146,7 +159,7 @@ void kernel_main() {
                 fabric_conn.send_payload_flush_blocking_from_address(
                     (uint32_t)unicast_packet_header, packet_header_size);
 
-                cb_pop_front(fabric_sender_cb_id, curr_packet_num_pages);
+                cb_fabric_sender.pop_front(curr_packet_num_pages);
 
                 num_pages_sent += curr_packet_num_pages;
                 packet++;
@@ -162,38 +175,51 @@ void kernel_main() {
         constexpr uint8_t v_output_core_xy[output_cores_per_device][2] = V_OUTPUT_CORE_XY;
 
         uint32_t head_idx = linear_output_page_start_idx / 2;  // each head has 2 pages/blocks
-        cb_wait_front(accumulator_cb_id, num_pages_per_packet);
+        cb_accumulator.wait_front(num_pages_per_packet);
 
-        auto accumulator_l1_addr = get_read_ptr(accumulator_cb_id);
+        auto accumulator_l1_addr = cb_accumulator.get_read_ptr();
         if (head_idx < q_heads) {  // write q heads
             for (uint32_t iblock = 0; iblock < num_pages_per_packet;
                  iblock += 2) {  // increment by 2 so that we can handle 1 head each time.
                 for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                    uint64_t noc_address = get_noc_addr(
-                        q_output_core_xy[istick][x_index],
-                        q_output_core_xy[istick][y_index],
-                        q_base_addr + head_idx * head_dim_bytes);
                     uint32_t l1_read_addr = accumulator_l1_addr + iblock * page_size_bytes + istick * stick_size_byte;
-                    noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint8_t>(l1_read_addr),
+                        UnicastEndpoint{},
+                        stick_size_byte,
+                        {},
+                        {.noc_x = q_output_core_xy[istick][x_index],
+                         .noc_y = q_output_core_xy[istick][y_index],
+                         .addr = q_base_addr + head_idx * head_dim_bytes});
                 }
                 head_idx++;  // next head as each packet has 2 heads = 4 blocks
             }
         } else {  // write kv heads
             uint32_t iblock1 = 0, iblock2 = 2;
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address =
-                    get_noc_addr(k_output_core_xy[istick][x_index], k_output_core_xy[istick][y_index], k_base_addr);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock1 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = k_output_core_xy[istick][x_index],
+                     .noc_y = k_output_core_xy[istick][y_index],
+                     .addr = k_base_addr});
             }
 
             for (uint32_t istick = 0; istick < num_sticks_per_block; istick++) {
-                uint64_t noc_address =
-                    get_noc_addr(v_output_core_xy[istick][x_index], v_output_core_xy[istick][y_index], v_base_addr);
                 uint32_t l1_read_addr = accumulator_l1_addr + iblock2 * page_size_bytes + istick * stick_size_byte;
-                noc_async_write(l1_read_addr, noc_address, stick_size_byte);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    stick_size_byte,
+                    {},
+                    {.noc_x = v_output_core_xy[istick][x_index],
+                     .noc_y = v_output_core_xy[istick][y_index],
+                     .addr = v_base_addr});
             }
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
@@ -4,6 +4,9 @@
 
 #include "api/compile_time_args.h"
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 
 namespace detail {
 
@@ -97,44 +100,45 @@ void kernel_main() {
     const auto token_parallel_core_id = get_arg_val<uint32_t>(arg_index++);
     const bool sync_core = get_arg_val<uint32_t>(arg_index++);
 
-    const uint32_t sync_semaphore_addr = get_semaphore(sync_semaphore_id);
+    Noc noc1_obj(1);
+    Semaphore<> sync_sem(sync_semaphore_id);
+    CircularBuffer cb_token_counts(token_counts_cb_id);
+    CircularBuffer cb_token_activations(token_activations_cb_id);
+    CircularBuffer cb_dense_token_maps(dense_token_maps_cb_id);
 
     const auto dense_token_maps_addrgen = TensorAccessor(dense_token_maps_ta_args, dense_token_maps_addr);
     const auto token_counts_addrgen = TensorAccessor(dense_token_counts_ta_args, dense_token_counts_addr);
     const auto token_activations_addrgen = TensorAccessor(token_activations_ta_args, token_activations_addr);
 
     // wait for metadata to be ready
-    auto* sync_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_semaphore_addr);
     if (sync_core) {
-        noc_semaphore_wait(sync_semaphore_ptr, 1);
+        sync_sem.wait(1);
         // swap start/end coordinates because this kernel is using NOC1
-        const uint64_t semaphore_mc_addr =
-            get_noc_multicast_addr(noc_x_end, noc_y_end, noc_x_start, noc_y_start, sync_semaphore_addr, /*noc=*/1);
-        noc_semaphore_set_multicast(
-            sync_semaphore_addr,
-            semaphore_mc_addr,
+        sync_sem.set_multicast(
+            noc1_obj,
+            noc_x_end,
+            noc_y_end,
+            noc_x_start,
+            noc_y_start,
             worker_bounding_box_size - 1,
-            /*linked=*/false,
-            /*noc=*/1);
-        noc_async_writes_flushed(/*noc=*/1);
+            /*linked=*/false);
+        noc1_obj.async_writes_flushed();
 
     } else {
-        noc_semaphore_wait_min(sync_semaphore_ptr, 1);
+        sync_sem.wait_min(1);
     }
 
     // read dense token counts
-    cb_reserve_back(token_counts_cb_id, 1);
-    const uint32_t token_counts_l1_addr = get_write_ptr(token_counts_cb_id);
-    const uint64_t token_counts_noc_addr = token_counts_addrgen.get_noc_addr(0, /*offset=*/0, /*noc=*/1);
-    noc_async_read(token_counts_noc_addr, token_counts_l1_addr, token_counts_page_size_bytes, /*noc=*/1);
-    noc_async_read_barrier(/*noc=*/1);
+    cb_token_counts.reserve_back(1);
+    const uint32_t token_counts_l1_addr = cb_token_counts.get_write_ptr();
+    noc1_obj.async_read(token_counts_addrgen, cb_token_counts, token_counts_page_size_bytes, {.page_id = 0}, {});
+    noc1_obj.async_read_barrier();
 
     // read activations
-    cb_reserve_back(token_activations_cb_id, 1);
-    const uint32_t token_activations_l1_addr = get_write_ptr(token_activations_cb_id);
-    const uint64_t token_activations_noc_addr = get_noc_addr(0, token_activations_addrgen, /*offset=*/0, /*noc=*/1);
-    noc_async_read(
-        token_activations_noc_addr, token_activations_l1_addr, aligned_token_activations_page_size_bytes, /*noc=*/1);
+    cb_token_activations.reserve_back(1);
+    const uint32_t token_activations_l1_addr = cb_token_activations.get_write_ptr();
+    noc1_obj.async_read(
+        token_activations_addrgen, cb_token_activations, aligned_token_activations_page_size_bytes, {.page_id = 0}, {});
 
     // split work
     auto* token_counts_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(token_counts_l1_addr);
@@ -144,21 +148,20 @@ void kernel_main() {
         token_parallel_core_id, token_counts_l1_ptr, token_split_counts, token_split_offsets);
 
     // read dense token maps
-    cb_reserve_back(dense_token_maps_cb_id, num_local_experts);
-    const uint32_t dense_token_maps_l1_addr = get_write_ptr(dense_token_maps_cb_id);
+    cb_dense_token_maps.reserve_back(num_local_experts);
+    const uint32_t dense_token_maps_l1_addr = cb_dense_token_maps.get_write_ptr();
     for (uint32_t e = 0, l1_offset = 0, maps_page = 0; e < num_local_experts; ++e) {
-        const uint64_t dense_token_maps_noc_addr =
-            get_noc_addr(maps_page++, dense_token_maps_addrgen, /*offset=*/0, /*noc=*/1);
-        noc_async_read(
-            dense_token_maps_noc_addr,
-            dense_token_maps_l1_addr + l1_offset,
+        noc1_obj.async_read(
+            dense_token_maps_addrgen,
+            cb_dense_token_maps,
             dense_token_maps_page_size_bytes,
-            /*noc=*/1);
+            {.page_id = maps_page++},
+            {.offset_bytes = l1_offset});
         l1_offset += dense_token_maps_page_size_bytes;
     }
 
     // wait for activations and dense token maps
-    noc_async_read_barrier(/*noc=*/1);
+    noc1_obj.async_read_barrier();
 
     auto* dense_token_maps_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dense_token_maps_l1_addr);
     auto* token_activations_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(token_activations_l1_addr);
@@ -181,9 +184,9 @@ void kernel_main() {
         token_counts_l1_ptr[num_local_experts + 2 * num_local_experts + e] = token_activation_offsets[e];
     }
 
-    cb_push_back(token_counts_cb_id, 1);
-    cb_push_back(dense_token_maps_cb_id, num_local_experts);
-    cb_push_back(token_activations_cb_id, 1);
+    cb_token_counts.push_back(1);
+    cb_dense_token_maps.push_back(num_local_experts);
+    cb_token_activations.push_back(1);
 
-    noc_semaphore_set(sync_semaphore_ptr, 0);
+    sync_sem.set(0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
@@ -4,6 +4,10 @@
 
 #include "api/compile_time_args.h"
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
@@ -51,6 +55,7 @@ private:
 
 public:
     DoubleBuffer(
+        const Noc& /*noc*/,
         const uint32_t /*compute_cores_per_combine_core*/,
         const uint32_t /*sync_semaphore_addr*/,
         size_t& /*rt_arg_count*/) :
@@ -67,6 +72,7 @@ public:
 template <>
 struct DoubleBuffer<true> {
 private:
+    const Noc& noc;
     const uint32_t compute_cores_per_combine_core;
     const uint32_t sync_semaphore_addr;
     volatile tt_l1_ptr uint32_t* core_coords_ptr;
@@ -75,7 +81,11 @@ private:
 
 public:
     DoubleBuffer(
-        const uint32_t compute_cores_per_combine_core, const uint32_t sync_semaphore_addr, size_t& rt_arg_count) :
+        const Noc& noc,
+        const uint32_t compute_cores_per_combine_core,
+        const uint32_t sync_semaphore_addr,
+        size_t& rt_arg_count) :
+        noc(noc),
         compute_cores_per_combine_core(compute_cores_per_combine_core),
         sync_semaphore_addr(sync_semaphore_addr),
         core_coords_ptr(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_arg_addr(rt_arg_count))),
@@ -84,7 +94,7 @@ public:
     };
 
     DoubleBuffer& operator++() {
-        noc_async_writes_flushed(/*noc=*/1);
+        noc.async_writes_flushed();
 
         for (uint32_t c = 0; c < compute_cores_per_combine_core; ++c) {
             const uint64_t sem_noc_addr = safe_get_noc_addr(
@@ -92,6 +102,9 @@ public:
                 core_coords_ptr[2 * c + 1],
                 sync_semaphore_addr,
                 /*noc_id=*/1);
+            // Device 2.0 migration: legacy primitive retained: sync_semaphore_addr is a
+            // fabric-mux sync address (not a get_semaphore<>(id) address) and the inc uses
+            // an explicit noc=1; Semaphore<>::up does not currently expose this. #45003 item 4.
             noc_semaphore_inc</*posted=*/true>(sem_noc_addr, 1, /*noc_id=*/1);
         }
         idx = !idx;
@@ -162,15 +175,27 @@ void kernel_main() {
     const auto output_base_addr = get_arg_val<uint32_t>(rt_arg_count++);
     const auto source_token_segment_size_bytes = get_arg_val<uint32_t>(rt_arg_count++);
     const auto dest_token_segment_offset_bytes = get_arg_val<uint32_t>(rt_arg_count++);
+    // Device 2.0 migration: legacy primitive retained: init_semaphore_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const auto init_semaphore_addr = get_arg_val<uint32_t>(rt_arg_count++);
+    // Device 2.0 migration: legacy primitive retained: global_semaphore_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const auto global_semaphore_addr = get_arg_val<uint32_t>(rt_arg_count++);
     const bool is_init_sync_core = get_arg_val<uint32_t>(rt_arg_count++);
+
+    Noc noc1_obj(1);
+    CircularBuffer cb_packet_header(packet_header_cb_id);
+    CircularBuffer cb_token_counts(token_counts_cb_id);
+    CircularBuffer cb_data(data_cb_id);
+    CircularBuffer cb_dense_token_maps(dense_token_maps_cb_id);
+    CircularBuffer cb_token_activations(token_activations_cb_id);
+    Semaphore<> compute_sync_sem(compute_sync_semaphore_id);
 
     const auto compute_sync_semaphore_addr = get_semaphore(compute_sync_semaphore_id);
 
     // rt_arg_count is incremented
     detail::DoubleBuffer<double_buffer_source> db(
-        compute_cores_per_combine_core, compute_sync_semaphore_addr, rt_arg_count);
+        noc1_obj, compute_cores_per_combine_core, compute_sync_semaphore_addr, rt_arg_count);
 
     // rt_arg_count does not get incremented
     MuxSyncCoreArgs sync_args(rt_arg_count);
@@ -188,10 +213,10 @@ void kernel_main() {
 
     volatile PACKET_HEADER_TYPE* packet_headers[3];
     for (uint8_t i = 0; i < 3; ++i) {
-        cb_reserve_back(packet_header_cb_id, 1);
-        const uint32_t packet_header_addr = get_write_ptr(packet_header_cb_id);
+        cb_packet_header.reserve_back(1);
+        const uint32_t packet_header_addr = cb_packet_header.get_write_ptr();
         packet_headers[i] = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
-        cb_push_back(packet_header_cb_id, 1);
+        cb_packet_header.push_back(1);
     }
 
     // mux_rt_arg_count does not get incremented
@@ -210,8 +235,8 @@ void kernel_main() {
             num_devices>(fabric_connections, packet_headers[1], dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
     }
 
-    cb_wait_front(token_counts_cb_id, 1);
-    const uint32_t token_counts_l1_addr = get_write_ptr(token_counts_cb_id);
+    cb_token_counts.wait_front(1);
+    const uint32_t token_counts_l1_addr = cb_token_counts.get_write_ptr();
     auto* token_counts_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(token_counts_l1_addr);
     uint32_t token_split_offsets[num_local_experts];
     uint32_t token_split_counts[num_local_experts];
@@ -221,24 +246,30 @@ void kernel_main() {
         token_split_counts[e] = token_counts_l1_ptr[num_local_experts + num_local_experts + e];
         token_activation_offsets[e] = token_counts_l1_ptr[num_local_experts + 2 * num_local_experts + e];
     }
-    cb_pop_front(token_counts_cb_id, 1);
+    cb_token_counts.pop_front(1);
 
-    cb_reserve_back(data_cb_id, 1);
-    const uint32_t src_data_l1_base_addr = get_write_ptr(data_cb_id);
+    cb_data.reserve_back(1);
+    const uint32_t src_data_l1_base_addr = cb_data.get_write_ptr();
 
-    cb_wait_front(dense_token_maps_cb_id, num_local_experts);
-    const uint32_t dense_token_maps_l1_addr = get_write_ptr(dense_token_maps_cb_id);
+    cb_dense_token_maps.wait_front(num_local_experts);
+    const uint32_t dense_token_maps_l1_addr = cb_dense_token_maps.get_write_ptr();
     auto* dense_token_maps_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dense_token_maps_l1_addr);
 
-    cb_wait_front(token_activations_cb_id, 1);
-    const uint32_t token_activations_l1_addr = get_write_ptr(token_activations_cb_id);
+    cb_token_activations.wait_front(1);
+    const uint32_t token_activations_l1_addr = cb_token_activations.get_write_ptr();
     auto* token_activations_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(token_activations_l1_addr);
 
     if constexpr (use_init_semaphore) {
         auto* init_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_addr);
         if (is_init_sync_core) {
+            // Device 2.0 migration: legacy primitive retained: init_semaphore_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+            // #45003 item 4.
             noc_semaphore_wait(init_semaphore_ptr, replicate_group_devices - 1);
             // swap start/end coordinates because this kernel is using NOC1
+            // Device 2.0 migration: legacy primitive retained: init_semaphore_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+            // #45003 item 4.
             const uint64_t semaphore_mc_addr =
                 get_noc_multicast_addr(noc_x_end, noc_y_end, noc_x_start, noc_y_start, init_semaphore_addr, /*noc=*/1);
             noc_semaphore_set_multicast(
@@ -247,21 +278,26 @@ void kernel_main() {
                 num_token_parallel_cores * num_data_parallel_cores - 1,
                 /*linked=*/false,
                 /*noc=*/1);
-            noc_async_writes_flushed(/*noc=*/1);
+            noc1_obj.async_writes_flushed();
 
         } else {
+            // Device 2.0 migration: legacy primitive retained: init_semaphore_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+            // #45003 item 4.
             noc_semaphore_wait(init_semaphore_ptr, replicate_group_devices - 1);
         }
+        // Device 2.0 migration: legacy primitive retained: init_semaphore_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+        // #45003 item 4.
         noc_semaphore_set(init_semaphore_ptr, 0);
     }
 
-    auto* compute_sync_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(compute_sync_semaphore_addr);
     uint32_t compute_sync_semaphore_val = compute_cores_per_combine_core;
     for (uint32_t e = 0; e < num_local_experts; ++e) {
         auto* expert_token_activations_ptr =
             token_activations_l1_ptr + token_activation_offsets[e] * activations_stride_elm;
 
-        noc_semaphore_wait(compute_sync_semaphore_ptr, compute_sync_semaphore_val);
+        compute_sync_sem.wait(compute_sync_semaphore_val);
 
         for (uint32_t dt = 0; dt < token_split_counts[e]; ++dt) {
             const uint32_t st = dense_token_maps_l1_ptr
@@ -288,10 +324,13 @@ void kernel_main() {
                 replicate_axis>(st);
 
             if (dest_device_idx == linearized_mesh_coord) {
-                const uint64_t output_noc_addr =
-                    get_noc_addr(output_page_idx, output_addrgen, dest_token_segment_offset_bytes, /*noc=*/1);
-                noc_async_write(src_data_l1_addr, output_noc_addr, source_token_segment_size_bytes, /*noc=*/1);
-                noc_async_writes_flushed(/*noc=*/1);
+                noc1_obj.async_write(
+                    CoreLocalMem<uint8_t>(src_data_l1_addr),
+                    output_addrgen,
+                    source_token_segment_size_bytes,
+                    {},
+                    {.page_id = output_page_idx, .offset_bytes = dest_token_segment_offset_bytes});
+                noc1_obj.async_writes_flushed();
             } else {
                 fabric_send_chip_unicast_noc_unicast_1d<
                     linearized_mesh_coord,
@@ -314,18 +353,21 @@ void kernel_main() {
         ++db;
     }
 
-    noc_semaphore_set(compute_sync_semaphore_ptr, 0);
+    compute_sync_sem.set(0);
 
-    cb_pop_front(dense_token_maps_cb_id, num_local_experts);
-    cb_pop_front(token_activations_cb_id, 1);
-    cb_push_back(data_cb_id, 1);
+    cb_dense_token_maps.pop_front(num_local_experts);
+    cb_token_activations.pop_front(1);
+    cb_data.push_back(1);
 
-    noc_async_write_barrier(/*noc=*/1);
+    noc1_obj.async_write_barrier();
 
     if (sync_args.is_sync_core) {
         auto termination_sync_semaphore_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_args.termination_sync_address);
 
+        // Device 2.0 migration: legacy primitive retained: termination_sync_address is a
+        // fabric-mux sync address (not a get_semaphore<>(id) address); Semaphore<> cannot
+        // bind to it today. #45003 item 4.
         noc_semaphore_wait(termination_sync_semaphore_ptr, num_data_parallel_cores - 1);
         noc_semaphore_set(termination_sync_semaphore_ptr, 0);
 
@@ -338,10 +380,13 @@ void kernel_main() {
             replicate_axis,
             true>(fabric_connections, packet_headers[1], packet_headers[2], global_noc_semaphore_addr);
 
+        // Device 2.0 migration: legacy primitive retained: global_semaphore_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+        // #45003 item 4.
         auto semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr);
 
-        noc_async_write_barrier(/*noc=*/1);
-        noc_async_atomic_barrier(/*noc=*/1);
+        noc1_obj.async_write_barrier();
+        noc1_obj.async_atomic_barrier();
 
         close_direction_connections<
             Num_Directions,
@@ -349,6 +394,9 @@ void kernel_main() {
             fabric_mux_termination_signal_address,
             num_mux_workers_per_link>(directions, fabric_connections, true, rt_arg_count);
 
+        // Device 2.0 migration: legacy primitive retained: global_semaphore_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+        // #45003 item 4.
         noc_semaphore_wait(semaphore_ptr, replicate_group_devices);
         noc_semaphore_set(semaphore_ptr, 0);
     } else {
@@ -363,9 +411,12 @@ void kernel_main() {
             sync_args.termination_master_noc_y,
             sync_args.termination_sync_address,
             /*noc=*/1);
+        // Device 2.0 migration: legacy primitive retained: termination_sync_address is a
+        // fabric-mux sync address (not a get_semaphore<>(id) address) and the inc uses
+        // an explicit noc=1; Semaphore<>::up does not currently expose this. #45003 item 4.
         noc_semaphore_inc(safe_termination_sync_address, 1, /*noc=*/1);
 
-        noc_async_write_barrier(/*noc=*/1);
-        noc_async_atomic_barrier(/*noc=*/1);
+        noc1_obj.async_write_barrier();
+        noc1_obj.async_atomic_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -12,7 +12,6 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/dataflow/circular_buffer.h"
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
@@ -112,32 +111,21 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
-    // CB ids
-    constexpr auto cb_s2c_in_id = tt::CBIndex::c_0;     // tilize_output_cb_id
-    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_5;
-    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md_id = tt::CBIndex::c_7;
+    // CBs
+    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
 
-    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
     // c_8 is unused on matmul cores when bias is off (CB not allocated); when has_bias, tilize uses c_8 only on
     // tilize cores. Only referenced in if constexpr(has_bias) branches below.
-    constexpr auto cb_c2c_ones_tile_id = tt::CBIndex::c_8;
+    constexpr auto cb_c2c_ones_tile = tt::CBIndex::c_8;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
-
-    // CircularBuffer typed wrappers
-    CircularBuffer cb_s2c_in(cb_s2c_in_id);
-    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
-    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
-    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
-    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
-    CircularBuffer cb_w2c_md(cb_w2c_md_id);
-    CircularBuffer cb_c2s_out(cb_c2s_out_id);
-    CircularBuffer cb_c2c_ones_tile(cb_c2c_ones_tile_id);
-    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
+    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
 
     // Pre-computed shard lookup tables — avoids runtime div/mod in inner loops.
     // ring_core_id is a runtime arg, but Nt/Ht/num_cores are compile-time.
@@ -183,30 +171,30 @@ void kernel_main() {
     if constexpr (has_bias) {
         // Create a ones-tile for bias addition (matmul with ones × bias_row = bias).
         // Same sequence as moe_gpt compute.cpp for GPT-OSS compatibility.
-        unary_op_init_common(cb_c2c_ones_tile_id, cb_c2c_ones_tile_id);
+        unary_op_init_common(cb_c2c_ones_tile, cb_c2c_ones_tile);
         tile_regs_acquire();
         fill_tile_init();
         constexpr uint32_t dst0 = 0;
         fill_tile(dst0, 1.f);
         tile_regs_commit();
         tile_regs_wait();
-        cb_c2c_ones_tile.reserve_back(1);
-        pack_tile(dst0, cb_c2c_ones_tile_id);
+        cb_reserve_back(cb_c2c_ones_tile, 1);
+        pack_tile(dst0, cb_c2c_ones_tile);
         tile_regs_release();
-        cb_c2c_ones_tile.push_back(1);
+        cb_push_back(cb_c2c_ones_tile, 1);
         // Synchronize: UNPACK must wait for PACK to finish writing before the first
         // matmul_block read. The tile is never popped so one cb_wait_front suffices.
-        cb_c2c_ones_tile.wait_front(1);
+        cb_wait_front(cb_c2c_ones_tile, 1);
     }
 
     // Pack is always configured to Float16_b
-    pack_reconfig_data_format(cb_s2c_in2_id);
+    pack_reconfig_data_format(cb_s2c_in2);
 
     // Unpacker B is for input/activation and eltiwse inputs, so Float16_b
-    reconfig_data_format_srcb(cb_s2c_in_id);
+    reconfig_data_format_srcb(cb_s2c_in);
 
     // Unpacker A is for W0,W1 and W2, so Bf4_b
-    reconfig_data_format_srca(cb_r2c_w0_w1_id);
+    reconfig_data_format_srca(cb_r2c_w0_w1);
 
     //-------------------------------------------------------------------------
     // Init synchronization with tilize cores
@@ -216,10 +204,10 @@ void kernel_main() {
     // We also use this CB to transfer (from the writer to compute) 2 semaphore addresses:
     // - 0: address of semaphore used to send metadata (number of tokens per expert)
     // - 1: address of semaphore used to notify matmuls cores that tilized chunks have arrived
-    cb_w2c_md.wait_front(2);
-    cb_w2c_md.pop_front(2);
+    cb_wait_front(cb_w2c_md, 2);
+    cb_pop_front(cb_w2c_md, 2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_read_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md_id, 0));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md, 0));
 
     // Read per-expert token counts from CB
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
@@ -252,21 +240,11 @@ void kernel_main() {
 
             // Initialize matmul for W0
             mm_block_init(
-                cb_s2c_in_id,
-                cb_r2c_w0_w1_id,
-                cb_s2c_in2_id,
-                /*transpose=*/false,
-                /*ct_dim=*/4,
-                /*rt_dim=*/1,
-                /*kt_dim=*/1);
+                cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
             // Wait for next chunk of tiles to arrive from the tilize cores
             // Min to allow tilize cores to send increment for second expert
             // while first expert still being processed
-            // Device 2.0 migration: legacy primitive retained: matmul_chunk_ready_semaphore_addr is a
-            // runtime-resolved L1 semaphore address (delivered via cb_w2c_md), not a per-program id.
-            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a resolved
-            // address. #45003 item 4.
             detail::noc_semaphore_wait_min(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
                 matmul_chunk_ready_semaphore_wait_value++);
@@ -280,15 +258,15 @@ void kernel_main() {
                 tile_regs_acquire();
                 [[maybe_unused]] uint32_t k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < Cfg::w0_w1_blocks_per_col; ++block_id) {
-                    cb_r2c_w0_w1.wait_front(w0_w1_tiles_per_block);
+                    cb_wait_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
 
                     for (uint32_t k = 0; k < w0_w1_tiles_per_block; k += 4) {
                         if constexpr (has_bias) {
                             if (k_tracker == num_w0_w1_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row)
                                 matmul_block(
-                                    cb_c2c_ones_tile_id,
-                                    cb_r2c_w0_w1_id,
+                                    cb_c2c_ones_tile,
+                                    cb_r2c_w0_w1,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -304,8 +282,8 @@ void kernel_main() {
                             }
                         }
                         matmul_block(
-                            cb_s2c_in_id,
-                            cb_r2c_w0_w1_id,
+                            cb_s2c_in,
+                            cb_r2c_w0_w1,
                             in0_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -317,7 +295,7 @@ void kernel_main() {
                             k_tracker++;
                         }
                     }
-                    cb_r2c_w0_w1.pop_front(w0_w1_tiles_per_block);
+                    cb_pop_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
                 }
 
                 tile_regs_commit();
@@ -339,20 +317,20 @@ void kernel_main() {
 
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
-                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
-                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2_id, /*output_tile_index=*/tile_id + 1);
+                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
+                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2, /*output_tile_index=*/tile_id + 1);
                 tile_regs_release();
             }
 
             // Signal to DM1 that the output from this core is ready
-            cb_c2w_rdy.reserve_back(1);
-            cb_c2w_rdy.push_back(1);
+            cb_reserve_back(cb_c2w_rdy, 1);
+            cb_push_back(cb_c2w_rdy, 1);
 
             //---------------------------------------------------------------------
             // Compute in2 @ W2 (in pairs of 4)
             //---------------------------------------------------------------------
 
-            cb_c2s_out.reserve_back(num_w0_w1_tiles_h);
+            cb_reserve_back(cb_c2s_out, num_w0_w1_tiles_h);
 
             // Init pack_untilize ONCE before the iter loop (hoisted, mirrors moe_gpt pattern).
             // Cycling init/uninit per-iter triggers BH's MATH reconfig_remap workaround
@@ -360,12 +338,12 @@ void kernel_main() {
             // execution and produces garbage output (NaN/Inf) on BH silicon.
             pack_untilize_dest_init<
                 /*block_ct_dim=*/w2_tiles_per_iter_w,
-                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out_id);
+                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out);
 
             for (uint32_t iter = 0; iter < Cfg::num_a2a_iters; ++iter) {
                 uint32_t src_core = ring_core_id;
                 uint32_t dm1_tiles_remaining = shard_tiles_lut[ring_core_id];
-                cb_w2c_rdy.wait_front(1);
+                cb_wait_front(cb_w2c_rdy, 1);
 
                 uint32_t in2_offset = 0, in2_index = 0;
 
@@ -373,14 +351,14 @@ void kernel_main() {
 
                 uint32_t w2_k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
-                    cb_r2c_w2.wait_front(w2_tiles_per_block);
+                    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {
                         if constexpr (has_bias) {
                             if (w2_k_tracker == num_w2_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row); padding K slots do not consume in2/dm1.
                                 matmul_block(
-                                    cb_c2c_ones_tile_id,
-                                    cb_r2c_w2_id,
+                                    cb_c2c_ones_tile,
+                                    cb_r2c_w2,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -396,8 +374,8 @@ void kernel_main() {
                             continue;  // skip padding K slots (bias: after bias tile; no_bias: at/past logical K)
                         }
                         if (dm1_tiles_remaining == 0) {
-                            cb_w2c_rdy.pop_front(1);
-                            cb_w2c_rdy.wait_front(1);
+                            cb_pop_front(cb_w2c_rdy, 1);
+                            cb_wait_front(cb_w2c_rdy, 1);
                             src_core = (src_core == 0) ? num_cores - 1 : src_core - 1;
                             dm1_tiles_remaining = shard_tiles_lut[src_core];
                             in2_offset += tiles_per_step;
@@ -406,8 +384,8 @@ void kernel_main() {
                         dm1_tiles_remaining--;
 
                         matmul_block(
-                            cb_s2c_in2_id,
-                            cb_r2c_w2_id,
+                            cb_s2c_in2,
+                            cb_r2c_w2,
                             in2_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -417,33 +395,33 @@ void kernel_main() {
                             /*kt_dim=*/1);
                         w2_k_tracker++;
                     }
-                    cb_r2c_w2.pop_front(w2_tiles_per_block);
+                    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
                 }
-                cb_w2c_rdy.pop_front(1);
+                cb_pop_front(cb_w2c_rdy, 1);
 
                 tile_regs_commit();
 
                 tile_regs_wait();
                 pack_untilize_dest</*block_ct_dim=*/w2_tiles_per_iter_w, /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(
-                    cb_c2s_out_id, /*block_rt_dim=*/1, /*block_c_index=*/iter);
+                    cb_c2s_out, /*block_rt_dim=*/1, /*block_c_index=*/iter);
 
                 tile_regs_release();
             }
 
             // Uninit pack_untilize ONCE after the iter loop (hoisted, mirrors moe_gpt pattern).
-            pack_untilize_uninit(cb_c2s_out_id);
+            pack_untilize_uninit(cb_c2s_out);
 
-            cb_c2s_out.push_back(num_w0_w1_tiles_h);
+            cb_push_back(cb_c2s_out, num_w0_w1_tiles_h);
 
             // Toggle the buffer to use
             use_second_half_buffer = !use_second_half_buffer;
             // Restore packer data format for next chunk's activation pipeline (mirrors moe_gpt:342).
-            pack_reconfig_data_format(cb_s2c_in2_id);
+            pack_reconfig_data_format(cb_s2c_in2);
 
         }  // end for (chunk)
     }  // end for (expert_id)
 
     // Drain the pipeline - the last dummy push
-    cb_r2c_w2.wait_front(w2_tiles_per_block);
-    cb_r2c_w2.pop_front(w2_tiles_per_block);
+    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
+    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/circular_buffer.h"
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
@@ -111,21 +112,32 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
-    // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
+    // CB ids
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_7;
 
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;  // matmul_writer_cb_id
     // c_8 is unused on matmul cores when bias is off (CB not allocated); when has_bias, tilize uses c_8 only on
     // tilize cores. Only referenced in if constexpr(has_bias) branches below.
-    constexpr auto cb_c2c_ones_tile = tt::CBIndex::c_8;
+    constexpr auto cb_c2c_ones_tile_id = tt::CBIndex::c_8;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_3;  // reuse cb_r2c_w0_w1
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_s2c_in(cb_s2c_in_id);
+    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
+    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
+    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
+    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
+    CircularBuffer cb_w2c_md(cb_w2c_md_id);
+    CircularBuffer cb_c2s_out(cb_c2s_out_id);
+    CircularBuffer cb_c2c_ones_tile(cb_c2c_ones_tile_id);
+    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
 
     // Pre-computed shard lookup tables — avoids runtime div/mod in inner loops.
     // ring_core_id is a runtime arg, but Nt/Ht/num_cores are compile-time.
@@ -171,30 +183,30 @@ void kernel_main() {
     if constexpr (has_bias) {
         // Create a ones-tile for bias addition (matmul with ones × bias_row = bias).
         // Same sequence as moe_gpt compute.cpp for GPT-OSS compatibility.
-        unary_op_init_common(cb_c2c_ones_tile, cb_c2c_ones_tile);
+        unary_op_init_common(cb_c2c_ones_tile_id, cb_c2c_ones_tile_id);
         tile_regs_acquire();
         fill_tile_init();
         constexpr uint32_t dst0 = 0;
         fill_tile(dst0, 1.f);
         tile_regs_commit();
         tile_regs_wait();
-        cb_reserve_back(cb_c2c_ones_tile, 1);
-        pack_tile(dst0, cb_c2c_ones_tile);
+        cb_c2c_ones_tile.reserve_back(1);
+        pack_tile(dst0, cb_c2c_ones_tile_id);
         tile_regs_release();
-        cb_push_back(cb_c2c_ones_tile, 1);
+        cb_c2c_ones_tile.push_back(1);
         // Synchronize: UNPACK must wait for PACK to finish writing before the first
         // matmul_block read. The tile is never popped so one cb_wait_front suffices.
-        cb_wait_front(cb_c2c_ones_tile, 1);
+        cb_c2c_ones_tile.wait_front(1);
     }
 
     // Pack is always configured to Float16_b
-    pack_reconfig_data_format(cb_s2c_in2);
+    pack_reconfig_data_format(cb_s2c_in2_id);
 
     // Unpacker B is for input/activation and eltiwse inputs, so Float16_b
-    reconfig_data_format_srcb(cb_s2c_in);
+    reconfig_data_format_srcb(cb_s2c_in_id);
 
     // Unpacker A is for W0,W1 and W2, so Bf4_b
-    reconfig_data_format_srca(cb_r2c_w0_w1);
+    reconfig_data_format_srca(cb_r2c_w0_w1_id);
 
     //-------------------------------------------------------------------------
     // Init synchronization with tilize cores
@@ -204,10 +216,10 @@ void kernel_main() {
     // We also use this CB to transfer (from the writer to compute) 2 semaphore addresses:
     // - 0: address of semaphore used to send metadata (number of tokens per expert)
     // - 1: address of semaphore used to notify matmuls cores that tilized chunks have arrived
-    cb_wait_front(cb_w2c_md, 2);
-    cb_pop_front(cb_w2c_md, 2);
+    cb_w2c_md.wait_front(2);
+    cb_w2c_md.pop_front(2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_read_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md, 0));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md_id, 0));
 
     // Read per-expert token counts from CB
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
@@ -240,11 +252,21 @@ void kernel_main() {
 
             // Initialize matmul for W0
             mm_block_init(
-                cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
+                cb_s2c_in_id,
+                cb_r2c_w0_w1_id,
+                cb_s2c_in2_id,
+                /*transpose=*/false,
+                /*ct_dim=*/4,
+                /*rt_dim=*/1,
+                /*kt_dim=*/1);
 
             // Wait for next chunk of tiles to arrive from the tilize cores
             // Min to allow tilize cores to send increment for second expert
             // while first expert still being processed
+            // Device 2.0 migration: legacy primitive retained: matmul_chunk_ready_semaphore_addr is a
+            // runtime-resolved L1 semaphore address (delivered via cb_w2c_md), not a per-program id.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a resolved
+            // address. #45003 item 4.
             detail::noc_semaphore_wait_min(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
                 matmul_chunk_ready_semaphore_wait_value++);
@@ -258,15 +280,15 @@ void kernel_main() {
                 tile_regs_acquire();
                 [[maybe_unused]] uint32_t k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < Cfg::w0_w1_blocks_per_col; ++block_id) {
-                    cb_wait_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.wait_front(w0_w1_tiles_per_block);
 
                     for (uint32_t k = 0; k < w0_w1_tiles_per_block; k += 4) {
                         if constexpr (has_bias) {
                             if (k_tracker == num_w0_w1_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row)
                                 matmul_block(
-                                    cb_c2c_ones_tile,
-                                    cb_r2c_w0_w1,
+                                    cb_c2c_ones_tile_id,
+                                    cb_r2c_w0_w1_id,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -282,8 +304,8 @@ void kernel_main() {
                             }
                         }
                         matmul_block(
-                            cb_s2c_in,
-                            cb_r2c_w0_w1,
+                            cb_s2c_in_id,
+                            cb_r2c_w0_w1_id,
                             in0_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -295,7 +317,7 @@ void kernel_main() {
                             k_tracker++;
                         }
                     }
-                    cb_pop_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.pop_front(w0_w1_tiles_per_block);
                 }
 
                 tile_regs_commit();
@@ -317,20 +339,20 @@ void kernel_main() {
 
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
-                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
-                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2, /*output_tile_index=*/tile_id + 1);
+                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
+                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2_id, /*output_tile_index=*/tile_id + 1);
                 tile_regs_release();
             }
 
             // Signal to DM1 that the output from this core is ready
-            cb_reserve_back(cb_c2w_rdy, 1);
-            cb_push_back(cb_c2w_rdy, 1);
+            cb_c2w_rdy.reserve_back(1);
+            cb_c2w_rdy.push_back(1);
 
             //---------------------------------------------------------------------
             // Compute in2 @ W2 (in pairs of 4)
             //---------------------------------------------------------------------
 
-            cb_reserve_back(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.reserve_back(num_w0_w1_tiles_h);
 
             // Init pack_untilize ONCE before the iter loop (hoisted, mirrors moe_gpt pattern).
             // Cycling init/uninit per-iter triggers BH's MATH reconfig_remap workaround
@@ -338,12 +360,12 @@ void kernel_main() {
             // execution and produces garbage output (NaN/Inf) on BH silicon.
             pack_untilize_dest_init<
                 /*block_ct_dim=*/w2_tiles_per_iter_w,
-                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out);
+                /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(cb_c2s_out_id);
 
             for (uint32_t iter = 0; iter < Cfg::num_a2a_iters; ++iter) {
                 uint32_t src_core = ring_core_id;
                 uint32_t dm1_tiles_remaining = shard_tiles_lut[ring_core_id];
-                cb_wait_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.wait_front(1);
 
                 uint32_t in2_offset = 0, in2_index = 0;
 
@@ -351,14 +373,14 @@ void kernel_main() {
 
                 uint32_t w2_k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
-                    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.wait_front(w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {
                         if constexpr (has_bias) {
                             if (w2_k_tracker == num_w2_tiles_h) {
                                 // Bias addition: matmul(ones_tile, bias_row); padding K slots do not consume in2/dm1.
                                 matmul_block(
-                                    cb_c2c_ones_tile,
-                                    cb_r2c_w2,
+                                    cb_c2c_ones_tile_id,
+                                    cb_r2c_w2_id,
                                     0,
                                     /*in1_index=*/k,
                                     /*idst=*/0,
@@ -374,8 +396,8 @@ void kernel_main() {
                             continue;  // skip padding K slots (bias: after bias tile; no_bias: at/past logical K)
                         }
                         if (dm1_tiles_remaining == 0) {
-                            cb_pop_front(cb_w2c_rdy, 1);
-                            cb_wait_front(cb_w2c_rdy, 1);
+                            cb_w2c_rdy.pop_front(1);
+                            cb_w2c_rdy.wait_front(1);
                             src_core = (src_core == 0) ? num_cores - 1 : src_core - 1;
                             dm1_tiles_remaining = shard_tiles_lut[src_core];
                             in2_offset += tiles_per_step;
@@ -384,8 +406,8 @@ void kernel_main() {
                         dm1_tiles_remaining--;
 
                         matmul_block(
-                            cb_s2c_in2,
-                            cb_r2c_w2,
+                            cb_s2c_in2_id,
+                            cb_r2c_w2_id,
                             in2_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -395,33 +417,33 @@ void kernel_main() {
                             /*kt_dim=*/1);
                         w2_k_tracker++;
                     }
-                    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.pop_front(w2_tiles_per_block);
                 }
-                cb_pop_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.pop_front(1);
 
                 tile_regs_commit();
 
                 tile_regs_wait();
                 pack_untilize_dest</*block_ct_dim=*/w2_tiles_per_iter_w, /*full_ct_dim=*/Cfg::w2_tiles_per_expert_w>(
-                    cb_c2s_out, /*block_rt_dim=*/1, /*block_c_index=*/iter);
+                    cb_c2s_out_id, /*block_rt_dim=*/1, /*block_c_index=*/iter);
 
                 tile_regs_release();
             }
 
             // Uninit pack_untilize ONCE after the iter loop (hoisted, mirrors moe_gpt pattern).
-            pack_untilize_uninit(cb_c2s_out);
+            pack_untilize_uninit(cb_c2s_out_id);
 
-            cb_push_back(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.push_back(num_w0_w1_tiles_h);
 
             // Toggle the buffer to use
             use_second_half_buffer = !use_second_half_buffer;
             // Restore packer data format for next chunk's activation pipeline (mirrors moe_gpt:342).
-            pack_reconfig_data_format(cb_s2c_in2);
+            pack_reconfig_data_format(cb_s2c_in2_id);
 
         }  // end for (chunk)
     }  // end for (expert_id)
 
     // Drain the pipeline - the last dummy push
-    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
-    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.wait_front(w2_tiles_per_block);
+    cb_r2c_w2.pop_front(w2_tiles_per_block);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "moe_ring_common.h"
 
 // Triple buffering constants
@@ -82,22 +84,27 @@ void kernel_main() {
     }
 
     // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_7;
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
+    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
-    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
-    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
-    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in_id);
+    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1_id);
+    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2_id);
+    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2_id);
 
     //-------------------------------------------------------------------------
     // W0 and W1 reading constants
@@ -186,7 +193,7 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // CB addresses
     //-------------------------------------------------------------------------
-    const uint32_t w_cb_base_addr = get_write_ptr(cb_r2c_w0_w1);
+    const uint32_t w_cb_base_addr = cb_r2c_w0_w1.get_write_ptr();
 
     // Precompute slot addresses (avoid multiply in hot loop)
     // Each slot holds 2 transactions (28 tiles)
@@ -204,12 +211,12 @@ void kernel_main() {
     //-------------------------------------------------------------------------
 
     // Receive number of tokens per expert from the tilize cores
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
-    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    metadata_ready_sem.wait_min(1);
 
     // Read per-expert token counts from CB
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
 
     // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
@@ -223,11 +230,16 @@ void kernel_main() {
     //-------------------------------------------------------------------------
 
     // We reserve one to kick start the pipeline, and then it is steady state
-    cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+    cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block);
 
     // Pre-set state for this ring core's first bank (WH fast path: when
     // pages_per_ring_core_total <= pages_per_bank_total). The bank-run loop below will
     // re-set_state only when shard_idx changes.
+    // Device 2.0 migration: legacy primitives retained: noc_async_read_set_trid /
+    // noc_async_read_one_packet_set_state / noc_async_read_one_packet_with_state_with_trid /
+    // noc_async_read_barrier_with_trid are the trid-pipelined state-machine API used to
+    // drive a triple-buffered DRAM read pipeline; Device 2.0 Noc wrapper does not yet expose
+    // typed equivalents for the set_state / with_state / with_trid family. #45003 item 4.
     const uint32_t initial_shard_idx_w0 =
         (ring_core_id * w0_w1_pages_per_ring_core_total + w0_w1_layer_offset_in_ring_core) / w0_w1_pages_per_bank_total;
     const uint32_t initial_bank_id_w0 = shard_to_bank[initial_shard_idx_w0];
@@ -326,12 +338,12 @@ void kernel_main() {
                 // Only when we first start the pipeline, we don't have any txns in flight
                 if (txns_in_flight) {
                     noc_async_read_barrier_with_trid(trid_to_wait);
-                    cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
 
                     ADVANCE_TRID(trid_to_wait);
 
                     // Reserve for next block
-                    cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block * 2);
+                    cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block * 2);
                 }
                 txns_in_flight = true;
             }
@@ -389,23 +401,23 @@ void kernel_main() {
                 ADVANCE_TRID(trid_to_issue);
 
                 noc_async_read_barrier_with_trid(trid_to_wait);
-                cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+                cb_r2c_w2.push_back(w2_tiles_per_block);
 
                 ADVANCE_TRID(trid_to_wait);
 
                 // Reserve for next block
-                cb_reserve_back(cb_r2c_w2, w2_tiles_per_block * 2);
+                cb_r2c_w2.reserve_back(w2_tiles_per_block * 2);
             }
         }
     }
 
     // Drain the pipeline - the last txn in flight
     noc_async_read_barrier_with_trid(trid_to_wait);
-    cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.push_back(w2_tiles_per_block);
 
     // We have one extra slot reserved, which we won't use.
     // For CB hygiene, we can push it back.
-    cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.push_back(w2_tiles_per_block);
 }
 
 #undef ADVANCE_TRID

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "moe_ring_common.h"
 
@@ -74,23 +77,37 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
+    // Noc typed wrapper
+    Noc noc_obj(noc_index);
+    // Secondary noc used for A2A ring writes and combine writes (always NOC 1)
+    Noc noc1_obj(1);
+
     // CBs
-    constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_0;     // tilize_output_cb_id
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_3;  // cb_r2c_w0
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_5;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_7;
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_s2c_in(cb_s2c_in_id);
+    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
+    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
+    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
+    CircularBuffer cb_w2c_md(cb_w2c_md_id);
+    CircularBuffer cb_c2s_out(cb_c2s_out_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
-    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
-    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
-    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in_id);
+    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1_id);
+    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2_id);
+    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2_id);
 
     // Pre-computed shard lookup tables — same LUT definitions as compute.cpp.
     constexpr auto shard_tiles_lut = moe_ring::make_shard_lut<Nt, num_cores>();
@@ -107,14 +124,17 @@ void kernel_main() {
     // constants needed for writing to combine sharded output
     constexpr uint32_t shard_offset_per_expert_bytes =
         token_expert_row_offset * combine_shard_width_tiles * tile_width_size_bytes;
-    cb_reserve_back(cb_s2c_in, 1);
-    const uint32_t output_base_l1_addr = get_write_ptr(cb_s2c_in);
-    cb_push_back(cb_s2c_in, 1);
+    cb_s2c_in.reserve_back(1);
+    const uint32_t output_base_l1_addr = cb_s2c_in.get_write_ptr();
+    cb_s2c_in.push_back(1);
     constexpr uint32_t source_width_tiles = Cfg::w2_tiles_per_expert_w;
     const uint32_t output_width_tiles_core = w2_shard_tiles_lut[ring_core_id];
     const uint32_t width_tile_base = w2_offset_lut[ring_core_id];
     constexpr uint32_t RING_CORES_PER_COMBINE_COL = num_cores / width_shard_dim;
     const uint32_t combine_core_x = ring_core_id / RING_CORES_PER_COMBINE_COL;
+    Semaphore<> combine_sem(matmul_combine_sync_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: raw L1 semaphore address used as the
+    // base for multicast destination addresses (safe_get_noc_addr below). #45003 item 4.
     const auto combine_semaphore_addr = get_semaphore(matmul_combine_sync_semaphore_id);
 
     //-------------------------------------------------------------------------
@@ -127,8 +147,9 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // Ring NoC setup
     //-------------------------------------------------------------------------
+    Semaphore<> ring_sem(ring_semaphore_id);
     uint32_t semaphore_addr = get_semaphore(ring_semaphore_id);
-    volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     const uint64_t neighbor_semaphore_noc_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, semaphore_addr);
 
@@ -144,7 +165,8 @@ void kernel_main() {
     constexpr uint32_t a2a_remainder_size = a2a_remainder_tiles * in2_tile_size;
 
     // Source and destination addresses for the all2all
-    const uint32_t local_base_addr = get_write_ptr(cb_s2c_in2);
+    const uint32_t local_base_addr = cb_s2c_in2.get_write_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     const uint64_t neighbor_base_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, local_base_addr);
 
@@ -160,8 +182,8 @@ void kernel_main() {
     //-------------------------------------------------------------------------
 
     // Receive number of tokens per expert from the tilize cores
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
-    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    metadata_ready_sem.wait_min(1);
 
     // Signal to the compute core that num_tokens_per_expert has arrived.
     // We also use this CB to transfer (from the writer to compute) 2 semaphore addresses:
@@ -169,16 +191,16 @@ void kernel_main() {
     // - 1: address of semaphore used to notify matmuls cores that tilized chunks have arrived
 
     // Read per-expert token counts from CB
-    const auto num_tokens_per_expert_addr = get_read_ptr(per_expert_total_tokens_cb_id);
+    const auto num_tokens_per_expert_addr = cb_per_expert_total_tokens.get_read_ptr();
     volatile tt_l1_ptr uint32_t* num_tokens_per_expert_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(num_tokens_per_expert_addr);
 
+    cb_w2c_md.reserve_back(2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_write_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_w2c_md));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_w2c_md.get_write_ptr());
     cb_w2c_md_write_ptr[0] = num_tokens_per_expert_addr;
     cb_w2c_md_write_ptr[1] = get_semaphore(matmul_chunk_ready_semaphore_id);
-    cb_reserve_back(cb_w2c_md, 2);
-    cb_push_back(cb_w2c_md, 2);
+    cb_w2c_md.push_back(2);
 
     // Precompute NUM_CHUNKS_PER_EXPERT
     uint32_t NUM_TOKENS_PER_EXPERT[num_experts];
@@ -190,6 +212,7 @@ void kernel_main() {
     }
 
     // Tilize core we signal to that tilize cores can send another chunk of tiles
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     uint64_t matmul_chunk_available_semaphore_noc_addr = get_noc_addr(
         tilize_drain_core_noc_x, tilize_drain_core_noc_y, get_semaphore(matmul_chunk_available_semaphore_id));
 
@@ -197,6 +220,8 @@ void kernel_main() {
     auto combine_semaphore_inc = [&](const uint32_t inc = 1) {
         for (uint32_t y = 0; y < height_shard_dim; ++y) {
             const uint32_t idx = combine_core_x + y * width_shard_dim;
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // (combine destination semaphore) cannot be wrapped by Semaphore<>::inc. #45003 item 4.
             const uint64_t dest_sem_noc_addr = safe_get_noc_addr(
                 output_shard_core_map[2 * idx],
                 output_shard_core_map[2 * idx + 1],
@@ -204,14 +229,13 @@ void kernel_main() {
                 /*noc_id=*/1);
             noc_semaphore_inc</*posted=*/true>(dest_sem_noc_addr, inc, /*noc_id=*/1, vchannel);
         };
-        noc_async_posted_writes_flushed(/*noc=*/1);
+        noc1_obj.async_writes_flushed<Noc::ResponseMode::POSTED>();
     };
 
     //-------------------------------------------------------------------------
     // Expert loop
     //-------------------------------------------------------------------------
     bool output_buffer_idx = 0;
-    auto* combine_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(combine_semaphore_addr);
     // both sections of the double buffer are initially free
     uint32_t combine_semaphore_val = 0;
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
@@ -228,11 +252,14 @@ void kernel_main() {
         // compute_only has no combine writer to coordinate with).
         if constexpr (!compute_only) {
             if (num_expert_chunks == 0) {
-                noc_semaphore_wait(combine_semaphore_ptr, combine_semaphore_val);
+                combine_sem.wait(combine_semaphore_val);
             }
         }
 
         for (uint32_t chunk = 0; chunk < num_expert_chunks; ++chunk) {
+            // Device 2.0 migration: legacy primitives retained: state-machine setup
+            // (noc_async_write_one_packet_set_state, noc_inline_dw_write_set_state) has no
+            // Device 2.0 wrappers. #45003 item 4.
             if constexpr (a2a_full_packets == 0 || a2a_remainder_tiles == 0) {
                 // Set only once here if there is only 1 type of packet: either all full with none partial, or none full
                 // with one partial
@@ -256,8 +283,8 @@ void kernel_main() {
 #endif
 
             // Wait for compute core to tell us that all mm01 data is ready
-            cb_wait_front(cb_c2w_rdy, 1);
-            cb_pop_front(cb_c2w_rdy, 1);
+            cb_c2w_rdy.wait_front(1);
+            cb_c2w_rdy.pop_front(1);
 
             // Take the data in cb_s2c_in2 and send it to the next core in the ring
             // Ring synchronization: all cores participate regardless of whether they had CB work
@@ -265,17 +292,18 @@ void kernel_main() {
                 for (uint32_t step = 0; step < num_a2a_steps_per_iter; ++step) {
                     if constexpr (a2a_full_packets > 0 && a2a_remainder_tiles > 0) {
                         // Resetting required as both full and partial packets exist
+                        // Device 2.0 migration: legacy primitive retained: state-machine setup
+                        // (noc_async_write_one_packet_set_state) has no Device 2.0 wrapper. #45003 item 4.
                         noc_async_write_one_packet_set_state</*posted=*/true>(
                             neighbor_base_addr, a2a_full_packet_size, /*noc=*/1, vchannel);
                     }
 
                     // Wait for current data to be ready in cb_s2c_in2
-                    while ((*my_semaphore_ptr) < semaphore_value) {
-                    };
+                    ring_sem.wait_min(semaphore_value);
 
                     // Signal to compute core that data is ready
-                    cb_reserve_back(cb_w2c_rdy, 1);
-                    cb_push_back(cb_w2c_rdy, 1);
+                    cb_w2c_rdy.reserve_back(1);
+                    cb_w2c_rdy.push_back(1);
 
                     // Write tiles from local cb_s2c_in2 to neighbor's cb_s2c_in2
                     // Double buffer offset: alternate between buffer 0 and buffer 1 based on step
@@ -285,6 +313,8 @@ void kernel_main() {
                     uint32_t pkt_offset = 0;
                     // Rely on compiler to remove loop if no full packet exists
                     for (uint32_t pkt = 0; pkt < a2a_full_packets; ++pkt) {
+                        // Device 2.0 migration: legacy primitive retained: paired with
+                        // noc_async_write_one_packet_set_state above. #45003 item 4.
                         noc_async_write_one_packet_with_state</*posted=*/true>(
                             local_src_addr + pkt_offset, neighbor_dst_addr + pkt_offset);
                         pkt_offset += a2a_full_packet_size;
@@ -293,24 +323,32 @@ void kernel_main() {
                         if constexpr (a2a_full_packets > 0) {
                             // Reset here if full packets exist, otherwise, it was already set once at the top and no
                             // reset required
+                            // Device 2.0 migration: legacy primitive retained: state-machine setup
+                            // (noc_async_write_one_packet_set_state) has no Device 2.0 wrapper. #45003 item 4.
                             noc_async_write_one_packet_set_state</*posted=*/true>(
                                 neighbor_base_addr, a2a_remainder_size, /*noc=*/1, vchannel);
                         }
+                        // Device 2.0 migration: legacy primitive retained: paired with
+                        // noc_async_write_one_packet_set_state above. #45003 item 4.
                         noc_async_write_one_packet_with_state</*posted=*/true>(
                             local_src_addr + pkt_offset, neighbor_dst_addr + pkt_offset);
                     }
 
                     // Signal neighbor that data is ready (increment their semaphore value).
-                    // Receiver waits via `while ((*my_semaphore_ptr) < semaphore_value)`; both
-                    // arches advance `semaphore_value` by 1 here, just by different mechanisms.
+                    // Receiver waits via Semaphore<>::wait_min(semaphore_value); both arches
+                    // advance `semaphore_value` by 1 here, just by different mechanisms.
 #if defined(ARCH_BLACKHOLE)
                     // BH-safe: noc_inline_dw_write_with_state to L1 hangs on BH
                     // (dataflow_api.h:2140,2181). Use atomic-increment pattern instead;
                     // receiver-side wait condition is value-equivalent.
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // (neighbor_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003 item 4.
                     noc_semaphore_inc</*posted=*/true>(neighbor_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, vchannel);
                     ++semaphore_value;
 #else
                     // WH: original stateful path.
+                    // Device 2.0 migration: legacy primitive retained: paired with
+                    // noc_inline_dw_write_set_state above. #45003 item 4.
                     noc_inline_dw_write_with_state<
                         /*update_addr_lo=*/false,
                         /*update_counter=*/true,
@@ -320,7 +358,7 @@ void kernel_main() {
 #endif
 
                     // Ensure writes have left the core before continuing
-                    noc_async_posted_writes_flushed(1);
+                    noc1_obj.async_writes_flushed<Noc::ResponseMode::POSTED>();
                 }
             }
 
@@ -329,9 +367,9 @@ void kernel_main() {
 
             const uint32_t num_tokens_block = std::min(tile_height, active_tokens - chunk * tile_height);
 
-            cb_wait_front(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.wait_front(num_w0_w1_tiles_h);
 
-            const uint32_t source_base_l1_addr = get_read_ptr(cb_c2s_out);
+            const uint32_t source_base_l1_addr = cb_c2s_out.get_read_ptr();
             const uint32_t elts_per_page = source_width_tiles * tile_width;
 
             while (width_tiles_to_send > 0) {
@@ -354,9 +392,9 @@ void kernel_main() {
                 // In compute_only there's no consumer to wait for, so we explicitly flush previous
                 // chunk's writes before reissuing set_state for this chunk.
                 if constexpr (compute_only) {
-                    noc_async_writes_flushed(/*noc=*/1);  // non-posted in compute_only; use NON-posted flush API
+                    noc1_obj.async_writes_flushed();  // non-posted in compute_only; use NON-posted flush API
                 } else if (chunk == 0) {
-                    noc_semaphore_wait(combine_semaphore_ptr, combine_semaphore_val);
+                    combine_sem.wait(combine_semaphore_val);
                 }
 
                 uint32_t dest_height_shard = dest_height_shard_start;
@@ -370,7 +408,11 @@ void kernel_main() {
                     const auto dest_noc_y =
                         output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard) + 1];
 
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // used as state-machine base. #45003 item 4.
                     const uint64_t dest_noc_addr_base = get_noc_addr(dest_noc_x, dest_noc_y, output_base_l1_addr, 1);
+                    // Device 2.0 migration: legacy primitive retained: state-machine setup
+                    // (noc_async_write_one_packet_set_state) has no Device 2.0 wrapper. #45003 item 4.
                     noc_async_write_one_packet_set_state</*posted=*/kPostedWrite>(
                         dest_noc_addr_base, width_transfer_bytes, /*noc=*/1, vchannel);
 
@@ -380,6 +422,8 @@ void kernel_main() {
                     const uint32_t source_l1_addr =
                         source_base_l1_addr + (bt * source_width_tiles + width_tiles_sent) * tile_width_size_bytes;
 
+                    // Device 2.0 migration: legacy primitive retained: paired with
+                    // noc_async_write_one_packet_set_state above. #45003 item 4.
                     noc_async_write_one_packet_with_state</*posted=*/kPostedWrite>(source_l1_addr, dest_l1_addr);
 
                     if (++shard_row == ((dest_height_shard < tokens_per_height_shard_rem)
@@ -403,13 +447,15 @@ void kernel_main() {
             // (kPostedWrite=false), so the posted-write counter is 0 -> posted-flush is a no-op
             // and cb_pop_front would race with in-flight reads -> source clobber.
             if constexpr (compute_only) {
-                noc_async_writes_flushed(/*noc=*/1);  // non-posted: flush issuer queue for non-posted writes
+                noc1_obj.async_writes_flushed();  // non-posted: flush issuer queue for non-posted writes
             } else {
-                noc_async_posted_writes_flushed(/*noc=*/1);  // production: original posted flush
+                noc1_obj.async_writes_flushed<Noc::ResponseMode::POSTED>();  // production: original posted flush
             }
-            cb_pop_front(cb_c2s_out, num_w0_w1_tiles_h);
+            cb_c2s_out.pop_front(num_w0_w1_tiles_h);
 
             // Signal to tilize cores that they can send another chunk of tiles
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // (matmul_chunk_available_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003 item 4.
             noc_semaphore_inc</*posted=*/true>(
                 matmul_chunk_available_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, /*vc=*/vchannel);
         }
@@ -426,11 +472,11 @@ void kernel_main() {
     if constexpr (compute_only) {
         // Non-posted matmul->combine writes need ACK-barrier (not just issuer-queue flush)
         // so destination L1 is committed before host reads matmul_output_tensor.
-        noc_async_write_barrier(/*noc=*/1);
+        noc1_obj.async_write_barrier();
     } else {
         // wait for combine to do its final semaphore increment before resetting. Otherwise, leads to hang.
-        noc_semaphore_wait(combine_semaphore_ptr, combine_semaphore_val);
-        noc_semaphore_set(combine_semaphore_ptr, 0);
-        noc_async_posted_writes_flushed(/*noc=*/1);
+        combine_sem.wait(combine_semaphore_val);
+        combine_sem.set(0);
+        noc1_obj.async_writes_flushed<Noc::ResponseMode::POSTED>();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_compute.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/cb_api.h"
 #include "api/compute/tilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 // Print a subset of a row-major bfloat16 buffer.
 // BufferWidth: total number of columns (elements) per row
@@ -109,12 +110,17 @@ void kernel_main() {
     // Constants
     constexpr uint32_t one_page = 1;
 
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_tilize_input(tilize_input_cb_id);
+    CircularBuffer cb_tilize_output(tilize_output_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+
     // Setup
     compute_kernel_hw_startup(tilize_input_cb_id, tilize_output_cb_id);
     fast_tilize_init(tilize_input_cb_id, tiles_per_local_chunk, tilize_output_cb_id);
 
     // Wait for writer to push total_chunks via CB
-    cb_wait_front(total_chunks_cb_id, one_page);
+    cb_total_chunks.wait_front(one_page);
 
     // Read total_chunks from the CB
     uint32_t total_chunks = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(total_chunks_cb_id, 0));
@@ -123,7 +129,7 @@ void kernel_main() {
     for (uint32_t chunk = 0; chunk < total_chunks; chunk++) {
         // Wait for reader to push tokens_per_chunk pages (row-major data)
         // Reader always reserves/pushes tokens_per_chunk for consistent synchronization
-        cb_wait_front(tilize_input_cb_id, tokens_per_chunk);
+        cb_tilize_input.wait_front(tokens_per_chunk);
 
         // DEBUG: Print subsets of input (row-major bfloat16)
         // Get CB address directly within UNPACK context (avoids mailbox sync issues with get_tile_address)
@@ -138,7 +144,7 @@ void kernel_main() {
 
         // we reserve the entire CB so that we treat it as single buffered
         // this is to allow us to gather into it before mcasting to the MM cores
-        cb_reserve_back(tilize_output_cb_id, shared_cb_num_pages);
+        cb_tilize_output.reserve_back(shared_cb_num_pages);
 
         fast_tilize_block(tilize_input_cb_id, tiles_per_local_chunk, tilize_output_cb_id);
 
@@ -150,12 +156,12 @@ void kernel_main() {
         //     // print_tile_rows(tilize_output_cb_id, tiles_per_local_chunk - 1, true, 0, 1, 0, 1);  // Last tile, 4x8
         // }));
 
-        cb_push_back(tilize_output_cb_id, shared_cb_num_pages);
+        cb_tilize_output.push_back(shared_cb_num_pages);
 
         // Pop input from reader (tokens_per_chunk pages)
-        cb_pop_front(tilize_input_cb_id, tokens_per_chunk);
+        cb_tilize_input.pop_front(tokens_per_chunk);
     }
 
     fast_tilize_uninit(tilize_input_cb_id, tilize_output_cb_id, tiles_per_local_chunk);
-    cb_pop_front(total_chunks_cb_id, one_page);
+    cb_total_chunks.pop_front(one_page);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
+#include "api/tensor/noc_traits.h"
 
 using namespace ttnn::operations::ccl::common;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
 using namespace ttnn::operations::ccl::common;
@@ -108,7 +111,7 @@ void print_tile_rows(
 //
 // Caller must call noc_async_read_barrier() before using the buffer.
 template <uint32_t selected_experts_k, uint32_t tokens, uint32_t experts_per_device, uint32_t l1_alignment>
-FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
+FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& cb) {
     constexpr uint32_t row_elements = 2 * experts_per_device + 1;
     constexpr uint32_t row_size_bytes_unaligned = row_elements * sizeof(uint32_t);
     // Align row size to l1_alignment for NOC transfer efficiency
@@ -118,7 +121,7 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
     // Minimum transfer size for maximum NOC throughput (~27.8 bytes/cycle)
     constexpr uint32_t MIN_EFFICIENT_BYTES = 512;
 
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t l1_write_addr = cb.get_write_ptr();
     volatile tt_l1_ptr uint32_t* buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
 
     // Write first row manually via L1 (~45 cycles for E=2)
@@ -134,6 +137,8 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         return;  // Only 1 token, nothing more to do
     }
 
+    // Device 2.0 migration: legacy primitive retained: get_noc_addr(local_l1_addr) is used to
+    // form a self-loopback NoC source for L1->L1 broadcast-doubling copies. #45003 item 4.
     uint64_t src_noc_addr = get_noc_addr(l1_write_addr);
     uint32_t rows_filled = 1;
 
@@ -156,8 +161,8 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         // Copy rows from start to current position
         uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
         uint32_t bytes_to_copy = rows_to_copy * aligned_row_size_bytes;
-        noc_async_read(src_noc_addr, dest_addr, bytes_to_copy);
-        noc_async_read_barrier();  // Must barrier before next doubling iteration
+        noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, bytes_to_copy);
+        noc.async_read_barrier();  // Must barrier before next doubling iteration
 
         rows_filled += rows_to_copy;
     }
@@ -170,7 +175,7 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         // Dispatch all full chunks in parallel
         while (rows_filled + chunk_rows <= tokens) {
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc_async_read(src_noc_addr, dest_addr, chunk_bytes);
+            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, chunk_bytes);
             rows_filled += chunk_rows;
         }
 
@@ -179,12 +184,12 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
             uint32_t remainder_rows = tokens - rows_filled;
             uint32_t remainder_bytes = remainder_rows * aligned_row_size_bytes;
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc_async_read(src_noc_addr, dest_addr, remainder_bytes);
+            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, remainder_bytes);
         }
     }
 
-    // Note: Caller must call noc_async_read_barrier() before using the buffer,
-    // then cb_push_back(cb_id, tokens) when ready to make data available.
+    // Note: Caller must call noc.async_read_barrier() before using the buffer,
+    // then cb.push_back(tokens) when ready to make data available.
 }
 
 // Debug print function for expert_activation buffer
@@ -192,14 +197,14 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
 // start_token/end_token allow printing a subset of rows
 template <uint32_t experts_per_device, uint32_t l1_alignment>
 FORCE_INLINE void print_expert_activation_buffer(
-    uint32_t cb_id, uint32_t start_token = 0, uint32_t end_token = 0xFFFFFFFF) {
+    CircularBuffer& cb, uint32_t start_token = 0, uint32_t end_token = 0xFFFFFFFF) {
     constexpr uint32_t row_elements = 2 * experts_per_device + 1;
     constexpr uint32_t row_size_bytes_unaligned = row_elements * sizeof(uint32_t);
     constexpr uint32_t aligned_row_size_bytes =
         ((row_size_bytes_unaligned + l1_alignment - 1) / l1_alignment) * l1_alignment;
     constexpr uint32_t aligned_row_elements = aligned_row_size_bytes / sizeof(uint32_t);
 
-    volatile tt_l1_ptr uint32_t* buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_id));
+    volatile tt_l1_ptr uint32_t* buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_read_ptr());
 
     DPRINT << "=== Expert Activation Buffer ===" << ENDL();
     DEVICE_PRINT("=== Expert Activation Buffer ===\n");
@@ -250,8 +255,8 @@ FORCE_INLINE void print_expert_activation_buffer(
 // Print the E-T buffer (Expert-Token buffer)
 // Format: E sections, each with up to T token IDs (16B aligned entries), terminated by -1
 template <uint32_t experts_per_device, uint32_t tokens, uint32_t entry_size>
-void print_e_t_buffer(uint32_t cb_id) {
-    uint32_t buffer_base = get_read_ptr(cb_id);
+void print_e_t_buffer(CircularBuffer& cb) {
+    uint32_t buffer_base = cb.get_read_ptr();
 
     DPRINT << "=== E-T Buffer (Expert -> Tokens) ===" << ENDL();
     DEVICE_PRINT("=== E-T Buffer (Expert -> Tokens) ===\n");
@@ -382,10 +387,35 @@ void kernel_main() {
     // kernels run on combine cores. Skip the metadata-ready signal to combine cores.
     constexpr bool compute_only = get_named_compile_time_arg_val("compute_only") == 1;
 
+    Semaphore<> partial_metadata_ready_sem(partial_metadata_ready_semaphore_id);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
+
+    // Device 2.0 migration: legacy primitives retained: these raw L1 semaphore addresses are
+    // used as bases for multicast destinations (set_multicast / get_safe_multicast_noc_addr /
+    // get_noc_addr) and for inter-core semaphore inc with precomposed uint64_t addresses.
+    // #45003 item 4.
     uint32_t partial_metadata_ready_semaphore_addr = get_semaphore(partial_metadata_ready_semaphore_id);
     uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
-    uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
     const uint32_t combine_sync_addr = get_semaphore(combine_sync_semaphore_id);
+
+    // Noc typed wrapper (reader uses default noc_index)
+    Noc noc_obj(noc_index);
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
+    CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
+    CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
+    CircularBuffer cb_tilize_input(tilize_input_cb_id);
+    CircularBuffer cb_e_t(e_t_cb_id);
+    CircularBuffer cb_expert_activation(expert_activation_cb_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+    CircularBuffer cb_brisc_e_t(brisc_e_t_cb_id);
+    CircularBuffer cb_brisc_expert_counts(brisc_expert_counts_cb_id);
+    CircularBuffer cb_brisc_expert_activation(brisc_expert_activation_cb_id);
+    CircularBuffer cb_brisc_activated_count(brisc_activated_count_cb_id);
+    CircularBuffer cb_remote_counts(remote_counts_cb_id);
 
     // Runtime arguments
     uint32_t rt_args_idx = 0;
@@ -465,15 +495,19 @@ void kernel_main() {
     // Read the mapping tensor page for this device (linearized_mesh_coord)
     // This gives us the expert -> device mapping from this device's perspective
     // Reserve all pages (tokens)
-    cb_reserve_back(mapping_tensor_cb_id, mapping_pages);
+    cb_mapping_tensor.reserve_back(mapping_pages);
     for (uint32_t i = 0; i < mapping_pages; i++) {
-        noc_async_read_page(
-            i, mapping_tensor_addr_gen, get_write_ptr(mapping_tensor_cb_id) + i * aligned_mapping_page_size);
+        noc_obj.async_read(
+            mapping_tensor_addr_gen,
+            cb_mapping_tensor,
+            aligned_mapping_page_size,
+            {.page_id = i},
+            {.offset_bytes = i * aligned_mapping_page_size});
     }
 
-    cb_reserve_back(expert_activation_cb_id, tokens);
+    cb_expert_activation.reserve_back(tokens);
     init_expert_activation_buffer_async<selected_experts_k, tokens, experts_per_device, l1_alignment>(
-        expert_activation_cb_id);
+        noc_obj, cb_expert_activation);
 
     // ========== NON-DRAIN CORES: Read indices/scores from drain core ==========
     // IMPORTANT: This must happen BEFORE pushing mapping_tensor_cb_id, since BRISC waits on that
@@ -486,8 +520,8 @@ void kernel_main() {
         uint32_t num_tokens_this_core = core_token_end - core_token_start;
 
         // Get local CB addresses (same relative address as drain core)
-        uint32_t local_indices_addr = get_read_ptr(indices_tensor_cb_id) + token_byte_offset_indices;
-        uint32_t local_scores_addr = get_write_ptr(scores_tensor_cb_id) + token_byte_offset_scores;
+        uint32_t local_indices_addr = cb_indices_tensor.get_read_ptr() + token_byte_offset_indices;
+        uint32_t local_scores_addr = cb_scores_tensor.get_write_ptr() + token_byte_offset_scores;
 
         // Calculate drain core's source addresses
         // Note: CB addresses are allocated at same L1 offset on all cores, so we use local get_read_ptr
@@ -498,24 +532,29 @@ void kernel_main() {
         // NOC read indices and scores for this core's token range
 
         if (num_tokens_this_core > 0) {
-            noc_async_read(
-                drain_indices_noc_addr, local_indices_addr, num_tokens_this_core * aligned_indices_page_size);
-            noc_async_read(drain_scores_noc_addr, local_scores_addr, num_tokens_this_core * aligned_scores_page_size);
+            noc_obj.async_read(
+                drain_indices_noc_addr,
+                {.offset_bytes = local_indices_addr},
+                num_tokens_this_core * aligned_indices_page_size);
+            noc_obj.async_read(
+                drain_scores_noc_addr,
+                {.offset_bytes = local_scores_addr},
+                num_tokens_this_core * aligned_scores_page_size);
         }
     }
 
     // Wait for all reads to complete (mapping + indices/scores for non-drain)
-    noc_async_read_barrier();
+    noc_obj.async_read_barrier();
 
     // Now safe to signal BRISC - all data is in place
-    cb_push_back(mapping_tensor_cb_id, mapping_pages);
-    cb_push_back(expert_activation_cb_id, tokens);
+    cb_mapping_tensor.push_back(mapping_pages);
+    cb_expert_activation.push_back(tokens);
 
-    // DEBUG: print_expert_activation_buffer<experts_per_device, l1_alignment>(expert_activation_cb_id, 0, tokens);
+    // DEBUG: print_expert_activation_buffer<experts_per_device, l1_alignment>(cb_expert_activation, 0, tokens);
 
     // Get pointer to the mapping data
     uint16_t* expert_to_device_map = reinterpret_cast<uint16_t*>(
-        get_read_ptr(mapping_tensor_cb_id) + linearized_mesh_coord * aligned_mapping_page_size);
+        cb_mapping_tensor.get_read_ptr() + linearized_mesh_coord * aligned_mapping_page_size);
     uint16_t local_expert_ids[experts_per_device];
     uint32_t local_expert_count = 0;
     for (uint32_t i = 0; i < experts; i++) {
@@ -538,8 +577,8 @@ void kernel_main() {
     }
 
     // Pre-compute base addresses (avoid repeated calls in hot loop)
-    const uint32_t mapping_base = get_read_ptr(mapping_tensor_cb_id);
-    const uint32_t e_t_buffer_base = get_write_ptr(e_t_cb_id);
+    const uint32_t mapping_base = cb_mapping_tensor.get_read_ptr();
+    const uint32_t e_t_buffer_base = cb_e_t.get_write_ptr();
 
     // Array to hold per-expert token counts (filled by all cores now)
     uint32_t num_activated_tokens_per_expert[experts_per_device] = {0};
@@ -555,9 +594,9 @@ void kernel_main() {
     // indices/scores are in CB - drain has shard, non-drain read via NOC in Step 2
     uint32_t num_activated_tokens = 0;
 
-    const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
-    const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
-    const uint32_t expert_activation_base = get_write_ptr(expert_activation_cb_id);
+    const uint32_t indices_base = cb_indices_tensor.get_read_ptr();
+    const uint32_t scores_base = cb_scores_tensor.get_read_ptr();
+    const uint32_t expert_activation_base = cb_expert_activation.get_write_ptr();
 
     // Cache source_device_mapping - only changes every tokens_per_device tokens
     // Reduces mapping loads from 512 to 16 (dispatch_devices)
@@ -630,20 +669,20 @@ void kernel_main() {
 
     // ========== ALL CORES: WAIT FOR BRISC AND MERGE ==========
     // Wait for BRISC to finish processing second half and push its counts
-    cb_wait_front(brisc_expert_counts_cb_id, one_page);
+    cb_brisc_expert_counts.wait_front(one_page);
     volatile tt_l1_ptr uint32_t* brisc_counts =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(brisc_expert_counts_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_brisc_expert_counts.get_read_ptr());
 
     // Wait for BRISC's e_t buffer to be ready
-    cb_wait_front(brisc_e_t_cb_id, one_page);
-    const uint32_t brisc_e_t_buffer_base = get_read_ptr(brisc_e_t_cb_id);
+    cb_brisc_e_t.wait_front(one_page);
+    const uint32_t brisc_e_t_buffer_base = cb_brisc_e_t.get_read_ptr();
 
     // Wait for BRISC's expert_activation buffer and count
-    cb_wait_front(brisc_activated_count_cb_id, one_page);
+    cb_brisc_activated_count.wait_front(one_page);
     uint32_t brisc_activated_count =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(brisc_activated_count_cb_id));
-    cb_wait_front(brisc_expert_activation_cb_id, one_page);
-    const uint32_t brisc_expert_activation_base = get_read_ptr(brisc_expert_activation_cb_id);
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_brisc_activated_count.get_read_ptr());
+    cb_brisc_expert_activation.wait_front(one_page);
+    const uint32_t brisc_expert_activation_base = cb_brisc_expert_activation.get_read_ptr();
 
     // Merge BRISC's e_t buffer entries into main e_t buffer using NOC DMA
     // For each expert: copy BRISC's tokens after NCRISC's tokens
@@ -659,8 +698,10 @@ void kernel_main() {
             uint32_t e_t_dst_addr = e_t_buffer_base + (e * (tokens + 1) + ncrisc_count) * e_t_entry_size;
 
             // Use NOC DMA for L1-to-L1 copy (local loopback)
+            // Device 2.0 migration: legacy primitive retained: get_noc_addr(local_l1_addr) is used
+            // to form a self-loopback NoC source for local L1->L1 copy. #45003 item 4.
             uint64_t src_noc_addr = get_noc_addr(brisc_e_t_src_addr);
-            noc_async_read(src_noc_addr, e_t_dst_addr, brisc_count * e_t_entry_size);
+            noc_obj.async_read(src_noc_addr, {.offset_bytes = e_t_dst_addr}, brisc_count * e_t_entry_size);
         }
 
         // Update total count for this expert
@@ -672,24 +713,26 @@ void kernel_main() {
     if (brisc_activated_count > 0) {
         uint32_t expert_activation_dst_addr =
             expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
+        // Device 2.0 migration: legacy primitive retained: get_noc_addr(local_l1_addr) is used
+        // to form a self-loopback NoC source for local L1->L1 copy. #45003 item 4.
         uint64_t brisc_activation_src_noc_addr = get_noc_addr(brisc_expert_activation_base);
-        noc_async_read(
+        noc_obj.async_read(
             brisc_activation_src_noc_addr,
-            expert_activation_dst_addr,
+            {.offset_bytes = expert_activation_dst_addr},
             brisc_activated_count * aligned_activation_row_bytes);
     }
 
     // Wait for all NOC DMA copies to complete
-    noc_async_read_barrier();
+    noc_obj.async_read_barrier();
 
     // Update total activated token count to include BRISC's tokens
     num_activated_tokens += brisc_activated_count;
 
     // Pop BRISC's CBs (cleanup)
-    cb_pop_front(brisc_expert_counts_cb_id, one_page);
-    cb_pop_front(brisc_e_t_cb_id, one_page);
-    cb_pop_front(brisc_expert_activation_cb_id, one_page);
-    cb_pop_front(brisc_activated_count_cb_id, one_page);
+    cb_brisc_expert_counts.pop_front(one_page);
+    cb_brisc_e_t.pop_front(one_page);
+    cb_brisc_expert_activation.pop_front(one_page);
+    cb_brisc_activated_count.pop_front(one_page);
 
     // ========== CROSS-CORE CONSOLIDATION (Steps 4-6) ==========
     // Non-drain cores: send counts to drain and wait for consolidated buffer
@@ -698,13 +741,11 @@ void kernel_main() {
         // ========== Step 5: Drain receives counts from non-drain cores and consolidates ==========
         if (num_tilize_cores > 1) {
             // Wait for all non-drain cores to send their counts
-            noc_semaphore_wait(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(partial_metadata_ready_semaphore_addr),
-                num_tilize_cores - 1);
+            partial_metadata_ready_sem.wait(num_tilize_cores - 1);
 
             // Read counts from each non-drain core and consolidate their buffers
             // tilize_noc_x and tilize_noc_y arrays were populated from runtime args earlier
-            const uint32_t remote_counts_base = get_read_ptr(remote_counts_cb_id);
+            const uint32_t remote_counts_base = cb_remote_counts.get_read_ptr();
 
             for (uint32_t core_idx = 1; core_idx < num_tilize_cores; core_idx++) {
                 // Read this core's counts from remote_counts_cb
@@ -727,14 +768,15 @@ void kernel_main() {
                     uint32_t remote_count = remote_e_t_counts[e];
                     if (remote_count > 0) {
                         // Source: remote core's e_t buffer, expert e's section starts at 0
-                        uint32_t remote_e_t_addr = get_write_ptr(e_t_cb_id) + e * (tokens + 1) * e_t_entry_size;
+                        uint32_t remote_e_t_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
                         uint64_t remote_e_t_noc_addr = get_noc_addr(remote_noc_x, remote_noc_y, remote_e_t_addr);
 
                         // Destination: drain's e_t buffer, after current entries for this expert
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
+                        noc_obj.async_read(
+                            remote_e_t_noc_addr, {.offset_bytes = local_e_t_dst}, remote_count * e_t_entry_size);
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -744,7 +786,7 @@ void kernel_main() {
                 // Pull this core's expert_activation buffer rows
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
-                    uint32_t remote_activation_addr = get_write_ptr(expert_activation_cb_id);
+                    uint32_t remote_activation_addr = cb_expert_activation.get_write_ptr();
                     uint64_t remote_activation_noc_addr =
                         get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 
@@ -752,9 +794,9 @@ void kernel_main() {
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    noc_async_read(
+                    noc_obj.async_read(
                         remote_activation_noc_addr,
-                        local_activation_dst,
+                        {.offset_bytes = local_activation_dst},
                         remote_activated_count * aligned_activation_row_bytes);
 
                     // Update drain's total activated count
@@ -763,49 +805,50 @@ void kernel_main() {
             }
 
             // Wait for all consolidation reads to complete
-            noc_async_read_barrier();
+            noc_obj.async_read_barrier();
         }
 
         // cap off e_t buffer with -1 (now includes merged counts, 16B aligned entries)
         for (uint32_t e = 0; e < experts_per_device; e++) {
-            uint32_t e_t_buffer_addr = get_write_ptr(e_t_cb_id) + e * (tokens + 1) * e_t_entry_size;
+            uint32_t e_t_buffer_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
             uint32_t* e_t_sentinel_ptr =
                 reinterpret_cast<uint32_t*>(e_t_buffer_addr + num_activated_tokens_per_expert[e] * e_t_entry_size);
             *e_t_sentinel_ptr = static_cast<uint32_t>(-1);
         }
 
         // Push per-expert token counts to CB for writer to read
-        cb_reserve_back(per_expert_total_tokens_cb_id, 1);
-        uint32_t* per_expert_counts_ptr = reinterpret_cast<uint32_t*>(get_write_ptr(per_expert_total_tokens_cb_id));
+        cb_per_expert_total_tokens.reserve_back(1);
+        uint32_t* per_expert_counts_ptr = reinterpret_cast<uint32_t*>(cb_per_expert_total_tokens.get_write_ptr());
         for (uint32_t e = 0; e < experts_per_device; e++) {
             per_expert_counts_ptr[e] = num_activated_tokens_per_expert[e];
         }
-        cb_push_back(per_expert_total_tokens_cb_id, 1);
+        cb_per_expert_total_tokens.push_back(1);
 
-        cb_reserve_back(total_chunks_cb_id, one_page);
+        cb_total_chunks.reserve_back(one_page);
         uint32_t total_chunks = 0;
         for (uint32_t e = 0; e < experts_per_device; e++) {
             total_chunks += (num_activated_tokens_per_expert[e] + tokens_per_chunk - 1) / tokens_per_chunk;
         }
-        *reinterpret_cast<uint32_t*>(get_write_ptr(total_chunks_cb_id)) = total_chunks;
-        cb_push_back(total_chunks_cb_id, one_page);
+        *reinterpret_cast<uint32_t*>(cb_total_chunks.get_write_ptr()) = total_chunks;
+        cb_total_chunks.push_back(one_page);
 
         // ========== Write expert_activation buffer to DRAM ==========
         // Write to DRAM: activated rows (num_activated_tokens) rows
         uint32_t expert_activation_write_size = num_activated_tokens * aligned_activation_row_bytes;
         uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
         if (num_activated_tokens > 0) {
-            noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
+            noc_obj.async_write(
+                {.offset_bytes = expert_activation_base}, expert_activation_dram_addr, expert_activation_write_size);
         }
         // Barrier for this write is at the very end of the kernel
 
-        // DEBUG: print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(e_t_cb_id);
+        // DEBUG: print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(cb_e_t);
 
         // Multicast e_t buffer, per_expert_counts, and total_chunks to non-drain-sync cores
         if (num_tilize_cores > 1) {
-            uint32_t e_t_cb_read_ptr = get_read_ptr(e_t_cb_id);
-            uint32_t per_expert_total_tokens_cb_read_ptr = get_read_ptr(per_expert_total_tokens_cb_id);
-            uint32_t total_chunks_cb_read_ptr = get_read_ptr(total_chunks_cb_id);
+            uint32_t e_t_cb_read_ptr = cb_e_t.get_read_ptr();
+            uint32_t per_expert_total_tokens_cb_read_ptr = cb_per_expert_total_tokens.get_read_ptr();
+            uint32_t total_chunks_cb_read_ptr = cb_total_chunks.get_read_ptr();
 
             uint64_t e_t_mcast_addr = get_safe_multicast_noc_addr(
                 tilize_mcast_start_x, tilize_mcast_start_y, tilize_mcast_end_x, tilize_mcast_end_y, e_t_cb_read_ptr);
@@ -825,10 +868,14 @@ void kernel_main() {
                 total_chunks_cb_read_ptr);
 
             // Multicast e_t buffer to all tilize cores
+            // Device 2.0 migration: legacy primitive retained: noc_async_write_multicast is invoked
+            // with precomposed uint64_t multicast destination address; Noc::async_write_multicast does
+            // not take a raw uint64_t multicast destination. #45003 item 4.
             noc_async_write_multicast(
                 e_t_cb_read_ptr, e_t_mcast_addr, e_t_buffer_total_size, tilize_bounding_box_num_cores - 1);
 
             // Multicast per_expert_counts to all tilize cores
+            // Device 2.0 migration: legacy primitive retained: see above. #45003 item 4.
             noc_async_write_multicast(
                 per_expert_total_tokens_cb_read_ptr,
                 per_expert_counts_mcast_addr,
@@ -836,12 +883,13 @@ void kernel_main() {
                 tilize_bounding_box_num_cores - 1);
 
             // Multicast total_chunks to all tilize cores
+            // Device 2.0 migration: legacy primitive retained: see above. #45003 item 4.
             noc_async_write_multicast(
                 total_chunks_cb_read_ptr, total_chunks_mcast_addr, sizeof(uint32_t), tilize_bounding_box_num_cores - 1);
 
             // Signal non-drain cores via semaphore multicast
             // First, set the local semaphore to 1 - this is the value that will be multicast
-            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+            metadata_ready_sem.set(1);
 
             uint64_t semaphore_mcast_addr = get_safe_multicast_noc_addr(
                 tilize_mcast_start_x,
@@ -852,15 +900,18 @@ void kernel_main() {
 
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
 
             // Multicast the value 1 to all non-drain tilize cores
+            // Device 2.0 migration: legacy primitive retained: multicast loopback semaphore set with
+            // precomposed uint64_t multicast destination (get_safe_multicast_noc_addr) and raw local
+            // sem address as source. #45003 item 4.
             noc_semaphore_set_multicast(
                 metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
         }
 
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
 
         // Multicast the per-expert token counts to ALL worker cores (tilize + matmul + combine)
         // this might be overkill, only matmul and combine need this right now but we can just do one big MC
@@ -869,19 +920,21 @@ void kernel_main() {
             all_worker_cores_mcast_start_y,
             all_worker_cores_mcast_end_x,
             all_worker_cores_mcast_end_y,
-            get_read_ptr(per_expert_total_tokens_cb_id));
+            cb_per_expert_total_tokens.get_read_ptr());
 
+        // Device 2.0 migration: legacy primitive retained: noc_async_write_multicast with precomposed
+        // uint64_t multicast destination. #45003 item 4.
         noc_async_write_multicast(
-            get_read_ptr(per_expert_total_tokens_cb_id),
+            cb_per_expert_total_tokens.get_read_ptr(),
             all_worker_cores_expert_counts_mcast_addr,
             per_expert_total_tokens_output_page_size,
             all_worker_cores_bounding_box_num_cores - 1);  // Exclude self
 
         // Ensure multicast completes before signaling semaphore
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
 
         // Signal readiness via semaphore
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+        metadata_ready_sem.set(1);
 
         // get mcast address for semaphore
         uint64_t matmul_metadata_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
@@ -892,6 +945,8 @@ void kernel_main() {
             metadata_ready_semaphore_addr);
 
         // multicast semaphore
+        // Device 2.0 migration: legacy primitive retained: multicast loopback semaphore set with
+        // precomposed uint64_t multicast destination. #45003 item 4.
         noc_semaphore_set_multicast(
             metadata_ready_semaphore_addr, matmul_metadata_ready_semaphore_mcast_addr, matmul_bounding_box_num_cores);
     }  // End of is_drain_tilize_core block
@@ -906,7 +961,7 @@ void kernel_main() {
         uint32_t remote_counts_offset = (tilize_core_idx - 1) * remote_counts_entry_size;
 
         // Get drain core's remote_counts_cb address
-        uint32_t local_counts_addr = get_read_ptr(remote_counts_cb_id);
+        uint32_t local_counts_addr = cb_remote_counts.get_read_ptr();
         uint64_t drain_counts_noc_addr =
             get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_counts_addr + remote_counts_offset);
 
@@ -918,58 +973,66 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
-        noc_async_write_barrier();
+        noc_obj.async_write({.offset_bytes = local_counts_addr}, drain_counts_noc_addr, remote_counts_entry_size);
+        noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address cannot
+        // be wrapped by Semaphore<>::inc which binds to a per-program id. #45003 item 4.
         uint64_t drain_semaphore_noc_addr =
             get_noc_addr(drain_core_noc_x, drain_core_noc_y, partial_metadata_ready_semaphore_addr);
         noc_semaphore_inc(drain_semaphore_noc_addr, 1);
 
         // ========== NON-DRAIN tilize CORE: Wait for drain core to multicast data ==========
         // Wait for the semaphore signal from drain core
-        noc_semaphore_wait(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+        metadata_ready_sem.wait(1);
 
         // Read per-expert counts from the CB (multicast by drain core)
         // The data was written directly to our CB by the multicast
         volatile tt_l1_ptr uint32_t* per_expert_counts =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
         for (uint32_t e = 0; e < experts_per_device; e++) {
             num_activated_tokens_per_expert[e] = per_expert_counts[e];
         }
 
         // Push per_expert_total_tokens_cb and total_chunks_cb so writer can read them
         // (drain core already pushed, non-drain cores need to mark as available)
-        cb_reserve_back(per_expert_total_tokens_cb_id, 1);
-        cb_push_back(per_expert_total_tokens_cb_id, 1);
-        cb_reserve_back(total_chunks_cb_id, one_page);
-        cb_push_back(total_chunks_cb_id, one_page);
+        cb_per_expert_total_tokens.reserve_back(1);
+        cb_per_expert_total_tokens.push_back(1);
+        cb_total_chunks.reserve_back(one_page);
+        cb_total_chunks.push_back(one_page);
     }
 
     if (is_drain_tilize_core) {
         // write out e_t_output_tensor
-        uint32_t l1_read_addr = get_read_ptr(e_t_cb_id);
         for (uint32_t e = 0; e < experts_per_device; ++e) {
-            noc_async_write_page(e, e_t_output_tensor_addr_gen, l1_read_addr);
-            l1_read_addr += e_t_output_page_size;
+            noc_obj.async_write(
+                cb_e_t,
+                e_t_output_tensor_addr_gen,
+                e_t_output_page_size,
+                {.offset_bytes = e * e_t_output_page_size},
+                {.page_id = e});
         }
 
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
 
         // signal to A2A combine that metadata is available. Separate signal from matmul because e_t write is also
         // needed. Skipped in compute_only mode (no combine kernels listening).
         if constexpr (!compute_only) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // (combine_sync target on a different core) cannot be wrapped by Semaphore<>::inc which
+            // binds to a per-program id. #45003 item 4.
             const uint64_t combine_sync_noc_addr =
                 safe_get_noc_addr(combine_sync_noc_x, combine_sync_noc_y, combine_sync_addr, 1);
             noc_semaphore_inc(combine_sync_noc_addr, 1);
 
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 
     // DEBUG
-    // print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(e_t_cb_id);
-    // print_expert_activation_buffer<experts_per_device, l1_alignment>(expert_activation_cb_id, 0,
+    // print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(cb_e_t);
+    // print_expert_activation_buffer<experts_per_device, l1_alignment>(cb_expert_activation, 0,
     // std::max(num_activated_tokens_per_expert[0], num_activated_tokens_per_expert[1]));
 
     // ========== ALL CORES: Read activated tokens from sparse buffer and pack into tilize input CB ==========
@@ -983,20 +1046,22 @@ void kernel_main() {
         for (uint32_t chunk_start = 0; chunk_start < num_tokens; chunk_start += tokens_per_chunk) {
             uint32_t tokens_in_chunk = std::min(tokens_per_chunk, num_tokens - chunk_start);
 
-            cb_reserve_back(tilize_input_cb_id, tokens_per_chunk);
+            cb_tilize_input.reserve_back(tokens_per_chunk);
 
             // Read each activated token from the sparse input buffer
             for (uint32_t i = 0; i < tokens_in_chunk; i++) {
                 // Get sparse token ID from e_t buffer (16B aligned entries)
                 uint32_t token_id = *reinterpret_cast<uint32_t*>(e_t_expert_addr + (chunk_start + i) * e_t_entry_size);
                 // read the token from the input tensor at the tilize subtoken offset and size
-                noc_async_read(
-                    get_noc_addr(token_id, input_tensor_addr_gen) + global_subtoken_offset,
-                    get_write_ptr(tilize_input_cb_id) + i * subtoken_size,
-                    subtoken_size);
+                noc_obj.async_read(
+                    input_tensor_addr_gen,
+                    cb_tilize_input,
+                    subtoken_size,
+                    {.page_id = token_id, .offset_bytes = global_subtoken_offset},
+                    {.offset_bytes = i * subtoken_size});
             }
-            noc_async_read_barrier();
-            cb_push_back(tilize_input_cb_id, tokens_per_chunk);  // Push full chunk (padding is garbage, that's OK)
+            noc_obj.async_read_barrier();
+            cb_tilize_input.push_back(tokens_per_chunk);  // Push full chunk (padding is garbage, that's OK)
             num_chunks_sent++;
 
             // Wait until previous chunk arrives on the matmul cores before reading in another chunk of tokens.
@@ -1005,8 +1070,7 @@ void kernel_main() {
             // idle during mcast. The very last wait is technically redundant since we won't be reading in another chunk
             // of tokens, however it's still required so we don't use NoC1 to write out the output tensors until the
             // last linked mcast completes.
-            noc_semaphore_wait(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(previous_chunk_sent_semaphore_addr), num_chunks_sent);
+            previous_chunk_sent_sem.wait(num_chunks_sent);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -162,7 +162,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
         // Copy rows from start to current position
         uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
         uint32_t bytes_to_copy = rows_to_copy * aligned_row_size_bytes;
-        noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, bytes_to_copy);
+        // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+        // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+        noc_async_read(src_noc_addr, dest_addr, bytes_to_copy);
         noc.async_read_barrier();  // Must barrier before next doubling iteration
 
         rows_filled += rows_to_copy;
@@ -176,7 +178,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
         // Dispatch all full chunks in parallel
         while (rows_filled + chunk_rows <= tokens) {
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, chunk_bytes);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+            noc_async_read(src_noc_addr, dest_addr, chunk_bytes);
             rows_filled += chunk_rows;
         }
 
@@ -185,7 +189,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
             uint32_t remainder_rows = tokens - rows_filled;
             uint32_t remainder_bytes = remainder_rows * aligned_row_size_bytes;
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, remainder_bytes);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+            noc_async_read(src_noc_addr, dest_addr, remainder_bytes);
         }
     }
 
@@ -533,14 +539,13 @@ void kernel_main() {
         // NOC read indices and scores for this core's token range
 
         if (num_tokens_this_core > 0) {
-            noc_obj.async_read(
-                drain_indices_noc_addr,
-                {.offset_bytes = local_indices_addr},
-                num_tokens_this_core * aligned_indices_page_size);
-            noc_obj.async_read(
-                drain_scores_noc_addr,
-                {.offset_bytes = local_scores_addr},
-                num_tokens_this_core * aligned_scores_page_size);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+            noc_async_read(
+                drain_indices_noc_addr, local_indices_addr, num_tokens_this_core * aligned_indices_page_size);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+            noc_async_read(drain_scores_noc_addr, local_scores_addr, num_tokens_this_core * aligned_scores_page_size);
         }
     }
 
@@ -702,7 +707,7 @@ void kernel_main() {
             // Device 2.0 migration: legacy primitive retained: get_noc_addr(local_l1_addr) is used
             // to form a self-loopback NoC source for local L1->L1 copy. #45003 item 4.
             uint64_t src_noc_addr = get_noc_addr(brisc_e_t_src_addr);
-            noc_obj.async_read(src_noc_addr, {.offset_bytes = e_t_dst_addr}, brisc_count * e_t_entry_size);
+            noc_async_read(src_noc_addr, e_t_dst_addr, brisc_count * e_t_entry_size);
         }
 
         // Update total count for this expert
@@ -717,9 +722,9 @@ void kernel_main() {
         // Device 2.0 migration: legacy primitive retained: get_noc_addr(local_l1_addr) is used
         // to form a self-loopback NoC source for local L1->L1 copy. #45003 item 4.
         uint64_t brisc_activation_src_noc_addr = get_noc_addr(brisc_expert_activation_base);
-        noc_obj.async_read(
+        noc_async_read(
             brisc_activation_src_noc_addr,
-            {.offset_bytes = expert_activation_dst_addr},
+            expert_activation_dst_addr,
             brisc_activated_count * aligned_activation_row_bytes);
     }
 
@@ -776,8 +781,9 @@ void kernel_main() {
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        noc_obj.async_read(
-                            remote_e_t_noc_addr, {.offset_bytes = local_e_t_dst}, remote_count * e_t_entry_size);
+                        // Device 2.0 migration: legacy primitive retained: src is a precomposed
+                        // uint64_t cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -795,9 +801,11 @@ void kernel_main() {
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    noc_obj.async_read(
+                    // Device 2.0 migration: legacy primitive retained: src is a precomposed
+                    // uint64_t cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+                    noc_async_read(
                         remote_activation_noc_addr,
-                        {.offset_bytes = local_activation_dst},
+                        local_activation_dst,
                         remote_activated_count * aligned_activation_row_bytes);
 
                     // Update drain's total activated count
@@ -838,8 +846,9 @@ void kernel_main() {
         uint32_t expert_activation_write_size = num_activated_tokens * aligned_activation_row_bytes;
         uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
         if (num_activated_tokens > 0) {
-            noc_obj.async_write(
-                {.offset_bytes = expert_activation_base}, expert_activation_dram_addr, expert_activation_write_size);
+            // Device 2.0 migration: legacy primitive retained: dst is a precomposed uint64_t DRAM
+            // NoC address from get_noc_addr(0, accessor). #45003 item 4.
+            noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
         }
         // Barrier for this write is at the very end of the kernel
 
@@ -974,7 +983,9 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        noc_obj.async_write({.offset_bytes = local_counts_addr}, drain_counts_noc_addr, remote_counts_entry_size);
+        // Device 2.0 migration: legacy primitive retained: dst is a precomposed uint64_t
+        // cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
 using namespace ttnn::operations::ccl::common;
@@ -27,14 +30,15 @@ FORCE_INLINE uint64_t get_safe_multicast_noc_addr(
 }
 
 FORCE_INLINE void noc_async_write_linked_multicast(
-    uint32_t src_local_l1_addr, uint64_t dst_noc_addr_multicast, uint32_t size, uint32_t num_dests, uint8_t noc) {
+    Noc& noc, uint32_t src_local_l1_addr, uint64_t dst_noc_addr_multicast, uint32_t size, uint32_t num_dests) {
     while (size > NOC_MAX_BURST_SIZE) {
-        noc_async_write_multicast(src_local_l1_addr, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true, noc);
+        noc.async_write_multicast(
+            {.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true);
         src_local_l1_addr += NOC_MAX_BURST_SIZE;
         dst_noc_addr_multicast += NOC_MAX_BURST_SIZE;
         size -= NOC_MAX_BURST_SIZE;
     }
-    noc_async_write_multicast(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, false, noc);
+    noc.async_write_multicast({.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, size, num_dests, false);
 }
 
 void print_tile_rows(
@@ -190,11 +194,36 @@ void kernel_main() {
         get_named_compile_time_arg_val("previous_chunk_sent_semaphore_id");
     constexpr uint32_t initial_gather_semaphore_id = get_named_compile_time_arg_val("initial_gather_semaphore_id");
 
+    Semaphore<> matmul_chunk_available_sem(matmul_chunk_available_semaphore_id);
+    Semaphore<> tilize_chunk_ready_sem(tilize_chunk_ready_semaphore_id);
+    Semaphore<> matmul_chunk_ready_sem(matmul_chunk_ready_semaphore_id);
+    Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
+    Semaphore<> initial_gather_sem(initial_gather_semaphore_id);
+
+    // Device 2.0 migration: legacy primitives retained: these raw L1 semaphore addresses are
+    // used as bases for multicast destinations (set_multicast / get_safe_multicast_noc_addr /
+    // get_noc_addr) and for direct noc_semaphore_set with the legacy address-taking overload.
+    // #45003 item 4.
     uint32_t matmul_chunk_available_semaphore_addr = get_semaphore(matmul_chunk_available_semaphore_id);
     uint32_t tilize_chunk_ready_semaphore_addr = get_semaphore(tilize_chunk_ready_semaphore_id);
     uint32_t matmul_chunk_ready_semaphore_addr = get_semaphore(matmul_chunk_ready_semaphore_id);
-    uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
     uint32_t initial_gather_semaphore_addr = get_semaphore(initial_gather_semaphore_id);
+
+    // Noc typed wrappers
+    Noc noc_obj(noc_index);
+    Noc noc_alt_obj(1 - noc_index);
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_tilize_output(tilize_output_cb_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+    CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
+    CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
+    CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
+    CircularBuffer cb_brisc_e_t(brisc_e_t_cb_id);
+    CircularBuffer cb_brisc_expert_counts(brisc_expert_counts_cb_id);
+    CircularBuffer cb_brisc_expert_activation(brisc_expert_activation_cb_id);
+    CircularBuffer cb_brisc_activated_count(brisc_activated_count_cb_id);
 
     // Runtime arguments
     uint32_t rt_args_idx = 0;
@@ -257,10 +286,10 @@ void kernel_main() {
     uint32_t brisc_tokens_capacity = tokens_this_core / 2;
 
     // Wait for NCRISC to finish reading the mapping tensor
-    cb_wait_front(mapping_tensor_cb_id, num_devices);
+    cb_mapping_tensor.wait_front(num_devices);
 
     // Get mapping base pointer (read by NCRISC)
-    const uint32_t mapping_base = get_read_ptr(mapping_tensor_cb_id);
+    const uint32_t mapping_base = cb_mapping_tensor.get_read_ptr();
 
     // Build local_expert_ids array - experts that map to this device
     uint16_t* expert_to_device_map =
@@ -278,12 +307,12 @@ void kernel_main() {
     }
 
     // Reserve BRISC's e_t buffer (single page contains all experts' token lists)
-    cb_reserve_back(brisc_e_t_cb_id, one_page);
-    const uint32_t brisc_e_t_buffer_base = get_write_ptr(brisc_e_t_cb_id);
+    cb_brisc_e_t.reserve_back(one_page);
+    const uint32_t brisc_e_t_buffer_base = cb_brisc_e_t.get_write_ptr();
 
     // Reserve BRISC's expert_activation buffer (single page contains all activation rows)
-    cb_reserve_back(brisc_expert_activation_cb_id, one_page);
-    const uint32_t brisc_expert_activation_base = get_write_ptr(brisc_expert_activation_cb_id);
+    cb_brisc_expert_activation.reserve_back(one_page);
+    const uint32_t brisc_expert_activation_base = cb_brisc_expert_activation.get_write_ptr();
 
     // Initialize BRISC's expert_activation buffer with sentinel values (selected_experts_k)
     for (uint32_t row = 0; row < brisc_tokens_capacity; row++) {
@@ -297,8 +326,8 @@ void kernel_main() {
     }
 
     // Indices and scores accessible via CB (drain has shard, non-drain read via NOC in reader)
-    const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
-    const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
+    const uint32_t indices_base = cb_indices_tensor.get_read_ptr();
+    const uint32_t scores_base = cb_scores_tensor.get_read_ptr();
 
     // Per-expert token counts for BRISC's half
     uint32_t brisc_num_tokens_per_expert[experts_per_device] = {0};
@@ -371,28 +400,28 @@ void kernel_main() {
     }
 
     // Push BRISC's e_t buffer (no -1 cap needed, NCRISC will cap final merged buffer)
-    cb_push_back(brisc_e_t_cb_id, one_page);
+    cb_brisc_e_t.push_back(one_page);
 
     // Push BRISC's expert_activation buffer
-    cb_push_back(brisc_expert_activation_cb_id, one_page);
+    cb_brisc_expert_activation.push_back(one_page);
 
     // Push BRISC's per-expert counts to CB for NCRISC to read
-    cb_reserve_back(brisc_expert_counts_cb_id, one_page);
-    uint32_t* brisc_counts_ptr = reinterpret_cast<uint32_t*>(get_write_ptr(brisc_expert_counts_cb_id));
+    cb_brisc_expert_counts.reserve_back(one_page);
+    uint32_t* brisc_counts_ptr = reinterpret_cast<uint32_t*>(cb_brisc_expert_counts.get_write_ptr());
     for (uint32_t e = 0; e < experts_per_device; e++) {
         brisc_counts_ptr[e] = brisc_num_tokens_per_expert[e];
     }
-    cb_push_back(brisc_expert_counts_cb_id, one_page);
+    cb_brisc_expert_counts.push_back(one_page);
 
     // Push BRISC's activated token count
-    cb_reserve_back(brisc_activated_count_cb_id, one_page);
-    *reinterpret_cast<uint32_t*>(get_write_ptr(brisc_activated_count_cb_id)) = brisc_num_activated_tokens;
-    cb_push_back(brisc_activated_count_cb_id, one_page);
+    cb_brisc_activated_count.reserve_back(one_page);
+    *reinterpret_cast<uint32_t*>(cb_brisc_activated_count.get_write_ptr()) = brisc_num_activated_tokens;
+    cb_brisc_activated_count.push_back(one_page);
 
     // Wait for reader to push per-expert token counts (includes merged NCRISC + BRISC counts)
-    cb_wait_front(per_expert_total_tokens_cb_id, 1);
+    cb_per_expert_total_tokens.wait_front(1);
     volatile tt_l1_ptr uint32_t* per_expert_counts =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
 
     // Read per-expert token counts into local array
     uint32_t num_tokens_per_expert[experts_per_device];
@@ -401,9 +430,9 @@ void kernel_main() {
     }
 
     // Wait for reader to push total_chunks
-    cb_wait_front(total_chunks_cb_id, one_page);
+    cb_total_chunks.wait_front(one_page);
     [[maybe_unused]] uint32_t total_chunks =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(total_chunks_cb_id));
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_total_chunks.get_read_ptr());
 
     /************************************************************************/
     /* Synchronization setup for signalling between tilize and matmul cores */
@@ -435,7 +464,7 @@ void kernel_main() {
 
     // This decides which half of the matmul input buffer we send to
     bool use_second_half_buffer = false;
-    uint32_t matmul_chunk_input_cb_base_addr = get_read_ptr(tilize_output_cb_id);
+    uint32_t matmul_chunk_input_cb_base_addr = cb_tilize_output.get_read_ptr();
     uint32_t first_half_buffer_addr = matmul_chunk_input_cb_base_addr;
     uint32_t second_half_buffer_addr =
         matmul_chunk_input_cb_base_addr + (tiles_per_global_chunk * tilize_output_page_size);
@@ -483,8 +512,8 @@ void kernel_main() {
 
         for (uint32_t chunk = 0; chunk < num_expert_chunks; chunk++) {
             // Wait for compute to push tiles_per_local_chunk tiles
-            cb_wait_front(tilize_output_cb_id, shared_cb_num_pages);
-            uint32_t l1_read_addr = get_read_ptr(tilize_output_cb_id);
+            cb_tilize_output.wait_front(shared_cb_num_pages);
+            uint32_t l1_read_addr = cb_tilize_output.get_read_ptr();
 
             /*
              * Send chunks to MM cores;
@@ -526,15 +555,16 @@ void kernel_main() {
             if (num_chunks_sent >= 2) {
                 // wait_min as MM may signal twice (once per buffer slot) before we acknowledge the first (empty) buffer
                 // slot
-                noc_semaphore_wait_min(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_available_semaphore_addr),
-                    matmul_chunk_available_semaphore_wait_value);
+                matmul_chunk_available_sem.wait_min(matmul_chunk_available_semaphore_wait_value);
                 matmul_chunk_available_semaphore_wait_value += num_matmul_cores;
 
                 // MM only signals to the drain-sync-core, which then forwards it to the non-drain-sync cores
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
+                    // Device 2.0 migration: legacy primitive retained: multicast loopback op using
+                    // a precomposed multicast NOC address that honors the NOC1 coordinate-swap
+                    // convention via get_safe_multicast_noc_addr. #45003 item 4.
                     noc_semaphore_set_multicast(
                         matmul_chunk_available_semaphore_addr,
                         matmul_chunk_available_semaphore_tilize_mcast_addr,
@@ -556,9 +586,7 @@ void kernel_main() {
 
                     // == 5a ==
                     // wait for all gathered sub-chunks to arrive
-                    noc_semaphore_wait(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(initial_gather_semaphore_addr),
-                        primary_mcast_gather_group_num_cores - 1);
+                    initial_gather_sem.wait(primary_mcast_gather_group_num_cores - 1);
 
                     // == 6a ==
 
@@ -575,22 +603,23 @@ void kernel_main() {
 
                     // mcast the data
                     noc_async_write_linked_multicast(
+                        noc_obj,
                         l1_read_addr,
                         first_iteration_primary_mcast_group_matmul_chunk_input_mcast_addr,
                         bytes_to_mcast,
-                        matmul_bounding_box_num_cores,
-                        noc_index);
+                        matmul_bounding_box_num_cores);
 
                     // == 8a ==
                     // wait for secondary mcaster to signal that all secondary mcast sub-chunks have been delivered
                     // also bump local value (value of primary mcast group)
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // (tilize_chunk_ready_drain_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003
+                    // item 4.
                     noc_semaphore_inc(
                         tilize_chunk_ready_drain_semaphore_noc_addr,
                         primary_mcast_gather_group_num_cores - 1,
                         noc_index);
-                    noc_semaphore_wait(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tilize_chunk_ready_semaphore_addr),
-                        tilize_chunk_ready_wait_value);
+                    tilize_chunk_ready_sem.wait(tilize_chunk_ready_wait_value);
                     tilize_chunk_ready_wait_value += (num_tilize_cores - 1);
                 } else if (is_secondary_mcaster) {
                     // mcasts data over NoC0 (secondary NoC for tilize cores, usually reserved for MM cores reading
@@ -598,9 +627,7 @@ void kernel_main() {
 
                     // == 5a ==
                     // wait for all gathered sub-chunks to arrive
-                    noc_semaphore_wait(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(initial_gather_semaphore_addr),
-                        secondary_mcast_gather_group_num_cores - 1);
+                    initial_gather_sem.wait(secondary_mcast_gather_group_num_cores - 1);
 
                     // == 6a ==
 
@@ -617,16 +644,19 @@ void kernel_main() {
 
                     // mcast the data
                     noc_async_write_linked_multicast(
+                        noc_alt_obj,
                         l1_read_addr,
                         first_iteration_secondary_mcast_group_matmul_chunk_input_mcast_addr,
                         bytes_to_mcast,
-                        matmul_bounding_box_num_cores,
-                        1 - noc_index);
+                        matmul_bounding_box_num_cores);
 
                     // == 7a ==
                     // explicit barrier since we're on different NoC than primary mcaster (which is the one that signals
                     // to MM cores) signal to primary mcaster (drain-sync core) that we've sent our sub-chunks
-                    noc_async_write_barrier(1 - noc_index);
+                    noc_alt_obj.async_write_barrier();
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // (tilize_chunk_ready_drain_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003
+                    // item 4.
                     noc_semaphore_inc(
                         tilize_chunk_ready_drain_semaphore_noc_addr, secondary_mcast_gather_group_num_cores, noc_index);
                 } else {
@@ -641,15 +671,16 @@ void kernel_main() {
                         initial_mcast_gather_core_nox_y,
                         target_l1_initial_gather_addr,
                         noc_index);
-                    noc_async_write(
-                        l1_read_addr,
+                    noc_obj.async_write(
+                        {.offset_bytes = l1_read_addr},
                         initial_gather_noc_addr,
-                        tiles_per_local_chunk * tilize_output_page_size,
-                        noc_index);
-                    noc_async_write_barrier(noc_index);
+                        tiles_per_local_chunk * tilize_output_page_size);
+                    noc_obj.async_write_barrier();
 
                     // == 4a ==
                     // signal to our initial mcast gather core that we've delivered our sub-chunk
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // (initial_gather_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003 item 4.
                     uint64_t initial_gather_semaphore_noc_addr = get_noc_addr(
                         initial_mcast_gather_core_nox_x,
                         initial_mcast_gather_core_nox_y,
@@ -664,9 +695,7 @@ void kernel_main() {
                 if (is_drain_tilize_core) {
                     // == 5b ==
                     // wait until non-drain-sync cores send us their sub-chunks
-                    noc_semaphore_wait(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tilize_chunk_ready_semaphore_addr),
-                        tilize_chunk_ready_wait_value);
+                    tilize_chunk_ready_sem.wait(tilize_chunk_ready_wait_value);
                     tilize_chunk_ready_wait_value += (num_tilize_cores - 1);
 
                     // == 6b ==
@@ -678,26 +707,28 @@ void kernel_main() {
 
                     // mcast the data
                     noc_async_write_linked_multicast(
+                        noc_obj,
                         l1_read_addr,
                         matmul_chunk_input_mcast_addr,
                         normal_iteration_bytes_to_mcast,
-                        matmul_bounding_box_num_cores,
-                        noc_index);
+                        matmul_bounding_box_num_cores);
                 } else {
                     // == 3b ==
                     // send to proper offset on global mmcast gather core (the drain-sync core)
                     uint32_t gather_addr = l1_read_addr + global_tile_offset * tilize_output_page_size;
                     uint64_t drain_gather_noc_addr =
                         get_noc_addr(drain_core_noc_x, drain_core_noc_y, gather_addr, noc_index);
-                    noc_async_write(
-                        l1_read_addr,
+                    noc_obj.async_write(
+                        {.offset_bytes = l1_read_addr},
                         drain_gather_noc_addr,
-                        tiles_per_local_chunk * tilize_output_page_size,
-                        noc_index);
-                    noc_async_write_barrier(noc_index);
+                        tiles_per_local_chunk * tilize_output_page_size);
+                    noc_obj.async_write_barrier();
 
                     // == 4b ==
                     // signal to global mcast gather core that we've delivered our sub-chunk
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // (tilize_chunk_ready_drain_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc. #45003
+                    // item 4.
                     noc_semaphore_inc(tilize_chunk_ready_drain_semaphore_noc_addr, 1, noc_index);
                 }
             }
@@ -707,12 +738,13 @@ void kernel_main() {
                 // signal to MM cores that entire chunk has arrived
 
                 // set local value
-                noc_semaphore_set(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
-                    matmul_chunk_ready_semaphore_set_value);
+                matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
                 // mcast sem set
+                // Device 2.0 migration: legacy primitive retained: multicast loopback set
+                // (noc_semaphore_set_multicast) uses precomposed multicast NoC address and is not yet
+                // wrapped by Semaphore<>::set_multicast in a way that takes a raw L1 source addr. #45003 item 4.
                 noc_semaphore_set_multicast(
                     matmul_chunk_ready_semaphore_addr,
                     matmul_chunk_ready_semaphore_mcast_addr,
@@ -725,6 +757,7 @@ void kernel_main() {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
+                    // Device 2.0 migration: legacy primitive retained: multicast loopback set. #45003 item 4.
                     noc_semaphore_set_multicast(
                         tilize_chunk_ready_semaphore_addr,
                         tilize_chunk_ready_mcast_addr,
@@ -736,31 +769,28 @@ void kernel_main() {
                 // == 11 ==
                 // wait until drain-sync signals to us that we can start using NoC again (read in next set of tokens,
                 // output another chunk, etc)
-                noc_semaphore_wait(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tilize_chunk_ready_semaphore_addr),
-                    tilize_chunk_ready_wait_value);
+                tilize_chunk_ready_sem.wait(tilize_chunk_ready_wait_value);
                 tilize_chunk_ready_wait_value += (num_tilize_cores - 1);
             }
 
             // we already barrier when using (1 - noc_index), so just need to flush on noc_index here
-            noc_async_writes_flushed(noc_index);
+            noc_obj.async_writes_flushed();
 
             // pop the tiles from CB
-            cb_pop_front(tilize_output_cb_id, shared_cb_num_pages);
+            cb_tilize_output.pop_front(shared_cb_num_pages);
             num_chunks_sent++;
             use_second_half_buffer = !use_second_half_buffer;
 
             // == 12 ==
             // signal to reader that they can start reading in another set of tokens
-            noc_semaphore_set(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(previous_chunk_sent_semaphore_addr), num_chunks_sent);
+            previous_chunk_sent_sem.set(num_chunks_sent);
         }
     }
 
     // Pop the per-expert counts and total_chunks (cleanup)
-    cb_pop_front(per_expert_total_tokens_cb_id, one_page);
-    cb_pop_front(total_chunks_cb_id, one_page);
+    cb_per_expert_total_tokens.pop_front(one_page);
+    cb_total_chunks.pop_front(one_page);
 
-    noc_async_write_barrier(noc_index);
-    noc_async_atomic_barrier(noc_index);
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -31,14 +31,18 @@ FORCE_INLINE uint64_t get_safe_multicast_noc_addr(
 
 FORCE_INLINE void noc_async_write_linked_multicast(
     Noc& noc, uint32_t src_local_l1_addr, uint64_t dst_noc_addr_multicast, uint32_t size, uint32_t num_dests) {
+    // Device 2.0 migration: legacy primitive retained: dst_noc_addr_multicast is a precomposed uint64_t
+    // NoC multicast address (returned by get_safe_multicast_noc_addr above). Noc::async_write_multicast
+    // takes a typed Dst (MulticastEndpoint, TensorAccessor) plus separate dst_args; there is no wrapper
+    // for a raw uint64_t multicast address today. #45003 item 4.
     while (size > NOC_MAX_BURST_SIZE) {
-        noc.async_write_multicast(
-            {.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true);
+        noc_async_write_multicast(
+            src_local_l1_addr, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true, noc.get_noc_id());
         src_local_l1_addr += NOC_MAX_BURST_SIZE;
         dst_noc_addr_multicast += NOC_MAX_BURST_SIZE;
         size -= NOC_MAX_BURST_SIZE;
     }
-    noc.async_write_multicast({.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, size, num_dests, false);
+    noc_async_write_multicast(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, false, noc.get_noc_id());
 }
 
 void print_tile_rows(
@@ -666,15 +670,20 @@ void kernel_main() {
                     // send to proper offset on our initial mcast gather core
                     uint32_t target_l1_initial_gather_addr =
                         l1_read_addr + mcast_group_tile_offset * tilize_output_page_size;
+                    // Device 2.0 migration: legacy primitive retained: initial_gather_noc_addr is a
+                    // precomposed uint64_t NoC unicast address. Noc::async_write takes a typed Dst
+                    // (UnicastEndpoint with .noc_x/.noc_y/.addr args, or TensorAccessor) — there is no
+                    // wrapper for a raw uint64_t address today. #45003 item 4.
                     uint64_t initial_gather_noc_addr = get_noc_addr(
                         initial_mcast_gather_core_nox_x,
                         initial_mcast_gather_core_nox_y,
                         target_l1_initial_gather_addr,
                         noc_index);
-                    noc_obj.async_write(
-                        {.offset_bytes = l1_read_addr},
+                    noc_async_write(
+                        l1_read_addr,
                         initial_gather_noc_addr,
-                        tiles_per_local_chunk * tilize_output_page_size);
+                        tiles_per_local_chunk * tilize_output_page_size,
+                        noc_index);
                     noc_obj.async_write_barrier();
 
                     // == 4a ==
@@ -716,12 +725,17 @@ void kernel_main() {
                     // == 3b ==
                     // send to proper offset on global mmcast gather core (the drain-sync core)
                     uint32_t gather_addr = l1_read_addr + global_tile_offset * tilize_output_page_size;
+                    // Device 2.0 migration: legacy primitive retained: drain_gather_noc_addr is a
+                    // precomposed uint64_t NoC unicast address. Noc::async_write takes a typed Dst
+                    // (UnicastEndpoint with .noc_x/.noc_y/.addr args, or TensorAccessor) — there is no
+                    // wrapper for a raw uint64_t address today. #45003 item 4.
                     uint64_t drain_gather_noc_addr =
                         get_noc_addr(drain_core_noc_x, drain_core_noc_y, gather_addr, noc_index);
-                    noc_obj.async_write(
-                        {.offset_bytes = l1_read_addr},
+                    noc_async_write(
+                        l1_read_addr,
                         drain_gather_noc_addr,
-                        tiles_per_local_chunk * tilize_output_page_size);
+                        tiles_per_local_chunk * tilize_output_page_size,
+                        noc_index);
                     noc_obj.async_write_barrier();
 
                     // == 4b ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/combine_dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/combine_dm1.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "moe_gpt_ring_common.h"
 
 //
@@ -20,11 +21,10 @@ void kernel_main() {
     uint32_t argidx = 0;
     const auto semaphore_id = get_arg_val<uint32_t>(argidx++);
 
-    uint32_t semaphore_addr = get_semaphore(semaphore_id);
-    volatile tt_l1_ptr uint32_t* semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
-    *semaphore_ptr = 0;
+    Semaphore<> sem(semaphore_id);
+    sem.set(0);
 
     constexpr uint32_t num_sources = moe_gpt_ring::RING_CORES_PER_COMBINE_COL;  // 4
 
-    noc_semaphore_wait_min(semaphore_ptr, num_sources);
+    sem.wait_min(num_sources);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/compute.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/circular_buffer.h"
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
@@ -51,26 +52,39 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
-    // CBs
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_0;
+    // CB ids
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_0;
 #ifdef TILIZE_FUSED
-    constexpr auto cb_s2c_in = tt::CBIndex::c_16;  // shared tilize→matmul CB
-    constexpr auto cb_w2c_md = tt::CBIndex::c_5;   // metadata bridge from dm1
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_16;  // shared tilize→matmul CB
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_5;   // metadata bridge from dm1
 #else
-    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_1;
 #endif
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
-    constexpr auto cb_c2c_ones_tile = tt::CBIndex::c_6;
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_4;
+    constexpr auto cb_c2c_ones_tile_id = tt::CBIndex::c_6;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_0;
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_0;
 #ifdef TILIZE_FUSED
-    constexpr auto cb_c2s_out = tt::CBIndex::c_14;  // untilized ROW_MAJOR output
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_14;  // untilized ROW_MAJOR output
 #else
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;
 #endif
+
+    // CircularBuffer typed wrappers
+    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
+    CircularBuffer cb_s2c_in(cb_s2c_in_id);
+#ifdef TILIZE_FUSED
+    CircularBuffer cb_w2c_md(cb_w2c_md_id);
+#endif
+    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
+    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
+    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
+    CircularBuffer cb_c2c_ones_tile(cb_c2c_ones_tile_id);
+    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
+    CircularBuffer cb_c2s_out(cb_c2s_out_id);
 
     // Constants for MoEGPT
     // GPT-OSS: K=2880 -> 90 tiles height, N=2880 -> 90 tiles
@@ -118,29 +132,30 @@ void kernel_main() {
     // Compute
     //-------------------------------------------------------------------------
     // Create a ones-tile for bias addition (matmul with ones × bias_row = bias)
-    unary_op_init_common(cb_c2c_ones_tile, cb_c2c_ones_tile);
+    unary_op_init_common(cb_c2c_ones_tile_id, cb_c2c_ones_tile_id);
     tile_regs_acquire();
     fill_tile_init();
     constexpr uint32_t dst0 = 0;
     fill_tile(dst0, 1.f);
     tile_regs_commit();
     tile_regs_wait();
-    cb_reserve_back(cb_c2c_ones_tile, 1);
-    pack_tile(dst0, cb_c2c_ones_tile);
+    cb_c2c_ones_tile.reserve_back(1);
+    pack_tile(dst0, cb_c2c_ones_tile_id);
     tile_regs_release();
-    cb_push_back(cb_c2c_ones_tile, 1);
+    cb_c2c_ones_tile.push_back(1);
 
     // Pack is always configured to Float16_b
-    pack_reconfig_data_format(cb_s2c_in2);
+    pack_reconfig_data_format(cb_s2c_in2_id);
 
     // Unpacker B is for input/activation and eltwise inputs, so Float16_b
-    reconfig_data_format_srcb(cb_s2c_in);
+    reconfig_data_format_srcb(cb_s2c_in_id);
 
     // Unpacker A is for W0,W1 and W2, so Bf4_b
-    reconfig_data_format_srca(cb_r2c_w0_w1);
+    reconfig_data_format_srca(cb_r2c_w0_w1_id);
 
     // Initialize matmul for W0
-    mm_block_init(cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
+    mm_block_init(
+        cb_s2c_in_id, cb_r2c_w0_w1_id, cb_s2c_in2_id, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
     // Initialize SFPU for GPT-OSS SwiGLU activation
     PACK((llk_math_eltwise_binary_sfpu_swiglu_init()));
@@ -157,9 +172,9 @@ void kernel_main() {
     // Receive per-expert token counts + chunk_ready semaphore from dm1 via cb_w2c_md
     //   [0..num_experts-1] = raw token counts per expert
     //   [num_experts]      = matmul_chunk_ready_semaphore address
-    cb_wait_front(cb_w2c_md, 2);
+    cb_w2c_md.wait_front(2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_read_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md, 0));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_w2c_md_id, 0));
 
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t e = 0; e < num_experts; ++e) {
@@ -167,7 +182,7 @@ void kernel_main() {
         NUM_CHUNKS_PER_EXPERT[e] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
     uint32_t chunk_ready_sem_addr = cb_w2c_md_read_ptr[num_experts];
-    cb_pop_front(cb_w2c_md, 2);
+    cb_w2c_md.pop_front(2);
 
     // Unified chunk loop: SwiGLU → A2A (via dm1) → W2 matmul → untilize
     // Full pipeline completes per chunk, matching the deepseek moe_compute pattern.
@@ -186,6 +201,9 @@ void kernel_main() {
         for (uint32_t chunk = 0; chunk < num_expert_chunks; ++chunk) {
             // Wait for tilize drain to deliver this chunk via multicast
             UNPACK(({
+                // Device 2.0 migration: legacy primitive retained: chunk_ready_sem_addr is a runtime-resolved L1
+                // semaphore address (delivered via cb_w2c_md), not a per-program id. Semaphore<> binds to per-program
+                // ids via get_semaphore<>(id), so it cannot wrap a resolved address. #45003 item 4.
                 noc_semaphore_wait_min(chunk_ready_sem_ptr, chunk_ready_wait_value);
                 chunk_ready_wait_value++;
             }));
@@ -200,7 +218,7 @@ void kernel_main() {
                 tile_regs_acquire();
                 uint32_t k_tracker = 0;
                 for (uint32_t block_id = 0; block_id < w0_w1_blocks_per_two_elt_tile; ++block_id) {
-                    cb_wait_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.wait_front(w0_w1_tiles_per_block);
                     uint32_t last_k_index = 0;
                     for (uint32_t k = 0; k < w0_w1_tiles_per_block; k += 4) {
                         if (k_tracker == num_w0_w1_tiles_h) {
@@ -208,8 +226,8 @@ void kernel_main() {
                             break;
                         }
                         matmul_block(
-                            cb_s2c_in,
-                            cb_r2c_w0_w1,
+                            cb_s2c_in_id,
+                            cb_r2c_w0_w1_id,
                             in0_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -222,8 +240,8 @@ void kernel_main() {
                     if (k_tracker == num_w0_w1_tiles_h) {
                         // Bias addition: matmul(ones_tile, bias_row)
                         matmul_block(
-                            cb_c2c_ones_tile,
-                            cb_r2c_w0_w1,
+                            cb_c2c_ones_tile_id,
+                            cb_r2c_w0_w1_id,
                             0,
                             /*in1_index=*/last_k_index,
                             /*idst=*/0,
@@ -232,7 +250,7 @@ void kernel_main() {
                             /*rt_dim=*/1,
                             /*kt_dim=*/1);
                     }
-                    cb_pop_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.pop_front(w0_w1_tiles_per_block);
                 }
 
                 tile_regs_commit();
@@ -249,26 +267,26 @@ void kernel_main() {
 
                 PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
-                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
-                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2, /*output_tile_index=*/tile_id + 1);
+                pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
+                pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2_id, /*output_tile_index=*/tile_id + 1);
                 tile_regs_release();
             }
 
             // Signal dm1 that SwiGLU output is ready
-            cb_reserve_back(cb_c2w_rdy, 1);
-            cb_push_back(cb_c2w_rdy, 1);
+            cb_c2w_rdy.reserve_back(1);
+            cb_c2w_rdy.push_back(1);
 
             // W2 matmul + untilize (dm1 does A2A ring, compute does W2) (with bias)
-            cb_reserve_back(cb_c2s_out, moe_gpt_ring::TOKENS_PER_CHUNK);  // 32 pages
+            cb_c2s_out.reserve_back(moe_gpt_ring::TOKENS_PER_CHUNK);  // 32 pages
             constexpr uint32_t w2_bias_blocks_per_iter_fused = w2_blocks_per_expert / num_a2a_iters;
 
             // Init pack_untilize once before the iter loop (overlaps with matmul compute)
-            pack_untilize_dest_init</*block_ct_dim=*/4, /*full_ct_dim=*/source_width_tiles>(cb_c2s_out);
+            pack_untilize_dest_init</*block_ct_dim=*/4, /*full_ct_dim=*/source_width_tiles>(cb_c2s_out_id);
 
             for (uint32_t iter = 0; iter < num_a2a_iters; ++iter) {
                 uint32_t dm1_step = 0;
                 uint32_t dm1_tiles_remaining = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
-                cb_wait_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.wait_front(1);
 
                 // 6-buffer cycling: each A2A step uses buf (step % 6)
                 uint32_t in2_buf = 0, in2_offset = 0, in2_index = 0;
@@ -277,7 +295,7 @@ void kernel_main() {
                 uint32_t k_tracker = 0;
 
                 for (uint32_t block_id = 0; block_id < w2_bias_blocks_per_iter_fused; ++block_id) {
-                    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.wait_front(w2_tiles_per_block);
                     uint32_t last_k_index = 0;
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += 4) {
                         if (k_tracker == num_w0_w1_tiles_h) {
@@ -285,8 +303,8 @@ void kernel_main() {
                             break;
                         }
                         if (dm1_tiles_remaining == 0) {
-                            cb_pop_front(cb_w2c_rdy, 1);
-                            cb_wait_front(cb_w2c_rdy, 1);
+                            cb_w2c_rdy.pop_front(1);
+                            cb_w2c_rdy.wait_front(1);
                             dm1_tiles_remaining =
                                 moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][++dm1_step];
                             in2_buf = (in2_buf >= 5) ? 0 : in2_buf + 1;  // 6 buffers: cycle 0..5
@@ -296,8 +314,8 @@ void kernel_main() {
                         dm1_tiles_remaining--;
 
                         matmul_block(
-                            cb_s2c_in2,
-                            cb_r2c_w2,
+                            cb_s2c_in2_id,
+                            cb_r2c_w2_id,
                             in2_index++,
                             /*in1_index=*/k,
                             /*idst=*/0,
@@ -310,8 +328,8 @@ void kernel_main() {
                     if (k_tracker == num_w0_w1_tiles_h) {
                         // Bias addition: matmul(ones_tile, bias_row)
                         matmul_block(
-                            cb_c2c_ones_tile,
-                            cb_r2c_w2,
+                            cb_c2c_ones_tile_id,
+                            cb_r2c_w2_id,
                             0,
                             /*in1_index=*/last_k_index,
                             /*idst=*/0,
@@ -320,32 +338,32 @@ void kernel_main() {
                             /*rt_dim=*/1,
                             /*kt_dim=*/1);
                     }
-                    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+                    cb_r2c_w2.pop_front(w2_tiles_per_block);
                 }
 
-                cb_pop_front(cb_w2c_rdy, 1);
+                cb_w2c_rdy.pop_front(1);
 
                 tile_regs_commit();
 
                 // Untilize W2 output to cb_c2s_out (ROW_MAJOR)
                 tile_regs_wait();
                 pack_untilize_dest</*block_ct_dim=*/4, /*full_ct_dim=*/source_width_tiles>(
-                    cb_c2s_out, /*block_rt_dim=*/1, /*block_c_index=*/iter);
+                    cb_c2s_out_id, /*block_rt_dim=*/1, /*block_c_index=*/iter);
                 tile_regs_release();
             }
 
-            pack_untilize_uninit(cb_c2s_out);
-            cb_push_back(cb_c2s_out, moe_gpt_ring::TOKENS_PER_CHUNK);  // 32 pages
+            pack_untilize_uninit(cb_c2s_out_id);
+            cb_c2s_out.push_back(moe_gpt_ring::TOKENS_PER_CHUNK);  // 32 pages
 
             // Toggle input buffer and reinit packer for next chunk's SwiGLU
             use_second_half_buffer = !use_second_half_buffer;
-            pack_reconfig_data_format(cb_s2c_in2);
+            pack_reconfig_data_format(cb_s2c_in2_id);
         }
     }
 
     // Drain W2 pipeline: dm0 pushes extra blocks at end
-    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
-    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.wait_front(w2_tiles_per_block);
+    cb_r2c_w2.pop_front(w2_tiles_per_block);
 
 #else
     // NON-FUSED MODE: Standard expert loop with A2A (with bias)
@@ -354,8 +372,8 @@ void kernel_main() {
     uint32_t out_offset_per_expert = 0;
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         if (expert_id > 0) {
-            cb_wait_front(cb_w2c_rdy, 1);
-            cb_pop_front(cb_w2c_rdy, 1);
+            cb_w2c_rdy.wait_front(1);
+            cb_w2c_rdy.pop_front(1);
         }
 
         // Compute in @ {W0,W1} with bias
@@ -365,7 +383,7 @@ void kernel_main() {
             tile_regs_acquire();
             uint32_t k_tracker = 0;
             for (uint32_t block_id = 0; block_id < w0_w1_blocks_per_two_elt_tile; ++block_id) {
-                cb_wait_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                cb_r2c_w0_w1.wait_front(w0_w1_tiles_per_block);
                 uint32_t last_k_index = 0;
                 for (uint32_t k = 0; k < w0_w1_tiles_per_block; k += 4) {
                     if (k_tracker == moe_gpt_ring::NUM_W0_W1_TILES_H) {
@@ -373,8 +391,8 @@ void kernel_main() {
                         break;
                     }
                     matmul_block(
-                        cb_s2c_in,
-                        cb_r2c_w0_w1,
+                        cb_s2c_in_id,
+                        cb_r2c_w0_w1_id,
                         in0_index++,
                         /*in1_index=*/k,
                         /*idst=*/0,
@@ -387,8 +405,8 @@ void kernel_main() {
                 if (k_tracker == moe_gpt_ring::NUM_W0_W1_TILES_H) {
                     // Bias addition: matmul(ones_tile, bias_row)
                     matmul_block(
-                        cb_c2c_ones_tile,
-                        cb_r2c_w0_w1,
+                        cb_c2c_ones_tile_id,
+                        cb_r2c_w0_w1_id,
                         0,
                         /*in1_index=*/last_k_index,
                         /*idst=*/0,
@@ -397,7 +415,7 @@ void kernel_main() {
                         /*rt_dim=*/1,
                         /*kt_dim=*/1);
                 }
-                cb_pop_front(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                cb_r2c_w0_w1.pop_front(w0_w1_tiles_per_block);
             }
 
             tile_regs_commit();
@@ -412,20 +430,20 @@ void kernel_main() {
             PACK((llk_math_eltwise_binary_sfpu_swiglu<false>(2, 3, 2)));
             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
-            pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
-            pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2, /*output_tile_index=*/tile_id + 1);
+            pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2_id, /*output_tile_index=*/tile_id);
+            pack_tile</*out_of_order_output=*/true>(2, cb_s2c_in2_id, /*output_tile_index=*/tile_id + 1);
             tile_regs_release();
         }
 
-        cb_reserve_back(cb_c2w_rdy, 1);
-        cb_push_back(cb_c2w_rdy, 1);
+        cb_c2w_rdy.reserve_back(1);
+        cb_c2w_rdy.push_back(1);
 
         // Compute in2 @ W2 with bias
         uint32_t out_tile_index = expert_id * num_w0_w1_tiles_h;
         for (uint32_t iter = 0; iter < num_a2a_iters; ++iter) {
             uint32_t dm1_step = 0;
             uint32_t dm1_tiles_remaining = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
-            cb_wait_front(cb_w2c_rdy, 1);
+            cb_w2c_rdy.wait_front(1);
 
             uint32_t in2_buf = 0, in2_offset = 0, in2_index = 0;
 
@@ -433,7 +451,7 @@ void kernel_main() {
             uint32_t k_tracker = 0;
             constexpr uint32_t w2_bias_blocks_per_iter = w2_blocks_per_expert / num_a2a_iters;
             for (uint32_t block_id = 0; block_id < w2_bias_blocks_per_iter; ++block_id) {
-                cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
+                cb_r2c_w2.wait_front(w2_tiles_per_block);
                 uint32_t last_k_index = 0;
                 for (uint32_t k = 0; k < w2_tiles_per_block; k += 4) {
                     if (k_tracker == moe_gpt_ring::NUM_W0_W1_TILES_H) {
@@ -441,8 +459,8 @@ void kernel_main() {
                         break;
                     }
                     if (dm1_tiles_remaining == 0) {
-                        cb_pop_front(cb_w2c_rdy, 1);
-                        cb_wait_front(cb_w2c_rdy, 1);
+                        cb_w2c_rdy.pop_front(1);
+                        cb_w2c_rdy.wait_front(1);
                         dm1_tiles_remaining = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][++dm1_step];
                         in2_buf = (in2_buf >= 5) ? 0 : in2_buf + 1;  // 6 buffers: cycle 0..5
                         in2_offset = in2_buf * tiles_per_step;
@@ -450,8 +468,8 @@ void kernel_main() {
                     }
                     dm1_tiles_remaining--;
                     matmul_block(
-                        cb_s2c_in2,
-                        cb_r2c_w2,
+                        cb_s2c_in2_id,
+                        cb_r2c_w2_id,
                         in2_index++,
                         /*in1_index=*/k,
                         /*idst=*/0,
@@ -464,8 +482,8 @@ void kernel_main() {
                 if (k_tracker == moe_gpt_ring::NUM_W0_W1_TILES_H) {
                     // Bias addition: matmul(ones_tile, bias_row)
                     matmul_block(
-                        cb_c2c_ones_tile,
-                        cb_r2c_w2,
+                        cb_c2c_ones_tile_id,
+                        cb_r2c_w2_id,
                         0,
                         /*in1_index=*/last_k_index,
                         /*idst=*/0,
@@ -474,24 +492,24 @@ void kernel_main() {
                         /*rt_dim=*/1,
                         /*kt_dim=*/1);
                 }
-                cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+                cb_r2c_w2.pop_front(w2_tiles_per_block);
             }
 
-            cb_pop_front(cb_w2c_rdy, 1);
+            cb_w2c_rdy.pop_front(1);
 
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile</*out_of_order_output=*/true>(0, cb_c2s_out, /*output_tile_index=*/out_tile_index++);
-            pack_tile</*out_of_order_output=*/true>(1, cb_c2s_out, /*output_tile_index=*/out_tile_index++);
-            pack_tile</*out_of_order_output=*/true>(2, cb_c2s_out, /*output_tile_index=*/out_tile_index++);
-            pack_tile</*out_of_order_output=*/true>(3, cb_c2s_out, /*output_tile_index=*/out_tile_index++);
+            pack_tile</*out_of_order_output=*/true>(0, cb_c2s_out_id, /*output_tile_index=*/out_tile_index++);
+            pack_tile</*out_of_order_output=*/true>(1, cb_c2s_out_id, /*output_tile_index=*/out_tile_index++);
+            pack_tile</*out_of_order_output=*/true>(2, cb_c2s_out_id, /*output_tile_index=*/out_tile_index++);
+            pack_tile</*out_of_order_output=*/true>(3, cb_c2s_out_id, /*output_tile_index=*/out_tile_index++);
             tile_regs_release();
         }
     }  // end for (expert_id)
 
     // Drain the pipeline
-    cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
-    cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.wait_front(w2_tiles_per_block);
+    cb_r2c_w2.pop_front(w2_tiles_per_block);
 
 #endif  // TILIZE_FUSED
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm0.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "moe_gpt_ring_common.h"
 
 // Triple buffering constants
@@ -54,22 +56,28 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
+    // Noc typed wrapper
+    Noc noc_obj(noc_index);
+
     // CBs
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_0;
-    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_0;
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_1;
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_4;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_0;
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_0;
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_1;
+
+    CircularBuffer cb_r2c_w0_w1(cb_r2c_w0_w1_id);
+    CircularBuffer cb_r2c_w2(cb_r2c_w2_id);
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
-    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
-    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
-    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in_id);
+    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1_id);
+    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2_id);
+    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2_id);
 
     // Constants for MoEGPT
     constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_PLUS_BIAS_H;  // 91 (90 weight + 1 bias)
@@ -127,7 +135,7 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // CB addresses
     //-------------------------------------------------------------------------
-    const uint32_t w_cb_base_addr = get_write_ptr(cb_r2c_w0_w1);
+    const uint32_t w_cb_base_addr = cb_r2c_w0_w1.get_write_ptr();
 
     // Precompute slot addresses (avoid multiply in hot loop)
     // Each slot holds 1 block (20 tiles = 10 tiles/txn * 2 txns/block)
@@ -138,6 +146,8 @@ void kernel_main() {
     // Expert loop
     //-------------------------------------------------------------------------
     // Set w0_w1 state once before loop (will be reused for all experts)
+    // Device 2.0 migration: legacy primitive retained: noc_async_read_one_packet_set_state is a
+    // state-machine setup with no Device 2.0 wrapper. #45003 item 4.
     noc_async_read_one_packet_set_state<true>(dram_noc_addr, w0_w1_bytes_per_txn, vchannel);
 
     //-------------------------------------------------------------------------
@@ -147,7 +157,7 @@ void kernel_main() {
     bool txns_in_flight = false;
 
     // We reserve one to kick start the pipeline, and then it is steady state
-    cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+    cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block);
 
 #ifdef TILIZE_FUSED
     //-------------------------------------------------------------------------
@@ -155,17 +165,14 @@ void kernel_main() {
     //-------------------------------------------------------------------------
 
     // Wait for metadata from tilize drain core
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
-    volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr);
-    noc_semaphore_wait_min(metadata_ready_semaphore_ptr, 1);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    metadata_ready_sem.wait_min(1);
 
     // Read per-expert token counts from dedicated semaphores
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t e = 0; e < num_experts; ++e) {
-        volatile tt_l1_ptr uint32_t* count_sem_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_count_semaphore_base_id + e));
-        uint32_t num_tokens = *count_sem_ptr;
+        Semaphore<> count_sem(metadata_count_semaphore_base_id + e);
+        uint32_t num_tokens = count_sem.get();
         NUM_CHUNKS_PER_EXPERT[e] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
 
@@ -180,6 +187,8 @@ void kernel_main() {
             uint32_t w0_w1_dram_read_offset = w0_w1_expert_offset;
 
             for (uint32_t block_id = 0; block_id < w0_w1_blocks_per_expert; ++block_id) {
+                // Device 2.0 migration: legacy primitives retained: trid-based one-packet state-machine
+                // reads have no Device 2.0 wrappers. #45003 item 4.
                 noc_async_read_set_trid(trid_to_issue);
                 noc_async_read_one_packet_with_state_with_trid<false, true>(
                     dram_noc_addr, w0_w1_dram_read_offset, slot_addr[slot_to_issue], trid_to_issue);
@@ -196,10 +205,12 @@ void kernel_main() {
                 ADVANCE_TRID(trid_to_issue);
 
                 if (txns_in_flight) {
+                    // Device 2.0 migration: legacy primitive retained: trid-based barrier paired with
+                    // noc_async_read_one_packet_with_state_with_trid. #45003 item 4.
                     noc_async_read_barrier_with_trid(trid_to_wait);
-                    cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                    cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
                     ADVANCE_TRID(trid_to_wait);
-                    cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block * 2);
+                    cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block * 2);
                 }
                 txns_in_flight = true;
             }
@@ -208,6 +219,8 @@ void kernel_main() {
             uint32_t w2_dram_read_offset = w2_expert_offset;
 
             for (uint32_t block_id = 0; block_id < w2_blocks_per_expert; ++block_id) {
+                // Device 2.0 migration: legacy primitives retained: trid-based one-packet state-machine
+                // reads have no Device 2.0 wrappers. #45003 item 4.
                 noc_async_read_set_trid(trid_to_issue);
                 noc_async_read_one_packet_with_state_with_trid<false, true>(
                     dram_noc_addr, w2_dram_read_offset, slot_addr[slot_to_issue], trid_to_issue);
@@ -220,10 +233,11 @@ void kernel_main() {
                 ADVANCE_SLOT(slot_to_issue);
                 ADVANCE_TRID(trid_to_issue);
 
+                // Device 2.0 migration: legacy primitive retained: trid-based barrier. #45003 item 4.
                 noc_async_read_barrier_with_trid(trid_to_wait);
-                cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
                 ADVANCE_TRID(trid_to_wait);
-                cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block * 2);
+                cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block * 2);
             }
         }
 
@@ -232,9 +246,10 @@ void kernel_main() {
     }
 
     // Drain the pipeline
+    // Device 2.0 migration: legacy primitive retained: trid-based barrier. #45003 item 4.
     noc_async_read_barrier_with_trid(trid_to_wait);
-    cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
-    cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+    cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
+    cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
 
 #else
     // NON-FUSED MODE: Read all W0/W1 then W2 for each expert
@@ -246,6 +261,8 @@ void kernel_main() {
 
         for (uint32_t block_id = 0; block_id < w0_w1_blocks_per_expert; ++block_id) {
             // Issue reads with current trid
+            // Device 2.0 migration: legacy primitives retained: trid-based one-packet state-machine
+            // reads have no Device 2.0 wrappers. #45003 item 4.
             noc_async_read_set_trid(trid_to_issue);
             noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
                 dram_noc_addr, w0_w1_dram_read_offset, slot_addr[slot_to_issue], trid_to_issue);
@@ -260,15 +277,16 @@ void kernel_main() {
 
             // Only when we first start the pipeline, we don't have any txns in flight
             if (txns_in_flight) {
+                // Device 2.0 migration: legacy primitive retained: trid-based barrier. #45003 item 4.
                 noc_async_read_barrier_with_trid(trid_to_wait);
-                cb_push_back(cb_r2c_w0_w1, w0_w1_tiles_per_block);
+                cb_r2c_w0_w1.push_back(w0_w1_tiles_per_block);
 
                 ADVANCE_TRID(trid_to_wait);
 
                 // Reserve for next block
                 // Reserve back is not incremental, so to reserve one more, we need to reserve 2
                 // This accounts for the one we already have reserved (for in-flight read)
-                cb_reserve_back(cb_r2c_w0_w1, w0_w1_tiles_per_block * 2);
+                cb_r2c_w0_w1.reserve_back(w0_w1_tiles_per_block * 2);
             }
             txns_in_flight = true;
         }
@@ -280,6 +298,8 @@ void kernel_main() {
 
         for (uint32_t block_id = 0; block_id < w2_blocks_per_expert; ++block_id) {
             // Issue reads with current trid
+            // Device 2.0 migration: legacy primitives retained: trid-based one-packet state-machine
+            // reads have no Device 2.0 wrappers. #45003 item 4.
             noc_async_read_set_trid(trid_to_issue);
             noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
                 dram_noc_addr, w2_dram_read_offset, slot_addr[slot_to_issue], trid_to_issue);
@@ -292,15 +312,16 @@ void kernel_main() {
             ADVANCE_SLOT(slot_to_issue);
             ADVANCE_TRID(trid_to_issue);
 
+            // Device 2.0 migration: legacy primitive retained: trid-based barrier. #45003 item 4.
             noc_async_read_barrier_with_trid(trid_to_wait);
-            cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+            cb_r2c_w2.push_back(w2_tiles_per_block);
 
             ADVANCE_TRID(trid_to_wait);
 
             // Reserve for next block
             // Reserve back is not incremental, so to reserve one more, we need to reserve 2
             // This accounts for the one we already have reserved (for in-flight read)
-            cb_reserve_back(cb_r2c_w2, w2_tiles_per_block * 2);
+            cb_r2c_w2.reserve_back(w2_tiles_per_block * 2);
         }
 
         // Update offsets for next expert
@@ -309,12 +330,13 @@ void kernel_main() {
     }
 
     // Drain the pipeline - the last txn in flight
+    // Device 2.0 migration: legacy primitive retained: trid-based barrier. #45003 item 4.
     noc_async_read_barrier_with_trid(trid_to_wait);
-    cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.push_back(w2_tiles_per_block);
 
     // We have one extra slot reserved, which we won't use.
     // For CB hygiene, we can push it back.
-    cb_push_back(cb_r2c_w2, w2_tiles_per_block);
+    cb_r2c_w2.push_back(w2_tiles_per_block);
 #endif  // TILIZE_FUSED
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm1.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "moe_gpt_ring_common.h"
 
 void kernel_main() {
@@ -41,22 +43,32 @@ void kernel_main() {
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
+    // Noc typed wrapper (uses default noc_index)
+    Noc noc_obj(noc_index);
+    // Secondary noc used for A2A ring writes and combine writes (always NOC 1)
+    Noc noc1_obj(1);
+
     // CBs
-    constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_0;
-    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_3;
-    constexpr auto cb_s2c_in2 = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_5;
+    constexpr auto cb_r2c_w0_w1_id = tt::CBIndex::c_0;
+    constexpr auto cb_s2c_in_id = tt::CBIndex::c_1;
+    constexpr auto cb_c2w_rdy_id = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_rdy_id = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_in2_id = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_md_id = tt::CBIndex::c_5;
 
     // CB Aliases
-    constexpr auto cb_r2c_w2 = tt::CBIndex::c_0;
+    constexpr auto cb_r2c_w2_id = tt::CBIndex::c_0;
+
+    CircularBuffer cb_c2w_rdy(cb_c2w_rdy_id);
+    CircularBuffer cb_w2c_rdy(cb_w2c_rdy_id);
+    CircularBuffer cb_s2c_in2(cb_s2c_in2_id);
+    CircularBuffer cb_w2c_md(cb_w2c_md_id);
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
-    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
-    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
-    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in_id);
+    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1_id);
+    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2_id);
+    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2_id);
 
     // Constants for MoEGPT
     constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;
@@ -88,7 +100,8 @@ void kernel_main() {
     constexpr uint32_t tiles_per_step = moe_gpt_ring::IN2_TILES_PER_STEP_A;  // 8
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_14;  // untilized ROW_MAJOR output
+    constexpr auto cb_c2s_out_id = tt::CBIndex::c_14;  // untilized ROW_MAJOR output
+    CircularBuffer cb_c2s_out(cb_c2s_out_id);
 
     // Additional runtime args for fused combine mode
     const auto combine_semaphore_id = get_arg_val<uint32_t>(10);
@@ -102,16 +115,15 @@ void kernel_main() {
     //-------------------------------------------------------------------------
 
     // Wait for tilize drain to deliver metadata (token counts per expert)
-    uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
-    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    metadata_ready_sem.wait_min(1);
 
     // Read per-expert token counts from dedicated semaphores
     uint32_t NUM_TOKENS_PER_EXPERT[num_experts];
     uint32_t NUM_CHUNKS_PER_EXPERT[num_experts];
     for (uint32_t e = 0; e < num_experts; ++e) {
-        volatile tt_l1_ptr uint32_t* count_sem_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_count_semaphore_base_id + e));
-        uint32_t num_tokens = *count_sem_ptr;
+        Semaphore<> count_sem(metadata_count_semaphore_base_id + e);
+        uint32_t num_tokens = count_sem.get();
         NUM_TOKENS_PER_EXPERT[e] = num_tokens;
         NUM_CHUNKS_PER_EXPERT[e] = (num_tokens + tokens_per_chunk - 1) / tokens_per_chunk;
     }
@@ -119,19 +131,19 @@ void kernel_main() {
     // Transfer per-expert token counts + chunk_ready semaphore address to compute via cb_w2c_md:
     //   [0..num_experts-1] = raw token counts per expert
     //   [num_experts]      = matmul_chunk_ready_semaphore address
-    cb_reserve_back(cb_w2c_md, 2);
+    cb_w2c_md.reserve_back(2);
     volatile tt_l1_ptr uint32_t* cb_w2c_md_write_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_w2c_md));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_w2c_md.get_write_ptr());
     for (uint32_t e = 0; e < num_experts; ++e) {
-        volatile tt_l1_ptr uint32_t* count_sem_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_count_semaphore_base_id + e));
-        cb_w2c_md_write_ptr[e] = *count_sem_ptr;
+        Semaphore<> count_sem(metadata_count_semaphore_base_id + e);
+        cb_w2c_md_write_ptr[e] = count_sem.get();
     }
     cb_w2c_md_write_ptr[num_experts] = get_semaphore(matmul_chunk_ready_semaphore_id);
-    cb_push_back(cb_w2c_md, 2);
+    cb_w2c_md.push_back(2);
 
     // NOC address to signal tilize drain that matmul has consumed a chunk
     uint32_t local_chunk_available_sem_addr = get_semaphore(matmul_chunk_available_semaphore_id);
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     uint64_t matmul_chunk_available_noc_addr =
         get_noc_addr(tilize_drain_core_noc_x, tilize_drain_core_noc_y, local_chunk_available_sem_addr);
 
@@ -152,9 +164,10 @@ void kernel_main() {
     constexpr uint32_t num_a2a_iters = moe_gpt_ring::NUM_A2A_ITERS_A;     // 2
     constexpr uint32_t num_a2a_steps_per_iter = moe_gpt_ring::NUM_CORES;  // 12
 
+    Semaphore<> ring_sem(ring_semaphore_id);
     uint32_t semaphore_addr = get_semaphore(ring_semaphore_id);
-    volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     const uint64_t neighbor_semaphore_noc_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, semaphore_addr);
 
@@ -163,7 +176,8 @@ void kernel_main() {
     constexpr uint32_t a2a_packet_size = a2a_tiles_per_packet * in2_tile_size;
     constexpr uint32_t a2a_num_packets = tiles_per_step / a2a_tiles_per_packet;
 
-    const uint32_t local_base_addr = get_write_ptr(cb_s2c_in2);
+    const uint32_t local_base_addr = cb_s2c_in2.get_write_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address. #45003 item 4.
     const uint64_t neighbor_base_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, local_base_addr);
 
@@ -173,7 +187,7 @@ void kernel_main() {
         LOCAL_BUFFER_OFFSET[i] = local_base_addr + i * a2a_xfer_bytes_per_step;
     }
 
-    noc_semaphore_set(my_semaphore_ptr, 0);
+    ring_sem.set(0);
     uint32_t semaphore_value = 0;
 
     //-------------------------------------------------------------------------
@@ -198,24 +212,26 @@ void kernel_main() {
         for (uint32_t chunk = 0; chunk < num_expert_chunks; ++chunk) {
             // Set NOC 1 write state at top of chunk, before waiting for compute.
             // This overlaps setup with compute's SwiGLU work.
+            // Device 2.0 migration: legacy primitives retained: state-machine setup
+            // (noc_async_write_one_packet_set_state, noc_inline_dw_write_set_state) has no
+            // Device 2.0 wrappers. #45003 item 4.
             noc_async_write_one_packet_set_state<true>(neighbor_base_addr, a2a_packet_size, 1, vchannel);
             noc_inline_dw_write_set_state<true, false>(
                 neighbor_semaphore_noc_addr, 0, 0xF, write_at_cmd_buf, 1, vchannel);
 
             // Wait for compute's SwiGLU output
-            cb_wait_front(cb_c2w_rdy, 1);
-            cb_pop_front(cb_c2w_rdy, 1);
+            cb_c2w_rdy.wait_front(1);
+            cb_c2w_rdy.pop_front(1);
 
             // A2A ring rotation for this chunk's SwiGLU output
             for (uint32_t i = 0; i < num_a2a_iters; ++i) {
                 for (uint32_t step = 0; step < num_a2a_steps_per_iter; ++step) {
                     // Wait for data from predecessor
-                    while ((*my_semaphore_ptr) < semaphore_value) {
-                    };
+                    ring_sem.wait_min(semaphore_value);
 
                     // Signal compute that A2A data is ready for W2 matmul
-                    cb_reserve_back(cb_w2c_rdy, 1);
-                    cb_push_back(cb_w2c_rdy, 1);
+                    cb_w2c_rdy.reserve_back(1);
+                    cb_w2c_rdy.push_back(1);
 
                     // Send to ring neighbor
                     const uint32_t src_buf = step % NUM_A2A_BUFFERS;
@@ -225,15 +241,19 @@ void kernel_main() {
 
                     for (uint32_t pkt = 0; pkt < a2a_num_packets; ++pkt) {
                         uint32_t pkt_offset = pkt * a2a_packet_size;
+                        // Device 2.0 migration: legacy primitive retained: paired with
+                        // noc_async_write_one_packet_set_state above. #45003 item 4.
                         noc_async_write_one_packet_with_state<true>(
                             local_src_addr + pkt_offset, neighbor_dst_addr + pkt_offset);
                     }
 
                     // Signal neighbor that data is ready. No flush needed between data and
                     // semaphore: same destination, same NOC, NOC ordering guarantees order.
+                    // Device 2.0 migration: legacy primitive retained: paired with
+                    // noc_inline_dw_write_set_state above. #45003 item 4.
                     noc_inline_dw_write_with_state<false, true, true, false, true>(++semaphore_value);
 
-                    noc_async_posted_writes_flushed(1);
+                    noc1_obj.async_posted_writes_flushed(1);
                 }
             }
 
@@ -248,8 +268,8 @@ void kernel_main() {
             const uint32_t num_tokens_block =
                 std::min(tokens_per_chunk_combine, active_tokens - chunk * tokens_per_chunk_combine);
 
-            cb_wait_front(cb_c2s_out, tokens_per_chunk_combine);
-            const uint32_t source_base_l1_addr = get_read_ptr(cb_c2s_out);
+            cb_c2s_out.wait_front(tokens_per_chunk_combine);
+            const uint32_t source_base_l1_addr = cb_c2s_out.get_read_ptr();
 
             uint32_t width_tiles_to_send = output_width_tiles_core;
             uint32_t width_tiles_sent = 0;
@@ -276,7 +296,11 @@ void kernel_main() {
                     const auto dest_noc_y =
                         output_shard_core_map[2 * (dest_height_shard * width_shard_dim + dest_width_shard) + 1];
 
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                    // used as state-machine base. #45003 item 4.
                     const uint64_t dest_noc_addr_base = get_noc_addr(dest_noc_x, dest_noc_y, output_base_l1_addr, 1);
+                    // Device 2.0 migration: legacy primitive retained: state-machine setup
+                    // (noc_async_write_one_packet_set_state) has no Device 2.0 wrapper. #45003 item 4.
                     noc_async_write_one_packet_set_state<true>(dest_noc_addr_base, width_transfer_bytes, 1, vchannel);
 
                     const uint32_t dest_l1_addr =
@@ -285,6 +309,8 @@ void kernel_main() {
                     const uint32_t source_l1_addr =
                         source_base_l1_addr + (bt * source_width_tiles + width_tiles_sent) * tile_width_size_bytes;
 
+                    // Device 2.0 migration: legacy primitive retained: paired with
+                    // noc_async_write_one_packet_set_state above. #45003 item 4.
                     noc_async_write_one_packet_with_state<true>(source_l1_addr, dest_l1_addr);
 
                     const uint32_t shard_capacity = (dest_height_shard < tokens_per_height_shard_rem)
@@ -304,10 +330,13 @@ void kernel_main() {
                 }
             }
 
-            noc_async_posted_writes_flushed(1);
-            cb_pop_front(cb_c2s_out, tokens_per_chunk_combine);
+            noc1_obj.async_posted_writes_flushed(1);
+            cb_c2s_out.pop_front(tokens_per_chunk_combine);
 
             // Signal tilize drain that this chunk has been consumed
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // (matmul_chunk_available_noc_addr) cannot be wrapped by Semaphore<>::inc which
+            // binds to a per-program id, not a resolved address. #45003 item 4.
             noc_semaphore_inc<true>(matmul_chunk_available_noc_addr, 1, 1, vchannel);
         }
     }
@@ -316,9 +345,11 @@ void kernel_main() {
     uint32_t combine_semaphore_addr = get_semaphore(combine_semaphore_id);
     for (uint32_t y = 0; y < height_shard_dim; ++y) {
         uint32_t idx = combine_core_x + y * width_shard_dim;
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+        // (combine destination semaphore) cannot be wrapped by Semaphore<>::inc. #45003 item 4.
         uint64_t dest_sem_noc_addr =
             get_noc_addr(output_shard_core_map[2 * idx], output_shard_core_map[2 * idx + 1], combine_semaphore_addr);
         noc_semaphore_inc(dest_sem_noc_addr, 1, 1, vchannel);
     }
-    noc_async_atomic_barrier(1);
+    noc_obj.async_atomic_barrier(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_compute.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/cb_api.h"
 #include "api/compute/tilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 // Compute kernel for tilizing incoming tokens from the reader.
 // Waits for writer to pass total_chunks via CB, then processes each chunk:
@@ -27,34 +28,39 @@ void kernel_main() {
     // Constants
     constexpr uint32_t one_page = 1;
 
+    CircularBuffer cb_tilize_input(tilize_input_cb_id);
+    CircularBuffer cb_tilize_output(tilize_output_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+
     // Setup
-    compute_kernel_hw_startup(tilize_input_cb_id, tilize_output_cb_id);
-    fast_tilize_init(tilize_input_cb_id, tiles_per_local_chunk, tilize_output_cb_id);
+    compute_kernel_hw_startup(cb_tilize_input.get_cb_id(), cb_tilize_output.get_cb_id());
+    fast_tilize_init(cb_tilize_input.get_cb_id(), tiles_per_local_chunk, cb_tilize_output.get_cb_id());
 
     // Wait for writer to push total_chunks via CB
-    cb_wait_front(total_chunks_cb_id, one_page);
+    cb_total_chunks.wait_front(one_page);
 
     // Read total_chunks from the CB
-    uint32_t total_chunks = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(total_chunks_cb_id, 0));
+    uint32_t total_chunks =
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_tile_address(cb_total_chunks.get_cb_id(), 0));
 
     // Process each chunk
     for (uint32_t chunk = 0; chunk < total_chunks; chunk++) {
         // Wait for reader to push tokens_per_chunk pages (row-major data)
         // Reader always reserves/pushes tokens_per_chunk for consistent synchronization
-        cb_wait_front(tilize_input_cb_id, tokens_per_chunk);
+        cb_tilize_input.wait_front(tokens_per_chunk);
 
         // we reserve the entire CB so that we treat it as single buffered
         // this is to allow us to gather into it before mcasting to the MM cores
-        cb_reserve_back(tilize_output_cb_id, shared_cb_num_pages);
+        cb_tilize_output.reserve_back(shared_cb_num_pages);
 
-        fast_tilize_block(tilize_input_cb_id, tiles_per_local_chunk, tilize_output_cb_id);
+        fast_tilize_block(cb_tilize_input.get_cb_id(), tiles_per_local_chunk, cb_tilize_output.get_cb_id());
 
-        cb_push_back(tilize_output_cb_id, shared_cb_num_pages);
+        cb_tilize_output.push_back(shared_cb_num_pages);
 
         // Pop input from reader (tokens_per_chunk pages)
-        cb_pop_front(tilize_input_cb_id, tokens_per_chunk);
+        cb_tilize_input.pop_front(tokens_per_chunk);
     }
 
-    fast_tilize_uninit(tilize_input_cb_id, tilize_output_cb_id, tiles_per_local_chunk);
-    cb_pop_front(total_chunks_cb_id, one_page);
+    fast_tilize_uninit(cb_tilize_input.get_cb_id(), cb_tilize_output.get_cb_id(), tiles_per_local_chunk);
+    cb_total_chunks.pop_front(one_page);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
+#include "api/tensor/noc_traits.h"
 
 using namespace ttnn::operations::ccl::common;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
 using namespace ttnn::operations::ccl::common;
@@ -56,9 +58,9 @@ inline uint32_t get_device_idx_from_global_token_idx(const uint32_t t) {
 // 3. Parallel dispatch remaining copies at max efficiency
 // 4. Handle remainder rows
 //
-// Caller must call noc_async_read_barrier() before using the buffer.
+// Caller must call noc.async_read_barrier() before using the buffer.
 template <uint32_t selected_experts_k, uint32_t tokens, uint32_t experts_per_device, uint32_t l1_alignment>
-FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
+FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& cb) {
     constexpr uint32_t row_elements = 2 * experts_per_device + 1;
     constexpr uint32_t row_size_bytes_unaligned = row_elements * sizeof(uint32_t);
     // Align row size to l1_alignment for NOC transfer efficiency
@@ -68,7 +70,7 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
     // Minimum transfer size for maximum NOC throughput (~27.8 bytes/cycle)
     constexpr uint32_t MIN_EFFICIENT_BYTES = 512;
 
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    uint32_t l1_write_addr = cb.get_write_ptr();
     volatile tt_l1_ptr uint32_t* buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
 
     // Write first row manually via L1 (~45 cycles for E=2)
@@ -84,6 +86,8 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         return;  // Only 1 token, nothing more to do
     }
 
+    // Device 2.0 migration: legacy primitive retained: local-L1 self-read source address uses
+    // get_noc_addr(l1_write_addr) (current core, MEM_ZEROS-style local loopback). #45003 item 4.
     uint64_t src_noc_addr = get_noc_addr(l1_write_addr);
     uint32_t rows_filled = 1;
 
@@ -106,8 +110,8 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         // Copy rows from start to current position
         uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
         uint32_t bytes_to_copy = rows_to_copy * aligned_row_size_bytes;
-        noc_async_read(src_noc_addr, dest_addr, bytes_to_copy);
-        noc_async_read_barrier();  // Must barrier before next doubling iteration
+        noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, bytes_to_copy);
+        noc.async_read_barrier();  // Must barrier before next doubling iteration
 
         rows_filled += rows_to_copy;
     }
@@ -120,7 +124,7 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
         // Dispatch all full chunks in parallel
         while (rows_filled + chunk_rows <= tokens) {
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc_async_read(src_noc_addr, dest_addr, chunk_bytes);
+            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, chunk_bytes);
             rows_filled += chunk_rows;
         }
 
@@ -129,12 +133,12 @@ FORCE_INLINE void init_expert_activation_buffer_async(uint32_t cb_id) {
             uint32_t remainder_rows = tokens - rows_filled;
             uint32_t remainder_bytes = remainder_rows * aligned_row_size_bytes;
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc_async_read(src_noc_addr, dest_addr, remainder_bytes);
+            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, remainder_bytes);
         }
     }
 
-    // Note: Caller must call noc_async_read_barrier() before using the buffer,
-    // then cb_push_back(cb_id, tokens) when ready to make data available.
+    // Note: Caller must call noc.async_read_barrier() before using the buffer,
+    // then cb.push_back(tokens) when ready to make data available.
 }
 
 // Debug print function for expert_activation buffer
@@ -228,9 +232,16 @@ void kernel_main() {
     constexpr uint32_t previous_chunk_sent_semaphore_id =
         get_named_compile_time_arg_val("previous_chunk_sent_semaphore_id");
 
+    Semaphore<> partial_metadata_ready_sem(partial_metadata_ready_semaphore_id);
+    Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
+    Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
+
     uint32_t partial_metadata_ready_semaphore_addr = get_semaphore(partial_metadata_ready_semaphore_id);
     uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
+
+    // Noc typed wrapper
+    Noc noc_obj(noc_index);
 
     // Runtime arguments
     uint32_t rt_args_idx = 0;
@@ -281,6 +292,28 @@ void kernel_main() {
         TensorAccessor(expert_activation_output_args, expert_activation_output_address);
     const auto e_t_output_tensor_addr_gen = TensorAccessor(e_t_output_args, e_t_output_address);
 
+    // CB typed wrappers
+    CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
+    CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
+    CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
+    CircularBuffer cb_tilize_input(tilize_input_cb_id);
+    CircularBuffer cb_e_t(e_t_cb_id);
+    CircularBuffer cb_expert_activation(expert_activation_cb_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+    CircularBuffer cb_brisc_e_t(brisc_e_t_cb_id);
+    CircularBuffer cb_brisc_expert_counts(brisc_expert_counts_cb_id);
+    CircularBuffer cb_brisc_expert_activation(brisc_expert_activation_cb_id);
+    CircularBuffer cb_brisc_activated_count(brisc_activated_count_cb_id);
+    CircularBuffer cb_remote_counts(remote_counts_cb_id);
+
+    // Endpoints (for TensorAccessor-based reads/writes)
+    UnicastEndpoint mapping_tensor_endpoint(mapping_tensor_addr_gen);
+    UnicastEndpoint input_tensor_endpoint(input_tensor_addr_gen);
+    UnicastEndpoint expert_activation_output_endpoint(expert_activation_output_tensor_addr_gen);
+    UnicastEndpoint per_expert_total_tokens_output_endpoint(per_expert_total_tokens_output_tensor_addr_gen);
+    UnicastEndpoint e_t_output_endpoint(e_t_output_tensor_addr_gen);
+
     // Constants
     constexpr uint32_t one_page = 1;
 
@@ -313,15 +346,17 @@ void kernel_main() {
     // Read the mapping tensor page for this device (linearized_mesh_coord)
     // This gives us the expert -> device mapping from this device's perspective
     // Reserve all pages (tokens)
-    cb_reserve_back(mapping_tensor_cb_id, mapping_pages);
+    cb_mapping_tensor.reserve_back(mapping_pages);
     for (uint32_t i = 0; i < mapping_pages; i++) {
-        noc_async_read_page(
-            i, mapping_tensor_addr_gen, get_write_ptr(mapping_tensor_cb_id) + i * aligned_mapping_page_size);
+        noc_obj.async_read(
+            mapping_tensor_endpoint,
+            {.page_id = i},
+            {.offset_bytes = cb_mapping_tensor.get_write_ptr() + i * aligned_mapping_page_size});
     }
 
-    cb_reserve_back(expert_activation_cb_id, tokens);
+    cb_expert_activation.reserve_back(tokens);
     init_expert_activation_buffer_async<selected_experts_k, tokens, experts_per_device, l1_alignment>(
-        expert_activation_cb_id);
+        noc_obj, cb_expert_activation);
 
     // Both tilize cores bulk-read indices/scores from the dispatch drain core.
     // The dispatch drain core holds the HEIGHT_SHARDED shard but cannot host user kernels,
@@ -329,28 +364,32 @@ void kernel_main() {
     // the dispatch drain core.  Use aligned_page_size so we copy the full buffer allocation.
     // Note: drain_core_noc_x/y refer to tilize_cores[0] (tilize drain) for cross-tilize semaphores.
     {
+        // Device 2.0 migration: legacy primitives retained: precomposed uint64_t NoC addresses
+        // built via NOC_XY_ADDR with DYNAMIC_NOC_X/Y macros. #45003 item 4.
         uint64_t src_indices = NOC_XY_ADDR(
             DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
             DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
             indices_tensor_address);
-        noc_async_read(src_indices, get_read_ptr(indices_tensor_cb_id), aligned_indices_page_size * indices_pages);
+        noc_obj.async_read(
+            src_indices, {.offset_bytes = cb_indices_tensor.get_read_ptr()}, aligned_indices_page_size * indices_pages);
         uint64_t src_scores = NOC_XY_ADDR(
             DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
             DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
             scores_tensor_address);
-        noc_async_read(src_scores, get_read_ptr(scores_tensor_cb_id), aligned_scores_page_size * scores_pages);
+        noc_obj.async_read(
+            src_scores, {.offset_bytes = cb_scores_tensor.get_read_ptr()}, aligned_scores_page_size * scores_pages);
     }
 
     // Wait for all reads to complete (mapping + indices/scores)
-    noc_async_read_barrier();
+    noc_obj.async_read_barrier();
 
     // Now safe to signal BRISC - all data is in place
-    cb_push_back(mapping_tensor_cb_id, mapping_pages);
-    cb_push_back(expert_activation_cb_id, tokens);
+    cb_mapping_tensor.push_back(mapping_pages);
+    cb_expert_activation.push_back(tokens);
 
     // Get pointer to the mapping data
     uint16_t* expert_to_device_map = reinterpret_cast<uint16_t*>(
-        get_read_ptr(mapping_tensor_cb_id) + linearized_mesh_coord * aligned_mapping_page_size);
+        cb_mapping_tensor.get_read_ptr() + linearized_mesh_coord * aligned_mapping_page_size);
     uint16_t local_expert_ids[experts_per_device];
     uint32_t local_expert_count = 0;
     for (uint32_t i = 0; i < experts; i++) {
@@ -368,8 +407,8 @@ void kernel_main() {
     }
 
     // Pre-compute base addresses (avoid repeated calls in hot loop)
-    const uint32_t mapping_base = get_read_ptr(mapping_tensor_cb_id);
-    const uint32_t e_t_buffer_base = get_write_ptr(e_t_cb_id);
+    const uint32_t mapping_base = cb_mapping_tensor.get_read_ptr();
+    const uint32_t e_t_buffer_base = cb_e_t.get_write_ptr();
 
     // Array to hold per-expert token counts (filled by all cores now)
     uint32_t num_activated_tokens_per_expert[experts_per_device] = {0};
@@ -385,9 +424,9 @@ void kernel_main() {
     // indices/scores are in CB - drain has shard, non-drain read via NOC in Step 2
     uint32_t num_activated_tokens = 0;
 
-    const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
-    const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
-    const uint32_t expert_activation_base = get_read_ptr(expert_activation_cb_id);
+    const uint32_t indices_base = cb_indices_tensor.get_read_ptr();
+    const uint32_t scores_base = cb_scores_tensor.get_read_ptr();
+    const uint32_t expert_activation_base = cb_expert_activation.get_read_ptr();
 
     // Cache source_device_mapping - only changes every tokens_per_device tokens
     // Reduces mapping loads from 512 to 16 (dispatch_devices)
@@ -476,20 +515,20 @@ void kernel_main() {
 
     // ========== ALL CORES: WAIT FOR BRISC AND MERGE ==========
     // Wait for BRISC to finish processing second half and push its counts
-    cb_wait_front(brisc_expert_counts_cb_id, one_page);
+    cb_brisc_expert_counts.wait_front(one_page);
     volatile tt_l1_ptr uint32_t* brisc_counts =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(brisc_expert_counts_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_brisc_expert_counts.get_read_ptr());
 
     // Wait for BRISC's e_t buffer to be ready
-    cb_wait_front(brisc_e_t_cb_id, one_page);
-    const uint32_t brisc_e_t_buffer_base = get_read_ptr(brisc_e_t_cb_id);
+    cb_brisc_e_t.wait_front(one_page);
+    const uint32_t brisc_e_t_buffer_base = cb_brisc_e_t.get_read_ptr();
 
     // Wait for BRISC's expert_activation buffer and count
-    cb_wait_front(brisc_activated_count_cb_id, one_page);
+    cb_brisc_activated_count.wait_front(one_page);
     uint32_t brisc_activated_count =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(brisc_activated_count_cb_id));
-    cb_wait_front(brisc_expert_activation_cb_id, one_page);
-    const uint32_t brisc_expert_activation_base = get_read_ptr(brisc_expert_activation_cb_id);
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_brisc_activated_count.get_read_ptr());
+    cb_brisc_expert_activation.wait_front(one_page);
+    const uint32_t brisc_expert_activation_base = cb_brisc_expert_activation.get_read_ptr();
 
     // Merge BRISC's e_t buffer entries into main e_t buffer using NOC DMA
     // For each expert: copy BRISC's tokens after NCRISC's tokens
@@ -505,8 +544,10 @@ void kernel_main() {
             uint32_t e_t_dst_addr = e_t_buffer_base + (e * (tokens + 1) + ncrisc_count) * e_t_entry_size;
 
             // Use NOC DMA for L1-to-L1 copy (local loopback)
+            // Device 2.0 migration: legacy primitive retained: local-L1 self-read source address
+            // uses get_noc_addr(brisc_e_t_src_addr) (current core loopback). #45003 item 4.
             uint64_t src_noc_addr = get_noc_addr(brisc_e_t_src_addr);
-            noc_async_read(src_noc_addr, e_t_dst_addr, brisc_count * e_t_entry_size);
+            noc_obj.async_read(src_noc_addr, {.offset_bytes = e_t_dst_addr}, brisc_count * e_t_entry_size);
         }
 
         // Update total count for this expert
@@ -518,24 +559,26 @@ void kernel_main() {
     if (brisc_activated_count > 0) {
         uint32_t expert_activation_dst_addr =
             expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read source address
+        // uses get_noc_addr(brisc_expert_activation_base) (current core loopback). #45003 item 4.
         uint64_t brisc_activation_src_noc_addr = get_noc_addr(brisc_expert_activation_base);
-        noc_async_read(
+        noc_obj.async_read(
             brisc_activation_src_noc_addr,
-            expert_activation_dst_addr,
+            {.offset_bytes = expert_activation_dst_addr},
             brisc_activated_count * aligned_activation_row_bytes);
     }
 
     // Wait for all NOC DMA copies to complete
-    noc_async_read_barrier();
+    noc_obj.async_read_barrier();
 
     // Update total activated token count to include BRISC's tokens
     num_activated_tokens += brisc_activated_count;
 
     // Pop BRISC's CBs (cleanup)
-    cb_pop_front(brisc_expert_counts_cb_id, one_page);
-    cb_pop_front(brisc_e_t_cb_id, one_page);
-    cb_pop_front(brisc_expert_activation_cb_id, one_page);
-    cb_pop_front(brisc_activated_count_cb_id, one_page);
+    cb_brisc_expert_counts.pop_front(one_page);
+    cb_brisc_e_t.pop_front(one_page);
+    cb_brisc_expert_activation.pop_front(one_page);
+    cb_brisc_activated_count.pop_front(one_page);
 
     // ========== CROSS-CORE CONSOLIDATION (Steps 4-6) ==========
     // Non-drain cores: send counts to drain and wait for consolidated buffer
@@ -544,13 +587,11 @@ void kernel_main() {
         // ========== Step 5: Drain receives counts from non-drain cores and consolidates ==========
         if (num_tilize_cores > 1) {
             // Wait for all non-drain cores to send their counts
-            noc_semaphore_wait(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(partial_metadata_ready_semaphore_addr),
-                num_tilize_cores - 1);
+            partial_metadata_ready_sem.wait_min(num_tilize_cores - 1);
 
             // Read counts from each non-drain core and consolidate their buffers
             // tilize_noc_x and tilize_noc_y arrays were populated from runtime args earlier
-            const uint32_t remote_counts_base = get_read_ptr(remote_counts_cb_id);
+            const uint32_t remote_counts_base = cb_remote_counts.get_read_ptr();
 
             for (uint32_t core_idx = 1; core_idx < num_tilize_cores; core_idx++) {
                 // Read this core's counts from remote_counts_cb
@@ -573,14 +614,17 @@ void kernel_main() {
                     uint32_t remote_count = remote_e_t_counts[e];
                     if (remote_count > 0) {
                         // Source: remote core's e_t buffer, expert e's section starts at 0
-                        uint32_t remote_e_t_addr = get_write_ptr(e_t_cb_id) + e * (tokens + 1) * e_t_entry_size;
+                        uint32_t remote_e_t_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
+                        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC
+                        // address (remote tilize core). #45003 item 4.
                         uint64_t remote_e_t_noc_addr = get_noc_addr(remote_noc_x, remote_noc_y, remote_e_t_addr);
 
                         // Destination: drain's e_t buffer, after current entries for this expert
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
+                        noc_obj.async_read(
+                            remote_e_t_noc_addr, {.offset_bytes = local_e_t_dst}, remote_count * e_t_entry_size);
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -590,7 +634,9 @@ void kernel_main() {
                 // Pull this core's expert_activation buffer rows
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
-                    uint32_t remote_activation_addr = get_read_ptr(expert_activation_cb_id);
+                    uint32_t remote_activation_addr = cb_expert_activation.get_read_ptr();
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC
+                    // address (remote tilize core). #45003 item 4.
                     uint64_t remote_activation_noc_addr =
                         get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 
@@ -598,9 +644,9 @@ void kernel_main() {
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    noc_async_read(
+                    noc_obj.async_read(
                         remote_activation_noc_addr,
-                        local_activation_dst,
+                        {.offset_bytes = local_activation_dst},
                         remote_activated_count * aligned_activation_row_bytes);
 
                     // Update drain's total activated count
@@ -609,32 +655,32 @@ void kernel_main() {
             }
 
             // Wait for all consolidation reads to complete
-            noc_async_read_barrier();
+            noc_obj.async_read_barrier();
         }
 
         // cap off e_t buffer with -1 (now includes merged counts, 16B aligned entries)
         for (uint32_t e = 0; e < experts_per_device; e++) {
-            uint32_t e_t_buffer_addr = get_write_ptr(e_t_cb_id) + e * (tokens + 1) * e_t_entry_size;
+            uint32_t e_t_buffer_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
             uint32_t* e_t_sentinel_ptr =
                 reinterpret_cast<uint32_t*>(e_t_buffer_addr + num_activated_tokens_per_expert[e] * e_t_entry_size);
             *e_t_sentinel_ptr = static_cast<uint32_t>(-1);
         }
 
         // Push per-expert token counts to CB for writer to read
-        cb_reserve_back(per_expert_total_tokens_cb_id, 1);
-        uint32_t* per_expert_counts_ptr = reinterpret_cast<uint32_t*>(get_write_ptr(per_expert_total_tokens_cb_id));
+        cb_per_expert_total_tokens.reserve_back(1);
+        uint32_t* per_expert_counts_ptr = reinterpret_cast<uint32_t*>(cb_per_expert_total_tokens.get_write_ptr());
         for (uint32_t e = 0; e < experts_per_device; e++) {
             per_expert_counts_ptr[e] = num_activated_tokens_per_expert[e];
         }
-        cb_push_back(per_expert_total_tokens_cb_id, 1);
+        cb_per_expert_total_tokens.push_back(1);
 
-        cb_reserve_back(total_chunks_cb_id, one_page);
+        cb_total_chunks.reserve_back(one_page);
         uint32_t total_chunks = 0;
         for (uint32_t e = 0; e < experts_per_device; e++) {
             total_chunks += (num_activated_tokens_per_expert[e] + tokens_per_chunk - 1) / tokens_per_chunk;
         }
-        *reinterpret_cast<uint32_t*>(get_write_ptr(total_chunks_cb_id)) = total_chunks;
-        cb_push_back(total_chunks_cb_id, one_page);
+        *reinterpret_cast<uint32_t*>(cb_total_chunks.get_write_ptr()) = total_chunks;
+        cb_total_chunks.push_back(one_page);
 
         // ========== Write expert_activation buffer to DRAM ==========
         // Cap off expert_activation buffer with sentinel row
@@ -646,15 +692,18 @@ void kernel_main() {
         // Skip if address is 0 (fused mode: no output tensors allocated)
         if (expert_activation_output_address != 0) {
             uint32_t expert_activation_write_size = (num_activated_tokens + 1) * aligned_activation_row_bytes;
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // for DRAM write target. #45003 item 4.
             uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
-            noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
+            noc_obj.async_write(
+                {.offset_bytes = expert_activation_base}, expert_activation_dram_addr, expert_activation_write_size);
         }
 
         // Multicast e_t buffer, per_expert_counts, and total_chunks to non-drain-sync cores
         if (num_tilize_cores > 1) {
-            uint32_t e_t_cb_read_ptr = get_read_ptr(e_t_cb_id);
-            uint32_t per_expert_total_tokens_cb_read_ptr = get_read_ptr(per_expert_total_tokens_cb_id);
-            uint32_t total_chunks_cb_read_ptr = get_read_ptr(total_chunks_cb_id);
+            uint32_t e_t_cb_read_ptr = cb_e_t.get_read_ptr();
+            uint32_t per_expert_total_tokens_cb_read_ptr = cb_per_expert_total_tokens.get_read_ptr();
+            uint32_t total_chunks_cb_read_ptr = cb_total_chunks.get_read_ptr();
 
             uint64_t e_t_mcast_addr = get_safe_multicast_noc_addr(
                 tilize_mcast_start_x, tilize_mcast_start_y, tilize_mcast_end_x, tilize_mcast_end_y, e_t_cb_read_ptr);
@@ -674,23 +723,29 @@ void kernel_main() {
                 total_chunks_cb_read_ptr);
 
             // Multicast e_t buffer to all tilize cores
-            noc_async_write_multicast(
-                e_t_cb_read_ptr, e_t_mcast_addr, e_t_buffer_total_size, tilize_bounding_box_num_cores - 1);
+            noc_obj.async_write_multicast(
+                {.offset_bytes = e_t_cb_read_ptr},
+                e_t_mcast_addr,
+                e_t_buffer_total_size,
+                tilize_bounding_box_num_cores - 1);
 
             // Multicast per_expert_counts to all tilize cores
-            noc_async_write_multicast(
-                per_expert_total_tokens_cb_read_ptr,
+            noc_obj.async_write_multicast(
+                {.offset_bytes = per_expert_total_tokens_cb_read_ptr},
                 per_expert_counts_mcast_addr,
                 experts_per_device * sizeof(uint32_t),
                 num_tilize_cores - 1);
 
             // Multicast total_chunks to all tilize cores
-            noc_async_write_multicast(
-                total_chunks_cb_read_ptr, total_chunks_mcast_addr, sizeof(uint32_t), tilize_bounding_box_num_cores - 1);
+            noc_obj.async_write_multicast(
+                {.offset_bytes = total_chunks_cb_read_ptr},
+                total_chunks_mcast_addr,
+                sizeof(uint32_t),
+                tilize_bounding_box_num_cores - 1);
 
             // Signal non-drain cores via semaphore multicast
             // First, set the local semaphore to 1 - this is the value that will be multicast
-            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+            metadata_ready_sem.set(1);
 
             uint64_t semaphore_mcast_addr = get_safe_multicast_noc_addr(
                 tilize_mcast_start_x,
@@ -700,12 +755,16 @@ void kernel_main() {
                 metadata_ready_semaphore_addr);
 
             // Multicast the value 1 to all non-drain tilize cores
+            // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
+            // precomposed multicast uint64_t NoC address (semaphore_mcast_addr) and uses raw local
+            // sem address as source; Semaphore<>::set_multicast does not provide a wrapper that takes
+            // both. #45003 item 4.
             noc_semaphore_set_multicast(
                 metadata_ready_semaphore_addr, semaphore_mcast_addr, tilize_bounding_box_num_cores - 1);
 
             // Flush writes since we change the local value of metadata_ready_semaphore when signalling
             // to the matmul cores (vs here where we signal to the non-drain-sync tilize cores )
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         }
 
         /*
@@ -718,13 +777,12 @@ void kernel_main() {
         // == 1 == Write per-expert token counts to individual semaphores
 
         volatile tt_l1_ptr uint32_t* num_tokens_per_expert =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
 
         // Write each expert's token count to its dedicated semaphore
         for (uint32_t e = 0; e < experts_per_device; ++e) {
-            volatile tt_l1_ptr uint32_t* count_sem_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(metadata_count_semaphore_base_id + e));
-            *count_sem_ptr = num_tokens_per_expert[e];
+            Semaphore<> count_sem(metadata_count_semaphore_base_id + e);
+            count_sem.set(num_tokens_per_expert[e]);
         }
 
         // == 2 == Multicast per-expert count semaphores to matmul cores
@@ -742,15 +800,16 @@ void kernel_main() {
         uint32_t count_sems_end_addr = get_semaphore(metadata_count_semaphore_base_id + experts_per_device - 1);
         uint32_t count_sems_total_bytes = count_sems_end_addr - count_sems_start_addr + 16;  // include last semaphore
 
-        noc_async_write_multicast(
-            count_sems_start_addr, matmul_mcast_dest, count_sems_total_bytes, matmul_bounding_box_num_cores);
-        noc_async_write_barrier();
+        noc_obj.async_write_multicast(
+            {.offset_bytes = count_sems_start_addr},
+            matmul_mcast_dest,
+            count_sems_total_bytes,
+            matmul_bounding_box_num_cores);
+        noc_obj.async_write_barrier();
 
         // == 3 == Signal ready semaphore (value=1, no encoded data)
 
-        volatile tt_l1_ptr uint32_t* metadata_ready_semaphore_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr);
-        *metadata_ready_semaphore_ptr = 1;
+        metadata_ready_sem.set(1);
 
         uint64_t matmul_metadata_ready_semaphore_mcast_addr = get_safe_multicast_noc_addr(
             matmul_mcast_start_x,
@@ -759,6 +818,8 @@ void kernel_main() {
             matmul_mcast_end_y,
             metadata_ready_semaphore_addr);
 
+        // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
+        // precomposed multicast uint64_t NoC address. #45003 item 4.
         noc_semaphore_set_multicast(
             metadata_ready_semaphore_addr, matmul_metadata_ready_semaphore_mcast_addr, matmul_bounding_box_num_cores);
     }  // End of is_drain_tilize_core block
@@ -773,7 +834,9 @@ void kernel_main() {
         uint32_t remote_counts_offset = (tilize_core_idx - 1) * remote_counts_entry_size;
 
         // Get drain core's remote_counts_cb address
-        uint32_t local_counts_addr = get_read_ptr(remote_counts_cb_id);
+        uint32_t local_counts_addr = cb_remote_counts.get_read_ptr();
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+        // (drain tilize core target). #45003 item 4.
         uint64_t drain_counts_noc_addr =
             get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_counts_addr + remote_counts_offset);
 
@@ -785,32 +848,34 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
-        noc_async_write_barrier();
+        noc_obj.async_write({.offset_bytes = local_counts_addr}, drain_counts_noc_addr, remote_counts_entry_size);
+        noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address used
+        // for cross-core semaphore increment. #45003 item 4.
         uint64_t drain_semaphore_noc_addr =
             get_noc_addr(drain_core_noc_x, drain_core_noc_y, partial_metadata_ready_semaphore_addr);
         noc_semaphore_inc(drain_semaphore_noc_addr, 1);
 
         // ========== NON-DRAIN tilize CORE: Wait for drain core to multicast data ==========
         // Wait for the semaphore signal from drain core
-        noc_semaphore_wait(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(metadata_ready_semaphore_addr), 1);
+        metadata_ready_sem.wait(1);
 
         // Read per-expert counts from the CB (multicast by drain core)
         // The data was written directly to our CB by the multicast
         volatile tt_l1_ptr uint32_t* per_expert_counts =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
         for (uint32_t e = 0; e < experts_per_device; e++) {
             num_activated_tokens_per_expert[e] = per_expert_counts[e];
         }
 
         // Push per_expert_total_tokens_cb and total_chunks_cb so writer can read them
         // (drain core already pushed, non-drain cores need to mark as available)
-        cb_reserve_back(per_expert_total_tokens_cb_id, 1);
-        cb_push_back(per_expert_total_tokens_cb_id, 1);
-        cb_reserve_back(total_chunks_cb_id, one_page);
-        cb_push_back(total_chunks_cb_id, one_page);
+        cb_per_expert_total_tokens.reserve_back(1);
+        cb_per_expert_total_tokens.push_back(1);
+        cb_total_chunks.reserve_back(one_page);
+        cb_total_chunks.push_back(one_page);
     }
 
     // print_e_t_buffer<experts_per_device, tokens, e_t_entry_size>(e_t_cb_id);
@@ -828,20 +893,24 @@ void kernel_main() {
         for (uint32_t chunk_start = 0; chunk_start < num_tokens; chunk_start += tokens_per_chunk) {
             uint32_t tokens_in_chunk = std::min(tokens_per_chunk, num_tokens - chunk_start);
 
-            cb_reserve_back(tilize_input_cb_id, tokens_per_chunk);
+            cb_tilize_input.reserve_back(tokens_per_chunk);
 
             // Read each activated token from the sparse input buffer
             for (uint32_t i = 0; i < tokens_in_chunk; i++) {
                 // Get sparse token ID from e_t buffer (16B aligned entries)
                 uint32_t token_id = *reinterpret_cast<uint32_t*>(e_t_expert_addr + (chunk_start + i) * e_t_entry_size);
                 // read the token from the input tensor at the tilize subtoken offset and size
-                noc_async_read(
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC source
+                // address constructed from TensorAccessor get_noc_addr + a byte offset
+                // (global_subtoken_offset); Endpoint accessors expect a page id, not an additive offset.
+                // #45003 item 4.
+                noc_obj.async_read(
                     get_noc_addr(token_id, input_tensor_addr_gen) + global_subtoken_offset,
-                    get_write_ptr(tilize_input_cb_id) + i * subtoken_size,
+                    {.offset_bytes = cb_tilize_input.get_write_ptr() + i * subtoken_size},
                     subtoken_size);
             }
-            noc_async_read_barrier();
-            cb_push_back(tilize_input_cb_id, tokens_per_chunk);  // Push full chunk (padding is garbage, that's OK)
+            noc_obj.async_read_barrier();
+            cb_tilize_input.push_back(tokens_per_chunk);  // Push full chunk (padding is garbage, that's OK)
             num_chunks_sent++;
 
             // Wait until previous chunk arrives on the matmul cores before reading in another chunk of tokens.
@@ -850,8 +919,7 @@ void kernel_main() {
             // idle during mcast. The very last wait is technically redundent since we won't be reading in another chunk
             // of tokens, however it's still required so we don't use NoC1 to write out the output tensors until the
             // last linked mcast completes.
-            noc_semaphore_wait(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(previous_chunk_sent_semaphore_addr), num_chunks_sent);
+            previous_chunk_sent_sem.wait(num_chunks_sent);
         }
     }
 
@@ -860,21 +928,21 @@ void kernel_main() {
     if (is_drain_tilize_core && e_t_output_address != 0) {
         // Write e_t directly in internal format: 1 page per expert, stride-4 with (T+1) entries.
         // This matches moe_compute's output format expected by selective_reduce_combine.
-        uint32_t l1_read_addr = get_read_ptr(e_t_cb_id);
+        uint32_t l1_read_addr = cb_e_t.get_read_ptr();
         for (uint32_t e = 0; e < experts_per_device; ++e) {
-            noc_async_write_page(e, e_t_output_tensor_addr_gen, l1_read_addr);
+            noc_obj.async_write({.offset_bytes = l1_read_addr}, e_t_output_endpoint, {.page_id = e});
             l1_read_addr += e_t_output_page_size;
         }
     }
 
     // write out per_expert_total_tokens_output_tensor
     if (is_drain_tilize_core && per_expert_total_tokens_output_tensor_address != 0) {
-        uint32_t l1_read_addr = get_read_ptr(per_expert_total_tokens_cb_id);
-        noc_async_write_page(0, per_expert_total_tokens_output_tensor_addr_gen, l1_read_addr);
+        uint32_t l1_read_addr = cb_per_expert_total_tokens.get_read_ptr();
+        noc_obj.async_write({.offset_bytes = l1_read_addr}, per_expert_total_tokens_output_endpoint, {.page_id = 0});
     }
 
     // Explicit write barrier for expert_activation DRAM write, e_t L1 write, and per_expert_total_tokens L1 write
     // (drain core only issued these writes)
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -111,7 +111,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
         // Copy rows from start to current position
         uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
         uint32_t bytes_to_copy = rows_to_copy * aligned_row_size_bytes;
-        noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, bytes_to_copy);
+        // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+        // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+        noc_async_read(src_noc_addr, dest_addr, bytes_to_copy);
         noc.async_read_barrier();  // Must barrier before next doubling iteration
 
         rows_filled += rows_to_copy;
@@ -125,7 +127,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
         // Dispatch all full chunks in parallel
         while (rows_filled + chunk_rows <= tokens) {
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, chunk_bytes);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+            noc_async_read(src_noc_addr, dest_addr, chunk_bytes);
             rows_filled += chunk_rows;
         }
 
@@ -134,7 +138,9 @@ FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& 
             uint32_t remainder_rows = tokens - rows_filled;
             uint32_t remainder_bytes = remainder_rows * aligned_row_size_bytes;
             uint32_t dest_addr = l1_write_addr + rows_filled * aligned_row_size_bytes;
-            noc.async_read(src_noc_addr, {.offset_bytes = dest_addr}, remainder_bytes);
+            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
+            // self-loopback NoC address (L1->L1 broadcast-doubling). #45003 item 4.
+            noc_async_read(src_noc_addr, dest_addr, remainder_bytes);
         }
     }
 
@@ -350,9 +356,11 @@ void kernel_main() {
     cb_mapping_tensor.reserve_back(mapping_pages);
     for (uint32_t i = 0; i < mapping_pages; i++) {
         noc_obj.async_read(
-            mapping_tensor_endpoint,
+            mapping_tensor_addr_gen,
+            cb_mapping_tensor,
+            aligned_mapping_page_size,
             {.page_id = i},
-            {.offset_bytes = cb_mapping_tensor.get_write_ptr() + i * aligned_mapping_page_size});
+            {.offset_bytes = i * aligned_mapping_page_size});
     }
 
     cb_expert_activation.reserve_back(tokens);
@@ -371,14 +379,12 @@ void kernel_main() {
             DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
             DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
             indices_tensor_address);
-        noc_obj.async_read(
-            src_indices, {.offset_bytes = cb_indices_tensor.get_read_ptr()}, aligned_indices_page_size * indices_pages);
+        noc_async_read(src_indices, cb_indices_tensor.get_read_ptr(), aligned_indices_page_size * indices_pages);
         uint64_t src_scores = NOC_XY_ADDR(
             DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
             DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
             scores_tensor_address);
-        noc_obj.async_read(
-            src_scores, {.offset_bytes = cb_scores_tensor.get_read_ptr()}, aligned_scores_page_size * scores_pages);
+        noc_async_read(src_scores, cb_scores_tensor.get_read_ptr(), aligned_scores_page_size * scores_pages);
     }
 
     // Wait for all reads to complete (mapping + indices/scores)
@@ -548,7 +554,7 @@ void kernel_main() {
             // Device 2.0 migration: legacy primitive retained: local-L1 self-read source address
             // uses get_noc_addr(brisc_e_t_src_addr) (current core loopback). #45003 item 4.
             uint64_t src_noc_addr = get_noc_addr(brisc_e_t_src_addr);
-            noc_obj.async_read(src_noc_addr, {.offset_bytes = e_t_dst_addr}, brisc_count * e_t_entry_size);
+            noc_async_read(src_noc_addr, e_t_dst_addr, brisc_count * e_t_entry_size);
         }
 
         // Update total count for this expert
@@ -563,9 +569,9 @@ void kernel_main() {
         // Device 2.0 migration: legacy primitive retained: local-L1 self-read source address
         // uses get_noc_addr(brisc_expert_activation_base) (current core loopback). #45003 item 4.
         uint64_t brisc_activation_src_noc_addr = get_noc_addr(brisc_expert_activation_base);
-        noc_obj.async_read(
+        noc_async_read(
             brisc_activation_src_noc_addr,
-            {.offset_bytes = expert_activation_dst_addr},
+            expert_activation_dst_addr,
             brisc_activated_count * aligned_activation_row_bytes);
     }
 
@@ -624,8 +630,7 @@ void kernel_main() {
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        noc_obj.async_read(
-                            remote_e_t_noc_addr, {.offset_bytes = local_e_t_dst}, remote_count * e_t_entry_size);
+                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -645,9 +650,9 @@ void kernel_main() {
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    noc_obj.async_read(
+                    noc_async_read(
                         remote_activation_noc_addr,
-                        {.offset_bytes = local_activation_dst},
+                        local_activation_dst,
                         remote_activated_count * aligned_activation_row_bytes);
 
                     // Update drain's total activated count
@@ -696,8 +701,7 @@ void kernel_main() {
             // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
             // for DRAM write target. #45003 item 4.
             uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
-            noc_obj.async_write(
-                {.offset_bytes = expert_activation_base}, expert_activation_dram_addr, expert_activation_write_size);
+            noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
         }
 
         // Multicast e_t buffer, per_expert_counts, and total_chunks to non-drain-sync cores
@@ -724,25 +728,24 @@ void kernel_main() {
                 total_chunks_cb_read_ptr);
 
             // Multicast e_t buffer to all tilize cores
-            noc_obj.async_write_multicast(
-                {.offset_bytes = e_t_cb_read_ptr},
-                e_t_mcast_addr,
-                e_t_buffer_total_size,
-                tilize_bounding_box_num_cores - 1);
+            // Device 2.0 migration: legacy primitive retained: noc_async_write_multicast is invoked
+            // with precomposed uint64_t multicast destination address; Noc::async_write_multicast
+            // does not take a raw uint64_t multicast destination. #45003 item 4.
+            noc_async_write_multicast(
+                e_t_cb_read_ptr, e_t_mcast_addr, e_t_buffer_total_size, tilize_bounding_box_num_cores - 1);
 
             // Multicast per_expert_counts to all tilize cores
-            noc_obj.async_write_multicast(
-                {.offset_bytes = per_expert_total_tokens_cb_read_ptr},
+            // Device 2.0 migration: legacy primitive retained: see above. #45003 item 4.
+            noc_async_write_multicast(
+                per_expert_total_tokens_cb_read_ptr,
                 per_expert_counts_mcast_addr,
                 experts_per_device * sizeof(uint32_t),
                 num_tilize_cores - 1);
 
             // Multicast total_chunks to all tilize cores
-            noc_obj.async_write_multicast(
-                {.offset_bytes = total_chunks_cb_read_ptr},
-                total_chunks_mcast_addr,
-                sizeof(uint32_t),
-                tilize_bounding_box_num_cores - 1);
+            // Device 2.0 migration: legacy primitive retained: see above. #45003 item 4.
+            noc_async_write_multicast(
+                total_chunks_cb_read_ptr, total_chunks_mcast_addr, sizeof(uint32_t), tilize_bounding_box_num_cores - 1);
 
             // Signal non-drain cores via semaphore multicast
             // First, set the local semaphore to 1 - this is the value that will be multicast
@@ -801,11 +804,10 @@ void kernel_main() {
         uint32_t count_sems_end_addr = get_semaphore(metadata_count_semaphore_base_id + experts_per_device - 1);
         uint32_t count_sems_total_bytes = count_sems_end_addr - count_sems_start_addr + 16;  // include last semaphore
 
-        noc_obj.async_write_multicast(
-            {.offset_bytes = count_sems_start_addr},
-            matmul_mcast_dest,
-            count_sems_total_bytes,
-            matmul_bounding_box_num_cores);
+        // Device 2.0 migration: legacy primitive retained: noc_async_write_multicast with
+        // precomposed uint64_t multicast destination. #45003 item 4.
+        noc_async_write_multicast(
+            count_sems_start_addr, matmul_mcast_dest, count_sems_total_bytes, matmul_bounding_box_num_cores);
         noc_obj.async_write_barrier();
 
         // == 3 == Signal ready semaphore (value=1, no encoded data)
@@ -849,7 +851,9 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        noc_obj.async_write({.offset_bytes = local_counts_addr}, drain_counts_noc_addr, remote_counts_entry_size);
+        // Device 2.0 migration: legacy primitive retained: dst is a precomposed uint64_t
+        // cross-core NoC address from get_noc_addr(x,y,addr). #45003 item 4.
+        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment
@@ -905,9 +909,9 @@ void kernel_main() {
                 // address constructed from TensorAccessor get_noc_addr + a byte offset
                 // (global_subtoken_offset); Endpoint accessors expect a page id, not an additive offset.
                 // #45003 item 4.
-                noc_obj.async_read(
+                noc_async_read(
                     get_noc_addr(token_id, input_tensor_addr_gen) + global_subtoken_offset,
-                    {.offset_bytes = cb_tilize_input.get_write_ptr() + i * subtoken_size},
+                    cb_tilize_input.get_write_ptr() + i * subtoken_size,
                     subtoken_size);
             }
             noc_obj.async_read_barrier();
@@ -929,17 +933,24 @@ void kernel_main() {
     if (is_drain_tilize_core && e_t_output_address != 0) {
         // Write e_t directly in internal format: 1 page per expert, stride-4 with (T+1) entries.
         // This matches moe_compute's output format expected by selective_reduce_combine.
-        uint32_t l1_read_addr = cb_e_t.get_read_ptr();
         for (uint32_t e = 0; e < experts_per_device; ++e) {
-            noc_obj.async_write({.offset_bytes = l1_read_addr}, e_t_output_endpoint, {.page_id = e});
-            l1_read_addr += e_t_output_page_size;
+            noc_obj.async_write(
+                cb_e_t,
+                e_t_output_tensor_addr_gen,
+                e_t_output_page_size,
+                {.offset_bytes = e * e_t_output_page_size},
+                {.page_id = e});
         }
     }
 
     // write out per_expert_total_tokens_output_tensor
     if (is_drain_tilize_core && per_expert_total_tokens_output_tensor_address != 0) {
-        uint32_t l1_read_addr = cb_per_expert_total_tokens.get_read_ptr();
-        noc_obj.async_write({.offset_bytes = l1_read_addr}, per_expert_total_tokens_output_endpoint, {.page_id = 0});
+        noc_obj.async_write(
+            cb_per_expert_total_tokens,
+            per_expert_total_tokens_output_tensor_addr_gen,
+            per_expert_total_tokens_output_page_size,
+            {},
+            {.page_id = 0});
     }
 
     // Explicit write barrier for expert_activation DRAM write, e_t L1 write, and per_expert_total_tokens L1 write

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
 using namespace ttnn::operations::ccl::common;
@@ -24,14 +26,15 @@ FORCE_INLINE uint64_t get_safe_multicast_noc_addr(
 }
 
 FORCE_INLINE void noc_async_write_linked_multicast(
-    uint32_t src_local_l1_addr, uint64_t dst_noc_addr_multicast, uint32_t size, uint32_t num_dests, uint8_t noc) {
+    Noc& noc, uint32_t src_local_l1_addr, uint64_t dst_noc_addr_multicast, uint32_t size, uint32_t num_dests) {
     while (size > NOC_MAX_BURST_SIZE) {
-        noc_async_write_multicast(src_local_l1_addr, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true, noc);
+        noc.async_write_multicast(
+            {.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, NOC_MAX_BURST_SIZE, num_dests, true);
         src_local_l1_addr += NOC_MAX_BURST_SIZE;
         dst_noc_addr_multicast += NOC_MAX_BURST_SIZE;
         size -= NOC_MAX_BURST_SIZE;
     }
-    noc_async_write_multicast(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, false, noc);
+    noc.async_write_multicast({.offset_bytes = src_local_l1_addr}, dst_noc_addr_multicast, size, num_dests, false);
 }
 
 template <
@@ -144,11 +147,32 @@ void kernel_main() {
         get_named_compile_time_arg_val("previous_chunk_sent_semaphore_id");
     constexpr uint32_t initial_gather_semaphore_id = get_named_compile_time_arg_val("initial_gather_semaphore_id");
 
+    Semaphore<> matmul_chunk_available_sem(matmul_chunk_available_semaphore_id);
+    Semaphore<> tilize_chunk_ready_sem(tilize_chunk_ready_semaphore_id);
+    Semaphore<> matmul_chunk_ready_sem(matmul_chunk_ready_semaphore_id);
+    Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
+    Semaphore<> initial_gather_sem(initial_gather_semaphore_id);
+
     uint32_t matmul_chunk_available_semaphore_addr = get_semaphore(matmul_chunk_available_semaphore_id);
     uint32_t tilize_chunk_ready_semaphore_addr = get_semaphore(tilize_chunk_ready_semaphore_id);
     uint32_t matmul_chunk_ready_semaphore_addr = get_semaphore(matmul_chunk_ready_semaphore_id);
     uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
     uint32_t initial_gather_semaphore_addr = get_semaphore(initial_gather_semaphore_id);
+
+    // Noc typed wrapper
+    Noc noc_obj(noc_index);
+
+    // CB typed wrappers
+    CircularBuffer cb_tilize_output(tilize_output_cb_id);
+    CircularBuffer cb_per_expert_total_tokens(per_expert_total_tokens_cb_id);
+    CircularBuffer cb_total_chunks(total_chunks_cb_id);
+    CircularBuffer cb_indices_tensor(indices_tensor_cb_id);
+    CircularBuffer cb_scores_tensor(scores_tensor_cb_id);
+    CircularBuffer cb_mapping_tensor(mapping_tensor_cb_id);
+    CircularBuffer cb_brisc_e_t(brisc_e_t_cb_id);
+    CircularBuffer cb_brisc_expert_counts(brisc_expert_counts_cb_id);
+    CircularBuffer cb_brisc_expert_activation(brisc_expert_activation_cb_id);
+    CircularBuffer cb_brisc_activated_count(brisc_activated_count_cb_id);
 
     // Runtime arguments
     uint32_t rt_args_idx = 0;
@@ -211,10 +235,10 @@ void kernel_main() {
     uint32_t brisc_tokens_capacity = tokens_this_core / 2;
 
     // Wait for NCRISC to finish reading the mapping tensor
-    cb_wait_front(mapping_tensor_cb_id, num_devices);
+    cb_mapping_tensor.wait_front(num_devices);
 
     // Get mapping base pointer (read by NCRISC)
-    const uint32_t mapping_base = get_read_ptr(mapping_tensor_cb_id);
+    const uint32_t mapping_base = cb_mapping_tensor.get_read_ptr();
 
     // Build local_expert_ids array - experts that map to this device
     uint16_t* expert_to_device_map =
@@ -232,12 +256,12 @@ void kernel_main() {
     }
 
     // Reserve BRISC's e_t buffer (single page contains all experts' token lists)
-    cb_reserve_back(brisc_e_t_cb_id, one_page);
-    const uint32_t brisc_e_t_buffer_base = get_write_ptr(brisc_e_t_cb_id);
+    cb_brisc_e_t.reserve_back(one_page);
+    const uint32_t brisc_e_t_buffer_base = cb_brisc_e_t.get_write_ptr();
 
     // Reserve BRISC's expert_activation buffer (single page contains all activation rows)
-    cb_reserve_back(brisc_expert_activation_cb_id, one_page);
-    const uint32_t brisc_expert_activation_base = get_write_ptr(brisc_expert_activation_cb_id);
+    cb_brisc_expert_activation.reserve_back(one_page);
+    const uint32_t brisc_expert_activation_base = cb_brisc_expert_activation.get_write_ptr();
 
     // Initialize BRISC's expert_activation buffer with sentinel values (selected_experts_k)
     for (uint32_t row = 0; row < brisc_tokens_capacity; row++) {
@@ -251,8 +275,8 @@ void kernel_main() {
     }
 
     // Indices and scores accessible via CB (drain has shard, non-drain read via NOC in reader)
-    const uint32_t indices_base = get_read_ptr(indices_tensor_cb_id);
-    const uint32_t scores_base = get_read_ptr(scores_tensor_cb_id);
+    const uint32_t indices_base = cb_indices_tensor.get_read_ptr();
+    const uint32_t scores_base = cb_scores_tensor.get_read_ptr();
 
     // Per-expert token counts for BRISC's half
     uint32_t brisc_num_tokens_per_expert[experts_per_device] = {0};
@@ -341,28 +365,28 @@ void kernel_main() {
     }
 
     // Push BRISC's e_t buffer (no -1 cap needed, NCRISC will cap final merged buffer)
-    cb_push_back(brisc_e_t_cb_id, one_page);
+    cb_brisc_e_t.push_back(one_page);
 
     // Push BRISC's expert_activation buffer
-    cb_push_back(brisc_expert_activation_cb_id, one_page);
+    cb_brisc_expert_activation.push_back(one_page);
 
     // Push BRISC's per-expert counts to CB for NCRISC to read
-    cb_reserve_back(brisc_expert_counts_cb_id, one_page);
-    uint32_t* brisc_counts_ptr = reinterpret_cast<uint32_t*>(get_write_ptr(brisc_expert_counts_cb_id));
+    cb_brisc_expert_counts.reserve_back(one_page);
+    uint32_t* brisc_counts_ptr = reinterpret_cast<uint32_t*>(cb_brisc_expert_counts.get_write_ptr());
     for (uint32_t e = 0; e < experts_per_device; e++) {
         brisc_counts_ptr[e] = brisc_num_tokens_per_expert[e];
     }
-    cb_push_back(brisc_expert_counts_cb_id, one_page);
+    cb_brisc_expert_counts.push_back(one_page);
 
     // Push BRISC's activated token count
-    cb_reserve_back(brisc_activated_count_cb_id, one_page);
-    *reinterpret_cast<uint32_t*>(get_write_ptr(brisc_activated_count_cb_id)) = brisc_num_activated_tokens;
-    cb_push_back(brisc_activated_count_cb_id, one_page);
+    cb_brisc_activated_count.reserve_back(one_page);
+    *reinterpret_cast<uint32_t*>(cb_brisc_activated_count.get_write_ptr()) = brisc_num_activated_tokens;
+    cb_brisc_activated_count.push_back(one_page);
 
     // Wait for reader to push per-expert token counts (includes merged NCRISC + BRISC counts)
-    cb_wait_front(per_expert_total_tokens_cb_id, 1);
+    cb_per_expert_total_tokens.wait_front(1);
     volatile tt_l1_ptr uint32_t* per_expert_counts =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(per_expert_total_tokens_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_per_expert_total_tokens.get_read_ptr());
 
     // Read per-expert token counts into local array
     uint32_t num_tokens_per_expert[experts_per_device];
@@ -371,9 +395,9 @@ void kernel_main() {
     }
 
     // Wait for reader to push total_chunks
-    cb_wait_front(total_chunks_cb_id, one_page);
+    cb_total_chunks.wait_front(one_page);
     [[maybe_unused]] uint32_t total_chunks =
-        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(total_chunks_cb_id));
+        *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_total_chunks.get_read_ptr());
 
     /************************************************************************/
     /* Synchronization setup for signalling between tilize and matmul cores */
@@ -400,12 +424,14 @@ void kernel_main() {
     uint32_t num_chunks_sent = 0;
 
     bool use_second_half_buffer = false;
-    uint32_t matmul_chunk_input_cb_base_addr = get_read_ptr(tilize_output_cb_id);
+    uint32_t matmul_chunk_input_cb_base_addr = cb_tilize_output.get_read_ptr();
     uint32_t first_half_buffer_addr = matmul_chunk_input_cb_base_addr;
     uint32_t second_half_buffer_addr =
         matmul_chunk_input_cb_base_addr + (tiles_per_global_chunk * tilize_output_page_size);
 
     uint32_t tilize_chunk_ready_wait_value = num_tilize_cores - 1;
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address (drain tilize
+    // core target for semaphore increment). #45003 item 4.
     uint64_t tilize_chunk_ready_drain_semaphore_noc_addr =
         get_noc_addr(drain_core_noc_x, drain_core_noc_y, tilize_chunk_ready_semaphore_addr, noc_index);
     uint64_t tilize_chunk_ready_mcast_addr = get_safe_multicast_noc_addr(
@@ -444,8 +470,8 @@ void kernel_main() {
 
         for (uint32_t chunk = 0; chunk < num_expert_chunks; chunk++) {
             // Wait for compute to push tiles_per_local_chunk tiles
-            cb_wait_front(tilize_output_cb_id, shared_cb_num_pages);
-            uint32_t l1_read_addr = get_read_ptr(tilize_output_cb_id);
+            cb_tilize_output.wait_front(shared_cb_num_pages);
+            uint32_t l1_read_addr = cb_tilize_output.get_read_ptr();
 
             /*
              * Send chunks to MM cores;
@@ -487,15 +513,16 @@ void kernel_main() {
             if (num_chunks_sent >= 2) {
                 // wait_min as MM may signal twice (once per buffer slot) before we acknowledge the first (empty) buffer
                 // slot
-                noc_semaphore_wait_min(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_available_semaphore_addr),
-                    matmul_chunk_available_semaphore_wait_value);
+                matmul_chunk_available_sem.wait_min(matmul_chunk_available_semaphore_wait_value);
                 matmul_chunk_available_semaphore_wait_value += num_matmul_cores;
 
                 // MM only signals to the drain-sync-core, which then forwards it to the non-drain-sync cores
                 if (is_drain_tilize_core && num_tilize_cores > 1) {
                     // use the local value of the semaphore, which is the value we just waited on (no need to set local
                     // value)
+                    // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
+                    // precomposed multicast uint64_t NoC address with raw local sem address as source.
+                    // #45003 item 4.
                     noc_semaphore_set_multicast(
                         matmul_chunk_available_semaphore_addr,
                         matmul_chunk_available_semaphore_tilize_mcast_addr,
@@ -510,9 +537,7 @@ void kernel_main() {
             if (is_drain_tilize_core) {
                 // == 5b ==
                 // wait until non-drain-sync cores send us their sub-chunks
-                noc_semaphore_wait(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tilize_chunk_ready_semaphore_addr),
-                    tilize_chunk_ready_wait_value);
+                tilize_chunk_ready_sem.wait(tilize_chunk_ready_wait_value);
                 tilize_chunk_ready_wait_value += (num_tilize_cores - 1);
 
                 // == 6b ==
@@ -524,23 +549,29 @@ void kernel_main() {
 
                 // mcast the data
                 noc_async_write_linked_multicast(
+                    noc_obj,
                     l1_read_addr,
                     matmul_chunk_input_mcast_addr,
                     normal_iteration_bytes_to_mcast,
-                    matmul_bounding_box_num_cores,
-                    noc_index);
+                    matmul_bounding_box_num_cores);
             } else {
                 // == 3b ==
                 // send to proper offset on global mmcast gather core (the drain-sync core)
                 uint32_t gather_addr = l1_read_addr + global_tile_offset * tilize_output_page_size;
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                // (drain tilize core target). #45003 item 4.
                 uint64_t drain_gather_noc_addr =
                     get_noc_addr(drain_core_noc_x, drain_core_noc_y, gather_addr, noc_index);
-                noc_async_write(
-                    l1_read_addr, drain_gather_noc_addr, tiles_per_local_chunk * tilize_output_page_size, noc_index);
-                noc_async_write_barrier(noc_index);
+                noc_obj.async_write(
+                    {.offset_bytes = l1_read_addr},
+                    drain_gather_noc_addr,
+                    tiles_per_local_chunk * tilize_output_page_size);
+                noc_obj.async_write_barrier();
 
                 // == 4b ==
                 // signal to global mcast gather core that we've delivered our sub-chunk
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+                // cannot be wrapped by Semaphore<>::inc which binds to a per-program id. #45003 item 4.
                 noc_semaphore_inc(tilize_chunk_ready_drain_semaphore_noc_addr, 1, noc_index);
             }
 
@@ -549,12 +580,13 @@ void kernel_main() {
                 // signal to MM cores that entire chunk has arrived
 
                 // set local value
-                noc_semaphore_set(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(matmul_chunk_ready_semaphore_addr),
-                    matmul_chunk_ready_semaphore_set_value);
+                matmul_chunk_ready_sem.set(matmul_chunk_ready_semaphore_set_value);
                 matmul_chunk_ready_semaphore_set_value++;
 
                 // mcast sem set
+                // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
+                // precomposed multicast uint64_t NoC address with raw local sem address as source.
+                // #45003 item 4.
                 noc_semaphore_set_multicast(
                     matmul_chunk_ready_semaphore_addr,
                     matmul_chunk_ready_semaphore_mcast_addr,
@@ -567,6 +599,9 @@ void kernel_main() {
                     // Signal to non-drain-sync cores that they can start sending the next chunk
                     // Use local semaphore value (no need to explicitly set it)
                     // Local value is from when drain-sync waits until gather process is done (8a and 5b)
+                    // Device 2.0 migration: legacy primitive retained: noc_semaphore_set_multicast targets a
+                    // precomposed multicast uint64_t NoC address with raw local sem address as source.
+                    // #45003 item 4.
                     noc_semaphore_set_multicast(
                         tilize_chunk_ready_semaphore_addr,
                         tilize_chunk_ready_mcast_addr,
@@ -578,31 +613,28 @@ void kernel_main() {
                 // == 11 ==
                 // wait until drain-sync signals to us that we can start using NoC again (read in next set of tokens,
                 // output another chunk, etc)
-                noc_semaphore_wait(
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tilize_chunk_ready_semaphore_addr),
-                    tilize_chunk_ready_wait_value);
+                tilize_chunk_ready_sem.wait(tilize_chunk_ready_wait_value);
                 tilize_chunk_ready_wait_value += (num_tilize_cores - 1);
             }
 
             // we already barrier when using (1 - noc_index), so just need to flush on noc_index here
-            noc_async_writes_flushed(noc_index);
+            noc_obj.async_writes_flushed();
 
             // pop the tiles from CB
-            cb_pop_front(tilize_output_cb_id, shared_cb_num_pages);
+            cb_tilize_output.pop_front(shared_cb_num_pages);
             num_chunks_sent++;
             use_second_half_buffer = !use_second_half_buffer;
 
             // == 12 ==
             // signal to reader that they can start reading in another set of tokens
-            noc_semaphore_set(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(previous_chunk_sent_semaphore_addr), num_chunks_sent);
+            previous_chunk_sent_sem.set(num_chunks_sent);
         }
     }
 
     // Pop the per-expert counts and total_chunks (cleanup)
-    cb_pop_front(per_expert_total_tokens_cb_id, one_page);
-    cb_pop_front(total_chunks_cb_id, one_page);
+    cb_per_expert_total_tokens.pop_front(one_page);
+    cb_total_chunks.pop_front(one_page);
 
-    noc_async_write_barrier(noc_index);
-    noc_async_atomic_barrier(noc_index);
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 
@@ -29,6 +31,9 @@ void kernel_main() {
     uint32_t read_size = stick_size;
     const auto src_accessor = TensorAccessor(src_args, input_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     for (uint32_t s = 0; s < rows_count; s++) {
         const uint32_t linear_row = total_rows_start + s;  // [0 .. outer_dim_size*input_halo_dim_size)
         const uint32_t outer_idx = linear_row / input_halo_dim_size;
@@ -37,13 +42,11 @@ void kernel_main() {
 
         uint32_t src_stick_id = t * num_sticks_per_halo_dim + stick_start_id + outer_dim_offset;
         for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-            cb_reserve_back(cb_output_id, 1);
-            uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
-            uint64_t src_noc_addr = src_accessor.get_noc_addr(src_stick_id);
-            noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+            cb_output.reserve_back(1);
+            noc_obj.async_read(src_accessor, cb_output, read_size, {.page_id = src_stick_id}, {});
             src_stick_id++;
-            noc_async_read_barrier();
-            cb_push_back(cb_output_id, 1);
+            noc_obj.async_read_barrier();
+            cb_output.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 
@@ -18,10 +21,14 @@ inline void zeroWrite(uint64_t dst_noc_addr) {
     constexpr uint32_t num_full_writes = stick_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_write_size = stick_size_bytes % MEM_ZEROS_SIZE;
     for (uint32_t i = 0; i < num_full_writes; ++i) {
+        // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE source (local L1); no LocalL1 source
+        // endpoint on main. #45003 item 4.
         noc_async_write((uint32_t)MEM_ZEROS_BASE, dst_noc_addr, MEM_ZEROS_SIZE);
         dst_noc_addr += MEM_ZEROS_SIZE;
     }
     if constexpr (partial_write_size > 0) {
+        // Device 2.0 migration: legacy primitive retained: MEM_ZEROS_BASE source (local L1); no LocalL1 source
+        // endpoint on main. #45003 item 4.
         noc_async_write((uint32_t)MEM_ZEROS_BASE, dst_noc_addr, partial_write_size);
     }
 }
@@ -50,12 +57,15 @@ void kernel_main() {
 
     const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     // Phase A: zero-fill this core's slice of the T-front output region.
     // Covers all H positions (interior + H-halo) at T < t_front_pad.
     for (uint32_t s = 0; s < zero_fill_count; ++s) {
         uint64_t dst_noc_addr = dst_accessor.get_noc_addr(zero_fill_start + s);
         zeroWrite<stick_size>(dst_noc_addr);
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
 
     // Phase B: copy input sticks (from CB) to output at T-offset t_front_pad_stick_offset.
@@ -69,19 +79,18 @@ void kernel_main() {
         uint32_t dst_stick_id =
             (t + padding_left) * num_sticks_per_halo_dim + stick_start_id + outer_dim_offset + t_front_pad_stick_offset;
         for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-            cb_wait_front(cb_output_id, 1);
-            uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-            uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id);
+            cb_output.wait_front(1);
             if (masked) {
+                uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id);
                 zeroWrite<stick_size>(dst_noc_addr);
             } else {
-                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                noc_obj.async_write(cb_output, dst_accessor, stick_size, {}, {.page_id = dst_stick_id});
             }
 
             dst_stick_id++;
-            noc_async_write_barrier();
-            cb_pop_front(cb_output_id, 1);
+            noc_obj.async_write_barrier();
+            cb_output.pop_front(1);
         }
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/endpoints.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <cstdint>
 
 using address_t = uint32_t;
@@ -19,18 +22,24 @@ constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_src);
 constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_src + 1);
 
 template <uint32_t stick_size_bytes>
-inline void zeroPad(uint32_t cb_output_id) {
+inline void zeroPad(Noc& noc, CircularBuffer& cb_output) {
     //  Zero-fill from MEM_ZEROS
     constexpr uint32_t num_full_reads = stick_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_read_size = stick_size_bytes % MEM_ZEROS_SIZE;
+    // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no LocalL1
+    // source endpoint on main. #45003 item 4.
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t cb_write_addr = get_write_ptr(cb_output_id);
+    uint32_t cb_write_addr = cb_output.get_write_ptr();
 
     for (uint32_t i = 0; i < num_full_reads; ++i) {
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;
     }
     if (partial_read_size > 0) {
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(zeros_noc_addr, cb_write_addr, partial_read_size);
     }
 }
@@ -63,6 +72,10 @@ void kernel_main() {
     uint32_t read_size = stick_size;
     const auto src_accessor = TensorAccessor(src_ct_args, input_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+    CircularBuffer cb_recv(recv_cb_id);
+
     uint32_t outer_dim_offset = outer_dim_offset_start_id;
     for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
         if (is_first_chip) {
@@ -76,22 +89,20 @@ void kernel_main() {
                 }
                 src_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                    cb_reserve_back(cb_output_id, 1);
-                    uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
+                    cb_output.reserve_back(1);
 
-                    uint64_t src_noc_addr = src_accessor.get_noc_addr(src_stick_id);
-                    noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+                    noc_obj.async_read(src_accessor, cb_output, read_size, {.page_id = src_stick_id}, {});
 
                     src_stick_id++;
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_output_id, 1);
+                    noc_obj.async_read_barrier();
+                    cb_output.push_back(1);
                 }
             } else {
-                cb_reserve_back(cb_output_id, 1);
-                zeroPad<stick_size>(cb_output_id);
-                noc_async_read_barrier();
-                cb_push_back(cb_output_id, 1);
+                cb_output.reserve_back(1);
+                zeroPad<stick_size>(noc_obj, cb_output);
+                noc_obj.async_read_barrier();
+                cb_output.push_back(1);
             }
         }
 
@@ -106,16 +117,14 @@ void kernel_main() {
                 }
                 src_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                    cb_reserve_back(cb_output_id, 1);
-                    uint32_t src_buffer_l1_addr = get_write_ptr(cb_output_id);
+                    cb_output.reserve_back(1);
 
-                    uint64_t src_noc_addr = src_accessor.get_noc_addr(src_stick_id);
-                    noc_async_read(src_noc_addr, src_buffer_l1_addr, read_size);
+                    noc_obj.async_read(src_accessor, cb_output, read_size, {.page_id = src_stick_id}, {});
 
                     src_stick_id++;
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_output_id, 1);
+                    noc_obj.async_read_barrier();
+                    cb_output.push_back(1);
                 }
             }
         }
@@ -130,7 +139,7 @@ void kernel_main() {
         if constexpr (use_l1_intermediate) {
             // L1 intermediate: fabric delivered H halo data to our L1 recv buffer.
             // Push it into CB for the paired writer to write to output DRAM.
-            uint32_t recv_buf_addr = get_write_ptr(recv_cb_id);
+            uint32_t recv_buf_addr = cb_recv.get_write_ptr();
             uint32_t buf_offset = 0;  // Accumulates across all outer_dims (no L1 reuse)
 
             for (uint32_t od = 0; od < outer_dim_size; od++) {
@@ -138,26 +147,40 @@ void kernel_main() {
                 // Using cumulative waits (od+1) instead of resetting to 0 each iteration
                 // avoids a race where the writer sends multiple sem incs before the reader
                 // processes them — resetting to 0 would discard pending incs and cause a hang.
+                // Device 2.0 migration: legacy primitive retained: h_neighbor_sem is a GlobalSemaphore address.
+                // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+                // #45003 item 4.
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), od + 1);
 
                 for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
                     // Use num_l1_recv_sticks_per_row (corners-only count) instead of
                     // num_sticks_to_read (full row width) for the L1 recv path.
                     for (uint32_t iter = 0; iter < num_l1_recv_sticks_per_row; iter++) {
-                        cb_reserve_back(cb_output_id, 1);
-                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                        cb_output.reserve_back(1);
+                        uint32_t dst_l1_addr = cb_output.get_write_ptr();
+                        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via
+                        // get_noc_addr(local_l1_addr); no LocalL1 source endpoint on main. #45003 item 4.
                         noc_async_read(get_noc_addr(recv_buf_addr + buf_offset), dst_l1_addr, stick_size);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_output_id, 1);
+                        noc_obj.async_read_barrier();
+                        cb_output.push_back(1);
                         buf_offset += stick_size;
                     }
                 }
             }
             // Reset after all waits are complete (safe: no more fabric increments expected)
+            // Device 2.0 migration: legacy primitive retained: h_neighbor_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
         } else {
             // 1D case: fabric wrote directly to DRAM; just wait for all outer_dims
+            // Device 2.0 migration: legacy primitive retained: h_neighbor_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), outer_dim_size);
+            // Device 2.0 migration: legacy primitive retained: h_neighbor_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -20,6 +20,7 @@
 #include "tt_metal/fabric/hw/inc/linear/api.h"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -112,10 +116,14 @@ void kernel_main() {
 
     const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+    CircularBuffer cb_recv(recv_cb_id);
+
     // L1 intermediate: discover the recv CB base address (same on neighbor device due to identical program)
     uint32_t recv_buf_base = 0;
     if constexpr (use_l1_intermediate) {
-        recv_buf_base = get_write_ptr(recv_cb_id);
+        recv_buf_base = cb_recv.get_write_ptr();
     }
 
     // pre-populate packet headers with proper routing
@@ -184,6 +192,9 @@ void kernel_main() {
             }
 
             if constexpr (ring_size > 1) {
+                // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+                // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+                // #45003 item 4.
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
             }
         } else {
@@ -229,9 +240,14 @@ void kernel_main() {
             // Wait for 1 barrier inc from each adjacent W device (if it exists)
             uint32_t w_barrier_wait = (is_first_chip ? 0u : 1u) + (is_last_chip ? 0u : 1u);
             if (w_barrier_wait > 0) {
+                // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+                // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore.
+                // #45003 item 4.
                 noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), w_barrier_wait);
             }
         }
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address. Semaphore<> binds
+        // to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
@@ -269,24 +285,27 @@ void kernel_main() {
                 }
                 dst_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                    cb_wait_front(cb_output_id, 1);
+                    cb_output.wait_front(1);
                     if constexpr (is_w_fabric_writer) {
                         if (!fabric_opened) {
                             fabric_connection.open();
                             fabric_opened = true;
                         }
                     }
-                    uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                    uint32_t l1_read_addr = cb_output.get_read_ptr();
 
                     for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
-                        uint64_t dst_noc_addr =
-                            dst_accessor.get_noc_addr(dst_stick_id + pad_id * num_sticks_per_halo_dim);
-                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                        noc_obj.async_write(
+                            CoreLocalMem<uint8_t>(l1_read_addr),
+                            dst_accessor,
+                            stick_size,
+                            {},
+                            {.page_id = dst_stick_id + pad_id * num_sticks_per_halo_dim});
                     }
                     dst_stick_id++;
 
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_output_id, 1);
+                    noc_obj.async_write_barrier();
+                    cb_output.pop_front(1);
                 }
             } else {
                 uint32_t dst_stick_id = 0;
@@ -296,25 +315,28 @@ void kernel_main() {
                     dst_stick_id = stick_start_id;
                 }
                 dst_stick_id += outer_dim_offset;
-                cb_wait_front(cb_output_id, 1);
+                cb_output.wait_front(1);
                 if constexpr (is_w_fabric_writer) {
                     if (!fabric_opened) {
                         fabric_connection.open();
                         fabric_opened = true;
                     }
                 }
-                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                uint32_t l1_read_addr = cb_output.get_read_ptr();
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
                     for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
-                        uint64_t dst_noc_addr =
-                            dst_accessor.get_noc_addr(dst_stick_id + pad_id * num_sticks_per_halo_dim);
-                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+                        noc_obj.async_write(
+                            CoreLocalMem<uint8_t>(l1_read_addr),
+                            dst_accessor,
+                            stick_size,
+                            {},
+                            {.page_id = dst_stick_id + pad_id * num_sticks_per_halo_dim});
                     }
                     dst_stick_id++;
 
-                    noc_async_write_barrier();
+                    noc_obj.async_write_barrier();
                 }
-                cb_pop_front(cb_output_id, 1);
+                cb_output.pop_front(1);
             }
         }
 
@@ -330,14 +352,14 @@ void kernel_main() {
                 }
                 dst_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
-                    cb_wait_front(cb_output_id, 1);
+                    cb_output.wait_front(1);
                     if constexpr (is_w_fabric_writer) {
                         if (!fabric_opened) {
                             fabric_connection.open();
                             fabric_opened = true;
                         }
                     }
-                    uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                    uint32_t l1_read_addr = cb_output.get_read_ptr();
 
                     uint64_t dst_noc_addr;
                     if constexpr (use_l1_intermediate && !is_w_fabric_writer) {
@@ -375,12 +397,12 @@ void kernel_main() {
                         fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
                             (uint32_t)pkt_hdr, sizeof(PACKET_HEADER_TYPE));
                     }
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
 
                     dst_stick_id++;
 
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_output_id, 1);
+                    noc_obj.async_write_barrier();
+                    cb_output.pop_front(1);
                 }
             }
 
@@ -402,7 +424,7 @@ void kernel_main() {
                 fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
                     (uint32_t)pkt_hdr_sem_inc, sizeof(PACKET_HEADER_TYPE));
             }
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         }
     };  // end process_one_row
 
@@ -443,7 +465,7 @@ void kernel_main() {
     }
 
     // Ensure all DRAM writes from main loop are complete.
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 
     // Incoming writes: pop sticks that the paired reader pushed from its L1 recv buffer
     // (fabric-delivered padding from neighbor) and write to output DRAM.
@@ -465,45 +487,38 @@ void kernel_main() {
                         if (pad2_right_sticks + pad2_left_sticks >= num_sticks_to_read) {
                             // Overlap: all sticks are corners, pop exactly num_sticks_to_read
                             for (uint32_t c = 0; c < num_sticks_to_read; c++) {
-                                cb_wait_front(cb_output_id, 1);
-                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-                                uint64_t dst_noc_addr = dst_accessor.get_noc_addr(base_dst + c);
-                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-                                noc_async_write_barrier();
-                                cb_pop_front(cb_output_id, 1);
+                                cb_output.wait_front(1);
+                                noc_obj.async_write(cb_output, dst_accessor, stick_size, {}, {.page_id = base_dst + c});
+                                noc_obj.async_write_barrier();
+                                cb_output.pop_front(1);
                             }
                         } else {
                             // Corners-only: pop left corners then right corners from CB
                             // Left corners: first pad2_right_sticks of interior
                             for (uint32_t c = 0; c < pad2_right_sticks; c++) {
-                                cb_wait_front(cb_output_id, 1);
-                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-                                uint64_t dst_noc_addr = dst_accessor.get_noc_addr(base_dst + c);
-                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-                                noc_async_write_barrier();
-                                cb_pop_front(cb_output_id, 1);
+                                cb_output.wait_front(1);
+                                noc_obj.async_write(cb_output, dst_accessor, stick_size, {}, {.page_id = base_dst + c});
+                                noc_obj.async_write_barrier();
+                                cb_output.pop_front(1);
                             }
                             // Right corners: last pad2_left_sticks of interior
                             uint32_t right_start = base_dst + (num_sticks_to_read - pad2_left_sticks);
                             for (uint32_t c = 0; c < pad2_left_sticks; c++) {
-                                cb_wait_front(cb_output_id, 1);
-                                uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-                                uint64_t dst_noc_addr = dst_accessor.get_noc_addr(right_start + c);
-                                noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-                                noc_async_write_barrier();
-                                cb_pop_front(cb_output_id, 1);
+                                cb_output.wait_front(1);
+                                noc_obj.async_write(
+                                    cb_output, dst_accessor, stick_size, {}, {.page_id = right_start + c});
+                                noc_obj.async_write_barrier();
+                                cb_output.pop_front(1);
                             }
                         }
                     } else {
                         // Original: all sticks sequentially
                         uint32_t dst_stick_id = base_dst;
                         for (uint32_t iter = 0; iter < num_sticks_to_read; iter++) {
-                            cb_wait_front(cb_output_id, 1);
-                            uint32_t l1_read_addr = get_read_ptr(cb_output_id);
-                            uint64_t dst_noc_addr = dst_accessor.get_noc_addr(dst_stick_id);
-                            noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-                            noc_async_write_barrier();
-                            cb_pop_front(cb_output_id, 1);
+                            cb_output.wait_front(1);
+                            noc_obj.async_write(cb_output, dst_accessor, stick_size, {}, {.page_id = dst_stick_id});
+                            noc_obj.async_write_barrier();
+                            cb_output.pop_front(1);
                             dst_stick_id++;
                         }
                     }
@@ -515,15 +530,18 @@ void kernel_main() {
 
     // Close fabric connection.
     if (fabric_opened) {
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
         fabric_connection.close();
     }
 
     // Signal Phase 2 AFTER fabric close and all work is complete.
     // Uses barrier_sem from CRTA[3] — same for all targets.
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
     for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address. Semaphore<> binds
+        // to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
         uint64_t sem_noc_addr = get_noc_addr(signal_noc_x[st], signal_noc_y[st], barrier_sem);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
         noc_semaphore_inc(sem_noc_addr, 1);
     }
     noc_async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
@@ -16,6 +16,9 @@
 // This overlaps ~(h_in/h_out) of the W exchange with the H exchange.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 
@@ -32,16 +35,22 @@ constexpr uint32_t ct_after_dst = dst_args.next_compile_time_args_offset();
 constexpr auto src_args = TensorAccessorArgs<ct_after_dst>();
 
 template <uint32_t stick_size_bytes>
-inline void zeroPad(uint32_t cb_id) {
+inline void zeroPad(Noc& noc, CircularBuffer& cb) {
     constexpr uint32_t num_full_reads = stick_size_bytes / MEM_ZEROS_SIZE;
     constexpr uint32_t partial_read_size = stick_size_bytes % MEM_ZEROS_SIZE;
+    // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no LocalL1
+    // source endpoint on main. #45003 item 4.
     const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t cb_write_addr = get_write_ptr(cb_id);
+    uint32_t cb_write_addr = cb.get_write_ptr();
     for (uint32_t i = 0; i < num_full_reads; ++i) {
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
         cb_write_addr += MEM_ZEROS_SIZE;
     }
     if (partial_read_size > 0) {
+        // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+        // LocalL1 source endpoint on main. #45003 item 4.
         noc_async_read(zeros_noc_addr, cb_write_addr, partial_read_size);
     }
 }
@@ -78,6 +87,9 @@ void kernel_main() {
     const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address);
     const auto src_accessor = TensorAccessor(src_args, input_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_output(cb_output_id);
+
     // =========================================================================
     // Phase 1: interior rows from INPUT DRAM (no barrier wait)
     // =========================================================================
@@ -98,19 +110,18 @@ void kernel_main() {
             uint32_t input_row_base = (t_input * h_in + h) * num_interior_sticks;
 
             if (is_first_chip) {
-                cb_reserve_back(cb_output_id, 1);
+                cb_output.reserve_back(1);
                 if (is_t_front || h_masked || is_padding_zeros) {
-                    zeroPad<stick_size>(cb_output_id);
-                    noc_async_read_barrier();
+                    zeroPad<stick_size>(noc_obj, cb_output);
+                    noc_obj.async_read_barrier();
                 } else {
                     // direction=0: replicate leftmost input col; direction=1: rightmost
                     uint32_t input_col = direction ? (num_interior_sticks - 1) : 0;
                     uint32_t src_stick = input_row_base + input_col;
-                    uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                    noc_async_read(src_accessor.get_noc_addr(src_stick), dst_l1_addr, stick_size);
-                    noc_async_read_barrier();
+                    noc_obj.async_read(src_accessor, cb_output, stick_size, {.page_id = src_stick}, {});
+                    noc_obj.async_read_barrier();
                 }
-                cb_push_back(cb_output_id, 1);
+                cb_output.push_back(1);
             }
 
             if (!is_last_chip) {
@@ -118,20 +129,19 @@ void kernel_main() {
                 // is_padding_zeros. is_padding_zeros only gates the tensor-global edge pad
                 // (is_first_chip branch above), never inter-device boundaries.
                 for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
-                    cb_reserve_back(cb_output_id, 1);
+                    cb_output.reserve_back(1);
                     if (is_t_front || h_masked) {
-                        zeroPad<stick_size>(cb_output_id);
-                        noc_async_read_barrier();
+                        zeroPad<stick_size>(noc_obj, cb_output);
+                        noc_obj.async_read_barrier();
                     } else {
                         // direction=0: send rightmost boundary cols (W_in - pad_id)
                         // direction=1: send leftmost boundary cols (padding - pad_id)
                         uint32_t input_col = direction ? (padding - pad_id) : (num_interior_sticks - pad_id);
                         uint32_t src_stick = input_row_base + input_col;
-                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                        noc_async_read(src_accessor.get_noc_addr(src_stick), dst_l1_addr, stick_size);
-                        noc_async_read_barrier();
+                        noc_obj.async_read(src_accessor, cb_output, stick_size, {.page_id = src_stick}, {});
+                        noc_obj.async_read_barrier();
                     }
-                    cb_push_back(cb_output_id, 1);
+                    cb_output.push_back(1);
                 }
             }
         }
@@ -141,7 +151,11 @@ void kernel_main() {
     // Phase 2: H-pad rows (corners) from OUTPUT DRAM (after H halo received)
     // =========================================================================
     if (barrier_count > 0) {
+        // Device 2.0 migration: legacy primitive retained: barrier_sem_addr is a GlobalSemaphore address. Semaphore<>
+        // binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), barrier_count);
+        // Device 2.0 migration: legacy primitive retained: barrier_sem_addr is a GlobalSemaphore address. Semaphore<>
+        // binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), 0);
     }
 
@@ -158,35 +172,33 @@ void kernel_main() {
             uint32_t row_base = output_row * output_row_width;
 
             if (is_first_chip) {
-                cb_reserve_back(cb_output_id, 1);
+                cb_output.reserve_back(1);
                 if (is_t_front || is_padding_zeros) {
-                    zeroPad<stick_size>(cb_output_id);
-                    noc_async_read_barrier();
+                    zeroPad<stick_size>(noc_obj, cb_output);
+                    noc_obj.async_read_barrier();
                 } else {
                     // direction=0: leftmost interior col; direction=1: rightmost
                     uint32_t col = direction ? (pad2_left + num_interior_sticks - 1) : pad2_left;
-                    uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                    noc_async_read(dst_accessor.get_noc_addr(row_base + col), dst_l1_addr, stick_size);
-                    noc_async_read_barrier();
+                    noc_obj.async_read(dst_accessor, cb_output, stick_size, {.page_id = row_base + col}, {});
+                    noc_obj.async_read_barrier();
                 }
-                cb_push_back(cb_output_id, 1);
+                cb_output.push_back(1);
             }
 
             if (!is_last_chip) {
                 // Inter-device W exchange: ship real boundary data regardless of is_padding_zeros.
                 for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
-                    cb_reserve_back(cb_output_id, 1);
+                    cb_output.reserve_back(1);
                     if (is_t_front) {
-                        zeroPad<stick_size>(cb_output_id);
-                        noc_async_read_barrier();
+                        zeroPad<stick_size>(noc_obj, cb_output);
+                        noc_obj.async_read_barrier();
                     } else {
                         uint32_t col = direction ? (pad2_left + (padding - pad_id))
                                                  : (pad2_left + num_interior_sticks - pad_id);
-                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                        noc_async_read(dst_accessor.get_noc_addr(row_base + col), dst_l1_addr, stick_size);
-                        noc_async_read_barrier();
+                        noc_obj.async_read(dst_accessor, cb_output, stick_size, {.page_id = row_base + col}, {});
+                        noc_obj.async_read_barrier();
                     }
-                    cb_push_back(cb_output_id, 1);
+                    cb_output.push_back(1);
                 }
             }
         }
@@ -197,34 +209,32 @@ void kernel_main() {
             uint32_t row_base = output_row * output_row_width;
 
             if (is_first_chip) {
-                cb_reserve_back(cb_output_id, 1);
+                cb_output.reserve_back(1);
                 if (is_t_front || is_padding_zeros) {
-                    zeroPad<stick_size>(cb_output_id);
-                    noc_async_read_barrier();
+                    zeroPad<stick_size>(noc_obj, cb_output);
+                    noc_obj.async_read_barrier();
                 } else {
                     uint32_t col = direction ? (pad2_left + num_interior_sticks - 1) : pad2_left;
-                    uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                    noc_async_read(dst_accessor.get_noc_addr(row_base + col), dst_l1_addr, stick_size);
-                    noc_async_read_barrier();
+                    noc_obj.async_read(dst_accessor, cb_output, stick_size, {.page_id = row_base + col}, {});
+                    noc_obj.async_read_barrier();
                 }
-                cb_push_back(cb_output_id, 1);
+                cb_output.push_back(1);
             }
 
             if (!is_last_chip) {
                 // Inter-device W exchange: ship real boundary data regardless of is_padding_zeros.
                 for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
-                    cb_reserve_back(cb_output_id, 1);
+                    cb_output.reserve_back(1);
                     if (is_t_front) {
-                        zeroPad<stick_size>(cb_output_id);
-                        noc_async_read_barrier();
+                        zeroPad<stick_size>(noc_obj, cb_output);
+                        noc_obj.async_read_barrier();
                     } else {
                         uint32_t col = direction ? (pad2_left + (padding - pad_id))
                                                  : (pad2_left + num_interior_sticks - pad_id);
-                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
-                        noc_async_read(dst_accessor.get_noc_addr(row_base + col), dst_l1_addr, stick_size);
-                        noc_async_read_barrier();
+                        noc_obj.async_read(dst_accessor, cb_output, stick_size, {.page_id = row_base + col}, {});
+                        noc_obj.async_read_barrier();
                     }
-                    cb_push_back(cb_output_id, 1);
+                    cb_output.push_back(1);
                 }
             }
         }
@@ -237,7 +247,13 @@ void kernel_main() {
         volatile tt_l1_ptr uint32_t* w_neighbor_sem_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(w_neighbor_sem_addr);
         // Wait for t_count * h_out increments (one per row sent by our W neighbor)
+        // Device 2.0 migration: legacy primitive retained: w_neighbor_sem_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_wait_min(w_neighbor_sem_ptr, t_count * h_out);
+        // Device 2.0 migration: legacy primitive retained: w_neighbor_sem_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(w_neighbor_sem_ptr, 0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
@@ -21,6 +21,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -182,7 +182,7 @@ void kernel_main() {
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_in0.reserve_back(tile_granularity);
-                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                    uint32_t l1_write_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
                         noc_obj.async_read(
@@ -190,8 +190,8 @@ void kernel_main() {
                             cb_in0,
                             page_size,
                             {.page_id = tile_id},
-                            {.offset_bytes = l1_write_addr});
-                        l1_write_addr += page_size;
+                            {.offset_bytes = l1_write_offset});
+                        l1_write_offset += page_size;
                     }
                     tiles_read += num_pages_to_read;
 
@@ -213,7 +213,7 @@ void kernel_main() {
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_in0.reserve_back(tile_granularity);
-                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                    uint32_t l1_write_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
                         noc_obj.async_read(
@@ -221,8 +221,8 @@ void kernel_main() {
                             cb_in0,
                             page_size,
                             {.page_id = tile_id},
-                            {.offset_bytes = l1_write_addr});
-                        l1_write_addr += page_size;
+                            {.offset_bytes = l1_write_offset});
+                        l1_write_offset += page_size;
                     }
 
                     if (chunk_count % chunks_per_sync == 0) {
@@ -236,7 +236,7 @@ void kernel_main() {
 
                     // read the next intermediate slice out of intermediate buffer, and put it in intermediate CB
                     cb_intermediate.reserve_back(tile_granularity);
-                    l1_write_addr = cb_intermediate.get_write_ptr();
+                    l1_write_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = intermediate_tile_id_start + tiles_read + j;
                         noc_obj.async_read(
@@ -244,8 +244,8 @@ void kernel_main() {
                             cb_intermediate,
                             page_size,
                             {.page_id = tile_id},
-                            {.offset_bytes = l1_write_addr});
-                        l1_write_addr += page_size;
+                            {.offset_bytes = l1_write_offset});
+                        l1_write_offset += page_size;
                     }
 
                     tiles_read += num_pages_to_read;
@@ -296,7 +296,7 @@ void kernel_main() {
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                 cb_in0.reserve_back(tile_granularity);
-                uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                uint32_t l1_write_offset = 0;
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t tile_id = tile_id_start + tiles_read + j;
                     if (detail::do_accumulate_output(is_forward)) {
@@ -305,16 +305,16 @@ void kernel_main() {
                             cb_in0,
                             page_size,
                             {.page_id = tile_id},
-                            {.offset_bytes = l1_write_addr});
+                            {.offset_bytes = l1_write_offset});
                     } else {
                         noc_obj.async_read(
                             input_tensor_addrgen,
                             cb_in0,
                             page_size,
                             {.page_id = tile_id},
-                            {.offset_bytes = l1_write_addr});
+                            {.offset_bytes = l1_write_offset});
                     }
-                    l1_write_addr += page_size;
+                    l1_write_offset += page_size;
                 }
 
                 if (chunk_count % chunks_per_sync == 0) {
@@ -327,7 +327,7 @@ void kernel_main() {
 
                 // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
                 cb_intermediate.reserve_back(tile_granularity);
-                l1_write_addr = cb_intermediate.get_write_ptr();
+                l1_write_offset = 0;
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t intermediate_tile_id = intermediate_tile_id_start + tiles_read + j;
                     noc_obj.async_read(
@@ -335,8 +335,8 @@ void kernel_main() {
                         cb_intermediate,
                         page_size,
                         {.page_id = intermediate_tile_id},
-                        {.offset_bytes = l1_write_addr});
-                    l1_write_addr += page_size;
+                        {.offset_bytes = l1_write_offset});
+                    l1_write_offset += page_size;
                 }
 
                 tiles_read += num_pages_to_read;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/tools/profiler/kernel_profiler.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -49,7 +52,7 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
     const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
@@ -135,6 +138,11 @@ void kernel_main() {
     auto output_tensor_addrgen = TensorAccessor(output_tensor_args, output_tensor_address);
 #endif
 
+    Noc noc_obj;
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_intermediate(cb_intermediate_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     /**
      * Intermediate buffer is double-sized (shape [2, *input_shape]) to accommodate forward and backward.
      * BWD indexes into second half of intermediate buffer.
@@ -162,7 +170,7 @@ void kernel_main() {
 
         if (is_first_device_in_direction) {
             // We have no incoming slices, so forward directly to writer
-            uint32_t cb_in0 = cb_reader_output_id;
+            CircularBuffer& cb_in0 = cb_reader_output;
 
             for (uint32_t b = 0; b < slice_B; ++b) {
                 uint32_t tiles_read = start_tiles_read;
@@ -172,24 +180,28 @@ void kernel_main() {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_reserve_back(cb_in0, tile_granularity);
-                    uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(tile_granularity);
+                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        noc_obj.async_read(
+                            input_tensor_addrgen,
+                            cb_in0,
+                            page_size,
+                            {.page_id = tile_id},
+                            {.offset_bytes = l1_write_addr});
                         l1_write_addr += page_size;
                     }
                     tiles_read += num_pages_to_read;
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, tile_granularity);
+                    noc_obj.async_read_barrier();
+                    cb_in0.push_back(tile_granularity);
                 }
                 input_tile_id_start += batch_num_pages;
             }
         } else {
             // I have incoming slices, so write my output to compute kernel and read intermediate input
-            uint32_t cb_in0 = cb_input_id;
+            CircularBuffer& cb_in0 = cb_input;
 
             for (uint32_t b = 0; b < slice_B; ++b) {
                 uint32_t tiles_read = start_tiles_read;
@@ -199,35 +211,46 @@ void kernel_main() {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_reserve_back(cb_in0, tile_granularity);
-                    uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(tile_granularity);
+                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        noc_obj.async_read(
+                            input_tensor_addrgen,
+                            cb_in0,
+                            page_size,
+                            {.page_id = tile_id},
+                            {.offset_bytes = l1_write_addr});
                         l1_write_addr += page_size;
                     }
 
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+                        // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can
+                        // wrap). #45003 item 4.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                     }
                     chunk_count++;
 
                     // read the next intermediate slice out of intermediate buffer, and put it in intermediate CB
-                    cb_reserve_back(cb_intermediate_id, tile_granularity);
-                    l1_write_addr = get_write_ptr(cb_intermediate_id);
+                    cb_intermediate.reserve_back(tile_granularity);
+                    l1_write_addr = cb_intermediate.get_write_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = intermediate_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        noc_obj.async_read(
+                            intermediate_tensor_addrgen,
+                            cb_intermediate,
+                            page_size,
+                            {.page_id = tile_id},
+                            {.offset_bytes = l1_write_addr});
                         l1_write_addr += page_size;
                     }
 
                     tiles_read += num_pages_to_read;
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, tile_granularity);
-                    cb_push_back(cb_intermediate_id, tile_granularity);
+                    noc_obj.async_read_barrier();
+                    cb_in0.push_back(tile_granularity);
+                    cb_intermediate.push_back(tile_granularity);
                 }
                 input_tile_id_start += batch_num_pages;
                 intermediate_tile_id_start += batch_num_pages;
@@ -257,7 +280,7 @@ void kernel_main() {
          */
         uint32_t tile_id_start = detail::do_accumulate_output(is_forward) ? output_tile_id_start : input_tile_id_start;
 
-        uint32_t cb_in0 = cb_input_id;
+        CircularBuffer& cb_in0 = cb_input;
         for (uint32_t b = 0; b < slice_B; ++b) {
             uint32_t tiles_read = start_tiles_read;
             uint32_t tiles_to_read = start_tiles_to_read;
@@ -265,43 +288,60 @@ void kernel_main() {
             while (tiles_read < tiles_to_read) {
                 // Wait for FWD writer to signal that it has done its final reduction
                 if (detail::do_accumulate_output(is_forward)) {
-                    noc_semaphore_wait_min(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
+                    fwd_bwd_sem.wait(++fwd_sync_cnt);
                 }
 
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                cb_reserve_back(cb_in0, tile_granularity);
-                uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                cb_in0.reserve_back(tile_granularity);
+                uint32_t l1_write_addr = cb_in0.get_write_ptr();
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t tile_id = tile_id_start + tiles_read + j;
-                    uint64_t noc_read_addr = detail::do_accumulate_output(is_forward)
-                                                 ? get_noc_addr(tile_id, output_tensor_addrgen)
-                                                 : get_noc_addr(tile_id, input_tensor_addrgen);
-                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                    if (detail::do_accumulate_output(is_forward)) {
+                        noc_obj.async_read(
+                            output_tensor_addrgen,
+                            cb_in0,
+                            page_size,
+                            {.page_id = tile_id},
+                            {.offset_bytes = l1_write_addr});
+                    } else {
+                        noc_obj.async_read(
+                            input_tensor_addrgen,
+                            cb_in0,
+                            page_size,
+                            {.page_id = tile_id},
+                            {.offset_bytes = l1_write_addr});
+                    }
                     l1_write_addr += page_size;
                 }
 
                 if (chunk_count % chunks_per_sync == 0) {
+                    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+                    // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can
+                    // wrap). #45003 item 4.
                     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                 }
                 chunk_count++;
 
                 // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
-                cb_reserve_back(cb_intermediate_id, tile_granularity);
-                l1_write_addr = get_write_ptr(cb_intermediate_id);
+                cb_intermediate.reserve_back(tile_granularity);
+                l1_write_addr = cb_intermediate.get_write_ptr();
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t intermediate_tile_id = intermediate_tile_id_start + tiles_read + j;
-                    uint64_t noc_read_addr = get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
-                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                    noc_obj.async_read(
+                        intermediate_tensor_addrgen,
+                        cb_intermediate,
+                        page_size,
+                        {.page_id = intermediate_tile_id},
+                        {.offset_bytes = l1_write_addr});
                     l1_write_addr += page_size;
                 }
 
                 tiles_read += num_pages_to_read;
-                noc_async_read_barrier();
-                cb_push_back(cb_in0, tile_granularity);
-                cb_push_back(cb_intermediate_id, tile_granularity);
+                noc_obj.async_read_barrier();
+                cb_in0.push_back(tile_granularity);
+                cb_intermediate.push_back(tile_granularity);
             }
             tile_id_start += batch_num_pages;
             intermediate_tile_id_start += batch_num_pages;
@@ -309,5 +349,7 @@ void kernel_main() {
     }
 
     // Reset my output ready semaphore
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1 semaphore
+    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -372,16 +372,16 @@ void kernel_main() {
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                 cb_compute_output.wait_front(tile_granularity);
-                size_t l1_read_addr = cb_compute_output.get_read_ptr();
+                size_t l1_read_offset = 0;
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t output_tile_id = output_tile_id_start + tiles_read;
                     noc_obj.async_write(
                         cb_compute_output,
                         output_addrgen,
                         page_size,
-                        {.offset_bytes = l1_read_addr},
+                        {.offset_bytes = l1_read_offset},
                         {.page_id = output_tile_id});
-                    l1_read_addr += page_size;
+                    l1_read_offset += page_size;
                     tiles_read++;
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -21,6 +21,7 @@
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -79,7 +82,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     uint32_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
@@ -112,6 +115,10 @@ void kernel_main() {
     uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
+
+    Noc noc_obj;
+    CircularBuffer cb_compute_output(cb_compute_output_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
 
     const auto& unicast_route_info = (is_forward) ? forward_unicast_route_info : backward_unicast_route_info;
     const auto& multicast_route_info = (is_forward) ? forward_multicast_route_info : backward_multicast_route_info;
@@ -234,6 +241,8 @@ void kernel_main() {
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opposite_direction_barrier_sem_noc_addr_in_pkt, 0});
         }
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a precomposed L1 semaphore
+        // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -272,7 +281,7 @@ void kernel_main() {
     int slice_idx = is_forward ? ring_size - 1 : 0;
 
     for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
-        const uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
+        CircularBuffer& cb_output = is_first_device_in_direction ? cb_reader_output : cb_compute_output;
         chunk_count = 0;
 
         uint32_t intermediate_tile_id_start = slice_idx * output_num_pages + intermediate_full_offset;
@@ -285,8 +294,8 @@ void kernel_main() {
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                cb_wait_front(cb_output_id, tile_granularity);
-                size_t l1_read_addr = get_read_ptr(cb_output_id);
+                cb_output.wait_front(tile_granularity);
+                size_t l1_read_addr = cb_output.get_read_ptr();
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t num_pages_to_write = std::min(contig_pages_advanced, num_pages_to_read - j);
 
@@ -317,9 +326,9 @@ void kernel_main() {
                     } else {
                         ASSERT(false);
                     }
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
                 }
-                cb_pop_front(cb_output_id, tile_granularity);
+                cb_output.pop_front(tile_granularity);
 
                 chunk_count++;
                 if (chunk_count % chunks_per_sync == 0) {
@@ -361,52 +370,60 @@ void kernel_main() {
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                cb_wait_front(cb_compute_output_id, tile_granularity);
-                size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
+                cb_compute_output.wait_front(tile_granularity);
+                size_t l1_read_addr = cb_compute_output.get_read_ptr();
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t output_tile_id = output_tile_id_start + tiles_read;
-                    uint64_t local_noc_addr = get_noc_addr(output_tile_id, output_addrgen);
-                    noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                    noc_obj.async_write(
+                        cb_compute_output,
+                        output_addrgen,
+                        page_size,
+                        {.offset_bytes = l1_read_addr},
+                        {.page_id = output_tile_id});
                     l1_read_addr += page_size;
                     tiles_read++;
                 }
 
                 if (detail::do_forward_sync(is_forward)) {
-                    noc_async_write_barrier();
+                    noc_obj.async_write_barrier();
                 } else {
-                    noc_async_writes_flushed();
+                    noc_obj.async_writes_flushed();
                 }
-                cb_pop_front(cb_compute_output_id, tile_granularity);
+                cb_compute_output.pop_front(tile_granularity);
                 if (detail::do_forward_sync(is_forward)) {
                     // Tell local backwards reader that it can proceed
-                    uint64_t fwd_bwd_sem_noc_addr =
-                        safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
-                    noc_semaphore_inc(fwd_bwd_sem_noc_addr, 1);
+                    fwd_bwd_sem.up(noc_obj, opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, 1);
                 }
             }
             output_tile_id_start += batch_num_pages;
         }
-        noc_async_write_barrier();
+        noc_obj.async_write_barrier();
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if (is_termination_master) {
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a precomposed
+            // L1 semaphore address obtained via get_semaphore(id); the kernel uses it as a raw pointer
+            // alongside a precomposed uint64_t NoC address from safe_get_noc_addr, so Semaphore<> cannot
+            // wrap it cleanly. #45003 item 4.
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
+            // (dest_addr) cannot be wrapped by Noc::async_* or Semaphore<>::up. #45003 item 4.
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -18,6 +19,10 @@ void kernel_main() {
     const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_output(output_cb);
+
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);
 
@@ -30,18 +35,18 @@ void kernel_main() {
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                 uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                cb_wait_front(input_cb_id, tile_granularity);
-                cb_wait_front(intermediate_cb, tile_granularity);
-                cb_reserve_back(output_cb, tile_granularity);
+                cb_input.wait_front(tile_granularity);
+                cb_intermediate.wait_front(tile_granularity);
+                cb_output.reserve_back(tile_granularity);
                 acquire_dst();
                 for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
                     add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
                     pack_tile(tile_id, output_cb);
                 }
                 release_dst();
-                cb_pop_front(input_cb_id, tile_granularity);
-                cb_pop_front(intermediate_cb, tile_granularity);
-                cb_push_back(output_cb, tile_granularity);
+                cb_input.pop_front(tile_granularity);
+                cb_intermediate.pop_front(tile_granularity);
+                cb_output.push_back(tile_granularity);
 
                 tiles_read += num_pages_to_read;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
@@ -106,7 +106,7 @@ void kernel_main() {
                 }
 
                 cb_in0.reserve_back(tile_granularity);
-                uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                uint32_t l1_write_offset = 0;
                 for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                     uint32_t input_tile_id = tile_id_start + tiles_read + j;
                     noc_obj.async_read(
@@ -114,14 +114,14 @@ void kernel_main() {
                         cb_in0,
                         page_size,
                         {.page_id = input_tile_id},
-                        {.offset_bytes = l1_write_addr});
-                    l1_write_addr += page_size;
+                        {.offset_bytes = l1_write_offset});
+                    l1_write_offset += page_size;
                 }
 
                 if (do_reduce) {
                     // read next intermediate slice out of the intermediate buffer, and put it in intermediate CB
                     cb_intermediate.reserve_back(tile_granularity);
-                    uint32_t intermediate_l1_write_addr = cb_intermediate.get_write_ptr();
+                    uint32_t intermediate_l1_write_offset = 0;
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t intermediate_tile_id = tile_id_start + tiles_read + j;
                         noc_obj.async_read(
@@ -129,8 +129,8 @@ void kernel_main() {
                             cb_intermediate,
                             page_size,
                             {.page_id = intermediate_tile_id},
-                            {.offset_bytes = intermediate_l1_write_addr});
-                        intermediate_l1_write_addr += page_size;
+                            {.offset_bytes = intermediate_l1_write_offset});
+                        intermediate_l1_write_offset += page_size;
                     }
 
                     noc_obj.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -50,12 +53,17 @@ void kernel_main() {
     constexpr auto intermediate_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_intermediate(cb_intermediate_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     uint32_t sem_target = 0;
 
     int slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
     for (uint32_t i = 0; i < ring_size; ++i) {
         const bool do_reduce = i != 0;
-        uint32_t cb_in0 = do_reduce ? cb_input_id : cb_reader_output_id;
+        CircularBuffer& cb_in0 = do_reduce ? cb_input : cb_reader_output;
 
         uint32_t actual_slice_idx;
         if (direction) {
@@ -80,6 +88,9 @@ void kernel_main() {
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
 
                 if (do_reduce && (chunk_count % chunks_per_sync == 0)) {
+                    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+                    // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can
+                    // wrap). #45003 item 4.
                     noc_semaphore_wait_min(
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                     sem_target++;
@@ -93,34 +104,41 @@ void kernel_main() {
                     tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
                 }
 
-                cb_reserve_back(cb_in0, tile_granularity);
-                uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                cb_in0.reserve_back(tile_granularity);
+                uint32_t l1_write_addr = cb_in0.get_write_ptr();
                 for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                     uint32_t input_tile_id = tile_id_start + tiles_read + j;
-                    uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(input_tile_id);
-                    noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                    noc_obj.async_read(
+                        input_tensor_addrgen,
+                        cb_in0,
+                        page_size,
+                        {.page_id = input_tile_id},
+                        {.offset_bytes = l1_write_addr});
                     l1_write_addr += page_size;
                 }
 
                 if (do_reduce) {
                     // read next intermediate slice out of the intermediate buffer, and put it in intermediate CB
-                    cb_reserve_back(cb_intermediate_id, tile_granularity);
-                    uint32_t intermediate_l1_write_addr = get_write_ptr(cb_intermediate_id);
+                    cb_intermediate.reserve_back(tile_granularity);
+                    uint32_t intermediate_l1_write_addr = cb_intermediate.get_write_ptr();
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t intermediate_tile_id = tile_id_start + tiles_read + j;
-                        uint64_t intermediate_noc_read_addr =
-                            intermediate_tensor_addrgen.get_noc_addr(intermediate_tile_id);
-                        noc_async_read(intermediate_noc_read_addr, intermediate_l1_write_addr, page_size);
+                        noc_obj.async_read(
+                            intermediate_tensor_addrgen,
+                            cb_intermediate,
+                            page_size,
+                            {.page_id = intermediate_tile_id},
+                            {.offset_bytes = intermediate_l1_write_addr});
                         intermediate_l1_write_addr += page_size;
                     }
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_intermediate_id, tile_granularity);
+                    noc_obj.async_read_barrier();
+                    cb_intermediate.push_back(tile_granularity);
                 }
 
                 tiles_read += tiles_to_read_in_current_direction;
-                noc_async_read_barrier();
-                cb_push_back(cb_in0, tile_granularity);
+                noc_obj.async_read_barrier();
+                cb_in0.push_back(tile_granularity);
 
                 // Skip the tiles going the other direction
                 tiles_remaining_to_read = tiles_to_read - tiles_read;
@@ -145,6 +163,9 @@ void kernel_main() {
         }
 
         if (do_reduce && (i == (ring_size - 1))) {
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+            // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can wrap).
+            // #45003 item 4.
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
             sem_target = 0;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_reader.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using tt::tt_metal::BufferType;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -112,6 +115,10 @@ void kernel_main() {
     constexpr auto output_tensor_args = TensorAccessorArgs<intermediate_tensor_args.next_compile_time_args_offset()>();
     auto output_addrgen = TensorAccessor(output_tensor_args, output_address);
 
+    Noc noc_obj;
+    CircularBuffer cb_compute_output(cb_compute_output_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
 #ifdef USE_WORKER_MUX
     auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
         fabric_mux_x,
@@ -174,6 +181,8 @@ void kernel_main() {
             pkt_hdr_mcastseminc,
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a precomposed L1 semaphore
+        // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -198,8 +207,8 @@ void kernel_main() {
 
     int slice_idx = direction ? my_chip_id - 1 : my_chip_id + 1;
     for (uint32_t i = 0; i < ring_size; ++i) {
-        // If not the last slice, write what's on cb_output_id forward
-        uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
+        // If not the last slice, write what's on cb_output forward
+        CircularBuffer& cb_output = i > 0 ? cb_compute_output : cb_reader_output;
 
         uint32_t actual_slice_idx;
         if (direction) {
@@ -232,8 +241,8 @@ void kernel_main() {
                         tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
                     }
 
-                    cb_wait_front(cb_output_id, tile_granularity);
-                    size_t l1_read_addr = get_read_ptr(cb_output_id);
+                    cb_output.wait_front(tile_granularity);
+                    size_t l1_read_addr = cb_output.get_read_ptr();
                     while (tiles_read_in_current_direction < tiles_to_read_in_current_direction) {
                         uint32_t tiles_remaining_to_read_in_current_direction =
                             tiles_to_read_in_current_direction - tiles_read_in_current_direction;
@@ -275,9 +284,9 @@ void kernel_main() {
                                 break;
                             }
                         }
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                     }
-                    cb_pop_front(cb_output_id, tile_granularity);
+                    cb_output.pop_front(tile_granularity);
 
                     // Skip the tiles going the other direction
                     tiles_remaining_to_read = tiles_to_read - tiles_read;
@@ -314,7 +323,7 @@ void kernel_main() {
                     pkt_hdr_seminc,
                     tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
             }
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
         } else {
             // Otherwise, on the last slice, write it to output buffer
             uint32_t output_tile_id_start = 0;
@@ -335,18 +344,22 @@ void kernel_main() {
                         tiles_to_read_in_current_direction = std::min(tiles_remaining_to_read, tile_granularity);
                     }
 
-                    cb_wait_front(cb_output_id, tile_granularity);
-                    size_t l1_read_addr = get_read_ptr(cb_output_id);
+                    cb_output.wait_front(tile_granularity);
+                    size_t l1_read_addr = cb_output.get_read_ptr();
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t output_tile_id = output_tile_id_start + tiles_read;
-                        uint64_t local_noc_addr = output_addrgen.get_noc_addr(output_tile_id);
-                        noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                        noc_obj.async_write(
+                            cb_output,
+                            output_addrgen,
+                            page_size,
+                            {.offset_bytes = l1_read_addr},
+                            {.page_id = output_tile_id});
                         l1_read_addr += page_size;
                         tiles_read++;
                     }
 
-                    noc_async_write_barrier();
-                    cb_pop_front(cb_output_id, tile_granularity);
+                    noc_obj.async_write_barrier();
+                    cb_output.pop_front(tile_granularity);
 
                     // Skip the tiles going the other direction
                     tiles_remaining_to_read = tiles_to_read - tiles_read;
@@ -378,26 +391,33 @@ void kernel_main() {
         fabric_connection_ptr,
         pkt_hdr_mcastseminc,
         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{batch_ready_sem_noc_addr_in_pkt, 0});
-    noc_async_writes_flushed();
+    noc_obj.async_writes_flushed();
 
     // Reset the global semaphore
+    // Device 2.0 migration: legacy primitive retained: batch_ready_sem is a precomposed L1 semaphore
+    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
     noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), ring_size - 1);
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), 0);
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
 #ifdef USE_WORKER_MUX
     tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
     if (is_termination_master) {
+        // Device 2.0 migration: legacy primitive retained: termination_sync_address is a precomposed L1
+        // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can wrap).
+        // #45003 item 4.
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
+        // Device 2.0 migration: legacy primitive retained: dest_addr is a precomposed uint64_t NoC
+        // address; Semaphore<> wraps a Metal semaphore id, not a raw address. #45003 item 4.
         uint64_t dest_addr =
             safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
         noc_semaphore_inc(dest_addr, 1);
-        noc_async_atomic_barrier();
+        noc_obj.async_atomic_barrier();
     }
 #else
     if (fabric_connection.is_logically_connected()) {
@@ -405,5 +425,5 @@ void kernel_main() {
     }
 #endif
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
@@ -346,16 +346,16 @@ void kernel_main() {
                     }
 
                     cb_output.wait_front(tile_granularity);
-                    size_t l1_read_addr = cb_output.get_read_ptr();
+                    size_t l1_read_offset = 0;
                     for (uint32_t j = 0; j < tiles_to_read_in_current_direction; ++j) {
                         uint32_t output_tile_id = output_tile_id_start + tiles_read;
                         noc_obj.async_write(
                             cb_output,
                             output_addrgen,
                             page_size,
-                            {.offset_bytes = l1_read_addr},
+                            {.offset_bytes = l1_read_offset},
                             {.page_id = output_tile_id});
-                        l1_read_addr += page_size;
+                        l1_read_offset += page_size;
                         tiles_read++;
                     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
@@ -19,6 +19,7 @@
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -18,6 +19,10 @@ void kernel_main() {
     uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);
+
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_output(output_cb);
 
     // Initialize binary operations - use the same constants consistently
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
@@ -43,18 +48,18 @@ void kernel_main() {
                 } else {
                     num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
                 }
-                cb_wait_front(input_cb_id, tile_granularity);
-                cb_wait_front(intermediate_cb, tile_granularity);
-                cb_reserve_back(output_cb, tile_granularity);
+                cb_input.wait_front(tile_granularity);
+                cb_intermediate.wait_front(tile_granularity);
+                cb_output.reserve_back(tile_granularity);
                 acquire_dst();
                 for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
                     add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
                     pack_tile(tile_id, output_cb);
                 }
                 release_dst();
-                cb_pop_front(input_cb_id, tile_granularity);
-                cb_pop_front(intermediate_cb, tile_granularity);
-                cb_push_back(output_cb, tile_granularity);
+                cb_input.pop_front(tile_granularity);
+                cb_intermediate.pop_front(tile_granularity);
+                cb_output.push_back(tile_granularity);
                 tiles_read += num_pages_to_read;
 
                 // Skip the tiles going the other direction

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -204,7 +204,7 @@ void kernel_main() {
                         uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                         cb_in0.reserve_back(tile_granularity);
-                        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                        uint32_t l1_write_offset = 0;
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
                             noc_obj.async_read(
@@ -212,8 +212,8 @@ void kernel_main() {
                                 cb_in0,
                                 page_size,
                                 {.page_id = tile_id},
-                                {.offset_bytes = l1_write_addr});
-                            l1_write_addr += page_size;
+                                {.offset_bytes = l1_write_offset});
+                            l1_write_offset += page_size;
 
                             input_pages_read_in_row++;
                             if (input_pages_read_in_row == slice_Wt) {
@@ -246,7 +246,7 @@ void kernel_main() {
                         uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                         cb_in0.reserve_back(tile_granularity);
-                        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                        uint32_t l1_write_offset = 0;
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
                             noc_obj.async_read(
@@ -254,8 +254,8 @@ void kernel_main() {
                                 cb_in0,
                                 page_size,
                                 {.page_id = tile_id},
-                                {.offset_bytes = l1_write_addr});
-                            l1_write_addr += page_size;
+                                {.offset_bytes = l1_write_offset});
+                            l1_write_offset += page_size;
 
                             input_pages_read_in_row++;
                             if (input_pages_read_in_row == slice_Wt) {
@@ -276,7 +276,7 @@ void kernel_main() {
 
                         // read the next intermediate slice out of intermediate buffer, and put it in intermediate CB
                         cb_intermediate.reserve_back(tile_granularity);
-                        l1_write_addr = cb_intermediate.get_write_ptr();
+                        l1_write_offset = 0;
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id =
                                 intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
@@ -285,8 +285,8 @@ void kernel_main() {
                                 cb_intermediate,
                                 page_size,
                                 {.page_id = tile_id},
-                                {.offset_bytes = l1_write_addr});
-                            l1_write_addr += page_size;
+                                {.offset_bytes = l1_write_offset});
+                            l1_write_offset += page_size;
 
                             intermediate_pages_read_in_row++;
                             if (intermediate_pages_read_in_row == slice_Wt) {
@@ -387,7 +387,7 @@ void kernel_main() {
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_in0.reserve_back(tile_granularity);
-                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
+                    uint32_t l1_write_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
                         if (accumulate_output) {
@@ -396,16 +396,16 @@ void kernel_main() {
                                 cb_in0,
                                 page_size,
                                 {.page_id = tile_id},
-                                {.offset_bytes = l1_write_addr});
+                                {.offset_bytes = l1_write_offset});
                         } else {
                             noc_obj.async_read(
                                 input_tensor_addrgen,
                                 cb_in0,
                                 page_size,
                                 {.page_id = tile_id},
-                                {.offset_bytes = l1_write_addr});
+                                {.offset_bytes = l1_write_offset});
                         }
-                        l1_write_addr += page_size;
+                        l1_write_offset += page_size;
 
                         pages_read_in_row++;
                         if (pages_read_in_row == slice_Wt) {
@@ -426,7 +426,7 @@ void kernel_main() {
 
                     // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
                     cb_intermediate.reserve_back(tile_granularity);
-                    l1_write_addr = cb_intermediate.get_write_ptr();
+                    l1_write_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t intermediate_tile_id =
                             intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
@@ -435,8 +435,8 @@ void kernel_main() {
                             cb_intermediate,
                             page_size,
                             {.page_id = intermediate_tile_id},
-                            {.offset_bytes = l1_write_addr});
-                        l1_write_addr += page_size;
+                            {.offset_bytes = l1_write_offset});
+                        l1_write_offset += page_size;
 
                         intermediate_pages_read_in_row++;
                         if (intermediate_pages_read_in_row == slice_Wt) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -12,6 +12,7 @@
 #include "tt_metal/tools/profiler/kernel_profiler.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -48,7 +51,7 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
     const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
@@ -141,6 +144,11 @@ void kernel_main() {
         matmul_receiver = ReduceScatterOpReceiver(arg_idx);
     }
 
+    Noc noc_obj;
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_intermediate(cb_intermediate_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     /**
      * Intermediate buffer is double-sized (shape [2, *input_shape]) to accommodate forward and backward.
      * BWD indexes into second half of intermediate buffer.
@@ -182,7 +190,7 @@ void kernel_main() {
 
             if (is_first_device_in_direction) {
                 // We have no incoming slices, so forward directly to writer
-                uint32_t cb_in0 = cb_reader_output_id;
+                CircularBuffer& cb_in0 = cb_reader_output;
                 for (uint32_t c = 0; c < slice_C; ++c) {
                     uint32_t input_pages_read_in_row = start_pages_read_in_row;
                     uint32_t input_row_offset = start_row_offset;
@@ -194,12 +202,16 @@ void kernel_main() {
                         uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                         uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                        cb_reserve_back(cb_in0, tile_granularity);
-                        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                        cb_in0.reserve_back(tile_granularity);
+                        uint32_t l1_write_addr = cb_in0.get_write_ptr();
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                            noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                            noc_obj.async_read(
+                                input_tensor_addrgen,
+                                cb_in0,
+                                page_size,
+                                {.page_id = tile_id},
+                                {.offset_bytes = l1_write_addr});
                             l1_write_addr += page_size;
 
                             input_pages_read_in_row++;
@@ -210,14 +222,14 @@ void kernel_main() {
                         }
                         tiles_read += num_pages_to_read;
 
-                        noc_async_read_barrier();
-                        cb_push_back(cb_in0, tile_granularity);
+                        noc_obj.async_read_barrier();
+                        cb_in0.push_back(tile_granularity);
                     }
                     input_tile_id_start += input_channel_num_pages;
                 }
             } else {
                 // I have incoming slices, so write my output to compute kernel and read intermediate input
-                uint32_t cb_in0 = cb_input_id;
+                CircularBuffer& cb_in0 = cb_input;
                 for (uint32_t c = 0; c < slice_C; ++c) {
                     uint32_t input_pages_read_in_row = start_pages_read_in_row;
                     uint32_t input_row_offset = start_row_offset;
@@ -232,12 +244,16 @@ void kernel_main() {
                         uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                         uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                        cb_reserve_back(cb_in0, tile_granularity);
-                        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                        cb_in0.reserve_back(tile_granularity);
+                        uint32_t l1_write_addr = cb_in0.get_write_ptr();
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
-                            noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                            noc_obj.async_read(
+                                input_tensor_addrgen,
+                                cb_in0,
+                                page_size,
+                                {.page_id = tile_id},
+                                {.offset_bytes = l1_write_addr});
                             l1_write_addr += page_size;
 
                             input_pages_read_in_row++;
@@ -249,19 +265,26 @@ void kernel_main() {
                         tiles_read += num_pages_to_read;
 
                         if (chunk_count % chunks_per_sync == 0) {
+                            // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+                            // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can
+                            // wrap). #45003 item 4.
                             noc_semaphore_wait_min(
                                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                         }
                         chunk_count++;
 
                         // read the next intermediate slice out of intermediate buffer, and put it in intermediate CB
-                        cb_reserve_back(cb_intermediate_id, tile_granularity);
-                        l1_write_addr = get_write_ptr(cb_intermediate_id);
+                        cb_intermediate.reserve_back(tile_granularity);
+                        l1_write_addr = cb_intermediate.get_write_ptr();
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id =
                                 intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
-                            noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                            noc_obj.async_read(
+                                intermediate_tensor_addrgen,
+                                cb_intermediate,
+                                page_size,
+                                {.page_id = tile_id},
+                                {.offset_bytes = l1_write_addr});
                             l1_write_addr += page_size;
 
                             intermediate_pages_read_in_row++;
@@ -271,9 +294,9 @@ void kernel_main() {
                             }
                         }
 
-                        noc_async_read_barrier();
-                        cb_push_back(cb_in0, tile_granularity);
-                        cb_push_back(cb_intermediate_id, tile_granularity);
+                        noc_obj.async_read_barrier();
+                        cb_in0.push_back(tile_granularity);
+                        cb_intermediate.push_back(tile_granularity);
                     }
                     input_tile_id_start += input_channel_num_pages;
                     intermediate_tile_id_start += input_channel_num_pages;
@@ -335,7 +358,7 @@ void kernel_main() {
                 channel_num_pages = input_channel_num_pages;
             }
 
-            uint32_t cb_in0 = cb_input_id;
+            CircularBuffer& cb_in0 = cb_input;
             for (uint32_t c = 0; c < slice_C; ++c) {
                 uint32_t pages_read_in_row;
                 uint32_t row_offset;
@@ -356,20 +379,31 @@ void kernel_main() {
                 while (tiles_read < tiles_to_read) {
                     // Wait for FWD writer to signal that it has done its final reduction
                     if (accumulate_output) {
-                        noc_semaphore_wait_min(
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
+                        fwd_bwd_sem.wait_min(++fwd_sync_cnt);
                     }
 
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_reserve_back(cb_in0, tile_granularity);
-                    uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                    cb_in0.reserve_back(tile_granularity);
+                    uint32_t l1_write_addr = cb_in0.get_write_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-                        uint64_t noc_read_addr = accumulate_output ? get_noc_addr(tile_id, output_tensor_addrgen)
-                                                                   : get_noc_addr(tile_id, input_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        if (accumulate_output) {
+                            noc_obj.async_read(
+                                output_tensor_addrgen,
+                                cb_in0,
+                                page_size,
+                                {.page_id = tile_id},
+                                {.offset_bytes = l1_write_addr});
+                        } else {
+                            noc_obj.async_read(
+                                input_tensor_addrgen,
+                                cb_in0,
+                                page_size,
+                                {.page_id = tile_id},
+                                {.offset_bytes = l1_write_addr});
+                        }
                         l1_write_addr += page_size;
 
                         pages_read_in_row++;
@@ -381,19 +415,26 @@ void kernel_main() {
                     tiles_read += num_pages_to_read;
 
                     if (chunk_count % chunks_per_sync == 0) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1
+                        // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can wrap).
+                        // #45003 item 4.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), ++sem_target);
                     }
                     chunk_count++;
 
                     // read the next intermediate slice out of the intermediate buffer, and put it in intermediate CB
-                    cb_reserve_back(cb_intermediate_id, tile_granularity);
-                    l1_write_addr = get_write_ptr(cb_intermediate_id);
+                    cb_intermediate.reserve_back(tile_granularity);
+                    l1_write_addr = cb_intermediate.get_write_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t intermediate_tile_id =
                             intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                        uint64_t noc_read_addr = get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
-                        noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                        noc_obj.async_read(
+                            intermediate_tensor_addrgen,
+                            cb_intermediate,
+                            page_size,
+                            {.page_id = intermediate_tile_id},
+                            {.offset_bytes = l1_write_addr});
                         l1_write_addr += page_size;
 
                         intermediate_pages_read_in_row++;
@@ -403,9 +444,9 @@ void kernel_main() {
                         }
                     }
 
-                    noc_async_read_barrier();
-                    cb_push_back(cb_in0, tile_granularity);
-                    cb_push_back(cb_intermediate_id, tile_granularity);
+                    noc_obj.async_read_barrier();
+                    cb_in0.push_back(tile_granularity);
+                    cb_intermediate.push_back(tile_granularity);
                 }
                 tile_id_start += channel_num_pages;
                 intermediate_tile_id_start += input_channel_num_pages;
@@ -413,5 +454,7 @@ void kernel_main() {
         }
     }
     // Reset my output ready semaphore
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a precomposed L1 semaphore
+    // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -405,16 +405,16 @@ void kernel_main() {
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
                     cb_compute_output.wait_front(tile_granularity);
-                    size_t l1_read_addr = cb_compute_output.get_read_ptr();
+                    size_t l1_read_offset = 0;
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t output_tile_id = output_tile_id_start + tiles_read;
                         noc_obj.async_write(
                             cb_compute_output,
                             output_addrgen,
                             page_size,
-                            {.offset_bytes = l1_read_addr},
+                            {.offset_bytes = l1_read_offset},
                             {.page_id = output_tile_id});
-                        l1_read_addr += page_size;
+                        l1_read_offset += page_size;
                         tiles_read++;
                     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -86,7 +89,7 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     uint32_t opposite_core_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t opposite_core_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
@@ -205,6 +208,10 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_connect_finish(*mux_connection_handle);
     }
 
+    Noc noc_obj;
+    CircularBuffer cb_compute_output(cb_compute_output_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     auto pkt_scatter_hdr = PacketHeaderPool::allocate_header();
     auto pkt_unicast_hdr = PacketHeaderPool::allocate_header();
     auto pkt_hdr_seminc = PacketHeaderPool::allocate_header();
@@ -239,6 +246,8 @@ void kernel_main() {
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opposite_direction_barrier_sem_noc_addr_in_pkt, 0});
         }
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a precomposed L1 semaphore
+        // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -279,7 +288,7 @@ void kernel_main() {
 
         uint32_t batch_offset = input_batch_num_pages * b;
         for (uint32_t iter = 0; iter < num_targets_in_direction; ++iter) {
-            const uint32_t cb_output_id = is_first_device_in_direction ? cb_reader_output_id : cb_compute_output_id;
+            CircularBuffer& cb_output = is_first_device_in_direction ? cb_reader_output : cb_compute_output;
             chunk_count = 0;
 
             uint32_t intermediate_tile_id_start;
@@ -305,8 +314,8 @@ void kernel_main() {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_wait_front(cb_output_id, tile_granularity);
-                    size_t l1_read_addr = get_read_ptr(cb_output_id);
+                    cb_output.wait_front(tile_granularity);
+                    size_t l1_read_addr = cb_output.get_read_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                         uint32_t num_pages_to_write = std::min(contig_pages_advanced, num_pages_to_read - j);
 
@@ -349,10 +358,10 @@ void kernel_main() {
                         } else {
                             ASSERT(false);
                         }
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                         tiles_read += num_pages_to_write;
                     }
-                    cb_pop_front(cb_output_id, tile_granularity);
+                    cb_output.pop_front(tile_granularity);
 
                     chunk_count++;
                     if (chunk_count % chunks_per_sync == 0) {
@@ -394,53 +403,60 @@ void kernel_main() {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_wait_front(cb_compute_output_id, tile_granularity);
-                    size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
+                    cb_compute_output.wait_front(tile_granularity);
+                    size_t l1_read_addr = cb_compute_output.get_read_ptr();
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t output_tile_id = output_tile_id_start + tiles_read;
-                        uint64_t local_noc_addr = get_noc_addr(output_tile_id, output_addrgen);
-                        noc_async_write(l1_read_addr, local_noc_addr, page_size);
+                        noc_obj.async_write(
+                            cb_compute_output,
+                            output_addrgen,
+                            page_size,
+                            {.offset_bytes = l1_read_addr},
+                            {.page_id = output_tile_id});
                         l1_read_addr += page_size;
                         tiles_read++;
                     }
 
                     if (detail::do_forward_sync(is_forward)) {
-                        noc_async_write_barrier();
+                        noc_obj.async_write_barrier();
                     } else {
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                     }
-                    cb_pop_front(cb_compute_output_id, tile_granularity);
+                    cb_compute_output.pop_front(tile_granularity);
                     if (detail::do_forward_sync(is_forward)) {
                         // Tell local backwards reader that it can proceed
-                        uint64_t fwd_bwd_sem_noc_addr =
-                            safe_get_noc_addr(opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, fwd_bwd_sem_addr, 0);
-                        noc_semaphore_inc(fwd_bwd_sem_noc_addr, 1);
+                        fwd_bwd_sem.up(noc_obj, opposite_core_sem_noc0_x, opposite_core_sem_noc0_y, 1);
                     }
                 }
                 output_tile_id_start += output_channel_num_pages;
             }
-            noc_async_write_barrier();
+            noc_obj.async_write_barrier();
         }
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 
     if (mux_connection_valid) {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if (is_termination_master) {
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a precomposed L1
+            // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can wrap).
+            // #45003 item 4.
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
+            // Device 2.0 migration: legacy primitive retained: dest_addr is a precomposed uint64_t NoC
+            // address; Semaphore<> wraps a Metal semaphore id, not a raw address. #45003 item 4.
             uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -21,6 +21,7 @@
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -19,6 +20,10 @@ void kernel_main() {
     const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_output(output_cb);
+
     binary_op_init_common(input_cb_id, intermediate_cb, output_cb);
     add_tiles_init(input_cb_id, intermediate_cb, false);
 
@@ -32,18 +37,18 @@ void kernel_main() {
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;
                     uint32_t num_pages_to_read = std::min(tiles_remaining_to_read, tile_granularity);
 
-                    cb_wait_front(input_cb_id, tile_granularity);
-                    cb_wait_front(intermediate_cb, tile_granularity);
-                    cb_reserve_back(output_cb, tile_granularity);
+                    cb_input.wait_front(tile_granularity);
+                    cb_intermediate.wait_front(tile_granularity);
+                    cb_output.reserve_back(tile_granularity);
                     acquire_dst();
                     for (uint32_t tile_id = 0; tile_id < num_pages_to_read; tile_id++) {
                         add_tiles(input_cb_id, intermediate_cb, tile_id, tile_id, tile_id);
                         pack_tile(tile_id, output_cb);
                     }
                     release_dst();
-                    cb_pop_front(input_cb_id, tile_granularity);
-                    cb_pop_front(intermediate_cb, tile_granularity);
-                    cb_push_back(output_cb, tile_granularity);
+                    cb_input.pop_front(tile_granularity);
+                    cb_intermediate.pop_front(tile_granularity);
+                    cb_output.push_back(tile_granularity);
 
                     tiles_read += num_pages_to_read;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
@@ -72,6 +75,12 @@ void kernel_main() {
     if constexpr (fuse_op) {
         matmul_receiver = ReduceScatterOpReceiver(arg_idx);
     }
+
+    Noc noc_obj;
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_interm(cb_interm_id);
+    CircularBuffer cb_interm2(cb_interm2_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
 
     uint32_t sem_target = 0;
     uint32_t sem2_target = 0;
@@ -206,16 +215,21 @@ void kernel_main() {
                     } else {
                         const bool reduce_interm =
                             (is_even_chunk && reduce_even_chunks) || (!is_even_chunk && reduce_odd_chunks);
-                        const uint32_t cb_in =
-                            reduce_interm ? cb_input_id : cb_reader_output_id;  // to compute or writer
+                        CircularBuffer& cb_in = reduce_interm ? cb_input : cb_reader_output;  // to compute or writer
 
                         // Wait for intermediate_tensor data to be available
                         if (reduce_interm) {
                             if (chunk_count == 0) {
+                                // Device 2.0 migration: legacy primitive retained: out_ready_sem is a
+                                // precomposed L1 semaphore address passed via a runtime arg (not a per-program
+                                // id Semaphore<> can wrap). #45003 item 4.
                                 noc_semaphore_wait_min(
                                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), sem_target + 1);
                                 ++sem_target;
                                 if (reduce_output) {
+                                    // Device 2.0 migration: legacy primitive retained: out2_ready_sem is a
+                                    // precomposed L1 semaphore address passed via a runtime arg (not a
+                                    // per-program id Semaphore<> can wrap). #45003 item 4.
                                     noc_semaphore_wait_min(
                                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out2_ready_sem),
                                         sem2_target + 1);
@@ -225,15 +239,15 @@ void kernel_main() {
                             chunk_count = (chunk_count == chunks_per_sync - 1) ? 0 : (chunk_count + 1);
                         }
 
-                        cb_reserve_back(cb_in, tile_granularity);
-                        uint32_t l1_write_addr = get_write_ptr(cb_in);
+                        cb_in.reserve_back(tile_granularity);
+                        uint32_t l1_write_addr = cb_in.get_write_ptr();
                         uint32_t interm_l1_write_addr, interm2_l1_write_addr;
                         if (reduce_interm) {
-                            cb_reserve_back(cb_interm_id, tile_granularity);
-                            interm_l1_write_addr = get_write_ptr(cb_interm_id);
+                            cb_interm.reserve_back(tile_granularity);
+                            interm_l1_write_addr = cb_interm.get_write_ptr();
                             if (reduce_output) {
-                                cb_reserve_back(cb_interm2_id, tile_granularity);
-                                interm2_l1_write_addr = get_write_ptr(cb_interm2_id);
+                                cb_interm2.reserve_back(tile_granularity);
+                                interm2_l1_write_addr = cb_interm2.get_write_ptr();
                             }
                         }
                         for (uint32_t j = 0; j < tiles_to_read; ++j) {
@@ -242,32 +256,44 @@ void kernel_main() {
                             auto output_tile_id = get_next_output_tile_id();
 
                             // input_tensor from reader -> compute or writer
-                            uint64_t noc_read_addr = input_tensor_accessor.get_noc_addr(input_tile_id);
-                            noc_async_read(noc_read_addr, l1_write_addr, page_size);
+                            noc_obj.async_read(
+                                input_tensor_accessor,
+                                cb_in,
+                                page_size,
+                                {.page_id = input_tile_id},
+                                {.offset_bytes = l1_write_addr});
                             l1_write_addr += page_size;
 
                             if (reduce_interm) {
                                 // interm_tensor from reader -> compute
-                                uint64_t interm_noc_read_addr = interm_tensor_accessor.get_noc_addr(interm_tile_id);
-                                noc_async_read(interm_noc_read_addr, interm_l1_write_addr, page_size);
+                                noc_obj.async_read(
+                                    interm_tensor_accessor,
+                                    cb_interm,
+                                    page_size,
+                                    {.page_id = interm_tile_id},
+                                    {.offset_bytes = interm_l1_write_addr});
                                 interm_l1_write_addr += page_size;
 
                                 if (reduce_output) {
                                     // output_tensor from reader -> compute
-                                    uint64_t output_noc_read_addr = output_tensor_accessor.get_noc_addr(output_tile_id);
-                                    noc_async_read(output_noc_read_addr, interm2_l1_write_addr, page_size);
+                                    noc_obj.async_read(
+                                        output_tensor_accessor,
+                                        cb_interm2,
+                                        page_size,
+                                        {.page_id = output_tile_id},
+                                        {.offset_bytes = interm2_l1_write_addr});
                                     interm2_l1_write_addr += page_size;
                                 }
                             }
                         }
                         tiles_read += tiles_to_read;
-                        noc_async_read_barrier();
-                        cb_push_back(cb_in, tile_granularity);
+                        noc_obj.async_read_barrier();
+                        cb_in.push_back(tile_granularity);
                         if (reduce_interm) {
-                            cb_push_back(cb_interm_id, tile_granularity);
+                            cb_interm.push_back(tile_granularity);
 
                             if (reduce_output) {
-                                cb_push_back(cb_interm2_id, tile_granularity);
+                                cb_interm2.push_back(tile_granularity);
                             }
                         }
                     }  // if skip or process
@@ -285,6 +311,9 @@ void kernel_main() {
         }
 
         // Reset the semaphore before the next batch
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem and out2_ready_sem are precomposed
+        // L1 semaphore addresses passed via runtime args (not per-program ids Semaphore<> can wrap).
+        // #45003 item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out2_ready_sem), 0);
         sem_target = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using tt::tt_metal::BufferType;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_reader.cpp
@@ -241,14 +241,12 @@ void kernel_main() {
                         }
 
                         cb_in.reserve_back(tile_granularity);
-                        uint32_t l1_write_addr = cb_in.get_write_ptr();
-                        uint32_t interm_l1_write_addr, interm2_l1_write_addr;
+                        uint32_t l1_write_offset = 0;
+                        uint32_t interm_l1_write_offset = 0, interm2_l1_write_offset = 0;
                         if (reduce_interm) {
                             cb_interm.reserve_back(tile_granularity);
-                            interm_l1_write_addr = cb_interm.get_write_ptr();
                             if (reduce_output) {
                                 cb_interm2.reserve_back(tile_granularity);
-                                interm2_l1_write_addr = cb_interm2.get_write_ptr();
                             }
                         }
                         for (uint32_t j = 0; j < tiles_to_read; ++j) {
@@ -262,8 +260,8 @@ void kernel_main() {
                                 cb_in,
                                 page_size,
                                 {.page_id = input_tile_id},
-                                {.offset_bytes = l1_write_addr});
-                            l1_write_addr += page_size;
+                                {.offset_bytes = l1_write_offset});
+                            l1_write_offset += page_size;
 
                             if (reduce_interm) {
                                 // interm_tensor from reader -> compute
@@ -272,8 +270,8 @@ void kernel_main() {
                                     cb_interm,
                                     page_size,
                                     {.page_id = interm_tile_id},
-                                    {.offset_bytes = interm_l1_write_addr});
-                                interm_l1_write_addr += page_size;
+                                    {.offset_bytes = interm_l1_write_offset});
+                                interm_l1_write_offset += page_size;
 
                                 if (reduce_output) {
                                     // output_tensor from reader -> compute
@@ -282,8 +280,8 @@ void kernel_main() {
                                         cb_interm2,
                                         page_size,
                                         {.page_id = output_tile_id},
-                                        {.offset_bytes = interm2_l1_write_addr});
-                                    interm2_l1_write_addr += page_size;
+                                        {.offset_bytes = interm2_l1_write_offset});
+                                    interm2_l1_write_offset += page_size;
                                 }
                             }
                         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -425,7 +425,7 @@ void kernel_main() {
                         } else {
                             // Write tiles to local tensor
                             cb_out.wait_front(tile_granularity);
-                            size_t l1_read_addr = cb_out.get_read_ptr();
+                            size_t l1_read_offset = 0;
                             for (uint32_t j = 0; j < tiles_to_read; ++j) {
                                 auto interm_tile_id = get_next_interm_tile_id();
                                 auto output_tile_id = get_next_output_tile_id();
@@ -434,17 +434,17 @@ void kernel_main() {
                                         cb_out,
                                         interm_tensor_accessor,
                                         page_size,
-                                        {.offset_bytes = l1_read_addr},
+                                        {.offset_bytes = l1_read_offset},
                                         {.page_id = interm_tile_id});
                                 } else {
                                     noc_obj.async_write(
                                         cb_out,
                                         output_tensor_accessor,
                                         page_size,
-                                        {.offset_bytes = l1_read_addr},
+                                        {.offset_bytes = l1_read_offset},
                                         {.page_id = output_tile_id});
                                 }
-                                l1_read_addr += page_size;
+                                l1_read_offset += page_size;
                                 tiles_read++;
                             }
                             noc_obj.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -164,6 +167,10 @@ void kernel_main() {
     auto* fabric_direction_connection =
         direction ? &fabric_connection.get_forward_connection() : &fabric_connection.get_backward_connection();
 #endif
+
+    Noc noc_obj;
+    CircularBuffer cb_compute_output(cb_compute_output_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
     fabric_multicast_noc_unicast_atomic_inc_set_state<
         UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
         pkt_hdr_mcastseminc,
@@ -188,6 +195,8 @@ void kernel_main() {
             pkt_hdr_mcastseminc,
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
 
+        // Device 2.0 migration: legacy primitive retained: barrier_sem is a precomposed L1 semaphore
+        // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 2 * (ring_size - 1));
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
@@ -332,13 +341,13 @@ void kernel_main() {
                     } else {
                         const bool reduce_interm =
                             (is_even_chunk && reduce_even_chunks) || (!is_even_chunk && reduce_odd_chunks);
-                        const uint32_t cb_out =
-                            reduce_interm ? cb_compute_output_id : cb_reader_output_id;  // from compute or reader
+                        CircularBuffer& cb_out =
+                            reduce_interm ? cb_compute_output : cb_reader_output;  // from compute or reader
 
                         if (write_to_remote) {
                             // Write tiles to remote tensor over Fabric
-                            cb_wait_front(cb_out, tile_granularity);
-                            size_t l1_read_addr = get_read_ptr(cb_out);
+                            cb_out.wait_front(tile_granularity);
+                            size_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t j = 0; j < tiles_to_read; j += num_tiles_to_write_per_packet) {
                                 uint32_t tiles_to_put_in_current_packet =
                                     std::min(tiles_to_read - j, num_tiles_to_write_per_packet);
@@ -373,11 +382,11 @@ void kernel_main() {
                                         l1_read_addr,
                                         NocUnicastCommandHeader{remote_noc_addrs[0]});
                                 }
-                                noc_async_writes_flushed();
+                                noc_obj.async_writes_flushed();
                                 l1_read_addr += page_size * tiles_to_put_in_current_packet;
                                 tiles_read += tiles_to_put_in_current_packet;
                             }
-                            cb_pop_front(cb_out, tile_granularity);
+                            cb_out.pop_front(tile_granularity);
 
                             // Send semaphore increment to remote worker core
                             ++chunk_count;
@@ -391,7 +400,7 @@ void kernel_main() {
                                         fabric_direction_connection,
                                         pkt_hdr_seminc,
                                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{even_core_sem_noc_addr, 0});
-                                    noc_async_writes_flushed();
+                                    noc_obj.async_writes_flushed();
                                 } else if (!is_even_chunk && odd_chunk_count == chunks_per_sync) {
                                     odd_chunk_count = 0;
                                     fabric_unicast_noc_unicast_atomic_inc_with_state<
@@ -399,7 +408,7 @@ void kernel_main() {
                                         fabric_direction_connection,
                                         pkt_hdr_seminc,
                                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{odd_core_sem_noc_addr, 0});
-                                    noc_async_writes_flushed();
+                                    noc_obj.async_writes_flushed();
                                 }
                             } else {
                                 if (chunk_count == chunks_per_sync) {
@@ -409,28 +418,36 @@ void kernel_main() {
                                         fabric_direction_connection,
                                         pkt_hdr_seminc,
                                         tt::tt_fabric::NocUnicastAtomicIncCommandHeader{this_core_sem_noc_addr, 0});
-                                    noc_async_writes_flushed();
+                                    noc_obj.async_writes_flushed();
                                 }
                             }
                         } else {
                             // Write tiles to local tensor
-                            cb_wait_front(cb_out, tile_granularity);
-                            size_t l1_read_addr = get_read_ptr(cb_out);
+                            cb_out.wait_front(tile_granularity);
+                            size_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t j = 0; j < tiles_to_read; ++j) {
                                 auto interm_tile_id = get_next_interm_tile_id();
                                 auto output_tile_id = get_next_output_tile_id();
-                                uint64_t local_noc_addr;
                                 if (write_to_interm) {
-                                    local_noc_addr = interm_tensor_accessor.get_noc_addr(interm_tile_id);
+                                    noc_obj.async_write(
+                                        cb_out,
+                                        interm_tensor_accessor,
+                                        page_size,
+                                        {.offset_bytes = l1_read_addr},
+                                        {.page_id = interm_tile_id});
                                 } else {
-                                    local_noc_addr = output_tensor_accessor.get_noc_addr(output_tile_id);
+                                    noc_obj.async_write(
+                                        cb_out,
+                                        output_tensor_accessor,
+                                        page_size,
+                                        {.offset_bytes = l1_read_addr},
+                                        {.page_id = output_tile_id});
                                 }
-                                noc_async_write(l1_read_addr, local_noc_addr, page_size);
                                 l1_read_addr += page_size;
                                 tiles_read++;
                             }
-                            noc_async_write_barrier();
-                            cb_pop_front(cb_out, tile_granularity);
+                            noc_obj.async_write_barrier();
+                            cb_out.pop_front(tile_granularity);
                         }  // if remote or local
                     }  // if skip or process
 
@@ -450,14 +467,14 @@ void kernel_main() {
                             fabric_direction_connection,
                             pkt_hdr_seminc,
                             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{even_core_sem_noc_addr, 0});
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                     }
                     if (odd_chunks && odd_chunk_count != 0) {
                         fabric_unicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
                             fabric_direction_connection,
                             pkt_hdr_seminc,
                             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{odd_core_sem_noc_addr, 0});
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                     }
                 } else {
                     if (chunk_count != 0) {
@@ -465,7 +482,7 @@ void kernel_main() {
                             fabric_direction_connection,
                             pkt_hdr_seminc,
                             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{this_core_sem_noc_addr, 0});
-                        noc_async_writes_flushed();
+                        noc_obj.async_writes_flushed();
                     }
                 }
             }
@@ -480,33 +497,40 @@ void kernel_main() {
             fabric_direction_connection,
             pkt_hdr_mcastseminc,
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{batch_ready_sem_noc_addr_in_pkt, 0});
-        noc_async_writes_flushed();
+        noc_obj.async_writes_flushed();
 
         batch_ready_sem_noc_addr_in_pkt = safe_get_noc_addr(opposite_core_x, opposite_core_y, batch_ready_sem, 0);
         fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
             fabric_direction_connection,
             pkt_hdr_mcastseminc,
             tt::tt_fabric::NocUnicastAtomicIncCommandHeader{batch_ready_sem_noc_addr_in_pkt, 0});
-        noc_async_writes_flushed();
+        noc_obj.async_writes_flushed();
 
+        // Device 2.0 migration: legacy primitive retained: batch_ready_sem is a precomposed L1 semaphore
+        // address passed via a runtime arg (not a per-program id Semaphore<> can wrap). #45003 item 4.
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), 2 * (ring_size - 1));
         noc_semaphore_set(
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), 0);  // reset semaphore before next batch
     }
 
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 #ifdef USE_WORKER_MUX
     tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
     if (is_termination_master) {
+        // Device 2.0 migration: legacy primitive retained: termination_sync_address is a precomposed L1
+        // semaphore address passed via a runtime arg (not a per-program id Semaphore<> can wrap).
+        // #45003 item 4.
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
+        // Device 2.0 migration: legacy primitive retained: dest_addr is a precomposed uint64_t NoC
+        // address; Semaphore<> wraps a Metal semaphore id, not a raw address. #45003 item 4.
         uint64_t dest_addr =
             safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
         noc_semaphore_inc(dest_addr, 1);
-        noc_async_atomic_barrier();
+        noc_obj.async_atomic_barrier();
     }
 #else
     if (fabric_connection.is_logically_connected()) {
@@ -514,5 +538,5 @@ void kernel_main() {
     }
 #endif
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -19,6 +19,7 @@
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using ttnn::ccl::Topology;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduction.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Define all compile-time arguments at the beginning
@@ -23,6 +24,11 @@ void kernel_main() {
     uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);
+
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_interm(cb_interm_id);
+    CircularBuffer cb_interm2(cb_interm2_id);
+    CircularBuffer cb_compute_output(cb_compute_output_id);
 
     compute_kernel_hw_startup(cb_interm_id, cb_input_id, cb_compute_output_id);
 
@@ -83,10 +89,10 @@ void kernel_main() {
                         if (reduce_interm) {
                             // If reduce_output, add 3 tensors. Else add 2 tensors.
                             if (reduce_output) {
-                                cb_wait_front(cb_interm2_id, tile_granularity);
+                                cb_interm2.wait_front(tile_granularity);
                             }
-                            cb_wait_front(cb_input_id, tile_granularity);
-                            cb_wait_front(cb_interm_id, tile_granularity);
+                            cb_input.wait_front(tile_granularity);
+                            cb_interm.wait_front(tile_granularity);
 
                             tile_regs_acquire();  // acquire DST registers for MATH thread, resets DST to 0
                             if (reduce_output) {
@@ -104,19 +110,19 @@ void kernel_main() {
                             tile_regs_commit();  // release lock on DST by MATH thread, signal the PACK thread
 
                             if (reduce_output) {
-                                cb_pop_front(cb_interm2_id, tile_granularity);
+                                cb_interm2.pop_front(tile_granularity);
                             }
-                            cb_pop_front(cb_input_id, tile_granularity);
-                            cb_pop_front(cb_interm_id, tile_granularity);
+                            cb_input.pop_front(tile_granularity);
+                            cb_interm.pop_front(tile_granularity);
 
-                            cb_reserve_back(cb_compute_output_id, tile_granularity);
+                            cb_compute_output.reserve_back(tile_granularity);
                             tile_regs_wait();  // acquire lock on DST for PACK thread
                             for (uint32_t tile_id = 0; tile_id < tiles_to_read; ++tile_id) {
                                 pack_tile(tile_id, cb_compute_output_id, tile_id);  // pack results from DST registers
                                                                                     // to output circular buffers
                             }
                             tile_regs_release();  // release lock on DST by PACK thread
-                            cb_push_back(cb_compute_output_id, tile_granularity);
+                            cb_compute_output.push_back(tile_granularity);
                         }
                         tiles_read += tiles_to_read;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_compute.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp"
 
 // SPLIT REDUCE across Cores
@@ -66,6 +67,20 @@ void kernel_main() {
 
     constexpr uint32_t cb_x2 = cb_x;  // x^2
 
+    CircularBuffer cb_in_obj(cb_in);
+    CircularBuffer cb_x2_obj(cb_x2);
+    CircularBuffer cb_scaler_obj(cb_scaler);
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_signaling(signaling_cb);
+    CircularBuffer cb_stats_obj(cb_stats);
+    CircularBuffer cb_var_obj(cb_var);
+    CircularBuffer cb_eps_obj(cb_eps);
+    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    CircularBuffer cb_im_obj(cb_im);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+    CircularBuffer cb_xmm_obj(cb_xmm);
+    CircularBuffer cb_gamma_obj(cb_gamma);
+
     const uint32_t subblock_w = (block_w <= 2) ? subblock_w_volatile : subblock_w_const;
 
     int index_subblock_w_offset = 0;
@@ -79,7 +94,7 @@ void kernel_main() {
     pack_reconfig_data_format(cb_in);
     reconfig_data_format(cb_in0, cb_in1);
     add_tiles_init(cb_in0, cb_in1);
-    cb_reserve_back(cb_in, num_tiles_per_block);
+    cb_in_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -96,8 +111,8 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_push_back(cb_in, num_tiles_per_block);
-    cb_wait_front(cb_in, num_tiles_per_block);
+    cb_in_obj.push_back(num_tiles_per_block);
+    cb_in_obj.wait_front(num_tiles_per_block);
     pack_reconfig_data_format(cb_in, cb_x2);
     reconfig_data_format(cb_in0, cb_in, cb_in1, cb_in);
 #else
@@ -107,7 +122,7 @@ void kernel_main() {
     // X^2
     mul_tiles_init(cb_in, cb_in);
     index_h_offset = 0;
-    cb_reserve_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -124,16 +139,16 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_push_back(cb_x2, num_tiles_per_block);
+    cb_x2_obj.push_back(num_tiles_per_block);
 
     // E(x^2)
     reconfig_data_format_srca(cb_in, cb_x2);
     reconfig_data_format_srcb(cb_in, cb_scaler);
 
-    cb_wait_front(cb_x2, num_tiles_per_block);
-    cb_wait_front(cb_scaler, 1);
+    cb_x2_obj.wait_front(num_tiles_per_block);
+    cb_scaler_obj.wait_front(1);
 
-    cb_reserve_back(cb_ex_partial2, 1);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
+    cb_ex_partial2_obj.reserve_back(1);  // RMS E(x2) #Layernorm //E(x) and E(x^2)
 
     reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW>(cb_x2, cb_scaler, cb_ex_partial2);
     index_h_offset = 0;
@@ -150,8 +165,8 @@ void kernel_main() {
     tile_regs_release();
     index_h_offset += block_w;
     reduce_uninit();
-    cb_pop_front(cb_x2, num_tiles_per_block);
-    cb_push_back(cb_ex_partial2, 1);
+    cb_x2_obj.pop_front(num_tiles_per_block);
+    cb_ex_partial2_obj.push_back(1);
 
     // global reduce, cb_ex <-- cb_ex_external2, cb_ex_partial2
     if constexpr (is_allgather_worker) {
@@ -175,8 +190,8 @@ void kernel_main() {
     }
 
     // Waits for stats tensor to have valid data
-    cb_wait_front(signaling_cb, 1);
-    cb_pop_front(signaling_cb, 1);
+    cb_signaling.wait_front(1);
+    cb_signaling.pop_front(1);
     constexpr uint32_t post_dst0 = 0;
     constexpr uint32_t post_scaler0 = 0;
     binary_op_init_common(cb_stats, post_cb_scaler_global, cb_var);
@@ -185,6 +200,7 @@ void kernel_main() {
     index = 0;
 
     constexpr uint32_t cb_outgamma = cb_out;
+    CircularBuffer cb_outgamma_obj(cb_outgamma);
     if constexpr (is_allgather_worker) {
         const bool enable_sqrt = get_arg_val<uint32_t>(4) == 1;
         if (enable_sqrt) {
@@ -199,13 +215,13 @@ void kernel_main() {
                 post_cb_scaler_global,
                 cb_var,
                 compute_kernel_lib::ReduceInputBlockShape::row(num_distributed_blocks));
-            cb_pop_front(cb_stats, num_distributed_blocks);
+            cb_stats_obj.pop_front(num_distributed_blocks);
 
             // 1/[sqrt(Var + eps)],
             reconfig_data_format(cb_var, cb_eps);  // cb_var is cb_stats in case of RMS norm
             pack_reconfig_data_format(cb_stats_reduced);
-            cb_wait_front(cb_var, 1);
-            cb_wait_front(cb_eps, 1);
+            cb_var_obj.wait_front(1);
+            cb_eps_obj.wait_front(1);
 
             add_tiles_init(cb_var, cb_eps);
             tile_regs_acquire();
@@ -215,12 +231,12 @@ void kernel_main() {
             rsqrt_tile<true>(post_dst0);
             tile_regs_commit();
             tile_regs_wait();
-            cb_reserve_back(cb_stats_reduced, 1);
+            cb_stats_reduced_obj.reserve_back(1);
             pack_tile(post_dst0, cb_stats_reduced);
             tile_regs_release();
-            cb_pop_front(cb_var, 1);
-            cb_pop_front(cb_eps, 1);
-            cb_push_back(cb_stats_reduced, 1);
+            cb_var_obj.pop_front(1);
+            cb_eps_obj.pop_front(1);
+            cb_stats_reduced_obj.push_back(1);
         }
     }
     pack_reconfig_data_format(cb_im);
@@ -228,9 +244,9 @@ void kernel_main() {
     reconfig_data_format(cb_xmm, cb_ex_global);
     mul_bcast_cols_init_short(cb_xmm, cb_ex_global);
     index_h_offset = 0;
-    cb_reserve_back(cb_im, num_tiles_per_block);
+    cb_im_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
-    cb_wait_front(cb_ex_global, 1);
+    cb_ex_global_obj.wait_front(1);
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
         for (uint32_t w = 0; w < subblock_w; w++) {
@@ -248,18 +264,18 @@ void kernel_main() {
         index_subblock_w_offset += subblock_w;
     }
     index_h_offset += block_w;
-    cb_pop_front(cb_ex_global, 1);
-    cb_push_back(cb_im, num_tiles_per_block);
+    cb_ex_global_obj.pop_front(1);
+    cb_im_obj.push_back(num_tiles_per_block);
 
-    cb_pop_front(cb_xmm, num_tiles_per_block);
-    cb_wait_front(cb_im, num_tiles_per_block);
+    cb_xmm_obj.pop_front(num_tiles_per_block);
+    cb_im_obj.wait_front(num_tiles_per_block);
 
     reconfig_data_format(cb_im, cb_gamma);
     pack_reconfig_data_format(cb_out);
     mul_bcast_rows_init_short(cb_im, cb_gamma);
-    cb_wait_front(cb_gamma, block_w);
+    cb_gamma_obj.wait_front(block_w);
     index_h_offset = 0;
-    cb_reserve_back(cb_outgamma, num_tiles_per_block);
+    cb_outgamma_obj.reserve_back(num_tiles_per_block);
     index_subblock_w_offset = 0;
     for (uint32_t j = 0; j < num_subblocks_w; j++) {
         tile_regs_acquire();
@@ -274,8 +290,8 @@ void kernel_main() {
         }
         tile_regs_release();
         index_subblock_w_offset += subblock_w;
-        cb_push_back(cb_outgamma, subblock_w);
+        cb_outgamma_obj.push_back(subblock_w);
     }
     index_h_offset += block_w;
-    cb_pop_front(cb_im, num_tiles_per_block);
+    cb_im_obj.pop_front(num_tiles_per_block);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/reshard_writer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/reshard_writer.hpp
@@ -6,6 +6,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 template <
     uint32_t cb_out,
@@ -13,13 +17,18 @@ template <
     uint32_t worker_core_stride_w_bytes,
     uint32_t storage_core_stride_w_bytes>
 inline void write_minimal_resharded_data(
-    uint32_t num_segments_to_write_back, uint32_t storage_core_start_offset, tt_l1_ptr uint32_t* segment_args) {
+    Noc& noc,
+    uint32_t num_segments_to_write_back,
+    uint32_t storage_core_start_offset,
+    tt_l1_ptr uint32_t* segment_args) {
+    CircularBuffer cb_out_obj(cb_out);
+    CircularBuffer cb_out_resharded_obj(cb_out_resharded);
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
     uint32_t args_idx = 0;
     uint32_t worker_core_read_offset = 0;
 
-    uint32_t cb_out_read_base_addr = get_read_ptr(cb_out);
-    uint32_t cb_out_reshard_write_base_addr = get_write_ptr(cb_out_resharded);
+    uint32_t cb_out_read_base_addr = cb_out_obj.get_read_ptr();
+    uint32_t cb_out_reshard_write_base_addr = cb_out_resharded_obj.get_write_ptr();
 
     for (uint32_t i = 0; i < num_segments_to_write_back; ++i) {
         uint32_t write_size = segment_args[args_idx++];
@@ -35,19 +44,21 @@ inline void write_minimal_resharded_data(
             local_storage_core_write_addr += storage_core_start_offset;
         }
 
-        uint64_t remote_storage_core_write_addr =
-            get_noc_addr(storage_core_x, storage_core_y, local_storage_core_write_addr);
-
         for (uint32_t w = 0; w < num_tiles_to_write_in_current_segment; ++w) {
-            cb_wait_front(cb_out, 1);
-            noc_async_write(worker_core_read_addr, remote_storage_core_write_addr, out_single_tile_size_bytes);
+            cb_out_obj.wait_front(1);
+            noc.async_write(
+                CoreLocalMem<uint8_t>(worker_core_read_addr),
+                UnicastEndpoint{},
+                out_single_tile_size_bytes,
+                {},
+                {.noc_x = storage_core_x, .noc_y = storage_core_y, .addr = local_storage_core_write_addr});
             worker_core_read_addr += out_single_tile_size_bytes;
-            remote_storage_core_write_addr += out_single_tile_size_bytes;
-            cb_pop_front(cb_out, 1);
+            local_storage_core_write_addr += out_single_tile_size_bytes;
+            cb_out_obj.pop_front(1);
         }
         worker_core_read_addr += worker_core_stride_w_bytes;
-        remote_storage_core_write_addr += storage_core_stride_w_bytes;
+        local_storage_core_write_addr += storage_core_stride_w_bytes;
         worker_core_read_offset += write_size * out_single_tile_size_bytes;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_receiver_reader.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "hostdevcommon/common_values.hpp"
 
 // split REDUCE across cores
@@ -24,10 +27,19 @@ void kernel_main() {
     constexpr uint32_t cb_ex_external2 = get_compile_time_arg_val(13);
     constexpr uint32_t post_semaphore_id = get_compile_time_arg_val(14);
     constexpr uint32_t cb_ex_global = get_compile_time_arg_val(15);  // [E[x], E[X^2]] global to all cores
-    uint32_t post_reduce_sender_semaphore_addr = get_semaphore(post_semaphore_id);
-    volatile tt_l1_ptr uint32_t* post_reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(post_reduce_sender_semaphore_addr);
-    noc_semaphore_set(post_reduce_sender_semaphore_addr_ptr, INVALID);
+
+    Noc noc_obj;
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_ex2_obj(cb_ex2);
+    CircularBuffer cb_ex_external2_obj(cb_ex_external2);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+
+    Semaphore<> post_reduce_sender_sem(post_semaphore_id);
+    Semaphore<> reduce_second_stage_sem(reduce_second_stage_semaphore_id);
+    Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+
+    post_reduce_sender_sem.set(INVALID);
 
     const uint32_t all_to_all_tile_offset_bytes = get_arg_val<uint32_t>(0);
     const bool is_second_stage_reader = get_arg_val<uint32_t>(1);
@@ -38,11 +50,9 @@ void kernel_main() {
 
     const DataFormat data_format = get_dataformat(cb_ex_partial2);  // data format
 
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(reduce_second_stage_semaphore_id);
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(reduce_receiver_semaphore_id);
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(reduce_sender_semaphore_id);
-
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
     if constexpr (is_all_to_all_worker) {
         if constexpr (use_two_stage_reduce) {
@@ -79,42 +89,31 @@ void kernel_main() {
         remote_noc_addrs_second_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
     }
 
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr =
-        get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
-    const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
-        remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
-
     // global reduce
     // wait for local data ready
-    cb_wait_front(cb_ex_partial2, 1);
+    cb_ex_partial2_obj.wait_front(1);
 
     // inc mcast sender
-    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
-    noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
-    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+    reduce_sender_sem.set(INVALID);
+    reduce_receiver_sem.up(noc_obj, in0_remote_noc_x[0], in0_remote_noc_y[0], 1);
+    reduce_sender_sem.wait(VALID);
 
     if constexpr (is_all_to_all_worker) {
         // read data from other cores - reduce first stage
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_ex_partial2);
+        uint32_t l1_read_addr_ex_par = cb_ex_partial2_obj.get_read_ptr();
         l1_read_addr_ex_par += all_to_all_tile_offset_bytes;
         // read data from other cores - second stage reduce
         uint32_t l1_read_addr_ex = 0;
         uint32_t block_index_stride = 0;
         if constexpr (use_two_stage_reduce) {
-            l1_read_addr_ex = get_read_ptr(cb_ex2);
+            l1_read_addr_ex = cb_ex2_obj.get_read_ptr();
             block_index_stride = num_x;
         }
-        cb_reserve_back(cb_ex_external2, num_blocks_first_stage);
-        uint32_t l1_write_addr_external = get_write_ptr(cb_ex_external2);
+        cb_ex_external2_obj.reserve_back(num_blocks_first_stage);
+        uint32_t l1_write_addr_external = cb_ex_external2_obj.get_write_ptr();
 
         for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
             uint64_t noc_addr_ex_par =
                 remote_noc_addrs_first_stage[block] | (l1_read_addr_ex_par);  // Updating read address for reading
                                                                               // SUm(X) and Sum(X2) per core
@@ -122,34 +121,38 @@ void kernel_main() {
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
-        noc_async_read_barrier();
-        cb_push_back(cb_ex_external2, num_blocks_first_stage);
+        noc_obj.async_read_barrier();
+        cb_ex_external2_obj.push_back(num_blocks_first_stage);
 
         // read data from other cores - reduce first stage
         if constexpr (use_two_stage_reduce) {
             if (is_second_stage_reader) {  // gather data from a column of cores (if row major)
-                noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-                noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+                reduce_second_stage_sem.set(0);
                 // read data from other cores - second stage reduce
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                     uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
                     noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                     l1_write_addr_external += single_tile_size_bytes;
                 }
                 l1_read_addr_ex += single_tile_size_bytes;
-                noc_async_read_barrier();
-                cb_push_back(cb_ex_external2, num_blocks_second_stage - 1);
+                noc_obj.async_read_barrier();
+                cb_ex_external2_obj.push_back(num_blocks_second_stage - 1);
             }
         }
 
         // sync with the gather worker
-        cb_wait_front(cb_ex2, 1);
+        cb_ex2_obj.wait_front(1);
+        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
+        const uint64_t reduce_second_stage_receiver_semaphore_noc_addr =
+            remote_noc_addrs_second_stage[0] | get_semaphore(reduce_second_stage_semaphore_id);
         noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);
     }
-    cb_pop_front(cb_ex_partial2, 1);
+    cb_ex_partial2_obj.pop_front(1);
     // Signal the compute kernel cb_ex_global ready
-    cb_reserve_back(cb_ex_global, 1);
-    noc_semaphore_wait(post_reduce_sender_semaphore_addr_ptr, VALID);
-    cb_push_back(cb_ex_global, 1);
-    cb_pop_front(cb_ex2, 1);
+    cb_ex_global_obj.reserve_back(1);
+    post_reduce_sender_sem.wait(VALID);
+    cb_ex_global_obj.push_back(1);
+    cb_ex2_obj.pop_front(1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_sender_reader.cpp
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 
 // split REDUCE across cores
@@ -25,7 +30,18 @@ void kernel_main() {
     constexpr uint32_t cb_stats_reduced = get_compile_time_arg_val(14);  // [E[x], E[x^2]] local to sender
     constexpr uint32_t cb_ex_global = get_compile_time_arg_val(15);      // [E[x], E[X^2]] global to all cores
 
-    uint32_t post_reduce_sender_semaphore_addr = get_semaphore(post_reduce_sender_semaphore_id);
+    Noc noc_obj;
+    CircularBuffer cb_ex_partial2_obj(cb_ex_partial2);
+    CircularBuffer cb_ex2_obj(cb_ex2);
+    CircularBuffer cb_ex_external2_obj(cb_ex_external2);
+    CircularBuffer cb_stats_reduced_obj(cb_stats_reduced);
+    CircularBuffer cb_ex_global_obj(cb_ex_global);
+
+    Semaphore<> post_reduce_sender_sem(post_reduce_sender_semaphore_id);
+    Semaphore<> reduce_receiver_sem(reduce_receiver_semaphore_id);
+    Semaphore<> reduce_sender_sem(reduce_sender_semaphore_id);
+    Semaphore<> reduce_second_stage_sem(reduce_second_stage_semaphore_id);
+
     const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(0);
     const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(1);
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
@@ -36,12 +52,9 @@ void kernel_main() {
     tt_l1_ptr uint32_t* in0_remote_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
     tt_l1_ptr uint32_t* in0_remote_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
 
-    uint32_t reduce_receiver_semaphore_addr = get_semaphore(reduce_receiver_semaphore_id);
-    uint32_t reduce_sender_semaphore_addr = get_semaphore(reduce_sender_semaphore_id);
-    uint32_t reduce_second_stage_semaphore_addr = get_semaphore(reduce_second_stage_semaphore_id);
-
     const DataFormat data_format = get_dataformat(cb_ex_partial2);
 
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     uint64_t remote_noc_addrs[num_blocks];
 
     uint32_t x = start_x, y = start_y;
@@ -57,100 +70,102 @@ void kernel_main() {
         }
     }
 
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-
-    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const auto& global_reduce_sender = [&](const uint32_t cb_partial,
-                                           const uint32_t cb_external,
-                                           const uint32_t cb_reduce_first_stage) __attribute__((always_inline)) {
+    const auto& global_reduce_sender = [&](CircularBuffer& cb_partial,
+                                           CircularBuffer& cb_external,
+                                           CircularBuffer& cb_reduce_first_stage) __attribute__((always_inline)) {
         // global reduce
         // wait for local data ready
-        cb_wait_front(cb_partial, 1);  // TODO test for layernorm
+        cb_partial.wait_front(1);  // TODO test for layernorm
 
         // inc semaphore of other cores, tell other all-to-all workers to start
         if constexpr (num_blocks > 1) {
-            *reduce_sender_semaphore_addr_ptr = VALID;
-            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks - 1);
-            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
-            noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks - 1);
+            reduce_sender_sem.set(VALID);
+            reduce_receiver_sem.wait(num_blocks - 1);
+            reduce_receiver_sem.set(0);
+            reduce_sender_sem.set_multicast(
+                noc_obj,
+                mcast_dest_noc_start_x,
+                mcast_dest_noc_start_y,
+                mcast_dest_noc_end_x,
+                mcast_dest_noc_end_y,
+                num_blocks - 1);
         }
 
         // read data from other cores - first stage reduce
-        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+        uint32_t l1_read_addr_ex_par = cb_partial.get_read_ptr();
         // read from both stage
         // first stage
-        cb_reserve_back(cb_external, num_blocks_first_stage);
-        uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+        cb_external.reserve_back(num_blocks_first_stage);
+        uint32_t l1_write_addr_external = cb_external.get_write_ptr();
         for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
+            // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
             uint64_t noc_addr_ex_par = remote_noc_addrs[block] | (l1_read_addr_ex_par);
             noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
             l1_write_addr_external += single_tile_size_bytes;
         }
         l1_read_addr_ex_par += single_tile_size_bytes;
-        noc_async_read_barrier();
-        cb_push_back(cb_external, num_blocks_first_stage);
+        noc_obj.async_read_barrier();
+        cb_external.push_back(num_blocks_first_stage);
 
         // sync with second-stage all-to-all workers
         if constexpr (use_two_stage_reduce) {
-            uint32_t l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+            uint32_t l1_read_addr_ex = cb_reduce_first_stage.get_read_ptr();
             uint32_t block_index_stride = num_x;
-            noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage - 1);
-            noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+            reduce_second_stage_sem.wait(num_blocks_second_stage - 1);
+            reduce_second_stage_sem.set(0);
 
             uint32_t curr_block_index = block_index_stride;
             for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | (l1_read_addr_ex);
                 noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
                 l1_write_addr_external += single_tile_size_bytes;
                 curr_block_index += block_index_stride;
             }
             l1_read_addr_ex += single_tile_size_bytes;
-            noc_async_read_barrier();
-            cb_push_back(
-                cb_external,
+            noc_obj.async_read_barrier();
+            cb_external.push_back(
                 (num_blocks_second_stage - 1));  // push back partials from all cores -> compute can start reducing now
         }
-        cb_pop_front(cb_partial, 1);
+        cb_partial.pop_front(1);
     };
-    global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
+    global_reduce_sender(cb_ex_partial2_obj, cb_ex_external2_obj, cb_ex2_obj);
 
-    const uint64_t post_reduce_sender_semaphore_noc_addr = multicast_data_noc | post_reduce_sender_semaphore_addr;
-
-    volatile tt_l1_ptr uint32_t* post_reduce_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(post_reduce_sender_semaphore_addr);
     const auto& global_semaphore_set = [&]() __attribute__((always_inline)) {
-        *post_reduce_sender_semaphore_addr_ptr = VALID;
+        post_reduce_sender_sem.set(VALID);
 
-        noc_semaphore_set_multicast_loopback_src(
-            post_reduce_sender_semaphore_addr, post_reduce_sender_semaphore_noc_addr, num_blocks, false);
-        noc_async_write_barrier();
+        post_reduce_sender_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+            noc_obj,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            num_blocks);
+        noc_obj.async_write_barrier();
     };
 
-    const auto& post_global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global)
+    const auto& post_global_reduce_sender = [&](CircularBuffer& cb_ex, CircularBuffer& cb_ex_global_arg)
                                                 __attribute__((always_inline)) {
-                                                    uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
-                                                    uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
-                                                    noc_async_write_multicast_loopback_src(
-                                                        l1_read_addr_ex,
-                                                        multicast_data_noc | l1_read_addr_ex_global,
+                                                    uint32_t l1_read_addr_ex = cb_ex.get_read_ptr();
+                                                    uint32_t l1_read_addr_ex_global = cb_ex_global_arg.get_read_ptr();
+                                                    noc_obj.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                                        CoreLocalMem<uint8_t>(l1_read_addr_ex),
+                                                        MulticastEndpoint{},
                                                         single_tile_size_bytes,
                                                         num_blocks,
+                                                        {},
+                                                        {.noc_x_start = mcast_dest_noc_start_x,
+                                                         .noc_y_start = mcast_dest_noc_start_y,
+                                                         .noc_x_end = mcast_dest_noc_end_x,
+                                                         .noc_y_end = mcast_dest_noc_end_y,
+                                                         .addr = l1_read_addr_ex_global},
                                                         false);
-                                                    noc_async_write_barrier();
+                                                    noc_obj.async_write_barrier();
                                                 };
-    cb_wait_front(cb_stats_reduced, 1);
-    cb_reserve_back(cb_ex_global, 1);
-    post_global_reduce_sender(cb_stats_reduced, cb_ex_global);
-    cb_push_back(cb_ex_global, 1);
-    cb_pop_front(cb_stats_reduced, 1);
+    cb_stats_reduced_obj.wait_front(1);
+    cb_ex_global_obj.reserve_back(1);
+    post_global_reduce_sender(cb_stats_reduced_obj, cb_ex_global_obj);
+    cb_ex_global_obj.push_back(1);
+    cb_stats_reduced_obj.pop_front(1);
     global_semaphore_set();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -19,6 +19,7 @@
 #include "reshard_writer.hpp"
 #include <cstdint>
 #include <utility>
+#include "api/tensor/noc_traits.h"
 void kernel_main() {
     constexpr bool is_all_to_all_worker = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_in_2 = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
@@ -49,7 +53,14 @@ void kernel_main() {
     constexpr uint32_t num_blocks = get_compile_time_arg_val(23);
     constexpr auto gamma_args = TensorAccessorArgs<24>();
 
-    uint32_t stats_set_semaphore_addr = get_semaphore(stats_set_semaphore_id);
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb_to_allgather_writer_obj(cb_to_allgather_writer);
+    CircularBuffer cb_signaling(signaling_cb);
+    CircularBuffer cb_gamma_obj(cb_gamma);
+
+    Semaphore<> stats_set_sem(stats_set_semaphore_id);
+
     size_t arg_idx = 0;
     const uint32_t base_post_rt =
         get_arg_val<uint32_t>(arg_idx++);  // RT 0 holds how many pre RTs there are (which can vary core by core)
@@ -91,14 +102,11 @@ void kernel_main() {
     const uint32_t eps = get_arg_val<uint32_t>(base_post_rt + 1);
     generate_bcast_col_scalar(eps_cb_id, eps);
     const uint32_t iteration_number = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
     ttnn::ccl::address_t tensor_address0 = get_arg_val<ttnn::ccl::address_t>(arg_idx++);
-    const uint64_t multicast_data_noc = get_noc_multicast_addr(
-        mcast_dest_noc_start_x, mcast_dest_noc_start_y, mcast_dest_noc_end_x, mcast_dest_noc_end_y, 0);
-    const uint64_t stats_set_semaphore_noc_addr = multicast_data_noc | stats_set_semaphore_addr;
-    volatile tt_l1_ptr uint32_t* stats_set_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stats_set_semaphore_addr);
     // Start the all gather part
     if (iteration_number == 0) {
         // Do this only on one of the cores
@@ -117,15 +125,15 @@ void kernel_main() {
                 arg_idx);
 
         // packet header cb
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
-        cb_reserve_back(reserved_packet_header_cb_id, 1);
-        auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-        cb_push_back(reserved_packet_header_cb_id, 1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_addr_forward = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_addr_backward = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
+        cb_packet_header.reserve_back(1);
+        auto packet_header_buffer_seminc = cb_packet_header.get_write_ptr();
+        cb_packet_header.push_back(1);
         // pre-populate packet headers
         volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
@@ -145,8 +153,8 @@ void kernel_main() {
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
         // Send data and the semaphore with the last tile
         uint32_t num_tiles_to_read_this_core = 1;
-        cb_wait_front(cb_to_allgather_writer, num_tiles_to_read_this_core);
-        size_t l1_read_addr = get_read_ptr(cb_to_allgather_writer);
+        cb_to_allgather_writer_obj.wait_front(num_tiles_to_read_this_core);
+        size_t l1_read_addr = cb_to_allgather_writer_obj.get_read_ptr();
         uint64_t noc0_dest_noc_addr = safe_get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0);
         noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
         fused_write_atomic_and_advance_local_read_address_for_fabric_write(
@@ -161,7 +169,7 @@ void kernel_main() {
             false);
 
         fabric_connection.close_start();
-        cb_pop_front(cb_to_allgather_writer, num_tiles_to_read_this_core);
+        cb_to_allgather_writer_obj.pop_front(num_tiles_to_read_this_core);
         // increment locally
         uint64_t out_ready_sem_noc_addr =
             safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -169,31 +177,48 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr);
         if constexpr (num_links == 1) {
             // We deduct the local increment from the target semaphore value as we don't need internal synchronization
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_wait(out_ready_sem_bank_addr_ptr, out_ready_sem_wait_value - 1);
         } else {
             // if multiple links then we need to also ensure the local ones have completed by having them also
             // increment the semaphore and including them in the total
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+            // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_wait(
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_bank_addr), out_ready_sem_wait_value);
         }
 
         // 4. global semaphore reset
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem_bank_addr is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(out_ready_sem_bank_addr_ptr, 0);
         // Signal the other local cores that the semaphore has returned
 
-        noc_semaphore_set(stats_set_semaphore_addr_ptr, VALID);
-        noc_semaphore_set_multicast_loopback_src(
-            stats_set_semaphore_addr, stats_set_semaphore_noc_addr, num_blocks, false);
-        noc_async_write_barrier();
+        stats_set_sem.set(VALID);
+        stats_set_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+            noc_obj,
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            num_blocks);
+        noc_obj.async_write_barrier();
         fabric_connection.close_finish();  // Includes a noc async write barrier
     } else {
         // Wait for the signal that the stats semaphore was written in the all gather core
-        noc_semaphore_wait(stats_set_semaphore_addr_ptr, VALID);
+        stats_set_sem.wait(VALID);
     }
     // Tell the compute kernel it is ok to proceed
-    cb_reserve_back(signaling_cb, 1);
-    cb_push_back(signaling_cb, 1);
+    cb_signaling.reserve_back(1);
+    cb_signaling.push_back(1);
 
     if constexpr (fuse_gamma) {
         const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma);
@@ -203,23 +228,25 @@ void kernel_main() {
         constexpr uint32_t bytes_in_two_facelines = bytes_in_faceline * 2;
         constexpr uint32_t mask_read_tile_offset_bytes = FLOAT32_DTYPE_GAMMA ? 1024 : 512;
 
-        uint32_t l1_write_addr_gamma = get_write_ptr(cb_gamma);
-        cb_reserve_back(cb_gamma, block_w);
+        uint32_t l1_write_addr_gamma = cb_gamma_obj.get_write_ptr();
+        cb_gamma_obj.reserve_back(block_w);
         for (uint32_t w = 0; w < block_w; w++) {
             uint32_t tile_id = gamma_tile_start_id + w;
-            uint64_t gamma_noc_addr = get_noc_addr(tile_id, gamma);
-            noc_async_read(gamma_noc_addr, l1_write_addr_gamma, bytes_in_two_facelines);
-            gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + bytes_in_faceline);
-            noc_async_read_barrier();  // might be faster to do two separate read instead of barrier.
+            noc_obj.async_read(
+                gamma, CoreLocalMem<uint8_t>(l1_write_addr_gamma), bytes_in_two_facelines, {.page_id = tile_id}, {});
+            // Device 2.0 migration: legacy primitive retained: local-L1 self-read via get_noc_addr(local_l1_addr); no
+            // LocalL1 source endpoint on main. #45003 item 4.
+            uint64_t gamma_noc_addr = get_noc_addr(l1_write_addr_gamma + bytes_in_faceline);
+            noc_obj.async_read_barrier();  // might be faster to do two separate read instead of barrier.
             noc_async_read(gamma_noc_addr, l1_write_addr_gamma + mask_read_tile_offset_bytes, bytes_in_faceline);
             l1_write_addr_gamma += gamma_tile_bytes;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_gamma, block_w);
+        noc_obj.async_read_barrier();
+        cb_gamma_obj.push_back(block_w);
     }
 
 #ifndef SKIP_WRITE_BACK
     write_minimal_resharded_data<cb_out, cb_out_resharded, worker_core_stride_w_bytes, storage_core_stride_w_bytes>(
-        num_segments_to_write_back, storage_core_start_offset, segment_args);
+        noc_obj, num_segments_to_write_back, storage_core_start_offset, segment_args);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
@@ -6,6 +6,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
 ///////////////////////////////////////////////////
@@ -36,11 +39,14 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing reads from upstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     fabric_connection.open();
 
     // Create Socket Interface
@@ -58,13 +64,17 @@ void kernel_main() {
             socket_wait_for_pages(receiver_socket, 1);
             uint32_t l1_read_addr = receiver_socket.read_ptr;
             for (uint32_t j = 0; j < num_pages_per_packet; ++j) {
-                auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-                noc_async_write<output_page_size>(l1_read_addr, noc_write_addr, output_page_size);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    output_addr_gen,
+                    output_page_size,
+                    {},
+                    {.page_id = page_index});
                 page_index++;
                 l1_read_addr += socket_page_size;
             }
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
 
@@ -72,13 +82,17 @@ void kernel_main() {
             socket_wait_for_pages(receiver_socket, 1);
             uint32_t l1_read_addr = receiver_socket.read_ptr;
             for (uint32_t j = 0; j < num_pages_remainder; ++j) {
-                auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-                noc_async_write<output_page_size>(l1_read_addr, noc_write_addr, output_page_size);
+                noc_obj.async_write(
+                    CoreLocalMem<uint8_t>(l1_read_addr),
+                    output_addr_gen,
+                    output_page_size,
+                    {},
+                    {.page_id = page_index});
                 page_index++;
                 l1_read_addr += socket_page_size;
             }
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
 
@@ -86,12 +100,16 @@ void kernel_main() {
     // Large pages. We write page chunks from multiple packets.
     else {
         for (uint32_t i = 0; i < num_pages; ++i) {
-            auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
             socket_wait_for_pages(receiver_socket, 1);
-            noc_async_write<output_page_size>(receiver_socket.read_ptr, noc_write_addr, output_page_size);
+            noc_obj.async_write(
+                CoreLocalMem<uint8_t>(receiver_socket.read_ptr),
+                output_addr_gen,
+                output_page_size,
+                {},
+                {.page_id = page_index});
             page_index++;
             socket_pop_pages(receiver_socket, 1);
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
             fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_inplace_writer.cpp
@@ -11,6 +11,7 @@
 #include "api/core_local_mem.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_reader.cpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
 ///////////////////////////////////////////////////
@@ -17,8 +19,10 @@ constexpr uint32_t socket_block_size = get_compile_time_arg_val(2);  // This is 
 constexpr uint32_t socket_page_size = get_compile_time_arg_val(3);
 constexpr bool is_dram = get_compile_time_arg_val(4);
 
-template <uint32_t page_size, uint32_t cb_id, bool is_dram>
+template <uint32_t page_size, bool is_dram>
 FORCE_INLINE void read_data_from_remote_core(
+    Noc& noc_obj,
+    CircularBuffer& cb,
     SocketReceiverInterface& receiver_socket,
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     uint32_t bank_id,
@@ -26,12 +30,13 @@ FORCE_INLINE void read_data_from_remote_core(
     uint32_t num_pages_per_block) {
     uint32_t block_size = num_pages_per_block * page_size;
     socket_wait_for_pages(receiver_socket, 1);
-    cb_reserve_back(cb_id, num_pages_per_block);
+    cb.reserve_back(num_pages_per_block);
     auto remote_read_addr = get_noc_addr_from_bank_id<is_dram>(bank_id, receiver_socket.read_ptr);
-    auto l1_write_addr = get_write_ptr(cb_id);
+    auto l1_write_addr = cb.get_write_ptr();
+    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
     noc_async_read(remote_read_addr, l1_write_addr, block_size);
-    noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages_per_block);
+    noc_obj.async_read_barrier();
+    cb.push_back(num_pages_per_block);
     socket_pop_pages(receiver_socket, 1);
     fabric_socket_notify_sender(receiver_socket, fabric_connection, socket_packet_header_addr);
 }
@@ -52,11 +57,15 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    Noc noc_obj;
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+    CircularBuffer cb_scratch_buffer(scratch_buffer_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing reads from upstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     fabric_connection.open();
 
     // Create Socket Interface
@@ -64,13 +73,25 @@ void kernel_main() {
     set_receiver_socket_page_size(receiver_socket, socket_block_size);
 
     for (uint32_t i = 0; i < num_blocks; ++i) {
-        read_data_from_remote_core<socket_page_size, scratch_buffer_cb_id, is_dram>(
-            receiver_socket, fabric_connection, bank_id, socket_packet_header_addr, num_pages_per_block);
+        read_data_from_remote_core<socket_page_size, is_dram>(
+            noc_obj,
+            cb_scratch_buffer,
+            receiver_socket,
+            fabric_connection,
+            bank_id,
+            socket_packet_header_addr,
+            num_pages_per_block);
     }
 
     if (block_remainder_pages > 0) {
-        read_data_from_remote_core<socket_page_size, scratch_buffer_cb_id, is_dram>(
-            receiver_socket, fabric_connection, bank_id, socket_packet_header_addr, block_remainder_pages);
+        read_data_from_remote_core<socket_page_size, is_dram>(
+            noc_obj,
+            cb_scratch_buffer,
+            receiver_socket,
+            fabric_connection,
+            bank_id,
+            socket_packet_header_addr,
+            block_remainder_pages);
     }
     update_socket_config(receiver_socket);
     fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
@@ -9,6 +9,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/kernels/receiver_writer.cpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/tensor/tensor_accessor.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -29,13 +31,14 @@ void kernel_main() {
     auto output_addr_gen_args = TensorAccessorArgs<output_args_cta_idx, output_args_crta_idx>();
     auto output_addr_gen = TensorAccessor(output_addr_gen_args, output_base_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb_scratch_buffer(scratch_buffer_cb_id);
+
     for (uint32_t page_index = start_page_index; page_index < start_page_index + num_pages; ++page_index) {
-        cb_wait_front(scratch_buffer_cb_id, 1);
-        uint32_t l1_read_addr = get_read_ptr(scratch_buffer_cb_id);
-        auto noc_write_addr = output_addr_gen.get_noc_addr(page_index);
-        noc_async_write<page_size>(l1_read_addr, noc_write_addr, page_size);
-        noc_async_writes_flushed();
-        cb_pop_front(scratch_buffer_cb_id, 1);
+        cb_scratch_buffer.wait_front(1);
+        noc_obj.async_write(cb_scratch_buffer, output_addr_gen, page_size, {}, {.page_id = page_index});
+        noc_obj.async_writes_flushed();
+        cb_scratch_buffer.pop_front(1);
     }
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
@@ -9,6 +9,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/noc_traits.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
 ///////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_reader.cpp
@@ -5,6 +5,9 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/tensor_accessor.h"
 ///////////////////////////////////////////////////
 // COMPILE TIME ARGS
@@ -32,35 +35,38 @@ void kernel_main() {
     auto input_addr_gen_args = TensorAccessorArgs<input_args_cta_idx, input_args_crta_idx>();
     auto input_addr_gen = TensorAccessor(input_addr_gen_args, input_base_addr);
 
+    Noc noc_obj;
+    CircularBuffer cb0(cb0_id);
+
     // TODO #24995: Instead of page by page transfers, we can transfer bank by bank
 
     // Small pages. We pack multiple pages into a single packet.
     uint32_t page_index = page_start_offset;
     if constexpr (num_pages_per_packet > 0) {
         for (uint32_t i = 0; i < num_whole_packets; ++i) {
-            cb_reserve_back(cb0_id, 1);
-            auto l1_write_addr = get_write_ptr(cb0_id);
+            cb0.reserve_back(1);
+            auto l1_write_addr = cb0.get_write_ptr();
             for (uint32_t j = 0; j < num_pages_per_packet; ++j) {
-                auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
-                noc_async_read<input_page_size>(noc_read_addr, l1_write_addr, input_page_size);
+                noc_obj.async_read(
+                    input_addr_gen, CoreLocalMem<uint8_t>(l1_write_addr), input_page_size, {.page_id = page_index}, {});
                 page_index++;
                 l1_write_addr += socket_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb0_id, 1);
+            noc_obj.async_read_barrier();
+            cb0.push_back(1);
         }
 
         if (num_pages_remainder > 0) {
-            cb_reserve_back(cb0_id, 1);
-            auto l1_write_addr = get_write_ptr(cb0_id);
+            cb0.reserve_back(1);
+            auto l1_write_addr = cb0.get_write_ptr();
             for (uint32_t j = 0; j < num_pages_remainder; ++j) {
-                auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
-                noc_async_read<input_page_size>(noc_read_addr, l1_write_addr, input_page_size);
+                noc_obj.async_read(
+                    input_addr_gen, CoreLocalMem<uint8_t>(l1_write_addr), input_page_size, {.page_id = page_index}, {});
                 page_index++;
                 l1_write_addr += socket_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb0_id, 1);
+            noc_obj.async_read_barrier();
+            cb0.push_back(1);
         }
 
     }
@@ -70,19 +76,21 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_pages; ++i) {
             auto noc_read_addr = input_addr_gen.get_noc_addr(page_index);
             for (uint32_t j = 0; j < num_whole_packets_per_page; ++j) {
-                cb_reserve_back(cb0_id, 1);
-                auto l1_write_addr = get_write_ptr(cb0_id);
+                cb0.reserve_back(1);
+                auto l1_write_addr = cb0.get_write_ptr();
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_read<whole_packet_size>(noc_read_addr, l1_write_addr, whole_packet_size);
                 noc_read_addr += whole_packet_size;
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, 1);
+                noc_obj.async_read_barrier();
+                cb0.push_back(1);
             }
             if constexpr (partial_packet_size > 0) {
-                cb_reserve_back(cb0_id, 1);
-                auto l1_write_addr = get_write_ptr(cb0_id);
+                cb0.reserve_back(1);
+                auto l1_write_addr = cb0.get_write_ptr();
+                // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address; #45003 item 4.
                 noc_async_read<partial_packet_size>(noc_read_addr, l1_write_addr, partial_packet_size);
-                noc_async_read_barrier();
-                cb_push_back(cb0_id, 1);
+                noc_obj.async_read_barrier();
+                cb0.push_back(1);
             }
             page_index++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/kernels/sender_writer.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/socket_api.h"
 
 ///////////////////////////////////////////////////
@@ -21,20 +22,21 @@ constexpr uint32_t aligned_partial_packet_size = get_compile_time_arg_val(6);
 constexpr uint32_t whole_packet_size = get_compile_time_arg_val(7);
 constexpr bool is_dram = get_compile_time_arg_val(8);
 
-template <uint32_t cb_id, bool is_dram>
+template <bool is_dram>
 FORCE_INLINE void write_data_to_remote_core(
+    CircularBuffer& cb,
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     uint64_t dst_addr,
     uint32_t packet_size,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr) {
-    cb_wait_front(cb_id, 1);
-    auto l1_read_addr = get_read_ptr(cb_id);
+    cb.wait_front(1);
+    auto l1_read_addr = cb.get_read_ptr();
     data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, packet_size);
     fabric_connection.wait_for_empty_write_slot();
     fabric_connection.send_payload_without_header_non_blocking_from_address(l1_read_addr, packet_size);
     fabric_connection.send_payload_flush_blocking_from_address(
         (uint32_t)data_packet_header_addr, sizeof(PACKET_HEADER_TYPE));
-    cb_pop_front(cb_id, 1);
+    cb.pop_front(1);
 }
 
 void kernel_main() {
@@ -53,14 +55,17 @@ void kernel_main() {
     tt::tt_fabric::WorkerToFabricEdmSender fabric_connection =
         tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(rt_args_idx);
 
+    CircularBuffer cb_fabric_packet_header(fabric_packet_header_cb_id);
+    CircularBuffer cb_data(data_cb_id);
+
     // This kernel relies on two fabric headers stored in fabric_packet_header_cb:
     //  - data_packet_header: Used for issuing writes to downstream data cores
     //  - socket_packet_header: Used by socket APIs for control flow
     volatile tt_l1_ptr PACKET_HEADER_TYPE* data_packet_header_addr =
-        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(get_write_ptr(fabric_packet_header_cb_id));
+        reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(cb_fabric_packet_header.get_write_ptr());
     volatile tt_l1_ptr PACKET_HEADER_TYPE* socket_packet_header_addr =
         reinterpret_cast<volatile tt_l1_ptr PACKET_HEADER_TYPE*>(
-            get_write_ptr(fabric_packet_header_cb_id) + sizeof(PACKET_HEADER_TYPE));
+            cb_fabric_packet_header.get_write_ptr() + sizeof(PACKET_HEADER_TYPE));
     fabric_connection.open();
 
     // Create Socket Interface
@@ -81,8 +86,8 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_whole_packets; ++i) {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
-            write_data_to_remote_core<data_cb_id, is_dram>(
-                fabric_connection, dst_addr, full_packet_size, data_packet_header_addr);
+            write_data_to_remote_core<is_dram>(
+                cb_data, fabric_connection, dst_addr, full_packet_size, data_packet_header_addr);
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
         }
@@ -90,8 +95,8 @@ void kernel_main() {
         if (num_pages_remainder > 0) {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
-            write_data_to_remote_core<data_cb_id, is_dram>(
-                fabric_connection, dst_addr, remainder_packet_size, data_packet_header_addr);
+            write_data_to_remote_core<is_dram>(
+                cb_data, fabric_connection, dst_addr, remainder_packet_size, data_packet_header_addr);
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);
         }
@@ -103,13 +108,13 @@ void kernel_main() {
             socket_reserve_pages(sender_socket, 1);
             uint64_t dst_addr = receiver_noc_coord_addr + sender_socket.write_ptr + sender_socket.downstream_fifo_addr;
             for (uint32_t j = 0; j < num_whole_packets_per_page; ++j) {
-                write_data_to_remote_core<data_cb_id, is_dram>(
-                    fabric_connection, dst_addr, whole_packet_size, data_packet_header_addr);
+                write_data_to_remote_core<is_dram>(
+                    cb_data, fabric_connection, dst_addr, whole_packet_size, data_packet_header_addr);
                 dst_addr += whole_packet_size;
             }
             if constexpr (aligned_partial_packet_size > 0) {
-                write_data_to_remote_core<data_cb_id, is_dram>(
-                    fabric_connection, dst_addr, aligned_partial_packet_size, data_packet_header_addr);
+                write_data_to_remote_core<is_dram>(
+                    cb_data, fabric_connection, dst_addr, aligned_partial_packet_size, data_packet_header_addr);
             }
             socket_push_pages(sender_socket, 1);
             fabric_socket_notify_receiver(sender_socket, fabric_connection, socket_packet_header_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_reduction.cpp
@@ -21,6 +21,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/dprint.h"
 #include "strided_ring_reduce_scatter_common.hpp"
 
@@ -61,6 +62,15 @@ void kernel_main() {
     const uint32_t last_mm_core_idx = mm_cores_y - 1;
     const uint32_t effective_worker_id = worker_id + (direction ? num_workers : 0);
     const uint32_t effective_advance_by_tiles = 2 * num_workers;
+
+    CircularBuffer cb_in(input_cb);
+    CircularBuffer cb_intermediate(intermediate_cb);
+    CircularBuffer cb_out(output_cb);
+#ifdef FUSE_RS_ADDCMUL
+    CircularBuffer cb_addcmul_temp(addcmul_temp_cb);
+    CircularBuffer cb_addcmul_a(addcmul_a_cb);
+    CircularBuffer cb_addcmul_b(addcmul_b_cb);
+#endif
 
     binary_op_init_common(input_cb, intermediate_cb, output_cb);
     add_tiles_init(input_cb, intermediate_cb, false);
@@ -121,9 +131,9 @@ void kernel_main() {
                                 //
                                 // Step 1: acc = input + intermediate -> addcmul_temp_cb
                                 // -------------------------------------------------------
-                                cb_wait_front(input_cb, tile_granularity);
-                                cb_wait_front(intermediate_cb, tile_granularity);
-                                cb_reserve_back(addcmul_temp_cb, tile_granularity);
+                                cb_in.wait_front(tile_granularity);
+                                cb_intermediate.wait_front(tile_granularity);
+                                cb_addcmul_temp.reserve_back(tile_granularity);
 
                                 add_tiles_init(input_cb, intermediate_cb, false);
                                 reconfig_data_format(input_cb, intermediate_cb);
@@ -135,17 +145,17 @@ void kernel_main() {
                                     pack_tile(tile_id, addcmul_temp_cb);
                                 }
                                 release_dst();
-                                cb_pop_front(input_cb, tile_granularity);
-                                cb_pop_front(intermediate_cb, tile_granularity);
-                                cb_push_back(addcmul_temp_cb, tile_granularity);
+                                cb_in.pop_front(tile_granularity);
+                                cb_intermediate.pop_front(tile_granularity);
+                                cb_addcmul_temp.push_back(tile_granularity);
 
                                 // -------------------------------------------------------
                                 // Step 2: scalar * acc * b -> pack back to addcmul_temp_cb
                                 // When ADDCMUL_B_BROADCAST: b has 1 row per tile, broadcast across acc's rows.
                                 // Otherwise: b has full rows (per-token), element-wise multiply.
                                 // -------------------------------------------------------
-                                cb_wait_front(addcmul_temp_cb, tile_granularity);
-                                cb_wait_front(addcmul_b_cb, tile_granularity);
+                                cb_addcmul_temp.wait_front(tile_granularity);
+                                cb_addcmul_b.wait_front(tile_granularity);
 
 #ifdef ADDCMUL_B_BROADCAST
                                 mul_bcast_rows_init_short(addcmul_temp_cb, addcmul_b_cb);
@@ -170,17 +180,17 @@ void kernel_main() {
                                     pack_tile(0, addcmul_temp_cb);
                                     tile_regs_release();
                                 }
-                                cb_pop_front(addcmul_b_cb, tile_granularity);
-                                cb_pop_front(addcmul_temp_cb, tile_granularity);
-                                cb_reserve_back(addcmul_temp_cb, tile_granularity);
-                                cb_push_back(addcmul_temp_cb, tile_granularity);
+                                cb_addcmul_b.pop_front(tile_granularity);
+                                cb_addcmul_temp.pop_front(tile_granularity);
+                                cb_addcmul_temp.reserve_back(tile_granularity);
+                                cb_addcmul_temp.push_back(tile_granularity);
 
                                 // -------------------------------------------------------
                                 // Step 3: a + scalar*acc*b -> output_cb
                                 // -------------------------------------------------------
-                                cb_wait_front(addcmul_temp_cb, tile_granularity);
-                                cb_wait_front(addcmul_a_cb, tile_granularity);
-                                cb_reserve_back(output_cb, tile_granularity);
+                                cb_addcmul_temp.wait_front(tile_granularity);
+                                cb_addcmul_a.wait_front(tile_granularity);
+                                cb_out.reserve_back(tile_granularity);
 
                                 add_tiles_init(addcmul_temp_cb, addcmul_a_cb, false);
                                 reconfig_data_format(addcmul_temp_cb, addcmul_a_cb);
@@ -192,24 +202,24 @@ void kernel_main() {
                                     pack_tile(tile_id, output_cb);
                                 }
                                 release_dst();
-                                cb_pop_front(addcmul_temp_cb, tile_granularity);
-                                cb_pop_front(addcmul_a_cb, tile_granularity);
-                                cb_push_back(output_cb, tile_granularity);
+                                cb_addcmul_temp.pop_front(tile_granularity);
+                                cb_addcmul_a.pop_front(tile_granularity);
+                                cb_out.push_back(tile_granularity);
                             } else {
 #endif
                                 // Normal ring accumulation step: acc = input + intermediate
-                                cb_wait_front(input_cb, tile_granularity);
-                                cb_wait_front(intermediate_cb, tile_granularity);
-                                cb_reserve_back(output_cb, tile_granularity);
+                                cb_in.wait_front(tile_granularity);
+                                cb_intermediate.wait_front(tile_granularity);
+                                cb_out.reserve_back(tile_granularity);
                                 acquire_dst();
                                 for (uint32_t tile_id = 0; tile_id < tiles_to_read_in_this_step; tile_id++) {
                                     add_tiles(input_cb, intermediate_cb, tile_id, tile_id, tile_id);
                                     pack_tile(tile_id, output_cb);
                                 }
                                 release_dst();
-                                cb_pop_front(input_cb, tile_granularity);
-                                cb_pop_front(intermediate_cb, tile_granularity);
-                                cb_push_back(output_cb, tile_granularity);
+                                cb_in.pop_front(tile_granularity);
+                                cb_intermediate.pop_front(tile_granularity);
+                                cb_out.push_back(tile_granularity);
 #ifdef FUSE_RS_ADDCMUL
                             }  // end else (non-final ring step)
 #endif

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -26,6 +26,10 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -72,10 +76,17 @@ void kernel_main() {
     // ARGS
     ///////////////////////////////////////////////////
 
+    Noc noc_obj;
+    CircularBuffer cb_input(cb_input_id);
+    CircularBuffer cb_intermediate(cb_intermediate_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     uint32_t arg_idx = 0;
     // Load the input tensor spec
     const address_t input_tensor_address = get_arg_val<address_t>(arg_idx++);
     const address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t worker_id = get_arg_val<uint32_t>(arg_idx++);
@@ -125,7 +136,8 @@ void kernel_main() {
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address);
 #endif
 #ifdef FUSE_MM_OP_SIGNALER
-    size_t mm_op_ready_sem = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t mm_op_ready_sem_id = get_arg_val<uint32_t>(arg_idx++);
+    Semaphore<> mm_op_ready_sem(mm_op_ready_sem_id);
     uint32_t mm_sem_target = 0;
 #endif
 
@@ -150,6 +162,8 @@ void kernel_main() {
     constexpr auto addcmul_b_tensor_args = TensorAccessorArgs<ct_idx_addcmul_base + 2 + ct_offset_a>();
     auto addcmul_a_addrgen = TensorAccessor(addcmul_a_tensor_args, addcmul_a_address);
     auto addcmul_b_addrgen = TensorAccessor(addcmul_b_tensor_args, addcmul_b_address);
+    CircularBuffer cb_addcmul_a(addcmul_a_cb);
+    CircularBuffer cb_addcmul_b(addcmul_b_cb);
     // a tile index: batch * (mm_cores_y * slice_Ht_per_core * slice_Wt) + slice_row * slice_Wt + col_in_slice
     // b tile index (broadcast):     batch * slice_Wt + col_in_slice  (b has 1 row per batch)
     // b tile index (non-broadcast): same as a  (b has full N rows per batch)
@@ -192,14 +206,14 @@ void kernel_main() {
                 // signals guarantees all N-full-blocks covering this chunk are ready.
                 const uint32_t sem_increment = (effective_chunk_width_in_tiles + mm_block_wt - 1) / mm_block_wt;
                 mm_sem_target += sem_increment;
-                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_op_ready_sem), mm_sem_target);
+                mm_op_ready_sem.wait_min(mm_sem_target);
 #endif
                 // Run a full bidirectional ring reduce-scatter for the current chunk.
                 // i=0: read input -> reader_output_cb (writer forwards to neighbor, no compute).
                 // i>0: read input -> input_cb, read intermediate -> intermediate_cb (compute reduces).
                 for (uint32_t i = 0; i < ring_size; i++) {
                     const bool do_reduce = i != 0;
-                    const uint32_t cb_in0 = do_reduce ? cb_input_id : cb_reader_output_id;
+                    CircularBuffer& cb_in0 = do_reduce ? cb_input : cb_reader_output;
                     const uint32_t actual_slice_idx = wrap_slice_idx(slice_idx, direction, ring_size);
 #ifdef FUSE_RS_ADDCMUL
                     // At the final ring step the local chip's slice is written to DRAM by the writer.
@@ -213,6 +227,9 @@ void kernel_main() {
                     // Wait for the neighboring device's writer to signal that it has finished
                     // writing this chunk's tiles into our intermediate buffer.
                     if (do_reduce) {
+                        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+                        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a
+                        // GlobalSemaphore. #45003 item 4.
                         noc_semaphore_wait_min(
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), out_ready_sem_target + 1);
                         out_ready_sem_target++;
@@ -245,21 +262,21 @@ void kernel_main() {
                             const uint32_t tiles_to_read_in_this_step = std::min(tiles_to_read, tile_granularity);
                             tiles_to_read -= tiles_to_read_in_this_step;
 
-                            cb_reserve_back(cb_in0, tile_granularity);
-                            uint32_t l1_write_addr = get_write_ptr(cb_in0);
+                            cb_in0.reserve_back(tile_granularity);
+                            uint32_t l1_write_addr = cb_in0.get_write_ptr();
                             uint32_t intermediate_l1_write_addr;
                             if (do_reduce) {
-                                cb_reserve_back(cb_intermediate_id, tile_granularity);
-                                intermediate_l1_write_addr = get_write_ptr(cb_intermediate_id);
+                                cb_intermediate.reserve_back(tile_granularity);
+                                intermediate_l1_write_addr = cb_intermediate.get_write_ptr();
                             }
 #ifdef FUSE_RS_ADDCMUL
                             uint32_t addcmul_a_l1_write_addr = 0;
                             uint32_t addcmul_b_l1_write_addr = 0;
                             if (is_final_ring_step) {
-                                cb_reserve_back(addcmul_a_cb, tile_granularity);
-                                addcmul_a_l1_write_addr = get_write_ptr(addcmul_a_cb);
-                                cb_reserve_back(addcmul_b_cb, tile_granularity);
-                                addcmul_b_l1_write_addr = get_write_ptr(addcmul_b_cb);
+                                cb_addcmul_a.reserve_back(tile_granularity);
+                                addcmul_a_l1_write_addr = cb_addcmul_a.get_write_ptr();
+                                cb_addcmul_b.reserve_back(tile_granularity);
+                                addcmul_b_l1_write_addr = cb_addcmul_b.get_write_ptr();
                             }
 #endif
 
@@ -282,13 +299,19 @@ void kernel_main() {
                                     const uint32_t global_tile_idx = slice_coordinates_to_global_tile_index(
                                         slice_row, col_in_slice, actual_slice_idx, slice_Wt, input_tensor_Wt);
                                     const uint32_t input_tile_id = global_tile_idx + batch_offset;
-                                    noc_async_read(
-                                        get_noc_addr(input_tile_id, input_tensor_addrgen), l1_write_addr, page_size);
+                                    noc_obj.async_read(
+                                        input_tensor_addrgen,
+                                        CoreLocalMem<uint8_t>(l1_write_addr),
+                                        page_size,
+                                        {.page_id = input_tile_id},
+                                        {});
                                     if (do_reduce) {
-                                        noc_async_read(
-                                            get_noc_addr(global_tile_idx, intermediate_tensor_addrgen),
-                                            intermediate_l1_write_addr,
-                                            page_size);
+                                        noc_obj.async_read(
+                                            intermediate_tensor_addrgen,
+                                            CoreLocalMem<uint8_t>(intermediate_l1_write_addr),
+                                            page_size,
+                                            {.page_id = global_tile_idx},
+                                            {});
                                     }
 #ifdef FUSE_RS_ADDCMUL
                                     if (is_final_ring_step) {
@@ -300,14 +323,18 @@ void kernel_main() {
                                         const uint32_t b_gate_idx =
                                             b * addcmul_a_batch_pages + slice_row * slice_Wt + col_in_slice;
 #endif
-                                        noc_async_read(
-                                            get_noc_addr(a_tile_idx, addcmul_a_addrgen),
-                                            addcmul_a_l1_write_addr,
-                                            page_size);
-                                        noc_async_read(
-                                            get_noc_addr(b_gate_idx, addcmul_b_addrgen),
-                                            addcmul_b_l1_write_addr,
-                                            page_size);
+                                        noc_obj.async_read(
+                                            addcmul_a_addrgen,
+                                            CoreLocalMem<uint8_t>(addcmul_a_l1_write_addr),
+                                            page_size,
+                                            {.page_id = a_tile_idx},
+                                            {});
+                                        noc_obj.async_read(
+                                            addcmul_b_addrgen,
+                                            CoreLocalMem<uint8_t>(addcmul_b_l1_write_addr),
+                                            page_size,
+                                            {.page_id = b_gate_idx},
+                                            {});
                                     }
 #endif
                                 }
@@ -333,15 +360,15 @@ void kernel_main() {
                                     effective_chunk_width_in_tiles,
                                     current_mm_block_ht);
                             }
-                            noc_async_read_barrier();
-                            cb_push_back(cb_in0, tile_granularity);
+                            noc_obj.async_read_barrier();
+                            cb_in0.push_back(tile_granularity);
                             if (do_reduce) {
-                                cb_push_back(cb_intermediate_id, tile_granularity);
+                                cb_intermediate.push_back(tile_granularity);
                             }
 #ifdef FUSE_RS_ADDCMUL
                             if (is_final_ring_step) {
-                                cb_push_back(addcmul_a_cb, tile_granularity);
-                                cb_push_back(addcmul_b_cb, tile_granularity);
+                                cb_addcmul_a.push_back(tile_granularity);
+                                cb_addcmul_b.push_back(tile_granularity);
                             }
 #endif
                         }
@@ -352,15 +379,20 @@ void kernel_main() {
             }
         }
         // Reset between batches so the counter doesn't overflow across batches.
+        // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+        // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+        // item 4.
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
         out_ready_sem_target = 0;
 
 #ifdef FUSE_MM_OP_SIGNALER
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_op_ready_sem), 0);
+        mm_op_ready_sem.set(0);
         mm_sem_target = 0;
 #endif
     }
 
     // Explicit cleanup: guarantee the semaphore is 0 when this kernel exits
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include "api/debug/dprint.h"
 #include "strided_ring_reduce_scatter_common.hpp"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using tt::tt_metal::BufferType;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -22,6 +22,10 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -95,14 +99,24 @@ void kernel_main() {
     // ARGS
     ///////////////////////////////////////////////////
 
+    Noc noc_obj;
+    CircularBuffer cb_compute_output(cb_compute_output_id);
+    CircularBuffer cb_reader_output(cb_reader_output_id);
+
     uint32_t arg_idx = 0;
     const address_t intermediate_address = get_arg_val<address_t>(arg_idx++);
     const address_t output_address = get_arg_val<address_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: out_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: batch_ready_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t batch_ready_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+    // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003 item 4.
     const size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const bool direction = get_arg_val<uint32_t>(arg_idx++);  // 1 is forward, 0 is backward
     const uint32_t worker_id = get_arg_val<uint32_t>(arg_idx++);
@@ -117,6 +131,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
+    // Device 2.0 migration: legacy primitive retained: termination_sync_address is a fabric-mux sync address (not a
+    // get_semaphore<>(id) address); #45003 item 4.
     const uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -221,7 +237,13 @@ void kernel_main() {
                 pkt_hdr_mcastseminc,
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{barrier_sem_noc_addr_in_pkt, 0});
 
+            // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
+            // Device 2.0 migration: legacy primitive retained: barrier_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
         }
 
@@ -278,7 +300,7 @@ void kernel_main() {
                     // i=R-1: consume output_cb, write final reduced tiles to local output.
                     for (uint32_t i = 0; i < ring_size; i++) {
                         const uint32_t actual_slice_idx = wrap_slice_idx(slice_idx, direction, ring_size);
-                        const uint32_t cb_output_id = i > 0 ? cb_compute_output_id : cb_reader_output_id;
+                        CircularBuffer& cb_output = i > 0 ? cb_compute_output : cb_reader_output;
 
                         const auto [mm_N_full_blocks_per_slice, cols_before_actual_slice] =
                             get_slice_N_block_info(actual_slice_idx, slice_Wt, N_full_block_wt);
@@ -309,8 +331,8 @@ void kernel_main() {
                                 const uint32_t tiles_to_read_in_this_step = std::min(tiles_to_read, tile_granularity);
                                 tiles_to_read -= tiles_to_read_in_this_step;
 
-                                cb_wait_front(cb_output_id, tile_granularity);
-                                size_t l1_read_addr = get_read_ptr(cb_output_id);
+                                cb_output.wait_front(tile_granularity);
+                                size_t l1_read_addr = cb_output.get_read_ptr();
 
                                 uint32_t tiles_remaining_in_step = tiles_to_read_in_this_step;
                                 while (tiles_remaining_in_step > 0) {
@@ -419,20 +441,23 @@ void kernel_main() {
                                                 }
                                             }
                                         }
-                                        noc_async_writes_flushed();
+                                        noc_obj.async_writes_flushed();
                                     } else {
                                         // Write the tile to the output buffer on this device.
                                         if (num_in_bounds_tiles > 0) {
                                             const uint32_t output_tile_id = output_tile_id_start + slice_tile_idx_first;
-                                            const uint64_t local_noc_addr =
-                                                get_noc_addr(output_tile_id, output_addrgen);
-                                            noc_async_write(valid_l1_addrs[0], local_noc_addr, page_size);
+                                            noc_obj.async_write(
+                                                CoreLocalMem<uint8_t>(valid_l1_addrs[0]),
+                                                output_addrgen,
+                                                page_size,
+                                                {},
+                                                {.page_id = output_tile_id});
                                         }
                                     }
                                     l1_read_addr += page_size * tiles_to_put_in_current_packet;
                                 }
-                                noc_async_write_barrier();
-                                cb_pop_front(cb_output_id, tile_granularity);
+                                noc_obj.async_write_barrier();
+                                cb_output.pop_front(tile_granularity);
                             }
                         }
 
@@ -445,9 +470,9 @@ void kernel_main() {
                                 &mux_connection_handle,
                                 pkt_hdr_seminc,
                                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 0});
-                            noc_async_writes_flushed();
+                            noc_obj.async_writes_flushed();
                         } else {
-                            noc_async_write_barrier();
+                            noc_obj.async_write_barrier();
                         }
 
                         // Move to the next slice
@@ -464,28 +489,38 @@ void kernel_main() {
                 &mux_connection_handle,
                 pkt_hdr_mcastseminc,
                 tt::tt_fabric::NocUnicastAtomicIncCommandHeader{batch_ready_sem_noc_addr_in_pkt, 0});
-            noc_async_writes_flushed();
+            noc_obj.async_writes_flushed();
 
+            // Device 2.0 migration: legacy primitive retained: batch_ready_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), ring_size - 1);
+            // Device 2.0 migration: legacy primitive retained: batch_ready_sem is a GlobalSemaphore address.
+            // Semaphore<> binds to per-program ids via get_semaphore<>(id), so it cannot wrap a GlobalSemaphore. #45003
+            // item 4.
             noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_ready_sem), 0);
         }
 
-        noc_async_write_barrier();
-        noc_async_atomic_barrier();
+        noc_obj.async_write_barrier();
+        noc_obj.async_atomic_barrier();
 
         tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
 
         if (is_termination_master) {
             auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a fabric-mux sync address
+            // (not a get_semaphore<>(id) address); #45003 item 4.
             noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             const uint64_t dest_addr =
                 safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+            // Device 2.0 migration: legacy primitive retained: termination_sync_address is a fabric-mux sync address
+            // (not a get_semaphore<>(id) address); #45003 item 4.
             noc_semaphore_inc(dest_addr, 1);
-            noc_async_atomic_barrier();
+            noc_obj.async_atomic_barrier();
         }
     }
 
-    noc_async_write_barrier();
+    noc_obj.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -40,6 +40,7 @@
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include "strided_ring_reduce_scatter_common.hpp"
+#include "api/tensor/noc_traits.h"
 
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;


### PR DESCRIPTION
### PR Category
  Cleanup

  CCL / experimental — kernel API migration (issue #45003 item 4, follow-up to #45061). No host-side or op-API changes; only kernels under ttnn/cpp/ttnn/operations/experimental/ccl/.

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
  Continues the migration of CCL kernels to the Device 2.0 kernel data-movement API (Noc, CircularBuffer, Semaphore<>, typed endpoints, TensorAccessor) per the migration guide. #45061 covered the two kernel-side helpers (worker_sync_utils.hpp, device_api_migration_guide) and eight smaller ops. This PR finishes the remaining 14 ops under experimental/ccl/:
  send_recv_async, llama_reduce_scatter_create_heads, all_to_all_async, moe/selective_reduce_combine, all_to_all_dispatch_metadata, strided_reduce_scatter_async, rms_allgather, neighbor_pad_async, all_gather_async, all_gather_minimal_matmul_async, llama_all_gather_matmul_async, moe_gpt, moe_compute, reduce_scatter_minimal_async.

  With this PR, every op under experimental/ccl/ uses the Device 2.0 API for non-fabric data movement; step 4 of #45003 closes pending the two endpoint-extension follow-ups described below.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Notes for Reviewers
  
  Per-op migration

  Each commit follows the same template as #45061: add Device 2.0 headers, declare wrappers (Noc noc_obj;, CircularBuffer cb_(cb_id);, Semaphore<> where the program factory passes a semaphore id), migrate noc_async_* / cb_* / noc_semaphore_* where the mapping is mechanical, leave fabric untouched, and explain what stays on legacy and why. Helpers that touched data movement (e.g. neighbor_pad_async's zero-fill, all_gather_minimal_matmul_async/matmul_dataflow_common.hpp) were refactored to thread Noc& / CircularBuffer& rather than cb_id / raw addresses, so each leaf is fully migrated rather than left for a second-tier cleanup.

  Compute kernels that only use cb_* macros (no NoC) are migrated 1:1 to CircularBuffer methods in the same per-op commit (e.g. reduce_scatter_minimal_async/*_reduction.cpp, rms_allgather/compute/rms_compute.cpp, llama_reduce_scatter_create_heads/compute/reduction.cpp).

Categories of retained legacy primitives

  Each retained block carries a #45003 item 4 audit comment. ~140 such sites across the 14 ops, grouping into five
  categories — three structural and two unblocked by small additions to the Device 2.0 endpoint API.

  1. GlobalSemaphore-bound semaphore ops — structural

  noc_semaphore_wait / set / inc on GlobalSemaphore L1 addresses (barrier_sem, out_ready_sem(_bank_addr),
  init_semaphore_addr, global_semaphore_addr, receiver_semaphore_address, h_neighbor_sem / w_neighbor_sem_addr, batch_ready_sem, …). Semaphore<> binds to per-program ids via get_semaphore<>(id); GlobalSemaphore exposes only address() (no id()), because cross-device fabric signaling needs a mesh-wide stable L1 address that a per-program id cannot provide. This is the largest single category (~70 sites) and shows up in every op that participates in fabric signaling — reduce_scatter_minimal_async, all_gather_async, all_gather_minimal_matmul_async, llama_all_gather_matmul_async, rms_allgather, neighbor_pad_async, all_to_all_dispatch_metadata, send_recv_async, moe_gpt, moe_compute, strided_reduce_scatter_async, llama_reduce_scatter_create_heads.

  2. Fabric-mux sync addresses (termination_sync_address, termination_sync_address_arr) — structural
  
  Raw L1 pointers handed to the kernel by the fabric-mux protocol, not a per-program semaphore id. Same gap as
  GlobalSemaphore: no id() to bind a Semaphore<> to. Sites: reduce_scatter_minimal_async/*_writer.cpp,
  rms_allgather/dataflow/rms_*_reader.cpp, all_gather_minimal_matmul_async/dm_in1_sender_out.cpp.

  3. noc_semaphore_set_multicast / loopback variants — structural

  Multicast semaphore set with a precomposed uint64_t multicast destination (get_safe_multicast_noc_addr) and a raw local sem address as source. Semaphore<>::set_multicast does not provide a wrapper that takes both a precomposed multicast destination and an unrelated local source. Sites: moe_compute/tilize_reader.cpp (drain-core
  e_t/per-expert/total-chunks multicasts + metadata-ready semaphore mcast), moe_gpt/tilize_reader.cpp (same
  pattern), all_to_all_dispatch_metadata/writer_all_to_all_dispatch_metadata.cpp.

  4. MEM_ZEROS_BASE / raw local L1 as NoC src — could be fixed by a LocalL1 endpoint

  Self-reads for zero-fill: noc_async_read(get_noc_addr(MEM_ZEROS_BASE), dst_l1, size), plus zero-page broadcast doubling in moe_compute / moe_gpt tilize_reader.cpp (init_expert_activation_buffer_async's exponential-doubling broadcast). Same structural gap as #45061: no Device 2.0 endpoint carries "fixed L1 address on this core" through Noc::async_read / Noc::async_write. The LocalL1 tag + trait sketched on iwrosz/ccl-device2-local-l1-endpoint (commit e249fbd) would close all of these.

  Sites: neighbor_pad_async/local_copy_writer.cpp (MEM_ZEROS_BASE write source), moe_compute/tilize_reader.cpp and moe_gpt/tilize_reader.cpp (L1→L1 self-loopback broadcast doubling), assorted page-write loops across the larger writers. 
  
  5. Precomposed uint64_t NoC address — fix: RawNocAddress endpoint

  By far the second-largest category (~55 sites). Hot loops hoist noc_addresses[i] = get_noc_addr(x, y, addr, noc)
  (or get_noc_addr(0, accessor) for DRAM, or NOC_XY_ADDR(DYNAMIC_NOC_X(..), DYNAMIC_NOC_Y(..), addr) for cross-core targets) out of the inner loop and reuse the precomputed uint64_t per iteration; UnicastEndpoint would re-encode every call and undo the optimization. Also covers cases where the same iteration writes to heterogeneous targets (DRAM tile + cross-core sync) and the address is decomposed differently across them. The RawNocAddress tag + trait sketched on iwrosz/ccl-device2-local-l1-endpoint (commit 2b7ae271b76) would close these.
  
  Sites are spread across nearly every op but cluster in the large writers / readers:
  all_gather_minimal_matmul_async/matmul_dataflow_common.hpp,
  llama_all_gather_matmul_async/{reader_bmm_tile_layout_in1_ring_all_gather, worker_reader, worker_writer}.cpp,
  moe_compute/{tilize_reader, tilize_writer, dm1}.cpp, moe_gpt/{tilize_reader, tilize_writer, dm0, dm1, 
  compute}.cpp, reduce_scatter_minimal_async/*_{reader,writer}.cpp (cross-link mcast addrs),
  rms_allgather/dataflow/rms_*.cpp, neighbor_pad_async/{phase2_w_reader, minimal_default_*}.cpp,
  all_to_all_dispatch_metadata/dataflow/{reader,writer}_all_to_all_dispatch_metadata.cpp.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ccl-device2-remaining-ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ccl-device2-remaining-ops)