### PR TITLE
Bug fix: Fix test_device_print in CI with new "debug" pytest marker

### DIFF
--- a/.github/workflows/llk-e2e-impl.yaml
+++ b/.github/workflows/llk-e2e-impl.yaml
@@ -7,7 +7,7 @@ on:
         description: "Pytest mark expression for LLK python_tests"
         required: false
         type: string
-        default: "not perf and not quasar"
+        default: "not perf and not quasar and not debug"
       coverage:
         description: "Enable coverage collection and merge job"
         required: false

--- a/.github/workflows/llk-e2e.yaml
+++ b/.github/workflows/llk-e2e.yaml
@@ -9,7 +9,7 @@ on:
       pytest_markers:
         description: "Pytest mark expression for testing (e.g., 'nightly', 'perf')"
         required: false
-        default: "not perf and not quasar"
+        default: "not perf and not quasar and not debug"
         type: string
 
 permissions:

--- a/.github/workflows/llk-smoke-impl.yaml
+++ b/.github/workflows/llk-smoke-impl.yaml
@@ -15,7 +15,7 @@ on:
         description: "Pytest mark expression for LLK python_tests"
         required: false
         type: string
-        default: "not perf and not nightly and not quasar"
+        default: "not perf and not nightly and not quasar and not debug"
 
 permissions:
   checks: write

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -495,7 +495,7 @@ jobs:
     with:
       docker-image: ${{ needs.build-docker-images.outputs.llk-ci-tag }}
       enabled-skus: wh_n150_civ2
-      pytest-markers: "not perf and not nightly and not quasar"
+      pytest-markers: "not perf and not nightly and not quasar and not debug"
 
   # LLK Functional Unit Tests on Blackhole (PR gate - runs on blackhole/common/sfpi/test/ci changes)
   llk-test-blackhole:
@@ -515,7 +515,7 @@ jobs:
     with:
       docker-image: ${{ needs.build-docker-images.outputs.llk-ci-tag }}
       enabled-skus: bh_p150b_civ2
-      pytest-markers: "not perf and not nightly and not quasar"
+      pytest-markers: "not perf and not nightly and not quasar and not debug"
 
   # LLK Quasar Build Check (compile-only, no hardware needed)
   llk-build-quasar:

--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -1,7 +1,7 @@
 # LLK smoke — PR-gate python_tests (no coverage, 4-way split, markers not perf and not nightly and not quasar and not debug).
 # PYTEST_MARKERS is set by llk-smoke-impl.yaml / workflow_call inputs. ci-quiet log mode is hard-coded.
-# Debug-marked tests (e.g. test_device_print) run in dedicated groups with LOGURU_LEVEL=DEBUG so the
-# device-print kernel build path is enabled in both compile-producer and compile-consumer phases.
+# Tests marked with debug (e.g. test_device_print) run in dedicated groups with LOGURU_LEVEL=DEBUG so the
+# device print kernel build path is enabled in both compile-producer and compile-consumer phases.
 
 - name: llk_smoke_wormhole group 1/4
   split_group: 1

--- a/tests/pipeline_reorg/llk_smoke_tests.yaml
+++ b/tests/pipeline_reorg/llk_smoke_tests.yaml
@@ -1,5 +1,7 @@
-# LLK smoke — PR-gate python_tests (no coverage, 4-way split, markers not perf and not nightly and not quasar).
+# LLK smoke — PR-gate python_tests (no coverage, 4-way split, markers not perf and not nightly and not quasar and not debug).
 # PYTEST_MARKERS is set by llk-smoke-impl.yaml / workflow_call inputs. ci-quiet log mode is hard-coded.
+# Debug-marked tests (e.g. test_device_print) run in dedicated groups with LOGURU_LEVEL=DEBUG so the
+# device-print kernel build path is enabled in both compile-producer and compile-consumer phases.
 
 - name: llk_smoke_wormhole group 1/4
   split_group: 1
@@ -191,4 +193,40 @@
   skus:
     bh_p150b_civ2:
       timeout: 15
+  owner_id: U07J3K6KS1K
+
+- name: llk_smoke_wormhole debug
+  split_group: 5
+  team: llk
+  coverage: false
+  cmd: |
+    set -euo pipefail
+    cd tests/python_tests
+    PYTEST_EXTRA="-q --override-ini=log_cli=false"
+    LOGURU_LEVEL=DEBUG pytest $PYTEST_EXTRA --compile-producer -m debug --timeout=60 \
+      --junitxml=pytest-report-wormhole-5-compile.xml .
+    LOGURU_LEVEL=DEBUG pytest $PYTEST_EXTRA --compile-consumer -x -m debug --timeout=60 \
+      --junitxml=pytest-report-wormhole-5-run.xml .
+    junitparser merge pytest-report-wormhole-5-compile.xml pytest-report-wormhole-5-run.xml pytest-report-wormhole-5.xml
+  skus:
+    wh_n150_civ2:
+      timeout: 10
+  owner_id: U07J3K6KS1K
+
+- name: llk_smoke_blackhole debug
+  split_group: 5
+  team: llk
+  coverage: false
+  cmd: |
+    set -euo pipefail
+    cd tests/python_tests
+    PYTEST_EXTRA="-q --override-ini=log_cli=false"
+    LOGURU_LEVEL=DEBUG pytest $PYTEST_EXTRA --compile-producer -m debug --timeout=60 \
+      --junitxml=pytest-report-blackhole-5-compile.xml .
+    LOGURU_LEVEL=DEBUG pytest $PYTEST_EXTRA --compile-consumer -x -m debug --timeout=60 \
+      --junitxml=pytest-report-blackhole-5-run.xml .
+    junitparser merge pytest-report-blackhole-5-compile.xml pytest-report-blackhole-5-run.xml pytest-report-blackhole-5.xml
+  skus:
+    bh_p150b_civ2:
+      timeout: 10
   owner_id: U07J3K6KS1K

--- a/tt_metal/tt-llk/tests/python_tests/pytest.ini
+++ b/tt_metal/tt-llk/tests/python_tests/pytest.ini
@@ -14,6 +14,7 @@ markers =
     perf: marks tests as performance benchmarks (deselect with '-m "not perf"')
     nightly: marks tests as nightly benchmarks (deselect with '-m "not nightly"')
     quasar: marks tests as quasar tests (deselect with '-m "not quasar"')
+    debug: marks tests that require debug logging (deselect with '-m "not debug"')
 log_date_format = %Y-%m-%d %H:%M:%S
 log_format = %(asctime)s | %(levelname)-8s | %(name)s:%(funcName)s:%(lineno)d - %(message)s
 log_cli_format = %(asctime)s | %(levelname)-8s | %(name)s:%(funcName)s:%(lineno)d - %(message)s

--- a/tt_metal/tt-llk/tests/python_tests/test_device_print.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_device_print.py
@@ -9,16 +9,7 @@ from helpers.param_config import input_output_formats
 from helpers.test_config import TestConfig
 
 
-# We force device print to be enabled during this test,
-# and turn it back off when it completes.
-@pytest.fixture(scope="module", autouse=True)
-def _force_device_print_enabled():
-    prev = TestConfig.DEVICE_PRINT_ENABLED
-    TestConfig.DEVICE_PRINT_ENABLED = True
-    yield
-    TestConfig.DEVICE_PRINT_ENABLED = prev
-
-
+@pytest.mark.debug
 def test_device_print():
     formats = input_output_formats([DataFormat.Int32])[0]
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`test_device_print` was failing in CI because the dprint kernel build path depends on the logging level being debug in both producer and consumer phases. My previous attempt at addressing that, in my original dprint PR #43981, fell short because of that. At @fvranicTT's suggestion, I added a new pytest marker that handles this test.

### Notes for reviewers
The only consumer of `debug` is `test_device_print` right now.