### PR TITLE
Feature: DRAM-core DRISC prefetcher

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_bench_discard_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_bench_discard_receiver.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bandwidth-bench worker receiver for the DRAM-core vs worker-core prefetcher
+// BW comparison. Per-page wait_front + pop_front in a loop, discards data.
+//
+// Unlike gcb_smoke_receiver.cpp (one big wait_front(num_pages) + pop_front(num_pages)),
+// this kernel drains pages one-at-a-time so the GCB fifo (which only holds a few
+// pages of in-flight data) keeps refilling as the sender pushes through num_iters
+// total pages.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/remote_circular_buffer.h"
+
+void kernel_main() {
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_iters = get_compile_time_arg_val(1);
+
+    for (uint32_t i = 0; i < num_iters; ++i) {
+        experimental::remote_cb_wait_front(remote_cb_id, 1);
+        experimental::remote_cb_pop_front(remote_cb_id, 1);
+    }
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Validator receiver for the prefetcher-vs-matmul contract.
+// See tt_metal/impl/buffers/prefetcher_matmul_design.md §3 ("Per-block source tiles") for the
+// (bank, receiver, block) -> tile-range mapping this kernel derives expected
+// bytes from.
+//
+// Per pushed page (one block per layer per receiver):
+//   1. remote_cb_wait_front(1)
+//   2. read the receiver's expected tile range from the source tensor via
+//      TensorAccessor (bank routing handled by the accessor — no hand-rolled
+//      addr arithmetic)
+//   3. memcmp expected vs received page; on mismatch DPRINT details + hang
+//   4. remote_cb_pop_front(1)
+// After num_layers * num_blocks iterations, bounded-poll for extra pages so
+// sender overshoot still surfaces.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/remote_circular_buffer.h"
+#include "api/tensor/tensor_accessor.h"
+#include "api/debug/dprint.h"
+
+namespace {
+
+constexpr uint32_t kExtraPollCycles = 1u << 18;  // ~262k spin iterations
+
+}  // namespace
+
+void kernel_main() {
+    // ---- Compile-time args ----
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t scratch_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t num_layers = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(3);
+    constexpr uint32_t num_senders = get_compile_time_arg_val(4);
+    constexpr uint32_t print_stride = get_compile_time_arg_val(5);
+    // TensorAccessor compile-time args start at index 6.
+    constexpr auto tensor_args = TensorAccessorArgs<6>();
+
+    // ---- Runtime args ----
+    uint32_t rt_idx = 0;
+    const uint32_t bank_id = get_arg_val<uint32_t>(rt_idx++);           // sender's DRAM bank
+    const uint32_t recv_idx_in_bank = get_arg_val<uint32_t>(rt_idx++);  // 0 .. num_receivers_per_sender-1
+    const uint32_t bank_base_addr = get_arg_val<uint32_t>(rt_idx++);    // source tensor base addr
+    const uint32_t k_block_w_tiles = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t n_per_bank_tiles = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t n_per_recv_tiles = get_arg_val<uint32_t>(rt_idx++);
+
+    const auto accessor = TensorAccessor(tensor_args, bank_base_addr);
+    const uint32_t tile_bytes = accessor.get_aligned_page_size();
+    const uint32_t total_n_tiles = num_senders * n_per_bank_tiles;
+    const uint32_t slice_bytes = n_per_recv_tiles * tile_bytes;
+    const uint32_t page_bytes = k_block_w_tiles * slice_bytes;
+    const uint32_t n_col_start = bank_id * n_per_bank_tiles + recv_idx_in_bank * n_per_recv_tiles;
+
+    const uint32_t scratch_addr = get_write_ptr(scratch_cb_id);
+
+    DPRINT << "VALIDATOR_START bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << " num_layers=" << num_layers
+           << " num_blocks=" << num_blocks << " page=" << page_bytes << " tile=" << tile_bytes << ENDL();
+
+    uint32_t global_iter = 0;
+    for (uint32_t layer = 0; layer < num_layers; ++layer) {
+        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+            experimental::remote_cb_wait_front(remote_cb_id, 1);
+            RemoteReceiverCBInterface& iface = get_remote_receiver_cb_interface(remote_cb_id);
+            const uint32_t page_addr = iface.fifo_rd_ptr;
+
+            // Read expected tiles via TensorAccessor. Per tt_metal/impl/buffers/prefetcher_matmul_design.md §3,
+            // page row h = tiles (blk*kw + h, n_col_start + n) for n in [0, n_per_recv). One
+            // accessor call per tile keeps bank-routing logic out of this kernel.
+            uint32_t scratch_cursor = scratch_addr;
+            for (uint32_t h = 0; h < k_block_w_tiles; ++h) {
+                const uint32_t k_row = blk * k_block_w_tiles + h;
+                const uint32_t row_page_base = k_row * total_n_tiles + n_col_start;
+                for (uint32_t n = 0; n < n_per_recv_tiles; ++n) {
+                    const uint64_t src_noc = accessor.get_noc_addr(row_page_base + n);
+                    noc_async_read(src_noc, scratch_cursor, tile_bytes);
+                    scratch_cursor += tile_bytes;
+                }
+            }
+            noc_async_read_barrier();
+
+            // Byte-for-byte compare. Word-stride loop; report the first mismatching word.
+            volatile tt_l1_ptr uint32_t* received = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_addr);
+            volatile tt_l1_ptr uint32_t* expected = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_addr);
+            const uint32_t words = page_bytes / sizeof(uint32_t);
+            uint32_t mismatch_word = words;
+            for (uint32_t w = 0; w < words; ++w) {
+                if (received[w] != expected[w]) {
+                    mismatch_word = w;
+                    break;
+                }
+            }
+            if (mismatch_word != words) {
+                DPRINT << "VALIDATOR_MISMATCH layer=" << layer << " blk=" << blk << " bank=" << bank_id
+                       << " recv_idx=" << recv_idx_in_bank << " word=" << mismatch_word << " got=0x" << HEX()
+                       << received[mismatch_word] << " exp=0x" << expected[mismatch_word] << ENDL();
+                // Hang so the dispatch timeout surfaces this core.
+                while (true) {
+                    ;
+                }
+            }
+
+            const bool log = (global_iter < 2) || (global_iter + 1 == num_layers * num_blocks) ||
+                             (print_stride > 0 && (global_iter % print_stride == 0));
+            if (log) {
+                DPRINT << "VALIDATOR ok layer=" << layer << " blk=" << blk << " bank=" << bank_id
+                       << " recv_idx=" << recv_idx_in_bank << ENDL();
+            }
+
+            experimental::remote_cb_pop_front(remote_cb_id, 1);
+            ++global_iter;
+        }
+    }
+
+    DPRINT << "VALIDATOR_LOOP_DONE bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << ENDL();
+
+    // Bounded-poll for an extra page (sender overshoot).
+    volatile tt_l1_ptr uint32_t* pages_acked_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        get_remote_receiver_cb_interface(remote_cb_id).aligned_pages_acked_ptr);
+    volatile tt_l1_ptr uint32_t* pages_sent_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        get_remote_receiver_cb_interface(remote_cb_id).aligned_pages_acked_ptr - L1_ALIGNMENT);
+    for (uint32_t spin = 0; spin < kExtraPollCycles; ++spin) {
+        invalidate_l1_cache();
+        const uint32_t sent = *pages_sent_ptr;
+        const uint32_t acked = *pages_acked_ptr;
+        if (sent != acked) {
+            DPRINT << "VALIDATOR_OVERFLOW: sender pushed an extra page; pages_sent=" << sent << " pages_acked=" << acked
+                   << ENDL();
+            while (true) {
+                ;
+            }
+        }
+    }
+
+    DPRINT << "VALIDATOR_DONE ok bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << ENDL();
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc_async_atomic_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp
@@ -59,8 +59,14 @@ void kernel_main() {
 
     const uint32_t scratch_addr = get_write_ptr(scratch_cb_id);
 
-    DPRINT << "VALIDATOR_START bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << " num_layers=" << num_layers
-           << " num_blocks=" << num_blocks << " page=" << page_bytes << " tile=" << tile_bytes << ENDL();
+    DPRINT(
+        "VALIDATOR_START bank={} recv_idx={} num_layers={} num_blocks={} page={} tile={}\n",
+        bank_id,
+        recv_idx_in_bank,
+        num_layers,
+        num_blocks,
+        page_bytes,
+        tile_bytes);
 
     uint32_t global_iter = 0;
     for (uint32_t layer = 0; layer < num_layers; ++layer) {
@@ -96,9 +102,15 @@ void kernel_main() {
                 }
             }
             if (mismatch_word != words) {
-                DPRINT << "VALIDATOR_MISMATCH layer=" << layer << " blk=" << blk << " bank=" << bank_id
-                       << " recv_idx=" << recv_idx_in_bank << " word=" << mismatch_word << " got=0x" << HEX()
-                       << received[mismatch_word] << " exp=0x" << expected[mismatch_word] << ENDL();
+                DPRINT(
+                    "VALIDATOR_MISMATCH layer={} blk={} bank={} recv_idx={} word={} got=0x{:x} exp=0x{:x}\n",
+                    layer,
+                    blk,
+                    bank_id,
+                    recv_idx_in_bank,
+                    mismatch_word,
+                    (uint32_t)received[mismatch_word],
+                    (uint32_t)expected[mismatch_word]);
                 // Hang so the dispatch timeout surfaces this core.
                 while (true) {
                     ;
@@ -108,8 +120,7 @@ void kernel_main() {
             const bool log = (global_iter < 2) || (global_iter + 1 == num_layers * num_blocks) ||
                              (print_stride > 0 && (global_iter % print_stride == 0));
             if (log) {
-                DPRINT << "VALIDATOR ok layer=" << layer << " blk=" << blk << " bank=" << bank_id
-                       << " recv_idx=" << recv_idx_in_bank << ENDL();
+                DPRINT("VALIDATOR ok layer={} blk={} bank={} recv_idx={}\n", layer, blk, bank_id, recv_idx_in_bank);
             }
 
             experimental::remote_cb_pop_front(remote_cb_id, 1);
@@ -117,7 +128,7 @@ void kernel_main() {
         }
     }
 
-    DPRINT << "VALIDATOR_LOOP_DONE bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << ENDL();
+    DPRINT("VALIDATOR_LOOP_DONE bank={} recv_idx={}\n", bank_id, recv_idx_in_bank);
 
     // Bounded-poll for an extra page (sender overshoot).
     volatile tt_l1_ptr uint32_t* pages_acked_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
@@ -129,15 +140,14 @@ void kernel_main() {
         const uint32_t sent = *pages_sent_ptr;
         const uint32_t acked = *pages_acked_ptr;
         if (sent != acked) {
-            DPRINT << "VALIDATOR_OVERFLOW: sender pushed an extra page; pages_sent=" << sent << " pages_acked=" << acked
-                   << ENDL();
+            DPRINT("VALIDATOR_OVERFLOW: sender pushed an extra page; pages_sent={} pages_acked={}\n", sent, acked);
             while (true) {
                 ;
             }
         }
     }
 
-    DPRINT << "VALIDATOR_DONE ok bank=" << bank_id << " recv_idx=" << recv_idx_in_bank << ENDL();
+    DPRINT("VALIDATOR_DONE ok bank={} recv_idx={}\n", bank_id, recv_idx_in_bank);
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
     noc_async_atomic_barrier();
 }

--- a/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import ttnn
+
+from models.common.utility_functions import run_for_blackhole
+
+
+pytestmark = [
+    run_for_blackhole("DramSenderGCB requires Blackhole"),
+    pytest.mark.skipif(
+        os.environ.get("TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES", "0") != "1",
+        reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
+    ),
+]
+
+
+def _single_recv(x: int, y: int) -> ttnn.CoreRangeSet:
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y))})
+
+
+def test_create_dram_sender_global_circular_buffer_single_bank(device):
+    bank_to_receivers = [(0, _single_recv(0, 0))]
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, 1024)
+    assert gcb.size() == 1024
+    assert gcb.sender_cores().num_cores() == 1
+    assert gcb.receiver_cores().num_cores() == 1
+
+
+def test_create_dram_sender_global_circular_buffer_multi_bank_disjoint(device):
+    # Each bank gets a disjoint single-core receiver set.
+    bank_to_receivers = [(b, _single_recv(b, 0)) for b in range(4)]
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, 2048)
+    assert gcb.size() == 2048
+    assert gcb.sender_cores().num_cores() == 4
+    assert gcb.receiver_cores().num_cores() == 4

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -25,6 +25,14 @@ from tracy import signpost
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import get_core_ranges
 
 
+def round_up(n, m):
+    return ((n + m - 1) // m) * m
+
+
+def bytes_per_tile(dtype) -> int:
+    return {ttnn.bfloat16: 2048, ttnn.bfloat8_b: 1088}[dtype]
+
+
 def run_prefetcher_mm(
     device,
     num_tensors,

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -188,10 +188,8 @@ def _gcb_size_capped(block_size_bytes: int, k: int, ring_size: int, max_buffered
     # Matmul receiver needs ~block_size_bytes of L1 for in1_CB (the per-receiver weight slice
     # fully buffered for gather_in0). To fit GCB + in1_CB + other matmul CBs in ~1.4 MB L1,
     # the GCB itself can't exceed ~(1.4 MB - block_size_bytes - matmul overhead).
-    # CRITICAL: gcb_size MUST be an exact multiple of the matmul's receiver fifo_page_size
-    # (= in1_block_size_bytes). If not, remote_cb_wait_front's wrap-adjustment math fires at
-    # the layer boundary and inflates the wait count by (fifo_size % page_size), causing the
-    # receiver to wait forever for pages the sender will never push.
+    # gcb_size is snapped (below) to a multiple of the matmul's receiver fifo_page_size
+    # (= in1_block_size_bytes) so the per-receiver fifo holds a whole number of pages.
     in1_block_size = _matmul_in1_block_size_bytes(k, ring_size)
     upper_l1 = max(block_size_bytes, 1_400_000 - block_size_bytes - _L1_BANK_HEADROOM_BYTES)
     upper_cb_pages_bytes = 65000 * 16  # 16 B page * <65535 pages = ~1 MB
@@ -453,9 +451,11 @@ def test_bench_dram_core_repeats(device, op_name, shape):
     # Capture a trace of `trace_repeats` cached single-matmul dispatches and replay it once.
     # The prefetcher feeds one layer per matmul, so num_prefetch_layers = 1 + trace_repeats.
     bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    bench_output = None
     for _ in range(trace_repeats):
         bench_output = single_linear()  # Keep a named reference so the output buffer stays alive.
     ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+    assert bench_output is not None  # trace_repeats > 0, so the loop ran at least once.
 
     t0 = time.perf_counter()
     ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)
@@ -658,9 +658,11 @@ def test_bench_workercore_repeats(device, op_name, shape):
 
     # Capture a trace of `trace_repeats` cached single-matmul dispatches and replay it once.
     bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    bench_output = None
     for _ in range(trace_repeats):
         bench_output = single_linear()  # Keep named so the output buffer stays alive.
     ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+    assert bench_output is not None  # trace_repeats > 0, so the loop ran at least once.
 
     t0 = time.perf_counter()
     ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -1,0 +1,676 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark: DRAM-core prefetcher vs worker-core prefetcher on Blackhole.
+
+Parametrized over Llama-3.2-1B, Llama-3.2-3B, Llama-3.1-8B, Llama-3.3-70B production
+prefetcher matmuls (QKV / WO / FF1 / FF2). For models that need multi-device tensor
+parallelism in production (`is_prefetcher_supported` returns False at lower device
+counts), tensor shapes are computed at the smallest device count where the worker
+prefetcher fits: 1B/3B at 1 device, 8B at 2 devices, 70B at 8 devices.
+
+Both paths share the same gather_in0 matmul kernels and the same production scattered
+receiver layout / receiver sub-device / stall group setup. The only difference is
+which prefetcher is used:
+- DRAM-core: DRISC kernel on DRAM cores, started once via
+  `start_dram_core_prefetcher(num_layers=N+1)` before the trace, stopped after.
+- Worker-core: BRISC+NCRISC kernels on worker cores, dispatched once via
+  `ttnn.dram_prefetcher(num_layers=N+1)` before the trace.
+
+Both push N+1 layers (1 warmup + N traced); both traces contain only N matmul
+launches. Sender/receiver layout from `models/tt_transformers/tt/prefetcher/prefetcher_config.yaml`
+(production col-0/col-7 senders, scattered receivers); matmul pinned to receivers
+via `sub_device_id`.
+
+Shape envs `BENCH_K / BENCH_N / BENCH_DTYPE / BENCH_RECV_PER_BANK` override the
+parametrize values for ad-hoc runs. `BENCH_TRACE_REPEATS` (default 100) controls the
+trace replay length for both paths. All shapes use ring=64 (8 banks × 8
+receivers/bank) and bfloat8_b.
+
+Per-shape results: see `docs/dram_core_prefetcher_bench_results.md`. The
+table there was measured with the previous worker-core trace shape and is
+pending re-measurement after the move to N discrete `ttnn.linear` launches.
+
+Caveats:
+- Both paths trace exactly N single matmul dispatches; the prefetcher runs once
+  out-of-band ahead of the trace and is consumed by the warmup matmul + the N
+  traced matmuls (production-faithful: each decoder layer is a separate dispatch).
+- TFLOP/s uses unpadded (K, N) for both paths (the formula honors the actual matmul
+  work; padding for ring divisibility doesn't count as useful flops).
+"""
+
+import math
+import os
+import time
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import run_for_blackhole
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+pytestmark = [
+    run_for_blackhole("DRAM-core prefetcher requires Blackhole"),
+    pytest.mark.skipif(
+        os.environ.get("TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES", "0") != "1",
+        reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
+    ),
+]
+
+
+def _round_up(n, m):
+    return ((n + m - 1) // m) * m
+
+
+def _select_num_dram_banks(available_banks: int) -> int:
+    n_tiles = _N // ttnn.TILE_SIZE
+    candidates = [b for b in range(available_banks, 0, -1) if n_tiles % b == 0 and _N % b == 0]
+    return candidates[0]
+
+
+def _select_num_receivers_per_bank(num_dram_banks: int) -> int:
+    n_tiles_per_bank = (_N // num_dram_banks) // ttnn.TILE_SIZE
+    candidates = [r for r in range(_NUM_RECV_PER_BANK, n_tiles_per_bank + 1) if n_tiles_per_bank % r == 0]
+    return candidates[0]
+
+
+_M = 32
+_NUM_DRAM_BANKS = 8
+
+# Module-level shape vars. Mutable: rewritten by `_apply_shape()` at the top of each test
+# from the pytest parameter (with BENCH_* env overrides for ad-hoc runs). Helpers below
+# read these as ambient module state so we don't have to thread `K, N, dtype, recv_per_bank`
+# through every helper signature. `_N` is the **padded** N (up to ring*TILE_SIZE) used by
+# all sizing math; `_N_ORIG` is the original N used only in the TFLOP/s formula.
+_K = 512
+_K_ORIG = 512
+_N = 1024
+_N_ORIG = 1024
+_NUM_RECV_PER_BANK = 1
+_RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
+_RING_COLS = 8
+_RING_ROWS = 1
+_DTYPE_NAME = "bfloat16"
+_DTYPE = ttnn.bfloat16
+_DTYPE_BYTES = 2
+
+_DTYPE_FROM_NAME = {"bfloat16": ttnn.bfloat16, "bfloat8_b": ttnn.bfloat8_b}
+_DTYPE_BYTES_FROM_NAME = {"bfloat16": 2, "bfloat8_b": 1088 / 1024.0}  # bf8_b includes per-tile header
+
+
+# Production Llama prefetcher-fed matmul shapes on Blackhole (ring=64, bf8_b).
+# Per-device shapes from tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py:
+# QKV is N-sharded (qkv_size = head_dim*(2*n_kv_heads + n_heads)), WO is K-sharded
+# (n_heads*head_dim), FF1/FF3 are N-sharded (hidden_dim), FF2 is K-sharded (hidden_dim).
+# For models that don't fit single-device (Llama-3.1-8B, Llama-3.3-70B), shapes are
+# computed for tensor parallelism = 2 devices (per the goal).
+#
+# Llama-3.2-1B  (1 dev): dim=2048, hidden_dim=8192,  n_heads=32, n_kv_heads=8, head_dim=64,  qkv=3072
+# Llama-3.2-3B  (1 dev): dim=3072, hidden_dim=8192,  n_heads=24, n_kv_heads=8, head_dim=128, qkv=5120
+# Llama-3.1-8B  (2 dev): dim=4096, hidden_dim=14336, n_heads=32, n_kv_heads=8, head_dim=128, qkv=6144
+# Llama-3.3-70B (2 dev): dim=8192, hidden_dim=28672, n_heads=64, n_kv_heads=8, head_dim=128, qkv=10240
+#
+# All shapes use ring=64 (8 banks × 8 receivers/bank); N gets padded up to ring*TILE_SIZE in
+# the test body when not already a multiple.
+LLAMA_SHAPES = [
+    # Llama-3.2-1B, single-device per-op shapes (no TP).
+    pytest.param("1B_QKV", dict(K=2048, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="1B_QKV"),
+    pytest.param("1B_WO", dict(K=2048, N=2048, dtype="bfloat8_b", recv_per_bank=8), id="1B_WO"),
+    pytest.param("1B_FF1", dict(K=2048, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="1B_FF1"),
+    pytest.param("1B_FF2", dict(K=8192, N=2048, dtype="bfloat8_b", recv_per_bank=8), id="1B_FF2"),
+    # Llama-3.2-3B, single-device.
+    pytest.param("3B_QKV", dict(K=3072, N=5120, dtype="bfloat8_b", recv_per_bank=8), id="3B_QKV"),
+    pytest.param("3B_WO", dict(K=3072, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="3B_WO"),
+    pytest.param("3B_FF1", dict(K=3072, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="3B_FF1"),
+    pytest.param("3B_FF2", dict(K=8192, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="3B_FF2"),
+    # Llama-3.1-8B at 2 devices (single-device doesn't fit worker L1 budget).
+    pytest.param("8B_QKV_2d", dict(K=4096, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="8B_QKV_2d"),
+    pytest.param("8B_WO_2d", dict(K=2048, N=4096, dtype="bfloat8_b", recv_per_bank=8), id="8B_WO_2d"),
+    pytest.param("8B_FF1_2d", dict(K=4096, N=7168, dtype="bfloat8_b", recv_per_bank=8), id="8B_FF1_2d"),
+    pytest.param("8B_FF2_2d", dict(K=7168, N=4096, dtype="bfloat8_b", recv_per_bank=8), id="8B_FF2_2d"),
+    # Llama-3.3-70B at 8 devices (2/4 don't fit is_prefetcher_supported's 1 MB/core).
+    # dim=8192, hidden=28672, n_heads=64, n_kv_heads=8, head_dim=128, qkv_size=10240.
+    # Per-device: qkv N=10240/8=1280, wo K=64*128/8=1024, ff1 N=28672/8=3584, ff2 K=28672/8=3584.
+    pytest.param("70B_QKV_8d", dict(K=8192, N=1280, dtype="bfloat8_b", recv_per_bank=8), id="70B_QKV_8d"),
+    pytest.param("70B_WO_8d", dict(K=1024, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="70B_WO_8d"),
+    pytest.param("70B_FF1_8d", dict(K=8192, N=3584, dtype="bfloat8_b", recv_per_bank=8), id="70B_FF1_8d"),
+    pytest.param("70B_FF2_8d", dict(K=3584, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="70B_FF2_8d"),
+]
+
+
+def _apply_shape(shape: dict) -> None:
+    """Set module globals from the parametrize dict, allowing BENCH_* env vars to override.
+
+    Tests call this at the top of their body so all helpers below see the shape via ambient
+    module state. Run with `BENCH_K=... BENCH_N=...` to override the parametrize values for
+    ad-hoc one-off runs.
+
+    `_N` is the padded N (up to ring*TILE_SIZE) used by all sizing math; `_N_ORIG` is the
+    original N from the shape, used in the TFLOP/s formula so headline numbers reflect the
+    actual matmul work (not the padded extra).
+    """
+    global _K, _K_ORIG, _N, _N_ORIG, _NUM_RECV_PER_BANK, _RING_SIZE, _RING_ROWS
+    global _DTYPE_NAME, _DTYPE, _DTYPE_BYTES
+    _K_ORIG = int(os.environ.get("BENCH_K", shape["K"]))
+    _N_ORIG = int(os.environ.get("BENCH_N", shape["N"]))
+    _NUM_RECV_PER_BANK = int(os.environ.get("BENCH_RECV_PER_BANK", shape["recv_per_bank"]))
+    _RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
+    assert _RING_SIZE % _RING_COLS == 0, f"ring_size {_RING_SIZE} not a clean rect on 8-col grid"
+    _RING_ROWS = _RING_SIZE // _RING_COLS
+    # Pad K and N to multiples of (ring_size * TILE_SIZE) so every ring receiver gets at
+    # least one tile in each direction. Matches production's pad_n_to_ring_size() in
+    # test_prefetcher_BH.py and the h_tiles_padded round-up in is_prefetcher_supported.
+    _K = _round_up(_K_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
+    _N = _round_up(_N_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
+    _DTYPE_NAME = os.environ.get("BENCH_DTYPE", shape["dtype"])
+    _DTYPE = _DTYPE_FROM_NAME[_DTYPE_NAME]
+    _DTYPE_BYTES = _DTYPE_BYTES_FROM_NAME[_DTYPE_NAME]
+
+
+# Cap GCB to leave headroom in L1 for the matmul CBs (in1 double-buffered, in2 ring history,
+# in0, out, interm0). The worker-core path also requires gcb_size >= one full per-receiver
+# tensor, so we clamp from below to that.
+_L1_BANK_HEADROOM_BYTES = 256 * 1024  # leave 256 KB for matmul + activation + output L1
+
+
+def _matmul_in1_block_size_bytes(k: int, ring_size: int) -> int:
+    """Matmul's receiver fifo_page_size = in0_block_w * per_core_N * tile_bytes.
+    in0_block_w (matmul-computed) = K_per_shard_tiles, per_core_N = N_per_recv_tiles."""
+    k_per_shard_tiles = (k // ring_size) // ttnn.TILE_SIZE
+    n_per_recv_tiles = (_N // ring_size) // ttnn.TILE_SIZE
+    return k_per_shard_tiles * n_per_recv_tiles * int(_DTYPE_BYTES * ttnn.TILE_SIZE * ttnn.TILE_SIZE)
+
+
+def _gcb_size_capped(block_size_bytes: int, k: int, ring_size: int, max_buffered_blocks: int = 4) -> int:
+    # Matmul receiver needs ~block_size_bytes of L1 for in1_CB (the per-receiver weight slice
+    # fully buffered for gather_in0). To fit GCB + in1_CB + other matmul CBs in ~1.4 MB L1,
+    # the GCB itself can't exceed ~(1.4 MB - block_size_bytes - matmul overhead).
+    # CRITICAL: gcb_size MUST be an exact multiple of the matmul's receiver fifo_page_size
+    # (= in1_block_size_bytes). If not, remote_cb_wait_front's wrap-adjustment math fires at
+    # the layer boundary and inflates the wait count by (fifo_size % page_size), causing the
+    # receiver to wait forever for pages the sender will never push.
+    in1_block_size = _matmul_in1_block_size_bytes(k, ring_size)
+    upper_l1 = max(block_size_bytes, 1_400_000 - block_size_bytes - _L1_BANK_HEADROOM_BYTES)
+    upper_cb_pages_bytes = 65000 * 16  # 16 B page * <65535 pages = ~1 MB
+    upper = min(upper_l1, upper_cb_pages_bytes)
+    desired = block_size_bytes * max_buffered_blocks
+    sized = max(block_size_bytes, min(desired, upper))
+    # Snap to a multiple of in1_block_size (rounding down so we stay under the L1 cap).
+    sized = max(in1_block_size, (sized // in1_block_size) * in1_block_size)
+    if sized // 16 >= 65535:
+        sized = (65000 * 16 // in1_block_size) * in1_block_size
+    return sized
+
+
+def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int, row_offset: int = 0):
+    """Return the CoreRangeSet for bank `bank_idx`'s receivers, laid out as the
+    contiguous row-major slice of the ring at positions [b*recv_per_bank, (b+1)*recv_per_bank).
+    `row_offset` shifts the whole rectangle down (used by worker-core to put senders on row 0)."""
+    cores = []
+    for k in range(recv_per_bank):
+        ring_pos = bank_idx * recv_per_bank + k
+        col = ring_pos % ring_cols
+        row = ring_pos // ring_cols + row_offset
+        cores.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+    return ttnn.CoreRangeSet(cores)
+
+
+def _build_program_config(
+    ring_size: int,
+    ring_cols: int,
+    ring_rows: int,
+    num_global_cb_receivers: int,
+) -> ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig:
+    in0_block_w = 1  # The DRISC prefetcher factory hard-codes in0_block_w_tiles=1.
+    out_block_h = _M // ttnn.TILE_SIZE
+    out_block_w = _N // ring_size // ttnn.TILE_SIZE
+    out_subblock_w = min(out_block_w, 8)
+    while out_subblock_w > 1 and out_block_w % out_subblock_w != 0:
+        out_subblock_w -= 1
+    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        per_core_M=out_block_h,
+        per_core_N=out_block_w,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=True,
+        hop_cores=ttnn.CoreRangeSet([]),
+        # Each bank's N-width is split across `_NUM_RECV_PER_BANK` matmul receivers.
+        # Matmul sizes in1_CB as `N_per_bank_tiles / num_global_cb_receivers`, so this
+        # must match the actual receiver count per bank, otherwise in1_CB is oversized
+        # (causing OOM or sender stall via mismatched cb sizes).
+        num_global_cb_receivers=num_global_cb_receivers,
+        untilize_out=False,
+    )
+
+
+def _flops_per_matmul(k: int) -> int:
+    # Use the unpadded K and N: padded zeros aren't useful flops. (Callers pass _K or
+    # _K_padded depending on what they have at hand; either way swap in _K_ORIG.)
+    return 2 * _M * _K_ORIG * _N_ORIG
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("op_name,shape", LLAMA_SHAPES)
+def test_bench_dram_core_repeats(device, op_name, shape):
+    """Trace replay of N single-matmul launches fed by the DRISC prefetcher.
+
+    Parametrized over Llama-3.1-8B prefetcher-fed matmul shapes (FF1, QKV, O, FF2).
+    BENCH_K / BENCH_N / BENCH_DTYPE / BENCH_RECV_PER_BANK env vars override per-parameter.
+    """
+    _apply_shape(shape)
+
+    trace_repeats = int(os.environ.get("BENCH_TRACE_REPEATS", "100"))
+    num_prefetch_layers = trace_repeats + 1  # 1 warmup + trace_repeats inside the trace
+    if device.dram_grid_size().x != 8:
+        pytest.skip("Production receiver layout requires 8 unharvested DRAM banks")
+    num_dram_banks = _select_num_dram_banks(device.dram_grid_size().x)
+    num_receivers_per_bank = _select_num_receivers_per_bank(num_dram_banks)
+    ring_size = num_dram_banks * num_receivers_per_bank
+    ring_cols = max(c for c in range(min(_NUM_DRAM_BANKS, ring_size), 0, -1) if ring_size % c == 0)
+    ring_rows = ring_size // ring_cols
+    k_padded = _round_up(_K, ring_size * ttnn.TILE_SIZE)
+    if num_dram_banks != _NUM_DRAM_BANKS or num_receivers_per_bank != _NUM_RECV_PER_BANK:
+        pytest.skip(
+            f"Production receiver layout requires {_NUM_DRAM_BANKS} banks x {_NUM_RECV_PER_BANK} recv/bank, "
+            f"got {num_dram_banks} x {num_receivers_per_bank}"
+        )
+
+    # Production scattered receiver layout (matches test_bench_workercore_repeats) so the
+    # matmul receiver/in0-gather NoC paths are identical between the two paths.
+    from models.tt_transformers.tt.prefetcher import generate_sender_receiver_mapping, ARCH_CONFIG
+
+    bh_cfg = ARCH_CONFIG["blackhole"]
+    raw_mapping = generate_sender_receiver_mapping(num_receivers_per_sender=num_receivers_per_bank)
+    left_y = bh_cfg["bank_ordered_y_coords"]["left"]
+    right_y = bh_cfg["bank_ordered_y_coords"]["right"]
+    left_col = bh_cfg["sender_cols"]["left"]
+    right_col = bh_cfg["sender_cols"]["right"]
+    ordered_senders = [(left_col, y) for y in left_y] + [(right_col, y) for y in right_y]
+    # Group production receivers by y-row, then sort rows so each group of 8 receivers
+    # occupies contiguous ring positions in the matmul's row-major walk. Then pair DRAM
+    # bank i with the i-th sorted y-row: bank i's N-slice lands at ring positions
+    # [i*recv_per_bank, (i+1)*recv_per_bank) — matching the matmul's expected layout.
+    receivers_by_y: dict = {}
+    for sx, sy in ordered_senders:
+        receivers_by_y.setdefault(sy, []).extend(raw_mapping[(sx, sy)])
+    sorted_ys = sorted(receivers_by_y.keys())
+    assert len(sorted_ys) == num_dram_banks, f"want {num_dram_banks} y-rows, got {len(sorted_ys)}"
+    receivers_per_y = [sorted(receivers_by_y[y]) for y in sorted_ys]  # row-major-sortable
+    receiver_core_range_set = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry)) for row in receivers_per_y for rx, ry in row]
+    )
+
+    # Pin the matmul to the receiver sub-device + stall group (matches worker-core test).
+    receiver_sub_device = ttnn.SubDevice([receiver_core_range_set])
+    sub_device_manager = device.create_sub_device_manager([receiver_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    receiver_sub_device_id = ttnn.SubDeviceId(0)
+    device.set_sub_device_stall_group([receiver_sub_device_id])
+
+    torch.manual_seed(0xBE7)
+    pt_weight = torch.zeros(1, 1, k_padded, _N)
+    pt_weight[:, :, :_K, :] = torch.randn(1, 1, _K, _N)
+    pt_act = torch.zeros(1, 1, _M, k_padded)
+    pt_act[:, :, :, :_K] = torch.randn(1, 1, _M, _K)
+
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [k_padded, _N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=_DTYPE, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    K_per_shard = k_padded // ring_size
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(_M, K_per_shard),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(
+        pt_act, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config
+    )
+
+    # tensor_addrs is unused by the DRAM-core path but required by op contract.
+    addrs = ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    # bytes/elem: bf16=2, bf8_b≈1.0625 (1088B/tile / 1024 elems/tile)
+    block_size_bytes = int((k_padded * (_N // num_dram_banks) // num_receivers_per_bank) * _DTYPE_BYTES)
+    # max_buffered_blocks=1 keeps GCB ~= one fifo-page, leaving room for matmul receiver
+    # CBs in worker L1 (1.4 MB). Larger shapes (70B FF1/FF2) overflow at deeper GCBs.
+    gcb_size = _gcb_size_capped(block_size_bytes, k=k_padded, ring_size=ring_size, max_buffered_blocks=1)
+    # Pair DRAM bank i with the receivers of the i-th sorted y-row so bank i pushes to
+    # ring positions [i*recv_per_bank, (i+1)*recv_per_bank) — required by the gather_in0
+    # matmul's bank-to-receivers ordering assertion.
+    bank_to_receivers = [
+        (
+            bank_idx,
+            ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry)) for rx, ry in row]),
+        )
+        for bank_idx, row in enumerate(receivers_per_y)
+    ]
+    cc_program_config = _build_program_config(
+        ring_size=ring_size,
+        ring_cols=ring_cols,
+        ring_rows=ring_rows,
+        num_global_cb_receivers=num_receivers_per_bank,
+    )
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [cc_program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=gcb_size,
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(_M, _N // ring_size),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    logger.info(
+        f"[dram_core][{op_name}] K={_K} K_padded={k_padded} N={_N} banks={num_dram_banks} ring={ring_size} "
+        f"gcb_size={gcb_size} trace_repeats={trace_repeats} num_prefetch_layers={num_prefetch_layers}"
+    )
+
+    optional_output_tensor = ttnn.from_torch(
+        torch.zeros(1, 1, _M, _N),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=output_mem_config,
+    )
+
+    def single_linear():
+        return ttnn.linear(
+            tt_act,
+            tt_weight,
+            program_config=cc_program_config,
+            memory_config=output_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=ttnn.bfloat16,
+            global_cb=gcb,
+            optional_output_tensor=optional_output_tensor,
+            sub_device_id=receiver_sub_device_id,
+        )
+
+    # One long-lived DRISC stream: 1 warmup/correctness layer + trace_repeats traced layers.
+    ttnn.experimental.start_dram_core_prefetcher(
+        device,
+        [tt_weight, addrs],
+        num_layers=num_prefetch_layers,
+        global_cb=gcb,
+    )
+
+    # Correctness + program-cache warmup: one real one-matmul launch.
+    cc_out = single_linear()
+    cc_torch = ttnn.to_torch(cc_out)
+    expected = pt_act.float() @ pt_weight.float()
+    passing, output_str = comp_pcc(expected, cc_torch, 0.99)
+    logger.info(f"[bench] PCC: {output_str}")
+    assert passing, f"[bench] PCC failed: {output_str}"
+
+    # Capture a trace of `trace_repeats` cached single-matmul dispatches and replay it once.
+    # The prefetcher feeds one layer per matmul, so num_prefetch_layers = 1 + trace_repeats.
+    bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    for _ in range(trace_repeats):
+        bench_output = single_linear()  # Keep a named reference so the output buffer stays alive.
+    ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+
+    t0 = time.perf_counter()
+    ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = time.perf_counter() - t0
+    ttnn.release_trace(device, bench_trace)
+
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+
+    per_matmul_us = elapsed / trace_repeats * 1e6
+    # Use unpadded K in the TFLOP/s formula so it's comparable across paths (worker-core uses
+    # _K directly; padding to ring-aligned K is wasted work that doesn't count as useful flops).
+    tflops = _flops_per_matmul(_K) * trace_repeats / elapsed / 1e12
+    logger.info(
+        f"[dram_core][{op_name}] trace_elapsed={elapsed * 1e3:.2f}ms repeats={trace_repeats} "
+        f"per_matmul={per_matmul_us:.2f}us -> {tflops:.4f} TFLOP/s"
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("op_name,shape", LLAMA_SHAPES)
+def test_bench_workercore_repeats(device, op_name, shape):
+    """A/B baseline: same shape under trace replay with the worker-core prefetcher
+    (BRISC+NCRISC senders on worker cores instead of DRISC on DRAM cores). Both the
+    prefetcher op and the matmuls execute under FD inside the trace.
+
+    Parametrized over the same Llama shapes as the DRAM-core test. FF2 skipped because
+    it exceeds the worker prefetcher's L1 budget (matches production behavior — the
+    full-model `Prefetcher` class in models/tt_transformers/tt/prefetcher.py routes FF2
+    to a DRAM-sharded matmul instead of the prefetcher path).
+
+    Uses dispatch_core_axis=COL like the canonical `test_prefetcher_BH` to keep the
+    sender/receiver core grid (logical rows 0..ring_rows) clear of dispatch cores.
+    """
+    _apply_shape(shape)
+    if device.dram_grid_size().x != 8:
+        pytest.skip("Worker-sender bench expects 8 unharvested DRAM banks")
+
+    trace_repeats = int(os.environ.get("BENCH_TRACE_REPEATS", "100"))
+    num_prefetch_layers = trace_repeats + 1  # 1 warmup + trace_repeats inside the trace
+    num_senders = _NUM_DRAM_BANKS
+    ring_size = _RING_SIZE
+    ring_cols = _RING_COLS
+    ring_rows = _RING_ROWS
+
+    # Use the production sender/receiver layout from
+    # models/tt_transformers/tt/prefetcher/prefetcher_config.yaml. The naive row-major
+    # grid in the original bench collides with dispatch cores at physical workers
+    # 14-2/14-3 on Blackhole P150; the production layout avoids them by placing
+    # senders on cols 0 (left) and 7 (right) with bank-ordered rows.
+    from models.tt_transformers.tt.prefetcher import generate_sender_receiver_mapping, ARCH_CONFIG
+
+    bh_cfg = ARCH_CONFIG["blackhole"]
+    raw_mapping = generate_sender_receiver_mapping(num_receivers_per_sender=_NUM_RECV_PER_BANK)
+    left_y = bh_cfg["bank_ordered_y_coords"]["left"]
+    right_y = bh_cfg["bank_ordered_y_coords"]["right"]
+    left_col = bh_cfg["sender_cols"]["left"]
+    right_col = bh_cfg["sender_cols"]["right"]
+    # Senders in bank-ID order: left first, then right.
+    ordered_senders = [(left_col, y) for y in left_y] + [(right_col, y) for y in right_y]
+    assert len(ordered_senders) == num_senders, f"want {num_senders} senders, got {len(ordered_senders)}"
+
+    sender_receiver_mapping = [
+        (
+            ttnn.CoreCoord(sx, sy),
+            ttnn.CoreRangeSet(
+                [ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry)) for rx, ry in raw_mapping[(sx, sy)]]
+            ),
+        )
+        for sx, sy in ordered_senders
+    ]
+    sender_core_range_set = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(sx, sy), ttnn.CoreCoord(sx, sy)) for sx, sy in ordered_senders]
+    )
+    receiver_core_range_set = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry))
+            for sx, sy in ordered_senders
+            for rx, ry in raw_mapping[(sx, sy)]
+        ]
+    )
+    # gather_in0 matmul ignores compute_with_storage_grid_size and runs on the cores given
+    # by sub_device_id. Set up: sub_device 0 = senders, sub_device 1 = receivers; matmul
+    # runs on the second sub-device.
+    sender_sub_device = ttnn.SubDevice([sender_core_range_set])
+    receiver_sub_device = ttnn.SubDevice([receiver_core_range_set])
+    sub_device_manager = device.create_sub_device_manager([sender_sub_device, receiver_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    receiver_sub_device_id = ttnn.SubDeviceId(1)
+    device.set_sub_device_stall_group([receiver_sub_device_id])
+
+    # Per-sender, per-block bytes (each sender pushes its share of the weight).
+    block_size_bytes = int((_K * (_N // num_senders) // _NUM_RECV_PER_BANK) * _DTYPE_BYTES)
+    gcb_size = _gcb_size_capped(block_size_bytes, k=_K, ring_size=ring_size)
+    gcb = ttnn.create_global_circular_buffer(device, sender_receiver_mapping, gcb_size)
+
+    torch.manual_seed(0xBE8)
+    pt_weight = torch.randn(1, 1, _K, _N)
+    pt_act = torch.randn(1, 1, _M, _K)
+
+    # Weight: width-sharded in DRAM across `num_senders` banks.
+    dram_core_range_set = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_senders - 1, 0))})
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [_K, _N // num_senders], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=_DTYPE, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    # tensor_addrs: worker-core BRISC reader expects num_layers addresses per sender (= same
+    # tt_weight repeated for each iteration since the bench reuses the same matmul).
+    def _build_tensor_addrs(n_addrs: int) -> ttnn.Tensor:
+        addr_row = torch.tensor([tt_weight.buffer_address()] * n_addrs, dtype=torch.int32).reshape(1, n_addrs)
+        tensor_addrs = addr_row.repeat(num_senders, 1)  # one row per sender, all rows identical
+        return ttnn.as_tensor(
+            tensor_addrs,
+            device=device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(sender_core_range_set, [1, n_addrs], ttnn.ShardOrientation.ROW_MAJOR),
+            ),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+    # One dram_prefetcher invocation with num_layers=num_prefetch_layers pushes that many
+    # copies of the weight; 1 warmup matmul + N traced matmul launches each consume one.
+    tt_addrs = _build_tensor_addrs(num_prefetch_layers)
+
+    K_per_shard = _round_up(math.ceil(_K / ring_size), ttnn.TILE_SIZE)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(_M, K_per_shard),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(
+        pt_act, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config
+    )
+
+    program_config = _build_program_config(
+        ring_size=ring_size,
+        ring_cols=ring_cols,
+        ring_rows=ring_rows,
+        num_global_cb_receivers=_NUM_RECV_PER_BANK,
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(_M, _N // ring_size),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    logger.info(
+        f"[workercore][{op_name}] K={_K} N={_N} ring={ring_size} gcb_size={gcb_size} "
+        f"trace_repeats={trace_repeats} num_prefetch_layers={num_prefetch_layers}"
+    )
+
+    def single_linear():
+        return ttnn.linear(
+            tt_act,
+            tt_weight,
+            program_config=program_config,
+            memory_config=output_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=ttnn.bfloat16,
+            global_cb=gcb,
+            sub_device_id=receiver_sub_device_id,
+        )
+
+    # One bulk dram_prefetcher dispatch before the trace, mirroring the DRAM-core path's
+    # start_dram_core_prefetcher call. The kernel runs async on device and pushes
+    # num_prefetch_layers worth of pages; the warmup matmul + N traced matmul launches
+    # drain them as they arrive (GCB credit gates the producer/consumer pipeline).
+    ttnn.dram_prefetcher([tt_weight, tt_addrs], num_layers=num_prefetch_layers, global_cb=gcb)
+
+    # Correctness + program-cache warmup: one real one-matmul launch.
+    cc_out = single_linear()
+    cc_torch = ttnn.to_torch(cc_out)
+    expected = pt_act.float() @ pt_weight.float()
+    passing, output_str = comp_pcc(expected, cc_torch, 0.99)
+    logger.info(f"[workercore] PCC: {output_str}")
+    assert passing, f"[workercore] PCC failed: {output_str}"
+
+    # Capture a trace of `trace_repeats` cached single-matmul dispatches and replay it once.
+    bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    for _ in range(trace_repeats):
+        bench_output = single_linear()  # Keep named so the output buffer stays alive.
+    ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+
+    t0 = time.perf_counter()
+    ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = time.perf_counter() - t0
+    ttnn.release_trace(device, bench_trace)
+
+    per_matmul_us = elapsed / trace_repeats * 1e6
+    tflops = _flops_per_matmul(_K) * trace_repeats / elapsed / 1e12
+    logger.info(
+        f"[workercore][{op_name}] trace_elapsed={elapsed * 1e3:.2f}ms repeats={trace_repeats} "
+        f"per_matmul={per_matmul_us:.2f}us -> {tflops:.4f} TFLOP/s"
+    )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -50,6 +50,7 @@ from loguru import logger
 
 from models.common.utility_functions import run_for_blackhole
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.prefetcher_common import round_up as _round_up
 
 
 pytestmark = [
@@ -59,10 +60,6 @@ pytestmark = [
         reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
     ),
 ]
-
-
-def _round_up(n, m):
-    return ((n + m - 1) // m) * m
 
 
 def _select_num_dram_banks(available_banks: int) -> int:

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Push-bandwidth bench: DRAM-core prefetcher vs worker-core prefetcher.
+
+Mirrors `test_prefetcher_BH_bench.py`'s shape parametrization, but swaps the
+matmul receiver for `ttnn.experimental.test_dram_prefetcher_consumer` — a discard receiver
+that does `wait_front(1) + pop_front(1)` in a loop and throws the data
+away. This isolates the prefetcher's push bandwidth from receiver-side
+compute (no matmul, no L1 budget for matmul CBs).
+
+Methodology (identical shape on both paths):
+- Prefetcher launched/enqueued **once** outside the trace with
+  `num_layers = trace_repeats + 1` (1 warmup + N traced layers).
+- One warmup consumer call outside the trace, draining one layer
+  (= ring_size pages). This also primes the cached MeshWorkload so the
+  kernel-binary write happens here.
+- Trace captures `trace_repeats` consumer ops (each draining one layer)
+  and is replayed once. We time the replay + sync.
+
+The consumer op caches its MeshWorkload across calls
+(see `dram_prefetcher_consumer.cpp`). The first call writes the kernel
+binary to DRAM (incompatible with trace capture); subsequent calls with
+the same args reuse the cached workload and skip that write — so the
+warmup call outside the trace is what makes capture-then-replay legal.
+
+For the worker-core path the GCB sender/receiver mapping comes from the
+production prefetcher_config.yaml, and a sub-device pins the consumer to
+the receivers so it doesn't collide with dispatch cores.
+
+Page size matches what each path pushes per receiver per ring-block:
+`page_size = (K_padded / ring_size) * (N_padded / ring_size) * tile_bytes`.
+Per-layer per receiver = ring_size pages = K_padded * (N_padded / ring_size)
+* tile_bytes = the full per-receiver weight bytes.
+
+Shapes are the production Llama prefetcher matmul shapes at the smallest
+device count where the worker prefetcher fits — same set as the matmul
+bench. See docs/dram_core_prefetcher_bench_results.md for the matmul
+companion numbers and docs/dram_core_prefetcher_bw_results.md for the BW
+results table.
+"""
+
+import os
+import time
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import run_for_blackhole
+
+
+pytestmark = [
+    run_for_blackhole("DRAM-core prefetcher requires Blackhole"),
+    pytest.mark.skipif(
+        os.environ.get("TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES", "0") != "1",
+        reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
+    ),
+]
+
+
+_M = 32
+_NUM_DRAM_BANKS = 8
+
+# Mutable shape globals populated by _apply_shape() at the top of each test.
+_K = 512
+_K_ORIG = 512
+_N = 1024
+_N_ORIG = 1024
+_NUM_RECV_PER_BANK = 1
+_RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
+_RING_COLS = 8
+_RING_ROWS = 1
+_DTYPE_NAME = "bfloat8_b"
+_DTYPE = ttnn.bfloat8_b
+_DTYPE_BYTES = 1088 / 1024.0  # bfloat8_b per-element bytes including per-tile header
+
+_DTYPE_FROM_NAME = {"bfloat16": ttnn.bfloat16, "bfloat8_b": ttnn.bfloat8_b}
+_DTYPE_BYTES_FROM_NAME = {"bfloat16": 2, "bfloat8_b": 1088 / 1024.0}
+
+
+# Same set of shapes as test_prefetcher_BH_bench.py::LLAMA_SHAPES. Kept duplicated rather
+# than imported to keep this file self-contained; if you add a row here add it there too.
+LLAMA_SHAPES = [
+    # Llama-3.2-1B @ 1 dev
+    pytest.param("1B_QKV", dict(K=2048, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="1B_QKV"),
+    pytest.param("1B_WO", dict(K=2048, N=2048, dtype="bfloat8_b", recv_per_bank=8), id="1B_WO"),
+    pytest.param("1B_FF1", dict(K=2048, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="1B_FF1"),
+    pytest.param("1B_FF2", dict(K=8192, N=2048, dtype="bfloat8_b", recv_per_bank=8), id="1B_FF2"),
+    # Llama-3.2-3B @ 1 dev
+    pytest.param("3B_QKV", dict(K=3072, N=5120, dtype="bfloat8_b", recv_per_bank=8), id="3B_QKV"),
+    pytest.param("3B_WO", dict(K=3072, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="3B_WO"),
+    pytest.param("3B_FF1", dict(K=3072, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="3B_FF1"),
+    pytest.param("3B_FF2", dict(K=8192, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="3B_FF2"),
+    # Llama-3.1-8B @ 2 dev (per-device shapes)
+    pytest.param("8B_QKV_2d", dict(K=4096, N=3072, dtype="bfloat8_b", recv_per_bank=8), id="8B_QKV_2d"),
+    pytest.param("8B_WO_2d", dict(K=2048, N=4096, dtype="bfloat8_b", recv_per_bank=8), id="8B_WO_2d"),
+    pytest.param("8B_FF1_2d", dict(K=4096, N=7168, dtype="bfloat8_b", recv_per_bank=8), id="8B_FF1_2d"),
+    pytest.param("8B_FF2_2d", dict(K=7168, N=4096, dtype="bfloat8_b", recv_per_bank=8), id="8B_FF2_2d"),
+    # Llama-3.3-70B @ 8 dev (per-device shapes)
+    pytest.param("70B_QKV_8d", dict(K=8192, N=1280, dtype="bfloat8_b", recv_per_bank=8), id="70B_QKV_8d"),
+    pytest.param("70B_WO_8d", dict(K=1024, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="70B_WO_8d"),
+    pytest.param("70B_FF1_8d", dict(K=8192, N=3584, dtype="bfloat8_b", recv_per_bank=8), id="70B_FF1_8d"),
+    pytest.param("70B_FF2_8d", dict(K=3584, N=8192, dtype="bfloat8_b", recv_per_bank=8), id="70B_FF2_8d"),
+]
+
+
+def _bench_trace_repeats() -> int:
+    return int(os.environ.get("BENCH_TRACE_REPEATS", "100"))
+
+
+def _round_up(n, m):
+    return ((n + m - 1) // m) * m
+
+
+def _apply_shape(shape: dict) -> None:
+    global _K, _K_ORIG, _N, _N_ORIG, _NUM_RECV_PER_BANK, _RING_SIZE, _RING_ROWS
+    global _DTYPE_NAME, _DTYPE, _DTYPE_BYTES
+    _K_ORIG = int(os.environ.get("BENCH_K", shape["K"]))
+    _N_ORIG = int(os.environ.get("BENCH_N", shape["N"]))
+    _NUM_RECV_PER_BANK = int(os.environ.get("BENCH_RECV_PER_BANK", shape["recv_per_bank"]))
+    _RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
+    assert _RING_SIZE % _RING_COLS == 0, f"ring_size {_RING_SIZE} not a clean rect on {_RING_COLS}-col grid"
+    _RING_ROWS = _RING_SIZE // _RING_COLS
+    _K = _round_up(_K_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
+    _N = _round_up(_N_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
+    _DTYPE_NAME = os.environ.get("BENCH_DTYPE", shape["dtype"])
+    _DTYPE = _DTYPE_FROM_NAME[_DTYPE_NAME]
+    _DTYPE_BYTES = _DTYPE_BYTES_FROM_NAME[_DTYPE_NAME]
+
+
+def _per_receiver_page_size_bytes() -> int:
+    """One ring-block's bytes on a single receiver — matches what both prefetchers push
+    per block (DRAM-core: k_block_w_tiles * n_per_recv_tiles * tile_bytes; worker-core:
+    same value via the matmul writer's block_size_per_receiver derivation).
+    """
+    k_block_w_tiles = (_K // _RING_SIZE) // ttnn.TILE_SIZE
+    n_per_recv_tiles = (_N // _RING_SIZE) // ttnn.TILE_SIZE
+    return k_block_w_tiles * n_per_recv_tiles * int(_DTYPE_BYTES * ttnn.TILE_SIZE * ttnn.TILE_SIZE)
+
+
+def _gcb_size_bytes(page_size: int, pages_per_layer: int) -> int:
+    """Per-receiver GCB size = one full layer's worth of pages. Matches what the worker
+    path passes (`pages_per_layer * page_size`) so the two paths have symmetric buffer
+    depth. Previously this was `4 * page_size` for the DRAM-core path, which left only
+    4 pages of in-flight headroom and gave `reserve_back` a ~16× backpressure tax vs the
+    worker — making the comparison unfair (see docs/dram_core_prefetcher_drisc_profile.md).
+    """
+    return pages_per_layer * page_size
+
+
+def _build_weight(device, num_dram_banks: int) -> ttnn.Tensor:
+    """DRAM-width-sharded weight tensor (the prefetcher pulls from this)."""
+    torch.manual_seed(0xBED)
+    pt_weight = torch.randn(1, 1, _K, _N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [_K, _N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.as_tensor(pt_weight, device=device, dtype=_DTYPE, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
+
+
+def _build_dummy_addrs(device) -> ttnn.Tensor:
+    """tensor_addrs is unused on the DRAM-core path but required by op contract."""
+    return ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+
+def _gbps(bytes_total: float, elapsed_s: float) -> float:
+    return bytes_total / elapsed_s / 1e9
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("op_name,shape", LLAMA_SHAPES)
+def test_bw_dram_core_prefetcher(device, op_name, shape):
+    """DRAM-core prefetcher → discard receiver. Prefetcher launched out-of-band with
+    num_layers = trace_repeats + 1 (1 warmup + N traced). A trace captures N consumer
+    ops (each draining one layer worth = ring_size pages) and is replayed once. Same
+    methodology as the matmul bench (test_bench_dram_core_repeats).
+    """
+    _apply_shape(shape)
+
+    trace_repeats = _bench_trace_repeats()
+    num_prefetch_layers = trace_repeats + 1  # 1 warmup + trace_repeats inside the trace
+
+    num_dram_banks = device.dram_grid_size().x
+    num_receivers = num_dram_banks * _NUM_RECV_PER_BANK
+    page_size = _per_receiver_page_size_bytes()
+    pages_per_layer = num_receivers  # = ring_size
+
+    tt_weight = _build_weight(device, num_dram_banks)
+    addrs = _build_dummy_addrs(device)
+
+    # DRAM-sender GCB with a simple grid receiver layout (banks 0..N-1 in row 0;
+    # receivers stacked in rows 0..recv_per_bank-1). Works for DRAM-core because senders
+    # are DRAM cores, not workers — no dispatch-core collision.
+    bank_to_receivers = [
+        (
+            b,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(b, 0), ttnn.CoreCoord(b, _NUM_RECV_PER_BANK - 1))}),
+        )
+        for b in range(num_dram_banks)
+    ]
+    gcb_size = _gcb_size_bytes(page_size, pages_per_layer)
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+
+    logger.info(
+        f"[dram_core_bw][{op_name}] K={_K_ORIG} K_padded={_K} N={_N_ORIG} N_padded={_N} "
+        f"ring={num_receivers} page_size={page_size} pages_per_layer={pages_per_layer} "
+        f"gcb_size={gcb_size} trace_repeats={trace_repeats} num_prefetch_layers={num_prefetch_layers}"
+    )
+
+    ttnn.experimental.start_dram_core_prefetcher(
+        device, [tt_weight, addrs], num_layers=num_prefetch_layers, global_cb=gcb
+    )
+
+    # Warmup: drain 1 layer's worth of pages — this also primes the cached MeshWorkload
+    # so the binary write happens here, not inside the trace.
+    ttnn.experimental.test_dram_prefetcher_consumer(
+        device, num_iters=pages_per_layer, page_size_bytes=page_size, global_cb=gcb
+    )
+    ttnn.synchronize_device(device)
+
+    # Trace: trace_repeats consumer ops, each draining one layer (= pages_per_layer pages).
+    bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    for _ in range(trace_repeats):
+        ttnn.experimental.test_dram_prefetcher_consumer(
+            device, num_iters=pages_per_layer, page_size_bytes=page_size, global_cb=gcb
+        )
+    ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+
+    t0 = time.perf_counter()
+    ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = time.perf_counter() - t0
+    ttnn.release_trace(device, bench_trace)
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+
+    if os.environ.get("TT_METAL_WATCHER", "0") == "1":
+        time.sleep(3)  # let watcher dump DRISC ring buffers before device close
+
+    bytes_per_recv = trace_repeats * pages_per_layer * page_size
+    bytes_total = bytes_per_recv * num_receivers
+    bw_total = _gbps(bytes_total, elapsed)
+    bw_per_recv = bw_total / num_receivers
+    logger.info(
+        f"[dram_core_bw][{op_name}] trace_elapsed={elapsed * 1e3:.2f}ms "
+        f"bytes_per_recv={bytes_per_recv / 1e6:.1f}MB total_bytes={bytes_total / 1e9:.2f}GB "
+        f"aggregate_bw={bw_total:.2f} GB/s per_recv_bw={bw_per_recv:.3f} GB/s"
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("op_name,shape", LLAMA_SHAPES)
+def test_bw_workercore_prefetcher(device, op_name, shape):
+    """Worker-core prefetcher → discard receiver. Same shape as test_bw_dram_core:
+    prefetcher enqueued ONCE outside the trace with `num_layers = trace_repeats + 1`,
+    one warmup consumer call (drains 1 layer, primes the cached workload), then trace
+    captures `trace_repeats` consumer ops (each drains one layer). Sub-device pins the
+    consumer to the GCB receivers to avoid dispatch-core collision. Sender/receiver
+    layout from `models/tt_transformers/tt/prefetcher/prefetcher_config.yaml`.
+    """
+    _apply_shape(shape)
+    if device.dram_grid_size().x != 8:
+        pytest.skip("Worker-sender bench expects 8 unharvested DRAM banks")
+
+    trace_repeats = _bench_trace_repeats()
+    num_prefetch_layers = trace_repeats + 1  # 1 warmup + trace_repeats inside the trace
+    num_senders = _NUM_DRAM_BANKS
+    page_size = _per_receiver_page_size_bytes()
+    pages_per_layer = _RING_SIZE  # one page per ring position per layer per tensor
+
+    # Production sender/receiver layout (cols 0/7 senders, scattered receivers) from the
+    # YAML config. The naive row-major grid collides with dispatch cores on this hardware.
+    from models.tt_transformers.tt.prefetcher import generate_sender_receiver_mapping, ARCH_CONFIG
+
+    bh_cfg = ARCH_CONFIG["blackhole"]
+    raw_mapping = generate_sender_receiver_mapping(num_receivers_per_sender=_NUM_RECV_PER_BANK)
+    left_col = bh_cfg["sender_cols"]["left"]
+    right_col = bh_cfg["sender_cols"]["right"]
+    ordered_senders = [(left_col, y) for y in bh_cfg["bank_ordered_y_coords"]["left"]] + [
+        (right_col, y) for y in bh_cfg["bank_ordered_y_coords"]["right"]
+    ]
+    assert len(ordered_senders) == num_senders, f"want {num_senders} senders, got {len(ordered_senders)}"
+    sender_receiver_mapping = [
+        (
+            ttnn.CoreCoord(sx, sy),
+            ttnn.CoreRangeSet(
+                [ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry)) for rx, ry in raw_mapping[(sx, sy)]]
+            ),
+        )
+        for sx, sy in ordered_senders
+    ]
+    sender_core_range_set = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(sx, sy), ttnn.CoreCoord(sx, sy)) for sx, sy in ordered_senders]
+    )
+    receiver_core_range_set = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(rx, ry), ttnn.CoreCoord(rx, ry))
+            for sx, sy in ordered_senders
+            for rx, ry in raw_mapping[(sx, sy)]
+        ]
+    )
+    # Pin the workload to senders/receivers via sub-devices; without this the consumer
+    # would land on the (0..7, 0..7) logical rect and collide with dispatch cores.
+    sender_sub_device = ttnn.SubDevice([sender_core_range_set])
+    receiver_sub_device = ttnn.SubDevice([receiver_core_range_set])
+    sub_device_manager = device.create_sub_device_manager([sender_sub_device, receiver_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    receiver_sub_device_id = ttnn.SubDeviceId(1)
+    device.set_sub_device_stall_group([receiver_sub_device_id])
+
+    # Worker prefetcher validates max_tensor_size <= gcb.size(); size GCB to one full
+    # per-receiver tensor (= pages_per_layer * page_size).
+    gcb_size = pages_per_layer * page_size
+    gcb = ttnn.create_global_circular_buffer(device, sender_receiver_mapping, gcb_size)
+
+    tt_weight = _build_weight(device, num_senders)
+
+    # tensor_addrs: per-sender per-layer addresses (worker reader reads from addrs_cb).
+    addr_row = torch.tensor([tt_weight.buffer_address()] * num_prefetch_layers, dtype=torch.int32).reshape(
+        1, num_prefetch_layers
+    )
+    tensor_addrs = addr_row.repeat(num_senders, 1)
+    tt_addrs = ttnn.as_tensor(
+        tensor_addrs,
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(sender_core_range_set, [1, num_prefetch_layers], ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    logger.info(
+        f"[workercore_bw][{op_name}] K={_K_ORIG} K_padded={_K} N={_N_ORIG} N_padded={_N} "
+        f"ring={_RING_SIZE} page_size={page_size} pages_per_layer={pages_per_layer} "
+        f"gcb_size={gcb_size} trace_repeats={trace_repeats} num_prefetch_layers={num_prefetch_layers}"
+    )
+
+    # Launch the prefetcher exactly once for the whole bench (mirrors the DRAM-core
+    # path's `start_dram_core_prefetcher` call). One op invocation pushes
+    # num_prefetch_layers tensors; the consumer drains them in pages_per_layer chunks.
+    ttnn.dram_prefetcher(
+        [tt_weight, tt_addrs], num_layers=num_prefetch_layers, global_cb=gcb, enable_performance_mode=True
+    )
+
+    # Warmup: drain 1 layer's worth of pages (also primes the cached consumer workload).
+    ttnn.experimental.test_dram_prefetcher_consumer(
+        device, num_iters=pages_per_layer, page_size_bytes=page_size, global_cb=gcb
+    )
+    ttnn.synchronize_device(device)
+
+    bench_trace = ttnn.begin_trace_capture(device, cq_id=0)
+    for _ in range(trace_repeats):
+        ttnn.experimental.test_dram_prefetcher_consumer(
+            device, num_iters=pages_per_layer, page_size_bytes=page_size, global_cb=gcb
+        )
+    ttnn.end_trace_capture(device, bench_trace, cq_id=0)
+
+    t0 = time.perf_counter()
+    ttnn.execute_trace(device, bench_trace, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+    elapsed = time.perf_counter() - t0
+    ttnn.release_trace(device, bench_trace)
+
+    bytes_per_recv = trace_repeats * pages_per_layer * page_size
+    bytes_total = bytes_per_recv * _RING_SIZE
+    bw_total = _gbps(bytes_total, elapsed)
+    bw_per_recv = bw_total / _RING_SIZE
+    logger.info(
+        f"[workercore_bw][{op_name}] trace_elapsed={elapsed * 1e3:.2f}ms "
+        f"bytes_per_recv={bytes_per_recv / 1e6:.1f}MB total_bytes={bytes_total / 1e9:.2f}GB "
+        f"aggregate_bw={bw_total:.2f} GB/s per_recv_bw={bw_per_recv:.3f} GB/s"
+    )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -49,6 +49,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.prefetcher_common import round_up as _round_up
 
 
 pytestmark = [
@@ -106,10 +107,6 @@ LLAMA_SHAPES = [
 
 def _bench_trace_repeats() -> int:
     return int(os.environ.get("BENCH_TRACE_REPEATS", "100"))
-
-
-def _round_up(n, m):
-    return ((n + m - 1) // m) * m
 
 
 def _apply_shape(shape: dict) -> None:

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -60,7 +60,6 @@ pytestmark = [
 ]
 
 
-_M = 32
 _NUM_DRAM_BANKS = 8
 
 # Mutable shape globals populated by _apply_shape() at the top of each test.
@@ -71,7 +70,6 @@ _N_ORIG = 1024
 _NUM_RECV_PER_BANK = 1
 _RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
 _RING_COLS = 8
-_RING_ROWS = 1
 _DTYPE_NAME = "bfloat8_b"
 _DTYPE = ttnn.bfloat8_b
 _DTYPE_BYTES = 1088 / 1024.0  # bfloat8_b per-element bytes including per-tile header
@@ -115,14 +113,13 @@ def _round_up(n, m):
 
 
 def _apply_shape(shape: dict) -> None:
-    global _K, _K_ORIG, _N, _N_ORIG, _NUM_RECV_PER_BANK, _RING_SIZE, _RING_ROWS
+    global _K, _K_ORIG, _N, _N_ORIG, _NUM_RECV_PER_BANK, _RING_SIZE
     global _DTYPE_NAME, _DTYPE, _DTYPE_BYTES
     _K_ORIG = int(os.environ.get("BENCH_K", shape["K"]))
     _N_ORIG = int(os.environ.get("BENCH_N", shape["N"]))
     _NUM_RECV_PER_BANK = int(os.environ.get("BENCH_RECV_PER_BANK", shape["recv_per_bank"]))
     _RING_SIZE = _NUM_DRAM_BANKS * _NUM_RECV_PER_BANK
     assert _RING_SIZE % _RING_COLS == 0, f"ring_size {_RING_SIZE} not a clean rect on {_RING_COLS}-col grid"
-    _RING_ROWS = _RING_SIZE // _RING_COLS
     _K = _round_up(_K_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
     _N = _round_up(_N_ORIG, _RING_SIZE * ttnn.TILE_SIZE)
     _DTYPE_NAME = os.environ.get("BENCH_DTYPE", shape["dtype"])

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
@@ -1,0 +1,572 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for the DRAM-core prefetcher path on single Blackhole.
+
+Two scopes:
+
+1. ``test_dram_core_prefetcher_BH_param`` — parameterized shape coverage with
+   PCC vs ``torch.matmul``. Topology: 8 DRAM banks × ``recv_per_bank``
+   receivers/bank → ring of 8 × recv_per_bank. Production Llama-3.1-8B on
+   single BH uses recv_per_bank=8 (ring=64); smaller rings are exercised for
+   QKV/FF cases that fit at lower recv_per_bank.
+
+   Each case builds a fresh DRAM-sender GlobalCircularBuffer, launches the
+   DRAM-core prefetcher via ``ttnn.experimental.start_dram_core_prefetcher``,
+   runs ``ttnn.linear`` with the same gcb, and PCC-checks against
+   ``torch.matmul``. ``stop_dram_core_prefetcher`` drains the pipeline after
+   the matmul finishes.
+
+   Receiver layout: each bank's receivers sit at row-major-adjacent ring
+   positions ``[b*recv_per_bank, (b+1)*recv_per_bank)`` on a
+   ``(RING_COLS × RING_ROWS)`` rectangle — the layout ``gather_in0`` expects.
+
+   DRISC L1 budget: 2 ping-pong stage buffers must fit in ~80 KB. The
+   factory automatically splits each per-K-block DMA into M chunks
+   (M divides num_receivers) when ``2 * dma_block > 80 KB``; the kernel does
+   M subset-pushes per K-block with fifo_wr_ptr rewinds so all receivers end
+   up with their full contiguous slice at the same fifo offset. M=1 keeps
+   the original single-push-per-K-block path; M=2 unlocks FF1
+   (K=4096 N=14336) at ring=64.
+
+2. ``test_dram_core_prefetcher_multi_tensor`` — multi-tensor smoke. The
+   DRAM-core kernel's main loop iterates
+   ``for layer in num_layers: for t in num_tensors:`` and prior versions
+   were documented as leaving the DRISC cores in reset state when
+   num_tensors > 1. After the chunked-DMA + receiver-layout fixes this case
+   re-verifies the multi-tensor path end-to-end against a discard receiver
+   (no matmul; the goal is to confirm both ops complete without
+   hang/OOM/PCC failure across multiple ``(num_tensors, num_layers)`` combos).
+"""
+
+import math
+import os
+import zlib
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import run_for_blackhole
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+# DRAM bank count is queried at runtime via `device.dram_grid_size().x`:
+#   - P150/P300 (unharvested): 8 banks → ring=8*recv_per_bank.
+#   - P100 (1 column harvested): 7 banks → ring=7*recv_per_bank.
+# The receiver grid is laid out as `num_dram_banks` columns × `recv_per_bank` rows so the
+# rectangle is always clean. Test names that suggest a fixed ring size (e.g. "r64") refer
+# to the unharvested case; on P100 the same parametrization runs at ring=7*recv_per_bank.
+
+
+pytestmark = [
+    run_for_blackhole("DRAM-core prefetcher requires Blackhole"),
+    pytest.mark.skipif(
+        os.environ.get("TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES", "0") != "1",
+        reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
+    ),
+]
+
+
+def _round_up(n, m):
+    return ((n + m - 1) // m) * m
+
+
+def _bytes_per_tile(dtype) -> int:
+    return {ttnn.bfloat16: 2048, ttnn.bfloat8_b: 1088}[dtype]
+
+
+def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int):
+    """Row-major-adjacent receivers: bank b -> ring positions [b*recv_per_bank, (b+1)*recv_per_bank)."""
+    cores = []
+    for k in range(recv_per_bank):
+        ring_pos = bank_idx * recv_per_bank + k
+        col = ring_pos % ring_cols
+        row = ring_pos // ring_cols
+        cores.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+    return ttnn.CoreRangeSet(cores)
+
+
+# ---------------------------------------------------------------------------
+# Parameterized shape coverage (PCC vs torch.matmul)
+# ---------------------------------------------------------------------------
+# Parameterize over (K, N) and (recv_per_bank, dtype). K and N are in tiles of
+# (ring_size, n_tiles_per_recv) units so the shapes work out cleanly across rings:
+#   K = k_tiles_per_shard * ring_size * TILE_SIZE
+#   N = ring_size * n_tiles_per_receiver * TILE_SIZE
+# Constraint: K_tiles_total = k_tiles_per_shard * ring_size must be a multiple of ring_size
+# (trivially true by construction) so gather_in0 doesn't pad K.
+@pytest.mark.parametrize(
+    "name,k_tiles_per_shard,n_tiles_per_receiver,recv_per_bank,dtype,gcb_size_misalign_bytes",
+    [
+        # --- Legacy ring=8 cases (recv_per_bank=1, bf16) ---
+        ("qkv_small", 8, 1, 1, ttnn.bfloat16, 0),  # K=256, N=8*32
+        ("qkv_med", 16, 1, 1, ttnn.bfloat16, 0),  # K=512, N=8*32
+        ("qkv_large", 32, 1, 1, ttnn.bfloat16, 0),  # K=1024, N=8*32
+        ("ff_wide", 8, 2, 1, ttnn.bfloat16, 0),  # K=256, N=8*2*32
+        ("ff_widest", 16, 4, 1, ttnn.bfloat16, 0),  # K=512, N=8*4*32
+        # --- Llama-3.1-8B production shapes at ring=64 (recv_per_bank=8, bf8_b) ---
+        # K=4096, all use k_tiles_per_shard=2 (= 4096/64/32).
+        ("o_proj_r64", 2, 2, 8, ttnn.bfloat8_b, 0),  # K=4096, N=4096
+        ("qkv_bf8_r64", 2, 6, 8, ttnn.bfloat8_b, 0),  # K=4096, N=12288 (combined Q+K+V at bf8_b)
+        ("ff1_r64", 2, 7, 8, ttnn.bfloat8_b, 0),  # K=4096, N=14336 (FF1 gate/up)
+        # --- Misaligned-gcb_size cases: gcb_size is NOT a multiple of in1_block_size.
+        # Exercises the wrap-adjustment path the previous factory always avoided by
+        # snapping gcb_size to LCM(in1_block_size). Misalignment is one L1_ALIGNMENT
+        # (=16 B on BH) so the underlying CB invariant `page_size % L1_ALIGNMENT == 0`
+        # still holds. ---
+        ("qkv_small_misaligned", 8, 1, 1, ttnn.bfloat16, 16),
+        ("ff_wide_misaligned", 8, 2, 1, ttnn.bfloat16, 16),
+    ],
+)
+def test_dram_core_prefetcher_BH_param(
+    device, name, k_tiles_per_shard, n_tiles_per_receiver, recv_per_bank, dtype, gcb_size_misalign_bytes
+):
+    # ---- Topology (queries DRAM bank count so the test adapts to harvested BHs) ----
+    num_dram_banks = device.dram_grid_size().x
+    num_receivers_per_bank = recv_per_bank
+    ring_size = num_dram_banks * num_receivers_per_bank
+    ring_cols = num_dram_banks
+    ring_rows = num_receivers_per_bank
+    assert ring_size == ring_cols * ring_rows, f"ring_size {ring_size} != ring_cols {ring_cols} * ring_rows {ring_rows}"
+
+    receiver_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+    )
+
+    # ---- Shapes ----
+    M = 32
+    K = k_tiles_per_shard * ring_size * ttnn.TILE_SIZE
+    N = ring_size * n_tiles_per_receiver * ttnn.TILE_SIZE
+
+    # ---- Weight tensor (B): width-sharded in DRAM across `num_dram_banks` banks ----
+    torch.manual_seed(zlib.crc32(name.encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    # ---- Activation (A): width-sharded on receiver cores; K split evenly across the ring ----
+    pt_act = torch.randn(1, 1, M, K)
+    K_per_shard = _round_up(math.ceil(K / ring_size), ttnn.TILE_SIZE)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, K_per_shard),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(
+        pt_act, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config
+    )
+
+    # ---- tensor_addrs (unused by the DRAM-core path; required by the op contract) ----
+    addrs = ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    # ---- Matmul program config (1D-mcast gather_in0) ----
+    in0_block_w = 1  # DRISC factory's kbw defaults to 1
+    out_block_h = M // ttnn.TILE_SIZE
+    out_block_w = N // ring_size // ttnn.TILE_SIZE
+    out_subblock_w = min(out_block_w, 8)
+    while out_subblock_w > 1 and out_block_w % out_subblock_w != 0:
+        out_subblock_w -= 1
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        per_core_M=out_block_h,
+        per_core_N=out_block_w,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=True,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=num_receivers_per_bank,
+        untilize_out=False,
+    )
+
+    # ---- DRAM-sender GlobalCircularBuffer (via matmul-aware factory) ----
+    # in1_block_size is the matmul's receiver fifo_page_size = in0_block_w * per_core_N * tile_bytes
+    # (matmul-computed in0_block_w = K_per_shard_tiles).
+    tile_bytes = _bytes_per_tile(dtype)
+    in1_block_size_bytes = k_tiles_per_shard * n_tiles_per_receiver * tile_bytes
+    # Per-receiver weight footprint = num_blocks * in1_block_size (the factory's minimum).
+    gcb_size = ring_size * in1_block_size_bytes
+    if gcb_size_misalign_bytes != 0:
+        gcb_size += gcb_size_misalign_bytes
+        assert (
+            gcb_size % in1_block_size_bytes != 0
+        ), "misalignment test requires gcb_size to NOT be a multiple of in1_block_size"
+
+    bank_to_receivers = [
+        (b, _bank_receivers_row_major(b, num_receivers_per_bank, ring_cols)) for b in range(num_dram_banks)
+    ]
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device, [program_config], [tt_weight], bank_to_receivers=bank_to_receivers, size=gcb_size
+    )
+    logger.info(
+        f"[{name}] M={M} K={K} N={N} ring={ring_size} recv/bank={num_receivers_per_bank} dtype={dtype} "
+        f"K_per_shard={K_per_shard} fifo_page={in1_block_size_bytes} gcb_size={gcb_size}"
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, N // ring_size),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    # ---- Run: prefetcher (async) -> matmul (consumes via gcb) -> stop drains ----
+    ttnn.experimental.start_dram_core_prefetcher(device, [tt_weight, addrs], num_layers=1, global_cb=gcb)
+    tt_out = ttnn.linear(
+        tt_act,
+        tt_weight,
+        program_config=program_config,
+        memory_config=output_mem_config,
+        compute_kernel_config=compute_kernel_config,
+        dtype=ttnn.bfloat16,
+        global_cb=gcb,
+    )
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+
+    # ---- Verify ----
+    out_torch = ttnn.to_torch(tt_out)
+    expected = pt_act.float() @ pt_weight.float()
+    # Lower PCC threshold for bf8_b cases (precision noise is larger than at bf16).
+    pcc_threshold = 0.999 if dtype == ttnn.bfloat16 else 0.99
+    passing, output_str = comp_pcc(expected, out_torch, pcc_threshold)
+    logger.info(f"[{name}] {output_str}")
+    assert passing, f"[{name}] PCC check failed: {output_str}"
+
+
+# ---------------------------------------------------------------------------
+# create_global_circular_buffer_for_matmul_1d factory
+# ---------------------------------------------------------------------------
+# Drive the same shape as the qkv_small case (K=256, N=8*32, bf16) but build the GCB
+# via the matmul-aware factory instead of calling create_global_circular_buffer_with_dram_senders
+# directly. End-to-end PCC check confirms the factory's bank-to-receivers mapping +
+# size validation match what the matmul + prefetcher expect.
+@pytest.mark.parametrize(
+    "layers_buffered",
+    [
+        1,  # minimum: exactly one layer worth of pages (num_blocks * in1_block_size)
+        2,  # 2 layers buffered: double-buffer between prefetcher and matmul
+    ],
+)
+def test_create_global_circular_buffer_for_matmul_1d(device, layers_buffered):
+    num_dram_banks = device.dram_grid_size().x
+    recv_per_bank = 1
+    ring_size = num_dram_banks * recv_per_bank
+    ring_cols = num_dram_banks
+    ring_rows = recv_per_bank
+    dtype = ttnn.bfloat16
+    k_tiles_per_shard = 8  # K = 8 * ring_size * TILE_SIZE
+    n_tiles_per_receiver = 1  # N = ring_size * 1 * TILE_SIZE
+    tile_bytes = _bytes_per_tile(dtype)
+
+    M = 32
+    K = k_tiles_per_shard * ring_size * ttnn.TILE_SIZE
+    N = ring_size * n_tiles_per_receiver * ttnn.TILE_SIZE
+    receiver_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+    )
+
+    # ---- Weight + activation (same setup as the qkv_small case) ----
+    torch.manual_seed(zlib.crc32(f"factory_{layers_buffered}".encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    pt_act = torch.randn(1, 1, M, K)
+    K_per_shard = _round_up(math.ceil(K / ring_size), ttnn.TILE_SIZE)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, K_per_shard),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(
+        pt_act, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config
+    )
+    addrs = ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    # ---- Matmul program config (must match the factory's expectations) ----
+    out_block_h = M // ttnn.TILE_SIZE
+    out_block_w = N // ring_size // ttnn.TILE_SIZE
+    out_subblock_w = min(out_block_w, 8)
+    while out_subblock_w > 1 and out_block_w % out_subblock_w != 0:
+        out_subblock_w -= 1
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        per_core_M=out_block_h,
+        per_core_N=out_block_w,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=True,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=recv_per_bank,
+        untilize_out=False,
+    )
+
+    # ---- Build GCB via the matmul-aware factory ----
+    # gather_in0 matmul uses actual_in0_block_w = weight_K_tiles / ring_size (= k_tiles_per_shard
+    # here), not program_config.in0_block_w; the factory matches that. The minimum useful size is
+    # num_blocks (= ring_size) * in1_block_size — one full layer's worth of pages.
+    weight_K_tiles = K // ttnn.TILE_SIZE
+    actual_in0_block_w = weight_K_tiles // ring_size
+    in1_block_size = actual_in0_block_w * program_config.per_core_N * tile_bytes
+    num_blocks = ring_size
+    size = num_blocks * in1_block_size * layers_buffered
+    bank_to_receivers = [(b, _bank_receivers_row_major(b, recv_per_bank, ring_cols)) for b in range(num_dram_banks)]
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device, [program_config], [tt_weight], bank_to_receivers=bank_to_receivers, size=size
+    )
+    logger.info(
+        f"[factory layers_buffered={layers_buffered}] in1_block={in1_block_size} num_blocks={num_blocks} size={size}"
+    )
+
+    # ---- Run: prefetcher (async) -> matmul (consumes via gcb) -> stop drains ----
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, N // ring_size),
+        core_grid=receiver_core_range_set,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+    ttnn.experimental.start_dram_core_prefetcher(device, [tt_weight, addrs], num_layers=1, global_cb=gcb)
+    tt_out = ttnn.linear(
+        tt_act,
+        tt_weight,
+        program_config=program_config,
+        memory_config=output_mem_config,
+        compute_kernel_config=compute_kernel_config,
+        dtype=ttnn.bfloat16,
+        global_cb=gcb,
+    )
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+
+    out_torch = ttnn.to_torch(tt_out)
+    expected = pt_act.float() @ pt_weight.float()
+    passing, output_str = comp_pcc(expected, out_torch, 0.999)
+    logger.info(f"[factory layers_buffered={layers_buffered}] {output_str}")
+    assert passing, f"[factory layers_buffered={layers_buffered}] PCC check failed: {output_str}"
+
+
+def test_create_global_circular_buffer_for_matmul_1d_rejects_undersized(device):
+    """Factory must TT_FATAL when size < num_blocks * in1_block_size (matmul would deadlock)."""
+    num_dram_banks = device.dram_grid_size().x
+    recv_per_bank = 1
+    ring_size = num_dram_banks * recv_per_bank
+    dtype = ttnn.bfloat16
+    tile_bytes = _bytes_per_tile(dtype)
+
+    K = 8 * ring_size * ttnn.TILE_SIZE
+    N = ring_size * ttnn.TILE_SIZE
+    pt_weight = torch.zeros(1, 1, K, N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(num_dram_banks, recv_per_bank),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=True,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=recv_per_bank,
+        untilize_out=False,
+    )
+
+    weight_K_tiles = K // ttnn.TILE_SIZE
+    actual_in0_block_w = weight_K_tiles // ring_size
+    in1_block_size = actual_in0_block_w * program_config.per_core_N * tile_bytes
+    num_blocks = ring_size
+    min_size = num_blocks * in1_block_size
+    bank_to_receivers = [
+        (b, _bank_receivers_row_major(b, recv_per_bank, num_dram_banks)) for b in range(num_dram_banks)
+    ]
+    with pytest.raises(RuntimeError, match="must be at least num_blocks"):
+        ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+            device,
+            [program_config],
+            [tt_weight],
+            bank_to_receivers=bank_to_receivers,
+            size=min_size - 16,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-tensor smoke (discard receiver)
+# ---------------------------------------------------------------------------
+_MT_NUM_RECV_PER_BANK = 2
+_MT_K = 2048
+# N must be divisible by `num_dram_banks * _MT_NUM_RECV_PER_BANK * TILE_SIZE` for any
+# supported BH bank count. lcm(7, 8) * 2 * 32 = 56 * 64 = 3584, so 3584 works on both
+# P100 (7 banks) and P150/P300 (8 banks). The DRAM-core prefetcher auto-derives K-sub
+# blocking from the DRISC L1 budget; K=2048 lands on the K-sub-with-M=1 path here.
+_MT_N = 3584
+_MT_TILE_BYTES = 1088  # bf8_b
+
+
+def _make_mt_weight(device, seed: int, num_dram_banks: int) -> ttnn.Tensor:
+    torch.manual_seed(seed)
+    pt_weight = torch.randn(1, 1, _MT_K, _MT_N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [_MT_K, _MT_N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.as_tensor(
+        pt_weight, device=device, dtype=ttnn.bfloat8_b, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+
+@pytest.mark.parametrize("num_tensors,num_layers", [(1, 1), (2, 1), (3, 1), (2, 5), (3, 10)])
+def test_dram_core_prefetcher_multi_tensor(device, num_tensors, num_layers):
+    # Query the chip's actual DRAM bank count so the test adapts to harvested BHs
+    # (P100 has 7, P150/P300 have 8). The receiver grid is laid out as
+    # `num_dram_banks` columns × `_MT_NUM_RECV_PER_BANK` rows.
+    num_dram_banks = device.dram_grid_size().x
+    num_receivers = num_dram_banks * _MT_NUM_RECV_PER_BANK
+
+    # Build `num_tensors` weight tensors, all same shape (so num_blocks matches).
+    weights = [_make_mt_weight(device, seed=0xB100 + i, num_dram_banks=num_dram_banks) for i in range(num_tensors)]
+    # The op contract requires an addrs tensor as the last input (unused on DRAM-core path).
+    addrs = ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    # The DRAM-core prefetcher auto-derives k_block_w_tiles = ceil(k_tiles / ring_size)
+    # and pushes ring_size blocks per (layer, tensor) regardless of k_tiles. GCB and
+    # consumer counts must follow ring_size, not k_tiles.
+    k_tiles = _MT_K // ttnn.TILE_SIZE
+    ring_size = num_receivers
+    k_block_w_tiles = (k_tiles + ring_size - 1) // ring_size
+    n_tiles_per_recv = (_MT_N // num_dram_banks // _MT_NUM_RECV_PER_BANK) // ttnn.TILE_SIZE
+    push_page_size = k_block_w_tiles * n_tiles_per_recv * _MT_TILE_BYTES
+    per_recv_bytes_per_tensor = ring_size * push_page_size
+    gcb_size = _round_up(per_recv_bytes_per_tensor, push_page_size)
+
+    bank_to_receivers = [
+        (b, _bank_receivers_row_major(b, _MT_NUM_RECV_PER_BANK, ring_cols=num_dram_banks))
+        for b in range(num_dram_banks)
+    ]
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+
+    # Per receiver per (layer, tensor): ring_size pushes.
+    num_iters_total = num_layers * num_tensors * ring_size
+    logger.info(
+        f"[multi_tensor] num_tensors={num_tensors} num_layers={num_layers} K={_MT_K} N={_MT_N} "
+        f"banks={num_dram_banks} ring={num_receivers} push_page={push_page_size} gcb_size={gcb_size} "
+        f"num_iters_total={num_iters_total}"
+    )
+
+    # Sender: push all `num_tensors` weights through the prefetcher, num_layers times.
+    ttnn.experimental.start_dram_core_prefetcher(
+        device,
+        weights + [addrs],
+        num_layers=num_layers,
+        global_cb=gcb,
+    )
+    # Receiver: discard all pushed data.
+    ttnn.experimental.test_dram_prefetcher_consumer(
+        device,
+        num_iters=num_iters_total,
+        page_size_bytes=push_page_size,
+        global_cb=gcb,
+    )
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+    ttnn.synchronize_device(device)
+    logger.info(f"[multi_tensor] num_tensors={num_tensors} num_layers={num_layers} completed cleanly")

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
@@ -50,6 +50,7 @@ from loguru import logger
 
 from models.common.utility_functions import run_for_blackhole
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.prefetcher_common import round_up as _round_up, bytes_per_tile as _bytes_per_tile
 
 
 # DRAM bank count is queried at runtime via `device.dram_grid_size().x`:
@@ -67,14 +68,6 @@ pytestmark = [
         reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
     ),
 ]
-
-
-def _round_up(n, m):
-    return ((n + m - 1) // m) * m
-
-
-def _bytes_per_tile(dtype) -> int:
-    return {ttnn.bfloat16: 2048, ttnn.bfloat8_b: 1088}[dtype]
 
 
 def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -20,6 +20,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.prefetcher_common import round_up as _round_up
 
 
 pytestmark = [
@@ -36,10 +37,6 @@ _GCB_DEPTH_PAGES = 4  # small ring so the validator stresses reserve_back/wait_f
 
 _TILE_BYTES_BF16 = 2048  # 32*32*2
 _TILE_BYTES_BF8 = 1088  # 32*32 (data) + 64 (exponent header)
-
-
-def _round_up(n, m):
-    return ((n + m - 1) // m) * m
 
 
 def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int, row_offset: int = 0):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validator-receiver smoke test for the prefetcher pipeline.
+
+Replaces the matmul consumer with a diagnostic kernel that DPRINTs progress
+and detects over/under-counts. Drives both the worker-core sender
+(`ttnn.dram_prefetcher`) and the DRAM-core sender
+(`ttnn.experimental.start_dram_core_prefetcher`) against the same validator so any
+divergence between the two paths surfaces immediately.
+
+See tt_metal/impl/buffers/prefetcher_matmul_design.md for the contract being validated.
+"""
+
+import os
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import run_for_blackhole
+
+
+pytestmark = [
+    run_for_blackhole("DRAM-core prefetcher requires Blackhole"),
+    pytest.mark.skipif(
+        os.environ.get("TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES", "0") != "1",
+        reason="TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES not set",
+    ),
+]
+
+
+_GCB_DEPTH_PAGES = 4  # small ring so the validator stresses reserve_back/wait_front handshakes
+
+
+_TILE_BYTES_BF16 = 2048  # 32*32*2
+_TILE_BYTES_BF8 = 1088  # 32*32 (data) + 64 (exponent header)
+
+
+def _round_up(n, m):
+    return ((n + m - 1) // m) * m
+
+
+def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int, row_offset: int = 0):
+    """CoreRangeSet for bank `bank_idx`'s receivers, laid out row-major on a
+    ring_cols-wide grid. Matches the bench's gather_in0 receiver layout."""
+    cores = []
+    for k in range(recv_per_bank):
+        ring_pos = bank_idx * recv_per_bank + k
+        col = ring_pos % ring_cols
+        row = ring_pos // ring_cols + row_offset
+        cores.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+    return ttnn.CoreRangeSet(cores)
+
+
+def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_layers):
+    """Build a DRAM-sender GCB sized to the prefetcher's per-receiver-per-block push.
+
+    Returns (tt_weight, addrs, gcb, num_iters_total, push_page_size_bytes, ring_size).
+    """
+    tile_bytes = _TILE_BYTES_BF16 if dtype == ttnn.bfloat16 else _TILE_BYTES_BF8
+    num_dram_banks = device.dram_grid_size().x
+    ring_size = num_dram_banks * recv_per_bank
+    ring_cols = max(c for c in range(min(num_dram_banks, ring_size), 0, -1) if ring_size % c == 0)
+    ring_rows = ring_size // ring_cols
+
+    K_padded = _round_up(K, ring_size * ttnn.TILE_SIZE)
+    k_tiles = K_padded // ttnn.TILE_SIZE
+    k_block_w_tiles = k_tiles // ring_size
+    n_per_recv_tiles = (N // num_dram_banks // recv_per_bank) // ttnn.TILE_SIZE
+    push_page_size = k_block_w_tiles * n_per_recv_tiles * tile_bytes
+
+    torch.manual_seed(0xC0FFEE)
+    pt_weight = torch.zeros(1, 1, K_padded, N)
+    pt_weight[:, :, :K, :] = torch.randn(1, 1, K, N)
+
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K_padded, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    # addrs tensor (unused on DRAM-core path but required by op contract).
+    addrs = ttnn.from_torch(
+        torch.zeros(1, 1),
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                [1, 1],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        ),
+    )
+
+    bank_to_receivers = [
+        (b, _bank_receivers_row_major(b, recv_per_bank, ring_cols=ring_cols, row_offset=0))
+        for b in range(num_dram_banks)
+    ]
+    gcb_size = _GCB_DEPTH_PAGES * push_page_size
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+
+    num_iters_total = num_layers * ring_size
+    logger.info(
+        f"[validator-dram] K={K} K_padded={K_padded} N={N} banks={num_dram_banks} ring={ring_size} "
+        f"k_block_w_tiles={k_block_w_tiles} push_page={push_page_size} gcb_size={gcb_size} "
+        f"num_layers={num_layers} num_iters_total={num_iters_total}"
+    )
+    return tt_weight, addrs, gcb, num_iters_total, push_page_size, ring_size
+
+
+def _setup_weight_and_gcb_worker_sender(device, K, N, dtype, recv_per_bank, num_layers):
+    """Build a worker-sender GCB and addrs tensor for ttnn.dram_prefetcher.
+
+    Returns (tt_weight, tt_addrs, gcb, num_iters_total, push_page_size_bytes, ring_size).
+    """
+    tile_bytes = _TILE_BYTES_BF16 if dtype == ttnn.bfloat16 else _TILE_BYTES_BF8
+    num_dram_banks = device.dram_grid_size().x
+    ring_size = num_dram_banks * recv_per_bank
+    ring_cols = max(c for c in range(min(num_dram_banks, ring_size), 0, -1) if ring_size % c == 0)
+    ring_rows = ring_size // ring_cols
+
+    K_padded = _round_up(K, ring_size * ttnn.TILE_SIZE)
+    k_tiles = K_padded // ttnn.TILE_SIZE
+    k_block_w_tiles = k_tiles // ring_size
+    n_per_recv_tiles = (N // num_dram_banks // recv_per_bank) // ttnn.TILE_SIZE
+    push_page_size = k_block_w_tiles * n_per_recv_tiles * tile_bytes
+
+    torch.manual_seed(0xC0FFEE)
+    pt_weight = torch.zeros(1, 1, K_padded, N)
+    pt_weight[:, :, :K, :] = torch.randn(1, 1, K, N)
+
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_core_range_set, [K_padded, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+    )
+
+    # Worker-sender layout: senders on row `ring_rows`, receivers on rows 0..ring_rows-1.
+    sender_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, ring_rows), ttnn.CoreCoord(num_dram_banks - 1, ring_rows))}
+    )
+    sender_receiver_mapping = [
+        (ttnn.CoreCoord(b, ring_rows), _bank_receivers_row_major(b, recv_per_bank, ring_cols=ring_cols))
+        for b in range(num_dram_banks)
+    ]
+    # Worker prefetcher validates max_tensor_size <= gcb.size() — a full layer's per-recv bytes.
+    gcb_size = ring_size * push_page_size
+    gcb = ttnn.create_global_circular_buffer(device, sender_receiver_mapping, gcb_size)
+
+    # Worker-sender expects num_layers address rows per sender.
+    addr_row = torch.tensor([tt_weight.buffer_address()] * num_layers, dtype=torch.int32).reshape(1, num_layers)
+    tensor_addrs = addr_row.repeat(num_dram_banks, 1)
+    tt_addrs = ttnn.as_tensor(
+        tensor_addrs,
+        device=device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(sender_core_range_set, [1, num_layers], ttnn.ShardOrientation.ROW_MAJOR),
+        ),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+    num_iters_total = num_layers * ring_size
+    logger.info(
+        f"[validator-worker] K={K} K_padded={K_padded} N={N} banks={num_dram_banks} ring={ring_size} "
+        f"k_block_w_tiles={k_block_w_tiles} push_page={push_page_size} gcb_size={gcb_size} "
+        f"num_layers={num_layers} num_iters_total={num_iters_total}"
+    )
+    return tt_weight, tt_addrs, gcb, num_iters_total, push_page_size, ring_size
+
+
+@pytest.mark.parametrize(
+    "K,N,dtype,recv_per_bank,num_layers",
+    [
+        (448, 1792, ttnn.bfloat16, 1, 2),  # default bench shape, fast path (full block fits)
+        (2048, 3584, ttnn.bfloat8_b, 2, 1),  # multi-tensor shape, K-sub path (M=1)
+        (4096, 14336, ttnn.bfloat8_b, 8, 1),  # FF1 production shape, K-sub+M path
+    ],
+    ids=["bench_default", "multi_ksub", "ff1_ksub_mchunk"],
+)
+def test_validator_dram_sender(device, K, N, dtype, recv_per_bank, num_layers):
+    tt_weight, addrs, gcb, num_iters_total, push_page_size, ring_size = _setup_weight_and_gcb_dram_sender(
+        device, K, N, dtype, recv_per_bank, num_layers
+    )
+
+    ttnn.experimental.start_dram_core_prefetcher(device, [tt_weight, addrs], num_layers=num_layers, global_cb=gcb)
+    ttnn.experimental.test_dram_prefetcher_validator(
+        device,
+        tt_weight,
+        num_layers=num_layers,
+        print_stride=max(1, ring_size // 4),
+        global_cb=gcb,
+    )
+    ttnn.experimental.stop_dram_core_prefetcher(device)
+    ttnn.synchronize_device(device)
+    logger.info(f"[validator-dram] K={K} N={N} recv_per_bank={recv_per_bank} num_layers={num_layers} OK")
+
+
+@pytest.mark.parametrize(
+    "K,N,dtype,recv_per_bank,num_layers",
+    [
+        (448, 1792, ttnn.bfloat16, 1, 2),  # baseline
+        (2048, 3584, ttnn.bfloat8_b, 2, 1),
+        (4096, 14336, ttnn.bfloat8_b, 8, 1),  # FF1
+    ],
+    ids=["bench_default", "multi", "ff1"],
+)
+def test_validator_worker_sender(device, K, N, dtype, recv_per_bank, num_layers):
+    if device.dram_grid_size().x != 8:
+        # Worker prefetcher's reader_dram.cpp uses a fixed per-row TRID layout that hits
+        # known issues on harvested cards (P100, 7 banks). Tracked separately from the
+        # DRAM-core refactor.
+        pytest.skip("Worker-sender validator requires an unharvested 8-bank device")
+
+    tt_weight, tt_addrs, gcb, num_iters_total, push_page_size, ring_size = _setup_weight_and_gcb_worker_sender(
+        device, K, N, dtype, recv_per_bank, num_layers
+    )
+
+    # Sub-device isolation: ttnn.dram_prefetcher's writer_l1 ends in remote_cb_sender_barrier
+    # waiting for receiver acks, so the prefetcher program never completes until receivers run.
+    # Without sub-devices, fast dispatch serializes on the prefetcher and the validator never
+    # launches (deadlock). Stall-group set to the worker sub-device after enqueueing the
+    # prefetcher lets the validator dispatch concurrently. Mirrors prefetcher_common.run_op.
+    prefetcher_sub_device = ttnn.SubDevice([gcb.sender_cores()])
+    worker_sub_device = ttnn.SubDevice([gcb.receiver_cores()])
+    sub_device_manager = device.create_sub_device_manager([prefetcher_sub_device, worker_sub_device], 0)
+    device.load_sub_device_manager(sub_device_manager)
+    worker_sub_device_id = ttnn.SubDeviceId(1)
+    try:
+        ttnn.dram_prefetcher([tt_weight, tt_addrs], num_layers=num_layers, global_cb=gcb)
+        device.set_sub_device_stall_group([worker_sub_device_id])
+        ttnn.experimental.test_dram_prefetcher_validator(
+            device,
+            tt_weight,
+            num_layers=num_layers,
+            print_stride=max(1, ring_size // 4),
+            global_cb=gcb,
+        )
+        ttnn.synchronize_device(device)
+        device.reset_sub_device_stall_group()
+    finally:
+        device.clear_loaded_sub_device_manager()
+        device.remove_sub_device_manager(sub_device_manager)
+    logger.info(f"[validator-worker] K={K} N={N} recv_per_bank={recv_per_bank} num_layers={num_layers} OK")

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -63,7 +63,6 @@ def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_la
     num_dram_banks = device.dram_grid_size().x
     ring_size = num_dram_banks * recv_per_bank
     ring_cols = max(c for c in range(min(num_dram_banks, ring_size), 0, -1) if ring_size % c == 0)
-    ring_rows = ring_size // ring_cols
 
     K_padded = _round_up(K, ring_size * ttnn.TILE_SIZE)
     k_tiles = K_padded // ttnn.TILE_SIZE

--- a/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Experimental Start/Stop lifecycle API for the DRAM-core (DRISC) prefetcher.
+// The prefetcher streams tensor shards from DRAM into a receiver ring via a
+// DRAM-sender GlobalCircularBuffer; only one prefetcher may be active on a
+// mesh device at a time. State (in-flight Program, runtime args, lifetime
+// references to inputs and the GCB) lives on MeshDeviceImpl.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace tt::tt_metal {
+
+class MeshTensor;
+
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+
+namespace experimental {
+
+class GlobalCircularBuffer;
+
+struct DramCorePrefetcherConfig {
+    uint32_t num_layers = 1;
+    bool enable_performance_mode = false;
+};
+
+// Launch the DRAM-core prefetcher on `mesh_device`. The prefetcher streams
+// each tensor in `input_tensors` from its DRAM bank into the receivers
+// configured in `gcb` for `config.num_layers` iterations. Non-blocking — the
+// host thread returns immediately and is free to enqueue consumer programs
+// (matmuls) that read from the GCB while the prefetcher kernel runs.
+//
+// Input tensor layout:
+//   Each data tensor in `input_tensors` (all entries except the last; the last
+//   is the addrs tensor, kept for op-contract parity with the worker-core
+//   path and unused on this path) must be:
+//     - DRAM-resident, TILE layout,
+//     - width-sharded across all DRAM banks (one shard per bank; each shard
+//       holds the full K dimension and `N / num_dram_banks` columns),
+//     - tile-aligned in both K and N (validated at Start).
+//
+//   Interaction with `gcb`:
+//     - Bank `b` is paired with the receiver CoreRangeSet at index `b` in
+//       the GCB's sender_receiver_core_mapping.
+//     - Per (layer, tensor), each receiver is pushed `num_blocks = num_senders
+//       * num_receivers_per_sender` pages, one per K-block (= ceil(K_tiles /
+//       num_blocks) tile-rows).
+//     - The N-stripe a given receiver sees is its per-bank slice:
+//       receiver r within bank b owns columns
+//       `[b * N_per_bank + r * N_per_recv, b * N_per_bank + (r+1) * N_per_recv)`,
+//       where N_per_bank = N / num_dram_banks and
+//       N_per_recv = N_per_bank / num_receivers_per_sender.
+//
+// Preconditions (TT_FATAL on violation):
+//   - sender_core_type(gcb) == SenderCoreType::Dram.
+//   - No other DRAM-core prefetcher is currently active on this mesh device
+//     (single-prefetcher-at-a-time invariant).
+//   - All MeshTensors live on `mesh_device` and outlive the Stop call.
+void StartDramCorePrefetcher(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<const MeshTensor*>& input_tensors,
+    const GlobalCircularBuffer& gcb,
+    const DramCorePrefetcherConfig& config);
+
+// Block until the active DRAM-core prefetcher finishes the natural exit of
+// its `num_layers` loop, then tear down the held Program and release the
+// resources it held. No-op if no prefetcher is active.
+//
+// Callers invoke Stop after enqueuing all the consuming matmuls — Stop is
+// what drains the pipeline.
+void StopDramCorePrefetcher(distributed::MeshDevice* mesh_device);
+
+}  // namespace experimental
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
@@ -27,7 +27,6 @@ class GlobalCircularBuffer;
 
 struct DramCorePrefetcherConfig {
     uint32_t num_layers = 1;
-    bool enable_performance_mode = false;
 };
 
 // Launch the DRAM-core prefetcher on `mesh_device`. The prefetcher streams
@@ -63,7 +62,7 @@ struct DramCorePrefetcherConfig {
 //     (single-prefetcher-at-a-time invariant).
 //   - All MeshTensors live on `mesh_device` and outlive the Stop call.
 void StartDramCorePrefetcher(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::vector<const MeshTensor*>& input_tensors,
     const GlobalCircularBuffer& gcb,
     const DramCorePrefetcherConfig& config);
@@ -74,7 +73,7 @@ void StartDramCorePrefetcher(
 //
 // Callers invoke Stop after enqueuing all the consuming matmuls — Stop is
 // what drains the pipeline.
-void StopDramCorePrefetcher(distributed::MeshDevice* mesh_device);
+void StopDramCorePrefetcher(distributed::MeshDevice& mesh_device);
 
 }  // namespace experimental
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -48,6 +48,7 @@
 #include <experimental/fabric/fabric_types.hpp>
 #include "distributed/fd_mesh_command_queue.hpp"
 #include "distributed/realtime_profiler_manager.hpp"
+#include "impl/buffers/dram_core_prefetcher_manager.hpp"
 #include "impl/buffers/drisc_l1_arena.hpp"
 #include "distributed/sd_mesh_command_queue.hpp"
 #include "tracy/Tracy.hpp"
@@ -924,9 +925,24 @@ bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
         realtime_profiler_.reset();
     }
 
-    // DRISC L1 arena is torn down here so any GCB-owned allocation handles have
-    // already been released (GCBs are user-owned and the user's invariant is to
-    // destroy them before close).
+    // Drain any in-flight DRAM-core prefetcher kernel and release its state before the
+    // rest of the mesh tears down. If the caller forgot to call StopDramCorePrefetcher
+    // we still wait for the kernel's natural num_layers exit so the GCB / receivers it
+    // touches remain valid until it returns.
+    if (dram_core_prefetcher_) {
+        if (dram_core_prefetcher_->is_active()) {
+            log_warning(
+                tt::LogMetal,
+                "DRAM-core prefetcher was active at MeshDevice close; auto-stopping. Call "
+                "tt::tt_metal::experimental::StopDramCorePrefetcher before close to avoid this.");
+            dram_core_prefetcher_->stop();
+        }
+        dram_core_prefetcher_.reset();
+    }
+
+    // DRISC L1 arena is torn down after the prefetcher manager so any GCB-owned
+    // allocation handles have already been released (GCBs are user-owned and the
+    // user's invariant is to destroy them before close).
     drisc_l1_arena_.reset();
 
     if (is_initialized()) {
@@ -1420,6 +1436,14 @@ D2HSocket* MeshDeviceImpl::get_realtime_profiler_socket() const {
         "initializing the MeshDevice");
     return *drisc_l1_arena_;
 }
+
+DramCorePrefetcherManager& MeshDeviceImpl::dram_core_prefetcher(MeshDevice* mesh_device) {
+    if (!dram_core_prefetcher_) {
+        dram_core_prefetcher_ = std::make_unique<DramCorePrefetcherManager>(mesh_device);
+    }
+    return *dram_core_prefetcher_;
+}
+
 
 CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
     const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -73,6 +73,7 @@ struct MeshTraceBuffer;
 class MeshCommandQueueBase;
 class MeshDevice;
 class RealtimeProfilerManager;
+class DramCorePrefetcherManager;
 
 namespace multihost {
 class DistributedContext;
@@ -166,6 +167,11 @@ private:
     // if the MeshDevice closes before their owning GCBs are destroyed (mirrors
     // the MeshBuffer / weak_ptr<MeshDevice> pattern).
     std::shared_ptr<::tt::tt_metal::DriscL1Arena> drisc_l1_arena_;
+
+    // Owns the DRAM-core (DRISC) prefetcher subsystem. Lazily constructed on first call
+    // to experimental::StartDramCorePrefetcher; torn down in close_impl() before the
+    // rest of the mesh shutdown so any in-flight kernel completes against live resources.
+    std::unique_ptr<DramCorePrefetcherManager> dram_core_prefetcher_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;
     // Recursively quiesce all submeshes.
@@ -304,6 +310,11 @@ public:
     // pages_sent allocations. Constructed eagerly in initialize_impl() when the
     // HAL exposes programmable DRAM cores; TT_FATAL otherwise.
     ::tt::tt_metal::DriscL1Arena& drisc_l1_arena();
+
+    // Lazily-constructed DRAM-core (DRISC) prefetcher subsystem. The first call materializes
+    // the manager bound to this mesh device; subsequent calls return the same instance.
+    // experimental::StartDramCorePrefetcher / StopDramCorePrefetcher delegate here.
+    DramCorePrefetcherManager& dram_core_prefetcher(MeshDevice* mesh_device);
 
     // Returns the logical DRAM core for `bank_id` whose physical NoC coord isn't already
     // claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -290,8 +290,7 @@ std::unique_ptr<Program> build_program(
             *program, kKernelPath, sender_logical, DramConfig{.noc = NOC::NOC_0, .compile_args = compile_args});
 
         // RT args: bank_id, then per-tensor blocks (length num_tensors each), then [recv_xy].
-        // Order must match the kernel's read order at the top of kernel_main; see
-        // tt_metal/impl/buffers/prefetcher_matmul_design.md §6 "Runtime args".
+        // Order must match the kernel's read order at the top of kernel_main.
         std::vector<uint32_t> rt_args;
         rt_args.reserve(1 + 10 * num_tensors + 2 * num_receivers);
         rt_args.push_back(/*bank_id=*/sender_logical.x);
@@ -397,18 +396,16 @@ void DramCorePrefetcherManager::stop() {
 namespace tt::tt_metal::experimental {
 
 void StartDramCorePrefetcher(
-    distributed::MeshDevice* mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::vector<const MeshTensor*>& input_tensors,
     const GlobalCircularBuffer& gcb,
     const DramCorePrefetcherConfig& config) {
-    TT_FATAL(mesh_device != nullptr, "StartDramCorePrefetcher requires a non-null MeshDevice");
-    auto& manager = mesh_device->impl().dram_core_prefetcher(mesh_device);
+    auto& manager = mesh_device.impl().dram_core_prefetcher(&mesh_device);
     manager.start(input_tensors, gcb, config);
 }
 
-void StopDramCorePrefetcher(distributed::MeshDevice* mesh_device) {
-    TT_FATAL(mesh_device != nullptr, "StopDramCorePrefetcher requires a non-null MeshDevice");
-    auto& manager = mesh_device->impl().dram_core_prefetcher(mesh_device);
+void StopDramCorePrefetcher(distributed::MeshDevice& mesh_device) {
+    auto& manager = mesh_device.impl().dram_core_prefetcher(&mesh_device);
     manager.stop();
 }
 

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "impl/buffers/dram_core_prefetcher_manager.hpp"
+
+#include "distributed/mesh_device_impl.hpp"
+#include "impl/buffers/drisc_l1_arena.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt_stl/assert.hpp>
+
+#include "impl/context/metal_context.hpp"
+#include "impl/kernels/kernel.hpp"  // DramConfig + CreateKernel(DramConfig)
+
+namespace tt::tt_metal::distributed {
+
+namespace {
+
+constexpr uint32_t kRemoteCBId = 31;
+
+// Bytes reserved above the arena's kernel_working_region_base for noc_xy + config and
+// alignment slack. The remainder of the kernel region is the budget for the two
+// ping-pong stage buffers (2 * chunk_size).
+constexpr uint32_t kKernelOverheadBytes = 2 * 1024;
+
+constexpr const char* kKernelPath = "tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp";
+
+inline uint32_t align_up(uint32_t a, uint32_t align) { return (a + align - 1) & ~(align - 1); }
+
+// Largest `page` (multiple of tile_size, <= max_page_size) such that num_tiles*tile_size
+// is divisible by page. Returns (page_size, num_pages). Identical algorithm to
+// ttnn::prim::get_max_page_size_and_num_pages.
+std::pair<uint32_t, uint32_t> pick_page_size(uint32_t max_page_size, uint32_t num_tiles, uint32_t tile_size) {
+    const uint64_t total = static_cast<uint64_t>(num_tiles) * tile_size;
+    uint32_t page = (max_page_size / tile_size) * tile_size;
+    while (page >= tile_size && total % page != 0) {
+        page -= tile_size;
+    }
+    TT_FATAL(
+        page >= tile_size,
+        "pick_page_size could not find a page that divides num_tiles*tile_size={} (tile={})",
+        static_cast<uint64_t>(total),
+        tile_size);
+    return {page, static_cast<uint32_t>(total / page)};
+}
+
+// Per-tensor geometry handed to the DRAM-core prefetcher kernel. All values are derived
+// from the tensor shape + dtype + GCB ring topology + DRISC L1 stage budget; the caller
+// (compute_tensor_geom) picks (rows_per_sub, M) by the fit ladder documented in
+// tt_metal/impl/buffers/prefetcher_matmul_design.md §6.
+//
+// Invariant: rows_per_sub > 1 implies M == 1 (the kernel cannot row-stride DMA).
+struct TensorGeom {
+    uint32_t bank_local_base = 0;      // GDDR offset where this tensor starts in the bank
+    uint32_t num_sub = 0;              // sub-bands per ring-block
+    uint32_t M = 0;                    // N-chunks per sub-band (divides num_receivers)
+    uint32_t rows_per_sub = 0;         // K-rows per sub-band
+    uint32_t coalesced_page_size = 0;  // bytes per K-row per receiver per coalesced page
+    uint32_t coalesced_num_pages = 0;  // coalesced pages per K-row per receiver
+    uint32_t sub_chunk_bytes = 0;      // bytes per DMA into one ring half
+    uint32_t sub_stride_bytes = 0;     // DRAM byte stride between sub-bands within a block
+    uint32_t block_stride_bytes = 0;   // DRAM byte stride between ring-blocks
+    uint32_t page_bytes_per_recv = 0;  // bytes per receiver per full block (fifo_page_size)
+};
+
+TensorGeom compute_tensor_geom(
+    const MeshTensor& t, uint32_t bank_local_base, uint32_t num_senders, uint32_t num_receivers, uint32_t ring_half) {
+    const auto* ref_buffer = t.mesh_buffer().get_reference_buffer();
+    const auto shard_shape = ref_buffer->shard_spec().shape();
+    const uint32_t tile_bytes = tt::tile_size(datatype_to_dataformat_converter(t.dtype()));
+    TT_FATAL(
+        shard_shape[0] % tt::constants::TILE_HEIGHT == 0 && shard_shape[1] % tt::constants::TILE_WIDTH == 0,
+        "DRAM-core prefetcher requires tile-aligned shards; got shard_shape=({}, {}), tile=({}, {})",
+        shard_shape[0],
+        shard_shape[1],
+        tt::constants::TILE_HEIGHT,
+        tt::constants::TILE_WIDTH);
+    const uint32_t k_tiles_raw = shard_shape[0] / tt::constants::TILE_HEIGHT;
+    const uint32_t n_per_bank = shard_shape[1] / tt::constants::TILE_WIDTH;
+    const uint32_t num_blocks = num_senders * num_receivers;
+    TT_FATAL(
+        n_per_bank % num_receivers == 0,
+        "n_per_bank ({}) must divide num_receivers ({}); reduce N_per_bank or grow num_receivers",
+        n_per_bank,
+        num_receivers);
+    // ceil-up matches worker-core ttnn.dram_prefetcher's tt::round_up(height, num_blocks);
+    // the tail block reads past the tensor bytes for tensors whose K_tiles doesn't divide
+    // ring_size. See tt_metal/impl/buffers/prefetcher_matmul_design.md §5.
+    const uint32_t k_block_w_tiles = (k_tiles_raw + num_blocks - 1) / num_blocks;
+    const uint32_t n_per_recv = n_per_bank / num_receivers;
+    const uint32_t row_bytes = n_per_bank * tile_bytes;
+    const uint32_t block_bytes = k_block_w_tiles * row_bytes;
+    const uint32_t noc_max_burst = MetalContext::instance().hal().get_noc_max_burst_size_bytes();
+    const auto [coalesced_page_size, coalesced_num_pages] = pick_page_size(noc_max_burst, n_per_recv, tile_bytes);
+    TT_FATAL(
+        coalesced_page_size <= noc_max_burst,
+        "DRAM-core prefetcher coalesced page size ({} B) exceeds the one-packet NoC write "
+        "limit ({} B). Reduce N_per_bank or increase num_global_cb_receivers.",
+        coalesced_page_size,
+        noc_max_burst);
+
+    // Fit ladder (tt_metal/impl/buffers/prefetcher_matmul_design.md §6).
+    uint32_t rows_per_sub = 0;
+    uint32_t M = 1;
+    if (block_bytes <= ring_half) {
+        // Case 1: full block fits — fast path, single-shot push.
+        rows_per_sub = k_block_w_tiles;
+        M = 1;
+    } else if (row_bytes <= ring_half) {
+        // Case 2: K-sub only. Largest divisor of k_block_w_tiles whose row-band fits.
+        rows_per_sub = 1;
+        for (uint32_t d = k_block_w_tiles; d >= 1; --d) {
+            if (k_block_w_tiles % d == 0 && static_cast<uint64_t>(d) * row_bytes <= ring_half) {
+                rows_per_sub = d;
+                break;
+            }
+        }
+        M = 1;
+    } else {
+        // Case 3: K-sub + N-chunk; rows_per_sub=1 forces M-chunking onto a single K-row
+        // (contiguous N-stripe per chunk).
+        rows_per_sub = 1;
+        bool picked = false;
+        for (uint32_t m = 1; m <= num_receivers; ++m) {
+            if (num_receivers % m == 0 && (row_bytes / m) <= ring_half) {
+                M = m;
+                picked = true;
+                break;
+            }
+        }
+        TT_FATAL(
+            picked,
+            "DRAM-core prefetcher cannot fit one K-row of tensor (k_tiles={}, n_per_bank={}, "
+            "tile_bytes={}, row_bytes={} B) into DRISC L1 stage half ({} B) even with "
+            "M=num_receivers ({}). Increase num_global_cb_receivers, reduce N_per_bank, or "
+            "use the worker-core prefetcher.",
+            k_tiles_raw,
+            n_per_bank,
+            tile_bytes,
+            row_bytes,
+            ring_half,
+            num_receivers);
+    }
+    const uint32_t num_sub = k_block_w_tiles / rows_per_sub;
+    const uint32_t sub_chunk_bytes = rows_per_sub * (n_per_bank / M) * tile_bytes;
+    TT_FATAL(
+        sub_chunk_bytes <= ring_half,
+        "Internal: chunk size {} B exceeds ring_half {} B after fit ladder. This is a bug "
+        "in compute_tensor_geom; please file an issue with k_tiles={}, n_per_bank={}, "
+        "tile_bytes={}, rows_per_sub={}, M={}.",
+        sub_chunk_bytes,
+        ring_half,
+        k_tiles_raw,
+        n_per_bank,
+        tile_bytes,
+        rows_per_sub,
+        M);
+
+    TensorGeom g;
+    g.bank_local_base = bank_local_base;
+    g.num_sub = num_sub;
+    g.M = M;
+    g.rows_per_sub = rows_per_sub;
+    g.coalesced_page_size = coalesced_page_size;
+    g.coalesced_num_pages = coalesced_num_pages;
+    g.sub_chunk_bytes = sub_chunk_bytes;
+    g.sub_stride_bytes = rows_per_sub * row_bytes;
+    g.block_stride_bytes = k_block_w_tiles * row_bytes;
+    g.page_bytes_per_recv = k_block_w_tiles * coalesced_num_pages * coalesced_page_size;
+    return g;
+}
+
+// Build a single-device DRISC prefetcher Program from the GCB + tensor metadata.
+// All devices in a LOCKSTEP mesh produce byte-identical Programs because buffer
+// addresses, GCB addresses, and DRISC L1 layout are all device-uniform.
+std::unique_ptr<Program> build_program(
+    MeshDevice* mesh_device,
+    const std::vector<const MeshTensor*>& input_tensors,
+    const experimental::GlobalCircularBuffer& gcb,
+    const experimental::DramCorePrefetcherConfig& config) {
+    TT_FATAL(input_tensors.size() >= 2, "Need at least one data tensor + the tensor_addrs tensor");
+
+    // Last tensor is the addrs tensor (kept for op-contract parity). DRISC path doesn't
+    // read it — runtime args carry buffer base addresses directly.
+    std::vector<const MeshTensor*> data_tensors;
+    data_tensors.reserve(input_tensors.size() - 1);
+    for (size_t i = 0; i + 1 < input_tensors.size(); ++i) {
+        data_tensors.push_back(input_tensors[i]);
+    }
+    const uint32_t num_tensors = static_cast<uint32_t>(data_tensors.size());
+
+    const auto& sender_receiver_core_mapping = gcb.sender_receiver_core_mapping();
+    const uint32_t num_senders = static_cast<uint32_t>(sender_receiver_core_mapping.size());
+    TT_FATAL(num_senders > 0, "DRAM-sender GlobalCircularBuffer must have at least one sender");
+
+    uint32_t num_receivers = sender_receiver_core_mapping.front().second.num_cores();
+    for (const auto& [_, recv] : sender_receiver_core_mapping) {
+        TT_FATAL(
+            recv.num_cores() == num_receivers,
+            "All senders must have the same receiver count for the DRAM-core prefetcher");
+    }
+
+    // num_blocks (= ring_size) is the per-layer push count per receiver per tensor;
+    // matches the receiver matmul's wait_front(num_blocks) at
+    // ttnn/.../reader_bmm_tile_layout_in1_ring_all_gather.cpp:141. All tensors share it.
+    const uint32_t num_blocks = num_senders * num_receivers;
+
+    // DRISC L1 layout (see tt_metal/impl/buffers/drisc_l1_arena.hpp):
+    //   kernel_working_region_base + [noc_xy table][config][stage_ring]
+    // The stage_ring is split into two halves by the kernel (ping-pong, ring_depth=2).
+    auto& arena = mesh_device->impl().drisc_l1_arena();
+    const uint32_t kernel_region_size = arena.kernel_working_region_size();
+    TT_FATAL(
+        kernel_region_size > kKernelOverheadBytes,
+        "DRISC L1 kernel region ({} B) too small for the prefetcher kernel overhead ({} B)",
+        kernel_region_size,
+        kKernelOverheadBytes);
+    const uint32_t l1_alignment = hal::get_l1_alignment();
+    const uint32_t pages_sent_addr = static_cast<uint32_t>(experimental::pages_sent_drisc_l1_base(gcb));
+    uint32_t cursor = static_cast<uint32_t>(arena.kernel_working_region_base());
+    cursor = align_up(cursor, l1_alignment);
+    const uint32_t noc_xy_addr = cursor;
+    cursor += 2 * sizeof(uint32_t) * num_receivers;
+    cursor = align_up(cursor, l1_alignment);
+    const uint32_t config_addr = cursor;
+    cursor += 16;
+    cursor = align_up(cursor, l1_alignment);
+    const uint32_t stage_ring_base = cursor;
+    const uint32_t region_end = static_cast<uint32_t>(arena.kernel_working_region_base()) + kernel_region_size;
+    TT_FATAL(
+        region_end > stage_ring_base,
+        "DRISC L1 kernel region too small after overhead: region_end={} stage_ring_base={}",
+        region_end,
+        stage_ring_base);
+    // Two halves; each half must be l1-aligned, so round the total down.
+    uint32_t stage_ring_size = (region_end - stage_ring_base);
+    stage_ring_size &= ~(2 * l1_alignment - 1);  // ensure both halves are l1-aligned
+    TT_FATAL(
+        stage_ring_size >= 2 * l1_alignment,
+        "DRISC L1 stage ring too small: {} B (region_end={} stage_ring_base={})",
+        stage_ring_size,
+        region_end,
+        stage_ring_base);
+    const uint32_t ring_half = stage_ring_size / 2;
+
+    // Compute per-tensor geometry; the fit ladder lives in compute_tensor_geom.
+    std::vector<TensorGeom> geoms;
+    geoms.reserve(data_tensors.size());
+    for (const auto* t : data_tensors) {
+        const uint32_t bank_local_base = static_cast<uint32_t>(t->mesh_buffer().address());
+        geoms.push_back(compute_tensor_geom(*t, bank_local_base, num_senders, num_receivers, ring_half));
+    }
+
+    auto program = std::make_unique<Program>();
+
+    for (uint32_t s = 0; s < num_senders; ++s) {
+        const auto& [sender_logical, _receivers] = sender_receiver_core_mapping[s];
+        std::vector<uint32_t> compile_args = {
+            config.num_layers,
+            num_tensors,
+            num_blocks,
+            num_receivers,
+            stage_ring_base,
+            stage_ring_size,
+            kRemoteCBId,
+            pages_sent_addr,
+            noc_xy_addr,
+            config_addr,
+            gcb.size(),
+            static_cast<uint32_t>(gcb.buffer_address()),
+            static_cast<uint32_t>(experimental::pages_sent_worker_l1_base(gcb)),
+        };
+
+        KernelHandle kernel_id = CreateKernel(
+            *program, kKernelPath, sender_logical, DramConfig{.noc = NOC::NOC_0, .compile_args = compile_args});
+
+        // RT args: bank_id, then per-tensor blocks (length num_tensors each), then [recv_xy].
+        // Order must match the kernel's read order at the top of kernel_main; see
+        // tt_metal/impl/buffers/prefetcher_matmul_design.md §6 "Runtime args".
+        std::vector<uint32_t> rt_args;
+        rt_args.reserve(1 + 10 * num_tensors + 2 * num_receivers);
+        rt_args.push_back(/*bank_id=*/sender_logical.x);
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.bank_local_base);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.num_sub);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.M);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.rows_per_sub);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.coalesced_page_size);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.coalesced_num_pages);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.sub_chunk_bytes);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.sub_stride_bytes);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.block_stride_bytes);
+        }
+        for (const auto& g : geoms) {
+            rt_args.push_back(g.page_bytes_per_recv);
+        }
+        const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(s);
+        for (const auto& c : receiver_phys) {
+            rt_args.push_back(c.x);
+            rt_args.push_back(c.y);
+        }
+        SetRuntimeArgs(*program, kernel_id, sender_logical, rt_args);
+    }
+
+    return program;
+}
+
+}  // namespace
+
+DramCorePrefetcherManager::DramCorePrefetcherManager(MeshDevice* mesh_device) : mesh_device_(mesh_device) {
+    TT_FATAL(mesh_device_ != nullptr, "DramCorePrefetcherManager requires a non-null MeshDevice");
+}
+
+DramCorePrefetcherManager::~DramCorePrefetcherManager() { stop(); }
+
+void DramCorePrefetcherManager::start(
+    const std::vector<const MeshTensor*>& input_tensors,
+    const experimental::GlobalCircularBuffer& gcb,
+    const experimental::DramCorePrefetcherConfig& config) {
+    TT_FATAL(
+        !is_active(),
+        "A DRAM-core prefetcher is already active on this mesh device. Call "
+        "StopDramCorePrefetcher before starting another.");
+    TT_FATAL(
+        experimental::sender_core_type(gcb) == experimental::SenderCoreType::Dram,
+        "StartDramCorePrefetcher requires a DRAM-sender GlobalCircularBuffer");
+
+    // Hold the GCB by value so it outlives Stop even if the caller drops their copy.
+    gcb_ = gcb;
+
+    // Build one Program per IDevice in the mesh and launch it in slow dispatch with
+    // wait_until_cores_done=false so the host returns immediately.
+    for (auto* device : mesh_device_->get_view().get_devices()) {
+        auto program = build_program(mesh_device_, input_tensors, gcb, config);
+        ::tt::tt_metal::detail::CompileProgram(device, *program, /*force_slow_dispatch=*/true);
+        ::tt::tt_metal::detail::WriteRuntimeArgsToDevice(device, *program, /*force_slow_dispatch=*/true);
+        ::tt::tt_metal::detail::LaunchProgram(
+            device, *program, /*wait_until_cores_done=*/false, /*force_slow_dispatch=*/true);
+        per_device_state_.push_back(PerDeviceState{device, std::move(program)});
+    }
+}
+
+void DramCorePrefetcherManager::stop() {
+    if (!is_active()) {
+        return;
+    }
+    for (auto& state : per_device_state_) {
+        if (state.device != nullptr && state.program != nullptr) {
+            ::tt::tt_metal::detail::WaitProgramDone(state.device, *state.program);
+        }
+    }
+    per_device_state_.clear();
+    gcb_.reset();
+}
+
+}  // namespace tt::tt_metal::distributed
+
+// -----------------------------------------------------------------------------
+// experimental::StartDramCorePrefetcher / StopDramCorePrefetcher
+//
+// Thin entry points that delegate to the per-mesh manager owned by MeshDeviceImpl.
+// Defined here (next to the manager) to avoid a separate TU just for two free
+// functions, and to keep MeshDeviceImpl::dram_core_prefetcher() the single point
+// of contact.
+// -----------------------------------------------------------------------------
+namespace tt::tt_metal::experimental {
+
+void StartDramCorePrefetcher(
+    distributed::MeshDevice* mesh_device,
+    const std::vector<const MeshTensor*>& input_tensors,
+    const GlobalCircularBuffer& gcb,
+    const DramCorePrefetcherConfig& config) {
+    TT_FATAL(mesh_device != nullptr, "StartDramCorePrefetcher requires a non-null MeshDevice");
+    auto& manager = mesh_device->impl().dram_core_prefetcher(mesh_device);
+    manager.start(input_tensors, gcb, config);
+}
+
+void StopDramCorePrefetcher(distributed::MeshDevice* mesh_device) {
+    TT_FATAL(mesh_device != nullptr, "StopDramCorePrefetcher requires a non-null MeshDevice");
+    auto& manager = mesh_device->impl().dram_core_prefetcher(mesh_device);
+    manager.stop();
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <tt-metalium/experimental/dram_core_prefetcher.hpp>
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
+
+namespace tt::tt_metal {
+
+class IDevice;
+class MeshTensor;
+class Program;
+
+namespace distributed {
+
+class MeshDevice;
+
+// Owns the DRAM-core (DRISC) prefetcher subsystem for a single MeshDevice. State is held
+// per-device (one Program per IDevice in the mesh) so each DRISC kernel runs on its own
+// chip. Single-prefetcher-at-a-time invariant: start() asserts is_active() is false.
+//
+// Lifecycle:
+//   * start(...) builds the Program(s), launches with wait_until_cores_done=false on
+//     each device's slow-dispatch path, and returns immediately. The host thread is then
+//     free to enqueue consumer kernels (matmuls) while the prefetcher kernel pushes
+//     layers into the GCB.
+//   * stop() blocks each launched Program's natural exit (kernel finishes its
+//     num_layers loop), then releases per-device state. No-op if not active.
+//   * Destructor calls stop().
+class DramCorePrefetcherManager {
+public:
+    explicit DramCorePrefetcherManager(MeshDevice* mesh_device);
+    ~DramCorePrefetcherManager();
+
+    DramCorePrefetcherManager(const DramCorePrefetcherManager&) = delete;
+    DramCorePrefetcherManager& operator=(const DramCorePrefetcherManager&) = delete;
+    DramCorePrefetcherManager(DramCorePrefetcherManager&&) = delete;
+    DramCorePrefetcherManager& operator=(DramCorePrefetcherManager&&) = delete;
+
+    void start(
+        const std::vector<const MeshTensor*>& input_tensors,
+        const experimental::GlobalCircularBuffer& gcb,
+        const experimental::DramCorePrefetcherConfig& config);
+
+    // Block until the per-device programs finish their num_layers loop, then release
+    // state. Safe to call when inactive (no-op).
+    void stop();
+
+    bool is_active() const { return !per_device_state_.empty(); }
+
+private:
+    struct PerDeviceState {
+        IDevice* device = nullptr;
+        std::unique_ptr<Program> program;
+    };
+
+    MeshDevice* mesh_device_;
+    std::vector<PerDeviceState> per_device_state_;
+
+    // Held for the duration of the launch so the buffers backing the input tensors and
+    // the GCB stay alive. The caller's invariant in StartDramCorePrefetcher requires
+    // them to outlive stop(); we copy/retain here only as a defense-in-depth measure
+    // against accidental destruction races.
+    std::optional<experimental::GlobalCircularBuffer> gcb_;
+};
+
+}  // namespace distributed
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// DRISC prefetcher kernel for the DRAM-core mode of ttnn.dram_prefetcher.
+// See tt_metal/impl/buffers/prefetcher_matmul_design.md for the architecture
+// and contract; in particular §3 (what a "block" is), §6 (DRAM-core path: fit
+// ladder, L1 layout, helpers, main loop), and §8 (cross-component invariants).
+//
+// Pipeline summary:
+//   For each (layer, tensor, block), reserve one fifo page on every receiver,
+//   then iterate (sub-band sb, chunk ch) over num_sub[t] * M[t] (sb, ch)
+//   pairs, streaming DMA chunks of sub_chunk_bytes[t] into the ping-pong
+//   stage ring and pushing each via prefetcher_write_chunk. At the end of
+//   the block, prefetcher_finalize_block bumps pages_sent once (per receiver)
+//   and advances iface.fifo_wr_ptr by page_bytes_per_recv[t].
+//
+//   When (rows_per_sub, M) == (k_block_w_tiles, 1) the inner loop reduces to
+//   a single chunk + finalize per block (the fast path, byte-for-byte
+//   identical to the pre-refactor single-shot push).
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/remote_circular_buffer.h"
+#include "experimental/drisc_mode.h"
+#include "experimental/gddr_dma.h"
+
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER)
+#include "api/debug/ring_buffer.h"
+#include "internal/tt-1xx/risc_common.h"
+#define DRISC_PROFILE 1
+#endif
+
+#ifdef DRISC_PROFILE
+#define PROFILE_T0() uint32_t _prof_t0 = get_timestamp_32b()
+#define PROFILE_ACCUM(acc)                       \
+    do {                                         \
+        uint32_t _prof_t1 = get_timestamp_32b(); \
+        (acc) += _prof_t1 - _prof_t0;            \
+        _prof_t0 = _prof_t1;                     \
+    } while (0)
+#else
+#define PROFILE_T0() ((void)0)
+#define PROFILE_ACCUM(acc) ((void)0)
+#endif
+
+// DRISC firmware doesn't define cb_interface (no CB infra on DRAM cores).
+CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
+
+namespace {
+
+// Writes one sub-band chunk's data to `num_receivers_in_chunk` receivers, each
+// receiver getting `num_rows` rows of (coalesced_num_pages_per_row *
+// coalesced_page_size) bytes, starting at `dest_l1_base` on the receiver. The
+// stage holds data laid out so receiver r's row h is at
+//
+//     src_l1_addr
+//       + h * (num_receivers_in_chunk * coalesced_num_pages_per_row * coalesced_page_size)
+//       + r * (coalesced_num_pages_per_row * coalesced_page_size)
+//
+// Mirrors the inner write loop of remote_cb_push_back_and_write_pages at
+// tt_metal/hw/inc/api/remote_circular_buffer.h:368-389, but takes an explicit
+// `dest_l1_base` and `recv_xy` so the caller drives receiver subset selection
+// and dest offset directly. No pages_sent / semaphore side effects, no
+// iface.fifo_wr_ptr advance — those happen exactly once per block in
+// prefetcher_finalize_block.
+// Template-specialized fast paths for the common cases:
+//   - `single_row`        — num_rows == 1 (no outer h loop)
+//   - `single_page`       — coalesced_num_pages_per_row == 1 (no inner w loop)
+// Dispatched at per-tensor scope so the per-chunk hot path has no branch on
+// loop-shape. The general path remains for `<false,false>`.
+template <bool single_row, bool single_page>
+FORCE_INLINE void prefetcher_write_chunk(
+    uint32_t src_l1_addr,
+    uint32_t dest_l1_base,
+    volatile tt_l1_ptr uint32_t* recv_xy,
+    uint32_t num_receivers_in_chunk,
+    uint32_t num_rows,
+    uint32_t coalesced_num_pages_per_row,
+    uint32_t coalesced_page_size,
+    uint8_t noc) {
+    const uint32_t row_bytes_per_recv = coalesced_num_pages_per_row * coalesced_page_size;
+    const uint32_t row_stride_in_stage = row_bytes_per_recv * num_receivers_in_chunk;
+
+    uint32_t recv_src_offset = 0;
+    for (uint32_t i = 0; i < num_receivers_in_chunk; ++i) {
+        const uint32_t remote_noc_xy =
+            uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, recv_xy[2 * i]), DYNAMIC_NOC_Y(noc, recv_xy[2 * i + 1])));
+        uint32_t dest_addr = dest_l1_base;
+        const uint64_t set_state_dest = get_noc_addr_helper(remote_noc_xy, dest_addr);
+        if constexpr (!(single_row && single_page)) {
+            // Multi-write paths use with_state, which requires set_state to have configured
+            // the cmd_buf first.
+            noc_async_write_one_packet_set_state</*posted=*/true>(set_state_dest, coalesced_page_size, noc);
+        }
+
+        uint32_t src_addr = src_l1_addr + recv_src_offset;
+        if constexpr (single_row && single_page) {
+            // 1 write per receiver. Use the fused noc_async_write_one_packet to skip
+            // the redundant `set_state` cmd_buf_ready spin — only one cmd is issued per
+            // receiver, so amortizing state across multiple `with_state` calls buys
+            // nothing here. One spin per receiver instead of two.
+            noc_async_write_one_packet</*enable_noc_tracing=*/false, /*posted=*/true>(
+                src_addr, set_state_dest, coalesced_page_size, noc);
+        } else if constexpr (single_row) {
+            // num_rows == 1; only inner w loop runs.
+            for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
+                const uint64_t dest_noc = get_noc_addr_helper(remote_noc_xy, dest_addr);
+                noc_async_write_one_packet_with_state</*posted=*/true>(src_addr, dest_noc, noc);
+                src_addr += coalesced_page_size;
+                dest_addr += coalesced_page_size;
+            }
+        } else if constexpr (single_page) {
+            // coalesced_num_pages_per_row == 1; only outer h loop runs.
+            for (uint32_t h = 0; h < num_rows; ++h) {
+                const uint64_t dest_noc = get_noc_addr_helper(remote_noc_xy, dest_addr);
+                noc_async_write_one_packet_with_state</*posted=*/true>(src_addr, dest_noc, noc);
+                src_addr += row_stride_in_stage;
+                dest_addr += coalesced_page_size;
+            }
+        } else {
+            // General: nested h × w loops.
+            for (uint32_t h = 0; h < num_rows; ++h) {
+                const uint32_t row_src_start = src_addr;
+                for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
+                    const uint64_t dest_noc = get_noc_addr_helper(remote_noc_xy, dest_addr);
+                    noc_async_write_one_packet_with_state</*posted=*/true>(src_addr, dest_noc, noc);
+                    src_addr += coalesced_page_size;
+                    dest_addr += coalesced_page_size;
+                }
+                src_addr = row_src_start + row_stride_in_stage;
+            }
+        }
+        recv_src_offset += row_bytes_per_recv;
+    }
+}
+
+// Finalizes one ring-block: bumps local pages_sent + remote NoC semaphore for
+// every receiver by the per-block aligned-page count, then advances
+// iface.fifo_wr_ptr by page_bytes_per_recv (wrapping at fifo_limit). Called
+// once per block, after all chunks have been written via prefetcher_write_chunk.
+//
+// The aligned-page count includes any wrap "gap" (mirrors the len_bytes
+// adjustment in remote_cb_push_back_and_write_pages at remote_circular_buffer.h:347-350)
+// so the receiver's pages_sent counter advances correctly across the buffer
+// boundary.
+//
+// With skip_ptr_update=true the NoC semaphore increments are posted; the caller
+// drains them once at end of stream via update_remote_cb_config_in_l1 +
+// noc_async_atomic_barrier (the same pattern remote_cb_push_back_and_write_pages
+// uses when its template flag is true). enable_performance_mode threads through.
+template <bool skip_ptr_update>
+FORCE_INLINE void prefetcher_finalize_block(
+    RemoteSenderCBInterface& iface, uint32_t page_bytes_per_recv, uint32_t num_receivers, uint8_t noc) {
+    uint32_t len_bytes = page_bytes_per_recv;
+    uint32_t next_wr_ptr = iface.fifo_wr_ptr + page_bytes_per_recv;
+    if (next_wr_ptr >= iface.fifo_limit_page_aligned) {
+        const uint32_t fifo_size = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.config_ptr)[3];
+        len_bytes += iface.fifo_start_addr + fifo_size - iface.fifo_limit_page_aligned;
+        next_wr_ptr = iface.fifo_start_addr + (next_wr_ptr - iface.fifo_limit_page_aligned);
+    }
+    const uint32_t fifo_pages_sent = len_bytes / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE;
+
+    volatile tt_l1_ptr uint32_t* local_pages_sent =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.aligned_pages_sent_ptr);
+    uint32_t remote_sent_base = remote_cb_remote_pages_sent_ptr(iface.num_receivers_and_remote_pages_sent_ptr);
+    volatile tt_l1_ptr uint32_t* recv_xy_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(iface.receiver_noc_xy_ptr);
+    for (uint32_t i = 0; i < num_receivers; ++i) {
+        const uint32_t remote_noc_xy =
+            uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, recv_xy_ptr[0]), DYNAMIC_NOC_Y(noc, recv_xy_ptr[1])));
+        *local_pages_sent += fifo_pages_sent;
+        const uint64_t remote_sent_addr = get_noc_addr_helper(remote_noc_xy, remote_sent_base);
+        noc_semaphore_inc<skip_ptr_update>(remote_sent_addr, fifo_pages_sent, noc);
+        local_pages_sent += experimental::REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
+        remote_sent_base += 2 * L1_ALIGNMENT;
+        recv_xy_ptr += 2;
+    }
+    iface.fifo_wr_ptr = next_wr_ptr;
+}
+
+}  // namespace
+
+void kernel_main() {
+    // ---- Compile-time args (13). See tt_metal/impl/buffers/prefetcher_matmul_design.md §6. ----
+    constexpr uint32_t num_layers = get_compile_time_arg_val(0);
+    constexpr uint32_t num_tensors = get_compile_time_arg_val(1);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
+    constexpr uint32_t num_receivers = get_compile_time_arg_val(3);
+    constexpr uint32_t stage_ring_base = get_compile_time_arg_val(4);
+    constexpr uint32_t stage_ring_size = get_compile_time_arg_val(5);
+    constexpr uint32_t remote_cb_id = get_compile_time_arg_val(6);
+    constexpr uint32_t pages_sent_l1_addr = get_compile_time_arg_val(7);
+    constexpr uint32_t noc_xy_l1_addr = get_compile_time_arg_val(8);
+    constexpr uint32_t config_l1_addr = get_compile_time_arg_val(9);
+    constexpr uint32_t fifo_size_per_receiver = get_compile_time_arg_val(10);
+    constexpr uint32_t receiver_buffer_address = get_compile_time_arg_val(11);
+    constexpr uint32_t remote_pages_sent_worker_l1_addr = get_compile_time_arg_val(12);
+    constexpr uint32_t ring_half = stage_ring_size / 2;
+    constexpr uint32_t stage_slot_a = stage_ring_base;
+    constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
+    (void)fifo_size_per_receiver;  // stored in cfg[3]; iface uses it via config_ptr.
+
+    // ---- Runtime args ----
+    // [0]: bank_id
+    // Then per-tensor blocks of length num_tensors each:
+    //   bank_local_base, num_sub, M, rows_per_sub, coalesced_page_size,
+    //   coalesced_num_pages, sub_chunk_bytes, sub_stride_bytes,
+    //   block_stride_bytes, page_bytes_per_recv
+    // Finally [2 * num_receivers] noc_x/noc_y pairs.
+    uint32_t rt_idx = 0;
+    const uint32_t bank_id = get_arg_val<uint32_t>(rt_idx++);
+    (void)bank_id;
+
+    const uint32_t bank_local_base_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t num_sub_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t M_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t rows_per_sub_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t coal_page_size_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t coal_num_pages_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t sub_chunk_bytes_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t sub_stride_bytes_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t block_stride_bytes_idx = rt_idx;
+    rt_idx += num_tensors;
+    const uint32_t page_bytes_per_recv_idx = rt_idx;
+    rt_idx += num_tensors;
+
+    // ---- One-time L1 setup (mirrors the pre-refactor kernel) ----
+    volatile tt_l1_ptr uint32_t* noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(noc_xy_l1_addr);
+    for (uint32_t i = 0; i < num_receivers; ++i) {
+        noc_xy_ptr[2 * i] = get_arg_val<uint32_t>(rt_idx++);
+        noc_xy_ptr[2 * i + 1] = get_arg_val<uint32_t>(rt_idx++);
+    }
+    volatile tt_l1_ptr uint32_t* psem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pages_sent_l1_addr);
+    const uint32_t psem_uints = (2 * L1_ALIGNMENT * num_receivers) / sizeof(uint32_t);
+    for (uint32_t i = 0; i < psem_uints; ++i) {
+        psem[i] = 0;
+    }
+    volatile tt_l1_ptr uint32_t* cfg = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(config_l1_addr);
+    cfg[0] = 1;
+    cfg[1] = num_receivers;
+    cfg[2] = receiver_buffer_address;
+    cfg[3] = fifo_size_per_receiver;
+
+    RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
+    iface.config_ptr = config_l1_addr;
+    iface.fifo_start_addr = receiver_buffer_address;
+    iface.fifo_wr_ptr = receiver_buffer_address;
+    iface.receiver_noc_xy_ptr = noc_xy_l1_addr;
+    iface.aligned_pages_sent_ptr = pages_sent_l1_addr;
+    iface.num_receivers_and_remote_pages_sent_ptr = remote_cb_pack(num_receivers, remote_pages_sent_worker_l1_addr);
+
+    experimental::drisc_set_stream_mode();
+
+    const uint32_t* bank_local_bases = reinterpret_cast<uint32_t*>(get_arg_addr(bank_local_base_idx));
+    const uint32_t* num_subs = reinterpret_cast<uint32_t*>(get_arg_addr(num_sub_idx));
+    const uint32_t* Ms = reinterpret_cast<uint32_t*>(get_arg_addr(M_idx));
+    const uint32_t* rows_per_subs = reinterpret_cast<uint32_t*>(get_arg_addr(rows_per_sub_idx));
+    const uint32_t* coal_page_sizes = reinterpret_cast<uint32_t*>(get_arg_addr(coal_page_size_idx));
+    const uint32_t* coal_num_pages = reinterpret_cast<uint32_t*>(get_arg_addr(coal_num_pages_idx));
+    const uint32_t* sub_chunk_bytes = reinterpret_cast<uint32_t*>(get_arg_addr(sub_chunk_bytes_idx));
+    const uint32_t* sub_stride_bytes = reinterpret_cast<uint32_t*>(get_arg_addr(sub_stride_bytes_idx));
+    const uint32_t* block_stride_bytes = reinterpret_cast<uint32_t*>(get_arg_addr(block_stride_bytes_idx));
+    const uint32_t* page_bytes_per_recv = reinterpret_cast<uint32_t*>(get_arg_addr(page_bytes_per_recv_idx));
+
+    // ---- Profiling accumulators (zero-cost when WATCHER_DISABLE_RING_BUFFER) ----
+#ifdef DRISC_PROFILE
+    uint32_t prof_reserve = 0;   // 0xA3
+    uint32_t prof_issue = 0;     // 0xA1 (next-DMA issue)
+    uint32_t prof_wait = 0;      // 0xA2 (DMA wait)
+    uint32_t prof_push = 0;      // 0xA4 (prefetcher_write_chunk)
+    uint32_t prof_flush = 0;     // 0xA5 (noc_async_posted_writes_flushed)
+    uint32_t prof_finalize = 0;  // 0xA6 (prefetcher_finalize_block)
+    uint32_t prof_chunks = 0;    // 0xFF (chunk count divisor)
+#endif
+
+    // ---- Main loop ----
+    for (uint32_t layer = 0; layer < num_layers; ++layer) {
+        for (uint32_t t = 0; t < num_tensors; ++t) {
+            const uint32_t tensor_base = bank_local_bases[t];
+            const uint32_t t_num_sub = num_subs[t];
+            const uint32_t t_M = Ms[t];
+            const uint32_t t_rows_per_sub = rows_per_subs[t];
+            const uint32_t t_coal_page_size = coal_page_sizes[t];
+            const uint32_t t_coal_num_pages = coal_num_pages[t];
+            const uint32_t t_chunk_bytes = sub_chunk_bytes[t];
+            const uint32_t t_sub_stride = sub_stride_bytes[t];
+            const uint32_t t_block_stride = block_stride_bytes[t];
+            const uint32_t t_page_bytes_per_recv = page_bytes_per_recv[t];
+            const uint32_t t_recv_per_chunk = num_receivers / t_M;
+            const uint32_t t_sub_band_per_block = t_num_sub * t_M;
+
+            // Set the sender fifo page size to one full per-receiver page so
+            // remote_cb_reserve_back reserves exactly one page per receiver.
+            experimental::resize_remote_sender_cb_interface</*update_remote_over_noc=*/false>(
+                remote_cb_id, t_page_bytes_per_recv, noc_index);
+
+            const uint32_t total_chunks = num_blocks * t_sub_band_per_block;
+
+            // Prologue: issue first DMA (chunk 0) into stage_slot_a. The body's
+            // "issue next" lookahead populates subsequent slots.
+            experimental::dma_async_read(/*stream=*/0, tensor_base, stage_slot_a, t_chunk_bytes);
+
+            uint32_t fifo_snapshot = 0;
+            uint32_t cum_offset_in_page = 0;
+
+            // Track (blk, sb, ch) via incremental successor logic instead of
+            // c / t_sub_band_per_block / (sb_ch / t_M) etc. — those generated `divu`/`remu`
+            // (6+ cyc each on BabyRISCV); we now just compare & increment counters.
+            uint32_t blk = 0;
+            uint32_t sb = 0;
+            uint32_t ch = 0;
+            // Maintain stage_slot directly; toggle via `(a + b) - slot`. Saves the
+            // per-iter conditional select that `parity == 0 ? slot_a : slot_b` compiled to.
+            constexpr uint32_t stage_slot_sum = stage_slot_a + stage_slot_b;
+            uint32_t stage_slot = stage_slot_a;
+            // has_next is true for every chunk except the very last; track as a flag and
+            // only flip when the successor crosses num_blocks. Avoids the per-iter
+            // `(next_blk < num_blocks)` sltu+branch in the hot path.
+            bool has_next = (total_chunks > 1);
+
+            for (uint32_t c = 0; c < total_chunks; ++c) {
+                PROFILE_T0();
+
+                if (sb == 0 && ch == 0) {
+                    experimental::remote_cb_reserve_back(remote_cb_id, 1);
+                    fifo_snapshot = iface.fifo_wr_ptr;
+                    cum_offset_in_page = 0;
+                    PROFILE_ACCUM(prof_reserve);
+                }
+
+                // Successor: next (blk, sb, ch). Cheap branches replace 4 div/mods.
+                uint32_t next_ch = ch + 1;
+                uint32_t next_sb = sb;
+                uint32_t next_blk = blk;
+                if (next_ch == t_M) {
+                    next_ch = 0;
+                    ++next_sb;
+                    if (next_sb == t_num_sub) {
+                        next_sb = 0;
+                        ++next_blk;
+                        if (next_blk == num_blocks) {
+                            has_next = false;
+                        }
+                    }
+                }
+                const uint32_t next_slot = stage_slot_sum - stage_slot;
+
+                // Issue the next DMA before waiting on this one (ping-pong, depth 2).
+                if (has_next) {
+                    const uint32_t next_src =
+                        tensor_base + next_blk * t_block_stride + next_sb * t_sub_stride + next_ch * t_chunk_bytes;
+                    experimental::dma_async_read(/*stream=*/0, next_src, next_slot, t_chunk_bytes);
+                }
+                PROFILE_ACCUM(prof_issue);
+                const uint32_t outstanding_after_wait = has_next ? 1u : 0u;
+                experimental::dma_async_read_wait_n(/*stream=*/0, outstanding_after_wait);
+                PROFILE_ACCUM(prof_wait);
+                volatile tt_l1_ptr uint32_t* chunk_recv_xy =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(noc_xy_l1_addr) + ch * t_recv_per_chunk * 2;
+                // Per-tensor-stable predicate; branches are 100% predictable across the
+                // chunk loop. Compiler folds the fast-path bodies via `if constexpr` in
+                // `prefetcher_write_chunk`.
+                if (t_rows_per_sub == 1) {
+                    if (t_coal_num_pages == 1) {
+                        prefetcher_write_chunk</*single_row=*/true, /*single_page=*/true>(
+                            stage_slot,
+                            fifo_snapshot + cum_offset_in_page,
+                            chunk_recv_xy,
+                            t_recv_per_chunk,
+                            t_rows_per_sub,
+                            t_coal_num_pages,
+                            t_coal_page_size,
+                            noc_index);
+                    } else {
+                        prefetcher_write_chunk</*single_row=*/true, /*single_page=*/false>(
+                            stage_slot,
+                            fifo_snapshot + cum_offset_in_page,
+                            chunk_recv_xy,
+                            t_recv_per_chunk,
+                            t_rows_per_sub,
+                            t_coal_num_pages,
+                            t_coal_page_size,
+                            noc_index);
+                    }
+                } else {
+                    if (t_coal_num_pages == 1) {
+                        prefetcher_write_chunk</*single_row=*/false, /*single_page=*/true>(
+                            stage_slot,
+                            fifo_snapshot + cum_offset_in_page,
+                            chunk_recv_xy,
+                            t_recv_per_chunk,
+                            t_rows_per_sub,
+                            t_coal_num_pages,
+                            t_coal_page_size,
+                            noc_index);
+                    } else {
+                        prefetcher_write_chunk</*single_row=*/false, /*single_page=*/false>(
+                            stage_slot,
+                            fifo_snapshot + cum_offset_in_page,
+                            chunk_recv_xy,
+                            t_recv_per_chunk,
+                            t_rows_per_sub,
+                            t_coal_num_pages,
+                            t_coal_page_size,
+                            noc_index);
+                    }
+                }
+                PROFILE_ACCUM(prof_push);
+
+                if (ch + 1 == t_M) {
+                    cum_offset_in_page += t_rows_per_sub * t_coal_num_pages * t_coal_page_size;
+                }
+
+                if (sb + 1 == t_num_sub && ch + 1 == t_M) {
+                    noc_async_posted_writes_flushed();
+                    PROFILE_ACCUM(prof_flush);
+                    prefetcher_finalize_block</*skip_ptr_update=*/true>(
+                        iface, t_page_bytes_per_recv, num_receivers, noc_index);
+                    PROFILE_ACCUM(prof_finalize);
+                }
+
+                // Advance counters to next chunk.
+                blk = next_blk;
+                sb = next_sb;
+                ch = next_ch;
+                stage_slot = next_slot;
+#ifdef DRISC_PROFILE
+                prof_chunks++;
+#endif
+            }
+
+            if (t == num_tensors - 1) {
+                experimental::remote_cb_sender_barrier(remote_cb_id);
+            }
+        }
+    }
+
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc_async_atomic_barrier();
+    experimental::drisc_set_noc2axi_mode();
+
+#ifdef DRISC_PROFILE
+    // Tag-prefixed totals; decode newest-first via `grep debug_ring_buffer`. Each entry's
+    // top byte is the stage tag; the low 24 bits are the cycle count (sufficient for
+    // a few hundred thousand cycles — wraps cleanly at large counts).
+    WATCHER_RING_BUFFER_PUSH(0xA1000000u | (prof_issue & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xA2000000u | (prof_wait & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xA3000000u | (prof_reserve & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xA4000000u | (prof_push & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xA5000000u | (prof_flush & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xA6000000u | (prof_finalize & 0x00FFFFFFu));
+    WATCHER_RING_BUFFER_PUSH(0xFF000000u | (prof_chunks & 0x00FFFFFFu));
+#endif
+}

--- a/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
@@ -5,7 +5,7 @@
 // DRISC prefetcher kernel for the DRAM-core mode of ttnn.dram_prefetcher.
 // See tt_metal/impl/buffers/prefetcher_matmul_design.md for the architecture
 // and contract; in particular §3 (what a "block" is), §6 (DRAM-core path: fit
-// ladder, L1 layout, helpers, main loop), and §8 (cross-component invariants).
+// ladder, L1 layout, helpers), and §8 (cross-component invariants).
 //
 // Pipeline summary:
 //   For each (layer, tensor, block), reserve one fifo page on every receiver,
@@ -16,8 +16,7 @@
 //   and advances iface.fifo_wr_ptr by page_bytes_per_recv[t].
 //
 //   When (rows_per_sub, M) == (k_block_w_tiles, 1) the inner loop reduces to
-//   a single chunk + finalize per block (the fast path, byte-for-byte
-//   identical to the pre-refactor single-shot push).
+//   a single chunk + finalize per block (the fast path).
 
 #include <stdint.h>
 
@@ -149,7 +148,7 @@ FORCE_INLINE void prefetcher_write_chunk(
 // With skip_ptr_update=true the NoC semaphore increments are posted; the caller
 // drains them once at end of stream via update_remote_cb_config_in_l1 +
 // noc_async_atomic_barrier (the same pattern remote_cb_push_back_and_write_pages
-// uses when its template flag is true). enable_performance_mode threads through.
+// uses when its template flag is true).
 template <bool skip_ptr_update>
 FORCE_INLINE void prefetcher_finalize_block(
     RemoteSenderCBInterface& iface, uint32_t page_bytes_per_recv, uint32_t num_receivers, uint8_t noc) {
@@ -183,7 +182,7 @@ FORCE_INLINE void prefetcher_finalize_block(
 }  // namespace
 
 void kernel_main() {
-    // ---- Compile-time args (13). See tt_metal/impl/buffers/prefetcher_matmul_design.md §6. ----
+    // ---- Compile-time args (13) ----
     constexpr uint32_t num_layers = get_compile_time_arg_val(0);
     constexpr uint32_t num_tensors = get_compile_time_arg_val(1);
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
@@ -234,7 +233,7 @@ void kernel_main() {
     const uint32_t page_bytes_per_recv_idx = rt_idx;
     rt_idx += num_tensors;
 
-    // ---- One-time L1 setup (mirrors the pre-refactor kernel) ----
+    // ---- One-time L1 setup ----
     volatile tt_l1_ptr uint32_t* noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(noc_xy_l1_addr);
     for (uint32_t i = 0; i < num_receivers; ++i) {
         noc_xy_ptr[2 * i] = get_arg_val<uint32_t>(rt_idx++);
@@ -313,19 +312,18 @@ void kernel_main() {
             uint32_t fifo_snapshot = 0;
             uint32_t cum_offset_in_page = 0;
 
-            // Track (blk, sb, ch) via incremental successor logic instead of
-            // c / t_sub_band_per_block / (sb_ch / t_M) etc. — those generated `divu`/`remu`
-            // (6+ cyc each on BabyRISCV); we now just compare & increment counters.
-            uint32_t blk = 0;
-            uint32_t sb = 0;
-            uint32_t ch = 0;
-            // Maintain stage_slot directly; toggle via `(a + b) - slot`. Saves the
-            // per-iter conditional select that `parity == 0 ? slot_a : slot_b` compiled to.
+            // The flat chunk index `c` decomposes into three nested counters,
+            // advanced by compare-and-increment (ch fastest, then sb, then blk):
+            uint32_t blk = 0;  // K-block index within the layer, in [0, num_blocks)
+            uint32_t sb = 0;   // sub-band index within the block, in [0, t_num_sub)
+            uint32_t ch = 0;   // chunk index within the sub-band, in [0, t_M)
+            // stage_slot ping-pongs between stage_slot_a and stage_slot_b; toggle via
+            // `(a + b) - slot`.
             constexpr uint32_t stage_slot_sum = stage_slot_a + stage_slot_b;
             uint32_t stage_slot = stage_slot_a;
-            // has_next is true for every chunk except the very last; track as a flag and
-            // only flip when the successor crosses num_blocks. Avoids the per-iter
-            // `(next_blk < num_blocks)` sltu+branch in the hot path.
+            // True for every chunk except the very last; flipped once the successor
+            // counters cross num_blocks, so the hot path reads a flag instead of
+            // recomputing the bound each iteration.
             bool has_next = (total_chunks > 1);
 
             for (uint32_t c = 0; c < total_chunks; ++c) {
@@ -338,7 +336,7 @@ void kernel_main() {
                     PROFILE_ACCUM(prof_reserve);
                 }
 
-                // Successor: next (blk, sb, ch). Cheap branches replace 4 div/mods.
+                // Compute the successor (blk, sb, ch) by incrementing the nested counters.
                 uint32_t next_ch = ch + 1;
                 uint32_t next_sb = sb;
                 uint32_t next_blk = blk;

--- a/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
@@ -427,6 +427,11 @@ void kernel_main() {
                     prefetcher_finalize_block</*skip_ptr_update=*/true>(
                         iface, t_page_bytes_per_recv, num_receivers, noc_index);
                     PROFILE_ACCUM(prof_finalize);
+                } else {
+                    // The ping-pong DMA can reuse this stage slot two chunks later.
+                    // Make sure all posted writes sourced from it have departed first.
+                    noc_async_posted_writes_flushed();
+                    PROFILE_ACCUM(prof_flush);
                 }
 
                 // Advance counters to next chunk.

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -1,0 +1,507 @@
+# Matmul + DRAM Prefetcher Design
+
+This document describes the contract between the gather-in0 matmul receiver
+and the two DRAM prefetcher implementations that feed it: the worker-core
+prefetcher (`ttnn.dram_prefetcher`) and the DRAM-core prefetcher
+(`ttnn.experimental.start_dram_core_prefetcher`). It exists so that a future maintainer
+touching either side can read one file and learn what is invariant across the
+two paths, without having to reverse-engineer the kernels.
+
+If you change the kernel structure or the per-tensor RTA layout in either
+prefetcher — or the receiver matmul's wait/pop contract — update this doc in
+the same commit. The implementation includes a sync-check pass at the end of
+the DRAM-core prefetcher refactor specifically to catch drift.
+
+## 1. Overview
+
+The prefetcher streams weight tensors (and similarly-shaped activation
+helpers) from DRAM into a ring of worker cores running a gather-in0 matmul.
+The matmul kernel reads its in0 (activations) from L1 and its in1 (weights)
+from a global circular buffer (GCB); the prefetcher's job is to keep that GCB
+full so the matmul never stalls on a DRAM read.
+
+Two prefetcher variants exist:
+
+- **Worker-core** (`ttnn.dram_prefetcher`, `ttnn/cpp/ttnn/operations/prefetcher/`):
+  runs a pair of kernels (BRISC reader + NCRISC writer) on a worker tile next
+  to each DRAM bank, with a triple-buffered local CB sitting in worker L1.
+  Most flexible (handles heterogeneous shapes/dtypes per launch), and has
+  ~1.5 MB of worker L1 to play with for the local CB.
+- **DRAM-core** (`ttnn.experimental.start_dram_core_prefetcher`, `tt_metal/distributed/`):
+  runs a single kernel on a DRISC core (i.e. on the DRAM core itself), doing
+  GDDR DMA and NoC push from the same RISC. Closer to the GDDR controller and
+  can run at higher throughput on production shapes, but its DRISC L1 working
+  region is only ~70 KB total, which constrains the staging strategy.
+
+Both feed the same receiver: worker cores running
+`bmm_large_block_zm_fused_bias_activation_gathered.cpp` (compute) +
+`reader_bmm_tile_layout_in1_ring_all_gather.cpp` (in1 reader). Receivers see
+the same byte layout regardless of which prefetcher produced it.
+
+Production usage on Llama-3.1-8B (single Blackhole, ring=64): the DRAM-core
+path covers FF1, QKV, and O matmuls; FF2 (K=14336) uses a separate
+DRAM-sharded matmul without a prefetcher.
+
+## 2. The ring
+
+Each tensor is *width-sharded* across `num_senders` DRAM banks, then each bank
+fans out to `num_receivers_per_sender` worker-core matmul receivers in a
+ring. The ring size `ring_size = num_senders * num_receivers_per_sender` is
+fixed for the launch.
+
+```
+senders (DRAM banks, num_senders=S):
+  +---+---+---+---+---+---+---+---+
+  | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     each holds N/S cols of every K-row
+  +---+---+---+---+---+---+---+---+
+     |       |       |       |
+     +--->+--->+--->+--->+--->...     (round-robin gather)
+     v       v       v       v
+receivers (worker cores, ring_size = S * recv_per_sender):
+  [r0][r1][r2]...[r_{ring-1}]         each gets one block per ring position
+                                       per layer per tensor
+```
+
+Each sender has its own GCB sender interface; each receiver has its own GCB
+receiver interface. The GCB topology (which senders feed which receivers) is
+fixed at GCB creation time and visible to the prefetcher via
+`GlobalCircularBuffer::sender_receiver_core_mapping()`.
+
+## 3. What is a "block"
+
+A **block** is the per-ring-position quantum of one tensor's data. There are
+`num_blocks = ring_size` blocks per layer per tensor, and one block lands on
+one receiver per layer per tensor.
+
+```
+Tensor (K rows x N cols), tiled (each cell = 32x32 tiles):
+
+        N-cols, sharded across S DRAM banks
+        <------ n_per_bank tiles per bank ------>
+        +-----------+-----------+-----------+...
+k_tiles |  bank 0   |  bank 1   |  bank 2   |   <- K-row 0
+rows    |           |           |           |
+        +-----------+-----------+-----------+
+        |           |           |           |   <- K-row 1
+        +-----------+-----------+-----------+
+        ...        (k_tiles K-rows total)
+
+Split K into ring_size strips:
+        K-block 0:  rows 0  .. kw-1
+        K-block 1:  rows kw .. 2kw-1
+        ...        (kw = k_tiles / ring_size = "k_block_w_tiles")
+
+One block (e.g. ring position p, bank b):
+        +-----------+
+        | kw x n/S  |   <- what sender b pushes to receiver p
+        +-----------+      once per layer per tensor
+```
+
+Definitions:
+
+- `k_tiles = K / TILE_HEIGHT` (32).
+- `n_per_bank_tiles = (N / num_senders) / TILE_WIDTH`.
+- `k_block_w_tiles = k_tiles / num_blocks` (K-rows per block).
+- `block_height_in_tiles = k_block_w_tiles` (synonym used by the worker-core
+  factory and the receiver matmul).
+- `n_per_recv_tiles = n_per_bank_tiles / num_receivers_per_sender`.
+- `tile_bytes = tt::tile_size(dtype)` — e.g. 2048 for bf16, 1088 for bf8_b.
+- `coalesced_page_size = n_per_recv_tiles * tile_bytes` (bytes per K-row per
+  receiver). With multi-tile receivers, `coalesced_num_pages` splits this
+  width further; for ring=64 production shapes it's 1.
+
+The on-receiver layout of one block is `block_height_in_tiles` contiguous
+K-rows, each `coalesced_num_pages * coalesced_page_size` bytes wide.
+
+### Per-block source tiles
+
+For block index `blk` (in `[0, num_blocks)`) pushed by sender bank `b` to its
+receiver with local index `r` (in `[0, num_receivers_per_sender)`), the page
+bytes correspond to the global-tensor tile range
+
+- K-rows: `[blk * k_block_w_tiles, (blk + 1) * k_block_w_tiles)`
+- N-cols: `[b * n_per_bank_tiles + r * n_per_recv_tiles, b * n_per_bank_tiles + (r + 1) * n_per_recv_tiles)`
+
+laid out K-row-major: row `h` of the receiver page contains tiles
+`(blk * k_block_w_tiles + h, b * n_per_bank_tiles + r * n_per_recv_tiles + n)`
+for `n` in `[0, n_per_recv_tiles)`, contiguous in K-row order.
+
+This holds verbatim for both prefetcher variants and across the fit-ladder
+sub-band/M-chunk paths — the receiver's per-block byte layout is
+sub-band/chunk-order invariant (see §6 for the DRAM-core proof). The
+DRAM-prefetcher validator
+(`tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp`)
+relies on this mapping to derive expected bytes from the source tensor via
+`TensorAccessor`.
+
+## 4. The receiver matmul contract
+
+The receiver matmul reader is
+`ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp`.
+Its in1 input arrives via the GCB:
+
+```c++
+constexpr uint32_t num_blocks = get_compile_time_arg_val(5);   // = ring_size
+
+for (uint32_t b = 0; b < batch; ++b) {
+  experimental::remote_cb_wait_front(remote_cb_id, num_blocks);   // wait for ring_size pages
+  /* iterate ring positions, multiply, accumulate */
+  experimental::remote_cb_pop_front(remote_cb_id, num_blocks);
+}
+```
+
+So **the prefetcher must push exactly `num_blocks = ring_size` pages per
+receiver per layer per tensor**, each page being the on-receiver block layout
+described in §3. The receiver doesn't care how those bytes were assembled —
+multiple NoC writes from the prefetcher are fine, as long as:
+
+- the page bytes are contiguous in the GCB slot before the receiver wakes up;
+- `pages_sent` is bumped exactly once per page per receiver, by
+  `fifo_page_size / REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE`.
+
+`fifo_page_size` (the receiver's notion of one page) is set by the sender via
+`experimental::resize_remote_sender_cb_interface(...)` and equals
+`block_height_in_tiles * coalesced_num_pages * coalesced_page_size`.
+
+## 5. Worker-core prefetcher
+
+### Architecture
+
+```
+For each DRAM bank b in [0, num_senders):
+  one worker core, two kernels:
+    BRISC  -> reader_dram.cpp        (DRAM -> reader_cb local CB)
+    NCRISC -> writer_l1.cpp          (reader_cb -> GCB remote write)
+  reader_cb sits in worker L1, triple-buffered (3 x max_block_size).
+```
+
+The reader does page-sized NoC reads from DRAM and pushes to the local
+reader_cb. The writer waits on reader_cb, reserves one remote-CB page on every
+receiver, then issues `remote_cb_push_back_and_write_pages` which does the
+multi-receiver multi-row contiguous write + the `pages_sent` increment in one
+call.
+
+### Per-tensor derivations (program factory)
+
+`ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp`:
+
+- `num_blocks = num_readers * num_receivers_per_reader` (= ring_size).
+- Per tensor, `t`:
+  - `height_in_tiles = round_up(shard[0] / TILE_H, num_blocks)` — round-up
+    handles tensors whose K doesn't divide ring_size; no FATAL.
+  - `tensor_block_num_tiles[t] = height_in_tiles * width_in_tiles / num_blocks`.
+  - `tensor_tile_size[t] = tile_size(dtype[t])`.
+  - `(page_size[t], block_num_pages[t]) = get_max_page_size_and_num_pages(8192,
+    block_num_tiles[t], tile_size[t])` — picks the largest `page_size <= 8 KB`
+    that's a multiple of `tile_size` and divides `block_num_tiles * tile_size`.
+  - `(coalesced_page_size[t], coalesced_num_pages[t]) =
+    get_max_page_size_and_num_pages(8192, width_in_tiles / num_receivers,
+    tile_size[t])`.
+  - `block_height_in_tiles[t] = height_in_tiles / num_blocks`.
+
+These per-tensor values flow through RTAs to the reader and writer kernels;
+the compile-time CB sizing uses worst-case across all tensors
+(`max_block_tiles`, `max_tile_size`). The reader CB is sized
+`max_block_size_per_reader_core * 3` for triple-buffering.
+
+### Why it handles arbitrary shapes / dtypes
+
+Everything that varies per tensor is per-tensor in the RTAs: page size, num
+pages, coalesced page size, num coalesced pages per row, num rows, tile size.
+Heterogeneous tensors in one launch each get their own values. The only
+cross-tensor invariant is `num_blocks` (= ring_size), enforced because it's a
+single compile-time arg.
+
+### Why staging budget isn't a problem
+
+Worker L1 has ~1.5 MB of CB space, so even a `3 * max_block_size` reader CB
+fits comfortably for production shapes.
+
+## 6. DRAM-core prefetcher
+
+### Architecture
+
+```
+For each DRAM bank b in [0, num_senders):
+  one DRISC core, one kernel: dram_core_prefetcher.cpp
+    do GDDR DMA into a ping-pong stage in DRISC L1
+    NoC push from stage to GCB remote
+  no local reader_cb; stage IS the working buffer.
+```
+
+The kernel uses `experimental::dma_async_read` (defined in
+`tt_metal/hw/inc/experimental/gddr_dma.h`) for GDDR reads and the GCB sender
+interface for NoC pushes. Both share the DRISC's working L1 region (see §6.5).
+
+### Two purpose-built helpers (kernel-private)
+
+The DRISC kernel does **not** call
+`experimental::remote_cb_push_back_and_write_pages`. That API conflates data
+movement and bookkeeping (it bumps `pages_sent` and the receiver semaphore as
+a side effect of every call), which makes "write a partial page and finalize
+later" impossible without abusing internal state. The DRAM-core kernel
+instead defines two helpers, each doing one thing:
+
+```c++
+// Writes one sub-band chunk from `src_l1_addr` to `dest_l1_base` on the given
+// receiver subset. No pages_sent, no semaphore, no iface.fifo_wr_ptr advance.
+// Layout matches the receiver-side block layout described in section 4.
+FORCE_INLINE void prefetcher_write_chunk(
+    uint32_t src_l1_addr,
+    uint32_t dest_l1_base,                       // start of this page on the receiver
+    const volatile uint32_t* recv_xy,            // noc_x/noc_y for chunk's receivers
+    uint32_t num_receivers_in_chunk,
+    uint32_t num_rows,
+    uint32_t coalesced_num_pages_per_row,
+    uint32_t coalesced_page_size,
+    uint8_t noc);
+
+// Bumps local pages_sent + remote NoC semaphore for all receivers by one
+// page (with wrap-gap adjustment), advances iface.fifo_wr_ptr by one page.
+// Called once per block, after all chunks of that block have been written
+// via prefetcher_write_chunk.
+template <bool skip_ptr_update>
+FORCE_INLINE void prefetcher_finalize_block(
+    RemoteSenderCBInterface& iface,
+    uint32_t page_bytes_per_recv,                // bytes per receiver per block
+    uint32_t num_receivers,
+    uint8_t noc);
+```
+
+### L1 budget
+
+DRISC L1 total: 128 KB. The relevant slice for the prefetcher kernel:
+
+```
+[UNRESERVED, UNRESERVED + kGcbZoneSize)   GCB pages_sent zone (1 KB)
+[UNRESERVED + kGcbZoneSize, END)          kernel_working_region    (~92 KB)
+
+  kernel_working_region:
+    +--- noc_xy table   (2 * 4 * num_receivers bytes)
+    +--- config struct  (16 B)
+    +--- alignment slack
+    +--- stage ring     (the rest; split into two halves for ping-pong)
+```
+
+See `tt_metal/impl/buffers/drisc_l1_arena.hpp` (specifically
+`kernel_working_region_base()` / `kernel_working_region_size()`). On
+Blackhole the kernel-region-minus-overhead works out to ~70 KB of stage
+budget; `ring_half = stage_budget / 2 ≈ 35 KB`.
+
+This is why the DRAM-core path can't pre-allocate a full block (let alone 3
+for triple-buffering): on production Llama shapes a single block is 100+ KB.
+The stage is sized to fit a *sub-band* of a block, not the whole block.
+
+### Fitting algorithm (per tensor)
+
+Per `compute_tensor_geom`, run this ladder to pick `(rows_per_sub, M)`:
+
+1. If `k_block_w_tiles * n_per_bank * tile_bytes <= ring_half`
+   -> `rows_per_sub = k_block_w_tiles`, `M = 1`. Single push per block
+   (matches the kernel's behavior pre-refactor for shapes that fit).
+2. Else if `n_per_bank * tile_bytes <= ring_half` (one K-row fits)
+   -> pick the largest `rows_per_sub <= k_block_w_tiles` such that the
+   sub-band fits `ring_half` and is a clean factor; `M = 1`. K-sub only.
+3. Else `rows_per_sub = 1`; pick the smallest `M | num_receivers_per_sender`
+   such that `(n_per_bank / M) * tile_bytes <= ring_half`. K-sub plus
+   N-chunking. M-chunking with `rows_per_sub = 1` reads a contiguous N-stripe
+   of a single K-row, which is bit-exact today's M>1 behavior.
+4. Else TT_FATAL with shape, budget, and a hint to grow the ring.
+
+The combination `(rows_per_sub > 1) and (M > 1)` is not supported and never
+chosen: it would need a row-strided DMA (multiple K-rows interleaved with
+multiple N-stripes), which the DMA engine doesn't expose. The ladder always
+collapses to `rows_per_sub = 1` before allowing `M > 1`.
+
+### Per-tensor derivations
+
+Computed by `compute_tensor_geom` in `dram_core_prefetcher_manager.cpp` (the
+DRAM-core analogue of the worker-core's per-tensor derivations in §5):
+
+- `(coalesced_page_size[t], coalesced_num_pages[t])` — same `pick_page_size`
+  algorithm as worker-core's `get_max_page_size_and_num_pages` (file-local
+  copy in the manager; algorithm identical but kept duplicated by design —
+  no shared header).
+- `rows_per_sub[t]`, `num_sub[t]`, `M[t]`, `sub_chunk_bytes[t]` —
+  DRAM-core-specific. Derived from the fit ladder above.
+- `sub_stride_bytes[t] = rows_per_sub × n_per_bank × tile_bytes` — GDDR
+  byte stride between sub-bands within a block.
+- `block_stride_bytes[t] = k_block_w_tiles × n_per_bank × tile_bytes` —
+  GDDR byte stride between ring-blocks.
+- `page_bytes_per_recv[t] = k_block_w_tiles × coalesced_num_pages ×
+  coalesced_page_size` — total bytes pushed per receiver per block (the
+  `resize_remote_sender_cb_interface` page size, and the argument to
+  `prefetcher_finalize_block`).
+
+### Compile-time args (13)
+
+```
+0  num_layers
+1  num_tensors
+2  num_blocks                          (= ring_size)
+3  num_receivers                       (= num_receivers_per_sender)
+4  stage_ring_base                     (L1 addr; split into two halves by kernel)
+5  stage_ring_size                     (bytes; 2 x ring_half)
+6  remote_cb_id                        (= 31)
+7  pages_sent_l1_addr                  (DRISC-local pages_sent slots)
+8  noc_xy_l1_addr                      (per-receiver noc xy table)
+9  config_l1_addr                      (4-uint32 iface config block)
+10 fifo_size_per_receiver              (= gcb.size())
+11 receiver_buffer_address             (GCB receiver-side fifo base)
+12 remote_pages_sent_worker_l1_addr    (per-receiver remote semaphore base)
+```
+
+Ring depth is fixed at 2 in the kernel (ping-pong slots derived from
+`stage_ring_base` and `stage_ring_base + stage_ring_size / 2`).
+
+Notably absent vs the pre-refactor kernel: `max_chunk_size`, `stage_a_addr`,
+`stage_b_addr`, `num_dma_chunks_per_block (M)`, `k_block_w_tiles`. `M` and
+`rows_per_sub` are per-tensor RTAs now; the kernel no longer needs a single
+`k_block_w_tiles` constant.
+
+### Runtime args
+
+```
+[0]                        bank_id
+[1 .. 1+num_tensors)       bank_local_base[t]       (GDDR bank-local offset)
+[+num_tensors]             num_sub[t]
+[+num_tensors]             M[t]
+[+num_tensors]             rows_per_sub[t]
+[+num_tensors]             coalesced_page_size[t]
+[+num_tensors]             coalesced_num_pages[t]
+[+num_tensors]             sub_chunk_bytes[t]       (rows_per_sub*n_per_bank/M*tile_bytes)
+[+num_tensors]             sub_stride_bytes[t]
+[+num_tensors]             block_stride_bytes[t]
+[+num_tensors]             page_bytes_per_recv[t]
+[2*num_receivers]          noc_x/noc_y per receiver
+```
+
+### Kernel main loop
+
+```
+setup_iface_once();                                       // noc_xy table, config, iface
+issue first DMA into stage_ring[0];                       // prologue for tensor 0
+for layer in [0, num_layers):
+  for t in [0, num_tensors):
+    pull per-tensor RTAs into locals;
+
+    for c in [0, num_blocks * num_sub[t] * M[t]):
+      blk = c / (num_sub[t] * M[t]);
+      sb  = (c % (num_sub[t] * M[t])) / M[t];
+      ch  = c % M[t];
+
+      // On block boundary: reserve a fifo page on every receiver, snapshot wr_ptr.
+      if (sb == 0 and ch == 0):
+        experimental::remote_cb_reserve_back(remote_cb_id, 1);
+        fifo_snapshot   = iface.fifo_wr_ptr;
+        cum_offset_in_page = 0;
+
+      // Issue NEXT DMA (depth=2 ping-pong) before waiting on the current chunk.
+      if (c + 1 < total_chunks):
+        compute (next_blk, next_sb, next_ch) and next_src;
+        experimental::dma_async_read(0, next_src, stage_ring[(c+1)&1], sub_chunk_bytes[t]);
+      experimental::dma_async_read_wait_n(0, has_next ? 1 : 0);
+
+      // Write this chunk to its receiver subset at (fifo_snapshot + cum_offset_in_page).
+      prefetcher_write_chunk(
+        /*src=*/   stage_ring[c & 1],
+        /*dest=*/  fifo_snapshot + cum_offset_in_page,
+        /*recv=*/  noc_xy_ptr + ch * recv_per_chunk * 2,
+        recv_per_chunk,
+        rows_per_sub[t],
+        coalesced_num_pages[t],
+        coalesced_page_size[t],
+        noc_index);
+
+      // After the last chunk of a sub-band, advance dest offset by the sub-band's
+      // per-receiver bytes (each receiver in the subset got rows_per_sub K-rows of
+      // coalesced_num_pages * coalesced_page_size bytes).
+      if (ch + 1 == M[t]):
+        cum_offset_in_page += rows_per_sub[t] * coalesced_num_pages[t]
+                            * coalesced_page_size[t];
+
+      // On block boundary: flush posted writes and finalize (one pages_sent inc per receiver).
+      if (sb + 1 == num_sub[t] and ch + 1 == M[t]):
+        noc_async_posted_writes_flushed();
+        prefetcher_finalize_block<skip_ptr_update=true>(
+          iface, page_bytes_per_recv[t], num_receivers, noc_index);
+
+    if (t == num_tensors - 1):
+      experimental::remote_cb_sender_barrier(remote_cb_id);
+
+experimental::update_remote_cb_config_in_l1(remote_cb_id);
+noc_async_atomic_barrier();
+experimental::drisc_set_noc2axi_mode();
+```
+
+The finalize uses `skip_ptr_update=true` (posted NoC semaphore writes); the
+end-of-stream `update_remote_cb_config_in_l1` + `noc_async_atomic_barrier`
+drain them. `enable_performance_mode` in `DramCorePrefetcherConfig` is
+currently a no-op (this fast-path is always selected); the flag is kept as
+an API hook for future tuning, e.g. wiring a `<false>` instantiation for
+sub-band-grained ptr updates when measured to matter.
+
+When `(rows_per_sub, M) = (k_block_w_tiles, 1)` (fast path), the inner loop
+collapses to a single `prefetcher_write_chunk` followed by
+`prefetcher_finalize_block` — same number of NoC writes and the same one
+`pages_sent` increment per block per receiver as the pre-refactor kernel.
+
+## 7. Llama-3.1-8B fit table
+
+Production ring=64 (8 banks x 8 recv/sender), bf8_b (tile_bytes=1088),
+stage_budget ≈ 70 KB so `ring_half ≈ 35 KB`:
+
+| Op  | K     | N     | k_tiles | k_block_w | n_per_bank | full block | one K-row | (rows_per_sub, M) |
+|-----|-------|-------|---------|-----------|------------|-----------:|----------:|-------------------|
+| FF1 | 4096  | 14336 | 128     | 2         | 56         | 121 856    | 60 928    | (1, 2)            |
+| QKV | 4096  | 12288 | 128     | 2         | 48         | 104 448    | 52 224    | (1, 2)            |
+| O   | 4096  | 4096  | 128     | 2         | 16         |  34 816    | 17 408    | (2, 1) — fast path|
+| FF2 | 14336 | 4096  | 448     | 7         | 16         | 121 856    | 17 408    | not used (DRAM-sharded variant) |
+
+Notes:
+
+- For FF1 / QKV even one K-row exceeds `ring_half`, so the fit ladder lands at
+  step 3 (`rows_per_sub = 1`, `M = 2`). 60 928 / 2 = 30 464 ≤ 35 008.
+- For O the full block just fits (34 816 ≤ 35 008), so we use the fast path.
+- FF2 isn't fed by this prefetcher in production, but if it were, the ladder
+  would pick `(rows_per_sub = 2, M = 1)`.
+
+## 8. Cross-component invariants
+
+Whoever changes prefetcher or receiver code must preserve these:
+
+1. **Per-tensor page bytes match.** The prefetcher's per-page push bytes equal
+   `block_height_in_tiles[t] * coalesced_num_pages[t] * coalesced_page_size[t]`,
+   and the receiver sees this many bytes per `wait_front(1)`-equivalent slot.
+2. **Receiver `num_blocks` compile arg equals ring_size.** Enforced because
+   both prefetchers derive `num_blocks = num_senders * num_receivers_per_sender`
+   from the GCB.
+3. **One `pages_sent` increment per page per receiver per layer per tensor.**
+   The DRAM-core kernel's `prefetcher_finalize_block` is the single
+   `pages_sent`-bumping primitive; `prefetcher_write_chunk` never touches it.
+   The worker-core writer gets the same property by issuing exactly one
+   `remote_cb_push_back_and_write_pages` per block.
+4. **All tensors in a launch share `num_blocks`** (= ring_size). The kernel
+   takes a single `num_blocks` compile-time arg; all other geometry is
+   per-tensor.
+5. **The pair `(rows_per_sub > 1, M > 1)` never occurs** in the DRAM-core
+   fit ladder. The kernel uses this invariant to assume DMAs are linear
+   reads (no row-strided DMA support).
+
+## 9. Where to look in the code
+
+- Receiver matmul reader:
+  `ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp`
+- Receiver matmul compute:
+  `ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp`
+- Worker-core prefetcher:
+  `ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_program_factory.cpp`,
+  `kernels/reader_dram.cpp`, `kernels/writer_l1.cpp`.
+- DRAM-core prefetcher:
+  `tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp`,
+  `tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp`.
+- GCB / remote CB API:
+  `tt_metal/hw/inc/api/remote_circular_buffer.h`,
+  `tt_metal/impl/buffers/global_circular_buffer.cpp`.
+- DRISC L1 arena: `tt_metal/impl/buffers/drisc_l1_arena.hpp`.
+- DRISC GDDR DMA: `tt_metal/hw/inc/experimental/gddr_dma.h`.

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -9,8 +9,8 @@ two paths, without having to reverse-engineer the kernels.
 
 If you change the kernel structure or the per-tensor RTA layout in either
 prefetcher — or the receiver matmul's wait/pop contract — update this doc in
-the same commit. The implementation includes a sync-check pass at the end of
-the DRAM-core prefetcher refactor specifically to catch drift.
+the same commit. The DRAM-core prefetcher includes a sync-check pass
+specifically to catch such drift.
 
 ## 1. Overview
 
@@ -55,12 +55,14 @@ senders (DRAM banks, num_senders=S):
   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     each holds N/S cols of every K-row
   +---+---+---+---+---+---+---+---+
      |       |       |       |
-     +--->+--->+--->+--->+--->...     (round-robin gather)
-     v       v       v       v
+     v       v       v       v        (each bank pushes its cols to its receivers)
 receivers (worker cores, ring_size = S * recv_per_sender):
-  [r0][r1][r2]...[r_{ring-1}]         each gets one block per ring position
-                                       per layer per tensor
+  [r0][r1][r2]...[r_{ring-1}]         each gets one page per block per layer
+                                       per tensor
 ```
+
+The round-robin gather itself happens inside the matmul (the gather-in0 reader
+walks the ring), not in the sender→receiver transfer.
 
 Each sender has its own GCB sender interface; each receiver has its own GCB
 receiver interface. The GCB topology (which senders feed which receivers) is
@@ -69,9 +71,15 @@ fixed at GCB creation time and visible to the prefetcher via
 
 ## 3. What is a "block"
 
-A **block** is the per-ring-position quantum of one tensor's data. There are
-`num_blocks = ring_size` blocks per layer per tensor, and one block lands on
-one receiver per layer per tensor.
+A **block** is one of the `num_blocks = ring_size` K-stripes the tensor's K
+dimension is split into (each `k_block_w_tiles` tile-rows tall). A block spans
+all of this DRAM core's columns, so it carries data for every receiver this
+core feeds. Each receiver's portion of a block is its
+`k_block_w_tiles × n_per_recv_tiles` tile region — `block_height_in_tiles`
+K-rows, each `coalesced_num_pages` tensor pages wide, so a receiver generally
+gets more than one tensor page per block. The GCB carries that whole portion
+as a single fifo page, and each receiver is sent `num_blocks` fifo pages per
+layer per tensor (one per block).
 
 ```
 Tensor (K rows x N cols), tiled (each cell = 32x32 tiles):
@@ -91,10 +99,11 @@ Split K into ring_size strips:
         K-block 1:  rows kw .. 2kw-1
         ...        (kw = k_tiles / ring_size = "k_block_w_tiles")
 
-One block (e.g. ring position p, bank b):
+One block (e.g. K-stripe blk, bank b):
         +-----------+
-        | kw x n/S  |   <- what sender b pushes to receiver p
-        +-----------+      once per layer per tensor
+        | kw x n/S  |   <- sender b's kw x n_per_bank stripe; split across
+        +-----------+      its receivers (each gets a kw x n_per_recv slice),
+                           once per layer per tensor
 ```
 
 Definitions:
@@ -128,7 +137,8 @@ for `n` in `[0, n_per_recv_tiles)`, contiguous in K-row order.
 
 This holds verbatim for both prefetcher variants and across the fit-ladder
 sub-band/M-chunk paths — the receiver's per-block byte layout is
-sub-band/chunk-order invariant (see §6 for the DRAM-core proof). The
+sub-band/chunk-order invariant (see §6 for how the DRAM-core path splits a
+block into sub-bands/chunks). The
 DRAM-prefetcher validator
 (`tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp`)
 relies on this mapping to derive expected bytes from the source tensor via
@@ -231,7 +241,8 @@ For each DRAM bank b in [0, num_senders):
 
 The kernel uses `experimental::dma_async_read` (defined in
 `tt_metal/hw/inc/experimental/gddr_dma.h`) for GDDR reads and the GCB sender
-interface for NoC pushes. Both share the DRISC's working L1 region (see §6.5).
+interface for NoC pushes. Both share the DRISC's working L1 region (see the
+"L1 budget" subsection below).
 
 ### Two purpose-built helpers (kernel-private)
 
@@ -297,15 +308,14 @@ The stage is sized to fit a *sub-band* of a block, not the whole block.
 Per `compute_tensor_geom`, run this ladder to pick `(rows_per_sub, M)`:
 
 1. If `k_block_w_tiles * n_per_bank * tile_bytes <= ring_half`
-   -> `rows_per_sub = k_block_w_tiles`, `M = 1`. Single push per block
-   (matches the kernel's behavior pre-refactor for shapes that fit).
+   -> `rows_per_sub = k_block_w_tiles`, `M = 1`. Single push per block.
 2. Else if `n_per_bank * tile_bytes <= ring_half` (one K-row fits)
    -> pick the largest `rows_per_sub <= k_block_w_tiles` such that the
    sub-band fits `ring_half` and is a clean factor; `M = 1`. K-sub only.
 3. Else `rows_per_sub = 1`; pick the smallest `M | num_receivers_per_sender`
    such that `(n_per_bank / M) * tile_bytes <= ring_half`. K-sub plus
    N-chunking. M-chunking with `rows_per_sub = 1` reads a contiguous N-stripe
-   of a single K-row, which is bit-exact today's M>1 behavior.
+   of a single K-row.
 4. Else TT_FATAL with shape, budget, and a hint to grow the ring.
 
 The combination `(rows_per_sub > 1) and (M > 1)` is not supported and never
@@ -332,119 +342,6 @@ DRAM-core analogue of the worker-core's per-tensor derivations in §5):
   coalesced_page_size` — total bytes pushed per receiver per block (the
   `resize_remote_sender_cb_interface` page size, and the argument to
   `prefetcher_finalize_block`).
-
-### Compile-time args (13)
-
-```
-0  num_layers
-1  num_tensors
-2  num_blocks                          (= ring_size)
-3  num_receivers                       (= num_receivers_per_sender)
-4  stage_ring_base                     (L1 addr; split into two halves by kernel)
-5  stage_ring_size                     (bytes; 2 x ring_half)
-6  remote_cb_id                        (= 31)
-7  pages_sent_l1_addr                  (DRISC-local pages_sent slots)
-8  noc_xy_l1_addr                      (per-receiver noc xy table)
-9  config_l1_addr                      (4-uint32 iface config block)
-10 fifo_size_per_receiver              (= gcb.size())
-11 receiver_buffer_address             (GCB receiver-side fifo base)
-12 remote_pages_sent_worker_l1_addr    (per-receiver remote semaphore base)
-```
-
-Ring depth is fixed at 2 in the kernel (ping-pong slots derived from
-`stage_ring_base` and `stage_ring_base + stage_ring_size / 2`).
-
-Notably absent vs the pre-refactor kernel: `max_chunk_size`, `stage_a_addr`,
-`stage_b_addr`, `num_dma_chunks_per_block (M)`, `k_block_w_tiles`. `M` and
-`rows_per_sub` are per-tensor RTAs now; the kernel no longer needs a single
-`k_block_w_tiles` constant.
-
-### Runtime args
-
-```
-[0]                        bank_id
-[1 .. 1+num_tensors)       bank_local_base[t]       (GDDR bank-local offset)
-[+num_tensors]             num_sub[t]
-[+num_tensors]             M[t]
-[+num_tensors]             rows_per_sub[t]
-[+num_tensors]             coalesced_page_size[t]
-[+num_tensors]             coalesced_num_pages[t]
-[+num_tensors]             sub_chunk_bytes[t]       (rows_per_sub*n_per_bank/M*tile_bytes)
-[+num_tensors]             sub_stride_bytes[t]
-[+num_tensors]             block_stride_bytes[t]
-[+num_tensors]             page_bytes_per_recv[t]
-[2*num_receivers]          noc_x/noc_y per receiver
-```
-
-### Kernel main loop
-
-```
-setup_iface_once();                                       // noc_xy table, config, iface
-issue first DMA into stage_ring[0];                       // prologue for tensor 0
-for layer in [0, num_layers):
-  for t in [0, num_tensors):
-    pull per-tensor RTAs into locals;
-
-    for c in [0, num_blocks * num_sub[t] * M[t]):
-      blk = c / (num_sub[t] * M[t]);
-      sb  = (c % (num_sub[t] * M[t])) / M[t];
-      ch  = c % M[t];
-
-      // On block boundary: reserve a fifo page on every receiver, snapshot wr_ptr.
-      if (sb == 0 and ch == 0):
-        experimental::remote_cb_reserve_back(remote_cb_id, 1);
-        fifo_snapshot   = iface.fifo_wr_ptr;
-        cum_offset_in_page = 0;
-
-      // Issue NEXT DMA (depth=2 ping-pong) before waiting on the current chunk.
-      if (c + 1 < total_chunks):
-        compute (next_blk, next_sb, next_ch) and next_src;
-        experimental::dma_async_read(0, next_src, stage_ring[(c+1)&1], sub_chunk_bytes[t]);
-      experimental::dma_async_read_wait_n(0, has_next ? 1 : 0);
-
-      // Write this chunk to its receiver subset at (fifo_snapshot + cum_offset_in_page).
-      prefetcher_write_chunk(
-        /*src=*/   stage_ring[c & 1],
-        /*dest=*/  fifo_snapshot + cum_offset_in_page,
-        /*recv=*/  noc_xy_ptr + ch * recv_per_chunk * 2,
-        recv_per_chunk,
-        rows_per_sub[t],
-        coalesced_num_pages[t],
-        coalesced_page_size[t],
-        noc_index);
-
-      // After the last chunk of a sub-band, advance dest offset by the sub-band's
-      // per-receiver bytes (each receiver in the subset got rows_per_sub K-rows of
-      // coalesced_num_pages * coalesced_page_size bytes).
-      if (ch + 1 == M[t]):
-        cum_offset_in_page += rows_per_sub[t] * coalesced_num_pages[t]
-                            * coalesced_page_size[t];
-
-      // On block boundary: flush posted writes and finalize (one pages_sent inc per receiver).
-      if (sb + 1 == num_sub[t] and ch + 1 == M[t]):
-        noc_async_posted_writes_flushed();
-        prefetcher_finalize_block<skip_ptr_update=true>(
-          iface, page_bytes_per_recv[t], num_receivers, noc_index);
-
-    if (t == num_tensors - 1):
-      experimental::remote_cb_sender_barrier(remote_cb_id);
-
-experimental::update_remote_cb_config_in_l1(remote_cb_id);
-noc_async_atomic_barrier();
-experimental::drisc_set_noc2axi_mode();
-```
-
-The finalize uses `skip_ptr_update=true` (posted NoC semaphore writes); the
-end-of-stream `update_remote_cb_config_in_l1` + `noc_async_atomic_barrier`
-drain them. `enable_performance_mode` in `DramCorePrefetcherConfig` is
-currently a no-op (this fast-path is always selected); the flag is kept as
-an API hook for future tuning, e.g. wiring a `<false>` instantiation for
-sub-band-grained ptr updates when measured to matter.
-
-When `(rows_per_sub, M) = (k_block_w_tiles, 1)` (fast path), the inner loop
-collapses to a single `prefetcher_write_chunk` followed by
-`prefetcher_finalize_block` — same number of NoC writes and the same one
-`pages_sent` increment per block per receiver as the pre-refactor kernel.
 
 ## 7. Llama-3.1-8B fit table
 

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -31,6 +31,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/drisc_l1_arena.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffers/dram_core_prefetcher_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -381,6 +381,7 @@ private:
 
     uint32_t eth_interrupt_mode_base_reg_{};
     uint32_t eth_interrupt_num_vecs_{};
+    uint32_t noc_max_burst_size_bytes_{};
 
     float eps_ = 0.0f;
     float nan_ = 0.0f;
@@ -480,6 +481,8 @@ public:
     uint32_t get_arch_num_circular_buffers() const {
         return (arch_ == tt::ARCH::WORMHOLE_B0) ? 32 : NUM_CIRCULAR_BUFFERS;
     }
+
+    uint32_t get_noc_max_burst_size_bytes() const { return noc_max_burst_size_bytes_; }
 
     template <typename IndexType, typename SizeType, typename CoordType>
     auto noc_coordinate(IndexType noc_index, SizeType noc_size, CoordType coord) const

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -431,6 +431,7 @@ void Hal::initialize_bh(
     this->noc_node_id_ = NOC_NODE_ID;
     this->noc_node_id_mask_ = NOC_NODE_ID_MASK;
     this->noc_addr_node_id_bits_ = NOC_ADDR_NODE_ID_BITS;
+    this->noc_max_burst_size_bytes_ = NOC_MAX_BURST_SIZE;
     this->noc_encoding_reg_ = COORDINATE_VIRTUALIZATION_ENABLED ? NOC_CFG(NOC_ID_LOGICAL) : NOC_NODE_ID;
     this->noc_coord_reg_offset_ = NOC_COORD_REG_OFFSET;
     this->noc_overlay_start_addr_ = NOC_OVERLAY_START_ADDR;

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -357,6 +357,7 @@ void Hal::initialize_wh(
     this->noc_node_id_ = NOC_NODE_ID;
     this->noc_node_id_mask_ = NOC_NODE_ID_MASK;
     this->noc_addr_node_id_bits_ = NOC_ADDR_NODE_ID_BITS;
+    this->noc_max_burst_size_bytes_ = NOC_MAX_BURST_SIZE;
     this->noc_encoding_reg_ = COORDINATE_VIRTUALIZATION_ENABLED ? NOC_CFG(NOC_ID_LOGICAL) : NOC_NODE_ID;
     this->noc_coord_reg_offset_ = NOC_COORD_REG_OFFSET;
     this->noc_overlay_start_addr_ = NOC_OVERLAY_START_ADDR;

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -495,6 +495,7 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes, bo
     this->noc_node_id_ = NOC_NODE_ID;
     this->noc_node_id_mask_ = NOC_NODE_ID_MASK;
     this->noc_addr_node_id_bits_ = NOC_ADDR_NODE_ID_BITS;
+    this->noc_max_burst_size_bytes_ = NOC_MAX_BURST_SIZE;
     this->noc_encoding_reg_ = NOC_NODE_ID;                                   // TODO: add correct value
     this->noc_coord_reg_offset_ = NOC_COORD_REG_OFFSET;                      // TODO: add correct value
     this->noc_overlay_start_addr_ = 0;                                       // TODO: add correct value

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -246,6 +246,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::CNN
         TTNN::Ops::Experimental::Conv3d
         TTNN::Ops::Experimental::Copy
+        TTNN::Ops::Experimental::DramCorePrefetcher
         TTNN::Ops::Experimental::Dropout
         TTNN::Ops::Experimental::IsIn
         TTNN::Ops::Experimental::Matmul
@@ -504,6 +505,7 @@ add_subdirectory(cpp/ttnn/operations/experimental/conv3d)
 add_subdirectory(cpp/ttnn/operations/experimental/copy)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce)
+add_subdirectory(cpp/ttnn/operations/experimental/dram_core_prefetcher)
 add_subdirectory(cpp/ttnn/operations/experimental/dropout)
 add_subdirectory(cpp/ttnn/operations/experimental/isin)
 add_subdirectory(cpp/ttnn/operations/experimental/matmul)

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -6,6 +6,8 @@
 
 #include <memory>
 #include <tt-metalium/global_circular_buffer.hpp>
+#include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn::global_circular_buffer {
@@ -21,6 +23,52 @@ GlobalCircularBuffer create_global_circular_buffer(
 GlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* mesh_device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type = BufferType::L1);
+
+// DRAM-sender variant: senders are programmable DRAM cores identified by DRAM bank id.
+// The returned GlobalCircularBuffer is the same type as the worker variant; the sender
+// domain is queryable via tt::tt_metal::experimental::sender_core_type(gcb).
+GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
+    MeshDevice* mesh_device,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type = BufferType::L1);
+
+// Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true)
+// from the given weight tensors. The caller supplies `bank_to_receivers` (the same layout
+// the low-level `create_global_circular_buffer_with_dram_senders` takes), and the factory
+// validates it is compatible with the matmul program configs and weight shapes.
+//
+// One (program_config, weight) pair per matmul. Each pair is validated independently:
+//   * weight K is tile-aligned AND divisible by ring_size (so activation K_per_shard is
+//     integer-tile, the silent-hang case where matmul pads K beyond what the prefetcher
+//     pushes),
+//   * weight N shards evenly across senders (num_senders = bank_to_receivers.size()) and
+//     per-bank N splits evenly across receivers,
+//   * matmul's per_core_N matches the weight per-receiver N.
+// All configs must agree on compute_with_storage_grid_size and num_global_cb_receivers
+// (the GCB has one receiver rectangle shared across all consumer matmuls).
+//
+// `bank_to_receivers` shape is checked: num_senders * num_global_cb_receivers must equal
+// ring_size, and every bank must own exactly num_global_cb_receivers cores. The factory
+// does NOT check that the receivers row-major-walk into the same order as the matmul's
+// activation grid — the matmul op asserts that at construction time.
+//
+// `size` is the GCB size in bytes. Picking it:
+//   * Minimum = num_blocks * largest_in1_block_size (one full layer's pages). The matmul
+//     does wait_front(num_blocks) per layer, so anything smaller deadlocks.
+//   * Larger values let the DRISC prefetcher run further ahead. Past one full layer worth
+//     more buffering does not increase throughput — the DRISC stalls on
+//     remote_cb_reserve_back.
+//   * The factory only caps `size` against a conservative remote-CB page-count limit; it
+//     does NOT check L1 capacity. Callers must size the GCB to fit alongside the matmul's
+//     in0/in1/out/interm CBs on the receiver cores.
+GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
+    MeshDevice* mesh_device,
+    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
+    const std::vector<tt::tt_metal::Tensor>& weights,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1);
 

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -4,8 +4,14 @@
 
 #include "ttnn/global_circular_buffer.hpp"
 
+#include <algorithm>
 #include <memory>
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tile.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace ttnn::global_circular_buffer {
 
@@ -25,6 +31,229 @@ GlobalCircularBuffer create_global_circular_buffer(
     BufferType buffer_type) {
     return tt::tt_metal::experimental::CreateGlobalCircularBuffer(
         device, sender_receiver_core_mapping, size, buffer_type);
+}
+
+GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
+    MeshDevice* mesh_device,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type) {
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferWithDramSenders(
+        *mesh_device, bank_to_receivers, size, buffer_type);
+}
+
+GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
+    MeshDevice* mesh_device,
+    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
+    const std::vector<tt::tt_metal::Tensor>& weights,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type) {
+    TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
+    TT_FATAL(
+        program_configs.size() == weights.size(),
+        "Expected one weight tensor per program config; got {} configs and {} weights",
+        program_configs.size(),
+        weights.size());
+    TT_FATAL(size > 0, "size must be > 0");
+    TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
+
+    // All matmuls share the same GCB receiver rectangle, so they must all agree on the
+    // ring shape and per-bank receiver count.
+    const auto& first = program_configs.front();
+    TT_FATAL(
+        first.gather_in0,
+        "create_global_circular_buffer_for_matmul_1d requires gather_in0=true on every program "
+        "config; config[0] has gather_in0=false");
+    TT_FATAL(first.num_global_cb_receivers > 0, "config[0].num_global_cb_receivers must be > 0");
+
+    const auto& grid = first.compute_with_storage_grid_size;
+    const uint32_t ring_cols = grid.x;
+    const uint32_t ring_rows = grid.y;
+    const uint32_t ring_size = ring_cols * ring_rows;
+    const uint32_t num_senders = static_cast<uint32_t>(bank_to_receivers.size());
+    const uint32_t num_recv_per_bank = static_cast<uint32_t>(first.num_global_cb_receivers);
+
+    // Validate bank_to_receivers shape against the program config:
+    //   - num_senders * num_recv_per_bank must equal ring_size (the matmul's worker count).
+    //   - Each bank must own exactly num_recv_per_bank receiver cores.
+    // We don't check that the receivers row-major-walk matches the matmul's activation grid in
+    // ring-position order — that's the matmul op's responsibility at op-construction time.
+    TT_FATAL(
+        num_senders * num_recv_per_bank == ring_size,
+        "bank_to_receivers has {} senders * {} receivers/bank = {} cores, but program_config "
+        "ring_size ({} x {} = {}) needs that many receivers",
+        num_senders,
+        num_recv_per_bank,
+        num_senders * num_recv_per_bank,
+        ring_cols,
+        ring_rows,
+        ring_size);
+    for (size_t b = 0; b < bank_to_receivers.size(); ++b) {
+        const uint32_t bank_recv_count = bank_to_receivers[b].second.num_cores();
+        TT_FATAL(
+            bank_recv_count == num_recv_per_bank,
+            "bank_to_receivers[{}] (bank_id={}) has {} receiver cores; expected num_global_cb_receivers={}",
+            b,
+            bank_to_receivers[b].first,
+            bank_recv_count,
+            num_recv_per_bank);
+    }
+
+    // Validate every (config, weight) pair against the matmul invariants, and collect
+    // the largest in1_block_size to size the buffer.
+    uint32_t max_in1_block_size = 0;
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        const auto& cfg = program_configs[i];
+        const auto& w = weights[i];
+
+        TT_FATAL(cfg.gather_in0, "config[{}].gather_in0 must be true", i);
+        TT_FATAL(cfg.num_global_cb_receivers > 0, "config[{}].num_global_cb_receivers must be > 0", i);
+        TT_FATAL(
+            cfg.compute_with_storage_grid_size.x == ring_cols && cfg.compute_with_storage_grid_size.y == ring_rows,
+            "config[{}] has compute_with_storage_grid_size {{{}, {}}}; must match config[0] {{{}, {}}} "
+            "(all matmuls sharing a GCB must use the same receiver rectangle)",
+            i,
+            cfg.compute_with_storage_grid_size.x,
+            cfg.compute_with_storage_grid_size.y,
+            ring_cols,
+            ring_rows);
+        TT_FATAL(
+            static_cast<uint32_t>(cfg.num_global_cb_receivers) == num_recv_per_bank,
+            "config[{}].num_global_cb_receivers ({}) must match config[0] ({}); the GCB has a single "
+            "receiver-per-bank count shared across all matmuls",
+            i,
+            cfg.num_global_cb_receivers,
+            num_recv_per_bank);
+
+        // ---- Weight shape & dtype ----
+        const auto& wp = w.padded_shape();
+        TT_FATAL(wp.rank() >= 2, "weights[{}] must be at least 2D; got rank {}", i, wp.rank());
+        const auto& tile = w.tensor_spec().tile();
+        const uint32_t tile_h = tile.get_height();
+        const uint32_t tile_w = tile.get_width();
+        const uint32_t weight_K = wp[-2];
+        const uint32_t weight_N = wp[-1];
+        TT_FATAL(weight_K % tile_h == 0, "weights[{}] K ({}) must be tile-aligned (tile_h={})", i, weight_K, tile_h);
+        TT_FATAL(weight_N % tile_w == 0, "weights[{}] N ({}) must be tile-aligned (tile_w={})", i, weight_N, tile_w);
+        const uint32_t weight_K_tiles = weight_K / tile_h;
+        const uint32_t weight_N_tiles = weight_N / tile_w;
+
+        // ---- The silent-hang check ----
+        TT_FATAL(
+            weight_K_tiles % ring_size == 0,
+            "weights[{}] K must be divisible by ring_size in tiles. Got weight_K_tiles={}, ring_size={} "
+            "(remainder={}). The matmul activation grid would pad K beyond what the prefetcher pushes "
+            "and the receivers would wait forever for in1 pages.",
+            i,
+            weight_K_tiles,
+            ring_size,
+            weight_K_tiles % ring_size);
+        TT_FATAL(
+            weight_K_tiles % cfg.in0_block_w == 0,
+            "weights[{}] K ({} tiles) must be divisible by config[{}].in0_block_w ({})",
+            i,
+            weight_K_tiles,
+            i,
+            cfg.in0_block_w);
+        TT_FATAL(
+            weight_N_tiles % num_senders == 0,
+            "weights[{}] N ({} tiles) must be divisible by num_senders ({})",
+            i,
+            weight_N_tiles,
+            num_senders);
+
+        // ---- Weight DRAM shard layout ----
+        TT_FATAL(w.buffer() != nullptr && w.buffer()->is_dram(), "weights[{}] must live in DRAM", i);
+        const auto& shard_shape = w.buffer()->shard_spec().shape();
+        const uint32_t shard_K = shard_shape[0];
+        const uint32_t shard_N = shard_shape[1];
+        TT_FATAL(
+            shard_K == weight_K,
+            "weights[{}] DRAM shard K ({}) must equal full K ({}); weight must be width-sharded across "
+            "banks with each bank holding the full K dimension",
+            i,
+            shard_K,
+            weight_K);
+        TT_FATAL(
+            shard_N * num_senders == weight_N,
+            "weights[{}] DRAM shard N ({}) * num_senders ({}) must equal full N ({})",
+            i,
+            shard_N,
+            num_senders,
+            weight_N);
+        const uint32_t shard_N_tiles = shard_N / tile_w;
+        TT_FATAL(
+            shard_N_tiles % num_recv_per_bank == 0,
+            "weights[{}] per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
+            i,
+            shard_N_tiles,
+            num_recv_per_bank);
+
+        const uint32_t per_recv_N_tiles = shard_N_tiles / num_recv_per_bank;
+        TT_FATAL(
+            per_recv_N_tiles == cfg.per_core_N,
+            "config[{}].per_core_N ({}) must equal weights[{}] per-receiver N ({} = shard_N_tiles {} "
+            "/ num_global_cb_receivers {})",
+            i,
+            cfg.per_core_N,
+            i,
+            per_recv_N_tiles,
+            shard_N_tiles,
+            num_recv_per_bank);
+
+        // ---- This matmul's in1 block size ----
+        // gather_in0 matmul derives its effective in0_block_w from weight_K_tiles / ring_size,
+        // not from cfg.in0_block_w (which is typically left at 1 in the program config). Use the
+        // same derivation here so the GCB page matches what the matmul will actually consume.
+        const uint32_t actual_in0_block_w = weight_K_tiles / ring_size;
+        const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
+        const uint32_t in1_block_size = static_cast<uint32_t>(actual_in0_block_w * cfg.per_core_N) * bytes_per_tile;
+        TT_FATAL(in1_block_size > 0, "config[{}] in1_block_size computed as 0", i);
+        max_in1_block_size = std::max(max_in1_block_size, in1_block_size);
+    }
+
+    // ---- Validate the caller-supplied size fits the remote-CB page-count cap and at
+    // least one full layer's worth of pages (the matmul does wait_front(num_blocks)).
+    //
+    // No L1 budget check here — receivers may have very different L1 usage on top of the
+    // GCB (matmul in0/in1/out/interm CBs etc.) and we don't have enough context at the
+    // factory to compute a real cap. Callers must size the GCB to fit their own L1.
+    //
+    // kMaxCbPagesBytes is a cap on fifo_aligned_num_pages = fifo_size /
+    // REMOTE_CIRCULAR_BUFFER_ALIGNED_PAGE_SIZE. Two reasons it exists:
+    //   1. The NoC stream overlay's STREAM_REMOTE_DEST_BUF_SIZE register holds the
+    //      buffer size in 16-byte words and is 17 bits wide on BH/WH (see
+    //      MEM_WORD_ADDR_WIDTH in noc_overlay_parameters.h), so the largest representable
+    //      buffer is (2^17 - 1) * 16 ≈ 2 MB. Paths that wire the GCB through the overlay
+    //      would silently truncate beyond that.
+    //   2. The remote-CB receiver tracks pages with 32-bit counters wrapped at 2^31
+    //      (noc_fast_atomic_increment wrap=31) and computes
+    //      free_pages = fifo_aligned_num_pages - (pages_sent - pages_acked) in unsigned
+    //      32-bit arithmetic. Keeping fifo_aligned_num_pages well under 2^30 leaves
+    //      plenty of headroom between the counter range and any plausible in-flight count
+    //      so signed/unsigned interpretation of the difference can never misfire.
+    // 2 MB satisfies both — it's the hardware overlay-field max, and ~5 orders of magnitude
+    // under the counter wrap.
+    constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
+    const uint32_t num_blocks = ring_size;
+    const uint32_t min_size = max_in1_block_size * num_blocks;
+    TT_FATAL(
+        size >= min_size,
+        "GCB size ({} B) must be at least num_blocks * largest in1_block ({} * {} = {} B); the "
+        "matmul does wait_front(num_blocks) so it needs that many pages buffered before it consumes.",
+        size,
+        num_blocks,
+        max_in1_block_size,
+        min_size);
+    TT_FATAL(
+        size <= kMaxCbPagesBytes,
+        "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
+        size,
+        kMaxCbPagesBytes);
+
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferWithDramSenders(
+        *mesh_device, bank_to_receivers, size, buffer_type);
 }
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
@@ -12,11 +12,21 @@
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/vector.h>
 
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
 #include "ttnn/global_circular_buffer.hpp"
 namespace ttnn::global_circular_buffer {
 
 void py_module_types(nb::module_& mod) {
-    nb::class_<GlobalCircularBuffer>(mod, "global_circular_buffer").def("size", &GlobalCircularBuffer::size);
+    nb::class_<GlobalCircularBuffer>(mod, "global_circular_buffer")
+        .def("size", &GlobalCircularBuffer::size)
+        .def("sender_cores", &GlobalCircularBuffer::sender_cores, nb::rv_policy::reference_internal)
+        .def("receiver_cores", &GlobalCircularBuffer::receiver_cores, nb::rv_policy::reference_internal)
+        .def("sender_core_type", [](const GlobalCircularBuffer& gcb) {
+            return tt::tt_metal::experimental::sender_core_type(gcb) ==
+                           tt::tt_metal::experimental::SenderCoreType::Worker
+                       ? "worker"
+                       : "dram";
+        });
 }
 
 void py_module(nb::module_& mod) {
@@ -59,6 +69,9 @@ void py_module(nb::module_& mod) {
                 size (int): Size of the global circular buffer per core in bytes.
                 buffer_type (BufferType): The type of buffer to use for the global circular buffer.
             )doc");
+
+    // DRAM-sender GCB factories live under ttnn.experimental.* — see
+    // ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp.
 }
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/CMakeLists.txt
@@ -1,0 +1,34 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_dram_core_prefetcher ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::DramCorePrefetcher ALIAS ttnn_op_experimental_dram_core_prefetcher)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_dram_core_prefetcher TTNN::PCH)
+
+set_target_properties(
+    ttnn_op_experimental_dram_core_prefetcher
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_experimental_dram_core_prefetcher
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_DRAM_CORE_PREFETCHER_SRCS}
+)
+
+target_include_directories(ttnn_op_experimental_dram_core_prefetcher PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_dram_core_prefetcher
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+)
+
+install(TARGETS ttnn_op_experimental_dram_core_prefetcher LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
@@ -13,8 +13,7 @@ void start_dram_core_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     const std::vector<ttnn::Tensor>& tensors,
     uint32_t num_layers,
-    const GlobalCircularBuffer& global_cb,
-    bool enable_performance_mode) {
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb) {
     std::vector<const tt::tt_metal::MeshTensor*> mesh_tensors;
     mesh_tensors.reserve(tensors.size());
     for (const auto& t : tensors) {
@@ -22,13 +21,12 @@ void start_dram_core_prefetcher(
     }
     tt::tt_metal::experimental::DramCorePrefetcherConfig config{
         .num_layers = num_layers,
-        .enable_performance_mode = enable_performance_mode,
     };
-    tt::tt_metal::experimental::StartDramCorePrefetcher(mesh_device, mesh_tensors, global_cb, config);
+    tt::tt_metal::experimental::StartDramCorePrefetcher(*mesh_device, mesh_tensors, global_cb, config);
 }
 
 void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device) {
-    tt::tt_metal::experimental::StopDramCorePrefetcher(mesh_device);
+    tt::tt_metal::experimental::StopDramCorePrefetcher(*mesh_device);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dram_core_prefetcher.hpp"
+
+#include <tt-metalium/experimental/dram_core_prefetcher.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+
+namespace ttnn::operations::experimental {
+
+void start_dram_core_prefetcher(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    const std::vector<ttnn::Tensor>& tensors,
+    uint32_t num_layers,
+    const GlobalCircularBuffer& global_cb,
+    bool enable_performance_mode) {
+    std::vector<const tt::tt_metal::MeshTensor*> mesh_tensors;
+    mesh_tensors.reserve(tensors.size());
+    for (const auto& t : tensors) {
+        mesh_tensors.push_back(&t.mesh_tensor());
+    }
+    tt::tt_metal::experimental::DramCorePrefetcherConfig config{
+        .num_layers = num_layers,
+        .enable_performance_mode = enable_performance_mode,
+    };
+    tt::tt_metal::experimental::StartDramCorePrefetcher(mesh_device, mesh_tensors, global_cb, config);
+}
+
+void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    tt::tt_metal::experimental::StopDramCorePrefetcher(mesh_device);
+}
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/global_circular_buffer.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace tt::tt_metal::distributed {
+class MeshDevice;
+}
+
+namespace ttnn::operations::experimental {
+
+// Thin ttnn-side wrappers around tt::tt_metal::experimental::Start/StopDramCorePrefetcher.
+// `tensors` is the same list shape as ttnn::dram_prefetcher: data tensors followed by a
+// trailing tensor_addrs tensor (unused on the DRAM-core path but kept for shape parity).
+//
+// start returns immediately; the kernel runs async on its DRISC core(s). Callers enqueue
+// the consuming matmul programs after start, then call stop to drain.
+void start_dram_core_prefetcher(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    const std::vector<ttnn::Tensor>& tensors,
+    uint32_t num_layers,
+    const GlobalCircularBuffer& global_cb,
+    bool enable_performance_mode = false);
+
+void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
@@ -26,8 +26,7 @@ void start_dram_core_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     const std::vector<ttnn::Tensor>& tensors,
     uint32_t num_layers,
-    const GlobalCircularBuffer& global_cb,
-    bool enable_performance_mode = false);
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb);
 
 void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);
 

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dram_core_prefetcher_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/vector.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "dram_core_prefetcher.hpp"
+#include "ttnn/global_circular_buffer.hpp"
+
+namespace ttnn::operations::experimental {
+
+void bind_dram_core_prefetcher(nb::module_& mod) {
+    ttnn::bind_function<"start_dram_core_prefetcher", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Start the DRAM-core (DRISC) prefetcher on `mesh_device`. Returns immediately;
+            the kernel runs asynchronously on its DRISC core(s) for `num_layers` iterations,
+            pushing each tensor in `tensors` into the receivers configured in `global_cb`.
+
+            Only one DRAM-core prefetcher may be active per mesh device at a time; calling
+            start again before stop will raise.
+
+            Args:
+                mesh_device (ttnn.MeshDevice): the mesh device to launch on.
+                tensors (List[ttnn.Tensor]): data tensors followed by a trailing tensor_addrs
+                    tensor. The addrs tensor is unused on the DRAM-core path but kept for
+                    shape parity with ttnn.dram_prefetcher.
+                num_layers (int): number of prefetch iterations the kernel will run.
+                global_cb (GlobalCircularBuffer): must be a DRAM-sender GCB
+                    (created via ttnn.experimental.create_global_circular_buffer_with_dram_senders).
+                enable_performance_mode (bool, optional): kept for API parity; currently a no-op.
+
+            Returns:
+                None
+        )doc",
+        &start_dram_core_prefetcher,
+        nb::arg("mesh_device"),
+        nb::arg("tensors"),
+        nb::arg("num_layers"),
+        nb::arg("global_cb"),
+        nb::kw_only(),
+        nb::arg("enable_performance_mode") = false);
+
+    ttnn::bind_function<"stop_dram_core_prefetcher", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Block until the active DRAM-core prefetcher finishes its num_layers loop, then
+            release its resources. No-op if no prefetcher is active.
+
+            Callers invoke stop after enqueuing all consuming matmul programs; stop is what
+            drains the pipeline.
+
+            Args:
+                mesh_device (ttnn.MeshDevice): the mesh device whose prefetcher to stop.
+        )doc",
+        &stop_dram_core_prefetcher,
+        nb::arg("mesh_device"));
+
+    // DRAM-sender GCB factories. MeshDevice-only (the per-mesh DRISC L1 arena lives on
+    // MeshDeviceImpl) and only ever paired with the DRAM-core prefetcher above.
+    ttnn::bind_function<"create_global_circular_buffer_with_dram_senders", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Create a GlobalCircularBuffer where senders are programmable DRAM cores (Blackhole DRISCs).
+            Each bank id is mapped to an unused DRAM subchannel; receiver sets across senders must
+            be disjoint and must not collide with the DRAM sender physical NOC coords.
+
+            Args:
+                mesh_device: The mesh device to create the buffer on.
+                bank_to_receivers: List of (bank_id, receivers) pairs.
+                size: Per-receiver fifo size in bytes.
+                buffer_type: Buffer type (L1 or L1_SMALL).
+        )doc",
+        &ttnn::global_circular_buffer::create_global_circular_buffer_with_dram_senders,
+        nb::keep_alive<0, 1>(),
+        nb::arg("mesh_device"),
+        nb::arg("bank_to_receivers"),
+        nb::arg("size"),
+        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1);
+
+    ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more 1D ring matmuls
+            (gather_in0=true) with their weight tensors. Size, page stride, and the
+            receiver-to-bank rectangle are derived from the matmul program configs so
+            host-side alignment checks fire as TT_FATAL at construction rather than as a
+            silent device hang during ttnn.linear.
+
+            One (program_config, weight) pair per matmul. The production pattern (e.g. llama 70B)
+            is to share a single GCB across XQKV/WO/FF1/FF2, where each consumer has a different
+            in1_block_size.
+
+            Validates per matmul:
+              * weight K is tile-aligned AND divisible by ring_size (no activation padding past K),
+              * weight N shards evenly across DRAM banks and per-bank N splits evenly across
+                num_global_cb_receivers,
+              * matmul per_core_N == weight per-receiver N.
+            All configs must agree on compute_with_storage_grid_size and num_global_cb_receivers.
+
+            Picking size (in bytes):
+              * Minimum = num_blocks * largest_in1_block_size (one full layer's pages).
+                The matmul does wait_front(num_blocks) per layer, so anything smaller deadlocks.
+              * Larger lets the DRISC prefetcher run further ahead. Past one full layer
+                worth more buffering doesn't add throughput; the DRISC just stalls on
+                remote_cb_reserve_back.
+              * The factory does not check L1 capacity. Callers must size the GCB to fit
+                alongside the matmul's in0/in1/out/interm CBs on the receiver cores.
+
+            Args:
+                mesh_device: The mesh device.
+                program_configs: List of 1D mcast matmul program configs (each gather_in0=True).
+                weights: List of DRAM-sharded in1 tensors, one per program_config.
+                bank_to_receivers: List of (bank_id, receivers) pairs. num_senders *
+                    num_global_cb_receivers must equal ring_size; every bank must own
+                    exactly num_global_cb_receivers receiver cores. The matmul op asserts
+                    at construction time that the receivers row-major-walk into the same
+                    order as its activation grid.
+                size: GCB size in bytes.
+                buffer_type: Buffer type (L1 or L1_SMALL).
+        )doc",
+        &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d,
+        nb::keep_alive<0, 1>(),
+        nb::arg("mesh_device"),
+        nb::arg("program_configs"),
+        nb::arg("weights"),
+        nb::arg("bank_to_receivers"),
+        nb::arg("size"),
+        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1);
+}
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
@@ -33,7 +33,6 @@ void bind_dram_core_prefetcher(nb::module_& mod) {
                 num_layers (int): number of prefetch iterations the kernel will run.
                 global_cb (GlobalCircularBuffer): must be a DRAM-sender GCB
                     (created via ttnn.experimental.create_global_circular_buffer_with_dram_senders).
-                enable_performance_mode (bool, optional): kept for API parity; currently a no-op.
 
             Returns:
                 None
@@ -42,9 +41,7 @@ void bind_dram_core_prefetcher(nb::module_& mod) {
         nb::arg("mesh_device"),
         nb::arg("tensors"),
         nb::arg("num_layers"),
-        nb::arg("global_cb"),
-        nb::kw_only(),
-        nb::arg("enable_performance_mode") = false);
+        nb::arg("global_cb"));
 
     ttnn::bind_function<"stop_dram_core_prefetcher", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace ttnn::operations::experimental {
+
+namespace nb = nanobind;
+
+void bind_dram_core_prefetcher(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/sources.cmake
@@ -1,0 +1,4 @@
+# Source files for ttnn_op_experimental_dram_core_prefetcher.
+# Module owners should update this file when adding/removing/renaming source files.
+
+set(TTNN_OP_EXPERIMENTAL_DRAM_CORE_PREFETCHER_SRCS dram_core_prefetcher.cpp)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -55,7 +55,9 @@
 #include "ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/all_reduce_create_qkv_heads_nanobind.hpp"
 #include "ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_nanobind.hpp"
 #include "ttnn/operations/experimental/padded_slice/padded_slice_nanobind.hpp"
+#include "ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.hpp"
 #include "ttnn/operations/experimental/test/hang_device/hang_device_operation_nanobind.hpp"
+#include "ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.hpp"
 #include "ttnn/operations/experimental/isin/isin_nanobind.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.hpp"
@@ -145,6 +147,8 @@ void py_module(nb::module_& mod) {
     gelu_backward::detail::bind_experimental_gelu_backward_operation(mod);
 
     test::bind_test_hang_device_operation(mod);
+    test::bind_test_dram_prefetcher_consumer(mod);
+    bind_dram_core_prefetcher(mod);
 
     // CCL ops
     auto m_experimental_ccl = mod.def_submodule("ccl_experimental", "experimental collective communication operations");

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
@@ -56,24 +56,26 @@ tt::stl::hash::hash_t DramPrefetcherConsumerDeviceOperation::compute_program_has
 
 ttnn::device_operation::CachedProgram<DramPrefetcherConsumerDeviceOperation::ProgramFactory::shared_variables_t>
 DramPrefetcherConsumerDeviceOperation::ProgramFactory::create_at(
-    const operation_attributes_t& attrs,
+    const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& /*mesh_coordinate*/,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& /*tensor_return_value*/) {
     using namespace tt::tt_metal;
 
     Program program = CreateProgram();
-    const auto& global_cb = attrs.global_cb.value();
+    const auto& global_cb = operation_attributes.global_cb.value();
     const CoreRangeSet receiver_cores = global_cb.receiver_cores();
 
     // Configure the receiver-side CB. set_page_size matches what the sender resizes the CB to
     // (in_block_w_tiles * n_tiles_per_recv * tile_bytes); receiver wait_front/pop_front operate
     // in units of this page size.
-    CircularBufferConfig cb_config(attrs.page_size_bytes);
-    cb_config.remote_index(kRemoteCBId).set_page_size(attrs.page_size_bytes).set_data_format(tt::DataFormat::Float16_b);
+    CircularBufferConfig cb_config(operation_attributes.page_size_bytes);
+    cb_config.remote_index(kRemoteCBId)
+        .set_page_size(operation_attributes.page_size_bytes)
+        .set_data_format(tt::DataFormat::Float16_b);
     tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, cb_config, global_cb);
 
-    const std::vector<uint32_t> compile_args = {kRemoteCBId, attrs.num_iters};
+    const std::vector<uint32_t> compile_args = {kRemoteCBId, operation_attributes.num_iters};
     CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/gcb_bench_discard_receiver.cpp",

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dram_prefetcher_consumer.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+namespace ttnn::operations::experimental::test {
+
+namespace {
+constexpr uint32_t kRemoteCBId = 31;
+}  // namespace
+
+void DramPrefetcherConsumerDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& /*tensor_args*/) {
+    TT_FATAL(attrs.mesh_device != nullptr, "mesh_device required");
+    TT_FATAL(attrs.num_iters > 0, "num_iters must be > 0");
+    TT_FATAL(attrs.page_size_bytes > 0, "page_size_bytes must be > 0");
+    TT_FATAL(attrs.global_cb.has_value(), "global_cb required");
+    TT_FATAL(attrs.global_cb->receiver_cores().num_cores() > 0, "GCB has no receiver cores");
+}
+
+void DramPrefetcherConsumerDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& /*tensor_args*/) {}
+
+DramPrefetcherConsumerDeviceOperation::spec_return_value_t DramPrefetcherConsumerDeviceOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return std::vector<ttnn::TensorSpec>{};
+}
+
+DramPrefetcherConsumerDeviceOperation::tensor_return_value_t
+DramPrefetcherConsumerDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t&) {
+    return std::vector<ttnn::Tensor>{};
+}
+
+tt::stl::hash::hash_t DramPrefetcherConsumerDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& /*tensor_args*/) {
+    // GlobalCircularBuffer isn't reflection-hashable; hash its identity via config_address
+    // (unique per GCB instance on this device) along with the other attrs.
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<DramPrefetcherConsumerDeviceOperation>,
+        attrs.num_iters,
+        attrs.page_size_bytes,
+        static_cast<uint64_t>(attrs.global_cb->config_address()));
+}
+
+ttnn::device_operation::CachedProgram<DramPrefetcherConsumerDeviceOperation::ProgramFactory::shared_variables_t>
+DramPrefetcherConsumerDeviceOperation::ProgramFactory::create_at(
+    const operation_attributes_t& attrs,
+    const ttnn::MeshCoordinate& /*mesh_coordinate*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
+    using namespace tt::tt_metal;
+
+    Program program = CreateProgram();
+    const auto& global_cb = attrs.global_cb.value();
+    const CoreRangeSet receiver_cores = global_cb.receiver_cores();
+
+    // Configure the receiver-side CB. set_page_size matches what the sender resizes the CB to
+    // (in_block_w_tiles * n_tiles_per_recv * tile_bytes); receiver wait_front/pop_front operate
+    // in units of this page size.
+    CircularBufferConfig cb_config(attrs.page_size_bytes);
+    cb_config.remote_index(kRemoteCBId).set_page_size(attrs.page_size_bytes).set_data_format(tt::DataFormat::Float16_b);
+    tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, cb_config, global_cb);
+
+    const std::vector<uint32_t> compile_args = {kRemoteCBId, attrs.num_iters};
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_bench_discard_receiver.cpp",
+        receiver_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = compile_args});
+
+    return {std::move(program), shared_variables_t{}};
+}
+
+void DramPrefetcherConsumerDeviceOperation::ProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& /*cached_workload*/,
+    const operation_attributes_t& /*attrs*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
+    // Nothing to override — all args are compile-time.
+}
+
+void test_dram_prefetcher_consumer(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    uint32_t num_iters,
+    uint32_t page_size_bytes,
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb) {
+    using OperationType = DramPrefetcherConsumerDeviceOperation;
+    OperationType::operation_attributes_t attrs{
+        .num_iters = num_iters,
+        .page_size_bytes = page_size_bytes,
+        .global_cb = global_cb,
+        .mesh_device = mesh_device,
+    };
+    OperationType::tensor_args_t tensor_args{};
+    ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/global_circular_buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::test {
+
+// Bench-only companion to `ttnn.dram_prefetcher`. Loads a discard-only receiver kernel
+// on each receiver core of the supplied GCB; each receiver runs `wait_front(1);
+// pop_front(1);` in a loop `num_iters` times.
+struct DramPrefetcherConsumerDeviceOperation {
+    struct operation_attributes_t {
+        uint32_t num_iters;
+        uint32_t page_size_bytes;
+        // optional<> because reflection-based profiler serialization needs a default-
+        // constructible attribute struct, and GlobalCircularBuffer has no default ctor.
+        std::optional<tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
+        ttnn::MeshDevice* mesh_device;
+    };
+
+    struct tensor_args_t {};
+
+    // Side-effect op (no output tensors).
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = std::vector<ttnn::Tensor>;
+
+    struct ProgramFactory {
+        struct shared_variables_t {};
+        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coordinate,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+// Public free function (kept for the nanobind binding `ttnn.experimental.test_dram_prefetcher_consumer`).
+void test_dram_prefetcher_consumer(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    uint32_t num_iters,
+    uint32_t page_size_bytes,
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb);
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dram_prefetcher_consumer_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "dram_prefetcher_consumer.hpp"
+#include "dram_prefetcher_validator.hpp"
+
+namespace ttnn::operations::experimental::test {
+
+void bind_test_dram_prefetcher_consumer(nb::module_& mod) {
+    ttnn::bind_function<"test_dram_prefetcher_consumer", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Bench-only consumer companion to ttnn.dram_prefetcher. Builds and enqueues a
+            program that loads a discard receiver kernel on each receiver core of the supplied
+            GCB, looping num_iters times of wait_front(1)+pop_front(1). Used to measure
+            prefetcher push bandwidth without matmul receiver-side effects.
+            Used for debugging purposes, please avoid to use in any production code.
+
+            Args:
+                mesh_device: the MeshDevice to enqueue on.
+                num_iters (int): total pages each receiver should consume (= num_layers * num_blocks).
+                page_size_bytes (int): receiver-side page size; must match what the sender pushes
+                    (in0_block_w_tiles * n_tiles_per_receiver * tile_bytes).
+                global_cb (GlobalCircularBuffer): either a worker-sender or DRAM-sender GCB.
+        )doc",
+        &test_dram_prefetcher_consumer,
+        nb::arg("mesh_device"),
+        nb::arg("num_iters"),
+        nb::arg("page_size_bytes"),
+        nb::kw_only(),
+        nb::arg("global_cb"));
+
+    ttnn::bind_function<"test_dram_prefetcher_validator", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Byte-for-byte validator receiver: for each pushed page, reads the expected
+            tile range from source_tensor via TensorAccessor and memcmps against the
+            received bytes. On any mismatch DPRINTs (layer, block, word) + the diverging
+            bytes and hangs the core; otherwise DPRINTs progress and a final OK. After
+            the expected num_layers * ring_size iterations, polls briefly for extra
+            pages (sender overshoot) and hangs on overflow.
+
+            The kernel derives its expected bytes from the (bank, receiver, block) ->
+            tile-range mapping documented in
+            tt_metal/impl/buffers/prefetcher_matmul_design.md §3 ("Per-block source tiles"). Used for
+            debugging purposes; please avoid in any production code.
+
+            Args:
+                mesh_device: the MeshDevice to enqueue on.
+                source_tensor (ttnn.Tensor): the same width-sharded DRAM tensor the
+                    prefetcher is being driven with.
+                num_layers (int): number of layers the prefetcher will push.
+                print_stride (int): DPRINT every Nth iter; first/last always logged. 0 = first/last only.
+                global_cb (GlobalCircularBuffer): worker-sender or DRAM-sender GCB.
+        )doc",
+        &test_dram_prefetcher_validator,
+        nb::arg("mesh_device"),
+        nb::arg("source_tensor"),
+        nb::arg("num_layers"),
+        nb::arg("print_stride"),
+        nb::kw_only(),
+        nb::arg("global_cb"));
+}
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace ttnn::operations::experimental::test {
+
+namespace nb = nanobind;
+
+void bind_test_dram_prefetcher_consumer(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <nanobind/nanobind.h>
+#include "ttnn-nanobind/nanobind_fwd.hpp"
 
 namespace ttnn::operations::experimental::test {
 

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -77,14 +77,14 @@ tt::stl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_ha
 
 ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>
 DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
-    const operation_attributes_t& attrs,
+    const operation_attributes_t& operation_attributes,
     const ttnn::MeshCoordinate& /*mesh_coordinate*/,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& /*tensor_return_value*/) {
     using namespace tt::tt_metal;
 
     const auto& source_tensor = tensor_args.source_tensor;
-    const auto& global_cb = attrs.global_cb.value();
+    const auto& global_cb = operation_attributes.global_cb.value();
 
     // Derive ring topology from the GCB (matches both worker-sender and DRAM-sender paths).
     const auto& sr_mapping = global_cb.sender_receiver_core_mapping();
@@ -142,10 +142,10 @@ DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
     std::vector<uint32_t> compile_args = {
         kValidatorRemoteCBId,
         kValidatorScratchCBId,
-        attrs.num_layers,
+        operation_attributes.num_layers,
         num_blocks,
         num_senders,
-        attrs.print_stride,
+        operation_attributes.print_stride,
     };
     TensorAccessorArgs(*tensor_buffer).append_to(compile_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dram_prefetcher_validator.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+namespace ttnn::operations::experimental::test {
+
+namespace {
+constexpr uint32_t kValidatorRemoteCBId = 31;
+constexpr uint32_t kValidatorScratchCBId = 0;
+}  // namespace
+
+void DramPrefetcherValidatorDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    TT_FATAL(attrs.num_layers > 0, "num_layers must be > 0");
+    const auto* tensor_buffer = tensor_args.source_tensor.buffer();
+    TT_FATAL(tensor_buffer != nullptr, "source_tensor must be on device");
+    TT_FATAL(tensor_buffer->is_dram(), "source_tensor must be a DRAM buffer");
+    TT_FATAL(attrs.global_cb.has_value(), "global_cb required");
+    TT_FATAL(attrs.global_cb->receiver_cores().num_cores() > 0, "GCB has no receiver cores");
+
+    const auto& sr_mapping = attrs.global_cb->sender_receiver_core_mapping();
+    TT_FATAL(!sr_mapping.empty(), "GCB has no senders");
+    const uint32_t num_receivers_per_sender = sr_mapping.front().second.num_cores();
+    for (const auto& [_, recv] : sr_mapping) {
+        TT_FATAL(
+            recv.num_cores() == num_receivers_per_sender,
+            "GCB has non-uniform receivers per sender ({} vs {}); validator requires uniform fanout",
+            recv.num_cores(),
+            num_receivers_per_sender);
+    }
+}
+
+void DramPrefetcherValidatorDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& /*tensor_args*/) {}
+
+DramPrefetcherValidatorDeviceOperation::spec_return_value_t
+DramPrefetcherValidatorDeviceOperation::compute_output_specs(const operation_attributes_t&, const tensor_args_t&) {
+    return std::vector<ttnn::TensorSpec>{};
+}
+
+DramPrefetcherValidatorDeviceOperation::tensor_return_value_t
+DramPrefetcherValidatorDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t&) {
+    return std::vector<ttnn::Tensor>{};
+}
+
+tt::stl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // GlobalCircularBuffer / Tensor aren't reflection-hashable here; pick the bits that
+    // determine Program shape: scalar attrs, GCB identity, the source tensor's DRAM
+    // address (compile-time arg via TensorAccessorArgs), and its dataformat.
+    const auto* tensor_buffer = tensor_args.source_tensor.buffer();
+    const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.source_tensor.dtype());
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<DramPrefetcherValidatorDeviceOperation>,
+        attrs.num_layers,
+        attrs.print_stride,
+        static_cast<uint64_t>(attrs.global_cb->config_address()),
+        static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
+        static_cast<uint32_t>(dataformat));
+}
+
+ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>
+DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
+    const operation_attributes_t& attrs,
+    const ttnn::MeshCoordinate& /*mesh_coordinate*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/) {
+    using namespace tt::tt_metal;
+
+    const auto& source_tensor = tensor_args.source_tensor;
+    const auto& global_cb = attrs.global_cb.value();
+
+    // Derive ring topology from the GCB (matches both worker-sender and DRAM-sender paths).
+    const auto& sr_mapping = global_cb.sender_receiver_core_mapping();
+    const uint32_t num_senders = static_cast<uint32_t>(sr_mapping.size());
+    const uint32_t num_receivers_per_sender = sr_mapping.front().second.num_cores();
+    const uint32_t num_blocks = num_senders * num_receivers_per_sender;
+
+    // Per-tensor geometry (single-tensor path; see prefetcher_matmul_design.md §3).
+    Buffer* tensor_buffer = source_tensor.buffer();
+    const auto shard_shape = tensor_buffer->shard_spec().shape();
+    const auto& tile_spec = source_tensor.tensor_spec().tile();
+    const auto tile_shape = tile_spec.get_tile_shape();
+    const uint32_t tile_h = tile_shape[0];
+    const uint32_t tile_w = tile_shape[1];
+    TT_FATAL(
+        shard_shape[0] % tile_h == 0 && shard_shape[1] % tile_w == 0,
+        "shard_shape ({}, {}) must be tile-aligned (tile {}x{})",
+        shard_shape[0],
+        shard_shape[1],
+        tile_h,
+        tile_w);
+    const uint32_t k_tiles = shard_shape[0] / tile_h;
+    const uint32_t n_per_bank_tiles = shard_shape[1] / tile_w;
+    TT_FATAL(
+        k_tiles % num_blocks == 0,
+        "k_tiles ({}) must be divisible by num_blocks ({}) for the validator's expected layout",
+        k_tiles,
+        num_blocks);
+    TT_FATAL(
+        n_per_bank_tiles % num_receivers_per_sender == 0,
+        "n_per_bank_tiles ({}) must be divisible by num_receivers_per_sender ({})",
+        n_per_bank_tiles,
+        num_receivers_per_sender);
+    const uint32_t k_block_w_tiles = k_tiles / num_blocks;
+    const uint32_t n_per_recv_tiles = n_per_bank_tiles / num_receivers_per_sender;
+    const tt::DataFormat tensor_dataformat = datatype_to_dataformat_converter(source_tensor.dtype());
+    const uint32_t tile_bytes = tile_spec.get_tile_size(tensor_dataformat);
+    const uint32_t page_bytes_per_recv = k_block_w_tiles * n_per_recv_tiles * tile_bytes;
+
+    const CoreRangeSet receiver_cores = global_cb.receiver_cores();
+
+    Program program = CreateProgram();
+
+    // Receiver-side remote CB: wait_front/pop_front units are one full per-receiver block.
+    CircularBufferConfig remote_cfg(page_bytes_per_recv);
+    remote_cfg.remote_index(kValidatorRemoteCBId).set_page_size(page_bytes_per_recv).set_data_format(tensor_dataformat);
+    tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, remote_cfg, global_cb);
+
+    // Scratch CB: holds the expected page bytes during a single block comparison.
+    CircularBufferConfig scratch_cfg(page_bytes_per_recv, {{kValidatorScratchCBId, tensor_dataformat}});
+    scratch_cfg.set_page_size(kValidatorScratchCBId, page_bytes_per_recv);
+    CreateCircularBuffer(program, receiver_cores, scratch_cfg);
+
+    // Compile-time args: scalars, then the TensorAccessor args for the source tensor.
+    std::vector<uint32_t> compile_args = {
+        kValidatorRemoteCBId,
+        kValidatorScratchCBId,
+        attrs.num_layers,
+        num_blocks,
+        num_senders,
+        attrs.print_stride,
+    };
+    TensorAccessorArgs(*tensor_buffer).append_to(compile_args);
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/gcb_validator_receiver.cpp",
+        receiver_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0, .compile_args = compile_args});
+
+    // Per-receiver runtime args: bank_id, recv_idx_in_bank, then per-tensor geometry.
+    // Receiver enumeration order within a sender's CoreRangeSet must match the order the
+    // sender uses to address them in its internal noc_xy table (row-major).
+    const uint32_t bank_base_addr = static_cast<uint32_t>(tensor_buffer->address());
+    for (uint32_t s = 0; s < num_senders; ++s) {
+        const auto& [sender_logical, receivers_set] = sr_mapping[s];
+        const uint32_t bank_id = sender_logical.x;
+        const auto recv_cores = corerange_to_cores(receivers_set, std::nullopt, /*row_wise=*/true);
+        TT_FATAL(
+            recv_cores.size() == num_receivers_per_sender,
+            "Sender {} has {} receivers but expected {}",
+            s,
+            recv_cores.size(),
+            num_receivers_per_sender);
+        for (uint32_t r = 0; r < recv_cores.size(); ++r) {
+            std::vector<uint32_t> rt_args = {
+                bank_id,
+                r,
+                bank_base_addr,
+                k_block_w_tiles,
+                n_per_bank_tiles,
+                n_per_recv_tiles,
+            };
+            SetRuntimeArgs(program, kernel_id, recv_cores[r], rt_args);
+        }
+    }
+
+    return {std::move(program), shared_variables_t{}};
+}
+
+void DramPrefetcherValidatorDeviceOperation::ProgramFactory::override_runtime_arguments(
+    cached_mesh_workload_t& /*cached_workload*/,
+    const operation_attributes_t& /*attrs*/,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/) {
+    // Nothing to override — buffer address is part of the cache key via compute_program_hash.
+}
+
+void test_dram_prefetcher_validator(
+    tt::tt_metal::distributed::MeshDevice* /*mesh_device*/,
+    const ttnn::Tensor& source_tensor,
+    uint32_t num_layers,
+    uint32_t print_stride,
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb) {
+    using OperationType = DramPrefetcherValidatorDeviceOperation;
+    OperationType::operation_attributes_t attrs{
+        .num_layers = num_layers,
+        .print_stride = print_stride,
+        .global_cb = global_cb,
+    };
+    OperationType::tensor_args_t tensor_args{.source_tensor = source_tensor};
+    ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.hpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/global_circular_buffer.hpp>
+#include <tt-metalium/mesh_device.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::test {
+
+// Byte-for-byte validator companion to ttnn.dram_prefetcher / start_dram_core_prefetcher.
+// Loads a validator kernel on each receiver core of the supplied GCB; for each pushed
+// page it reads the receiver's expected tile range from `source_tensor` (via
+// TensorAccessor) and memcmps against the received bytes.
+struct DramPrefetcherValidatorDeviceOperation {
+    struct operation_attributes_t {
+        uint32_t num_layers;
+        uint32_t print_stride;
+        // optional<> because reflection-based profiler serialization needs a default-
+        // constructible attribute struct, and GlobalCircularBuffer has no default ctor.
+        std::optional<tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
+    };
+
+    struct tensor_args_t {
+        const ttnn::Tensor& source_tensor;
+    };
+
+    // Side-effect op (no output tensors).
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+    using tensor_return_value_t = std::vector<ttnn::Tensor>;
+
+    struct ProgramFactory {
+        struct shared_variables_t {};
+        using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static ttnn::device_operation::CachedProgram<shared_variables_t> create_at(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coordinate,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+// Public free function (kept for the nanobind binding `ttnn.experimental.test_dram_prefetcher_validator`).
+void test_dram_prefetcher_validator(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    const ttnn::Tensor& source_tensor,
+    uint32_t num_layers,
+    uint32_t print_stride,
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb);
+
+}  // namespace ttnn::operations::experimental::test

--- a/ttnn/cpp/ttnn/operations/experimental/test/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/test/sources.cmake
@@ -1,4 +1,8 @@
 # Source files for ttnn_op_experimental_test.
 # Module owners should update this file when adding/removing/renaming source files.
 
-set(TTNN_OP_EXPERIMENTAL_TEST_SRCS hang_device/hang_device_operation.cpp)
+set(TTNN_OP_EXPERIMENTAL_TEST_SRCS
+    hang_device/hang_device_operation.cpp
+    prefetcher_consumer/dram_prefetcher_consumer.cpp
+    prefetcher_consumer/dram_prefetcher_validator.cpp
+)

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "tt-metalium/hal_types.hpp"
+#include "tt-metalium/experimental/global_circular_buffer.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "tt_stl/unreachable.hpp"
 
@@ -918,6 +919,112 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         TT_FATAL(
                             program_config.num_global_cb_receivers == 1,
                             "Num global CB receivers must be 1 when global CB is not provided.");
+                    }
+
+                    // Cross-validate the DRAM-sender global_cb's geometry against the matmul +
+                    // weight shape. These catch silent-hang configs where the matmul reads more
+                    // in1 pages than the prefetcher pushes (e.g. activation K padded past weight
+                    // K). Gated on the DRAM-sender path because the worker-sender variant predates
+                    // this work and uses different sizing/ordering conventions (no bank IDs;
+                    // gcb_size = N * max_tile_size).
+                    if (attributes.global_cb.has_value() && input_tensor_a.is_sharded() &&
+                        tt::tt_metal::experimental::sender_core_type(attributes.global_cb.value()) ==
+                            tt::tt_metal::experimental::SenderCoreType::Dram) {
+                        const auto& gcb = attributes.global_cb.value();
+                        const uint32_t ring_size = input_tensor_a.shard_spec().value().grid.num_cores();
+                        const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+                        const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+                        const uint32_t num_senders = gcb.sender_cores().num_cores();
+                        const uint32_t num_recv = gcb.receiver_cores().num_cores();
+                        const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
+
+                        TT_FATAL(
+                            num_senders > 0 && num_recv == num_senders * recv_per_bank,
+                            "global_cb receiver count ({}) must equal num_senders ({}) * "
+                            "num_global_cb_receivers ({})",
+                            num_recv,
+                            num_senders,
+                            recv_per_bank);
+                        TT_FATAL(
+                            num_recv == ring_size,
+                            "global_cb receiver count ({}) must equal in0 (activation) ring_size "
+                            "({} = num_cores of in0.shard_spec.grid). Receivers and matmul workers "
+                            "must be the same set of cores.",
+                            num_recv,
+                            ring_size);
+
+                        // Semantic check: bank b must push to exactly the receivers at ring
+                        // positions [b*recv_per_bank, (b+1)*recv_per_bank). If satisfied, the
+                        // bank-to-receivers union also equals the activation grid as a set, so
+                        // we don't need a separate set-equality assertion (CoreRangeSet::operator==
+                        // compares ranges literally, which is brittle when one side is merged
+                        // into rectangles and the other is a flat list of single-core ranges).
+                        const auto& act_grid = input_tensor_a.shard_spec().value().grid;
+                        const auto ring_walk =
+                            tt::tt_metal::corerange_to_cores(act_grid, std::nullopt, /*row_wise=*/true);
+                        const auto& mapping = gcb.sender_receiver_core_mapping();
+                        TT_FATAL(
+                            mapping.size() * recv_per_bank == ring_walk.size(),
+                            "global_cb sender_receiver mapping ({} senders * {} receivers each) "
+                            "doesn't cover the matmul ring ({} cores)",
+                            mapping.size(),
+                            recv_per_bank,
+                            ring_walk.size());
+                        for (size_t bank_idx = 0; bank_idx < mapping.size(); ++bank_idx) {
+                            const auto bank_recvs = tt::tt_metal::corerange_to_cores(
+                                mapping[bank_idx].second, std::nullopt, /*row_wise=*/true);
+                            TT_FATAL(
+                                bank_recvs.size() == recv_per_bank,
+                                "Sender at bank index {} owns {} receivers; expected "
+                                "num_global_cb_receivers={}",
+                                bank_idx,
+                                bank_recvs.size(),
+                                recv_per_bank);
+                            for (size_t k = 0; k < recv_per_bank; ++k) {
+                                const size_t ring_pos = bank_idx * recv_per_bank + k;
+                                TT_FATAL(
+                                    bank_recvs[k] == ring_walk[ring_pos],
+                                    "global_cb bank {}'s receiver at index {} is core {} but the "
+                                    "matmul ring walk expects core {} at ring position {}. The "
+                                    "bank-to-receivers mapping must place bank b's receivers at "
+                                    "ring positions [b*num_global_cb_receivers, (b+1)*num_global_cb_receivers).",
+                                    bank_idx,
+                                    k,
+                                    bank_recvs[k],
+                                    ring_walk[ring_pos],
+                                    ring_pos);
+                            }
+                        }
+                        TT_FATAL(
+                            weight_K_tiles % ring_size == 0,
+                            "Weight K must be divisible by ring_size in tiles for gather_in0 + global_cb. "
+                            "Got weight_K_tiles={}, ring_size={} (remainder={}). The activation grid would "
+                            "pad K past the weight K, and the matmul would wait forever for in1 pages the "
+                            "prefetcher never pushes.",
+                            weight_K_tiles,
+                            ring_size,
+                            weight_K_tiles % ring_size);
+                        TT_FATAL(
+                            weight_N_tiles % num_senders == 0,
+                            "Weight N ({} tiles) must be divisible by num_senders ({}) so it shards "
+                            "evenly across the DRAM banks the global_cb senders cover",
+                            weight_N_tiles,
+                            num_senders);
+                        const uint32_t per_bank_N_tiles = weight_N_tiles / num_senders;
+                        TT_FATAL(
+                            per_bank_N_tiles % recv_per_bank == 0,
+                            "Weight per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
+                            per_bank_N_tiles,
+                            recv_per_bank);
+                        const uint32_t per_recv_N_tiles = per_bank_N_tiles / recv_per_bank;
+                        TT_FATAL(
+                            per_recv_N_tiles == program_config.per_core_N,
+                            "Matmul per_core_N ({}) must equal weight per-receiver N ({} = per_bank_N_tiles {} "
+                            "/ num_global_cb_receivers {})",
+                            program_config.per_core_N,
+                            per_recv_N_tiles,
+                            per_bank_N_tiles,
+                            recv_per_bank);
                     }
 
                     TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -469,6 +469,112 @@ void warn_if_allowed_worker_cores_missing(
         program_config.value());
 }
 
+// Cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
+// These catch silent-hang configs where the matmul reads more in1 pages than the prefetcher
+// pushes (e.g. activation K padded past weight K). Gated by the caller on the DRAM-sender path
+// because the worker-sender variant predates this work and uses different sizing/ordering
+// conventions (no bank IDs; gcb_size = N * max_tile_size).
+void validate_dram_sender_global_cb_gather_in0_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_a,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    const uint32_t ring_size = input_tensor_a.shard_spec().value().grid.num_cores();
+    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+    const uint32_t num_senders = gcb.sender_cores().num_cores();
+    const uint32_t num_recv = gcb.receiver_cores().num_cores();
+    const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
+
+    TT_FATAL(
+        num_senders > 0 && num_recv == num_senders * recv_per_bank,
+        "global_cb receiver count ({}) must equal num_senders ({}) * "
+        "num_global_cb_receivers ({})",
+        num_recv,
+        num_senders,
+        recv_per_bank);
+    TT_FATAL(
+        num_recv == ring_size,
+        "global_cb receiver count ({}) must equal in0 (activation) ring_size "
+        "({} = num_cores of in0.shard_spec.grid). Receivers and matmul workers "
+        "must be the same set of cores.",
+        num_recv,
+        ring_size);
+
+    // Semantic check: bank b must push to exactly the receivers at ring
+    // positions [b*recv_per_bank, (b+1)*recv_per_bank). If satisfied, the
+    // bank-to-receivers union also equals the activation grid as a set, so
+    // we don't need a separate set-equality assertion (CoreRangeSet::operator==
+    // compares ranges literally, which is brittle when one side is merged
+    // into rectangles and the other is a flat list of single-core ranges).
+    const auto& act_grid = input_tensor_a.shard_spec().value().grid;
+    const auto ring_walk = tt::tt_metal::corerange_to_cores(act_grid, std::nullopt, /*row_wise=*/true);
+    const auto& mapping = gcb.sender_receiver_core_mapping();
+    TT_FATAL(
+        mapping.size() * recv_per_bank == ring_walk.size(),
+        "global_cb sender_receiver mapping ({} senders * {} receivers each) "
+        "doesn't cover the matmul ring ({} cores)",
+        mapping.size(),
+        recv_per_bank,
+        ring_walk.size());
+    for (size_t bank_idx = 0; bank_idx < mapping.size(); ++bank_idx) {
+        const auto bank_recvs =
+            tt::tt_metal::corerange_to_cores(mapping[bank_idx].second, std::nullopt, /*row_wise=*/true);
+        TT_FATAL(
+            bank_recvs.size() == recv_per_bank,
+            "Sender at bank index {} owns {} receivers; expected "
+            "num_global_cb_receivers={}",
+            bank_idx,
+            bank_recvs.size(),
+            recv_per_bank);
+        for (size_t k = 0; k < recv_per_bank; ++k) {
+            const size_t ring_pos = bank_idx * recv_per_bank + k;
+            TT_FATAL(
+                bank_recvs[k] == ring_walk[ring_pos],
+                "global_cb bank {}'s receiver at index {} is core {} but the "
+                "matmul ring walk expects core {} at ring position {}. The "
+                "bank-to-receivers mapping must place bank b's receivers at "
+                "ring positions [b*num_global_cb_receivers, (b+1)*num_global_cb_receivers).",
+                bank_idx,
+                k,
+                bank_recvs[k],
+                ring_walk[ring_pos],
+                ring_pos);
+        }
+    }
+    TT_FATAL(
+        weight_K_tiles % ring_size == 0,
+        "Weight K must be divisible by ring_size in tiles for gather_in0 + global_cb. "
+        "Got weight_K_tiles={}, ring_size={} (remainder={}). The activation grid would "
+        "pad K past the weight K, and the matmul would wait forever for in1 pages the "
+        "prefetcher never pushes.",
+        weight_K_tiles,
+        ring_size,
+        weight_K_tiles % ring_size);
+    TT_FATAL(
+        weight_N_tiles % num_senders == 0,
+        "Weight N ({} tiles) must be divisible by num_senders ({}) so it shards "
+        "evenly across the DRAM banks the global_cb senders cover",
+        weight_N_tiles,
+        num_senders);
+    const uint32_t per_bank_N_tiles = weight_N_tiles / num_senders;
+    TT_FATAL(
+        per_bank_N_tiles % recv_per_bank == 0,
+        "Weight per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
+        per_bank_N_tiles,
+        recv_per_bank);
+    const uint32_t per_recv_N_tiles = per_bank_N_tiles / recv_per_bank;
+    TT_FATAL(
+        per_recv_N_tiles == program_config.per_core_N,
+        "Matmul per_core_N ({}) must equal weight per-receiver N ({} = per_bank_N_tiles {} "
+        "/ num_global_cb_receivers {})",
+        program_config.per_core_N,
+        per_recv_N_tiles,
+        per_bank_N_tiles,
+        recv_per_bank);
+}
+
 }  // namespace
 
 MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_factory(
@@ -922,109 +1028,13 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                     }
 
                     // Cross-validate the DRAM-sender global_cb's geometry against the matmul +
-                    // weight shape. These catch silent-hang configs where the matmul reads more
-                    // in1 pages than the prefetcher pushes (e.g. activation K padded past weight
-                    // K). Gated on the DRAM-sender path because the worker-sender variant predates
-                    // this work and uses different sizing/ordering conventions (no bank IDs;
-                    // gcb_size = N * max_tile_size).
+                    // weight shape (silent-hang guards). Gated on the DRAM-sender path; see the
+                    // helper for why.
                     if (attributes.global_cb.has_value() && input_tensor_a.is_sharded() &&
                         tt::tt_metal::experimental::sender_core_type(attributes.global_cb.value()) ==
                             tt::tt_metal::experimental::SenderCoreType::Dram) {
-                        const auto& gcb = attributes.global_cb.value();
-                        const uint32_t ring_size = input_tensor_a.shard_spec().value().grid.num_cores();
-                        const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
-                        const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
-                        const uint32_t num_senders = gcb.sender_cores().num_cores();
-                        const uint32_t num_recv = gcb.receiver_cores().num_cores();
-                        const uint32_t recv_per_bank = static_cast<uint32_t>(program_config.num_global_cb_receivers);
-
-                        TT_FATAL(
-                            num_senders > 0 && num_recv == num_senders * recv_per_bank,
-                            "global_cb receiver count ({}) must equal num_senders ({}) * "
-                            "num_global_cb_receivers ({})",
-                            num_recv,
-                            num_senders,
-                            recv_per_bank);
-                        TT_FATAL(
-                            num_recv == ring_size,
-                            "global_cb receiver count ({}) must equal in0 (activation) ring_size "
-                            "({} = num_cores of in0.shard_spec.grid). Receivers and matmul workers "
-                            "must be the same set of cores.",
-                            num_recv,
-                            ring_size);
-
-                        // Semantic check: bank b must push to exactly the receivers at ring
-                        // positions [b*recv_per_bank, (b+1)*recv_per_bank). If satisfied, the
-                        // bank-to-receivers union also equals the activation grid as a set, so
-                        // we don't need a separate set-equality assertion (CoreRangeSet::operator==
-                        // compares ranges literally, which is brittle when one side is merged
-                        // into rectangles and the other is a flat list of single-core ranges).
-                        const auto& act_grid = input_tensor_a.shard_spec().value().grid;
-                        const auto ring_walk =
-                            tt::tt_metal::corerange_to_cores(act_grid, std::nullopt, /*row_wise=*/true);
-                        const auto& mapping = gcb.sender_receiver_core_mapping();
-                        TT_FATAL(
-                            mapping.size() * recv_per_bank == ring_walk.size(),
-                            "global_cb sender_receiver mapping ({} senders * {} receivers each) "
-                            "doesn't cover the matmul ring ({} cores)",
-                            mapping.size(),
-                            recv_per_bank,
-                            ring_walk.size());
-                        for (size_t bank_idx = 0; bank_idx < mapping.size(); ++bank_idx) {
-                            const auto bank_recvs = tt::tt_metal::corerange_to_cores(
-                                mapping[bank_idx].second, std::nullopt, /*row_wise=*/true);
-                            TT_FATAL(
-                                bank_recvs.size() == recv_per_bank,
-                                "Sender at bank index {} owns {} receivers; expected "
-                                "num_global_cb_receivers={}",
-                                bank_idx,
-                                bank_recvs.size(),
-                                recv_per_bank);
-                            for (size_t k = 0; k < recv_per_bank; ++k) {
-                                const size_t ring_pos = bank_idx * recv_per_bank + k;
-                                TT_FATAL(
-                                    bank_recvs[k] == ring_walk[ring_pos],
-                                    "global_cb bank {}'s receiver at index {} is core {} but the "
-                                    "matmul ring walk expects core {} at ring position {}. The "
-                                    "bank-to-receivers mapping must place bank b's receivers at "
-                                    "ring positions [b*num_global_cb_receivers, (b+1)*num_global_cb_receivers).",
-                                    bank_idx,
-                                    k,
-                                    bank_recvs[k],
-                                    ring_walk[ring_pos],
-                                    ring_pos);
-                            }
-                        }
-                        TT_FATAL(
-                            weight_K_tiles % ring_size == 0,
-                            "Weight K must be divisible by ring_size in tiles for gather_in0 + global_cb. "
-                            "Got weight_K_tiles={}, ring_size={} (remainder={}). The activation grid would "
-                            "pad K past the weight K, and the matmul would wait forever for in1 pages the "
-                            "prefetcher never pushes.",
-                            weight_K_tiles,
-                            ring_size,
-                            weight_K_tiles % ring_size);
-                        TT_FATAL(
-                            weight_N_tiles % num_senders == 0,
-                            "Weight N ({} tiles) must be divisible by num_senders ({}) so it shards "
-                            "evenly across the DRAM banks the global_cb senders cover",
-                            weight_N_tiles,
-                            num_senders);
-                        const uint32_t per_bank_N_tiles = weight_N_tiles / num_senders;
-                        TT_FATAL(
-                            per_bank_N_tiles % recv_per_bank == 0,
-                            "Weight per-bank N ({} tiles) must be divisible by num_global_cb_receivers ({})",
-                            per_bank_N_tiles,
-                            recv_per_bank);
-                        const uint32_t per_recv_N_tiles = per_bank_N_tiles / recv_per_bank;
-                        TT_FATAL(
-                            per_recv_N_tiles == program_config.per_core_N,
-                            "Matmul per_core_N ({}) must equal weight per-receiver N ({} = per_bank_N_tiles {} "
-                            "/ num_global_cb_receivers {})",
-                            program_config.per_core_N,
-                            per_recv_N_tiles,
-                            per_bank_N_tiles,
-                            recv_per_bank);
+                        validate_dram_sender_global_cb_gather_in0_geometry(
+                            attributes.global_cb.value(), input_tensor_a, b_shape_padded, in1_tile, program_config);
                     }
 
                     TT_FATAL(!optional_bias.has_value(), "Bias is not supported when using gather_in0.");

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/global_circular_buffer.hpp>
 #include <optional>
 
 namespace ttnn::prim {
@@ -16,6 +17,13 @@ void DramPrefetcherOperation::validate_on_program_cache_miss(
     TT_FATAL(!input_tensors.empty(), "Must have at least one input tensor");
     TT_FATAL(args.num_layers > 0, "Prefetcher must run for at least 1 layer");
     TT_FATAL(args.global_cb.has_value(), "Global circular buffer must be provided");
+
+    TT_FATAL(
+        tt::tt_metal::experimental::sender_core_type(*args.global_cb) !=
+            tt::tt_metal::experimental::SenderCoreType::Dram,
+        "ttnn.dram_prefetcher does not support DRAM-sender GlobalCircularBuffers. Use "
+        "ttnn.experimental.start_dram_core_prefetcher / ttnn.experimental.stop_dram_core_prefetcher instead.");
+
     const ttnn::Tensor& tensor_addrs = input_tensors.back();  // Last tensor is tensor_addrs
 
     auto global_cb = *(args.global_cb);

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
@@ -13,6 +13,9 @@
 
 namespace ttnn {
 
+// Worker-sender prefetcher op. `global_cb` must be a worker-sender GCB; passing a
+// DRAM-sender GCB will TT_FATAL with a redirect to
+// ttnn.experimental.start_dram_core_prefetcher / ttnn.experimental.stop_dram_core_prefetcher.
 ttnn::Tensor dram_prefetcher(
     std::vector<ttnn::Tensor>& tensors,
     uint32_t num_layers,

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -307,7 +307,9 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn/operations/data_movement/sort/sort_nanobind.cpp
     cpp/ttnn/operations/data_movement/gather/gather_nanobind.cpp
     cpp/ttnn/operations/data_movement/gather/tosa/gather_tosa_nanobind.cpp
+    cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
     cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation_nanobind.cpp
+    cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer_nanobind.cpp
     # ttnn-nanobind core files (appended in original CMakeLists.txt)
     cpp/ttnn-nanobind/__init__.cpp
     cpp/ttnn-nanobind/activation.cpp


### PR DESCRIPTION
### PR Category

Feature.

### Summary

Stacks on top of `jbauman/driscgcb` (the DRAM-sender GCB extraction). Adds a DRISC-side prefetcher that drives the new GCB: a DRAM-core kernel that pulls weight pages from DRAM banks and pushes them into the receiver ring, plus the host-side machinery and unit/bench coverage.

What lands here:

- **DRISC kernel** `tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp` — runs on the unused DRAM subchannel, reads weight pages and pushes into the receiver-side GCB ring.
- **Host API** `experimental::{Start,Stop}DramCorePrefetcher` in `tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp`, backed by `DramCorePrefetcherManager` (lazily constructed on `MeshDeviceImpl`).
- **Matmul-aware GCB factory** — `create_global_circular_buffer_for_matmul_1d` consumes a list of `(matmul_config, K_tiles, …)` and derives ring geometry + K-sub-blocking to fit L1.
- **TTNN op + bindings** under `ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/` (op, nanobind, validator/consumer test helpers).
- **Tests** — `test_prefetcher_BH_validator.py` does byte-for-byte page checks via `TensorAccessor`; `test_prefetcher_BH_bench.py` / `_bw_bench.py` / `_dram_core_large.py` cover Llama-shaped matmuls. All gated on Blackhole + `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1` via module-level `pytestmark`.
- Design notes in `tt_metal/impl/buffers/prefetcher_matmul_design.md`.


### Performance

Measured on Blackhole **P300**, single device, 8 unharvested DRAM banks. Covered the 16 Llama prefetcher-fed matmul shapes (1B/3B/8B/70B × QKV/WO/FF1/FF2) at the smallest device count where the prefetcher fits in L1.

**Push bandwidth** (`test_prefetcher_BH_bw_bench.py`, no matmul on receivers — isolates the push path):
- DRAM-core: **82–254 GB/s aggregate** / **1.28–3.96 GB/s per receiver** (64 receivers).
- vs. worker-core: **DRAM-core wins on 5/16 shapes** (1.09–1.14× — the small ≤4 KB block bucket where the worker's BRISC/NCRISC overlap doesn't have enough to chew on), **ties 2 more** (0.95×–0.96×), **loses on 9** (0.67×–0.76× — the Case-2 large-block shapes that split into two DMAs the worker can pipeline but DRAM-core has to serialize).

**End-to-end matmul** (`test_prefetcher_BH_bench.py`, prefetcher hoisted out of the trace on both paths so receiver-side compute can hide push cost):
- DRAM-core: **2.0–7.3 TFLOP/s** per device.
- vs. worker-core: roughly tied — **DRAM-core faster on 6/16 shapes** (up to 1.63× on 1B_WO), **within ±5% on 4**, **slower on 6** (down to 0.68× on 8B_FF1). No consistent winner per shape; matmul receiver-side compute often hides the BW gap visible in the push-only bench.

The structural ceiling: DRAM-core runs the whole pipeline (GDDR DMA → push → finalize) serially on one RISC per bank, while worker-core overlaps BRISC reads with NCRISC pushes. The value of DRAM-core isn't headline push throughput — it's freeing the worker cores from sender duty so they're available for the matmul itself (production benefit not measured in this single-chip bench).

### Notes for reviewers

⚠️ **The host API is not final.** `experimental::StartDramCorePrefetcher` / `StopDramCorePrefetcher` are placeholders for the current one-shot shape (fixed list of requests at start, stop teardown). They will be replaced by an API that lets callers **continually add new requests to an already-running prefetcher**. Please don't bikeshed the public surface yet — focus review on the kernel, the manager, and the GCB plumbing.

This branch is based on `jbauman/driscgcb`; it should only merge after that base lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/driscprefetcher2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/driscprefetcher2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/driscprefetcher2)
