### PR TITLE
Fix kernel-build warnings in conv-team-owned kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -10,16 +10,6 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
-// Math thread acquires DST exclusively.
-ALWI void ACQ() { tile_regs_acquire(); }
-// Boundary between math ops and pack ops: math signals done, pack waits for math.
-ALWI void COMMIT_WAIT() {
-    tile_regs_commit();
-    tile_regs_wait();
-}
-// Pack thread releases DST.
-ALWI void REL() { tile_regs_release(); }
-
 // Compute one block (one kernel-tap slice) of a 1D depthwise conv.
 //
 // Per output tile:
@@ -47,8 +37,7 @@ inline void mul_and_accumulate_block(
         in1_cb.wait_front(1);
         in0_cb.wait_front(1);
 
-        ACQ();
-
+        tile_regs_acquire();
         // mul: srcA = in0 (bf16), srcB = in1 (bf8/bf16) -> dst[0]
         reconfig_data_format_srcb(in1_cb_id);
         mul_tiles_init(in0_cb_id, in1_cb_id);
@@ -68,14 +57,13 @@ inline void mul_and_accumulate_block(
             // Restore srcA to in0's format for the next iteration's mul unpack.
             reconfig_data_format_srca(in0_cb_id);
         }
-
-        COMMIT_WAIT();
+        tile_regs_commit();
 
         out_cb.reserve_back(1);
+        tile_regs_wait();
         pack_tile(0, out_cb_id);
         out_cb.push_back(1);
-
-        REL();
+        tile_regs_release();
 
         in0_cb.pop_front(1);
         in1_cb.pop_front(1);
@@ -101,8 +89,7 @@ inline void mul_and_accumulate_coalesced_block(
 
     for (uint32_t h = 0; h < act_block_h_ntiles; ++h) {
         for (uint32_t c = 0; c < in_channels_ntiles; ++c) {
-            ACQ();
-
+            tile_regs_acquire();
             reconfig_data_format_srca(in0_cb_id);
             reconfig_data_format_srcb(in1_cb_id);
 
@@ -113,14 +100,13 @@ inline void mul_and_accumulate_coalesced_block(
                 mul_tiles_init(in0_cb_id, in1_cb_id, tap != 0 ? 1U : 0U, __builtin_LINE());
                 mul_tiles(in0_cb_id, in1_cb_id, act_tile_idx, weight_tile_idx, 0);
             }
-
-            COMMIT_WAIT();
+            tile_regs_commit();
 
             out_cb.reserve_back(1);
+            tile_regs_wait();
             pack_tile(0, out_cb_id);
             out_cb.push_back(1);
-
-            REL();
+            tile_regs_release();
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp
@@ -10,8 +10,15 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+// Math thread acquires DST exclusively.
+ALWI void ACQ() { tile_regs_acquire(); }
+// Boundary between math ops and pack ops: math signals done, pack waits for math.
+ALWI void COMMIT_WAIT() {
+    tile_regs_commit();
+    tile_regs_wait();
+}
+// Pack thread releases DST.
+ALWI void REL() { tile_regs_release(); }
 
 // Compute one block (one kernel-tap slice) of a 1D depthwise conv.
 //
@@ -62,6 +69,8 @@ inline void mul_and_accumulate_block(
             reconfig_data_format_srca(in0_cb_id);
         }
 
+        COMMIT_WAIT();
+
         out_cb.reserve_back(1);
         pack_tile(0, out_cb_id);
         out_cb.push_back(1);
@@ -104,6 +113,8 @@ inline void mul_and_accumulate_coalesced_block(
                 mul_tiles_init(in0_cb_id, in1_cb_id, tap != 0 ? 1U : 0U, __builtin_LINE());
                 mul_tiles(in0_cb_id, in1_cb_id, act_tile_idx, weight_tile_idx, 0);
             }
+
+            COMMIT_WAIT();
 
             out_cb.reserve_back(1);
             pack_tile(0, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp
@@ -137,7 +137,7 @@ void kernel_main() {
                         // Start new src->scratch transfer
 
                         noc_async_read_set_trid(active_trid);
-                        uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0);
+                        uint64_t src_noc_addr = s0.get_noc_addr(src_stick_id);
                         dest_write_addrs[slot] = current_src_buffer_l1_addr;
                         noc_async_read(src_noc_addr, scratch_write_addrs[slot], padded_stick_size + misalignment);
                         slot_states[slot] = SlotState::SRC_PENDING;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -161,7 +161,6 @@ void kernel_main() {
     uint32_t input_addr = 0;
     uint32_t global_grid_stick_start = 0;
     uint32_t grid_addr = 0;
-    uint32_t num_pages = 0;
     uint32_t start_page_id = 0;
     if constexpr (is_sharded) {
         // Runtime arguments - same as sharded reader
@@ -170,7 +169,6 @@ void kernel_main() {
     } else {
         input_addr = get_arg_val<uint32_t>(0);
         grid_addr = get_arg_val<uint32_t>(1);
-        num_pages = get_arg_val<uint32_t>(2);
         start_page_id = get_arg_val<uint32_t>(3);
         global_grid_stick_start = start_page_id;
     }


### PR DESCRIPTION
## Summary

Cleans up three `-Wdeprecated-declarations` / `-Wunused-but-set-variable` warnings that surface during JIT kernel compilation in the nightly conv/pool test jobs. All three sites are owned by `@tenstorrent/metalium-developers-convolutions` per `.github/CODEOWNERS`. The warnings produce noise in the terminal output of every conv/pool test run (e.g. [run 26437678698](https://github.com/tenstorrent/tt-metal/actions/runs/26437678698)).

## What changed

### 1. `ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp`

**Why:** The `ACQ()` / `REL()` helpers wrapped the deprecated monolithic `acquire_dst()` / `release_dst()` API. The deprecation message says *"Use tile_regs_acquire() instead"* and *"Use tile_regs_release() instead"*, but these are **not drop-in replacements** — the old monolithic calls bundled the math-side and pack-side synchronization into a single call, while the new API splits it into four steps:

| Old (deprecated)   | New                       | Thread                  |
|--------------------|---------------------------|-------------------------|
| `acquire_dst()`    | `tile_regs_acquire()`     | MATH waits for DST      |
|                    | `tile_regs_commit()`      | MATH signals done       |
|                    | `tile_regs_wait()`        | PACK waits for math     |
| `release_dst()`    | `tile_regs_release()`     | PACK signals done       |

A naïve rename would have broken the PACK-side synchronization. Instead this PR:
- Updates `ACQ()` to `tile_regs_acquire()`.
- Adds a `COMMIT_WAIT()` helper that does `tile_regs_commit(); tile_regs_wait();`.
- Updates `REL()` to `tile_regs_release()`.
- Inserts `COMMIT_WAIT()` at the math→pack boundary in both `mul_and_accumulate_block` and `mul_and_accumulate_coalesced_block` (immediately before `out_cb.reserve_back(1); pack_tile(...); out_cb.push_back(1);`).

This matches the canonical 4-step pattern already used in conv-team-owned kernels like `pool/generic/device/kernels/compute/compute_pool_2d.cpp:159-189`.

### 2. `ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp`

**Why:** `num_pages` was declared at line 164 and assigned at line 173 (`num_pages = get_arg_val<uint32_t>(2);`) but never read anywhere. `get_arg_val` is a pure load (`return *((tt_l1_ptr T*)(get_arg_addr(arg_idx)))`), so removing the call has no side effects. The arg layout at offsets 0/1/2/3 set by the host is unchanged — the kernel just stops reading slot 2.

### 3. `ttnn/cpp/ttnn/operations/experimental/padded_slice/device/kernels/dataflow/padded_slice_reader_rm_interleaved_start_id.cpp`

**Why:** `get_noc_addr(src_stick_id, s0)` was matching the deprecated free-function overload `get_noc_addr<bool DRAM>(uint32_t, const InterleavedAddrGen<DRAM>&, ...)` (decl at `dataflow_api_addrgen.h:453`). Replaced with the equivalent accessor method `s0.get_noc_addr(src_stick_id)` (`tensor_accessor.h:120`). Semantically identical (the templated free function just forwards to `addrgen.get_noc_addr(id, offset, noc)`), and avoids the deprecated overload entirely.

## Test plan
- [ ] CI: `ttnn nightly conv tests` and `ttnn nightly pool tests` on WH N150 + N300, BH P100 + P150b — verify the four warning lines are gone from JIT compile output.
- [ ] CI: Conv/pool unit tests pass — especially `tests/ttnn/unit_tests/operations/conv/test_conv1d.py` which exercises the depthwise 1D path that triggers `compute_depthwise_conv1d.cpp`. The math→pack boundary insertion is correctness-sensitive; PCC checks in these tests are the validation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/fix-conv-team-kernel-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/fix-conv-team-kernel-warnings)