### PR TITLE
[BH] Bump ufld_v2 device perf baseline 595 -> 613

### DIFF
--- a/models/demos/vision/segmentation/ufld_v2/blackhole/tests/perf/test_ufld_v2_perf.py
+++ b/models/demos/vision/segmentation/ufld_v2/blackhole/tests/perf/test_ufld_v2_perf.py
@@ -14,7 +14,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf,test",
     [
-        [1, 595, "UFLD-v2"],
+        [1, 613, "UFLD-v2"],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
## Summary

Bumps the `expected_perf` for the BH `ufld_v2` device perf test from **595** to **613** to absorb the BH `pack_untilize` MOP speedup that landed in #44596 on 2026-05-19. The current baseline sits right at the upper threshold and produces intermittent failures on the P150 BH device perf job.

## Why

After #44596 landed, `AVG DEVICE KERNEL SAMPLES/S` for ufld_v2 stepped from a steady ~604 (pre-2026-05-19) to a steady ~612.6 (post-2026-05-19). With `expected_perf=595` and `margin=0.03`, the upper threshold is **612.85**, so any run that lands slightly above the mean (e.g. **613.04** in run [26430231993](https://github.com/tenstorrent/tt-metal/actions/runs/26430231993/job/77802392451)) fails. #44596 bumped the affected SDXL `vae_encode_1024x1024` and ResNet50 b16/b32 baselines for the same speedup, but missed ufld_v2 — whose backbone is ResNet-34 and which goes through the same `pack_untilize` path via `to_layout(TILE_LAYOUT)` in `ttnn_resnet_34.py`.

## Trend (P150 BH, AVG DEVICE KERNEL SAMPLES/S)

| Window                | Steady value | Notes |
|-----------------------|--------------|-------|
| 2026-05-12 .. 05-18   | ~604         | pre-#44596 |
| **2026-05-19 onward** | **~612.6**   | post-#44596 |

Last 5 runs on the failing job (P150 BH device perf, ufld_v2 step):

| Date (UTC)   | Run | Status | AVG DEVICE KERNEL SAMPLES/S |
|--------------|-----|--------|------------------------------|
| 2026-05-26   | [26430231993](https://github.com/tenstorrent/tt-metal/actions/runs/26430231993) | FAIL   | 613.0400 |
| 2026-05-25   | [26423895761](https://github.com/tenstorrent/tt-metal/actions/runs/26423895761) | PASS   | 612.7909 |
| 2026-05-25   | [26418788793](https://github.com/tenstorrent/tt-metal/actions/runs/26418788793) | PASS   | 612.0105 |
| 2026-05-25   | [26412662130](https://github.com/tenstorrent/tt-metal/actions/runs/26412662130) | PASS   | 612.5413 |
| 2026-05-25   | [26407238115](https://github.com/tenstorrent/tt-metal/actions/runs/26407238115) | PASS   | 612.6434 |
| **Mean**     |     |        | **612.6052** |

Rounded to **613** (matches the integer convention used in this parametrize entry). New thresholds: `[594.61, 631.39]` — comfortable cushion above the observed max of 613.04.

## Test plan
- [ ] Wait for `(Single-card) Device perf regressions` workflow on `main` to pick up this change; verify P150 BH `ufld_v2 tests` step passes consistently across the next several scheduled runs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/bump-ufld-v2-bh-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/bump-ufld-v2-bh-perf-baseline)