### PR TITLE
[LLK] Remove deprecated non-templated copy_dest_values overloads

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -14,7 +14,6 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-// Generalized copy_dest_value that works with any DataFormat
 template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
     constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
@@ -29,18 +28,6 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const ui
         // ADDR_MOD PR #41879
         TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_in * dst_tile_size);
         TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_7, dst_index_out * dst_tile_size);
-        dst_reg++;
-    }
-}
-
-// Deprecated: Use the DataFormat template parameter version instead
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-[[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
-    for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -10,22 +10,12 @@
 
 namespace ckernel {
 
-// Generalized version that takes a DataFormat template parameter
 template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
-}
-
-// Deprecated: Use the template version with DataFormat parameter instead
-[[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
-void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
-    constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_(
-        sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h
@@ -14,7 +14,6 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-// Generalized copy_dest_value that works with any DataFormat
 template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
     constexpr uint8_t instr_mod_index = GetSfpLoadStoreInstrMod<DATA_FORMAT>();
@@ -29,18 +28,6 @@ void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const ui
         // ADDR_MOD PR #41879
         TT_SFPLOAD(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3, dst_index_in * dst_tile_size);
         TT_SFPSTORE(p_sfpu::LREG0, instr_mod_index, ADDR_MOD_3, dst_index_out * dst_tile_size);
-        dst_reg++;
-    }
-}
-
-// Deprecated: Use the DataFormat template parameter version instead
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-[[deprecated("Use copy_dest_value<DataFormat, APPROXIMATION_MODE, ITERATIONS> instead")]]
-void copy_dest_value(const uint dst_index_in, const uint dst_index_out, const uint /* unused */) {
-    for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
-        constexpr uint dst_tile_size_sfpi = 32;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = sfpi::vFloat(sfpi::dst_reg[dst_index_in * dst_tile_size_sfpi]);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h
@@ -10,22 +10,12 @@
 
 namespace ckernel {
 
-// Generalized version that takes a DataFormat template parameter
 template <DataFormat DATA_FORMAT>
 void llk_math_eltwise_binary_sfpu_copy_dest_values(
     uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
     constexpr bool APPROXIMATE = 0;
     _llk_math_eltwise_binary_sfpu_params_(
         sfpu::copy_dest_value<DATA_FORMAT, APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
-}
-
-// Deprecated: Use the template version with DataFormat parameter instead
-[[deprecated("Use llk_math_eltwise_binary_sfpu_copy_dest_values<DataFormat> instead")]]
-void llk_math_eltwise_binary_sfpu_copy_dest_values(
-    uint32_t dst_index_in, uint32_t dst_index_out, VectorMode vector_mode = VectorMode::RC) {
-    constexpr bool APPROXIMATE = 0;
-    _llk_math_eltwise_binary_sfpu_params_(
-        sfpu::copy_dest_value<APPROXIMATE>, dst_index_in, dst_index_out, 0 /*unused*/, vector_mode);
 }
 
 inline void llk_math_eltwise_binary_sfpu_copy_dest_values_init() {

--- a/tt_metal/hw/inc/api/compute/copy_dest_values.h
+++ b/tt_metal/hw/inc/api/compute/copy_dest_values.h
@@ -34,26 +34,6 @@ ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
     MATH(llk_math_eltwise_binary_sfpu_copy_dest_values<static_cast<DataFormat>(DATA_FORMAT)>(idst_in, idst_out));
 }
 
-// clang-format off
-/**
- * Copies all values from the tile in idst_in to the tile in idst_out in the DST register buffer.
- *
- * The DST register buffer must be in acquired state via *tile_regs_acquire* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
- * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst_in        | The index of the tile in DST register buffer to copy values from      | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst_out       | The index of the tile in DST register buffer to copy values to        | uint32_t | Must be less than the size of the DST register buffer | True     |
- */
-// clang-format on
-[[deprecated("Use copy_dest_values<DataFormat> instead")]]
-ALWI void copy_dest_values(uint32_t idst_in, uint32_t idst_out) {
-    MATH(llk_math_eltwise_binary_sfpu_copy_dest_values(idst_in, idst_out));
-}
-
 ALWI void copy_dest_values_init() { MATH(llk_math_eltwise_binary_sfpu_copy_dest_values_init()); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
@@ -223,8 +223,9 @@ void kernel_main() {
     // Retain a copy
     //-------------------------------------------------------------------------
     // Retain this copy for final scores (raw scores)
+    // Host config pins fp32_dest_acc_en=false for this kernel, so DST is in Float16_b layout.
     copy_dest_values_init();
-    copy_dest_values(0, 1);
+    copy_dest_values<DataFormat::Float16_b>(0, 1);
 
     //-------------------------------------------------------------------------
     // Add bias

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp
@@ -19,6 +19,10 @@
 #define M_SQRT2 1.41421356237309504880f    /* sqrt(2) */
 #define M_2_SQRTPI 1.12837916709551257390f /* 2/sqrt(pi) */
 
+// DST register format follows the host-side fp32_dest_acc_en setting (Float32 when enabled,
+// Float16_b otherwise). DST_ACCUM_MODE is injected by JIT codegen.
+constexpr DataFormat copy_format = DST_ACCUM_MODE ? DataFormat::Float32 : DataFormat::Float16_b;
+
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
 
@@ -66,7 +70,7 @@ void kernel_main() {
         // tile[1] = tanh(sqrt(2/π) * (x + 0.044715 * x^3))
         tanh_tile_init();
         tanh_tile(1);
-        copy_dest_values(1, 4);  // save tanh to tile[4]
+        copy_dest_values<copy_format>(1, 4);  // save tanh to tile[4]
 
         // CDF term: tile[1] = 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
         fill_tile(3, 1.0f);
@@ -78,7 +82,7 @@ void kernel_main() {
         square_tile(4);
         fill_tile(3, 1.0f);
         sub_binary_tile(3, 4, 3);
-        copy_dest_values(3, 4);
+        copy_dest_values<copy_format>(3, 4);
 
         // tile[2] = (1 + 0.134145 * x**2)
         fill_tile(3, kKappa * 3.0f);
@@ -93,7 +97,7 @@ void kernel_main() {
         mul_binary_tile(2, 3, 2);
 
         // tile[2] = x * pdf term
-        copy_dest_values(5, 3);
+        copy_dest_values<copy_format>(5, 3);
         mul_binary_tile(2, 3, 2);
 
         // result: tile[1] = grad * (cdf_term + x * pdf_term)


### PR DESCRIPTION
## Summary

Removes the `[[deprecated]]` non-templated overloads of `copy_dest_values` (Layer 3 public API) and its two underlying LLK functions (Layer 2 wrapper + Layer 2 SFPU primitive), and migrates the last 4 remaining caller sites to the templated form.

Companion to #45187, which handled the conv-team-owned kernel warnings. The `copy_dest_values` deprecation chain was the one warning we explicitly deferred there — it lives in the LLK headers and was out of scope for that PR.

## Why this PR

In #45187 we explained that the `compute_mpwi.cpp` warnings (68× per nightly pool job) were not caused by pool code — pool's compute_mpwi.cpp already uses the templated form `copy_dest_values<copy_format>(...)`. The warnings come from the **deprecated overload's body** in the LLK header itself, which calls another deprecated function. GCC emits `-Wdeprecated-declarations` at parse time of the header body, so **every TU that `#include`s `copy_dest_values.h`** gets the warnings — regardless of whether they call the deprecated overload.

This PR ends the warning chain by removing the deprecated bodies entirely, after migrating the last callers.

## What changed

### 1. Migrate the 4 remaining non-templated callers

**`ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/kernels/compute/eltwise_bw_gelu_approx_tanh.cpp`** (3 call sites at L69, L81, L96)

The kernel's DST register layout follows the host-side `fp32_dest_acc_en` setting, which the host factory derives from the output dtype (`gelu_backward_program_factory.cpp:111-112`):

```cpp
bool fp32_dest_acc_en = (dst_cb_data_format == DataFormat::Float32) || (dst_cb_data_format == DataFormat::Int32) ||
                        (dst_cb_data_format == DataFormat::UInt32);
```

The JIT codegen injects this as the `DST_ACCUM_MODE` constexpr. The migration uses a constexpr selector so the right `DataFormat` is picked per build:

```cpp
constexpr DataFormat copy_format = DST_ACCUM_MODE ? DataFormat::Float32 : DataFormat::Float16_b;
```

Each call site becomes `copy_dest_values<copy_format>(...)`.

**`ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp:227`** (1 call site)

The host factory pins `fp32_dest_acc_en = false` unconditionally (`moe_gate_mm_program_factory.cpp:187`), so DST is always Float16_b. Direct: `copy_dest_values<DataFormat::Float16_b>(0, 1)`.

### 2. Remove deprecated overloads from 3 LLK headers

Layer 3 — public Compute API:
- `tt_metal/hw/inc/api/compute/copy_dest_values.h`: removed `[[deprecated]] copy_dest_values(uint32_t, uint32_t)`.

Layer 2 — LLK SFPU API wrappers (per arch):
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h`: removed `[[deprecated]] llk_math_eltwise_binary_sfpu_copy_dest_values(uint32_t, uint32_t, VectorMode)`.
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_copy_dest_values.h`: same.

Layer 2 — SFPU primitive (per arch):
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h`: removed `[[deprecated]] sfpu::copy_dest_value<APPROXIMATION_MODE, ITERATIONS>` (had no callers once the Layer 2 wrapper deprecated form was gone).
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_copy_dest_values.h`: same.

## Caller verification

I did an exhaustive grep across the full repo (cpp/h/hpp/cc/cxx/py/cmake/yaml/md), excluding build/cache dirs and including the `tt_metal/tt-llk/` submodule, `tests/`, `models/`, `scripts/`, and `tt_metal/programming_examples/`. The 4 caller sites above were the only non-templated invocations anywhere. Every remaining reference to `copy_dest_values` / `copy_dest_value` is now one of:
- the new templated form,
- a `_init` helper that I kept,
- an `#include` only (e.g. `combine_welford.h:18`),
- or a CMake source-list entry (`tt_metal/hw/sources.cmake:42`).

## Test plan
- [ ] CI: `ttnn nightly pool tests` (WH/BH) — verify the ~68 `copy_dest_values` deprecation warning lines per job are gone from JIT output.
- [ ] CI: ops touching the migrated kernels — `gelu_backward` unit tests + `deepseek moe_gate_mm` op tests for both `fp32_dest_acc_en` branches (Float16_b output and Float32 output, for gelu_backward).
- [ ] CI: PCC must hold for the migrated kernels. The DataFormat choice is correctness-sensitive: a wrong format would silently corrupt the copied DST tile. Mapping rationale documented in the commit message.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/llk-remove-deprecated-copy-dest-values)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/llk-remove-deprecated-copy-dest-values)