### PR TITLE
[Feature] Add KV cache table checks in DS mla and DS prefill block test

### DIFF
--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -13,6 +13,7 @@ on:
           - module
           - moe_gate
           - mla
+          - kv_cache_table
           - prefill_block
           - prefill_transformer
         default: 'all'

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -26,8 +26,8 @@ from tests.ttnn.utils_for_testing import assert_equal
 # sp x tp
 @pytest.mark.parametrize(
     "mesh_device",
-    [(32, 4), (8, 4)],
-    ids=["32x4", "8x4"],
+    [(8, 4)],
+    ids=["8x4"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -44,9 +44,9 @@ from tests.ttnn.utils_for_testing import assert_equal
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.parametrize("seq_len", [25 * 1024], ids=["seq25k"])
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
-def test_mla_disaggregation(
+def test_kv_cache_table(
     use_pretrained,
     request,
     mesh_device,
@@ -116,9 +116,7 @@ def test_mla_disaggregation(
     # Initialize KVPE cache
     kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
 
-    # Initialise kvpe cache with 2 layers, but run only 1 layer.
-    # Other layer should be zeros
-    num_kvpe_cache_layers = 2
+    num_kvpe_cache_layers = 1
     tt_kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=kvpe_cache_head_dim,
         mesh_device=mesh_device,
@@ -171,36 +169,15 @@ def test_mla_disaggregation(
     # remember layer0 results
     tt_kvpe_cache_torch_layer0 = tt_kvpe_cache_torch[:1, :1, :, :]
 
-    # assert layer1 is zeros
-    tt_kvpe_cache_torch_layer1 = tt_kvpe_cache_torch[1:2, :1, :, :]
-    torch_layer_zeros = torch.zeros(1, 1, seq_len, kvpe_cache_head_dim)
-    logger.info(f"Checking that layer 1 is all zeros")
-    assert_equal(tt_kvpe_cache_torch_layer1, torch_layer_zeros)
-    logger.info(f"Check complete")
-
     # reorder into position continuous torch cache
     tt_kvpe_cache_torch_layer0 = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch_layer0, chunk_order, seq_dim=2)
 
-    # migrate layer0 of tt_kvpe_cache into layer1 of tt_kvpe_cache
-
-    # perform migration
-
-    # now assert equality of tt_kvpe_cache_torch_layer0 with tt_kvpe_cache_torch_layer1
-    # tt_kvpe_cache_torch = ttnn.to_torch(
-    #     tt_kvpe_cache,
-    #     mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
-    # ).to(torch.bfloat16)
-    # tt_kvpe_cache_torch_layer1 = tt_kvpe_cache_torch[1:2, :1, :, :]
-    # tt_kvpe_cache_torch_layer1 = reverse_reorder_tensor_chunks(tt_kvpe_cache_torch_layer1, chunk_order, seq_dim=2)
-    # assert_equal(tt_kvpe_cache_torch_layer0, tt_kvpe_cache_torch_layer1)
-    # we can also make sure layer 0 didn't get polluted
-    # assert_equal(tt_kvpe_cache_torch_layer0, tt_kvpe_cache_torch_layer0_new)
-    # ...
-
-    logger.info("Starting synchronize call")
-    ttnn.synchronize_device(mesh_device)
-    logger.info("Synchronize call ended")
-
-    logger.debug("  Distributed synchronization started")
-    ttnn.distributed_context_barrier()
-    logger.debug("✓ Distributed synchronization completed")
+    # Walk every chunk in layer 0, read it back via the address table, and
+    # compare against the corresponding 32-token slice of the gathered cache.
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        expected_chunk = tt_kvpe_cache_torch_layer0[:, :, position : position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, :]
+        assert_equal(chunk_torch, expected_chunk)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -67,7 +67,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     slice_non_padded,
     tokenize_prompt_to_isl,
 )
-from tests.ttnn.utils_for_testing import comp_pcc
+from tests.ttnn.utils_for_testing import assert_equal, comp_pcc
 
 PCC_THRESHOLD = 0.99
 TRACE_PCC_THRESHOLD = 0.97
@@ -556,6 +556,10 @@ def test_prefill_transformer(
             test_params=test_params,
         )
 
+    logger.info(
+        f"Params: pcc_validation={pcc_validation}, return_kv_cache={return_kv_cache}, do_return_kv={do_return_kv} is_balanced={is_balanced} ref_kvpe_list={ref_kvpe_list is not None}"
+    )
+
     # --- PCC check ---
     if pcc_validation:
         profiler.start("pcc_validation")
@@ -642,6 +646,24 @@ def test_prefill_transformer(
                     logger.error(f"{label:<20s}  KVPE PCC comparison failed: {e}")
                     pcc_results.append((f"{label}_kv", -1.0))
                     pcc_results.append((f"{label}_pe", -1.0))
+
+            # Per-layer chunk readback via the address table — verify the table
+            # maps to the same bytes as the gathered cache, chunk by chunk.
+            # Only meaningful when `is_balanced` so `tt_kvpe_all_layers` is
+            # position-continuous (matching the lookup table's position index).
+            if is_balanced:
+                logger.info(f"Starting KV cache table validity check")
+                chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
+                for layer in range(num_layers):
+                    for position in range(0, isl_total, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                        raw_bytes = lookup_table.read_device_chunk(layer=layer, position=position, slot=0)
+                        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+                        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+                        expected_chunk = tt_kvpe_all_layers[
+                            layer : layer + 1, :, position : position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, :
+                        ]
+                        assert_equal(chunk_torch, expected_chunk)
+                logger.info(f"KV cache table validity check passed!")
 
         # --- Logits PCC check (last-token logits vs trace reference) ---
         # Trace logits / next-token are products of the full traced model. They are

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -39,6 +39,19 @@
   owner_id: U08RL15T4N8
   team: models
 
+- name: "(Galaxy) DeepSeek Prefill - KV cache table"
+  cmd: |
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG
+    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained" -vvv --tb=short
+  test_type: kv_cache_table
+  test_group: module
+  skus:
+    bh_galaxy:
+      timeout: 30
+  owner_id: U08RL15T4N8
+  team: models
+
 - name: "(Galaxy) DeepSeek Prefill - Prefill Block"
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG

--- a/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp
@@ -108,6 +108,14 @@ public:
     // Check if a FabricNodeId has a registered host mapping.
     bool has_host(const tt::tt_fabric::FabricNodeId& node_id) const;
 
+    // --- Device reads ---
+
+    // Read a single chunk's raw bytes from the primary replica device
+    // (first FabricNodeId in the chunk's DeviceGroup). Returns a buffer
+    // of size loc.size_bytes. Resolves the device internally via the
+    // global ControlPlane — no device list required from the caller.
+    std::vector<uint8_t> read_device_chunk(uint32_t layer, uint32_t position, uint32_t slot) const;
+
     const KvChunkAddressTableConfig& config() const { return config_; }
     uint32_t num_position_chunks() const { return num_position_chunks_; }
     size_t total_entries() const { return entries_.size(); }

--- a/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
+++ b/tt_metal/impl/experimental/disaggregation/kv_chunk_address_table.cpp
@@ -5,10 +5,31 @@
 #include "tt_metal/api/tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp"
 
 #include <algorithm>
+#include <cstring>
 
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/assert.hpp>
 
+#include "impl/context/metal_context.hpp"
+
 namespace tt::tt_metal::experimental::disaggregation {
+
+namespace {
+
+// noc_addr encoding (set by kv_cache_utils.py): (bank_id << 32) | local_addr
+uint32_t addr_channel(uint64_t noc_addr) { return static_cast<uint32_t>(noc_addr >> 32); }
+uint32_t addr_local(uint64_t noc_addr) { return static_cast<uint32_t>(noc_addr & 0xFFFFFFFFull); }
+
+tt::tt_metal::IDevice* resolve_device(const tt::tt_fabric::FabricNodeId& node_id) {
+    const auto& cp = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto chip_id = cp.get_physical_chip_id_from_fabric_node_id(node_id);
+    auto* dev = tt::tt_metal::detail::GetActiveDevice(chip_id);
+    TT_FATAL(dev != nullptr, "GetActiveDevice({}) returned null for {}", chip_id, node_id);
+    return dev;
+}
+
+}  // namespace
 
 size_t KvChunkAddressTable::flat_index(uint32_t layer, uint32_t position_chunk, uint32_t slot) const {
     return (static_cast<size_t>(slot) * num_layers_x_chunks_) + (static_cast<size_t>(layer) * num_position_chunks_) +
@@ -102,4 +123,18 @@ bool KvChunkAddressTable::has_host(const tt::tt_fabric::FabricNodeId& node_id) c
     return fabric_node_to_host_.contains(node_id);
 }
 
+std::vector<uint8_t> KvChunkAddressTable::read_device_chunk(uint32_t layer, uint32_t position, uint32_t slot) const {
+    const auto& loc = lookup(layer, position, slot);
+    const auto& dg = get_device_group(loc.device_group_index);
+    TT_FATAL(
+        !dg.fabric_node_ids.empty(), "DeviceGroup for (layer={}, pos={}, slot={}) is empty", layer, position, slot);
+
+    std::vector<uint8_t> buf(loc.size_bytes);
+    tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
+        resolve_device(dg.fabric_node_ids.front()),
+        static_cast<int>(addr_channel(loc.noc_addr)),
+        addr_local(loc.noc_addr),
+        std::span<uint8_t>(buf));
+    return buf;
+}
 }  // namespace tt::tt_metal::experimental::disaggregation

--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -11,6 +11,8 @@
 #include <tt-metalium/experimental/disaggregation/kv_chunk_address_table.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
+#include "ttnn/experimental/disaggregation/tensor_helpers.hpp"
+
 namespace ttnn::disaggregation {
 
 void bind_disaggregation_api(nb::module_& mod) {
@@ -172,7 +174,37 @@ void bind_disaggregation_api(nb::module_& mod) {
             "num_position_chunks",
             &KvChunkAddressTable::num_position_chunks,
             "Number of position chunks (computed from config).")
-        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries in the table.");
+        .def("total_entries", &KvChunkAddressTable::total_entries, "Total number of entries in the table.")
+
+        // Device reads
+        .def(
+            "read_device_chunk",
+            [](const KvChunkAddressTable& table, uint32_t layer, uint32_t position, uint32_t slot) {
+                auto buf = table.read_device_chunk(layer, position, slot);
+                return nb::bytes(reinterpret_cast<const char*>(buf.data()), buf.size());
+            },
+            nb::arg("layer"),
+            nb::arg("position"),
+            nb::arg("slot"),
+            R"(
+            Read the raw bytes of a single chunk from the primary replica device.
+            Resolves the device internally via the global ControlPlane.
+            Position is in tokens (chunk-aligned).
+            )");
+
+    mod.def(
+        "tensor_from_bfp8_bytes",
+        [](const nb::bytes& raw_bytes, const std::vector<uint32_t>& shape) {
+            return ttnn::experimental::disaggregation::tensor_from_bfp8_bytes(
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(raw_bytes.c_str()), raw_bytes.size()), shape);
+        },
+        nb::arg("raw_bytes"),
+        nb::arg("shape"),
+        R"(
+        Wrap raw bfp8-packed bytes (uint32-aligned, TILE layout) as a host-side ttnn.Tensor
+        with the given shape — no quantization round-trip.
+        Used to compare KV-table reads against the live KV cache byte-for-byte.
+        )");
 }
 
 }  // namespace ttnn::disaggregation

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/experimental/disaggregation/tensor_helpers.hpp"
+
+#include <cstring>
+#include <utility>
+
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt_stl/span.hpp>
+
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::experimental::disaggregation {
+
+ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape) {
+    TT_FATAL(
+        raw_bytes.size() % sizeof(uint32_t) == 0,
+        "tensor_from_bfp8_bytes: raw byte size {} is not a multiple of 4 (bfp8 storage is uint32-packed)",
+        raw_bytes.size());
+
+    size_t n_words = raw_bytes.size() / sizeof(uint32_t);
+    std::vector<uint32_t> packed(n_words);
+    std::memcpy(packed.data(), raw_bytes.data(), raw_bytes.size());
+
+    tt::tt_metal::Shape tensor_shape(ttsl::Span<const uint32_t>(shape.data(), shape.size()));
+    tt::tt_metal::TensorLayout layout(
+        tt::tt_metal::DataType::BFLOAT8_B,
+        tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+        tt::tt_metal::MemoryConfig{});
+    tt::tt_metal::TensorSpec spec(tensor_shape, layout);
+
+    tt::tt_metal::HostBuffer host_buffer(std::move(packed));
+    return ttnn::Tensor(std::move(host_buffer), std::move(spec));
+}
+
+}  // namespace ttnn::experimental::disaggregation

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::disaggregation {
+
+// Wrap raw bfp8-packed bytes (uint32-aligned, TILE layout) as a host-side
+// ttnn::Tensor with the given shape — no quantization round-trip.
+// Used to compare KV-table reads against the live KV cache byte-for-byte.
+ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape);
+
+}  // namespace ttnn::experimental::disaggregation

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -319,6 +319,7 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn-nanobind/events.cpp
     cpp/ttnn-nanobind/fabric.cpp
     cpp/ttnn-nanobind/disaggregation.cpp
+    cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
     cpp/ttnn-nanobind/global_circular_buffer.cpp
     cpp/ttnn-nanobind/global_semaphore.cpp
     cpp/ttnn-nanobind/hd_socket.cpp


### PR DESCRIPTION
### Summary
Add KV cache table check in prefill tests (MLA single layer and test_prefill_transformer)
Expose D->H readback methods from KV cache table descriptor

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppopovic/kv_cache_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppopovic/kv_cache_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppopovic/kv_cache_check)