### PR TITLE
Clean up sampling separation in generators

### DIFF
--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -35,17 +35,7 @@ tt_tokens = sampling.sample(
 ```
 
 `SamplingGenerator.sample()` accepts `enable_trace=True` to record/replay
-sampling traces. Callers typically instantiate the module with tracing enabled
-and then choose per-request whether to split the trace.
-
-## Two-Part Trace Mode
-Before running decode, set `generator.enable_split_sampling = True` (or
-`False`) to choose between the two behaviors:
-
-1. **Split trace:** The model trace stops at logits and `SamplingGenerator`
-   captures/executes a dedicated sampling trace immediately afterward.
-2. **Single trace:** Sampling runs inline as part of the model trace for
-   maximum performance.
+sampling traces.
 
 ## File Map
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -97,7 +97,6 @@ class SamplingGenerator:
         args,
         mesh_device,
         tt_ccl,
-        enable_internal_trace: bool = True,
         cq_id: int = 0,
     ):
         self.mesh_device = mesh_device
@@ -105,8 +104,6 @@ class SamplingGenerator:
         self.args = args
         self._sampling_debug_enabled = is_llama33_70b_model(args)
         self.sub_core_grids = getattr(args, "sub_core_grids", None)
-        self.enable_internal_trace = enable_internal_trace
-
         self.tt_sampling = TTSampling(mesh_device=mesh_device, tt_ccl=tt_ccl, args=args)
         self.tt_penalties = TTPenalties(mesh_device=mesh_device, args=args)
 
@@ -389,9 +386,7 @@ class SamplingGenerator:
         force_argmax = self.tt_sampling.force_argmax_sampling
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
-        use_internal_trace = (
-            enable_trace and self.enable_internal_trace and not self.seed_manager.has_active_request_seed()
-        )
+        use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
         _log_sampling_debug(
             self._sampling_debug_enabled,
             "SamplingGenerator sample",

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -47,7 +47,7 @@ def _extract_all_tokens(tt_out_tok, mesh_device, batch_size_per_row):
 def _sample_device_tokens(mesh_device, ccl, args, torch_input, user_params):
     batch_size = USERS_PER_ROW * int(mesh_device.shape[0])
     tt_input = _make_lm_head_sharded_logits(torch_input, mesh_device)
-    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl, enable_internal_trace=False)
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl)
     params = format_sampling_params(user_params, max_batch_size=batch_size)
     sampling.reset_sampling_params(params)
     sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))
@@ -222,7 +222,7 @@ def test_deepseek_device_sampling_stochastic_behavior(mesh_device, ccl, hf_confi
     )
 
     tt_input = _make_lm_head_sharded_logits(torch_input, mesh_device)
-    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl, enable_internal_trace=use_tracing)
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=ccl)
     params = format_sampling_params(user_params, max_batch_size=batch_size)
     sampling.reset_sampling_params(params)
     sampling.reset_prompt_tokens(torch.zeros((USERS_PER_ROW, 1), dtype=torch.int64))

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -488,7 +488,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
             else:
                 # create new sampling generator
-                enable_internal_trace_sampling = enable_trace
                 self.sampling_args = make_deepseek_sampling_args(
                     self.mesh_device,
                     self.hf_config.vocab_size,
@@ -499,7 +498,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     args=self.sampling_args,
                     mesh_device=self.mesh_device,
                     tt_ccl=self.ccl,
-                    enable_internal_trace=enable_internal_trace_sampling,
                 )
                 self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
 
@@ -999,6 +997,11 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         user_slots: list[int] | None = None,
         skip_precompile: bool = False,
     ) -> ttnn.Tensor:
+        assert getattr(self, "sampling_generator", None) is not None, (
+            "_sample_tokens_device called before the sampling generator was created "
+            "_sample_tokens_device requires sampling_generator to be initialized first. "
+            "Call _validate_and_initialize_sampling(..., sample_on_device=True) before sampling."
+        )
         sampling_batch_size = self.sampling_generator.tt_sampling.max_batch_size
         sampling_logits = logits
         if logits.shape[2] != sampling_batch_size:
@@ -1041,7 +1044,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 sampling_logits = padded_logits
 
         self.sampling_generator.seed_manager.get_new_values(self._sampling_device_slots(user_slots))
-        self.sampling_generator.enable_internal_trace = enable_trace
         try:
             tt_out = self.sampling_generator.sample(
                 sampling_logits, enable_trace=enable_trace, skip_precompile=skip_precompile
@@ -1059,6 +1061,42 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             tt_out = tt_tokens
 
         return tt_out
+
+    def sample_decode_on_device(
+        self,
+        tt_logits,
+        sampling_params=None,
+        reset_batch=False,
+        prompt_tokens=None,
+        output_tokens=None,
+        slot_remap=None,
+        enable_trace=False,
+        user_slots=None,
+    ):
+        """Public on-device decode-sampling entry point.
+
+        Matches the ``tt_transformers.Generator.sample_decode_on_device`` method
+        name/signature so a model-agnostic caller (e.g. vLLM running forward and
+        sampling as separate steps) can sample uniformly: given the decode logits
+        returned by ``decode_forward(sample_on_device=True)``, return sampled
+        token ids on device.
+
+        Contract differences vs the tt_transformers base (deferred reconciliation):
+        - Deepseek applies sampling *state* (params/seeds, lazy generator
+          creation) in :meth:`_validate_and_initialize_sampling`, gated on
+          param change — not unconditionally per step. Passing ``sampling_params``
+          here refreshes that state (idempotent when unchanged); the vLLM bridge
+          already initialises it before the forward, so it passes ``None``.
+        - ``prompt_tokens`` / ``output_tokens`` / ``slot_remap`` are not yet
+          threaded into deepseek's penalty/seed state (see
+          :meth:`_reset_sampling_state` TODO); accepted for signature
+          compatibility and currently ignored.
+        """
+        if sampling_params is not None:
+            self._validate_and_initialize_sampling(sampling_params, sample_on_device=True, enable_trace=enable_trace)
+        return self._sample_tokens_device(
+            tt_logits, enable_trace=enable_trace, user_slots=user_slots, skip_precompile=True
+        )
 
     def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row: int) -> torch.Tensor:
         composed = ttnn.to_torch(

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -189,6 +189,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             )
 
             if sample_on_device:
+                # Prefill sampling is NOT separable from the forward the way decode is
+                # (no public sample_prefill_on_device): this loop prefills and samples
+                # one user at a time as logits are produced, so we sample in-line here
+                # rather than handing a logits handle back for a deferred sampling call.
                 prefill_logits_sampled_device = self._sample_tokens_device(
                     prefill_logits, user_slots=[user_id], skip_precompile=True
                 )
@@ -230,6 +234,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
         reset_batch = kwargs.get("reset_batch", False)
+        # NOTE: vLLM also passes `slot_remap` (the seed-slot reindex map from batch
+        # condense) in kwargs, but deepseek does not consume it — so per-request
+        # seeded determinism is not preserved across condense. Tracked by
+        # https://github.com/tenstorrent/tt-metal/issues/46350.
 
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
@@ -251,10 +259,9 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
 
         if sample_on_device:
-            decode_output = self._sample_tokens_device(
+            decode_output = self.sample_decode_on_device(
                 decode_step_output,
                 enable_trace=enable_trace,
-                skip_precompile=True,
             )
             if read_from_device:
                 decode_output = self._tokens_from_device(

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -189,10 +189,6 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             )
 
             if sample_on_device:
-                # Prefill sampling is NOT separable from the forward the way decode is
-                # (no public sample_prefill_on_device): this loop prefills and samples
-                # one user at a time as logits are produced, so we sample in-line here
-                # rather than handing a logits handle back for a deferred sampling call.
                 prefill_logits_sampled_device = self._sample_tokens_device(
                     prefill_logits, user_slots=[user_id], skip_precompile=True
                 )

--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -409,7 +409,7 @@ def run_generation(
                 rot_mat_idxs=device_inputs["position_int32"],  # pos_int32 passed as rot_mat_idxs
                 page_table=page_table_tt,
                 kv_cache=tt_kv_cache,
-                sampling_on_device=on_device_sampling,
+                on_device_logits=on_device_sampling,
                 pli_combined=device_inputs.get("pli"),
             )
 
@@ -423,12 +423,21 @@ def run_generation(
 
         def _extract_token(decode_output):
             """Extract next token from model output (token IDs or logits)."""
-            output_cpu = (
-                ttnn.to_torch(ttnn.get_device_tensors(decode_output)[0]) if is_mesh else ttnn.to_torch(decode_output)
-            )
             if on_device_sampling:
-                return output_cpu.reshape(-1)[0].item()
+                # Keep main behavior: decode sampling in this demo remains untraced.
+                # SamplingGenerator.sample() returns (tt_tokens, tt_log_probs); take the tokens.
+                sampled = model.sampling.sample(decode_output, enable_trace=False)
+                tt_tokens = sampled[0] if isinstance(sampled, tuple) else sampled
+                sampled_cpu = (
+                    ttnn.to_torch(ttnn.get_device_tensors(tt_tokens)[0]) if is_mesh else ttnn.to_torch(tt_tokens)
+                )
+                return sampled_cpu.reshape(-1)[0].item()
             else:
+                output_cpu = (
+                    ttnn.to_torch(ttnn.get_device_tensors(decode_output)[0])
+                    if is_mesh
+                    else ttnn.to_torch(decode_output)
+                )
                 return output_cpu.squeeze().argmax().item()
 
         sample_mode = "device" if on_device_sampling else "host"

--- a/models/demos/gemma4/tests/unit/test_sampling.py
+++ b/models/demos/gemma4/tests/unit/test_sampling.py
@@ -60,7 +60,7 @@ def test_sampling_greedy(mesh_device, reset_seeds):
     args.model_config = {}
     args.use_topk_logprobs = False
 
-    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
 
     # Shard logits: each device gets [1, 1, batch, vocab/TP]
     mesh_config = MeshConfig(mesh_device.shape, decode=ModeConfig(tp=tp))

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1835,7 +1835,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
         max_batch_size=1,
         num_blocks=uniform_num_blocks,
         can_sample_on_device=False,
-        non_greedy_decoding_on_device=False,
+        greedy_only=True,
     )
 
     # vLLM warmup — replicate the bridge's pre-decode setup so the
@@ -1852,7 +1852,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
             max_batch_size=1,
             num_blocks=warmup_num_blocks,
             can_sample_on_device=False,
-            non_greedy_decoding_on_device=False,
+            greedy_only=True,
         )
     finally:
         if hasattr(tt_model_vllm, "_active_page_tables_per_layer"):

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -45,11 +45,6 @@ class Gemma4Generator(Generator):
         "supports_async_decode": False,
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Gemma4 decode already returns sampled tokens when on-device sampling is enabled.
-        self.enable_split_sampling = False
-
     def _clear_prefill_traces(self):
         for trace_key, trace_id in list(self.trace_id_prefill.items()):
             if trace_id is not None:
@@ -60,12 +55,12 @@ class Gemma4Generator(Generator):
             self.trace_inputs_prefill[trace_key] = None
             self.trace_output_prefill[trace_key] = None
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
         super().warmup_model_prefill(
             kv_cache=kv_cache,
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
-            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+            greedy_only=greedy_only,
         )
         if enable_trace:
             # Gemma4 prefill depends on prompt-specific per-layer inputs.

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -50,10 +50,6 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Gemma4 decode traces return sampled tokens directly, like the working
-        # standalone demo. Do not split sampling into a second trace that
-        # assumes the first trace input tensor is a token buffer.
-        self.enable_split_sampling = False
         # Mirrors the env-var check in :meth:`initialize_vllm_model` so the
         # forward-side padding logic doesn't need to re-read the environment
         # on every step. Defaults to on; flip ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=0``

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -369,7 +369,6 @@ class Gemma4Model:
                     args=self._make_sampling_args(hf_config, mesh_device, tp),
                     mesh_device=mesh_device,
                     tt_ccl=None,
-                    enable_internal_trace=False,
                 )
                 logger.info(
                     f"On-device sampling initialized (vocab={hf_config.vocab_size}, per_device={per_device_padded})"
@@ -1066,8 +1065,7 @@ class Gemma4Model:
         rot_mat_idxs=None,
         page_table=None,
         kv_cache=None,
-        sampling_on_device=False,
-        capture_sampling_trace=False,
+        on_device_logits=False,
         pli_combined=None,
         page_tables_per_layer=None,
     ):
@@ -1082,8 +1080,7 @@ class Gemma4Model:
             rot_mat_idxs: Unused (RoPE computed internally from current_pos).
             page_table: Optional paged attention table.
             kv_cache: Optional KV cache override.
-            sampling_on_device: If True and self.sampling exists, sample on device.
-            capture_sampling_trace: If True, return logits for split-trace sampling.
+            on_device_logits: If True, return logits in on-device sampling layout.
             pli_combined: Optional [1,1,n_layers,pli_size] device tensor of host-precomputed
                 per-layer inputs (E2B/E4B). Required for Gemma3n-style models in decode.
             page_tables_per_layer: Optional list of per-layer page tables. Falls back to
@@ -1124,15 +1121,15 @@ class Gemma4Model:
             page_tables_per_layer=page_tables_per_layer,
         )
 
-        # On-device sampling
-        if sampling_on_device and self.sampling is not None:
-            if capture_sampling_trace:
-                return logits  # Split-trace: return logits for separate sampling trace
+        if on_device_logits:
+            assert self.sampling is not None, (
+                "decode forward got on_device_logits=True but no on-device sampling "
+                "module exists (self.sampling is None)."
+            )
             batch_dim = logits.shape[2]
             if batch_dim < 32:
                 logits = ttnn.pad(logits, padding=[(0, 0), (0, 0), (0, 32 - batch_dim), (0, 0)], value=0.0)
-            tt_tokens, tt_log_probs = self.sampling.sample(logits, enable_trace=False)
-            return tt_tokens, tt_log_probs
+            return logits
 
         return logits, None
 

--- a/models/demos/gpt_oss/tests/unit/test_sampling.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling.py
@@ -294,7 +294,7 @@ def test_gpt_oss_stochastic_sampling(sampling_params, batch_size, mesh_device, d
     # SamplingGenerator manages seeds between iterations (TTSampling re-seeds
     # from seeds_tt_tensor each forward call, so seeds must be updated via
     # SeedManager.get_new_values() to get different random samples).
-    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
     params = format_sampling_params(
         SamplingParams(temperature=temperature, top_k=top_k, top_p=top_p, seed=seed),
         batch_size,
@@ -386,7 +386,7 @@ def test_gpt_oss_penalties(penalty_params, mesh_device, device_params, reset_see
     # Shard and create SamplingGenerator with penalties
     tt_input = make_sharded_logits(torch_input, mesh_device, args.cluster_shape, dtype=ttnn.bfloat16)
 
-    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
 
     params = format_sampling_params(
         SamplingParams(
@@ -448,7 +448,7 @@ def test_gpt_oss_logprobs(mesh_device, device_params, reset_seeds):
 
     tt_input = make_sharded_logits(torch_input, mesh_device, args.cluster_shape, dtype=ttnn.bfloat16)
 
-    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
 
     seed = 42
     params = format_sampling_params(
@@ -515,7 +515,7 @@ def test_gpt_oss_topk_logprobs(mesh_device, device_params, reset_seeds):
     tt_input = make_sharded_logits(torch_input, mesh_device, args.cluster_shape, dtype=ttnn.bfloat16)
 
     # Create SamplingGenerator with use_topk_logprobs enabled
-    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
 
     num_logprobs = 5
     params = format_sampling_params(
@@ -588,7 +588,7 @@ def _make_seeded_generator(args, mesh_device, batch_size, per_user_seeds):
     caller is responsible for calling it before each sample() to advance the
     RNG state and copy fresh seeds to the device.
     """
-    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None, enable_internal_trace=False)
+    sg = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
     params = format_sampling_params(
         SamplingParams(temperature=1.0, top_k=32, top_p=0.95, seed=0),
         batch_size,

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -230,7 +230,6 @@ class Model:
                 args=self.args if hasattr(self, "args") else self._make_sampling_args(hf_config, mesh_device),
                 mesh_device=mesh_device,
                 tt_ccl=None,
-                enable_internal_trace=False,
             )
             # Hook reset_sampling_params to set prefill flag — Generator calls this
             # before prefill forward; tells _forward_layers_and_head to skip TP all-gather
@@ -334,7 +333,6 @@ class Model:
         get_last_token=-1,
         is_decode=True,
         user_id=0,
-        sampling_on_device=False,
         batch_size=1,
         skip_lm_head=False,
         page_tables_per_layer=None,
@@ -498,8 +496,7 @@ class Model:
         rot_mat_idxs=None,
         page_table=None,
         kv_cache=None,
-        sampling_on_device=False,
-        capture_sampling_trace=False,
+        on_device_logits=False,
         page_tables_per_layer=None,
     ):
         if page_tables_per_layer is None:
@@ -534,20 +531,20 @@ class Model:
             page_table=page_table,
             kv_cache=kv_cache,
             is_decode=True,
-            sampling_on_device=sampling_on_device,
             page_tables_per_layer=page_tables_per_layer,
         )
 
-        if sampling_on_device and self.sampling is not None:
-            # Pad logits batch to 32 (TTSampling requirement) before split-trace or sampling
+        if on_device_logits:
+            assert self.sampling is not None, (
+                "decode forward got on_device_logits=True but no on-device sampling "
+                "module exists (self.sampling is None)."
+            )
+            # Pad logits batch to 32 (TTSampling requirement) before sampling
             batch_dim = out.shape[-2]
             if batch_dim < 32:
                 out = ttnn.pad(out, padding=[(0, 0), (0, 0), (0, 32 - batch_dim), (0, 0)], value=0.0)
             self._increment_decode_positions_device(current_pos, rot_mat_idxs)
-            if capture_sampling_trace:
-                return out
-            tt_toks, tt_log_probs = self.sampling.sample(out, tt_out_tok=tokens, enable_trace=False)
-            return tt_toks, tt_log_probs
+            return out
 
         return out, None
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1712,7 +1712,6 @@ class Generator(WarmupForwardMixin):
         # Apply slot remap from condense before advancing seeds.
         if slot_remap is not None:
             sm_bs = seed_manager.max_batch_size
-            # Galaxy decode currently uses a single sampling module/rank, so slot_remap is local [0:sm_bs].
             rank_remap = slot_remap[0:sm_bs]
             _log_sampling_debug(
                 self._sampling_debug_enabled,
@@ -1726,22 +1725,9 @@ class Generator(WarmupForwardMixin):
                 "Galaxy decode slot remap applied",
                 seed_state_after=_seed_manager_debug_summary(seed_manager),
             )
-
-        # Only re-upload sampling params when inputs are being reset (new batch /
-        # mode switch / page-table change). The k/p/temp + penalty *coefficient*
-        # buffers persist on device between decode steps and are read in place by
-        # the sampling trace, so re-applying identical params every step is pure
-        # host->device overhead on the hot decode loop. Seed advancement and slot
-        # remap still run every step. (Penalty accumulation state is reset via
-        # reset_prompt_tokens/reset_output_state, gated on reset_batch.)
-        # `decode_forward` passes its richer `reset_inputs` (covers mode switch /
-        # page-table change); an external caller (e.g. vLLM deferred path) that
-        # only knows the portable `reset_batch` flag still triggers the upload.
-        if reset_inputs or reset_batch:
+        if reset_inputs and sampling_params is not None:
+            # If we have new inputs, we need to set up the sampling module again
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
-            # When some slots carry an explicit seed, fill the inactive slots'
-            # params from an active request so trace-replayed sampling stays
-            # deterministic regardless of how vLLM split request admission.
             if active_seed_slots is not None:
                 seed_values = _as_list(getattr(sampling_params, "seed", None))
                 has_active_seed = any(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -271,7 +271,7 @@ class Generator(WarmupForwardMixin):
         self.prev_page_table = None
         self.already_warmed_up_prefill = False
         self.warming_up_prefill = False
-        self.trace_ids_decode = defaultdict(lambda: None)  # {return_logits: {device_id: trace_id}}
+        self.trace_ids_decode = defaultdict(lambda: None)  # {on_device_logits: {device_id: trace_id}}
         self.trace_inputs_decode = defaultdict(lambda: None)
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
@@ -315,7 +315,7 @@ class Generator(WarmupForwardMixin):
         self.warming_up_prefill = True
 
         # Llama70b always supports on-device sampling from metal
-        sampling_on_device_enabled = True
+        on_device_sampling_enabled = True
 
         # Sweep all sampling parameters for prefill warmup just once since it is sequence length agnostic
         sampling_parameters_sweeped = False
@@ -354,7 +354,7 @@ class Generator(WarmupForwardMixin):
 
                 if not sampling_parameters_sweeped:
                     sampling_params_list = self._create_sampling_params(
-                        can_sample_on_device=sampling_on_device_enabled,
+                        can_sample_on_device=on_device_sampling_enabled,
                         batch_size=batch,
                     )
                 else:
@@ -535,8 +535,8 @@ class Generator(WarmupForwardMixin):
             tt_out_logits_all_users = torch.zeros(batch, 1, self.model.args.padded_vocab_size)
 
         # Prefill has two main modes:
-        # - return_logits=True: return logits to host (no on-device sampling)
-        # - return_logits=False: produce next-token ids; we only run on-device sampling when logits are not requested
+        # - host-logits mode: return logits to host (no on-device sampling)
+        # - on-device sampling mode: produce next-token ids when logits are not requested
         save_logits_to_host = tt_out_logits_all_users is not None
         do_device_sampling = (not return_logits) and (not save_logits_to_host)
 
@@ -1374,31 +1374,38 @@ class Generator(WarmupForwardMixin):
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
+        defer_device_sampling: bool = False,
     ):
         if getattr(self, "_disable_decode_tracing", False):
             enable_trace = False
 
         reset_reasons = []
-        if sampling_params is None:
-            return_logits = True
+        if sampling_params is None and not defer_device_sampling:
+            on_device_logits = False
             reset_inputs = True  # We didn't sample on device, so we need to load inputs.
             reset_reasons.append("host_sampling")
         else:
-            return_logits = False
+            on_device_logits = True
 
         # Track sampling mode changes to reset inputs when switching
         # between host sampling and device sampling (different trace has stale inputs)
-        sampling_on_device = sampling_params is not None
-        prev_sampling_on_device = getattr(self, "_prev_sampling_on_device", None)
-        self._prev_sampling_on_device = sampling_on_device
-        if prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device:
+        on_device_sampling = (sampling_params is not None) or defer_device_sampling
+        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
+        self._prev_on_device_sampling = on_device_sampling
+        if prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling:
             reset_inputs = True
             reset_reasons.append("sampling_mode_changed")
         if self._decode_inputs_need_reset:
+            # Prefill on-device sampling switches the model to decode mode, so the
+            # is_decode_setup check below won't fire; force a reset here so the
+            # first decode after such a prefill reloads host inputs.
             reset_inputs = True
             reset_reasons.append("decode_inputs_need_reset")
             self._decode_inputs_need_reset = False
         if sampling_params is not None:
+            # A batch that mixes greedy (temp==0) and random (temp!=0) users needs
+            # fresh sampling params uploaded; force a reset so sample_decode_on_device
+            # re-applies them.
             temperature_values = getattr(sampling_params, "temperature", None)
             if isinstance(temperature_values, torch.Tensor):
                 temperature_values = temperature_values.reshape(-1).tolist()
@@ -1451,84 +1458,17 @@ class Generator(WarmupForwardMixin):
             "is_cur_pos_sharded": is_cur_pos_sharded,
             "is_page_table_sharded": is_page_table_sharded,
         }
-        # Apply slot remap from condense before advancing seeds.
-        if slot_remap is not None:
-            sm_bs = self.model.sampling.seed_manager.max_batch_size
-            rank_remap = slot_remap[0:sm_bs]
-            _log_sampling_debug(
-                self._sampling_debug_enabled,
-                "Galaxy decode slot remap",
-                slot_remap=_slot_remap_debug_summary(rank_remap),
-                seed_state_before=_seed_manager_debug_summary(self.model.sampling.seed_manager),
-            )
-            self.model.sampling.seed_manager.apply_slot_remap(rank_remap)
-            _log_sampling_debug(
-                self._sampling_debug_enabled,
-                "Galaxy decode slot remap applied",
-                seed_state_after=_seed_manager_debug_summary(self.model.sampling.seed_manager),
-            )
-        if reset_inputs and sampling_params is not None:
-            # If we have new inputs, we need to set up the sampling module again
-            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
-            if active_seed_slots is not None:
-                seed_values = _as_list(getattr(sampling_params, "seed", None))
-                has_active_seed = any(
-                    slot < len(seed_values) and seed_values[slot] is not None for slot in active_seed_slots
-                )
-                if has_active_seed:
-                    sampling_params = _fill_inactive_params_from_active(
-                        sampling_params, active_seed_slots, self.model_args.max_batch_size
-                    )
+        if tt_out_logits_saved is not None:
+            decode_kwargs["tt_out_logits_saved"] = tt_out_logits_saved
 
-            sampling_module = self.model.sampling
-            sampling_module.reset_sampling_params(sampling_params)
-            if reset_batch:
-                sampling_module.reset_prompt_tokens(prompt_tokens)
-                sampling_module.reset_output_state(output_tokens)
-            _log_sampling_debug(
-                self._sampling_debug_enabled,
-                "Galaxy decode sampling params reset",
-                sampling_params=_sampling_params_debug_summary(sampling_params),
-                prompt_tokens=_tensor_debug_summary(prompt_tokens),
-                output_tokens=_tensor_debug_summary(output_tokens),
-            )
-
-        seed_manager = self.model.sampling.seed_manager
-        if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
-            seed_values = getattr(sampling_params, "seed", None)
-            if _seed_debug_enabled():
-                debug_slots = (
-                    active_seed_slots if active_seed_slots is not None else list(range(seed_manager.max_batch_size))
-                )
-                seed_values_list = _as_list(seed_values)
-                seed_slot_pairs = [
-                    (
-                        slot,
-                        seed_values_list[slot] if slot < len(seed_values_list) else None,
-                        seed_manager.seeds[slot],
-                        seed_manager.seed_counters[slot],
-                    )
-                    for slot in debug_slots
-                ]
-                logger.info(
-                    f"SeedDBG Galaxy decode: reset_batch={reset_batch}, active_seed_slots={active_seed_slots}, "
-                    f"seed_slot_pairs={seed_slot_pairs}"
-                )
-            seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-            if reset_inputs:
-                seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
-
-        # Advance seeds after parameter copies so seeded sampling observes
-        # one ordered params/seed state for this token.
-        seed_manager.get_new_values(active_seed_slots)
         _log_sampling_debug(
             self._sampling_debug_enabled,
             "Galaxy decode plan",
             reset_inputs=reset_inputs,
             reset_batch=reset_batch,
             reset_reasons=reset_reasons,
-            return_logits=return_logits,
-            sampling_on_device=sampling_on_device,
+            on_device_logits=on_device_logits,
+            on_device_sampling=on_device_sampling,
             active_slots=_compact_debug_list(active_seed_slots),
             start_pos=_compact_debug_list(start_pos),
             tokens=_tensor_debug_summary(tokens),
@@ -1537,25 +1477,37 @@ class Generator(WarmupForwardMixin):
             seed_state=_seed_manager_debug_summary(self.model.sampling.seed_manager, active_seed_slots),
         )
 
-        if tt_out_logits_saved is not None:
-            decode_kwargs["tt_out_logits_saved"] = tt_out_logits_saved
-
         if enable_trace:
             tt_tok, tt_log_probs = self._decode_easy_trace_text(
                 **decode_kwargs,
                 reset_inputs=reset_inputs,
                 page_table_changed=page_table_changed,
-                return_logits=return_logits,
+                on_device_logits=on_device_logits,
             )
         else:
             tt_tok, tt_log_probs = self._decode_forward_no_trace_text(
                 **decode_kwargs,
-                return_logits=return_logits,
+                on_device_logits=on_device_logits,
+            )
+
+        if defer_device_sampling:
+            return tt_tok
+        if sampling_params is not None:
+            tt_tok, tt_log_probs = self.sample_decode_on_device(
+                tt_tok,
+                sampling_params=sampling_params,
+                start_pos=start_pos,
+                reset_inputs=reset_inputs,
+                reset_batch=reset_batch,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+                slot_remap=slot_remap,
+                enable_trace=enable_trace,
             )
 
         if read_from_device:
-            # IMPORTANT: If split sampling is enabled, `tt_log_probs` is produced by the sampling
-            # module (potentially via its own trace). We must pass it through to the readback path;
+            # IMPORTANT: When on-device sampling ran, `tt_log_probs` is produced by the sampling
+            # module (via its own trace). We must pass it through to the readback path;
             # otherwise `process_output_decode()` will return log_probs=None and host code will fill
             # log_probs with torch.ones(), masking the real values.
             tt_out_for_read = (tt_tok, tt_log_probs) if tt_log_probs is not None else tt_tok
@@ -1563,7 +1515,7 @@ class Generator(WarmupForwardMixin):
             if async_read:
                 return tt_out
             else:
-                return self.process_decode_output_host(tt_out, is_tokens=(not return_logits))
+                return self.process_decode_output_host(tt_out, is_tokens=on_device_logits)
 
         return tt_tok, tt_log_probs
 
@@ -1576,7 +1528,7 @@ class Generator(WarmupForwardMixin):
         tt_out_logits_saved=None,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
-        return_logits=False,
+        on_device_logits=False,
     ):
         """
         Performs text decode step.
@@ -1593,14 +1545,11 @@ class Generator(WarmupForwardMixin):
             kv_cache=kv_cache,
             tt_out_logits_saved=tt_out_logits_saved,
             is_cur_pos_sharded=is_cur_pos_sharded,
-            return_logits=return_logits,
+            on_device_logits=on_device_logits,
         )
 
-        if not return_logits:
-            return self.model.sampling.sample(
-                logits=tt_tok[0],
-                enable_trace=False,
-            )
+        if on_device_logits:
+            return tt_tok[0], None
         return tt_tok
 
     def _capture_trace_text(
@@ -1611,7 +1560,7 @@ class Generator(WarmupForwardMixin):
         kv_cache=None,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
-        return_logits=False,
+        on_device_logits=False,
     ):
         """
         Captures a trace for the decode_forward method.
@@ -1625,7 +1574,7 @@ class Generator(WarmupForwardMixin):
             kv_cache=kv_cache,
             is_cur_pos_sharded=is_cur_pos_sharded,
             is_page_table_sharded=is_page_table_sharded,
-            return_logits=return_logits,
+            on_device_logits=on_device_logits,
         )
         logger.info("Done Compiling Model")
 
@@ -1643,7 +1592,7 @@ class Generator(WarmupForwardMixin):
             page_table_tt,
             kv_cache=kv_cache,
             is_cur_pos_sharded=is_cur_pos_sharded,
-            return_logits=return_logits,
+            on_device_logits=on_device_logits,
         )
 
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
@@ -1677,14 +1626,14 @@ class Generator(WarmupForwardMixin):
         page_table_changed=False,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
-        return_logits=False,
+        on_device_logits=False,
     ):
         """
         Run decode forward text with tracing
         """
         tokens = tokens.view(-1, 1)
-        # The trace is different depending on whether we are returning logits or sampling on device
-        if not self.trace_ids_decode[return_logits]:
+        # The trace is different depending on whether decode returns sampling-layout logits.
+        if not self.trace_ids_decode[on_device_logits]:
             trace_id, tt_out_tok, *device_inputs = self._capture_trace_text(
                 tokens,
                 current_pos,
@@ -1692,11 +1641,11 @@ class Generator(WarmupForwardMixin):
                 kv_cache=kv_cache,
                 is_cur_pos_sharded=is_cur_pos_sharded,
                 is_page_table_sharded=is_page_table_sharded,
-                return_logits=return_logits,
+                on_device_logits=on_device_logits,
             )
-            self.trace_ids_decode[return_logits] = trace_id
-            self.trace_inputs_decode[return_logits] = device_inputs
-            self.trace_output_decode[return_logits] = tt_out_tok
+            self.trace_ids_decode[on_device_logits] = trace_id
+            self.trace_inputs_decode[on_device_logits] = device_inputs
+            self.trace_output_decode[on_device_logits] = tt_out_tok
         if reset_inputs:
             # Full resets are required when host token/position inputs are
             # authoritative again (host sampling, trace switch, or batch reset).
@@ -1706,7 +1655,7 @@ class Generator(WarmupForwardMixin):
             shard_specs = self.model.prepare_decode_shard_configs(is_cur_pos_sharded, is_page_table_sharded)
             device_inputs = copy_host_to_device(
                 host_tensors=host_inputs,
-                device_tensors=self.trace_inputs_decode[return_logits],
+                device_tensors=self.trace_inputs_decode[on_device_logits],
                 shard_specs=shard_specs,
             )
         elif page_table_changed:
@@ -1718,28 +1667,134 @@ class Generator(WarmupForwardMixin):
                 tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
             )
             host_page_table = host_inputs[DECODE_PAGE_TABLE_INPUT_IDX]
-            device_page_table = self.trace_inputs_decode[return_logits][DECODE_PAGE_TABLE_INPUT_IDX]
+            device_page_table = self.trace_inputs_decode[on_device_logits][DECODE_PAGE_TABLE_INPUT_IDX]
             if host_page_table is not None:
                 ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
         if page_table_changed:
             self.prev_page_table = page_table.clone()
 
         trace_tok_rm = self._decode_forward_trace_text(
-            self.trace_ids_decode[return_logits],
-            self.trace_inputs_decode[return_logits],
-            self.trace_output_decode[return_logits],
+            self.trace_ids_decode[on_device_logits],
+            self.trace_inputs_decode[on_device_logits],
+            self.trace_output_decode[on_device_logits],
             tokens,
             current_pos,
             page_table=page_table,
         )
 
-        if not return_logits:
-            return self.model.sampling.sample(
-                logits=trace_tok_rm[0],
-                tt_out_tok=self.trace_inputs_decode[return_logits][0],
-            )
+        if on_device_logits:
+            return trace_tok_rm[0], None
 
         return trace_tok_rm
+
+    def sample_decode_on_device(
+        self,
+        tt_logits,
+        sampling_params,
+        start_pos=None,
+        reset_inputs=False,
+        reset_batch=False,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+        slot_remap=None,
+        enable_trace=False,
+    ):
+        tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
+        sampling_module = self.model.sampling
+        seed_manager = sampling_module.seed_manager
+
+        active_seed_slots = None
+        if start_pos is not None:
+            active_seed_slots = [
+                idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
+            ]
+
+        # Apply slot remap from condense before advancing seeds.
+        if slot_remap is not None:
+            sm_bs = seed_manager.max_batch_size
+            # Galaxy decode currently uses a single sampling module/rank, so slot_remap is local [0:sm_bs].
+            rank_remap = slot_remap[0:sm_bs]
+            _log_sampling_debug(
+                self._sampling_debug_enabled,
+                "Galaxy decode slot remap",
+                slot_remap=_slot_remap_debug_summary(rank_remap),
+                seed_state_before=_seed_manager_debug_summary(seed_manager),
+            )
+            seed_manager.apply_slot_remap(rank_remap)
+            _log_sampling_debug(
+                self._sampling_debug_enabled,
+                "Galaxy decode slot remap applied",
+                seed_state_after=_seed_manager_debug_summary(seed_manager),
+            )
+
+        # Only re-upload sampling params when inputs are being reset (new batch /
+        # mode switch / page-table change). The k/p/temp + penalty *coefficient*
+        # buffers persist on device between decode steps and are read in place by
+        # the sampling trace, so re-applying identical params every step is pure
+        # host->device overhead on the hot decode loop. Seed advancement and slot
+        # remap still run every step. (Penalty accumulation state is reset via
+        # reset_prompt_tokens/reset_output_state, gated on reset_batch.)
+        # `decode_forward` passes its richer `reset_inputs` (covers mode switch /
+        # page-table change); an external caller (e.g. vLLM deferred path) that
+        # only knows the portable `reset_batch` flag still triggers the upload.
+        if reset_inputs or reset_batch:
+            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
+            # When some slots carry an explicit seed, fill the inactive slots'
+            # params from an active request so trace-replayed sampling stays
+            # deterministic regardless of how vLLM split request admission.
+            if active_seed_slots is not None:
+                seed_values = _as_list(getattr(sampling_params, "seed", None))
+                has_active_seed = any(
+                    slot < len(seed_values) and seed_values[slot] is not None for slot in active_seed_slots
+                )
+                if has_active_seed:
+                    sampling_params = _fill_inactive_params_from_active(
+                        sampling_params, active_seed_slots, self.model_args.max_batch_size
+                    )
+            sampling_module.reset_sampling_params(sampling_params)
+            if reset_batch:
+                sampling_module.reset_prompt_tokens(prompt_tokens)
+                sampling_module.reset_output_state(output_tokens)
+            _log_sampling_debug(
+                self._sampling_debug_enabled,
+                "Galaxy decode sampling params reset",
+                sampling_params=_sampling_params_debug_summary(sampling_params),
+                prompt_tokens=_tensor_debug_summary(prompt_tokens),
+                output_tokens=_tensor_debug_summary(output_tokens),
+            )
+
+        if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
+            seed_values = getattr(sampling_params, "seed", None)
+            if _seed_debug_enabled():
+                debug_slots = (
+                    active_seed_slots if active_seed_slots is not None else list(range(seed_manager.max_batch_size))
+                )
+                seed_values_list = _as_list(seed_values)
+                seed_slot_pairs = [
+                    (
+                        slot,
+                        seed_values_list[slot] if slot < len(seed_values_list) else None,
+                        seed_manager.seeds[slot],
+                        seed_manager.seed_counters[slot],
+                    )
+                    for slot in debug_slots
+                ]
+                logger.info(
+                    f"SeedDBG Galaxy decode: reset_batch={reset_batch}, active_seed_slots={active_seed_slots}, "
+                    f"seed_slot_pairs={seed_slot_pairs}"
+                )
+            seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
+            if reset_inputs:
+                seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
+
+        # Advance seeds after parameter copies so seeded sampling observes
+        # one ordered params/seed state for this token.
+        seed_manager.get_new_values(active_seed_slots)
+        return self.model.sampling.sample(
+            logits=tt_logits,
+            tt_out_tok=tt_out_tok,
+            enable_trace=enable_trace,
+        )
 
     def read_decode_output(self, tt_out, async_read=True):
         if not async_read:

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -704,7 +704,7 @@ class TtTransformer(LightweightModule):
         kv_cache=None,
         tt_out_logits_saved=None,
         is_cur_pos_sharded=False,
-        return_logits=False,
+        on_device_logits=False,
     ):
         """
         This method will take device tensors and any other args to run forward.
@@ -722,7 +722,7 @@ class TtTransformer(LightweightModule):
         )
         self._increment_decode_positions_device(current_pos, rot_mat_idxs, is_cur_pos_sharded)
 
-        if return_logits:
+        if not on_device_logits:
             tt_logits = self.tt_ccl.line_all_gather(
                 tt_logits[0],
                 dim=3,

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -135,11 +135,11 @@ class GemmaMultimodalGenerator(Generator):
             # Only paged attention is supported for prefill
             enable_trace = False
 
-        sampling_on_device_requested = sampling_params is not None
+        on_device_sampling_requested = sampling_params is not None
 
         # we need this here because of tt-metal tests
         if warmup_prefill:
-            sampling_on_device_enabled = (
+            on_device_sampling_enabled = (
                 getattr(self.model[0], "_supports_on_device_sampling", False)
                 and getattr(self.model[0], "sampling", None) is not None
             )
@@ -147,7 +147,7 @@ class GemmaMultimodalGenerator(Generator):
             self.warmup_model_prefill(
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
-                can_sample_on_device=sampling_on_device_enabled,
+                can_sample_on_device=on_device_sampling_enabled,
             )
 
         batch_size, batch_seq_len = tokens.shape
@@ -211,7 +211,7 @@ class GemmaMultimodalGenerator(Generator):
             and not getattr(self.model_args[0], "disable_batched_prefill", False)
         )
 
-        if use_batched_prefill and sampling_on_device_requested:
+        if use_batched_prefill and on_device_sampling_requested:
             sampling_module, sampling_dp, _, _ = self._get_sampling_contract(0)
             if sampling_module is not None and sampling_dp > 1:
                 # NOTE: Batched prefill disabled: on-device sampling
@@ -265,7 +265,7 @@ class GemmaMultimodalGenerator(Generator):
             if getattr(self.model[model_id], "users_row_sharded", False):
                 local_kwargs["global_user_id"] = batch_user_ids if use_batched_prefill else user_id
             sampling_enabled = (
-                sampling_on_device_requested
+                on_device_sampling_requested
                 and getattr(self.model[model_id], "_supports_on_device_sampling", False)
                 and getattr(self.model[model_id], "sampling", None) is not None
             )

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -103,20 +103,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.trace_output_decode = defaultdict(lambda: None)
         self.prefill_traces_warmup = False
         self.already_warmed_up_prefill = False
-        # By default, enable split sampling (break the decode trace into two parts: upto logits, then sampling step)
-        self.enable_split_sampling = True
         self.mode = None
 
     # Class-level capabilities (VLLM specific, to be overridden by subclasses)
     model_capabilities = {
         "supports_prefix_caching": True,
     }
-
-    def _set_sampling_trace_mode(self, enabled: bool):
-        for model_instance in self.model:
-            sampling_module = getattr(model_instance, "sampling", None)
-            if sampling_module is not None:
-                sampling_module.enable_internal_trace = enabled
 
     def _get_sampling_contract(self, model_id: int):
         sampling_module = getattr(self.model[model_id], "sampling", None)
@@ -555,11 +547,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # Only paged attention is supported for prefill
             enable_trace = False
 
-        sampling_on_device_requested = sampling_params is not None
+        on_device_sampling_requested = sampling_params is not None
 
         # we need this here because of tt-metal tests
         if warmup_prefill:
-            sampling_on_device_enabled = (
+            on_device_sampling_enabled = (
                 getattr(self.model[0], "_supports_on_device_sampling", False)
                 and getattr(self.model[0], "sampling", None) is not None
             )
@@ -567,7 +559,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.warmup_model_prefill(
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
-                can_sample_on_device=sampling_on_device_enabled,
+                can_sample_on_device=on_device_sampling_enabled,
             )
 
         batch_size, batch_seq_len = tokens.shape
@@ -667,7 +659,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             )
             use_batched_prefill = False
 
-        if use_batched_prefill and sampling_on_device_requested:
+        if use_batched_prefill and on_device_sampling_requested:
             sampling_module, sampling_dp, _, _ = self._get_sampling_contract(0)
             if sampling_module is not None and sampling_dp > 1:
                 # NOTE: Batched prefill disabled: on-device sampling
@@ -722,7 +714,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             if getattr(self.model[model_id], "users_row_sharded", False):
                 local_kwargs["global_user_id"] = batch_user_ids if use_batched_prefill else user_id
             sampling_enabled = (
-                sampling_on_device_requested
+                on_device_sampling_requested
                 and getattr(self.model[model_id], "_supports_on_device_sampling", False)
                 and getattr(self.model[model_id], "sampling", None) is not None
             )
@@ -816,6 +808,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 if "image_sizes" in local_kwargs and local_kwargs["image_sizes"] is not None:
                     local_kwargs["image_sizes"] = local_kwargs["image_sizes"][idx]
 
+            # NOTE: Unlike decode (which supports `defer_device_sampling` so vLLM can
+            # run the forward and the sampling step separately), prefill sampling is
+            # NOT separable here: each user's logits are produced and sampled on the
+            # fly inside this per-user loop — state is applied per user via
+            # apply_prefill_state and then sampled immediately. There is no single
+            # post-forward logits handle to hand back, and deferring would force
+            # holding every user's logits until the end of the loop. So prefill
+            # always samples in-line.
             if sampling_enabled and not use_batched_prefill:
                 sampling_executed = True
                 sampling_dp = getattr(self.model[model_id], "sampling_dp", 1)
@@ -869,13 +869,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     sampling_module, sampling_dp, sampling_batch, _ = self._get_sampling_contract(model_id)
                     assert sampling_module is not None
                     assert sampling_batch is not None
-                    combined_params = format_sampling_params(sampling_params, sampling_batch)
                     max_prompt_len = max(int(prompt_lens[i]) for i in range(len(empty_slots)))
                     combined_prompt_tokens = torch.zeros(sampling_batch, max_prompt_len, dtype=torch.long)
                     for local_idx, slot in enumerate(empty_slots):
                         plen = int(prompt_lens[local_idx])
                         combined_prompt_tokens[slot, :plen] = prefill_ids[slot, :plen]
 
+                    combined_params = format_sampling_params(sampling_params, sampling_batch)
                     sampling_module.apply_prefill_state(
                         sampling_params=combined_params,
                         prompt_tokens=combined_prompt_tokens,
@@ -923,15 +923,20 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     ttnn.synchronize_device(self.model[model_id].mesh_device)
 
                     tokens_host = ttnn.to_torch(ttnn.get_device_tensors(tt_tokens)[0]).reshape(-1)
-                    log_probs_host = (
+                    # tt_log_probs may be a LogProbsResult (top-k logprobs mode) or a plain [B]
+                    # tensor (scalar logprobs); mirror the single-user handling so
+                    # reformat_logprobs receives per-slot LogProbsResult / scalar entries.
+                    plain_log_probs_host = (
                         ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0]).reshape(-1)
-                        if tt_log_probs is not None
+                        if tt_log_probs is not None and not isinstance(tt_log_probs, LogProbsResult)
                         else None
                     )
                     for local_idx, slot in enumerate(empty_slots):
                         output_tokens[slot] = tokens_host[slot]
-                        if log_probs_host is not None:
-                            output_log_probs[slot] = log_probs_host[slot]
+                        if isinstance(tt_log_probs, LogProbsResult):
+                            output_log_probs[slot] = tt_log_probs.extract_user(slot)
+                        elif plain_log_probs_host is not None:
+                            output_log_probs[slot] = plain_log_probs_host[slot]
                 else:
                     if return_hidden_states:
                         # Embedding models: trace returns hidden states; extract last-token hidden per slot
@@ -1208,6 +1213,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
+        defer_device_sampling: bool = False,
         **kwargs,
     ):
         mode_switched = False
@@ -1219,84 +1225,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.DECODE)
 
-        sampling_on_device = sampling_params is not None
-        split_sampling_enabled = bool(self.enable_split_sampling and sampling_on_device)
-        self._set_sampling_trace_mode(split_sampling_enabled)
-
+        on_device_sampling = (sampling_params is not None) or defer_device_sampling
         B = tokens.shape[0]
 
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
-        sampling_params_list = None
-        if sampling_params is not None:
-            # sampling_dp may differ from data_parallel for models that internally
-            # shard users across mesh rows (users_row_sharded) — each row samples
-            # 32 users independently, so sampling params must be chunked by the
-            # number of rows even though data_parallel=1 for the forward pass.
-            sampling_dp_values = [getattr(self.model[i], "sampling_dp", 1) for i in range(self.data_parallel)]
-            assert (
-                len(set(sampling_dp_values)) == 1
-            ), f"All model instances must have the same sampling_dp, got {sampling_dp_values}"
-            # NOTE: This assumes data_parallel and sampling_dp are mutually exclusive
-            # (one is always 1). If a future model needs both DP>1 and row-sharded
-            # sampling, this should become data_parallel * sampling_dp_values[0].
-            sampling_dp = max(self.data_parallel, sampling_dp_values[0])
-
-            sampling_params_list = chunk_sampling_params(sampling_params, sampling_dp)
-
-            prompt_chunks = (
-                torch.chunk(prompt_tokens, sampling_dp, 0) if prompt_tokens is not None else [None] * sampling_dp
-            )
-            output_chunks = (
-                torch.chunk(output_tokens, sampling_dp, 0) if output_tokens is not None else [None] * sampling_dp
-            )
-
-            for i in range(self.data_parallel):
-                sampling_module = getattr(self.model[i], "sampling", None)
-                assert sampling_module is not None, "Sampling module not found in model for sampling on device."
-                assert (
-                    sampling_dp % self.data_parallel == 0
-                ), f"sampling_dp ({sampling_dp}) must be divisible by data_parallel ({self.data_parallel})"
-                cpm = sampling_dp // self.data_parallel
-                start = i * cpm
-                model_chunks = sampling_params_list[start : start + cpm]
-
-                model_prompt = (
-                    torch.cat([c for c in prompt_chunks[start : start + cpm] if c is not None], 0)
-                    if prompt_tokens is not None
-                    else None
-                )
-                model_output = (
-                    torch.cat([c for c in output_chunks[start : start + cpm] if c is not None], 0)
-                    if output_tokens is not None
-                    else None
-                )
-
-                sampling_module.apply_decode_state(
-                    model_chunks,
-                    reset_batch=reset_batch,
-                    prompt_tokens=model_prompt,
-                    output_tokens=model_output,
-                )
-                active_seed_slots = None
-                if start_pos[i] is not None:
-                    max_seed_slots = sampling_module.seed_manager.max_batch_size
-                    start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
-                    active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
-                # Apply slot remap from condense before advancing seeds.
-                if slot_remap is not None:
-                    sm_bs = sampling_module.seed_manager.max_batch_size
-                    rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
-                    sampling_module.seed_manager.apply_slot_remap(rank_remap)
-                sampling_module.seed_manager.get_new_values(active_seed_slots)
-
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,
             "page_table": page_table,
             "kv_cache": kv_cache,
-            "sampling_on_device": sampling_on_device,
+            "on_device_sampling": on_device_sampling,
         }
 
         if enable_trace:
@@ -1304,11 +1244,30 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # token/current_pos trace buffers stale, not just a prefill->decode
             # mode switch, so both must force a full traced-input reset.
             tt_decode_output = self._decode_forward_trace_text(
-                **decode_kwargs, reset_batch=reset_batch or mode_switched
+                **decode_kwargs,
+                reset_batch=reset_batch or mode_switched,
             )
         else:
-            tt_decode_output = self._decode_forward_no_trace_text(**decode_kwargs)
+            tt_decode_output = self._decode_forward_no_trace_text(
+                **decode_kwargs,
+            )
 
+        # Device deferred
+        if defer_device_sampling and on_device_sampling:
+            return tt_decode_output
+        # Device immediate
+        if sampling_params is not None:
+            tt_decode_output = self.sample_decode_on_device(
+                tt_decode_output,
+                sampling_params=sampling_params,
+                start_pos=start_pos,
+                reset_batch=reset_batch,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+                slot_remap=slot_remap,
+                enable_trace=enable_trace,
+            )
+        # Host sampling
         if read_from_device:
             to_host = self.read_decode_output(tt_decode_output)
             return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
@@ -1320,7 +1279,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         current_pos,
         page_table=None,
         kv_cache=None,
-        sampling_on_device=False,
+        on_device_sampling=False,
     ):
         """
         Performs text decode step.
@@ -1352,14 +1311,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         for i in range(self.data_parallel):
             user_kv_cache = kv_cache[i] if kv_cache is not None else None
-            tt_logits_i, tt_log_probs_i = self.model[i].ttnn_decode_forward(
+            decode_out = self.model[i].ttnn_decode_forward(
                 tt_tokens[i],
                 tt_current_pos[i],
                 rot_mat_idxs=tt_rot_mat_idxs[i],
                 page_table=tt_page_table[i],
                 kv_cache=user_kv_cache,
-                sampling_on_device=sampling_on_device,
+                on_device_logits=on_device_sampling,
             )
+            if isinstance(decode_out, tuple):
+                tt_logits_i, tt_log_probs_i = decode_out
+            else:
+                tt_logits_i, tt_log_probs_i = decode_out, None
             tt_output.append((tt_logits_i, tt_log_probs_i))
 
         return tt_output
@@ -1370,7 +1333,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         current_pos,
         page_table=None,
         kv_cache=None,
-        sampling_on_device=False,
+        on_device_sampling=False,
     ):
         """
         Captures a trace for the decode_forward method.
@@ -1382,7 +1345,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             current_pos,
             page_table=page_table,
             kv_cache=kv_cache,
-            sampling_on_device=sampling_on_device,
+            on_device_sampling=on_device_sampling,
         )
         logger.info("Done Compiling Model")
 
@@ -1402,11 +1365,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         for i in range(self.data_parallel):
             sampling_module = getattr(self.model[i], "sampling", None)
-            split_enabled = (
-                sampling_on_device
-                and sampling_module is not None
-                and getattr(sampling_module, "enable_internal_trace", False)
-            )
+            sampling_trace_enabled = on_device_sampling and sampling_module is not None
             trace_id = ttnn.begin_trace_capture(self.model_args[i].mesh_device, cq_id=0)
             trace_ids[i] = trace_id
             user_kv_cache = kv_cache[i] if kv_cache is not None else None
@@ -1428,39 +1387,55 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 self.model[i].ttnn_decode_forward(
                     *model_inputs,
                     kv_cache=user_kv_cache,
-                    sampling_on_device=sampling_on_device,
-                    capture_sampling_trace=split_enabled,
+                    on_device_logits=on_device_sampling,
                 )
             )
             ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
 
-            if split_enabled:
-                sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=device_inputs[i][0])
+            if sampling_trace_enabled:
+                # NOTE: sampling trace can be keyed depending on sampling params,
+                # this traces only for the current ones.
+                # tt_out_tok feeds the sampled token back into the decode token
+                # buffer (device_inputs[0]) for the next traced step. Only do this
+                # for models that rely on on-device token feedback. Models that
+                # re-stage decode inputs from host every step (e.g. gemma4, via
+                # _tt_vllm_always_refresh_decode_trace_inputs) don't, and their
+                # token buffer is not shaped as a sampling output (gemma4's is
+                # rank-2; ttnn.sampling requires a rank-4 preallocated output) —
+                # pass None so sampling allocates its own output.
+                tt_out_tok = self._decode_token_feedback_buffer(self.model[i], device_inputs[i])
+                sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=tt_out_tok)
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
 
     def _decode_forward_trace_text(
-        self, tokens, current_pos, page_table=None, kv_cache=None, sampling_on_device=False, reset_batch=False
+        self,
+        tokens,
+        current_pos,
+        page_table=None,
+        kv_cache=None,
+        on_device_sampling=False,
+        reset_batch=False,
     ):
         """
         Run decode forward text with tracing
         """
         # The trace is different depending on whether we are doing device sampling or not
-        if not self.trace_ids_decode[sampling_on_device]:
+        if not self.trace_ids_decode[on_device_sampling]:
             trace_ids, tt_out_trace, *device_inputs = self._capture_decode_trace_text(
-                tokens, current_pos, page_table=page_table, kv_cache=kv_cache, sampling_on_device=sampling_on_device
+                tokens, current_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=on_device_sampling
             )
-            self.trace_ids_decode[sampling_on_device] = trace_ids
-            self.trace_inputs_decode[sampling_on_device] = device_inputs
-            self.trace_output_decode[sampling_on_device] = tt_out_trace
+            self.trace_ids_decode[on_device_sampling] = trace_ids
+            self.trace_inputs_decode[on_device_sampling] = device_inputs
+            self.trace_output_decode[on_device_sampling] = tt_out_trace
 
         # reset inputs when mode switches from prefill to decode,
-        # or when sampling_on_device changes (different trace has stale inputs)
-        prev_sampling_on_device = getattr(self, "_prev_sampling_on_device", None)
-        self._prev_sampling_on_device = sampling_on_device
-        sampling_mode_changed = prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device
-        reset_inputs = reset_batch or not sampling_on_device or sampling_mode_changed
+        # or when sampling mode changes (different trace has stale inputs)
+        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
+        self._prev_on_device_sampling = on_device_sampling
+        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
+        reset_inputs = reset_batch or not on_device_sampling or sampling_mode_changed
         page_table_changed = page_table is not None and (
             self.prev_page_table is None
             or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
@@ -1479,7 +1454,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
                 copy_host_to_device(
                     host_tensors=host_inputs_i,
-                    device_tensors=self.trace_inputs_decode[sampling_on_device][i],
+                    device_tensors=self.trace_inputs_decode[on_device_sampling][i],
                 )
             elif page_table_changed:
                 # With async device sampling, token/position inputs may
@@ -1489,31 +1464,129 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # preserve device-produced tokens.
                 host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
                 host_page_table = host_inputs_i[DECODE_PAGE_TABLE_INPUT_IDX]
-                device_page_table = self.trace_inputs_decode[sampling_on_device][i][DECODE_PAGE_TABLE_INPUT_IDX]
+                device_page_table = self.trace_inputs_decode[on_device_sampling][i][DECODE_PAGE_TABLE_INPUT_IDX]
                 if host_page_table is not None:
                     ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
 
         if page_table_changed:
             self.prev_page_table = tuple(pt.clone() for pt in page_table)
-        for i, trace_id in self.trace_ids_decode[sampling_on_device].items():
+        for i, trace_id in self.trace_ids_decode[on_device_sampling].items():
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
-        outputs = self.trace_output_decode[sampling_on_device]
-        if sampling_on_device:
-            new_outputs = []
-            for i in range(self.data_parallel):
-                sampling_module = getattr(self.model[i], "sampling", None)
-                if sampling_module is None or not getattr(sampling_module, "enable_internal_trace", False):
-                    new_outputs.append(outputs[i])
-                    continue
+        return self.trace_output_decode[on_device_sampling]
 
-                new_outputs.append(
-                    sampling_module.sample(
-                        logits=outputs[i],
-                        tt_out_tok=self.trace_inputs_decode[sampling_on_device][i][0],
-                    )
+    def sample_decode_on_device(
+        self,
+        tt_logits,
+        sampling_params,
+        start_pos=None,
+        reset_batch=False,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+        slot_remap=None,
+        enable_trace=False,
+    ):
+        # sampling_dp may differ from data_parallel for models that internally
+        # shard users across mesh rows (users_row_sharded) — each row samples
+        # 32 users independently, so sampling params must be chunked by the
+        # number of rows even though data_parallel=1 for the forward pass.
+        sampling_dp_values = [getattr(self.model[i], "sampling_dp", 1) for i in range(self.data_parallel)]
+        assert (
+            len(set(sampling_dp_values)) == 1
+        ), f"All model instances must have the same sampling_dp, got {sampling_dp_values}"
+        # NOTE: This assumes data_parallel and sampling_dp are mutually exclusive
+        # (one is always 1). If a future model needs both DP>1 and row-sharded
+        # sampling, this should become data_parallel * sampling_dp_values[0].
+        sampling_dp = max(self.data_parallel, sampling_dp_values[0])
+        sampling_params_list = chunk_sampling_params(sampling_params, sampling_dp)
+        prompt_chunks = (
+            torch.chunk(prompt_tokens, sampling_dp, 0) if prompt_tokens is not None else [None] * sampling_dp
+        )
+        output_chunks = (
+            torch.chunk(output_tokens, sampling_dp, 0) if output_tokens is not None else [None] * sampling_dp
+        )
+
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            assert sampling_module is not None, "Sampling module not found in model for sampling on device."
+            assert (
+                sampling_dp % self.data_parallel == 0
+            ), f"sampling_dp ({sampling_dp}) must be divisible by data_parallel ({self.data_parallel})"
+            cpm = sampling_dp // self.data_parallel
+            start = i * cpm
+            model_chunks = sampling_params_list[start : start + cpm]
+            model_prompt = (
+                torch.cat([c for c in prompt_chunks[start : start + cpm] if c is not None], 0)
+                if prompt_tokens is not None
+                else None
+            )
+            model_output = (
+                torch.cat([c for c in output_chunks[start : start + cpm] if c is not None], 0)
+                if output_tokens is not None
+                else None
+            )
+
+            sampling_module.apply_decode_state(
+                model_chunks,
+                reset_batch=reset_batch,
+                prompt_tokens=model_prompt,
+                output_tokens=model_output,
+            )
+            # Advance seeds only for active slots (start_pos >= 0); inactive
+            # slots must keep their counters untouched (they get SKIP values).
+            active_seed_slots = None
+            if start_pos is not None and start_pos[i] is not None:
+                max_seed_slots = sampling_module.seed_manager.max_batch_size
+                start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
+                active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
+            # Apply slot remap from condense before advancing seeds.
+            if slot_remap is not None:
+                sm_bs = sampling_module.seed_manager.max_batch_size
+                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
+                sampling_module.seed_manager.apply_slot_remap(rank_remap)
+            sampling_module.seed_manager.get_new_values(active_seed_slots)
+
+        sampled_outputs = []
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            if sampling_module is None:
+                sampled_outputs.append(tt_logits[i])
+                continue
+            logits_i = tt_logits[i]
+            if isinstance(logits_i, tuple):
+                logits_i = logits_i[0]
+            # Must match the capture-time decision in _capture_decode_trace_text:
+            # only feed the sampled token back into device_inputs[0] for models
+            # that use on-device token feedback (see _decode_token_feedback_buffer).
+            tt_out_tok = (
+                self._decode_token_feedback_buffer(self.model[i], self.trace_inputs_decode[True][i])
+                if enable_trace and self.trace_inputs_decode[True]
+                else None
+            )
+            sampled_outputs.append(
+                sampling_module.sample(
+                    logits=logits_i,
+                    tt_out_tok=tt_out_tok,
+                    enable_trace=enable_trace,
                 )
-            return new_outputs
-        return outputs
+            )
+        return sampled_outputs
+
+    @staticmethod
+    def _decode_token_feedback_buffer(model, device_inputs):
+        """Return the device token buffer to feed the sampled token back into for
+        the next traced decode step, or None if the model doesn't use on-device
+        token feedback.
+
+        Models that re-stage all decode trace inputs from host every step (e.g.
+        gemma4, ``_tt_vllm_always_refresh_decode_trace_inputs=True``) don't rely
+        on the device feedback and their token buffer (``device_inputs[0]``) may
+        not be a valid sampling output (gemma4's is rank-2; ``ttnn.sampling``
+        requires a rank-4 preallocated output). Returning None makes sampling
+        allocate its own output instead of writing into ``device_inputs[0]``.
+        """
+        if getattr(model, "_tt_vllm_always_refresh_decode_trace_inputs", False):
+            return None
+        return device_inputs[0]
 
     def _prefill_forward_single_user(
         self,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -808,14 +808,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 if "image_sizes" in local_kwargs and local_kwargs["image_sizes"] is not None:
                     local_kwargs["image_sizes"] = local_kwargs["image_sizes"][idx]
 
-            # NOTE: Unlike decode (which supports `defer_device_sampling` so vLLM can
-            # run the forward and the sampling step separately), prefill sampling is
-            # NOT separable here: each user's logits are produced and sampled on the
-            # fly inside this per-user loop — state is applied per user via
-            # apply_prefill_state and then sampled immediately. There is no single
-            # post-forward logits handle to hand back, and deferring would force
-            # holding every user's logits until the end of the loop. So prefill
-            # always samples in-line.
             if sampling_enabled and not use_batched_prefill:
                 sampling_executed = True
                 sampling_dp = getattr(self.model[model_id], "sampling_dp", 1)
@@ -1531,8 +1523,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 prompt_tokens=model_prompt,
                 output_tokens=model_output,
             )
-            # Advance seeds only for active slots (start_pos >= 0); inactive
-            # slots must keep their counters untouched (they get SKIP values).
             active_seed_slots = None
             if start_pos is not None and start_pos[i] is not None:
                 max_seed_slots = sampling_module.seed_manager.max_batch_size

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -778,8 +778,7 @@ class Transformer(LightweightModule):
         rot_mat_idxs=None,
         page_table=None,
         kv_cache=None,
-        sampling_on_device=False,
-        capture_sampling_trace=False,
+        on_device_logits=False,
         page_tables_per_layer=None,
     ):
         """
@@ -808,17 +807,13 @@ class Transformer(LightweightModule):
             page_tables_per_layer=page_tables_per_layer,
         )
 
-        if sampling_on_device and self.sampling is not None:
-            self._increment_decode_positions_device(current_pos, rot_mat_idxs)
-            if capture_sampling_trace:
-                return tt_logits
-            tt_toks, tt_log_probs = self.sampling.sample(
-                tt_logits,
-                tt_out_tok=x,
-                enable_trace=False,
+        if on_device_logits:
+            assert self.sampling is not None, (
+                "ttnn_decode_forward got on_device_logits=True but no on-device sampling "
+                "module exists (self.sampling is None)."
             )
-
-            return tt_toks, tt_log_probs
+            self._increment_decode_positions_device(current_pos, rot_mat_idxs)
+            return tt_logits
 
         # Gather the output across all devices and untilize the tensor (for argmax)
         if self.args.num_devices > 1:


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
* Remove the provisions for jointly tracing sampling with forward pass (this was hardcoded off, a never really valid as most cases would need the traces invalidated often)
* Have sampling be called in a separate function, for now with fallback (preparation for vllm cleanup and development)

### Notes for reviewers
The goal was for behaviour to not be modified in most cases - this is mostly code restructuring and cleanup.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/separated_sampling_minimal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/separated_sampling_minimal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/separated_sampling_minimal)