### PR TITLE
Reduce SDPA ring-joint code size

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -790,8 +790,8 @@ EXP_RING_JOINT_PERF_MARGIN = 0.005
 EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
     # (ring_size_expected, max_payload_size, payload_id, expected_util)
     # 4-device ring (QuietBox, 4xGalaxy analog)
-    (4, 4096, "4k", 65.1),
-    (4, 8192, "8k", 65.0),
+    (4, 4096, "4k", 65.3),
+    (4, 8192, "8k", 65.2),
 ]
 
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -1511,7 +1511,7 @@ RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox)
     ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 63.0),
+    ("mla_100k", 160, 320, 4, 63.2),
 ]
 
 

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -423,7 +423,7 @@ SDPA_PERF_MARGIN = 0.007
 SDPA_PERF_CHECK_CONFIGS = [
     # (shape_id, q_chunk_size, k_chunk_size, expected_util)
     ("wan2_2_1xGLX_analog", 288, 512, 70.0),
-    ("wan2_2_4xGLX_analog", 224, 512, 57.0),
+    ("wan2_2_4xGLX_analog", 224, 512, 57.5),
 ]
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -545,17 +545,6 @@ tt::tt_metal::ProgramDescriptor ExpRingJointSDPAProgramFactory::create_descripto
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
 
-    // Early format check: when all data formats are identical, reconfig calls can be skipped.
-    const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
-    const tt::DataFormat k_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
-    const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
-    const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
-    const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
-    const tt::DataFormat mask_df_early = tt::DataFormat::Float16_b;
-    const bool uniform_dataformat =
-        (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
-         q_df_early == mask_df_early && q_df_early == im_df_early);
-
     std::vector<uint32_t> compute_compile_time_args = {
         NH,
         DHt,
@@ -586,7 +575,6 @@ tt::tt_metal::ProgramDescriptor ExpRingJointSDPAProgramFactory::create_descripto
         static_cast<std::uint32_t>(use_streaming_compute),
         global_n_partial_col,
         joint_l_partial_col,
-        static_cast<std::uint32_t>(uniform_dataformat),
     };
 
     std::map<std::string, std::string> defines;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -932,7 +932,7 @@ static void sdpa_inner_loop_step(
         q_wait_tiles += q_subblock_num_tiles;
     }
 
-    sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * KT_stride);
+    cb_pop_front(cb_kt_in, DHt * KT_stride);
 
     // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
     // reader can start fetching the next Q chunk during Phase 2.
@@ -1095,8 +1095,8 @@ static void sdpa_inner_loop_step(
                         prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                 }
             }
-            sdpa_cb_pop_front_out_of_line(cb_exp_max_diff, sbh);
-            sdpa_cb_pop_front_out_of_line(prev.out, sbh * vDHt);
+            cb_pop_front(cb_exp_max_diff, sbh);
+            cb_pop_front(prev.out, sbh * vDHt);
             PACK((llk_pack_reconfig_l1_acc(0)));
         };
 
@@ -1254,8 +1254,8 @@ static void sdpa_inner_loop_step(
 
         // All rows pushed individually — no bulk push needed.
 
-        sdpa_cb_pop_front_out_of_line(cb_v_in, KT_stride * vDHt);
-        sdpa_cb_pop_front_out_of_line(cb_qkt_im, Sq_chunk_t * KT_stride);
+        cb_pop_front(cb_v_in, KT_stride * vDHt);
+        cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -17,14 +17,6 @@
 #include "api/compute/experimental/matmul_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
 #endif
-#ifdef ARCH_BLACKHOLE
-// BH has ample code size headroom; allow normal inlining and GCC IPA-CP cloning (no noinline/noclone).
-#define SDPA_NOINLINE
-#else
-// WH/T3000: Mochi leaves little headroom as ARCH_BLACKHOLE vs non-ARCH_BLACKHOLE
-// code paths used below are different — for now, prevent inlining and cloning.
-#define SDPA_NOINLINE __attribute__((noinline, noclone))
-#endif
 #include "tools/profiler/kernel_profiler.hpp"
 
 // Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
@@ -46,6 +38,14 @@ struct MaybeProfileScope<true, timer_id> : kernel_profiler::profileScope<timer_i
 #else
 #define MaybeDeviceZoneScopedN(ENABLED, name)
 #endif
+
+static __attribute__((noinline, noclone)) void sdpa_cb_push_back_out_of_line(uint32_t cb_id, uint32_t num_tiles) {
+    cb_push_back(cb_id, num_tiles);
+}
+
+static __attribute__((noinline, noclone)) void sdpa_cb_pop_front_out_of_line(uint32_t cb_id, uint32_t num_tiles) {
+    cb_pop_front(cb_id, num_tiles);
+}
 
 /**
  * Push tiles to make them visible for UNPACK reads, but rewind wr_ptr so
@@ -77,11 +77,61 @@ struct RingAccumulatorState {
 
 // Sentinel for "no CB" — beyond the valid 0-31 range.
 constexpr uint32_t INVALID_CB = 32;
-// On WH, blocked-pack reconfiguration costs more than it saves for narrow row packs.
+// BH benefits from blocked pack at width 4; WH keeps the threshold at 8 because
+// width-4 blocked-pack reconfiguration costs more than it saves there.
+#ifdef ARCH_BLACKHOLE
+constexpr uint32_t MIN_BLOCKED_PACK_TILES = 4;
+#else
 constexpr uint32_t MIN_BLOCKED_PACK_TILES = 8;
+#endif
 ALWI bool should_use_blocked_pack_width(uint32_t pack_width) { return pack_width >= MIN_BLOCKED_PACK_TILES; }
 
-ALWI void configure_pack_width(uint32_t cb, uint32_t pack_width) {
+template <uint32_t old_cb, uint32_t new_cb>
+ALWI void sdpa_maybe_pack_reconfig_data_format() {
+#ifdef TRISC_PACK
+    if constexpr (pack_dst_format[old_cb] != pack_dst_format[new_cb]) {
+        pack_reconfig_data_format(old_cb, new_cb);
+    }
+#endif
+}
+
+template <uint32_t old_cb, uint32_t new_cb>
+constexpr bool sdpa_unpack_format_changed() {
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    return unpack_src_format[old_cb] != unpack_src_format[new_cb] ||
+           unpack_dst_format[old_cb] != unpack_dst_format[new_cb] ||
+           unpack_tile_face_r_dim[old_cb] != unpack_tile_face_r_dim[new_cb] ||
+           unpack_tile_num_faces[old_cb] != unpack_tile_num_faces[new_cb];
+#else
+    return false;
+#endif
+}
+
+template <uint32_t srca_old_cb, uint32_t srca_new_cb, uint32_t srcb_old_cb, uint32_t srcb_new_cb>
+ALWI void sdpa_maybe_reconfig_data_format() {
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    if constexpr (
+        sdpa_unpack_format_changed<srca_old_cb, srca_new_cb>() ||
+        sdpa_unpack_format_changed<srcb_old_cb, srcb_new_cb>()) {
+        reconfig_data_format(srca_old_cb, srca_new_cb, srcb_old_cb, srcb_new_cb);
+    }
+#endif
+}
+
+template <uint32_t srca_old_cb, uint32_t srca_new_cb, uint32_t srcb_old_cb, uint32_t srcb_new_cb>
+ALWI void sdpa_maybe_reconfig_data_format(uint32_t runtime_srca_old_cb, uint32_t runtime_srcb_old_cb) {
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH)
+    if constexpr (
+        sdpa_unpack_format_changed<srca_old_cb, srca_new_cb>() ||
+        sdpa_unpack_format_changed<srcb_old_cb, srcb_new_cb>()) {
+        reconfig_data_format(runtime_srca_old_cb, srca_new_cb, runtime_srcb_old_cb, srcb_new_cb);
+    }
+#endif
+}
+
+// Keep this out-of-line even on BH: repeated pack-width configuration sites
+// inflate SDPA streaming code size more than this call costs in measured cases.
+static __attribute__((noinline, noclone)) void configure_pack_width(uint32_t cb, uint32_t pack_width) {
     // Pure MOP refresh: addrmod and packer strides are already configured from
     // the initial pack init, and changing pack_width only requires re-issuing
     // the MOP. Skipping the packer-strides reconfig saves a THCON stall per
@@ -166,7 +216,7 @@ ALWI void pack_contiguous_rows(
  * Always uses pack_tile<true> at row-major positions in out_cb.
  */
 template <bool transpose, uint32_t in1_stride, uint32_t out_num_cols>
-SDPA_NOINLINE void blocked_matmul_and_pack(
+void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
     uint32_t out_cb,
@@ -277,7 +327,7 @@ void reduce_c_row_group(
  * writes back to same positions. Accumulates row sums into reduce_cb.
  */
 template <bool profiling_enabled, uint32_t scale_fp32>
-SDPA_NOINLINE void sub_exp_block_bcast_cols(
+void sub_exp_block_bcast_cols(
     uint32_t inout_cb,
     uint32_t max_cb,
     uint32_t reduce_cb,
@@ -373,8 +423,7 @@ SDPA_NOINLINE void sub_exp_block_bcast_cols(
  * Operates on first-column subset of tiles.
  */
 template <bool profiling_enabled, uint32_t scale_fp32>
-SDPA_NOINLINE void sub_exp_first_col_blocks(
-    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t sbh) {
+void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t q_subblock, uint32_t sbh) {
     const uint32_t tiles_per_row = sbh;
     const uint32_t global_row_base = q_subblock * tiles_per_row;
     constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
@@ -499,14 +548,15 @@ void salad_correct_fused(
  * Consumes (pops) sum and output tiles, writes normalized output.
  * scratch_cb is a 1-tile CB reused for the reciprocal intermediate.
  */
-template <bool profiling_enabled, uint32_t head_dim_t_, uint32_t dst_size, bool uniform_pack_format = false>
-static __attribute__((noinline, noclone)) void normalize_row_streaming(
-    uint32_t cur_sum_cb,
-    uint32_t cur_out_cb,
+template <
+    bool profiling_enabled,
+    uint32_t head_dim_t_,
+    uint32_t dst_size,
     uint32_t col_identity_cb,
     uint32_t scratch_cb,
-    uint32_t normalized_out_cb,
-    uint32_t sbh) {
+    uint32_t normalized_out_cb>
+static __attribute__((noinline, noclone)) void normalize_row_streaming(
+    uint32_t cur_sum_cb, uint32_t cur_out_cb, uint32_t sbh) {
     configure_single_tile_pack(scratch_cb);
     for (uint32_t s = 0; s < sbh; s++) {
         // 1+2. Fused matmul_reduce + recip: sum × col_identity → recip → 1/sum in scratch
@@ -514,13 +564,10 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             MaybeDeviceZoneScopedN(profiling_enabled, "NORM_MATMUL_RECIP");
             constexpr uint32_t N = 1;
             mm_block_init_short(cur_sum_cb, col_identity_cb, 0, N, 1, N);
-            reconfig_data_format(col_identity_cb, cur_sum_cb);
-            // Pack format follows scratch_cb (Float16_b intermediate) for the recip output.
-            // Required when normalized_out_cb has a different format (e.g., Bfp8 output dtype):
-            // s>0 iterations re-enter here after the bcast loop set pack format to normalized_out_cb.
-            if constexpr (!uniform_pack_format) {
-                pack_reconfig_data_format(scratch_cb);
-            }
+            sdpa_maybe_reconfig_data_format<normalized_out_cb, col_identity_cb, normalized_out_cb, scratch_cb>();
+            // Pack format follows scratch_cb for the reciprocal intermediate. The old/new form folds away
+            // when scratch and normalized output formats match, and reconfigures after rows that packed output.
+            sdpa_maybe_pack_reconfig_data_format<normalized_out_cb, scratch_cb>();
 
             cb_wait_front(col_identity_cb, N);
             cb_wait_front(cur_sum_cb, 1);
@@ -551,11 +598,8 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             MaybeDeviceZoneScopedN(profiling_enabled, "NORM_MUL_BCAST");
             constexpr uint32_t batch = (head_dim_t_ < dst_size) ? head_dim_t_ : dst_size;
             mul_bcast_cols_init_short(cur_out_cb, scratch_cb);
-            // Pack output to normalized_out_cb (may be a different format than scratch_cb,
-            // e.g., Bfp8 output dtype with Float16_b intermediates).
-            if constexpr (!uniform_pack_format) {
-                pack_reconfig_data_format(normalized_out_cb);
-            }
+            // Pack output to normalized_out_cb; old/new skips when it has the same format as scratch.
+            sdpa_maybe_pack_reconfig_data_format<scratch_cb, normalized_out_cb>();
             cb_wait_front(cur_out_cb, head_dim_t_);
             cb_wait_front(scratch_cb, 1);
 
@@ -585,9 +629,7 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
     // with the right format. Without this, when normalized_out_cb has a different
     // format (e.g. Bfp8 output dtype), the format register stays Bfp8 and the next
     // pack to a F16b CB writes garbage that's later mis-decoded by F16b unpacks.
-    if constexpr (!uniform_pack_format) {
-        pack_reconfig_data_format(scratch_cb);
-    }
+    sdpa_maybe_pack_reconfig_data_format<normalized_out_cb, scratch_cb>();
 }
 
 // ===================== Streaming SDPA Core Functions =====================
@@ -612,7 +654,7 @@ static inline void l1_acc_single_tile(uint32_t mask_cb, uint32_t tile_idx, uint3
  * and llk_pack_reconfig_l1_acc(0) after calling.
  */
 template <uint32_t num_cols, bool is_causal_sdpa>
-static SDPA_NOINLINE void apply_lightweight_mask_streaming(
+static void apply_lightweight_mask_streaming(
     uint32_t mask_cb,
     uint32_t out_cb,
     uint32_t q_subblock,
@@ -716,7 +758,6 @@ template <
     bool use_padded_mask,
     bool ring_mode = false,
     bool is_causal_sdpa = false,
-    bool uniform_dataformat = false,
     uint32_t cb_q_in = 0,
     uint32_t cb_kt_in = 0,
     uint32_t cb_v_in = 0,
@@ -757,12 +798,6 @@ static void sdpa_inner_loop_step(
 
     static_assert(!(use_padded_mask && ring_mode), "use_padded_mask and ring_mode are mutually exclusive");
 
-    // When all CBs share the same data format (e.g. all Float16_b for bf16 models),
-    // reconfig calls are no-ops — skip entirely to save code size.
-    // uniform_dataformat is passed as a template parameter from the program factory.
-    constexpr bool uniform_unpack_format = uniform_dataformat;
-    constexpr bool uniform_pack_format = uniform_dataformat;
-
     uint32_t pushed_rows = 0;
     uint32_t q_wait_tiles = q_subblock_num_tiles;
     uint32_t q_index_offset = 0;
@@ -788,12 +823,8 @@ static void sdpa_inner_loop_step(
         cb_wait_front(cb_q_in, q_wait_tiles);
         kt_index_offset = 0;
 
-        if constexpr (!uniform_pack_format) {
-            pack_reconfig_data_format(cb_qkt_im);
-        }
-        if constexpr (!uniform_unpack_format) {
-            reconfig_data_format(cb_kt_in, cb_q_in);
-        }
+        sdpa_maybe_pack_reconfig_data_format<cb_normalized_out, cb_qkt_im>();
+        sdpa_maybe_reconfig_data_format<cb_qkt_im, cb_kt_in, cb_identity_scale_in, cb_q_in>();
         mm_no_mop_init_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
         // Configure pack once before the kt loop for cb_qkt_im. Both sub_exp
         // and blocked_matmul_and_pack skip their internal configure (same cb+width).
@@ -804,9 +835,7 @@ static void sdpa_inner_loop_step(
         for (uint32_t kt_subblock = 0; kt_subblock < kt_num_full_subblocks; ++kt_subblock) {
             if (q_subblock > 0) {
                 uint32_t prev_q_subblock = q_subblock - 1;
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
-                }
+                sdpa_maybe_reconfig_data_format<cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im>();
                 sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
                     cb_qkt_im,
                     cur.max,
@@ -817,12 +846,8 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_h,
                     actual_sbw,
                     /*skip_pack_configure=*/true);
-                if constexpr (!uniform_pack_format) {
-                    pack_reconfig_data_format(cb_qkt_im);
-                }
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in);
-                }
+                sdpa_maybe_pack_reconfig_data_format<cb_recip_scratch, cb_qkt_im>();
+                sdpa_maybe_reconfig_data_format<cb_qkt_im, cb_kt_in, cb_qkt_im, cb_q_in>();
                 mm_no_mop_reinit_short(cb_q_in, cb_kt_in, true, actual_sbw, qkt_subblock_h, in0_block_w);
             }
             {
@@ -847,9 +872,7 @@ static void sdpa_inner_loop_step(
             }
         }
         // Restore float16b for mask/reduce after Q@KT.
-        if constexpr (!uniform_unpack_format) {
-            reconfig_data_format(cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im);
-        }
+        sdpa_maybe_reconfig_data_format<cb_kt_in, cb_qkt_im, cb_q_in, cb_qkt_im>();
 
         // Lightweight mask stamp: L1-accumulate causal and/or padding masks onto cb_qkt_im
         // for this row group. Active for ring, causal non-ring, or non-causal padded with a
@@ -909,14 +932,14 @@ static void sdpa_inner_loop_step(
         q_wait_tiles += q_subblock_num_tiles;
     }
 
-    cb_pop_front(cb_kt_in, DHt * KT_stride);
+    sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * KT_stride);
 
     // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
     // reader can start fetching the next Q chunk during Phase 2.
     // In ring_mode, is_last_iter is always false — skip entirely.
     if constexpr (!ring_mode) {
         if (is_last_iter) {
-            cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+            sdpa_cb_pop_front_out_of_line(cb_q_in, Sq_chunk_t * DHt);
         }
     }
 
@@ -989,9 +1012,8 @@ static void sdpa_inner_loop_step(
                 {
                     MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
                     uint32_t v_index_offset = 0;
-                    if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
-                    }
+                    sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
+                        out_cb, out_cb);
                     // cb_qkt_im rows are laid out at KT_stride even when this kt_sub only consumes a
                     // narrower logical width. Keep unpack init on the physical stride; inner_dim below
                     // still limits how many V rows are multiplied.
@@ -1015,9 +1037,7 @@ static void sdpa_inner_loop_step(
                             /*skip_pack_configure=*/true);
                         v_index_offset += qktv_subblock_w;
                     }
-                    if constexpr (!uniform_unpack_format) {
-                        reconfig_data_format(cb_v_in, out_cb, cb_qkt_im, out_cb);
-                    }
+                    sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
                 }
 
                 if (kt_sub > 0) {
@@ -1043,8 +1063,13 @@ static void sdpa_inner_loop_step(
             MaybeDeviceZoneScopedN(profiling_enabled, "ROW_NORM");
             cb_push_back(cur.sum, sbh);
             cb_push_back(out_cb, sbh * vDHt);
-            normalize_row_streaming<profiling_enabled, vDHt, dst_size, uniform_pack_format>(
-                cur.sum, out_cb, cb_col_identity, cb_recip_scratch, cb_normalized_out, sbh);
+            normalize_row_streaming<
+                profiling_enabled,
+                vDHt,
+                dst_size,
+                cb_col_identity,
+                cb_recip_scratch,
+                cb_normalized_out>(cur.sum, out_cb, sbh);
             pushed++;
         };
 
@@ -1070,8 +1095,8 @@ static void sdpa_inner_loop_step(
                         prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                 }
             }
-            cb_pop_front(cb_exp_max_diff, sbh);
-            cb_pop_front(prev.out, sbh * vDHt);
+            sdpa_cb_pop_front_out_of_line(cb_exp_max_diff, sbh);
+            sdpa_cb_pop_front_out_of_line(prev.out, sbh * vDHt);
             PACK((llk_pack_reconfig_l1_acc(0)));
         };
 
@@ -1109,9 +1134,8 @@ static void sdpa_inner_loop_step(
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
                 uint32_t v_index_offset = 0;
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(out_cb, cb_v_in, out_cb, cb_qkt_im);
-                }
+                sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
+                    out_cb, out_cb);
                 // See the q_subblock-0 V matmul above: active_Sk can be narrower than the physical
                 // cb_qkt_im row stride, but the unpacker is configured for the physical layout.
                 mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, cur_h, KT_stride);
@@ -1134,9 +1158,7 @@ static void sdpa_inner_loop_step(
                         /*skip_pack_configure=*/true);
                     v_index_offset += qktv_subblock_w;
                 }
-                if constexpr (!uniform_unpack_format) {
-                    reconfig_data_format(cb_v_in, out_cb, cb_qkt_im, out_cb);
-                }
+                sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
             }
 
             // SALAD corrections for previous group (always full, h=qktv_h) + row-by-row push
@@ -1232,8 +1254,8 @@ static void sdpa_inner_loop_step(
 
         // All rows pushed individually — no bulk push needed.
 
-        cb_pop_front(cb_v_in, KT_stride * vDHt);
-        cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
+        sdpa_cb_pop_front_out_of_line(cb_v_in, KT_stride * vDHt);
+        sdpa_cb_pop_front_out_of_line(cb_qkt_im, Sq_chunk_t * KT_stride);
     }
 }
 
@@ -1278,7 +1300,6 @@ template <
     uint32_t cb_recip_scratch,
     uint32_t cb_normalized_out,
     uint32_t cb_mask_in,
-    bool uniform_dataformat = false,
     bool is_causal_sdpa = false>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
@@ -1372,7 +1393,6 @@ void sdpa_standard_v2(
                 use_padded_mask,
                 false,  // ring_mode
                 is_causal_sdpa,
-                uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
                 cb_v_in,
@@ -1455,12 +1475,12 @@ void sdpa_standard_v2(
             // Post-iteration cleanup
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
             if (!is_first) {
-                cb_pop_front(prev.max, Sq_chunk_t);
-                cb_pop_front(prev.sum, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(prev.max, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(prev.sum, Sq_chunk_t);
             }
 
             if (is_last) {
-                cb_pop_front(cur.max, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(cur.max, Sq_chunk_t);
             } else {
                 std::swap(prev, cur);
             }
@@ -1534,7 +1554,6 @@ template <
     uint32_t cb_max_out,
     uint32_t cb_prev_out,
     uint32_t cb_out,
-    bool uniform_dataformat = false,
     uint32_t cb_normalized_out = 0,
     uint32_t cb_sum_out = 0,
     uint32_t cb_sum_in = 0,
@@ -1545,7 +1564,11 @@ template <
     bool chunked_enabled = false,
     uint32_t local_padded_Nt = 0,
     uint32_t q_local_padded_Nt = 0,
-    uint32_t chunk_size_t = 0>
+    uint32_t chunk_size_t = 0,
+    bool global_n_mask_enabled = false,
+    bool local_n_mask_enabled = false,
+    bool joint_n_mask_enabled = false,
+    bool straddle_mask_enabled = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1570,7 +1593,6 @@ void sdpa_ring_v2(
     const ChunkedContext& chunked = {},
     const bool is_first_active_iter = true) {
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
-    constexpr bool uniform_format = uniform_dataformat;
     // is_causal: diagonal stamp only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
     const bool is_causal_iter = (is_causal_sdpa && (ring_iter == 0)) || chunked_enabled;
 
@@ -1583,19 +1605,30 @@ void sdpa_ring_v2(
     constexpr uint32_t full_sbw = qkt_subblock_w;
 
     // Pre-compute subblock widths for each mask type (hoisted out of per-chunk loop).
-    const uint32_t global_n_sbw = lw_mask.global_n_padded_tiles
-                                      ? largest_factor_le(Sk_chunk_t - lw_mask.global_n_padded_tiles, qkt_subblock_w)
-                                      : full_sbw;
-    const uint32_t local_n_sbw = lw_mask.local_n_padded_tiles
-                                     ? largest_factor_le(Sk_chunk_t - lw_mask.local_n_padded_tiles, qkt_subblock_w)
-                                     : full_sbw;
-    const uint32_t joint_n_sbw = lw_mask.joint_n_padded_tiles
-                                     ? largest_factor_le(Sk_chunk_t - lw_mask.joint_n_padded_tiles, qkt_subblock_w)
-                                     : full_sbw;
-    const uint32_t straddle_sbw =
-        lw_mask.straddle_num_padded_tiles
-            ? largest_factor_le(Sk_chunk_t - lw_mask.straddle_num_padded_tiles, qkt_subblock_w)
-            : full_sbw;
+    uint32_t global_n_sbw = full_sbw;
+    uint32_t local_n_sbw = full_sbw;
+    uint32_t joint_n_sbw = full_sbw;
+    uint32_t straddle_sbw = full_sbw;
+    if constexpr (global_n_mask_enabled) {
+        global_n_sbw = lw_mask.global_n_padded_tiles
+                           ? largest_factor_le(Sk_chunk_t - lw_mask.global_n_padded_tiles, qkt_subblock_w)
+                           : full_sbw;
+    }
+    if constexpr (local_n_mask_enabled) {
+        local_n_sbw = lw_mask.local_n_padded_tiles
+                          ? largest_factor_le(Sk_chunk_t - lw_mask.local_n_padded_tiles, qkt_subblock_w)
+                          : full_sbw;
+    }
+    if constexpr (joint_n_mask_enabled) {
+        joint_n_sbw = lw_mask.joint_n_padded_tiles
+                          ? largest_factor_le(Sk_chunk_t - lw_mask.joint_n_padded_tiles, qkt_subblock_w)
+                          : full_sbw;
+    }
+    if constexpr (straddle_mask_enabled) {
+        straddle_sbw = lw_mask.straddle_num_padded_tiles
+                           ? largest_factor_le(Sk_chunk_t - lw_mask.straddle_num_padded_tiles, qkt_subblock_w)
+                           : full_sbw;
+    }
 
     uint32_t KV_chunks_processed_in_iter = 0;
 
@@ -1620,12 +1653,17 @@ void sdpa_ring_v2(
                     q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
                 }
                 constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
-                normalize_row_streaming<false, vDHt, norm_dst_size, uniform_format>(
-                    q_prev_norm.sum, q_prev_norm.out, cb_col_identity, cb_recip_scratch, cb_normalized_out, Sq_chunk_t);
-                cb_pop_front(q_prev_norm.max, Sq_chunk_t);
+                normalize_row_streaming<
+                    false,
+                    vDHt,
+                    norm_dst_size,
+                    cb_col_identity,
+                    cb_recip_scratch,
+                    cb_normalized_out>(q_prev_norm.sum, q_prev_norm.out, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(q_prev_norm.max, Sq_chunk_t);
                 if (q_per_core > 1) {
                     cb_reserve_back(cb_signal, 1);
-                    cb_push_back(cb_signal, 1);
+                    sdpa_cb_push_back_out_of_line(cb_signal, 1);
                 }
                 return true;
             }
@@ -1651,9 +1689,9 @@ void sdpa_ring_v2(
         if constexpr (is_causal_sdpa) {
             if (is_causal_iter && k_chunk >= causal_k_limit) {
                 cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
-                cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+                sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
                 cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
-                cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+                sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * vDHt);
                 KV_chunks_processed_in_iter++;
                 return true;
             }
@@ -1743,30 +1781,55 @@ void sdpa_ring_v2(
             // Signal writer that last K-chunk is starting (for row-by-row DMA save/restore).
             if (is_last_k && q_per_core > 1) {
                 cb_reserve_back(cb_signal, 1);
-                cb_push_back(cb_signal, 1);
+                sdpa_cb_push_back_out_of_line(cb_signal, 1);
             }
 
             // Determine if this K chunk needs masking (partial tile within a tile boundary)
-            const bool is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
-            const bool is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
-            const bool is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
-                                               (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
+            bool is_global_n_mask_chunk = false;
+            bool is_local_n_mask_chunk = false;
+            bool is_joint_n_mask_chunk = false;
+            if constexpr (global_n_mask_enabled) {
+                is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
+            }
+            if constexpr (local_n_mask_enabled) {
+                is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
+            }
+            if constexpr (joint_n_mask_enabled) {
+                is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
+                                        (k_chunk - num_local_k_chunks) == joint_n_mask_chunk_id;
+            }
             // Straddle chunk (rix > rid balanced-causal with k_chunk_size ∤ coarse_chunk_size):
             // only the early-half columns attend; late-half columns must be dropped. Narrow
             // active_Sk like local_n; no partial-tile stamp needed for tile-aligned straddle.
-            const bool is_straddle_mask_chunk =
-                lw_mask.straddle_num_padded_tiles > 0 && k_chunk == lw_mask.straddle_mask_chunk_id;
+            bool is_straddle_mask_chunk = false;
+            if constexpr (straddle_mask_enabled) {
+                is_straddle_mask_chunk =
+                    lw_mask.straddle_num_padded_tiles > 0 && k_chunk == lw_mask.straddle_mask_chunk_id;
+            }
 
-            bool apply_mask = is_global_n_mask_chunk || is_joint_n_mask_chunk;
+            bool apply_mask = false;
+            if constexpr (global_n_mask_enabled) {
+                apply_mask = apply_mask || is_global_n_mask_chunk;
+            }
+            if constexpr (joint_n_mask_enabled) {
+                apply_mask = apply_mask || is_joint_n_mask_chunk;
+            }
 
             // Resolve lightweight mask params for partial tile masking
             uint32_t lw_partial_tile_idx = 0;
             if constexpr (lightweight_mask_enabled) {
                 if (apply_mask) {
-                    if (is_global_n_mask_chunk) {
-                        lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
-                    } else if (is_joint_n_mask_chunk) {
-                        lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+                    bool partial_tile_selected = false;
+                    if constexpr (global_n_mask_enabled) {
+                        if (is_global_n_mask_chunk) {
+                            lw_partial_tile_idx = lw_mask.global_n_partial_tile_idx;
+                            partial_tile_selected = true;
+                        }
+                    }
+                    if constexpr (joint_n_mask_enabled) {
+                        if (!partial_tile_selected && is_joint_n_mask_chunk) {
+                            lw_partial_tile_idx = lw_mask.joint_l_partial_tile_idx;
+                        }
                     }
                 }
             }
@@ -1776,18 +1839,33 @@ void sdpa_ring_v2(
             // Also select pre-computed subblock width for this chunk's mask type.
             uint32_t active_Sk_param = Sk_chunk_t;
             uint32_t chunk_sbw = full_sbw;
-            if (is_global_n_mask_chunk) {
-                active_Sk_param = Sk_chunk_t - lw_mask.global_n_padded_tiles;
-                chunk_sbw = global_n_sbw;
-            } else if (is_local_n_mask_chunk) {
-                active_Sk_param = Sk_chunk_t - lw_mask.local_n_padded_tiles;
-                chunk_sbw = local_n_sbw;
-            } else if (is_joint_n_mask_chunk) {
-                active_Sk_param = Sk_chunk_t - lw_mask.joint_n_padded_tiles;
-                chunk_sbw = joint_n_sbw;
-            } else if (is_straddle_mask_chunk) {
-                active_Sk_param = Sk_chunk_t - lw_mask.straddle_num_padded_tiles;
-                chunk_sbw = straddle_sbw;
+            bool narrowed_by_mask = false;
+            if constexpr (global_n_mask_enabled) {
+                if (is_global_n_mask_chunk) {
+                    active_Sk_param = Sk_chunk_t - lw_mask.global_n_padded_tiles;
+                    chunk_sbw = global_n_sbw;
+                    narrowed_by_mask = true;
+                }
+            }
+            if constexpr (local_n_mask_enabled) {
+                if (!narrowed_by_mask && is_local_n_mask_chunk) {
+                    active_Sk_param = Sk_chunk_t - lw_mask.local_n_padded_tiles;
+                    chunk_sbw = local_n_sbw;
+                    narrowed_by_mask = true;
+                }
+            }
+            if constexpr (joint_n_mask_enabled) {
+                if (!narrowed_by_mask && is_joint_n_mask_chunk) {
+                    active_Sk_param = Sk_chunk_t - lw_mask.joint_n_padded_tiles;
+                    chunk_sbw = joint_n_sbw;
+                    narrowed_by_mask = true;
+                }
+            }
+            if constexpr (straddle_mask_enabled) {
+                if (!narrowed_by_mask && is_straddle_mask_chunk) {
+                    active_Sk_param = Sk_chunk_t - lw_mask.straddle_num_padded_tiles;
+                    chunk_sbw = straddle_sbw;
+                }
             }
 
             // Causal narrowing on the diagonal-crossing K-chunk: cols past the last Q-row's
@@ -1861,7 +1939,6 @@ void sdpa_ring_v2(
                 false,  // use_padded_mask — ring uses ring mask instead
                 true,   // ring_mode
                 is_causal_sdpa || chunked_enabled,
-                uniform_dataformat,
                 cb_q_in,
                 cb_kt_in,
                 cb_v_in,
@@ -1894,13 +1971,13 @@ void sdpa_ring_v2(
             // Post-iteration cleanup: pop previous values and swap aliases
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
             if (!is_first) {
-                cb_pop_front(q_prev.max, Sq_chunk_t);
-                cb_pop_front(q_prev.sum, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(q_prev.max, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(q_prev.sum, Sq_chunk_t);
             }
 
             if (is_last_k_of_last_ring_iter) {
                 // Normalization consumed cur.sum and cur.out; pop cur.max.
-                cb_pop_front(q_cur.max, Sq_chunk_t);
+                sdpa_cb_pop_front_out_of_line(q_cur.max, Sq_chunk_t);
             } else {
                 std::swap(q_prev, q_cur);
                 // After K0's swap, q_cur holds staging buffers. Reset to original accumulator CBs.
@@ -1914,7 +1991,7 @@ void sdpa_ring_v2(
         // When q_per_core == 1, Q is identical across ring iterations so we keep it
         // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
         if (q_per_core > 1 || is_last_ring_iter) {
-            cb_pop_front(cb_q_in, Sq_chunk_t * DHt);
+            sdpa_cb_pop_front_out_of_line(cb_q_in, Sq_chunk_t * DHt);
         }
 
         // Persist or save accumulators for next ring iteration
@@ -1930,7 +2007,7 @@ void sdpa_ring_v2(
             // Pop the accumulator CB for max — dual-write doesn't replace the alias,
             // so the accumulator CB still has tiles from the last K-chunk's reduce.
             // (Sum doesn't need this because planting replaced the alias entirely.)
-            cb_pop_front(q_prev.max, Sq_chunk_t);
+            sdpa_cb_pop_front_out_of_line(q_prev.max, Sq_chunk_t);
         }
         // On last ring_iter: normalized output already in cb_out from normalize_row_streaming
     }
@@ -1938,10 +2015,8 @@ void sdpa_ring_v2(
     // Dummy KV pop for double-buffer alignment (same as sdpa_inner_loop for RING)
     if (KV_chunks_processed_in_iter % 2 == 0) {
         cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
-        cb_pop_front(cb_kt_in, DHt * Sk_chunk_t);
+        sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
         cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
-        cb_pop_front(cb_v_in, Sk_chunk_t * vDHt);
+        sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * vDHt);
     }
 }
-
-#undef SDPA_NOINLINE

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -45,7 +45,6 @@ void kernel_main() {
     constexpr bool use_streaming_compute = get_compile_time_arg_val(26) == 1;
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(27);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(28);
-    constexpr bool uniform_dataformat = get_compile_time_arg_val(29) == 1;
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
@@ -207,7 +206,6 @@ void kernel_main() {
                 cb_max_out,
                 cb_prev_out,
                 cb_out,
-                uniform_dataformat,
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
                 cb_sum_in,
@@ -216,7 +214,13 @@ void kernel_main() {
                 false,  // is_causal_sdpa
                 false,  // is_balanced_sdpa
                 false,  // chunked_enabled
-                local_padded_Nt>(
+                local_padded_Nt,
+                local_padded_Nt,  // q_local_padded_Nt
+                0,                // chunk_size_t
+                global_n_has_padding,
+                local_n_has_padding,
+                joint_has_padding,
+                false>(  // straddle_mask_enabled
                 global_q_start,
                 global_q_end,
                 num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -51,12 +51,11 @@ void kernel_main() {
     constexpr bool use_streaming_compute = get_compile_time_arg_val(33) == 1;
     constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(34);
     constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(35);
-    constexpr bool uniform_dataformat = get_compile_time_arg_val(36) == 1;
-    constexpr bool is_causal = get_compile_time_arg_val(37) == 1;
-    constexpr bool is_balanced = get_compile_time_arg_val(38) == 1;
-    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(39) == 1;
-    constexpr bool chunked_enabled = get_compile_time_arg_val(40) == 1;
-    constexpr uint32_t chunk_size_t = get_compile_time_arg_val(41);
+    constexpr bool is_causal = get_compile_time_arg_val(36) == 1;
+    constexpr bool is_balanced = get_compile_time_arg_val(37) == 1;
+    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(38) == 1;
+    constexpr bool chunked_enabled = get_compile_time_arg_val(39) == 1;
+    constexpr uint32_t chunk_size_t = get_compile_time_arg_val(40);
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. kernel_is_causal is masked off by the program factory when chunked is on, so only
     // one of the two paths drives the stamp per program — but they share the CB slot layout.
@@ -94,7 +93,7 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 42;
+    constexpr uint32_t cb_arg_offset = 41;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -264,7 +263,6 @@ void kernel_main() {
                 cb_max_out,
                 cb_prev_out,
                 cb_out,
-                uniform_dataformat,
                 cb_out,  // cb_normalized_out — output goes directly to cb_out
                 cb_sum_out,
                 cb_sum_in,
@@ -275,7 +273,11 @@ void kernel_main() {
                 chunked_enabled,
                 kv_local_padded_Nt,
                 q_local_padded_Nt,
-                chunk_size_t>(
+                chunk_size_t,
+                global_n_has_padding,
+                local_n_has_padding,
+                joint_has_padding,
+                has_straddle && is_causal && is_balanced>(
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -47,10 +47,9 @@ void kernel_main() {
     constexpr bool use_attention_sink = get_compile_time_arg_val(29) == 1;
     constexpr bool use_streaming_compute = get_compile_time_arg_val(30) == 1;
     constexpr uint32_t valid_Skt = get_compile_time_arg_val(31);
-    constexpr bool uniform_dataformat = get_compile_time_arg_val(32) == 1;
-    constexpr uint32_t k_partial_col = get_compile_time_arg_val(33);
+    constexpr uint32_t k_partial_col = get_compile_time_arg_val(32);
     // Zigzag remap flag drives the external remap_q_index call on the flat B*NQH*q_num_chunks range.
-    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(34) == 1;
+    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(33) == 1;
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t num_phases = get_arg_val<uint32_t>(1);
@@ -71,7 +70,7 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 35;
+    constexpr uint32_t cb_arg_offset = 34;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -159,7 +158,6 @@ void kernel_main() {
             cb_recip_scratch,
             cb_out,  // normalized output goes directly to output CB
             cb_mask_in,
-            uniform_dataformat,
             is_causal>(
             global_q_count,
             k_num_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -96,6 +96,23 @@ public:
     uint32_t id_of(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3) const {
         return i0 * strides[0] + i1 * strides[1] + i2 * strides[2] + i3 * strides[3];
     }
+
+    uint32_t d2() const { return shape[2]; }
+    uint32_t stride2() const { return strides[2]; }
+};
+
+template <uint32_t D0, uint32_t D1, uint32_t D2, uint32_t D3>
+class StaticTensorTileShape {
+public:
+    constexpr StaticTensorTileShape() = default;
+    constexpr StaticTensorTileShape(uint32_t, uint32_t, uint32_t, uint32_t) {}
+
+    uint32_t id_of(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3) const {
+        return i0 * D1 * D2 * D3 + i1 * D2 * D3 + i2 * D3 + i3;
+    }
+
+    static constexpr uint32_t d2() { return D2; }
+    static constexpr uint32_t stride2() { return D3; }
 };
 
 template <uint32_t tile_bytes, typename ReaderType, bool push_num_tiles = true>
@@ -1137,12 +1154,12 @@ struct CatAddrGenerator {
     }
 };
 
-template <typename ReaderType>
+template <typename ReaderType, typename TensorShapeType = TensorTileShape>
 struct PaddedAddrGenerator {
     ReaderType reader;
-    TensorTileShape tensor_shape;
+    TensorShapeType tensor_shape;
 
-    PaddedAddrGenerator(const ReaderType& reader, TensorTileShape tensor_shape) :
+    PaddedAddrGenerator(const ReaderType& reader, TensorShapeType tensor_shape) :
         reader(reader), tensor_shape(tensor_shape) {}
 
     // Issue async NoC reads for a slice to L1. No barrier — caller must
@@ -1158,7 +1175,7 @@ struct PaddedAddrGenerator {
         const uint32_t d2_start = slice.d2_start;
         const uint32_t rows = slice.get_d2_size();
         const uint32_t cols = slice.get_d3_size();
-        const uint32_t shape_d2 = tensor_shape.shape[2];
+        const uint32_t shape_d2 = tensor_shape.d2();
         const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
         const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
         uint32_t barrier_count = 0;
@@ -1167,7 +1184,7 @@ struct PaddedAddrGenerator {
         issue_block_reads(
             reader,
             tensor_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
-            tensor_shape.strides[2],
+            tensor_shape.stride2(),
             valid_rows,
             cols,
             /*dst_row_origin=*/0,
@@ -1198,7 +1215,7 @@ struct PaddedAddrGenerator {
         const uint32_t d2_start = slice.d2_start;
         const uint32_t rows = slice.get_d2_size();
         const uint32_t cols = slice.get_d3_size();
-        const uint32_t shape_d2 = tensor_shape.shape[2];
+        const uint32_t shape_d2 = tensor_shape.d2();
         const uint32_t bound = shape_d2 < end_seq_tile ? shape_d2 : end_seq_tile;
         const uint32_t valid_rows = (d2_start >= bound) ? 0 : std::min(rows, bound - d2_start);
 
@@ -1206,7 +1223,7 @@ struct PaddedAddrGenerator {
         issue_block_writes(
             reader,
             tensor_shape.id_of(slice.d0, slice.d1, d2_start, slice.d3_start),
-            tensor_shape.strides[2],
+            tensor_shape.stride2(),
             valid_rows,
             cols,
             /*src_row_origin=*/0,
@@ -1214,7 +1231,24 @@ struct PaddedAddrGenerator {
             outer_stride,
             inner_stride);
     }
+
+    void issue_writes_no_padding(
+        const Slice& slice, uint32_t src_addr, uint32_t outer_stride, uint32_t inner_stride) const {
+        issue_block_writes(
+            reader,
+            tensor_shape.id_of(slice.d0, slice.d1, slice.d2_start, slice.d3_start),
+            tensor_shape.stride2(),
+            slice.get_d2_size(),
+            slice.get_d3_size(),
+            /*src_row_origin=*/0,
+            src_addr,
+            outer_stride,
+            inner_stride);
+    }
 };
+
+template <typename ReaderType, typename TensorShapeType>
+PaddedAddrGenerator(const ReaderType&, TensorShapeType) -> PaddedAddrGenerator<ReaderType, TensorShapeType>;
 
 // Fetch tiles via NOC reads into a given L1 address. No CB lifecycle — caller manages
 // cb_reserve_back / cb_push_back. Used by forwarding paths that mcast before pushing.
@@ -1374,7 +1408,7 @@ void write_block_row_grouped(
 // with via noc_async_write_set_trid (0 = default); per-group flush uses
 // noc_async_write_flushed_with_trid(flush_trid) so it waits exactly for THIS drain's writes
 // to be source-L1-acked. Caller handles any final DRAM-arrival NoC barrier.
-template <typename CatAddrGeneratorType>
+template <bool all_rows_valid = false, typename CatAddrGeneratorType>
 void write_block_row_grouped_trid(
     const CatAddrGeneratorType& cat_addr_generator,
     const Slice& dst_slice,
@@ -1402,7 +1436,11 @@ void write_block_row_grouped_trid(
             dst_slice.d2_start + rg * sbh + rows_this_group,
             dst_slice.d3_start,
             dst_slice.d3_end);
-        cat_addr_generator.issue_writes(group_slice, end_seq_tile, get_read_ptr(cb_out), outer_stride, tile_bytes);
+        if constexpr (all_rows_valid) {
+            cat_addr_generator.issue_writes_no_padding(group_slice, get_read_ptr(cb_out), outer_stride, tile_bytes);
+        } else {
+            cat_addr_generator.issue_writes(group_slice, end_seq_tile, get_read_ptr(cb_out), outer_stride, tile_bytes);
+        }
         noc_async_write_flushed_with_trid(flush_trid);
         cb_pop_front(cb_out, tiles_this_group);
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <type_traits>
+
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -26,11 +28,11 @@
 // @param cb_lse_in           CB to push previous LSE tiles into (read by compute)
 // @param tile_bytes          Output tile size in bytes
 // @param stats_tile_bytes    Stats tile size in bytes
-template <typename ReaderType, typename TensorAccessorType>
+template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void read_prev_output_and_lse(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
-    const TensorTileShape& stats_tile_logical,
+    const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
@@ -56,15 +58,57 @@ void read_prev_output_and_lse(
     cb_push_back(cb_lse_in, Sq_chunk_t);
 }
 
+template <typename TensorAccessorType, typename StatsShapeType>
+static __attribute__((noinline, noclone)) void issue_stats_column_reads(
+    const TensorAccessorType& stats_writer,
+    const StatsShapeType& stats_tile_logical,
+    const uint32_t nb,
+    const uint32_t nq,
+    const uint32_t row_start,
+    const uint32_t num_rows,
+    const uint32_t cb_id,
+    const uint32_t reserve_tiles,
+    const uint32_t stats_tile_bytes) {
+    cb_reserve_back(cb_id, reserve_tiles);
+    uint32_t tile_id = stats_tile_logical.id_of(nb, nq, row_start, 0);
+    const uint32_t row_stride = stats_tile_logical.stride2();
+    uint32_t addr = get_write_ptr(cb_id);
+    for (uint32_t r = 0; r < num_rows; ++r) {
+        noc_async_read_page(tile_id, stats_writer, addr);
+        tile_id += row_stride;
+        addr += stats_tile_bytes;
+    }
+}
+
+template <typename TensorAccessorType, typename StatsShapeType>
+static __attribute__((noinline, noclone)) void issue_stats_column_writes(
+    const TensorAccessorType& stats_writer,
+    const StatsShapeType& stats_tile_logical,
+    const uint32_t nb,
+    const uint32_t nq,
+    const uint32_t row_start,
+    const uint32_t num_rows,
+    const uint32_t cb_id,
+    const uint32_t stats_tile_bytes) {
+    uint32_t tile_id = stats_tile_logical.id_of(nb, nq, row_start, 0);
+    const uint32_t row_stride = stats_tile_logical.stride2();
+    uint32_t addr = get_read_ptr(cb_id);
+    for (uint32_t r = 0; r < num_rows; ++r) {
+        noc_async_write_page(tile_id, stats_writer, addr);
+        tile_id += row_stride;
+        addr += stats_tile_bytes;
+    }
+}
+
 // Non-blocking restore: reserves CB space and issues NOC reads for all 3 accumulators.
 // Call complete_restore() later to barrier and push.
 // Split from blocking read_prev_accumulators to enable prefetch: issue reads for Q[q+1]
 // while Q[q]'s K-loop runs, hiding DRAM read latency behind compute.
-template <typename ReaderType, typename TensorAccessorType>
+template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void issue_restore_reads(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
-    const TensorTileShape& stats_tile_logical,
+    const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
@@ -88,7 +132,7 @@ void issue_restore_reads(
     issue_block_reads(
         cat_out_generator.reader,
         cat_out_generator.tensor_shape.id_of(out_slice.d0, out_slice.d1, out_slice.d2_start, out_slice.d3_start),
-        cat_out_generator.tensor_shape.strides[2],
+        cat_out_generator.tensor_shape.stride2(),
         out_rows,
         out_cols,
         /*dst_row_origin=*/0,
@@ -101,27 +145,27 @@ void issue_restore_reads(
     // Stats drains: single-column linear reads. Hoist id_of once per drain; advance by
     // strides[2] per row. All tiles assumed valid (no bounds clamp needed).
     const uint32_t stats_rows = stats_seq_end_tile - stats_seq_start_tile;
-    const uint32_t stats_row_stride = stats_tile_logical.strides[2];
 
-    // Issue max reads
-    cb_reserve_back(cb_max_in, Sq_chunk_t);
-    uint32_t max_tile_id = stats_tile_logical.id_of(nb, nq, stats_seq_start_tile, 0);
-    uint32_t max_addr = get_write_ptr(cb_max_in);
-    for (uint32_t r = 0; r < stats_rows; ++r) {
-        noc_async_read_page(max_tile_id, stats_writer, max_addr);
-        max_tile_id += stats_row_stride;
-        max_addr += stats_tile_bytes;
-    }
-
-    // Issue sum reads
-    cb_reserve_back(cb_sum_in, Sq_chunk_t);
-    uint32_t sum_tile_id = stats_tile_logical.id_of(nb, nq, sum_offset + stats_seq_start_tile, 0);
-    uint32_t sum_addr = get_write_ptr(cb_sum_in);
-    for (uint32_t r = 0; r < stats_rows; ++r) {
-        noc_async_read_page(sum_tile_id, stats_writer, sum_addr);
-        sum_tile_id += stats_row_stride;
-        sum_addr += stats_tile_bytes;
-    }
+    issue_stats_column_reads(
+        stats_writer,
+        stats_tile_logical,
+        nb,
+        nq,
+        stats_seq_start_tile,
+        stats_rows,
+        cb_max_in,
+        Sq_chunk_t,
+        stats_tile_bytes);
+    issue_stats_column_reads(
+        stats_writer,
+        stats_tile_logical,
+        nb,
+        nq,
+        sum_offset + stats_seq_start_tile,
+        stats_rows,
+        cb_sum_in,
+        Sq_chunk_t,
+        stats_tile_bytes);
     // NO barrier, NO push — caller must call complete_restore()
 }
 
@@ -151,11 +195,15 @@ constexpr uint32_t TRID_LAST = 3;
 
 // Save all 3 accumulators (out, max, sum) to DRAM, tagged with a TRID for prefetch barriers.
 // Output is drained row-by-row (overlapping with compute's SALAD pushes); max/sum are bulk-drained.
-template <typename ReaderType, typename TensorAccessorType>
+template <
+    bool all_output_rows_valid = false,
+    typename CatAddrGeneratorType,
+    typename TensorAccessorType,
+    typename StatsShapeType>
 void save_accumulators_with_trid(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
-    const TensorTileShape& stats_tile_logical,
+    const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
@@ -173,23 +221,25 @@ void save_accumulators_with_trid(
     const uint32_t save_trid) {
     noc_async_write_set_trid(save_trid);
 
-    write_block_row_grouped_trid(cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
+    write_block_row_grouped_trid<all_output_rows_valid>(
+        cat_out_generator, out_slice, end_seq_tile, cb_out, tile_bytes, sbh, save_trid);
 
     // Bulk drain of max/sum
     cb_wait_front(cb_max_out, Sq_chunk_t);
     cb_wait_front(cb_sum_out, Sq_chunk_t);
 
-    uint32_t max_write_addr = get_read_ptr(cb_max_out);
-    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_page(stats_tile_logical.id_of(nb, nq, i, 0), stats_writer, max_write_addr);
-        max_write_addr += stats_tile_bytes;
-    }
-
-    uint32_t sum_write_addr = get_read_ptr(cb_sum_out);
-    for (uint32_t i = stats_seq_start_tile; i < stats_seq_end_tile; i++) {
-        noc_async_write_page(stats_tile_logical.id_of(nb, nq, sum_offset + i, 0), stats_writer, sum_write_addr);
-        sum_write_addr += stats_tile_bytes;
-    }
+    const uint32_t stats_rows = stats_seq_end_tile - stats_seq_start_tile;
+    issue_stats_column_writes(
+        stats_writer, stats_tile_logical, nb, nq, stats_seq_start_tile, stats_rows, cb_max_out, stats_tile_bytes);
+    issue_stats_column_writes(
+        stats_writer,
+        stats_tile_logical,
+        nb,
+        nq,
+        sum_offset + stats_seq_start_tile,
+        stats_rows,
+        cb_sum_out,
+        stats_tile_bytes);
 
     noc_async_write_flushed_with_trid(save_trid);
     // Reset TRID to 0 to avoid leaking it to unrelated writes (e.g. write_block_row_grouped_trid on last ring iter).
@@ -219,11 +269,11 @@ void save_accumulators_with_trid(
 // @param cb_lse_out          CB to drain LSE tiles from
 // @param tile_bytes          Output tile size in bytes
 // @param stats_tile_bytes    Stats tile size in bytes
-template <typename ReaderType, typename TensorAccessorType>
+template <typename CatAddrGeneratorType, typename TensorAccessorType, typename StatsShapeType>
 void write_output_and_lse(
-    const PaddedAddrGenerator<ReaderType>& cat_out_generator,
+    const CatAddrGeneratorType& cat_out_generator,
     const TensorAccessorType& stats_writer,
-    const TensorTileShape& stats_tile_logical,
+    const StatsShapeType& stats_tile_logical,
     const uint32_t nb,
     const uint32_t nq,
     const uint32_t Sq_chunk_t,
@@ -382,11 +432,15 @@ void kernel_main() {
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);
     const auto stats_writer = TensorAccessor(stats_args, stats_addr);
 
-    const auto output_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, vDHt);
+    constexpr bool output_has_no_padding = !has_joint_q && (q_local_padded_Nt % Sq_chunk_t == 0);
+    using StaticOutputTileShape = StaticTensorTileShape<B, NH, q_local_padded_Nt, vDHt>;
+    using OutputTileShape = std::conditional_t<output_has_no_padding, StaticOutputTileShape, TensorTileShape>;
+
+    const auto output_tile_logical = OutputTileShape(B, NH, q_local_padded_Nt, vDHt);
     const auto joint_tile_logical = TensorTileShape(B, NH, Lt, vDHt);
     // stats tensor is 2× the sequence length: first half stores max (used by both eager and
     // deferred-norm paths), second half stores sum (deferred-norm only).
-    const auto stats_tile_logical = TensorTileShape(B, NH, (q_local_padded_Nt + Lt) * 2, 1);
+    const auto stats_tile_logical = StaticTensorTileShape<B, NH, (q_local_padded_Nt + Lt) * 2, 1>();
 
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
@@ -588,7 +642,7 @@ void kernel_main() {
                     }
                     return out_generator;
                 }();
-                save_accumulators_with_trid(
+                save_accumulators_with_trid<output_has_no_padding>(
                     gen,
                     stats_writer,
                     stats_tile_logical,
@@ -697,9 +751,8 @@ void kernel_main() {
                         }
                         return out_generator;
                     }();
-                    write_block_row_grouped_trid(
+                    write_block_row_grouped_trid<output_has_no_padding>(
                         gen, qi.out_slice, end_seq_tile, cb_out, tile_bytes, out_subblock_h, /*flush_trid=*/0);
-                    noc_async_write_barrier();
                 } else if (!single_q_chunk) {
                     deferred.pending = true;
                     deferred.trid = trid_for_q(q_index);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -358,11 +358,10 @@ ProgramDescriptor RingDistributedSdpaDeviceOperation::RingDistributedSdpaProgram
         scale_packed,
         0,          //(uint32_t)sliding_window_size,
         0,          //(std::uint32_t)use_attention_sink,
-        0,          //(std::uint32_t)use_streaming_compute — always false for ring distributed (causal)
+        0,          //(std::uint32_t)use_streaming_compute - always false for ring distributed (causal)
         valid_Skt,  // arg 31: unpadded K tiles for streaming padded_k_tiles
-        0,          // arg 32: uniform_dataformat — unused when streaming is off
-        0,          // arg 33: k_partial_col — non-streaming, no partial mask emitted
-        static_cast<uint32_t>(use_zigzag_balancing),  // arg 34
+        0u,         // arg 32: k_partial_col - unused on ring's non-streaming path
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 33: unified zigzag remap
     };
     std::map<std::string, std::string> defines_map;
     defines_map["STATS_GRANULARITY"] = std::to_string(stats_granularity);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -375,13 +375,8 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     const uint32_t out_in0_block_w = Sk_chunk_t;
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
-    // Streaming compute v2: eliminates row buffers via cb_push_back_hold_wr_ptr.
-    // Streaming v2 requires q_num_subblocks > 1 (Sq_chunk_t > subblock_h) because the Phase 2
-    // pipeline assumes at least one q_subblock iteration for correct softmax drain + SALAD overlap.
-    // The `Sk_chunk_t % qk_out_subblock_w == 0` clause is tautological — the selector already
-    // guarantees it — but kept explicit for clarity of the subblock-tiling requirement.
-    const bool use_streaming_compute =
-        !fp32_dest_acc_en && qk_out_subblock_h <= 2 && Sk_chunk_t % qk_out_subblock_w == 0 && qk_in0_num_subblocks > 1;
+    // Ring-joint streaming supports single-Q-subblock shapes; only fp32 dest acc stays on the legacy path.
+    const bool use_streaming_compute = !fp32_dest_acc_en;
     log_debug(
         tt::LogOp,
         "use_streaming_compute: {} (is_causal={}, Sq_chunk_t={}, Sk_chunk_t={}, sbh={}, sbw={})",
@@ -601,11 +596,11 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         args.all_gather_operation_attributes.ring_size,
         global_n_partial_col,
         joint_l_partial_col,
-        (std::uint32_t)use_streaming_compute,
+        static_cast<std::uint32_t>(use_streaming_compute),
         kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        (std::uint32_t)out_out_subblock_h,
+        static_cast<std::uint32_t>(out_out_subblock_h),
         static_cast<uint32_t>(tensor_args.is_chunked()),
         chunk_size_t,
     };
@@ -613,17 +608,6 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
-
-    // Early format check: when all data formats are identical, reconfig calls can be skipped.
-    const tt::DataFormat q_df_early = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_q.dtype());
-    const tt::DataFormat k_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_k.dtype());
-    const tt::DataFormat v_df_early = tt::tt_metal::datatype_to_dataformat_converter(gathered_input_tensor_v.dtype());
-    const tt::DataFormat out_df_early = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
-    const tt::DataFormat im_df_early = tt::DataFormat::Float16_b;
-    const tt::DataFormat mask_df_early = tt::DataFormat::Float16_b;
-    const bool uniform_dataformat =
-        (q_df_early == k_df_early && q_df_early == v_df_early && q_df_early == out_df_early &&
-         q_df_early == mask_df_early && q_df_early == im_df_early);
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,
@@ -659,10 +643,9 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         out_in1_num_subblocks,
         out_num_blocks,
         scale_packed,
-        (std::uint32_t)use_streaming_compute,
+        static_cast<std::uint32_t>(use_streaming_compute),
         global_n_partial_col,
         joint_l_partial_col,
-        (std::uint32_t)uniform_dataformat,
         kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -88,23 +88,6 @@ bool can_use_streaming_compute(
     return true;
 }
 
-// Check whether all data formats used by the compute kernel are uniform (allows skipping reconfigs).
-bool check_uniform_dataformat(
-    const Tensor& q,
-    const Tensor& k,
-    const Tensor& v,
-    const Tensor& out,
-    const std::optional<Tensor>& attn_mask,
-    bool use_streaming_compute) {
-    const tt::DataFormat q_df = tt::tt_metal::datatype_to_dataformat_converter(q.dtype());
-    const tt::DataFormat k_df = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
-    const tt::DataFormat v_df = tt::tt_metal::datatype_to_dataformat_converter(v.dtype());
-    const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(out.dtype());
-    const tt::DataFormat mask_df = select_mask_dataformat(attn_mask, use_streaming_compute);
-    const tt::DataFormat im_df = tt::DataFormat::Float16_b;
-    return (q_df == k_df && q_df == v_df && q_df == out_df && q_df == mask_df && q_df == im_df);
-}
-
 // Compute the largest granularity that evenly divides both DHt and vDHt (up to dst_size).
 uint32_t compute_dht_granularity(uint32_t DHt, uint32_t vDHt, uint32_t dst_size) {
     uint32_t g = std::min({DHt, vDHt, dst_size});
@@ -575,9 +558,6 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
-    const bool uniform_dataformat = check_uniform_dataformat(
-        input_tensor_q, input_tensor_k, input_tensor_v, output_tensor, attn_mask, use_streaming_compute);
-
     std::vector<uint32_t> compute_compile_time_args = {
         // matmul args
         B,
@@ -609,12 +589,11 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         static_cast<uint32_t>(is_chunked),
         scale_packed,
         sliding_window_size.value_or(0),
-        static_cast<uint32_t>(use_attention_sink),
-        static_cast<uint32_t>(use_streaming_compute),  // arg 30
-        valid_Skt,                                     // arg 31: unpadded K tile count for streaming padded_k_tiles
-        static_cast<uint32_t>(uniform_dataformat),     // arg 32: skip reconfig when all formats match
-        k_partial_col,                                 // arg 33: K partial-tile col (0 = no partial)
-        static_cast<uint32_t>(use_zigzag_balancing),   // arg 34
+        static_cast<std::uint32_t>(use_attention_sink),
+        static_cast<std::uint32_t>(use_streaming_compute),  // arg 30
+        valid_Skt,                                    // arg 31: unpadded K tile count for streaming padded_k_tiles
+        k_partial_col,                                // arg 32: K partial-tile col (0 = no partial)
+        static_cast<uint32_t>(use_zigzag_balancing),  // arg 33: unified zigzag remap
     };
 
     std::map<std::string, std::string> defines_map;


### PR DESCRIPTION
This is a code-size-focused change for SDPA, ring-joint SDPA, and exp ring-joint SDPA kernels. It consolidates shared pack/data-format handling and removes duplicated compile-time plumbing while keeping the CB arg layout aligned with the streaming CB setup.

It also restores the intended ring-joint streaming eligibility for all non-fp32-dest cases. The previous qk_subblock_h/q_num_subblocks gate was stale after the streaming kernel learned to handle single-Q-subblock shapes, and it left WAN q224/k128 variants on the legacy ring path.

Measured code-size impact on 8-device Blackhole single_ring_8x1:

- Full comparison sweep in docs/sdpa_main_comparison.md before the final gate fix had no measured regressions across ring-joint and exp ring-joint cases.

- Full-sweep averages before the final gate fix: WAN 1x -6,315 bytes, WAN 4x -6,690 bytes, Videogen -10,351 bytes, MLA -10,103 bytes, exp ring variants -10,124 bytes each.

- The formerly worst WAN case, wan2_2_1xGLX-q224-k128, is now forced onto streaming compute and drops from 62,304 bytes on origin/main to 46,492 bytes on this branch, a -15,812 byte delta.

- Relative to the branch before relaxing the stale streaming gate, wan2_2_1xGLX-q224-k128 drops from 62,252 to 46,492 bytes (-15,760 bytes).

- The q224/k128 margin to the 69,000-byte core budget is now 22,508 bytes.

Validation:

- ./build_metal.sh --release passed before the final gate amend.

- SDPA code-size sweep generated successfully before the final gate amend: 27 passed on branch and 27 passed on main.

- Correctness selection for ring_joint_sdpa, exp_ring_joint_sdpa, and scaled_dot_product_attention_sprint: 95 passed in 1288.89s before the final gate amend.

- SDPA_PERF_CHECKS=1 perf-gated pytest: 2 passed, 4 skipped because this host has ring size 8 while those ring-joint perf checks require ring size 4.

- Post-gate targeted checks passed: wan2_2_1xGLX-q224-k128 sweep smoke; wan2_2_1xGLX-q224-k128 accuracy with PCC 0.999187 and RMSE 0.010295; wan2_2_4xGLX-q224-k128, wan2_2_1xGLX-q288-k128, and wan2_2_4xGLX-q288-k128 sweep smoke.

- git diff --check passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sdpa-shared-pack-codesize-impact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sdpa-shared-pack-codesize-impact)