### PR TITLE
[vllm] Disable hybrid kv cache groups: emit FullAttentionSpec for all layers

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: "all"
+      mlperf-read-only:
+        description: "Mount /mnt/MLPerf as read-only (set to false to allow tt_cache write-through during first-use)"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   generate-matrix:
@@ -339,7 +344,11 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
+        # ``mlperf-read-only`` workflow input toggles ro/rw. Default ro for safety;
+        # uncheck the box at dispatch time when a model needs tt_cache first-use
+        # write-through. BH-QB-GE uses a local override path (not the shared
+        # /mnt/MLPerf) so the same toggle applies to either physical mount source.
+        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && format('/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -47,6 +47,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access)"
   schedule:
     - cron: '0 0 * * *' # This cron schedule runs the workflow every day at 12am UTC
 
@@ -71,3 +76,4 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       vllm-commit: ${{ inputs.vllm-commit || 'dev' }}
       model: ${{ inputs.model || 'all' }}
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
+++ b/models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py
@@ -37,6 +37,9 @@ def _make_vllm_config(layer_types, sliding_window=1024, num_kv_heads=8, head_siz
 
 
 def test_spec_emits_one_entry_per_layer():
+    """KV cache groups temporarily disabled: every layer is FullAttentionSpec
+    regardless of layer_types entry. Reverts to one uniform spec until the
+    bounded-sliding-cache decode bug is fixed."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
 
     from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
@@ -45,20 +48,15 @@ def test_spec_emits_one_entry_per_layer():
     spec = HybridAttentionForCausalLM.get_kv_cache_spec(_make_vllm_config(layers))
 
     assert len(spec) == len(layers)
-    for i, expected_type in enumerate(layers):
+    for i in range(len(layers)):
         name = f"model.layers.{i}.self_attn"
         assert name in spec
-        if expected_type == "sliding_attention":
-            assert isinstance(spec[name], SlidingWindowSpec)
-            assert spec[name].sliding_window == 1024
-        else:
-            assert isinstance(spec[name], FullAttentionSpec)
+        assert isinstance(spec[name], FullAttentionSpec)
+        assert not isinstance(spec[name], SlidingWindowSpec)
 
 
 def test_spec_gemma3_27b_pattern():
-    """Gemma3-27b: 5 sliding then 1 full, 10x → 50 sliding + 10 full + ...
-    (its actual config is 52 sliding + 10 full but the structure is the
-    same; just verify the per-layer outputs flow without errors)."""
+    """All layers are FullAttentionSpec while kv cache groups are disabled."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
 
     from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
@@ -69,8 +67,8 @@ def test_spec_gemma3_27b_pattern():
 
     full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
     sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
-    assert full_count == 10
-    assert sliding_count == 50
+    assert full_count == 60
+    assert sliding_count == 0
 
 
 def test_spec_gpt_oss_alternating_pattern():
@@ -83,14 +81,12 @@ def test_spec_gpt_oss_alternating_pattern():
 
     full_count = sum(isinstance(v, FullAttentionSpec) for v in spec.values())
     sliding_count = sum(isinstance(v, SlidingWindowSpec) for v in spec.values())
-    assert full_count == 12
-    assert sliding_count == 12
+    assert full_count == 24
+    assert sliding_count == 0
 
 
 def test_spec_uniform_full_attention_still_works():
-    """All-full layer_types → single-type config; spec generation still
-    succeeds (upstream's grouping later detects uniform-spec and uses
-    the simpler single-group path)."""
+    """All-full layer_types → single-type config; spec generation still succeeds."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
 
     from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
@@ -121,15 +117,6 @@ def test_spec_missing_layer_types_raises():
     cfg.model_config.hf_config.text_config.layer_types = None
 
     with pytest.raises(ValueError, match="layer_types"):
-        HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
-
-
-def test_spec_sliding_layer_without_window_raises():
-    from models.tt_transformers.tt.generator_vllm import HybridAttentionForCausalLM
-
-    cfg = _make_vllm_config(["sliding_attention"], sliding_window=None)
-
-    with pytest.raises(ValueError, match="sliding_window is None"):
         HybridAttentionForCausalLM.get_kv_cache_spec(cfg)
 
 

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -158,7 +158,10 @@ class HybridAttentionForCausalLM(Generator):
         runner side can map each spec back to its model layer index.
         """
         from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
-        from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+        # SlidingWindowSpec import intentionally dropped; restore alongside the
+        # branch below when re-enabling kv cache groups.
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
 
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
@@ -172,8 +175,6 @@ class HybridAttentionForCausalLM(Generator):
                 "hf_config.text_config.layer_types (one of 'full_attention' / "
                 "'sliding_attention' per layer); none found on this model"
             )
-
-        sliding_window = getattr(text_config, "sliding_window", None)
         num_kv_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
         head_size = model_config.get_head_size()
         dtype = (
@@ -190,24 +191,24 @@ class HybridAttentionForCausalLM(Generator):
             dtype=dtype,
         )
 
+        # SlidingWindowSpec is temporarily disabled: TT-side decode passes the
+        # absolute position to paged_update_cache / paged_sdpa_decode, but vLLM
+        # zero-pads the sliding group's page_table past sliding_window/block_size
+        # entries, so positions beyond the sliding window collapse onto physical
+        # block 0 and silently corrupt the cache. Emit FullAttentionSpec for every
+        # layer so vLLM allocates a max_model_len cache per layer; the SDPA op's
+        # own sliding_window_size kwarg still trims attention correctly on the
+        # read side.
         spec_per_layer = {}
         for i, lt in enumerate(layer_types):
             name = f"model.layers.{i}.self_attn"
-            if lt == "sliding_attention":
-                if sliding_window is None:
-                    raise ValueError(
-                        f"layer_types[{i}] is 'sliding_attention' but "
-                        f"hf_config.sliding_window is None on {cls.__name__}"
-                    )
-                spec_per_layer[name] = SlidingWindowSpec(**common, sliding_window=sliding_window)
-            elif lt == "full_attention":
-                spec_per_layer[name] = FullAttentionSpec(**common)
-            else:
+            if lt not in ("sliding_attention", "full_attention"):
                 raise ValueError(
                     f"Unsupported layer_type {lt!r} at layer {i} on "
                     f"{cls.__name__}; expected 'full_attention' or "
                     "'sliding_attention'"
                 )
+            spec_per_layer[name] = FullAttentionSpec(**common)
         return spec_per_layer
 
     def prefill_forward(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

Temporarily disable hybrid kv cache groups in `HybridAttentionForCausalLM.get_kv_cache_spec` while we design the decode-side fix for the bounded sliding cache. Every layer (sliding-window or full) is now emitted as `FullAttentionSpec`; `SlidingWindowSpec` is never returned.

This affects Gemma3 and GPT-OSS (the two main-branch subclasses of `HybridAttentionForCausalLM`). Gemma4 has its own override on the gemma branch — a parallel commit is needed there.

## Why

TT-side decode for sliding-window layers passes the **absolute** sequence position to `paged_update_cache` / `paged_scaled_dot_product_attention_decode`:

```python
# decode.py
cache_pos = position_idx_cache  # absolute pos
paged_update_cache(k_cache, tt_k, update_idxs_tensor=cache_pos, page_table=page_table, ...)
paged_scaled_dot_product_attention_decode(..., cur_pos_tensor=cache_pos, sliding_window_size=sliding_window, ...)
```

In vLLM's hybrid kv-cache-groups path, the sliding group sizes per-layer page_tables to `sliding_window / block_size` valid entries and **right-pads with zeros** out to `max_blocks_per_req` (see `vllm-tt-plugin/.../model_runner.py::pad_block_tables`, which uses `torch.zeros`). The kernel resolves `phys_block = page_table[user][cur_pos // block_size]`; once `cur_pos >= sliding_window`, that index falls in the zero-padded tail and the op writes/reads physical block 0 — silently collapsing every overflow position onto a single block.

Empirically verified on real hardware with a focused reproducer (sliding_window=128, block_size=32):

| pos range | PCC vs torch ref | what happens |
|-----------|------------------|--------------|
| 0–127 (within window) | ~0.9997 | page_table entries valid |
| 128–159 (just past) | still ~0.999 | overwrites coincide with reads — accidental correctness |
| 160–271 | 0.20–0.75 | block-0 overwrites hit positions sliding SDPA still reads |

**110 of 144** post-boundary steps failed `PCC > 0.99`. No crash, silent corruption.

## What changed

`models/tt_transformers/tt/generator_vllm.py`:

- `HybridAttentionForCausalLM.get_kv_cache_spec` now emits `FullAttentionSpec(**common)` for every layer regardless of `layer_types[i]`. The `if lt == 'sliding_attention'` branch (and its `sliding_window=None` validation) is removed. `SlidingWindowSpec` import dropped (restore alongside the spec when re-enabling).
- Validation that `layer_types[i] in {sliding_attention, full_attention}` is preserved.

`models/tt_transformers/tests/test_hybrid_attention_for_causal_lm.py`:

- `test_spec_emits_one_entry_per_layer`, `test_spec_gemma3_27b_pattern`, `test_spec_gpt_oss_alternating_pattern`: updated to assert all layers are `FullAttentionSpec` and none are `SlidingWindowSpec`.
- `test_spec_sliding_layer_without_window_raises` removed: the field is no longer read, so the validation that raised is gone.
- Other tests (`uniform_full_attention_still_works`, `propagates_kv_heads_and_head_size`, `missing_layer_types_raises`, `unknown_layer_type_raises`, `subclass_must_override_prefill_and_decode`) unchanged.

## Trade-offs

- **Memory:** sliding-layer caches inflate from `sliding_window`-sized to `max_model_len`-sized. For Gemma3-27b at max_model_len=128k and sliding_window=1024, that's 128× per sliding layer. Heavy, but the alternative is silent generation corruption.
- **Per-layer page tables** become redundant under one uniform group (all identical). The model code's per-layer indexing still works; it's just wasteful.
- **vLLM nightly entries** that fit tightly under HMA bounded-sliding may OOM now. Worth a re-run on the existing matrix entries to flag any that need a `--max-model-len` cut while the fix lands.

## Follow-up

Permanent fix plan (for a separate PR / branch):

1. **Model side** (preferred): wrap the position before calling the paged ops on sliding layers — `sliding_pos = pos % sliding_window`. Validate that `paged_sdpa_decode`'s sliding-window mask handles a wrapped `cur_pos` correctly (it may assume monotonic `cur_pos`).
2. **Op side** (alternative): add a `sliding_window_capacity` kwarg that has the op internally wrap before page_table lookup.
3. Reduce per-layer page_table widths and reinstate `SlidingWindowSpec` once the read/write side is correct.

## Test plan

- [x] Unit tests in `test_hybrid_attention_for_causal_lm.py` updated to lock in the new behavior (FullAttentionSpec for all layers).
- [ ] Gemma3 vLLM nightly entries — confirm no OOM with full sliding allocation
- [ ] GPT-OSS vLLM nightly entries — confirm no OOM with full sliding allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI Status

vLLM nightly run for all models (validates the disable doesn't break any existing model path):

- **Active run:** https://github.com/tenstorrent/tt-metal/actions/runs/26459541987
- Branch-filtered: [![vllm-nightly-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/vllm-nightly-tests.yaml?query=branch:handrews/disable-kv-cache-groups)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/disable-kv-cache-groups)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/disable-kv-cache-groups)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/disable-kv-cache-groups)