### PR TITLE
pipeline prefill runner

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
@@ -1,0 +1,57 @@
+# Mesh graph descriptor for 2-rank pipeline-parallel prefill on 2 independent BH galaxies.
+#
+# Two SEPARATE 8x4 single-galaxy meshes (mesh_id 0 and 1), one host each, grouped with NO
+# connections — cross-rank activations go host->host (PREFILL_PP_DIR), so the galaxies need
+# no fabric between them. Each mesh keeps only its own intra-galaxy fabric for CCL.
+#
+# Per-mesh shape mirrors tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
+# (8x4 = full galaxy = PREFILL_SP x PREFILL_TP). NOTE: the decode superpod descriptor
+# (blitz_decode_*_superpod) uses 4x2 / 8-chip meshes — that is decode's decomposition, NOT
+# this prefill 8x4 layout; do not copy from it.
+#
+# Pairs with pipeline_prefill_rank_binding_2rank.yaml (rank 0 -> mesh 0, rank 1 -> mesh 1).
+#
+# VERIFY against a known-good single-galaxy PREFILL run on this cluster:
+#   * dim_types [ LINE, RING ]: set per developer recollection ("pretty sure"), not confirmed
+#     against a descriptor — the dim0 (8) axis is open, dim1 (4) axis is an intra-galaxy torus.
+#     Confirm against the single-galaxy descriptor this cluster actually uses; wrong RING/LINE
+#     fails fabric init.
+#   * pinnings: anchor each mesh's logical chip 0 to its host's physical ASIC. tray_id/asic
+#     values copied from the single-galaxy template; confirm they match this pod, and that
+#     mesh 0 lands on the first --host (bh-glx-d03u02) and mesh 1 on the second (bh-glx-d03u08).
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+mesh_descriptors {
+  name: "M1"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+# Anchor each logical mesh to its host's physical galaxy (chip 0 -> tray 1, asic 1).
+pinnings {
+  logical_fabric_node_id { mesh_id: 0 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+pinnings {
+  logical_fabric_node_id { mesh_id: 1 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+
+# Group the two meshes with no connections -> independent meshes (host transport only).
+graph_descriptors {
+  name: "G0"
+  type: "POD"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
@@ -46,10 +46,14 @@ pinnings {
   physical_asic_position { tray_id: 1 asic_location: 1 }
 }
 
-# Group the two meshes with no connections -> independent meshes (host transport only).
+# One FABRIC graph holding the two meshes with NO connections: each galaxy trains only its
+# own intra-mesh 8x4 fabric, there is no inter-galaxy fabric, and cross-rank activations go
+# host->host. MGD 1.0 requires the single top graph to be type FABRIC
+# (mesh_graph_descriptor.cpp validate_graph_topology_and_connections) but requires no
+# connections — a connectionless multi-mesh graph is the correct independent-galaxy topology.
 graph_descriptors {
   name: "G0"
-  type: "POD"
+  type: "FABRIC"
   instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
   instances { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
 }

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_4galaxy_mesh_graph_descriptor.textproto
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_4galaxy_mesh_graph_descriptor.textproto
@@ -1,0 +1,69 @@
+# Mesh graph descriptor for 4-rank pipeline-parallel prefill on 4 independent BH galaxies.
+#
+# Four SEPARATE 8x4 single-galaxy meshes (mesh_id 0..3), one host each, in a single FABRIC graph
+# with NO connections — cross-rank activations go host->host (PREFILL_PP_DIR over shared NFS), so the
+# galaxies need no fabric between them; each mesh keeps only its own intra-galaxy fabric for CCL.
+#
+# Same per-mesh shape and the FABRIC-graph / no-connections / [LINE,RING] / tray1-asic1 pinning
+# conventions as pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto (verified working on the
+# d03 pod); this just scales 2 meshes -> 4. Pairs with pipeline_prefill_rank_binding_4rank.yaml
+# (rank N -> mesh N). MGD 1.0 requires the single top graph be type FABRIC but needs no connections.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+mesh_descriptors {
+  name: "M1"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+mesh_descriptors {
+  name: "M2"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+mesh_descriptors {
+  name: "M3"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+# Anchor each logical mesh to its host's physical galaxy (chip 0 -> tray 1, asic 1).
+pinnings {
+  logical_fabric_node_id { mesh_id: 0 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+pinnings {
+  logical_fabric_node_id { mesh_id: 1 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+pinnings {
+  logical_fabric_node_id { mesh_id: 2 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+pinnings {
+  logical_fabric_node_id { mesh_id: 3 chip_id: 0 }
+  physical_asic_position { tray_id: 1 asic_location: 1 }
+}
+
+# One FABRIC graph holding the four meshes with NO connections -> independent meshes (host transport).
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M2" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M3" mesh_id: 3 } }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_h2d_2rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_h2d_2rank.yaml
@@ -1,0 +1,35 @@
+# tt-run rank binding for the 2-galaxy pipeline split with rank0 fed by the H2D socket (Step 2).
+#
+# Same topology as pipeline_prefill_rank_binding_2rank.yaml (rank0 u02 layers [0,31)+embed,
+# rank1 u08 layers [31,61)+norm+lmhead, activation over NFS /data/jjovicic/pp_acts) — but rank0's
+# token input comes from the H2D socket service instead of the trace file (PREFILL_PP_H2D=1). An
+# external producer (prefill_h2d_producer.py) must run ON u02 and push PREFILL_STANDALONE_NCHUNKS
+# chunks; rank0 listens (h2d_socket_sync), runs its slice, dumps the activation, listens again.
+#
+# Launch (rank0+rank1 via tt-run; producer is a SEPARATE process on u02):
+#   bash models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh \
+#     models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_h2d_2rank.yaml
+#   # then, on u02, once rank0 logs "[h2d] service up":
+#   PREFILL_H2D_SERVICE_ID=ds_prefill PREFILL_STANDALONE_NCHUNKS=4 PREFILL_SP=8 PREFILL_TP=4 \
+#     PREFILL_H2D_CONNECT_TIMEOUT=900 \
+#     python3 -m models.demos.deepseek_v3_d_p.tt.runners.prefill_h2d_producer
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides: {}
+
+mesh_graph_desc_path: models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
+
+global_env:
+  PREFILL_PP_DIR: "/data/jjovicic/pp_acts"
+  PREFILL_STANDALONE_PCC: "1"
+  PREFILL_STANDALONE_NCHUNKS: "4"
+  # rank0 reads tokens from the H2D socket instead of the trace.
+  PREFILL_PP_H2D: "1"
+  PREFILL_H2D_SERVICE_ID: "ds_prefill"

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
@@ -46,6 +46,11 @@ global_env:
   # Turn on the per-rank KV-cache PCC gate (default off).
   PREFILL_STANDALONE_PCC: "1"
 
+  # 4 chunks x 5120 = 20480 tokens = the full per-user cache (max_seq_len = 4*chunk). Exercises
+  # the multi-chunk cross-host wavefront. The default (ceil(isl/chunk) for the 56320-token trace
+  # -> 11) would exceed the cache; keep this <= 4 unless PREFILL_MAX_SEQ_LEN is raised too.
+  PREFILL_STANDALONE_NCHUNKS: "4"
+
   # Everything else uses the runner's built-in defaults today: variant deepseek_v3_d_p,
   # PREFILL_SP=8 / PREFILL_TP=4 / NUM_LAYERS=61 / CHUNK_SIZE=5120 / MAX_SEQ_LEN=4*chunk /
   # NUM_USERS=2, PREFILL_PP_TRANSPORT=host, even 31/30 layer split, and the variant's HF

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
@@ -46,10 +46,9 @@ global_env:
   # Turn on the per-rank KV-cache PCC gate (default off).
   PREFILL_STANDALONE_PCC: "1"
 
-  # 4 chunks x 5120 = 20480 tokens = the full per-user cache (max_seq_len = 4*chunk). Exercises
-  # the multi-chunk cross-host wavefront. The default (ceil(isl/chunk) for the 56320-token trace
-  # -> 11) would exceed the cache; keep this <= 4 unless PREFILL_MAX_SEQ_LEN is raised too.
-  PREFILL_STANDALONE_NCHUNKS: "4"
+  # 11 chunks x 5120 = 56320 tokens (the full golden trace). max_seq_len auto-derives to
+  # chunk_size * num_chunks, so no separate cache-length knob is needed.
+  PREFILL_STANDALONE_NCHUNKS: "11"
 
   # Everything else uses the runner's built-in defaults today: variant deepseek_v3_d_p,
   # PREFILL_SP=8 / PREFILL_TP=4 / NUM_LAYERS=61 / CHUNK_SIZE=5120 / MAX_SEQ_LEN=4*chunk /

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
@@ -1,0 +1,52 @@
+# tt-run rank binding for a 2-rank pipeline-parallel prefill run.
+#
+# One 2-rank world (get_size()==2, get_rank()==0/1 in pipeline_prefill_runner),
+# two independent single-galaxy 8x4 meshes — rank 0 on mesh 0, rank 1 on mesh 1.
+# Cross-rank activations go host->host through PREFILL_PP_DIR (shared NFS), so the
+# two galaxies do NOT need fabric between them; only each mesh's own intra-galaxy
+# fabric is used.
+#
+# Launch (hostnames live in --mpi-args, NOT here):
+#   TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
+#   python3 "${TTRUN_PY}" \
+#     --tcp-interface <IFACE> \
+#     --rank-binding models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml \
+#     --mpi-args "--host bh-glx-d03u02:1,bh-glx-d03u08:1 --map-by slot --bind-to none --tag-output" \
+#     python3 -m models.demos.deepseek_v3_d_p.tt.runners.pipeline_prefill_runner
+#
+# VERIFY before running (cluster-specific, not guessable from the runner side):
+#   * mesh_graph_desc_path: must define TWO independent 8x4 BH-galaxy meshes
+#     (mesh_id 0 and 1) with NO required inter-galaxy links. A fused 16x4 descriptor
+#     is wrong (that is one mesh spanning both hosts). If no 2-mesh descriptor exists,
+#     give each rank its own single-galaxy 8x4 MGD via a per-rank mesh_graph_desc_path.
+#   * --tcp-interface and the --host slots: match a known-good multi-host launch on
+#     this pod (e.g. the deepseek_v3_b1 scaleout_configs / the scaleout team).
+#   * PREFILL_PP_DIR must resolve to the SAME shared directory on both hosts.
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {}        # full galaxy visible; no TT_VISIBLE_DEVICES carve
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides: {}
+
+# 2x independent 8x4 BH-galaxy mesh graph descriptor (see its VERIFY note: confirm dim_types).
+# Relative path resolves under TT_METAL_HOME.
+mesh_graph_desc_path: models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_2galaxy_mesh_graph_descriptor.textproto
+
+global_env:
+  # Host->host activation handoff dir. Must be shared across both hosts (the runner's
+  # /dev/shm default is per-host and won't cross). /data is NFS (10.32.13.1:/data) on this
+  # cluster; change this for a different setup.
+  PREFILL_PP_DIR: "/data/jjovicic/pp_acts"
+
+  # Turn on the per-rank KV-cache PCC gate (default off).
+  PREFILL_STANDALONE_PCC: "1"
+
+  # Everything else uses the runner's built-in defaults today: variant deepseek_v3_d_p,
+  # PREFILL_SP=8 / PREFILL_TP=4 / NUM_LAYERS=61 / CHUNK_SIZE=5120 / MAX_SEQ_LEN=4*chunk /
+  # NUM_USERS=2, PREFILL_PP_TRANSPORT=host, even 31/30 layer split, and the variant's HF
+  # model + TTNN weight-cache defaults. Override here only to diverge from those.

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_4rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_4rank.yaml
@@ -1,0 +1,37 @@
+# tt-run rank binding for a 4-rank pipeline-parallel prefill run across 4 BH galaxies.
+#
+# One 4-rank world: rank N owns mesh N (its own full 8x4 galaxy). The 61-layer model is split
+# four ways (compute_layer_split -> [16,15,15,15]): rank0 = embed + layers [0,16), rank1 = [16,31),
+# rank2 = [31,46), rank3 = [46,61) + norm + LM-head. Each rank hands its hidden-state activation to
+# the next via PREFILL_PP_DIR (shared NFS); no inter-galaxy fabric. Trace-fed (no H2D producer).
+#
+# Launch (hostnames in --mpi-args; pod d07/d08):
+#   bash models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh \
+#     models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_4rank.yaml \
+#     "bh-glx-d07u02:1,bh-glx-d07u08:1,bh-glx-d08u02:1,bh-glx-d08u08:1"
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 2
+    mesh_id: 2
+    mesh_host_rank: 0
+    env_overrides: {}
+  - rank: 3
+    mesh_id: 3
+    mesh_host_rank: 0
+    env_overrides: {}
+
+mesh_graph_desc_path: models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_4galaxy_mesh_graph_descriptor.textproto
+
+global_env:
+  PREFILL_PP_DIR: "/data/jjovicic/pp_acts"
+  PREFILL_STANDALONE_PCC: "1"
+  # 11 chunks (56320 tokens = full golden trace). max_seq_len auto-derives to chunk*num_chunks.
+  PREFILL_STANDALONE_NCHUNKS: "11"

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -29,5 +29,6 @@ mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_to
 global_env:
   # Per-rank KV-cache PCC gate against the golden trace.
   PREFILL_STANDALONE_PCC: "1"
-  # 4 chunks (20480 tokens) = full per-user cache; single-rank baseline for the 2-rank pipeline.
-  PREFILL_STANDALONE_NCHUNKS: "4"
+  # 11 chunks (56320 tokens = full golden trace); single-rank baseline. max_seq_len auto-derives.
+
+  PREFILL_STANDALONE_NCHUNKS: "11"

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -29,6 +29,5 @@ mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_to
 global_env:
   # Per-rank KV-cache PCC gate against the golden trace.
   PREFILL_STANDALONE_PCC: "1"
-  # One chunk (5120 tokens) for a fast first smoke; default would be ceil(isl/chunk) chunks,
-  # which exceeds the per-user cache (max_seq_len = 4*chunk).
-  PREFILL_STANDALONE_NCHUNKS: "1"
+  # 4 chunks (20480 tokens) = full per-user cache; single-rank baseline for the 2-rank pipeline.
+  PREFILL_STANDALONE_NCHUNKS: "4"

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -1,0 +1,34 @@
+# tt-run rank binding for a 1-rank REAL-model de-risk on ONE BH galaxy.
+#
+# Single rank, full galaxy: is_first == is_last == True, so the runner builds the WHOLE
+# 61-layer model (embedding + all layers + norm + LM head) and runs it with NO cross-rank
+# transport. Confirms, in isolation from the 2-host path, that:
+#   * per-galaxy FABRIC_1D trains with the [LINE, RING] 8x4 torus dim_types,
+#   * the model builds from the shared TTNN weight cache, and
+#   * the populated KV cache PCC-matches the golden trace.
+# It is the precursor to the 2-galaxy half-and-half split (pipeline_prefill_rank_binding_2rank.yaml).
+#
+# Uses the in-tree known-good single-galaxy descriptor (8x4, [LINE, RING]); our 2-galaxy
+# descriptor's two meshes are copies of it.
+#
+# Launch:
+#   python3 "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" \
+#     --tcp-interface ens5f0np0 \
+#     --rank-binding models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml \
+#     --mpi-args "--host bh-glx-d03u02:1 --map-by slot --bind-to none --tag-output --allow-run-as-root" \
+#     python3 -m models.demos.deepseek_v3_d_p.tt.runners.pipeline_prefill_runner
+
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides: {}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
+
+global_env:
+  # Per-rank KV-cache PCC gate against the golden trace.
+  PREFILL_STANDALONE_PCC: "1"
+  # One chunk (5120 tokens) for a fast first smoke; default would be ceil(isl/chunk) chunks,
+  # which exceeds the per-user cache (max_seq_len = 4*chunk).
+  PREFILL_STANDALONE_NCHUNKS: "1"

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -158,57 +158,72 @@ def _reshard_activation_to_device(mesh_device: ttnn.MeshDevice, host_tensor, mes
     )
 
 
-def send_activation(runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: int, chunk_idx: int, rank: int) -> None:
-    """Publish this rank's output activation to the downstream rank, then free the device tensor.
-    Atomic-rename so the consumer (single shared FS / NFS) never reads a partial file; the wavefront
-    barrier orders this rename before the consumer's read."""
+def send_activation(
+    runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: int, chunk_idx: int, rank: int, meta: dict
+) -> None:
+    """Publish this rank's output activation AND its per-chunk metadata to the downstream rank as one
+    payload, then free the device tensor. The atomic rename makes the file appear whole, so the
+    consumer's polling recv_activation never sees a partial write — that pair is the only cross-rank
+    sync (no barrier). Bundling activation+metadata mirrors what the D2D-socket op will carry in one
+    transfer, so the downstream rank needs no shared schedule."""
     import torch
 
-    t0 = time.perf_counter()
-    host = _gather_activation_to_host(runtime.mesh_device, activation)
+    t_to = time.perf_counter()
+    host = _gather_activation_to_host(runtime.mesh_device, activation)  # to_torch: device -> host
+    ms_to_torch = (time.perf_counter() - t_to) * 1000.0
+    t_w = time.perf_counter()
     final = _act_path(subctx, chunk_idx, rank)
     tmp = f"{final}.tmp.{rank}"  # same dir -> rename is atomic on the target FS
-    torch.save(host, tmp)
+    torch.save({"act": host, "meta": meta}, tmp)
     os.rename(tmp, final)
+    ms_write = (time.perf_counter() - t_w) * 1000.0
     ttnn.deallocate(activation)
     nbytes = host.element_size() * host.nelement()
     logger.info(
         f"[pp rank {rank}] SEND chunk={chunk_idx} -> {final} "
-        f"shape={tuple(host.shape)} dtype={host.dtype} bytes={nbytes} "
-        f"gather+write={(time.perf_counter() - t0) * 1000.0:.1f}ms"
+        f"shape={tuple(host.shape)} dtype={host.dtype} bytes={nbytes} meta={meta} "
+        f"[xfer] to_torch={ms_to_torch:.2f}ms write={ms_write:.2f}ms"
     )
 
 
-def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, producer_rank: int) -> ttnn.Tensor:
-    """Receive the upstream rank's activation for this chunk and reshard it onto this rank's mesh.
-    runtime.prefill() deallocates the returned tensor.
+def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, producer_rank: int) -> tuple:
+    """Receive the upstream rank's activation + metadata for this chunk and reshard the activation
+    onto this rank's mesh. Returns (device_tensor, meta_dict); runtime.prefill() deallocates the tensor.
 
-    The producer's rename is barrier-ordered before this read, but NFS can briefly serve a stale
-    negative dentry, so retry the open a bounded number of times before giving up."""
+    Polls for the file — the producer's atomic rename is the only ordering, no barrier — so block here
+    until it appears: the open fails while the producer is still computing/renaming (and, cross-host
+    over NFS, while a stale negative dentry lingers). Retry up to PREFILL_PP_RECV_RETRIES * 0.1s; size
+    that above the producer's worst-case per-chunk compute time."""
     import torch
 
     path = _act_path(subctx, chunk_idx, producer_rank)
-    attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "50"))
-    t0 = time.perf_counter()
+    attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "3000"))
+    # Wait (poll) for the producer's atomic-renamed file; time it separately from the transfer cost.
+    t_wait = time.perf_counter()
     waits = 0
     for attempt in range(attempts):
-        try:
-            host = torch.load(path)
+        if os.path.exists(path):
             break
-        except FileNotFoundError:
-            if attempt == attempts - 1:
-                raise
-            waits += 1  # file from the other host not visible yet -> cross-host propagation in flight
-            time.sleep(0.1)  # absorb NFS negative-dentry cache; barrier already ordered the write
+        if attempt == attempts - 1:
+            raise FileNotFoundError(path)
+        waits += 1  # producer hasn't published this chunk yet (still computing, or cross-host NFS lag)
+        time.sleep(0.1)
+    ms_wait = (time.perf_counter() - t_wait) * 1000.0
+    t_r = time.perf_counter()
+    payload = torch.load(path)
+    ms_read = (time.perf_counter() - t_r) * 1000.0
     os.unlink(path)
-    out = _reshard_activation_to_device(runtime.mesh_device, host, runtime.config.mesh_shape)
+    host, meta = payload["act"], payload["meta"]
+    t_from = time.perf_counter()
+    out = _reshard_activation_to_device(runtime.mesh_device, host, runtime.config.mesh_shape)  # from_torch
+    ms_from_torch = (time.perf_counter() - t_from) * 1000.0
     nbytes = host.element_size() * host.nelement()
     logger.info(
         f"[pp] RECV chunk={chunk_idx} <- {path} (from rank {producer_rank}) "
-        f"shape={tuple(host.shape)} bytes={nbytes} waits={waits} "
-        f"read+reshard={(time.perf_counter() - t0) * 1000.0:.1f}ms"
+        f"shape={tuple(host.shape)} bytes={nbytes} meta={meta} waits={waits} wait={ms_wait:.1f}ms "
+        f"[xfer] read={ms_read:.2f}ms from_torch={ms_from_torch:.2f}ms"
     )
-    return out
+    return out, meta
 
 
 def _subcontext_id() -> int:
@@ -256,75 +271,83 @@ def _first_rank_chunk_tokens(runtime: TtPrefillRuntime, token_ids: list[int], kv
     )
 
 
-def run_standalone_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> None:
+def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> None:
+    """Decoupled per-rank loop: each rank runs its own loop, coordinated ONLY by the
+    activation+metadata file handoff (atomic rename + polling recv) — no cross-rank barrier, so an
+    upstream rank can race ahead of a downstream one (pipeline overlap). The first rank drives the
+    chunk schedule from the trace; the per-chunk metadata (slot / actual_start / actual_end / is_last)
+    rides with each activation, so downstream ranks need no shared schedule and learn the end from
+    is_last. Every rank checks the KV slice it populated against golden."""
     cfg = runtime.config
     subctx = _subcontext_id()
-    token_ids = _load_token_ids()
-    actual_isl = len(token_ids)
     slot_id = int(os.environ.get("PREFILL_STANDALONE_SLOT", "0")) % cfg.num_users
 
-    nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
-    n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
-    total_len = n_chunks * cfg.chunk_size
-    if total_len > cfg.max_seq_len:
-        raise ValueError(
-            f"{n_chunks} chunks x {cfg.chunk_size} = {total_len} exceeds per-user cache "
-            f"max_seq_len={cfg.max_seq_len}. Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
-        )
-    token_ids = (token_ids + [1] * total_len)[:total_len]
+    token_ids = None
+    n_chunks = None
+    if cfg.is_first_rank:
+        # Only the first rank needs the input schedule; later ranks learn it from the metadata.
+        token_ids = _load_token_ids()
+        actual_isl = len(token_ids)
+        nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
+        n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
+        total_len = n_chunks * cfg.chunk_size
+        if total_len > cfg.max_seq_len:
+            raise ValueError(
+                f"{n_chunks} chunks x {cfg.chunk_size} = {total_len} exceeds per-user cache "
+                f"max_seq_len={cfg.max_seq_len}. Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
+            )
+        token_ids = (token_ids + [1] * total_len)[:total_len]
 
-    num_iterations = int(os.environ.get("PREFILL_STANDALONE_ITERS", "1"))
-    logger.info(f"[pp rank {rank}] actual_isl={actual_isl} slot={slot_id} " f"chunks={n_chunks} iters={num_iterations}")
+    logger.info(
+        f"[pp rank {rank}/{num_ranks}] decoupled loop start (is_first={cfg.is_first_rank} "
+        f"is_last={cfg.is_last_rank} slot={slot_id}" + (f" chunks={n_chunks}" if cfg.is_first_rank else "") + ")"
+    )
 
-    iter_times_ms = []
-    for it in range(num_iterations):
-        if _shutdown:
-            logger.info(f"[pp rank {rank}] shutdown requested, breaking loop")
-            break
-        t0 = time.perf_counter()
-        for c in range(n_chunks):
+    t0 = time.perf_counter()
+    c = 0
+    n_done = 0
+    while not _shutdown:
+        if cfg.is_first_rank:
+            if c >= n_chunks:
+                break
             kv_actual = c * cfg.chunk_size
-            # Barrier-ordered wavefront: a chunk has a strict rank0->rank1->...->rankN-1 data
-            # dependency, so ranks run one at a time. The barrier after each stage guarantees the
-            # producer's activation-file write lands before the next rank reads it. Fully serialized
-            # — a PCC/bring-up path, not a perf path.
-            for stage in range(num_ranks):
-                if rank == stage:
-                    if cfg.is_first_rank:
-                        inp = _first_rank_chunk_tokens(runtime, token_ids, kv_actual)
-                    else:
-                        inp = recv_activation(runtime, subctx, c, rank - 1)
-                    out = runtime.prefill(
-                        inp,
-                        slot_id=slot_id,
-                        actual_start=kv_actual,
-                        actual_end=kv_actual + cfg.chunk_size,  # standalone drives full chunks
-                    )
-                    if not cfg.is_last_rank:
-                        send_activation(runtime, out, subctx, c, rank)
-                ttnn.distributed_context_barrier()
-        ttnn.synchronize_device(runtime.mesh_device)
-        dt_ms = (time.perf_counter() - t0) * 1000.0
-        iter_times_ms.append(dt_ms)
-        logger.info(
-            f"[pp rank {rank}] [prefill timing] iter={it} num_tokens={total_len} "
-            f"chunks={n_chunks} slot={slot_id} wavefront = {dt_ms:.2f} ms"
+            inp = _first_rank_chunk_tokens(runtime, token_ids, kv_actual)
+            meta = {
+                "slot_id": slot_id,
+                "actual_start": kv_actual,
+                "actual_end": kv_actual + cfg.chunk_size,  # trace drives full chunks
+                "is_last": c == n_chunks - 1,
+            }
+        else:
+            inp, meta = recv_activation(runtime, subctx, c, rank - 1)
+            slot_id = meta["slot_id"]
+
+        out = runtime.prefill(
+            inp, slot_id=meta["slot_id"], actual_start=meta["actual_start"], actual_end=meta["actual_end"]
         )
-    logger.info(f"[pp rank {rank}] [iter timing summary] per-iter ms = {[round(t, 2) for t in iter_times_ms]}")
+        if not cfg.is_last_rank:
+            send_activation(runtime, out, subctx, c, rank, meta)  # out is None on the last rank
+
+        n_done += 1
+        c += 1
+        if meta["is_last"]:
+            break
+
+    ttnn.synchronize_device(runtime.mesh_device)
+    logger.info(
+        f"[pp rank {rank}] processed {n_done} chunks in "
+        f"{(time.perf_counter() - t0) * 1000.0:.2f} ms (decoupled, no barrier)"
+    )
 
     if os.environ.get("PREFILL_STANDALONE_PCC", "0") == "1":
-        # Each rank PCC-checks its own KV slice against the global golden trace (offset by
-        # first_layer_idx). All ranks passing == the rank-sliced model + host transport reproduce
-        # single-rank KV. Placeholder transport will fail this for non-first ranks, as intended.
+        # Each rank PCC-checks the KV slice it populated against the golden trace (offset by
+        # first_layer_idx); all ranks passing == the rank-sliced model + file handoff reproduce
+        # single-rank KV.
         from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import kv_cache_pcc_check
 
         trace_dir = resolve_trace_dir(os.environ.get("PREFILL_TRACE_DIR", VARIANT.prefill_trace_default))
         kv_cache_pcc_check(
-            runtime,
-            slot_id=slot_id,
-            n_chunks=n_chunks,
-            trace_dir=trace_dir,
-            first_layer_idx=cfg.first_layer_idx,
+            runtime, slot_id=slot_id, n_chunks=n_done, trace_dir=trace_dir, first_layer_idx=cfg.first_layer_idx
         )
 
 
@@ -383,15 +406,19 @@ def main() -> None:
         config=runtime_config,
     )
     runtime.compile()
-    ttnn.distributed_context_barrier()
 
+    # No distributed_context barrier anywhere: ranks run fully independently, coordinated only by the
+    # activation+metadata file handoff. A barrier would turn one rank's failure into a deadlock for the
+    # others (a dead producer hangs the barrier); without it, a missing producer just times out the
+    # consumer's bounded recv poll. The distributed context is used only for rank identity.
     # The activation-handoff dir must exist before the first send (send_activation does not mkdir).
     os.makedirs(_act_dir(), exist_ok=True)
 
-    logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
-    run_standalone_loop(runtime, rank, num_ranks)
+    logger.info(f"[pp rank {rank}] setup complete, entering decoupled pipeline loop")
+    run_pipeline_loop(runtime, rank, num_ranks)
 
-    ttnn.distributed_context_barrier()
+    # No teardown barrier: ranks finish asynchronously (an upstream rank exits once it has produced
+    # its last chunk, before a downstream rank consumes it), so each tears down independently.
     ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
     ttnn.close_mesh_device(mesh_device)
     logger.info(f"[pp rank {rank}] shutdown complete")

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Pipeline-parallel ("pipeline prefill") runner.
+
+Splits one prefill model across N ranks under tt-run: each rank owns a contiguous
+layer slice and builds the same TtPrefillRuntime the single-rank runner uses
+(prefill_runner.py), parameterized with first_layer_idx / is_first_rank /
+is_last_rank. The model class is the single source of truth — this driver only
+wires rank topology and the per-chunk schedule; it does not reimplement embed /
+layers / forward.
+
+Cross-rank activation transport is a host round-trip stand-in until the D2D-socket
+sync ops land (PREFILL_PP_TRANSPORT, see the transport section): "host" gathers each
+rank's output activation to host, hands it to the next rank through a file under
+PREFILL_PP_DIR, and reshards it on the far side (bit-exact, so a 4-rank run
+PCC-matches single-rank); "placeholder" feeds zeros (compile/timing smoke only).
+PREFILL_PP_DIR is /dev/shm for single-host; for multi-host set it to a directory on a
+filesystem shared by all hosts (e.g. NFS) — /dev/shm is per-host and won't cross hosts.
+When the sync ops arrive, only send_activation / recv_activation change.
+
+A chunk has a strict rank0->...->rankN-1 dependency, so ranks run as a barrier-ordered
+wavefront (one rank at a time, fully serialized). Combined with the host round-trip
+this is a correctness/PCC bring-up path, not a perf path.
+
+Scope: standalone (file/trace) input, no H2D socket service, no KV migration. Chunked
+prefill does not sample; the populated per-rank KV cache is the output. With
+PREFILL_STANDALONE_PCC=1 each rank checks its KV slice against the global golden trace.
+"""
+
+import os
+import signal
+import time
+
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import (
+    get_variant,
+    load_hf_config,
+    load_trace_token_ids,
+    open_mesh_device,
+    prepare_prefill_input_tensor,
+    resolve_trace_dir,
+    resolve_weight_cache_path,
+)
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_runtime import TtPrefillRuntime, TtPrefillRuntimeConfig
+
+VARIANT = get_variant(os.environ.get("PREFILL_MODEL_VARIANT", "deepseek_v3_d_p"))
+MODEL_CFG = VARIANT.model_config
+
+_sp = int(os.environ.get("PREFILL_SP", 8))
+_tp = int(os.environ.get("PREFILL_TP", 4))
+GLOBAL_MESH_SHAPE = (_sp, _tp)
+NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
+CHUNK_SIZE = int(os.environ.get("PREFILL_CHUNK_SIZE", 5 * 1024))
+MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 4 * CHUNK_SIZE))
+NUM_USERS = int(os.environ.get("PREFILL_NUM_USERS", 2))
+CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
+_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_gate_mode)
+
+os.environ.setdefault("PREFILL_TTNN_CACHE", VARIANT.ttnn_cache_default)
+
+_shutdown = False
+
+
+def _handle_sigterm(signum, frame):
+    global _shutdown
+    _shutdown = True
+
+
+# ---------------------------------------------------------------------------
+# Layer assignment
+# ---------------------------------------------------------------------------
+
+
+def compute_layer_split(num_layers: int, num_ranks: int) -> list[tuple[int, int]]:
+    """Contiguous (first_layer_idx, count) per rank. PREFILL_PP_LAYER_COUNTS, a
+    comma-separated count list summing to num_layers, overrides the default even
+    split (remainder handed to the earlier ranks)."""
+    override = os.environ.get("PREFILL_PP_LAYER_COUNTS")
+    if override:
+        counts = [int(x) for x in override.split(",")]
+        if len(counts) != num_ranks or sum(counts) != num_layers:
+            raise ValueError(
+                f"PREFILL_PP_LAYER_COUNTS={override!r} must list {num_ranks} counts summing to "
+                f"{num_layers} (got {len(counts)} counts summing to {sum(counts)})"
+            )
+    else:
+        base, rem = divmod(num_layers, num_ranks)
+        counts = [base + (1 if r < rem else 0) for r in range(num_ranks)]
+
+    ranges = []
+    start = 0
+    for count in counts:
+        ranges.append((start, count))
+        start += count
+    return ranges
+
+
+# ---------------------------------------------------------------------------
+# Cross-rank activation transport
+# ---------------------------------------------------------------------------
+#
+# Two modes (PREFILL_PP_TRANSPORT):
+#   "host"        — gather the activation to host, hand it to the next rank through a file
+#                   under PREFILL_PP_DIR, reshard on the far side. Bit-exact (no precision
+#                   loss beyond the activation's own dtype) so a 4-rank run PCC-matches
+#                   single-rank. Fully serialized + host round-trip => very slow; a
+#                   correctness/PCC bring-up, not a perf path.
+#   "placeholder" — non-first ranks consume zeros; cross-rank output is meaningless.
+#                   Compile/timing smoke test only.
+#
+# Both are stand-ins until the D2D-socket sync ops land; "host" is the one that lets us
+# validate the rank-sliced model now. The transport touches only these helpers.
+#
+# PREFILL_PP_DIR is the handoff directory:
+#   - single host: /dev/shm (default) — per-host tmpfs, fast.
+#   - multi host:  a directory on a filesystem SHARED by all hosts (e.g. NFS). /dev/shm
+#                  is per-host and will NOT work across hosts.
+# The write is staged to a temp file and atomically renamed so a reader (esp. over NFS,
+# whose write visibility is close-to-open) never observes a partial file; the wavefront
+# barrier orders the rename before the consumer's read.
+
+_TORCH_TO_TTNN_DTYPE = {}  # populated lazily (torch import is local to keep module import cheap)
+
+
+def _act_dir() -> str:
+    return os.environ.get("PREFILL_PP_DIR", "/dev/shm")
+
+
+def _act_path(subctx: int, chunk_idx: int, producer_rank: int) -> str:
+    return os.path.join(_act_dir(), f"pp_act_sub{subctx}_c{chunk_idx}_r{producer_rank}.pt")
+
+
+def _gather_activation_to_host(mesh_device: ttnn.MeshDevice, activation: ttnn.Tensor):
+    """SP+TP-sharded [1, 1, seq_per_chip, emb/tp] -> full host [1, 1, seq, emb].
+
+    Mirrors TtPrefillTransformer._to_host's composer (mesh rows=SP concat seq dim -2,
+    mesh cols=TP concat emb dim -1) but keeps 4D so the far side reshards symmetrically.
+    """
+    return ttnn.to_torch(
+        activation,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+    )
+
+
+def _reshard_activation_to_device(mesh_device: ttnn.MeshDevice, host_tensor, mesh_shape: tuple) -> ttnn.Tensor:
+    """Inverse of _gather_activation_to_host: full host [1, 1, seq, emb] -> SP+TP-sharded
+    device tensor matching the embedding output (seq across SP rows, emb across TP cols)."""
+    import torch
+
+    if not _TORCH_TO_TTNN_DTYPE:
+        _TORCH_TO_TTNN_DTYPE[torch.bfloat16] = ttnn.bfloat16
+        _TORCH_TO_TTNN_DTYPE[torch.float32] = ttnn.float32
+    return ttnn.from_torch(
+        host_tensor,
+        device=mesh_device,
+        dtype=_TORCH_TO_TTNN_DTYPE[host_tensor.dtype],
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(-2, -1)),
+    )
+
+
+def send_activation(runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: int, chunk_idx: int, rank: int) -> None:
+    """Publish this rank's output activation to the downstream rank, then free the device tensor.
+    Atomic-rename so the consumer (single shared FS / NFS) never reads a partial file; the wavefront
+    barrier orders this rename before the consumer's read."""
+    import torch
+
+    if _transport_mode() == "placeholder":
+        ttnn.deallocate(activation)
+        return
+    host = _gather_activation_to_host(runtime.mesh_device, activation)
+    final = _act_path(subctx, chunk_idx, rank)
+    tmp = f"{final}.tmp.{rank}"  # same dir -> rename is atomic on the target FS
+    torch.save(host, tmp)
+    os.rename(tmp, final)
+    ttnn.deallocate(activation)
+
+
+def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, producer_rank: int) -> ttnn.Tensor:
+    """Receive the upstream rank's activation for this chunk and reshard it onto this rank's mesh.
+    In placeholder mode, returns zeros instead. runtime.prefill() deallocates the returned tensor.
+
+    The producer's rename is barrier-ordered before this read, but NFS can briefly serve a stale
+    negative dentry, so retry the open a bounded number of times before giving up."""
+    import time as _time
+
+    import torch
+
+    if _transport_mode() == "placeholder":
+        return runtime.make_placeholder_activation()
+    path = _act_path(subctx, chunk_idx, producer_rank)
+    attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "50"))
+    for attempt in range(attempts):
+        try:
+            host = torch.load(path)
+            break
+        except FileNotFoundError:
+            if attempt == attempts - 1:
+                raise
+            _time.sleep(0.1)  # absorb NFS negative-dentry cache; barrier already ordered the write
+    os.unlink(path)
+    return _reshard_activation_to_device(runtime.mesh_device, host, runtime.config.mesh_shape)
+
+
+def _transport_mode() -> str:
+    mode = os.environ.get("PREFILL_PP_TRANSPORT", "host")
+    if mode not in ("host", "placeholder"):
+        raise ValueError(f"PREFILL_PP_TRANSPORT={mode!r} must be 'host' or 'placeholder'")
+    return mode
+
+
+# ---------------------------------------------------------------------------
+# Input
+# ---------------------------------------------------------------------------
+
+
+def _load_token_ids() -> list[int]:
+    """Load this run's token IDs (same source as the single-rank standalone loop).
+    All ranks load identically so they agree on the chunk schedule."""
+    import json
+
+    trace_dir = resolve_trace_dir(os.environ.get("PREFILL_TRACE_DIR", VARIANT.prefill_trace_default))
+    input_override = os.environ.get("PREFILL_STANDALONE_INPUT")
+    if input_override:
+        with open(input_override) as f:
+            token_ids = list(json.load(f)["token_ids"])
+        logger.info(f"[pp] input override: {len(token_ids)} token_ids from {input_override}")
+    else:
+        logger.info(f"[pp] reading input token_ids from {trace_dir}/metadata.json")
+        token_ids = load_trace_token_ids(trace_dir)
+    return token_ids
+
+
+# ---------------------------------------------------------------------------
+# Loop
+# ---------------------------------------------------------------------------
+
+
+def _first_rank_chunk_tokens(runtime: TtPrefillRuntime, token_ids: list[int], kv_actual: int) -> ttnn.Tensor:
+    cfg = runtime.config
+    return prepare_prefill_input_tensor(
+        token_ids[kv_actual : kv_actual + cfg.chunk_size],
+        runtime.mesh_device,
+        cfg.sp_factor,
+        False,  # chunked prefill is block-cyclic (non-balanced)
+        cfg.mesh_shape,
+        cfg.sp_axis,
+    )
+
+
+def run_standalone_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> None:
+    cfg = runtime.config
+    subctx = int(ttnn.distributed_context_subcontext_id())
+    token_ids = _load_token_ids()
+    actual_isl = len(token_ids)
+    slot_id = int(os.environ.get("PREFILL_STANDALONE_SLOT", "0")) % cfg.num_users
+
+    nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
+    n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
+    total_len = n_chunks * cfg.chunk_size
+    if total_len > cfg.max_seq_len:
+        raise ValueError(
+            f"{n_chunks} chunks x {cfg.chunk_size} = {total_len} exceeds per-user cache "
+            f"max_seq_len={cfg.max_seq_len}. Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
+        )
+    token_ids = (token_ids + [1] * total_len)[:total_len]
+
+    num_iterations = int(os.environ.get("PREFILL_STANDALONE_ITERS", "1"))
+    logger.info(
+        f"[pp rank {rank}] transport={_transport_mode()} actual_isl={actual_isl} slot={slot_id} "
+        f"chunks={n_chunks} iters={num_iterations}"
+    )
+
+    iter_times_ms = []
+    for it in range(num_iterations):
+        if _shutdown:
+            logger.info(f"[pp rank {rank}] shutdown requested, breaking loop")
+            break
+        t0 = time.perf_counter()
+        for c in range(n_chunks):
+            kv_actual = c * cfg.chunk_size
+            # Barrier-ordered wavefront: a chunk has a strict rank0->rank1->...->rankN-1 data
+            # dependency, so ranks run one at a time. The barrier after each stage guarantees the
+            # producer's activation-file write lands before the next rank reads it. Fully serialized
+            # — a PCC/bring-up path, not a perf path.
+            for stage in range(num_ranks):
+                if rank == stage:
+                    if cfg.is_first_rank:
+                        inp = _first_rank_chunk_tokens(runtime, token_ids, kv_actual)
+                    else:
+                        inp = recv_activation(runtime, subctx, c, rank - 1)
+                    out = runtime.prefill(
+                        inp,
+                        slot_id=slot_id,
+                        actual_start=kv_actual,
+                        actual_end=kv_actual + cfg.chunk_size,  # standalone drives full chunks
+                    )
+                    if not cfg.is_last_rank:
+                        send_activation(runtime, out, subctx, c, rank)
+                ttnn.distributed_context_barrier()
+        ttnn.synchronize_device(runtime.mesh_device)
+        dt_ms = (time.perf_counter() - t0) * 1000.0
+        iter_times_ms.append(dt_ms)
+        logger.info(
+            f"[pp rank {rank}] [prefill timing] iter={it} num_tokens={total_len} "
+            f"chunks={n_chunks} slot={slot_id} wavefront = {dt_ms:.2f} ms"
+        )
+    logger.info(f"[pp rank {rank}] [iter timing summary] per-iter ms = {[round(t, 2) for t in iter_times_ms]}")
+
+    if os.environ.get("PREFILL_STANDALONE_PCC", "0") == "1":
+        # Each rank PCC-checks its own KV slice against the global golden trace (offset by
+        # first_layer_idx). All ranks passing == the rank-sliced model + host transport reproduce
+        # single-rank KV. Placeholder transport will fail this for non-first ranks, as intended.
+        from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import kv_cache_pcc_check
+
+        trace_dir = resolve_trace_dir(os.environ.get("PREFILL_TRACE_DIR", VARIANT.prefill_trace_default))
+        kv_cache_pcc_check(
+            runtime,
+            slot_id=slot_id,
+            n_chunks=n_chunks,
+            trace_dir=trace_dir,
+            first_layer_idx=cfg.first_layer_idx,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+    signal.signal(signal.SIGINT, _handle_sigterm)
+
+    # tt-run pre-initializes the distributed context; bind the Python handle.
+    rank = int(ttnn.distributed_context_get_rank())
+    num_ranks = int(ttnn.distributed_context_get_size())
+
+    layer_split = compute_layer_split(NUM_LAYERS, num_ranks)
+    first_layer_idx, num_my_layers = layer_split[rank]
+    is_first_rank = rank == 0
+    is_last_rank = rank == num_ranks - 1
+    logger.info(
+        f"[pp rank {rank}/{num_ranks}] mesh={GLOBAL_MESH_SHAPE} layers=[{first_layer_idx}, "
+        f"{first_layer_idx + num_my_layers}) is_first={is_first_rank} is_last={is_last_rank} "
+        f"chunk_size={CHUNK_SIZE} max_seq_len={MAX_SEQ_LEN} num_users={NUM_USERS}"
+    )
+
+    mesh_device = open_mesh_device(GLOBAL_MESH_SHAPE, MODEL_CFG)
+
+    hf_config = load_hf_config(VARIANT)
+    hf_config.max_seq_len = MAX_SEQ_LEN
+
+    cache_path = resolve_weight_cache_path(VARIANT, GLOBAL_MESH_SHAPE)
+    runtime_config = TtPrefillRuntimeConfig(
+        num_layers=num_my_layers,
+        max_seq_len=MAX_SEQ_LEN,
+        mesh_shape=GLOBAL_MESH_SHAPE,
+        chunk_size=CHUNK_SIZE,
+        num_users=NUM_USERS,
+        num_links=2,
+        capacity_factor=CAPACITY_FACTOR,
+        gate_fallback_mode=GateComputeMode[_gate_mode_name],
+        weight_cache_path=cache_path,
+        model_cfg=MODEL_CFG,
+        first_layer_idx=first_layer_idx,
+        is_first_rank=is_first_rank,
+        is_last_rank=is_last_rank,
+    )
+
+    runtime = TtPrefillRuntime(
+        mesh_device=mesh_device,
+        hf_config=hf_config,
+        state_dict={},
+        config=runtime_config,
+    )
+    runtime.compile()
+    ttnn.distributed_context_barrier()
+
+    logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
+    run_standalone_loop(runtime, rank, num_ranks)
+
+    ttnn.distributed_context_barrier()
+    ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+    ttnn.close_mesh_device(mesh_device)
+    logger.info(f"[pp rank {rank}] shutdown complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -174,12 +174,19 @@ def send_activation(runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: 
     if _transport_mode() == "placeholder":
         ttnn.deallocate(activation)
         return
+    t0 = time.perf_counter()
     host = _gather_activation_to_host(runtime.mesh_device, activation)
     final = _act_path(subctx, chunk_idx, rank)
     tmp = f"{final}.tmp.{rank}"  # same dir -> rename is atomic on the target FS
     torch.save(host, tmp)
     os.rename(tmp, final)
     ttnn.deallocate(activation)
+    nbytes = host.element_size() * host.nelement()
+    logger.info(
+        f"[pp rank {rank}] SEND chunk={chunk_idx} -> {final} "
+        f"shape={tuple(host.shape)} dtype={host.dtype} bytes={nbytes} "
+        f"gather+write={(time.perf_counter() - t0) * 1000.0:.1f}ms"
+    )
 
 
 def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, producer_rank: int) -> ttnn.Tensor:
@@ -188,14 +195,14 @@ def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, prod
 
     The producer's rename is barrier-ordered before this read, but NFS can briefly serve a stale
     negative dentry, so retry the open a bounded number of times before giving up."""
-    import time as _time
-
     import torch
 
     if _transport_mode() == "placeholder":
         return runtime.make_placeholder_activation()
     path = _act_path(subctx, chunk_idx, producer_rank)
     attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "50"))
+    t0 = time.perf_counter()
+    waits = 0
     for attempt in range(attempts):
         try:
             host = torch.load(path)
@@ -203,9 +210,17 @@ def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, prod
         except FileNotFoundError:
             if attempt == attempts - 1:
                 raise
-            _time.sleep(0.1)  # absorb NFS negative-dentry cache; barrier already ordered the write
+            waits += 1  # file from the other host not visible yet -> cross-host propagation in flight
+            time.sleep(0.1)  # absorb NFS negative-dentry cache; barrier already ordered the write
     os.unlink(path)
-    return _reshard_activation_to_device(runtime.mesh_device, host, runtime.config.mesh_shape)
+    out = _reshard_activation_to_device(runtime.mesh_device, host, runtime.config.mesh_shape)
+    nbytes = host.element_size() * host.nelement()
+    logger.info(
+        f"[pp] RECV chunk={chunk_idx} <- {path} (from rank {producer_rank}) "
+        f"shape={tuple(host.shape)} bytes={nbytes} waits={waits} "
+        f"read+reshard={(time.perf_counter() - t0) * 1000.0:.1f}ms"
+    )
+    return out
 
 
 def _transport_mode() -> str:

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -383,6 +383,10 @@ def main() -> None:
     runtime.compile()
     ttnn.distributed_context_barrier()
 
+    # The activation-handoff dir must exist before the first send (send_activation does not mkdir).
+    if _transport_mode() == "host":
+        os.makedirs(_act_dir(), exist_ok=True)
+
     logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
     run_standalone_loop(runtime, rank, num_ranks)
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -64,7 +64,11 @@ _tp = int(os.environ.get("PREFILL_TP", 4))
 GLOBAL_MESH_SHAPE = (_sp, _tp)
 NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
 CHUNK_SIZE = int(os.environ.get("PREFILL_CHUNK_SIZE", 5 * 1024))
-MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 4 * CHUNK_SIZE))
+# Chunks this run drives. The per-user KV cache is sized to exactly hold them
+# (max_seq_len = chunk_size * num_chunks), so there is no separate cache-length knob to keep in sync.
+# PREFILL_MAX_SEQ_LEN still overrides if a larger cache is wanted.
+NUM_CHUNKS = int(os.environ.get("PREFILL_STANDALONE_NCHUNKS", 4))
+MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", CHUNK_SIZE * NUM_CHUNKS))
 NUM_USERS = int(os.environ.get("PREFILL_NUM_USERS", 2))
 CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
 _gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_gate_mode)
@@ -316,22 +320,17 @@ def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int, h2d_
     slot_id = int(os.environ.get("PREFILL_STANDALONE_SLOT", "0")) % cfg.num_users
 
     token_ids = None
-    n_chunks = None
+    n_chunks = NUM_CHUNKS if cfg.is_first_rank else None
     if cfg.is_first_rank:
-        # Only the first rank needs the schedule length; later ranks learn the end from is_last.
-        if h2d_service is not None:
-            # Socket mode: tokens arrive per push; the producer streams PREFILL_STANDALONE_NCHUNKS of them.
-            n_chunks = int(os.environ["PREFILL_STANDALONE_NCHUNKS"])
-        else:
+        # The first rank drives n_chunks (NUM_CHUNKS); later ranks learn the end from is_last. The cache
+        # is sized to chunk*num_chunks by default so this fits; the guard only catches a smaller override.
+        if h2d_service is None:
             token_ids = _load_token_ids()
-            actual_isl = len(token_ids)
-            nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
-            n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
             token_ids = (token_ids + [1] * (n_chunks * cfg.chunk_size))[: n_chunks * cfg.chunk_size]
         if n_chunks * cfg.chunk_size > cfg.max_seq_len:
             raise ValueError(
-                f"{n_chunks} chunks x {cfg.chunk_size} exceeds per-user cache max_seq_len={cfg.max_seq_len}. "
-                f"Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
+                f"{n_chunks} chunks x {cfg.chunk_size} exceeds per-user cache max_seq_len={cfg.max_seq_len}; "
+                f"raise PREFILL_MAX_SEQ_LEN."
             )
 
     logger.info(

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -206,16 +206,21 @@ def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, prod
     import torch
 
     path = _act_path(subctx, chunk_idx, producer_rank)
+    fname = os.path.basename(path)
+    act_dir = _act_dir()
     attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "3000"))
     # Wait (poll) for the producer's atomic-renamed file; time it separately from the transfer cost.
+    # Poll with os.listdir, NOT os.path.exists: a failed name lookup is cached by NFS as a negative
+    # dentry for up to acdirmax (~60s here), so a consumer that polls before the producer writes would
+    # not see the file for ~60s. os.listdir issues a READDIR that revalidates the directory each poll.
     t_wait = time.perf_counter()
     waits = 0
     for attempt in range(attempts):
-        if os.path.exists(path):
+        if fname in os.listdir(act_dir):
             break
         if attempt == attempts - 1:
             raise FileNotFoundError(path)
-        waits += 1  # producer hasn't published this chunk yet (still computing, or cross-host NFS lag)
+        waits += 1  # producer hasn't published this chunk yet (still computing)
         time.sleep(0.1)
     ms_wait = (time.perf_counter() - t_wait) * 1000.0
     t_r = time.perf_counter()
@@ -444,10 +449,13 @@ def main() -> None:
     )
     runtime.compile()
 
-    # No distributed_context barrier anywhere: ranks run fully independently, coordinated only by the
-    # activation+metadata file handoff. A barrier would turn one rank's failure into a deadlock for the
-    # others (a dead producer hangs the barrier); without it, a missing producer just times out the
-    # consumer's bounded recv poll. The distributed context is used only for rank identity.
+    # Warm-up sync — the ONLY barrier. Every rank finishes compile before any chunk enters the
+    # pipeline, so a downstream rank isn't still warming up while an upstream one races ahead: the
+    # ranks actually overlap and activations don't pile up. The per-chunk loop takes no barrier, so
+    # ranks still run independently once started. Trade-off: a rank that dies during compile hangs the
+    # others here — acceptable for this POC.
+    ttnn.distributed_context_barrier()
+
     # The activation-handoff dir must exist before the first send (send_activation does not mkdir).
     os.makedirs(_act_dir(), exist_ok=True)
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -12,13 +12,12 @@ wires rank topology and the per-chunk schedule; it does not reimplement embed /
 layers / forward.
 
 Cross-rank activation transport is a host round-trip stand-in until the D2D-socket
-sync ops land (PREFILL_PP_TRANSPORT, see the transport section): "host" gathers each
-rank's output activation to host, hands it to the next rank through a file under
-PREFILL_PP_DIR, and reshards it on the far side (bit-exact, so a 4-rank run
-PCC-matches single-rank); "placeholder" feeds zeros (compile/timing smoke only).
-PREFILL_PP_DIR is /dev/shm for single-host; for multi-host set it to a directory on a
-filesystem shared by all hosts (e.g. NFS) — /dev/shm is per-host and won't cross hosts.
-When the sync ops arrive, only send_activation / recv_activation change.
+sync ops land: each rank gathers its output activation to host, hands it to the next
+rank through a file under PREFILL_PP_DIR, and reshards it on the far side (bit-exact,
+so a multi-rank run PCC-matches single-rank). PREFILL_PP_DIR is /dev/shm for single-host;
+for multi-host set it to a directory on a filesystem shared by all hosts (e.g. NFS) —
+/dev/shm is per-host and won't cross hosts. When the sync ops arrive, only
+send_activation / recv_activation change.
 
 A chunk has a strict rank0->...->rankN-1 dependency, so ranks run as a barrier-ordered
 wavefront (one rank at a time, fully serialized). Combined with the host round-trip
@@ -104,17 +103,11 @@ def compute_layer_split(num_layers: int, num_ranks: int) -> list[tuple[int, int]
 # Cross-rank activation transport
 # ---------------------------------------------------------------------------
 #
-# Two modes (PREFILL_PP_TRANSPORT):
-#   "host"        — gather the activation to host, hand it to the next rank through a file
-#                   under PREFILL_PP_DIR, reshard on the far side. Bit-exact (no precision
-#                   loss beyond the activation's own dtype) so a 4-rank run PCC-matches
-#                   single-rank. Fully serialized + host round-trip => very slow; a
-#                   correctness/PCC bring-up, not a perf path.
-#   "placeholder" — non-first ranks consume zeros; cross-rank output is meaningless.
-#                   Compile/timing smoke test only.
-#
-# Both are stand-ins until the D2D-socket sync ops land; "host" is the one that lets us
-# validate the rank-sliced model now. The transport touches only these helpers.
+# Gather the activation to host, hand it to the next rank through a file under PREFILL_PP_DIR,
+# reshard on the far side. Bit-exact (no precision loss beyond the activation's own dtype) so a
+# multi-rank run PCC-matches single-rank. Fully serialized + host round-trip => very slow; a
+# correctness/PCC bring-up, not a perf path. A stand-in until the D2D-socket sync ops land — when
+# they do, only send_activation / recv_activation change.
 #
 # PREFILL_PP_DIR is the handoff directory:
 #   - single host: /dev/shm (default) — per-host tmpfs, fast.
@@ -171,9 +164,6 @@ def send_activation(runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: 
     barrier orders this rename before the consumer's read."""
     import torch
 
-    if _transport_mode() == "placeholder":
-        ttnn.deallocate(activation)
-        return
     t0 = time.perf_counter()
     host = _gather_activation_to_host(runtime.mesh_device, activation)
     final = _act_path(subctx, chunk_idx, rank)
@@ -191,14 +181,12 @@ def send_activation(runtime: TtPrefillRuntime, activation: ttnn.Tensor, subctx: 
 
 def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, producer_rank: int) -> ttnn.Tensor:
     """Receive the upstream rank's activation for this chunk and reshard it onto this rank's mesh.
-    In placeholder mode, returns zeros instead. runtime.prefill() deallocates the returned tensor.
+    runtime.prefill() deallocates the returned tensor.
 
     The producer's rename is barrier-ordered before this read, but NFS can briefly serve a stale
     negative dentry, so retry the open a bounded number of times before giving up."""
     import torch
 
-    if _transport_mode() == "placeholder":
-        return runtime.make_placeholder_activation()
     path = _act_path(subctx, chunk_idx, producer_rank)
     attempts = int(os.environ.get("PREFILL_PP_RECV_RETRIES", "50"))
     t0 = time.perf_counter()
@@ -227,13 +215,6 @@ def _subcontext_id() -> int:
     """0 when not launched under an MPI sub-context — subcontext_id() returns None there."""
     sub_id = ttnn.distributed_context_subcontext_id()
     return int(sub_id) if sub_id is not None else 0
-
-
-def _transport_mode() -> str:
-    mode = os.environ.get("PREFILL_PP_TRANSPORT", "host")
-    if mode not in ("host", "placeholder"):
-        raise ValueError(f"PREFILL_PP_TRANSPORT={mode!r} must be 'host' or 'placeholder'")
-    return mode
 
 
 # ---------------------------------------------------------------------------
@@ -293,10 +274,7 @@ def run_standalone_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) ->
     token_ids = (token_ids + [1] * total_len)[:total_len]
 
     num_iterations = int(os.environ.get("PREFILL_STANDALONE_ITERS", "1"))
-    logger.info(
-        f"[pp rank {rank}] transport={_transport_mode()} actual_isl={actual_isl} slot={slot_id} "
-        f"chunks={n_chunks} iters={num_iterations}"
-    )
+    logger.info(f"[pp rank {rank}] actual_isl={actual_isl} slot={slot_id} " f"chunks={n_chunks} iters={num_iterations}")
 
     iter_times_ms = []
     for it in range(num_iterations):
@@ -408,8 +386,7 @@ def main() -> None:
     ttnn.distributed_context_barrier()
 
     # The activation-handoff dir must exist before the first send (send_activation does not mkdir).
-    if _transport_mode() == "host":
-        os.makedirs(_act_dir(), exist_ok=True)
+    os.makedirs(_act_dir(), exist_ok=True)
 
     logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
     run_standalone_loop(runtime, rank, num_ranks)

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -36,7 +36,9 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.runners.h2d_socket_sync_op import h2d_socket_sync
 from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import (
+    build_h2d_service,
     get_variant,
     load_hf_config,
     load_trace_token_ids,
@@ -46,6 +48,13 @@ from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import (
     resolve_weight_cache_path,
 )
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_runtime import TtPrefillRuntime, TtPrefillRuntimeConfig
+
+# H2D socket service config (first rank, PREFILL_PP_H2D=1). Mirrors prefill_runner.py: one worker
+# core copies the pushed chunk into a fresh tensor; the producer packs a 12-byte PrefillMetadata
+# (slot_id, actual_start, actual_end) alongside each push.
+H2D_SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
+H2D_METADATA_SIZE_BYTES = 12
+H2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()])
 
 VARIANT = get_variant(os.environ.get("PREFILL_MODEL_VARIANT", "deepseek_v3_d_p"))
 MODEL_CFG = VARIANT.model_config
@@ -271,13 +280,32 @@ def _first_rank_chunk_tokens(runtime: TtPrefillRuntime, token_ids: list[int], kv
     )
 
 
-def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> None:
+def _h2d_request_mode() -> bool:
+    """First rank reads tokens from the H2D socket (driven by prefill_h2d_producer.py) instead of the
+    trace file. Off by default (file input)."""
+    return os.environ.get("PREFILL_PP_H2D") == "1"
+
+
+def _socket_next(h2d_service) -> tuple:
+    """Block on the next producer push: returns (tt_tokens, {slot_id, actual_start, actual_end})
+    decoded from the 12-byte PrefillMetadata. is_last is set by the caller — the socket carries no
+    end-of-stream marker, so the first rank derives it from its chunk count vs PREFILL_STANDALONE_NCHUNKS."""
+    import torch
+
+    tt_tokens, tt_metadata = h2d_socket_sync(
+        h2d_service, H2D_SYNC_WORKER_CORES, metadata_size_bytes=H2D_METADATA_SIZE_BYTES
+    )
+    m = ttnn.to_torch(ttnn.get_device_tensors(tt_metadata)[0]).view(torch.int32).flatten()
+    return tt_tokens, {"slot_id": int(m[0]), "actual_start": int(m[1]), "actual_end": int(m[2])}
+
+
+def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int, h2d_service=None) -> None:
     """Decoupled per-rank loop: each rank runs its own loop, coordinated ONLY by the
     activation+metadata file handoff (atomic rename + polling recv) — no cross-rank barrier, so an
-    upstream rank can race ahead of a downstream one (pipeline overlap). The first rank drives the
-    chunk schedule from the trace; the per-chunk metadata (slot / actual_start / actual_end / is_last)
-    rides with each activation, so downstream ranks need no shared schedule and learn the end from
-    is_last. Every rank checks the KV slice it populated against golden."""
+    upstream rank can race ahead of a downstream one (pipeline overlap). The first rank's input is
+    either the trace file or the H2D socket (h2d_service set); the per-chunk metadata (slot /
+    actual_start / actual_end / is_last) rides with each activation, so downstream ranks need no
+    shared schedule and learn the end from is_last. Every rank checks the KV slice it populated."""
     cfg = runtime.config
     subctx = _subcontext_id()
     slot_id = int(os.environ.get("PREFILL_STANDALONE_SLOT", "0")) % cfg.num_users
@@ -285,22 +313,27 @@ def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> N
     token_ids = None
     n_chunks = None
     if cfg.is_first_rank:
-        # Only the first rank needs the input schedule; later ranks learn it from the metadata.
-        token_ids = _load_token_ids()
-        actual_isl = len(token_ids)
-        nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
-        n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
-        total_len = n_chunks * cfg.chunk_size
-        if total_len > cfg.max_seq_len:
+        # Only the first rank needs the schedule length; later ranks learn the end from is_last.
+        if h2d_service is not None:
+            # Socket mode: tokens arrive per push; the producer streams PREFILL_STANDALONE_NCHUNKS of them.
+            n_chunks = int(os.environ["PREFILL_STANDALONE_NCHUNKS"])
+        else:
+            token_ids = _load_token_ids()
+            actual_isl = len(token_ids)
+            nchunks_env = os.environ.get("PREFILL_STANDALONE_NCHUNKS")
+            n_chunks = int(nchunks_env) if nchunks_env else ((actual_isl + cfg.chunk_size - 1) // cfg.chunk_size)
+            token_ids = (token_ids + [1] * (n_chunks * cfg.chunk_size))[: n_chunks * cfg.chunk_size]
+        if n_chunks * cfg.chunk_size > cfg.max_seq_len:
             raise ValueError(
-                f"{n_chunks} chunks x {cfg.chunk_size} = {total_len} exceeds per-user cache "
-                f"max_seq_len={cfg.max_seq_len}. Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
+                f"{n_chunks} chunks x {cfg.chunk_size} exceeds per-user cache max_seq_len={cfg.max_seq_len}. "
+                f"Lower PREFILL_STANDALONE_NCHUNKS or bump PREFILL_MAX_SEQ_LEN."
             )
-        token_ids = (token_ids + [1] * total_len)[:total_len]
 
     logger.info(
         f"[pp rank {rank}/{num_ranks}] decoupled loop start (is_first={cfg.is_first_rank} "
-        f"is_last={cfg.is_last_rank} slot={slot_id}" + (f" chunks={n_chunks}" if cfg.is_first_rank else "") + ")"
+        f"is_last={cfg.is_last_rank} slot={slot_id} input={'h2d' if h2d_service is not None else 'trace'}"
+        + (f" chunks={n_chunks}" if cfg.is_first_rank else "")
+        + ")"
     )
 
     t0 = time.perf_counter()
@@ -310,14 +343,18 @@ def run_pipeline_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> N
         if cfg.is_first_rank:
             if c >= n_chunks:
                 break
-            kv_actual = c * cfg.chunk_size
-            inp = _first_rank_chunk_tokens(runtime, token_ids, kv_actual)
-            meta = {
-                "slot_id": slot_id,
-                "actual_start": kv_actual,
-                "actual_end": kv_actual + cfg.chunk_size,  # trace drives full chunks
-                "is_last": c == n_chunks - 1,
-            }
+            if h2d_service is not None:
+                inp, meta = _socket_next(h2d_service)  # slot/start/end from the producer
+                meta["is_last"] = c == n_chunks - 1
+            else:
+                kv_actual = c * cfg.chunk_size
+                inp = _first_rank_chunk_tokens(runtime, token_ids, kv_actual)
+                meta = {
+                    "slot_id": slot_id,
+                    "actual_start": kv_actual,
+                    "actual_end": kv_actual + cfg.chunk_size,  # trace drives full chunks
+                    "is_last": c == n_chunks - 1,
+                }
         else:
             inp, meta = recv_activation(runtime, subctx, c, rank - 1)
             slot_id = meta["slot_id"]
@@ -414,8 +451,38 @@ def main() -> None:
     # The activation-handoff dir must exist before the first send (send_activation does not mkdir).
     os.makedirs(_act_dir(), exist_ok=True)
 
+    # First rank in H2D mode: stand up the socket service so an external producer
+    # (prefill_h2d_producer.py) can push token chunks. Other ranks / file mode: no service.
+    h2d_service = None
+    if is_first_rank and _h2d_request_mode():
+        # compile() leaves a custom sub-device manager loaded; the service's init program validates
+        # its worker cores against the default whole-chip sub-device, so revert first.
+        mesh_device.clear_loaded_sub_device_manager()
+        h2d_service = build_h2d_service(
+            mesh_device,
+            mesh_shape=GLOBAL_MESH_SHAPE,
+            chunk_size=CHUNK_SIZE,
+            mapper_config=H2D_MAPPER_CONFIG,
+            worker_cores=H2D_SYNC_WORKER_CORES,
+            metadata_size_bytes=H2D_METADATA_SIZE_BYTES,
+        )
+        service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
+        descriptor_path = h2d_service.export_descriptor(service_id)
+        logger.info(
+            f"[pp rank {rank}] [h2d] service up, descriptor service_id={service_id!r} -> {descriptor_path}; "
+            f"drive it with prefill_h2d_producer.py on this host."
+        )
+
     logger.info(f"[pp rank {rank}] setup complete, entering decoupled pipeline loop")
-    run_pipeline_loop(runtime, rank, num_ranks)
+    run_pipeline_loop(runtime, rank, num_ranks, h2d_service=h2d_service)
+
+    if h2d_service is not None:
+        # Free the service while the mesh + command queues are still alive (its dtor frees a command
+        # queue and the service-core L1; running after close_mesh_device aborts with cq_id-out-of-range).
+        import gc
+
+        del h2d_service
+        gc.collect()
 
     # No teardown barrier: ranks finish asynchronously (an upstream rank exits once it has produced
     # its last chunk, before a downstream rank consumes it), so each tears down independently.

--- a/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_runner.py
@@ -223,6 +223,12 @@ def recv_activation(runtime: TtPrefillRuntime, subctx: int, chunk_idx: int, prod
     return out
 
 
+def _subcontext_id() -> int:
+    """0 when not launched under an MPI sub-context — subcontext_id() returns None there."""
+    sub_id = ttnn.distributed_context_subcontext_id()
+    return int(sub_id) if sub_id is not None else 0
+
+
 def _transport_mode() -> str:
     mode = os.environ.get("PREFILL_PP_TRANSPORT", "host")
     if mode not in ("host", "placeholder"):
@@ -271,7 +277,7 @@ def _first_rank_chunk_tokens(runtime: TtPrefillRuntime, token_ids: list[int], kv
 
 def run_standalone_loop(runtime: TtPrefillRuntime, rank: int, num_ranks: int) -> None:
     cfg = runtime.config
-    subctx = int(ttnn.distributed_context_subcontext_id())
+    subctx = _subcontext_id()
     token_ids = _load_token_ids()
     actual_isl = len(token_ids)
     slot_id = int(os.environ.get("PREFILL_STANDALONE_SLOT", "0")) % cfg.num_users
@@ -353,7 +359,10 @@ def main() -> None:
     signal.signal(signal.SIGTERM, _handle_sigterm)
     signal.signal(signal.SIGINT, _handle_sigterm)
 
-    # tt-run pre-initializes the distributed context; bind the Python handle.
+    # tt-run launches the MPI ranks but does not stand up the distributed context;
+    # do it here before reading rank/size (idempotent across re-entry).
+    if not ttnn.distributed_context_is_initialized():
+        ttnn.init_distributed_context()
     rank = int(ttnn.distributed_context_get_rank())
     num_ranks = int(ttnn.distributed_context_get_size())
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -21,10 +21,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import (
     resolve_trace_dir,
     resolve_weight_cache_path,
 )
-from models.demos.deepseek_v3_d_p.tt.tt_deepseek_prefill_pipeline import (
-    TtDeepSeekPrefillPipeline,
-    TtPrefillPipelineConfig,
-)
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_runtime import TtPrefillRuntime, TtPrefillRuntimeConfig
 
 # Sync-op worker core. Single core suffices: the kernel only copies the
 # backing tensor's pages into a fresh output, no per-core parallelism needed.
@@ -78,7 +75,7 @@ def _handle_sigterm(signum, frame):
 os.environ.setdefault("PREFILL_TTNN_CACHE", VARIANT.ttnn_cache_default)
 
 
-def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:
+def run_standalone_loop(pipeline: TtPrefillRuntime) -> None:
     """Standalone chunked prefill: read the input token IDs from this variant's golden trace and drive
     them through the pipeline in chunk_size chunks (advancing kv_actual per chunk), filling slot_id's
     KV cache. No H2D socket, no SHM, no external producer — single process, for local bring-up / perf.
@@ -166,7 +163,7 @@ def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:
         kv_cache_pcc_check(pipeline, slot_id=slot_id, n_chunks=n_chunks, trace_dir=trace_dir)
 
 
-def run_request_loop(pipeline: TtDeepSeekPrefillPipeline, h2d_service: ttnn.H2DStreamService) -> None:
+def run_request_loop(pipeline: TtPrefillRuntime, h2d_service: ttnn.H2DStreamService) -> None:
     """Request loop: token IDs + per-iter control metadata arrive over the H2D
     socket service, pushed by a separate producer process (prefill_h2d_producer.py
     today; the inference-server / prefill scheduler in production).
@@ -281,7 +278,7 @@ def main() -> None:
     hf_config.max_seq_len = MAX_SEQ_LEN
 
     cache_path = resolve_weight_cache_path(VARIANT, GLOBAL_MESH_SHAPE)
-    pipeline_config = TtPrefillPipelineConfig(
+    pipeline_config = TtPrefillRuntimeConfig(
         num_layers=NUM_LAYERS,
         max_seq_len=MAX_SEQ_LEN,
         mesh_shape=GLOBAL_MESH_SHAPE,
@@ -294,7 +291,7 @@ def main() -> None:
         model_cfg=MODEL_CFG,
     )
 
-    pipeline = TtDeepSeekPrefillPipeline(
+    pipeline = TtPrefillRuntime(
         mesh_device=mesh_device,
         hf_config=hf_config,
         state_dict={},

--- a/models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh
+++ b/models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Thin launcher for the pipeline-parallel prefill runner under tt-run.
+#
+# All real config (mesh, layer split, chunk count, transport, PCC, PREFILL_* env) lives in the
+# rank-binding YAML's global_env — ttrun does NOT auto-propagate PREFILL_* from the shell, so
+# per-run knobs belong there, not here. This script only captures the launch boilerplate: env
+# exports, the host list / TCP interface, the activation-handoff dir cleanup, and the ttrun call.
+#
+# Usage:
+#   run_pipeline_prefill.sh <rank_binding.yaml> [host_list] [tcp_iface]
+#
+#   <rank_binding.yaml>  path (relative to TT_METAL_HOME or absolute) to the tt-run rank binding.
+#   [host_list]          mpirun --host value. Default: bh-glx-d03u02:1,bh-glx-d03u08:1 (2 galaxies).
+#                        For a single-rank/one-galaxy binding pass e.g. bh-glx-d03u02:1.
+#   [tcp_iface]          NIC for MPI TCP. Default: ens5f0np0 (the 10.32.24.x cluster net here).
+#
+# PREFILL_PP_DIR (the host->host activation handoff dir) is read from the YAML; this script clears
+# it before launch so a previous run's files can't be mistaken for this one's. Override by exporting
+# PP_DIR before invoking.
+#
+# Examples:
+#   # 2-galaxy half-and-half split (rank0 u02 layers 0-30, rank1 u08 layers 31-60):
+#   ./run_pipeline_prefill.sh models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_rank_binding_2rank.yaml
+#
+#   # single-galaxy 1-rank full-model de-risk:
+#   ./run_pipeline_prefill.sh models/demos/deepseek_v3_d_p/tt/runners/pipeline_prefill_real_1galaxy_1rank.yaml bh-glx-d03u02:1
+set -euo pipefail
+
+RANK_BINDING="${1:?usage: run_pipeline_prefill.sh <rank_binding.yaml> [host_list] [tcp_iface]}"
+HOST_LIST="${2:-bh-glx-d03u02:1,bh-glx-d03u08:1}"
+TCP_IFACE="${3:-ens5f0np0}"
+PP_DIR="${PP_DIR:-/data/jjovicic/pp_acts}"
+
+# TT_METAL_HOME = the tt-metal tree this script lives in
+# (models/demos/deepseek_v3_d_p/tt/runners -> 5 levels up).
+TT_METAL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+export TT_METAL_HOME PYTHONPATH="$TT_METAL_HOME"
+cd "$TT_METAL_HOME"
+
+# Fresh handoff dir so a stale activation file can never be read as this run's.
+mkdir -p "$PP_DIR"
+rm -f "$PP_DIR"/pp_act_* 2>/dev/null || true
+
+exec python3 ttnn/ttnn/distributed/ttrun.py \
+  --tcp-interface "$TCP_IFACE" \
+  --rank-binding "$RANK_BINDING" \
+  --mpi-args "--host ${HOST_LIST} --map-by slot --bind-to none --tag-output --allow-run-as-root" \
+  python3 -m models.demos.deepseek_v3_d_p.tt.runners.pipeline_prefill_runner

--- a/models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh
+++ b/models/demos/deepseek_v3_d_p/tt/runners/run_pipeline_prefill.sh
@@ -35,6 +35,10 @@ PP_DIR="${PP_DIR:-/data/jjovicic/pp_acts}"
 # (models/demos/deepseek_v3_d_p/tt/runners -> 5 levels up).
 TT_METAL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 export TT_METAL_HOME PYTHONPATH="$TT_METAL_HOME"
+# Per-host LOCAL JIT cache. A shared (NFS) TT_METAL_CACHE makes both hosts write the same generated
+# kernel files (defines_generated.h, ...) concurrently on a cold cache -> "Stale file handle" compile
+# failures. /tmp is per-host, so each rank compiles into its own dir. ttrun auto-propagates TT_* vars.
+export TT_METAL_CACHE="${PP_TT_METAL_CACHE:-/tmp/tt-metal-cache-pp}"
 cd "$TT_METAL_HOME"
 
 # Fresh handoff dir so a stale activation file can never be read as this run's.

--- a/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
@@ -442,7 +442,7 @@ def _load_golden_kv_post(trace_dir, layer_idx: int, total_len: int):
     return torch.cat(rows, dim=0)[:total_len].to(torch.float32)
 
 
-def kv_cache_pcc_check(pipeline, slot_id: int, n_chunks: int, trace_dir=None) -> float:
+def kv_cache_pcc_check(pipeline, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0) -> float:
     """Gather the device KV cache for `slot_id`, un-rotate the block-cyclic layout to natural order,
     and PCC-compare each layer against the golden DeepSeek-R1 `kv_post_transform` trace. Returns the
     min per-layer PCC and asserts (unless PREFILL_STANDALONE_CHUNKED_RECORD_ONLY=1) when any layer is
@@ -451,6 +451,10 @@ def kv_cache_pcc_check(pipeline, slot_id: int, n_chunks: int, trace_dir=None) ->
     `trace_dir` defaults to the resolved PREFILL_TRACE_DIR env (caller passes the variant's
     prefill_trace_default). The golden is loaded format-agnostically (DeepSeek single-file or Kimi vllm
     row-shards) via _load_golden_kv_post.
+
+    `first_layer_idx` offsets the golden layer index for a pipeline-parallel rank: the device cache
+    holds this rank's `num_layers` slice at local indices, but the golden trace is indexed by global
+    layer, so golden layer = first_layer_idx + local_idx. Defaults to 0 for single-rank.
 
     Env:
       PREFILL_STANDALONE_CHUNKED_PCC          min per-layer KV-cache PCC threshold (default 0.88)
@@ -487,13 +491,14 @@ def kv_cache_pcc_check(pipeline, slot_id: int, n_chunks: int, trace_dir=None) ->
     min_pcc = 1.0
     failures = []
     for i in range(num_layers):
-        # user-major slot layout: cache batch index = slot_id * num_layers + layer_idx
+        # user-major slot layout: cache batch index = slot_id * num_layers + local_layer_idx
         batch_idx = slot_id * num_layers + i
+        global_layer = first_layer_idx + i  # golden trace is indexed by global layer
         nat = torch.empty(seq_len_cache, kvpe_dim, dtype=torch.float32)
         nat[p] = cache_full[batch_idx, 0]  # un-rotate block-cyclic -> natural order
         dev_cache = nat[:total_len]
 
-        g_post = _load_golden_kv_post(trace_dir, i, total_len)
+        g_post = _load_golden_kv_post(trace_dir, global_layer, total_len)
         # nope (kv_lora) compares directly; the RoPE (pe) slice uses the Meta-interleaved basis while
         # the golden stores the HF half-split, so re-interleave the golden before comparing.
         _, pcc_nope = comp_pcc(g_post[:, :kv_lora], dev_cache[:, :kv_lora])
@@ -503,7 +508,10 @@ def kv_cache_pcc_check(pipeline, slot_id: int, n_chunks: int, trace_dir=None) ->
         _, pcc_pe = comp_pcc(ref_pe_int, dev_cache[:, kv_lora:])
         layer_pcc = min(pcc_nope, pcc_pe)
         min_pcc = min(min_pcc, layer_pcc)
-        logger.info(f"  cache layer {i} PCC: nope={pcc_nope:.6f} pe(interleaved)={pcc_pe:.6f} -> {layer_pcc:.6f}")
+        logger.info(
+            f"  cache layer local={i} global={global_layer} PCC: "
+            f"nope={pcc_nope:.6f} pe(interleaved)={pcc_pe:.6f} -> {layer_pcc:.6f}"
+        )
         if layer_pcc < threshold:
             failures.append((i, layer_pcc))
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+import torch
 from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
@@ -19,8 +20,8 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 
 @dataclass
-class TtPrefillPipelineConfig:
-    num_layers: int
+class TtPrefillRuntimeConfig:
+    num_layers: int  # layers built by THIS runtime (the rank's slice; == model total for single-rank)
     max_seq_len: int  # per-user KV-cache length (tokens), e.g. 60 * 1024
     mesh_shape: tuple = (32, 4)
     # Chunked prefill streams tokens in chunks of `chunk_size`, with `num_users` independent cache
@@ -42,6 +43,12 @@ class TtPrefillPipelineConfig:
     # (DeepSeekV3Config | KimiK26Config). Drives expert counts, dense-layer
     # count, route groups, etc. in the TT layer code.
     model_cfg: type = DeepSeekV3Config
+    # Pipeline-parallel rank slicing. first_layer_idx is the global index of this
+    # rank's first layer; is_first_rank/is_last_rank gate embedding and norm+LM-head.
+    # Defaults make a single-rank runtime own the whole model.
+    first_layer_idx: int = 0
+    is_first_rank: bool = True
+    is_last_rank: bool = True
 
     @property
     def sp_factor(self) -> int:
@@ -52,13 +59,23 @@ class TtPrefillPipelineConfig:
         return self.mesh_shape[self.tp_axis]
 
 
-class TtDeepSeekPrefillPipeline:
+class TtPrefillRuntime:
+    """Single-rank prefill execution lifecycle: build model -> allocate KV cache ->
+    compile -> prefill(chunk). Owns the KVPE cache and the per-layer LayerAck wiring.
+
+    A runtime owns one rank's layer slice. For single-rank prefill the slice is the
+    whole model (the config defaults). For pipeline-parallel prefill, a driver builds
+    one runtime per rank with first_layer_idx / is_first_rank / is_last_rank set, and
+    the non-boundary ranks consume/produce hidden-state activations instead of token
+    IDs / sampled tokens.
+    """
+
     def __init__(
         self,
         mesh_device: ttnn.MeshDevice,
         hf_config: PretrainedConfig,
         state_dict: dict,
-        config: TtPrefillPipelineConfig,
+        config: TtPrefillRuntimeConfig,
     ):
         self.mesh_device = mesh_device
         self.hf_config = hf_config
@@ -79,9 +96,11 @@ class TtDeepSeekPrefillPipeline:
 
     def _build_model(self, state_dict: dict) -> None:
         logger.info(
-            f"Building TtDeepSeekPrefillPipeline model: "
-            f"num_layers={self.config.num_layers}, max_seq_len={self.config.max_seq_len}, "
-            f"mesh_shape={self.config.mesh_shape}, chunk_size={self.config.chunk_size}, num_users={self.config.num_users}"
+            f"Building TtPrefillRuntime model: "
+            f"num_layers={self.config.num_layers}, first_layer_idx={self.config.first_layer_idx}, "
+            f"is_first_rank={self.config.is_first_rank}, is_last_rank={self.config.is_last_rank}, "
+            f"max_seq_len={self.config.max_seq_len}, mesh_shape={self.config.mesh_shape}, "
+            f"chunk_size={self.config.chunk_size}, num_users={self.config.num_users}"
         )
         model_cfg = self.config.model_cfg
         if self.config.weight_cache_path:
@@ -92,12 +111,15 @@ class TtDeepSeekPrefillPipeline:
                 self.config.num_layers,
                 experts_per_chip,
                 first_k_dense=model_cfg.NUM_DENSE_LAYERS,
+                first_layer_idx=self.config.first_layer_idx,
+                is_first_rank=self.config.is_first_rank,
+                is_last_rank=self.config.is_last_rank,
             ):
                 logger.info(f"TTNN weight cache complete at {self.config.weight_cache_path}; loading from disk")
             else:
                 logger.warning(
                     f"TTNN weight cache not complete at {self.config.weight_cache_path}; "
-                    f"pipeline build will fail without a populated cache. "
+                    f"build will fail without a populated cache. "
                     f"Run the pretrained smoke test once to populate it."
                 )
         self.model = TtPrefillTransformer(
@@ -123,6 +145,9 @@ class TtDeepSeekPrefillPipeline:
             lm_head_is_column_parallel=True,
             is_chunked=True,
             slot_num=self.config.num_users,
+            first_layer_idx=self.config.first_layer_idx,
+            is_first_rank=self.config.is_first_rank,
+            is_last_rank=self.config.is_last_rank,
         )
         self.model_built = True
 
@@ -141,31 +166,50 @@ class TtDeepSeekPrefillPipeline:
         )
         self.kv_cache_allocated = True
 
+    def make_placeholder_activation(self) -> ttnn.Tensor:
+        """Allocate a zero hidden-state activation matching the embedding output:
+        [1, 1, chunk_per_chip, emb_dim/tp], TILE_LAYOUT, DRAM, replicated.
+
+        Stand-in input for a non-first rank until the upstream D2D-socket sync op
+        delivers the real activation. The first block's attn_norm reads from this
+        tensor; once the sync op lands, the wait-op overwrites it in place.
+        """
+        chunk_per_chip = self.config.chunk_size // self.config.sp_factor
+        emb_per_tp = self.hf_config.hidden_size // self.config.tp_factor
+        zeros = torch.zeros(1, 1, chunk_per_chip, emb_per_tp, dtype=torch.bfloat16)
+        return ttnn.from_torch(
+            zeros,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+    def _make_chunk_input(self, token_ids: list[int]) -> ttnn.Tensor:
+        """First-rank chunk input is SP-sharded token IDs; a non-first rank instead
+        gets a placeholder hidden-state activation (it does not embed)."""
+        if self.config.is_first_rank:
+            return prepare_prefill_input_tensor(
+                token_ids,
+                self.mesh_device,
+                self.config.sp_factor,
+                False,  # chunked prefill is block-cyclic (non-balanced)
+                self.config.mesh_shape,
+                self.config.sp_axis,
+            )
+        return self.make_placeholder_activation()
+
     def compile(self) -> None:
         assert self.model_built and self.kv_cache_allocated
         chunk = self.config.chunk_size
-        logger.info(f"TtDeepSeekPrefillPipeline.compile() — warming up one {chunk}-token chunk")
+        logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
         t0 = time.perf_counter()
-        tt_tokens = prepare_prefill_input_tensor(
-            [0] * chunk,
-            self.mesh_device,
-            self.config.sp_factor,
-            False,  # chunked prefill is block-cyclic (non-balanced)
-            self.config.mesh_shape,
-            self.config.sp_axis,
-        )
-        self.model.forward(
-            tt_tokens,
-            self.kvpe_cache,
-            number_of_non_padded_tokens=chunk,
-            actual_start=0,
-            actual_end=chunk,
-            cache_user_id=0,
-        )
-        ttnn.deallocate(tt_tokens)
+        tt_input = self._make_chunk_input([0] * chunk)
+        self.prefill(tt_input, slot_id=0, actual_start=0, actual_end=chunk)
         ttnn.synchronize_device(self.mesh_device)
         warmup_ms = (time.perf_counter() - t0) * 1000.0
-        logger.info(f"[prefill timing] task_id=WARMUP num_tokens={chunk} pipeline.prefill(chunk) = {warmup_ms:.2f} ms")
+        logger.info(f"[prefill timing] task_id=WARMUP num_tokens={chunk} runtime.prefill(chunk) = {warmup_ms:.2f} ms")
         self.compiled = True
 
     def prefill(
@@ -174,9 +218,14 @@ class TtDeepSeekPrefillPipeline:
         slot_id: int,
         actual_start: int,
         actual_end: int,
-    ) -> None:
-        """Prefill ONE chunk into user `slot_id`'s KV cache. Does NOT sample — the populated cache is
-        the output (read by the decode stage / migration consumer).
+    ) -> Optional[ttnn.Tensor]:
+        """Prefill ONE chunk into user `slot_id`'s KV cache.
+
+        On the last rank (and single-rank) this returns None — the populated cache is
+        the output (read by the decode stage / migration consumer). On a non-last
+        pipeline rank it returns this rank's output hidden-state activation, which the
+        driver hands to the next rank (today via a placeholder; via a D2D-socket
+        publish op once that lands).
 
         [actual_start, actual_end) is the absolute KV-position range of this chunk's real (non-pad)
         tokens: actual_start is the cache write offset (cumulative valid KV before this chunk) and
@@ -187,13 +236,16 @@ class TtDeepSeekPrefillPipeline:
         it. If a LayerAck channel is registered (set_layer_ack_channel), the model bumps it per layer.
 
         Args:
-            input_tensor: one chunk's tokens, SP-sharded uint32 ROW_MAJOR DRAM tensor as produced by
-                prepare_prefill_input_tensor (block-cyclic, chip-major). Deallocated here.
+            input_tensor: on the first rank, one chunk's tokens as an SP-sharded uint32 ROW_MAJOR DRAM
+                tensor (prepare_prefill_input_tensor, block-cyclic, chip-major); on a non-first rank,
+                the upstream hidden-state activation. Deallocated here.
             slot_id: cache user slot to fill, in [0, num_users).
             actual_start: absolute KV pos of the chunk's first real token (the cache write offset).
             actual_end: absolute KV pos past the chunk's last real token.
         """
-        assert self.compiled, "Call compile() before prefill()"
+        # Not gated on self.compiled: compile() warms up by calling prefill() once before
+        # marking the runtime compiled. The model + KV cache must exist, though.
+        assert self.model_built and self.kv_cache_allocated, "build the model and KV cache before prefill()"
         assert 0 <= slot_id < self.config.num_users, f"slot_id {slot_id} out of range [0, {self.config.num_users})"
         assert (
             actual_start + self.config.chunk_size <= self.config.max_seq_len
@@ -202,7 +254,7 @@ class TtDeepSeekPrefillPipeline:
             actual_start <= actual_end <= actual_start + self.config.chunk_size
         ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
 
-        self.model.forward(
+        out = self.model.forward(
             input_tensor,
             self.kvpe_cache,
             number_of_non_padded_tokens=actual_end - actual_start,
@@ -212,6 +264,10 @@ class TtDeepSeekPrefillPipeline:
             cache_user_id=slot_id,
         )
         ttnn.deallocate(input_tensor)
+        # Non-last rank: forward returns the hidden-state activation to forward downstream.
+        # Last/single rank: forward returns the (token, prob, intermediates) tuple, which this
+        # KV-output path ignores.
+        return out if not self.config.is_last_rank else None
 
     def set_layer_ack_channel(self, layer_ack_channel) -> None:
         """Register the per-layer-ack channel (docs/scheduler/prefill.md §3.11).

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -49,6 +49,9 @@ class TtPrefillTransformer(LightweightModule):
         num_layers: int,
         experts_per_chip: int = 8,
         first_k_dense: int = 3,
+        first_layer_idx: int = 0,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
     ) -> bool:
         """
         Top-level cache completeness check for the full transformer.
@@ -58,9 +61,16 @@ class TtPrefillTransformer(LightweightModule):
 
         Args:
             cache_path: Path to TTNN weight cache directory
-            num_layers: Number of transformer layers
+            num_layers: Number of transformer layers built by this instance
             experts_per_chip: Number of routed experts per chip (default: 8)
             first_k_dense: Number of initial dense (non-MoE) layers (default: 3)
+            first_layer_idx: Global index of this instance's first layer. Non-zero
+                for a pipeline-parallel rank owning a layer slice; block cache keys
+                are global, so dense/MoE selection must use the global index.
+            is_first_rank / is_last_rank: a pipeline-parallel rank builds the
+                embedding only on the first rank and the final norm + LM head only
+                on the last, so check only the weights it actually loads. Both True
+                for single-rank.
 
         Returns:
             True if all expected cache files exist, False otherwise
@@ -72,23 +82,23 @@ class TtPrefillTransformer(LightweightModule):
         # Initialize fast cache checker for this directory
         init_checker(cache_path)
 
-        # Embedding
-        if not TtParallelEmbedding.check_cache_complete(cache_path):
+        # Embedding (first rank only)
+        if is_first_rank and not TtParallelEmbedding.check_cache_complete(cache_path):
             return False
 
-        # Per-layer blocks
-        for layer_idx in range(num_layers):
+        # Per-layer blocks — cache keys are global, so index globally.
+        for local_idx in range(num_layers):
+            layer_idx = first_layer_idx + local_idx
             is_dense = layer_idx < first_k_dense
             if not TtPrefillBlock.check_cache_complete(cache_path, layer_idx, is_dense, experts_per_chip):
                 return False
 
-        # Final norm
-        if not TtDistributedRmsNorm.check_cache_complete(cache_path, "norm"):
-            return False
-
-        # LM head
-        if not TtLMHead.check_cache_complete(cache_path):
-            return False
+        # Final norm + LM head (last rank only)
+        if is_last_rank:
+            if not TtDistributedRmsNorm.check_cache_complete(cache_path, "norm"):
+                return False
+            if not TtLMHead.check_cache_complete(cache_path):
+                return False
 
         logger.info(f"TTNN cache complete at {cache_path} ({num_layers} layers)")
         return True
@@ -118,12 +128,20 @@ class TtPrefillTransformer(LightweightModule):
         is_chunked: bool = False,
         slot_num: int = 1,
         max_seq_len: Optional[int] = None,
+        first_layer_idx: int = 0,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
     ):
         super().__init__()
         self.mesh_device = mesh_device
         self.seq_len = seq_len
         self.padding_side = padding_side
         self.is_chunked = is_chunked
+        # Pipeline-parallel slicing. A rank owns layers [first_layer_idx, first_layer_idx+num_layers)
+        # and builds the embedding only on the first rank and the norm + LM head only on the last.
+        # All three default so a single-rank instance builds the whole model unchanged.
+        self.is_first_rank = is_first_rank
+        self.is_last_rank = is_last_rank
 
         if not state_dict and not (weight_cache_path and weight_cache_path.exists()):
             raise ValueError(
@@ -133,29 +151,39 @@ class TtPrefillTransformer(LightweightModule):
 
         logger.info(f"Building TtPrefillTransformer with {num_layers} layers, seq_len={seq_len}")
 
-        # --- Embedding ---
-        self.embed = TtParallelEmbedding(
-            mesh_device=mesh_device,
-            vocab_size=config.vocab_size,
-            emb_dim=config.hidden_size,
-            torch_weight=state_dict.get("embed_weight"),  # None if cache exists
-            sp_axis=sp_axis,
-            tp_axis=tp_axis,
-            weight_cache_path=weight_cache_path,
+        # --- Embedding (first rank only) ---
+        self.embed = (
+            TtParallelEmbedding(
+                mesh_device=mesh_device,
+                vocab_size=config.vocab_size,
+                emb_dim=config.hidden_size,
+                torch_weight=state_dict.get("embed_weight"),  # None if cache exists
+                sp_axis=sp_axis,
+                tp_axis=tp_axis,
+                weight_cache_path=weight_cache_path,
+            )
+            if is_first_rank
+            else None
         )
 
         # --- Transformer layers ---
+        # layer_idx is the GLOBAL index (drives weight cache keys + dense/MoE selection);
+        # cache_layer_idx in forward is the LOCAL slot. layer_num is this instance's slice
+        # length so the block's flat KV slot (cache_user_id * layer_num + cache_layer_idx)
+        # matches the per-rank cache sized to num_layers.
         self.layers = []
-        for i in range(num_layers):
-            logger.info(f"Building layer {i}/{num_layers}...")
-            # Get layer weights or empty dict if loading from cache
-            layer_state = state_dict["layers"][i] if state_dict.get("layers") else {}
+        for local_idx in range(num_layers):
+            layer_idx = first_layer_idx + local_idx
+            logger.info(f"Building layer {local_idx}/{num_layers} (global idx {layer_idx})...")
+            # Get layer weights or empty dict if loading from cache. state_dict, when
+            # provided, holds this instance's slice (local indexing).
+            layer_state = state_dict["layers"][local_idx] if state_dict.get("layers") else {}
             layer = TtPrefillBlock(
                 mesh_device=mesh_device,
                 config=config,
                 model_cfg=model_cfg,
                 state_dict=layer_state,
-                layer_idx=i,
+                layer_idx=layer_idx,
                 seq_len=seq_len,
                 dispatch_buffer_capacity_factor=dispatch_buffer_capacity_factor,
                 num_links=num_links,
@@ -176,17 +204,21 @@ class TtPrefillTransformer(LightweightModule):
             )
             self.layers.append(layer)
 
-        # --- Final norm ---
-        self.norm = TtDistributedRmsNorm(
-            mesh_device=mesh_device,
-            emb_dim=config.hidden_size,
-            torch_weight=state_dict.get("norm_weight"),  # None if cache exists
-            epsilon=config.rms_norm_eps,
-            cluster_axis=tp_axis,
-            num_links=num_links,
-            topology=topology,
-            weight_cache_path=weight_cache_path,
-            cache_name_prefix="norm",
+        # --- Final norm (last rank only) ---
+        self.norm = (
+            TtDistributedRmsNorm(
+                mesh_device=mesh_device,
+                emb_dim=config.hidden_size,
+                torch_weight=state_dict.get("norm_weight"),  # None if cache exists
+                epsilon=config.rms_norm_eps,
+                cluster_axis=tp_axis,
+                num_links=num_links,
+                topology=topology,
+                weight_cache_path=weight_cache_path,
+                cache_name_prefix="norm",
+            )
+            if is_last_rank
+            else None
         )
 
         # --- RoPE (computed once, reused across all layers) ---
@@ -204,17 +236,21 @@ class TtPrefillTransformer(LightweightModule):
             else None
         )
 
-        # --- LM Head ---
-        self.lm_head = TtLMHead(
-            mesh_device=mesh_device,
-            emb_dim=config.hidden_size,
-            vocab_size=config.vocab_size,
-            torch_weight=state_dict.get("lm_head_weight"),  # None if cache exists
-            num_links=num_links,
-            topology=topology,
-            is_balanced=is_balanced,
-            weight_cache_path=weight_cache_path,
-            is_column_parallel=lm_head_is_column_parallel,
+        # --- LM Head (last rank only) ---
+        self.lm_head = (
+            TtLMHead(
+                mesh_device=mesh_device,
+                emb_dim=config.hidden_size,
+                vocab_size=config.vocab_size,
+                torch_weight=state_dict.get("lm_head_weight"),  # None if cache exists
+                num_links=num_links,
+                topology=topology,
+                is_balanced=is_balanced,
+                weight_cache_path=weight_cache_path,
+                is_column_parallel=lm_head_is_column_parallel,
+            )
+            if is_last_rank
+            else None
         )
 
         self.is_balanced = is_balanced
@@ -246,10 +282,16 @@ class TtPrefillTransformer(LightweightModule):
         cache_user_id: int = 0,
     ):
         """
-        Forward pass: embed -> [block x N] -> norm -> lm_head.
+        Forward pass: [embed] -> [block x N] -> [norm -> lm_head -> sample].
+
+        Pipeline-parallel ranks run a slice of this: the embedding runs only on the
+        first rank and the norm/LM-head/sample tail only on the last, so the input
+        and output are dual-mode (see Args/Returns).
 
         Args:
-            token_ids: [1, 1, seq_len_per_chip] uint32, SP-sharded
+            token_ids: on the first rank, [1, 1, seq_len_per_chip] uint32 SP-sharded
+                token IDs to embed; on a non-first rank, the [1, 1, seq_per_chip,
+                emb_dim/tp] hidden-state activation handed over from the previous rank.
             kvpe_cache: externally created KVPE cache [num_layers, 1, seq_len_local, head_dim];
                         each layer writes to its own slot via cache_layer_idx
             return_intermediates: if True, sync + snapshot to host after each stage
@@ -263,7 +305,11 @@ class TtPrefillTransformer(LightweightModule):
                 + zero padding. When None, no migration or zeroing.
 
         Returns:
-            Tuple of (first_token_id, first_token_prob, intermediates_dict or None)
+            On a non-last rank: the hidden-state activation tensor to hand to the next
+            rank (no token — the tail did not run).
+
+            On the last rank (and single-rank): a tuple of
+            (first_token_id, first_token_prob, intermediates_dict or None)
             - first_token_id: sampled token ID (for first temperature if list provided)
             - first_token_prob: probability of sampled token (for first temperature if list provided)
             - intermediates: dict with keys like "embed", "layer_0", "norm", "lm_head", "first_token"
@@ -281,12 +327,16 @@ class TtPrefillTransformer(LightweightModule):
             rope_tensors = self.rope_setup.get_rope_tensors(self.seq_len)
         intermediates = {} if return_intermediates else None
 
-        h = self.embed(token_ids)  # [1, seq_per_chip, emb_dim/tp]
-        h = ttnn.unsqueeze_to_4D(h)  # [1, 1, seq_per_chip, emb_dim/tp]
-
-        if return_intermediates:
-            ttnn.synchronize_device(self.mesh_device)
-            intermediates["embed"] = self._to_host(h)
+        if self.is_first_rank:
+            h = self.embed(token_ids)  # [1, seq_per_chip, emb_dim/tp]
+            h = ttnn.unsqueeze_to_4D(h)  # [1, 1, seq_per_chip, emb_dim/tp]
+            if return_intermediates:
+                ttnn.synchronize_device(self.mesh_device)
+                intermediates["embed"] = self._to_host(h)
+        else:
+            # token_ids carries the upstream rank's hidden-state activation, already
+            # [1, 1, seq_per_chip, emb_dim/tp]. No embedding on this rank.
+            h = token_ids
 
         for i, layer in enumerate(self.layers):
             signpost(f"forward_layer_{i}_start")
@@ -307,6 +357,12 @@ class TtPrefillTransformer(LightweightModule):
                 intermediates[f"layer_{i}"] = self._to_host(h)
             if read_profiler:
                 ttnn.ReadDeviceProfiler(self.mesh_device)
+
+        # Non-last pipeline ranks stop here: the layer slice's output activation is
+        # handed to the next rank, which continues from this hidden state. The norm /
+        # LM-head / sample tail (and its weights) live only on the last rank.
+        if not self.is_last_rank:
+            return h
 
         h = self.norm(h)
 


### PR DESCRIPTION
Bringup-scope runner that splits the 61-layer prefill across 4 ranks (layers 0-15/16-31/32-47/48-60) under tt-run sub-context. Each rank owns an 8x4 mesh; inter-rank activation transport is handled by D2D sockets inside the kernels (no Python-side socket plumbing). Standalone JSON input only — no SHM, KV migration, LM head, or sampling in this iteration.

Also factors setup helpers (open_mesh_device, load_hf_config, resolve_weight_cache_path, setdefault_cache_env) out of prefill_runner.py into runner_utils.py so both runners share them. Single-rank standalone verified post-refactor (first_token=4979 matches expected).

Adds upstream_d2d_socket / downstream_d2d_socket placeholder kwargs to TtPrefillBlock and TtDistributedRmsNorm — scaffolding for the kernel-side socket wiring that will hook into the first/last layer of each rank.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/pipeline-prefill-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/pipeline-prefill-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/pipeline-prefill-runner)