### PR TITLE
[Bug fix] moreh.layer_norm not populating rstd when mean=None

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -758,6 +758,6 @@ def test_moreh_layer_norm_rstd_only_mean_none(device):
 
     actual_rstd = to_torch(npu_rstd, shape=mean_rstd_shape)
 
-    pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=0.1, atol=0.1)
+    pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=0.09, atol=0.06)
     logger.debug(f"rstd's {out_rstd}")
     assert pass_rstd

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -721,3 +721,43 @@ def test_moreh_layer_norm_no_mean_rstd(input_shape_normalized_dims, elementwise_
     if dtype == ttnn.bfloat8_b:
         pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device, create_mean_rstd=False)
+
+
+# Validation test for moreh.layer_norm not populating rstd when mean=None, see #22089
+def test_moreh_layer_norm_rstd_only_mean_none(device):
+    torch.manual_seed(2023)
+    input_shape = [2, 32, 512]
+    normalized_dims = 1
+    eps = 1e-5
+    mean_rstd_shape = input_shape[:-normalized_dims]
+
+    cpu_input, cpu_gamma, cpu_beta, _ = make_input_tensors(input_shape, normalized_dims, elementwise_affine=True)
+
+    # expected
+    _, _, expected_rstd = torch_layer_norm(
+        cpu_input, normalized_dims=normalized_dims, eps=eps, gamma=cpu_gamma, beta=cpu_beta
+    )
+
+    # actual: pass mean=None, preallocate rstd
+    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
+    npu_gamma = to_ttnn(cpu_gamma, device=device, dtype=ttnn.bfloat16)
+    npu_beta = to_ttnn(cpu_beta, device=device, dtype=ttnn.bfloat16)
+    npu_output = to_ttnn(torch.empty_like(cpu_input), device=device, dtype=ttnn.bfloat16)
+    npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+
+    ttnn.operations.moreh.layer_norm(
+        npu_input,
+        normalized_dims,
+        eps,
+        npu_gamma,
+        npu_beta,
+        output=npu_output,
+        mean=None,
+        rstd=npu_rstd,
+    )
+
+    actual_rstd = to_torch(npu_rstd, shape=mean_rstd_shape)
+
+    pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=0.1, atol=0.1)
+    logger.debug(f"rstd's {out_rstd}")
+    assert pass_rstd

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -89,8 +89,8 @@ tt::tt_metal::ProgramDescriptor MorehLayerNormOperation::ProgramFactory::create_
     uint32_t mean_rstd_height = 0;
     uint32_t mean_rstd_width = 0;
 
-    if (mean_has_value) {
-        const auto mean_rstd_shape_without_padding = mean->logical_shape();
+    if (mean_has_value || rstd_has_value) {
+        const auto mean_rstd_shape_without_padding = mean_has_value ? mean->logical_shape() : rstd->logical_shape();
         mean_rstd_height = mean_rstd_shape_without_padding[-2];
         mean_rstd_width = mean_rstd_shape_without_padding[-1];
     }


### PR DESCRIPTION
### PR Category
- Bug fix

### Summary
- Fixes #22089.

`moreh.layer_norm` accepts `mean` and `rstd` as independently optional preallocated output buffers. When `mean=None` was passed alongside a preallocated rstd, the rstd buffer was silently never written and retained its initialized values (e.g. zeros).

**Root cause:** In `moreh_layer_norm_program_factory.cpp`, `mean_rstd_height` and `mean_rstd_width` were only populated inside an `if (mean_has_value)` branch. With `mean=None`, both stayed at 0. They are passed as runtime args to the writer kernel, where they drive the tile-loop bounds:
```c++
uint32_t Wt = (mean_rstd_width + TILE_WIDTH - 1) / TILE_WIDTH;    // -> 0
uint32_t Ht = (mean_rstd_height + TILE_HEIGHT - 1) / TILE_HEIGHT; // -> 0
```
With both at 0, the rstd-write loop never iterated, so the buffer was left untouched.

**Fix:** Added a symmetric `else if (rstd_has_value)` branch that derives the same dimensions from `rstd->logical_shape()` (which carries the same shape that mean would have had). 

### Notes for reviewers
- The C++ change is the small 2-line fix at [moreh_layer_norm_program_factory.cpp:92-93](https://github.com/tenstorrent/tt-metal/blob/9ebea5d375203e72f027f96839d22d93c912da5d/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp#L92-L93).
- Added a focused validation test `test_moreh_layer_norm_rstd_only_mean_none` that exercises the mean=None + preallocated rstd path and verifies rstd values match the torch reference.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-moreh-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-moreh-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-moreh-layernorm)