### PR TITLE
[skip ci] [cleanup] rename CPM googletest -> GTest to match upstream and UMD

### DIFF
--- a/cmake/stubs/cpm-stubs.cmake
+++ b/cmake/stubs/cpm-stubs.cmake
@@ -36,3 +36,7 @@ function(CPMAddPackage)
 
     cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
 endfunction()
+
+function(CPMRegisterPackage PACKAGE VERSION)
+    # no-op stub: when using cpm-stubs, packages are provided by the parent project
+endfunction()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -147,7 +147,7 @@ CPMAddPackage(
 ############################################################################################################################
 
 CPMAddPackage(
-    NAME googletest
+    NAME GTest
     GITHUB_REPOSITORY google/googletest
     GIT_TAG v1.13.0
     VERSION 1.13.0
@@ -155,6 +155,7 @@ CPMAddPackage(
         "INSTALL_GTEST OFF"
         "BUILD_SHARED_LIBS OFF"
 )
+CPMRegisterPackage("googletest" "1.13.0")
 
 ############################################################################################################################
 # boost-ext reflect : https://github.com/boost-ext/reflect

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -53,14 +53,8 @@ CPMAddPackage(
 # googletest
 ############################################################################################################################
 
-CPMAddPackage(
-    NAME googletest
-    GITHUB_REPOSITORY google/googletest
-    GIT_TAG v1.13.0
-    VERSION 1.13.0
-    OPTIONS
-        "INSTALL_GTEST OFF"
-)
+CPMAddPackage(NAME GTest GITHUB_REPOSITORY google/googletest GIT_TAG v1.13.0 VERSION 1.13.0 OPTIONS "INSTALL_GTEST OFF")
+CPMRegisterPackage("googletest" "1.13.0")
 
 ############################################################################################################################
 # boost-ext reflect : https://github.com/boost-ext/reflect


### PR DESCRIPTION
UMD renamed CPM's GTest name to fix CPM_LOCAL_PACKAGES_ONLY (cf: https://github.com/tenstorrent/tt-umd/pull/2188 )

Make the same change here in a way that is compatible with UMD's old and new versions to facilitate bumping UMD.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/gtest-name)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/gtest-name)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/gtest-name)