### PR TITLE
[ttnn] paged ops: add cache_position_modulo for bounded sliding-window kv caches

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -116,6 +116,7 @@ blackhole:
   - tests/ttnn/unit_tests/operations/pool/test_global_avg_pool2d.py
   - tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
   - tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+  - tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py
   - tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
   - tests/ttnn/unit_tests/operations/transformers/test_paged_fused_update_cache.py
 

--- a/tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py
@@ -271,3 +271,69 @@ def test_paged_update_cache_modulo_must_be_multiple_of_block_size(device):
             page_table=page_table_tt,
             cache_position_modulo=block_size + 1,  # not a multiple of 32
         )
+
+
+# ── paged_fill_cache: long prefill with wrap survives the last cache_position_modulo tokens ──
+
+
+@pytest.mark.timeout(60)
+def test_paged_fill_cache_bounded_capacity_wrap(device):
+    """A prefill of length > cache_position_modulo, written with the kwarg set, must
+    leave the cache holding *exactly* the last cache_position_modulo tokens (each at
+    its wrapped slot ``pos % cache_position_modulo``). The redundant earlier writes
+    are correctly overwritten; the surviving region matches the torch reference at
+    every position.
+    """
+    torch.manual_seed(3)
+
+    num_kv_heads = 1
+    head_dim = 128
+    block_size = 32
+    sliding_window = 128
+    sliding_blocks = sliding_window // block_size
+    num_users = 1
+    # Prefill length crosses the sliding boundary by one full block, so the wrap
+    # actually overwrites earlier writes.
+    prefill_len = sliding_window + block_size
+
+    max_blocks_per_req = sliding_blocks * 4  # vLLM-style oversize page_table
+
+    # Physical cache holds max_blocks_per_req blocks; only the first sliding_blocks
+    # entries of the page_table are valid (mimicking vLLM SlidingWindowSpec).
+    cache_torch = torch.zeros(max_blocks_per_req, num_kv_heads, block_size, head_dim).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.zeros(num_users, max_blocks_per_req, dtype=torch.int32)
+    page_table[0, :sliding_blocks] = torch.arange(sliding_blocks, dtype=torch.int32)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    # Input: full prefill_len tokens of K. The op writes seq_tile_id %= capacity_t
+    # per tile, so each token p in [0, prefill_len) writes to slot p % sliding_window.
+    K_full = torch.randn(1, num_kv_heads, prefill_len, head_dim).bfloat16().float()
+    Kt = ttnn.from_torch(K_full, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    ttnn.experimental.paged_fill_cache(
+        cache_tt,
+        Kt,
+        page_table_tt,
+        batch_idx=0,
+        cache_position_modulo=sliding_window,
+    )
+
+    # Read back and reconstruct logical positions [0, sliding_window) using page_table.
+    got = cache_tt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()  # [phys_blocks, kv, bs, d]
+    cache_view = torch.zeros(sliding_window, num_kv_heads, head_dim).bfloat16().float()
+    for vb in range(sliding_blocks):
+        phys = int(page_table[0, vb].item())
+        cache_view[vb * block_size : (vb + 1) * block_size] = (
+            got[phys, :, :, :].transpose(0, 1).squeeze(1).reshape(block_size, num_kv_heads, head_dim)
+        )
+
+    # Expected: for each slot s in [0, sliding_window), the value is the K at the
+    # largest absolute pos p < prefill_len with p % sliding_window == s.
+    ref = torch.zeros(sliding_window, num_kv_heads, head_dim).bfloat16().float()
+    for p in range(prefill_len):
+        ref[p % sliding_window] = K_full[0, :, p, :]
+
+    eq, msg = comp_pcc(ref, cache_view, pcc=0.99)
+    assert eq, f"Bounded fill_cache wrap mismatch: {msg}"

--- a/tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``cache_position_modulo`` kwarg on ``paged_update_cache`` and
+``paged_scaled_dot_product_attention_decode``.
+
+Background: vLLM's hybrid kv-cache-groups manager allocates sliding-window layers
+with only ``sliding_window/block_size`` blocks per sequence, and zero-pads the
+per-layer page_table out to ``max_model_len/block_size`` (see
+``vllm-tt-plugin/.../model_runner.py::pad_block_tables``). With the legacy ops
+that take only absolute positions, any position ``>= sliding_window`` collapses
+onto physical block 0 (the zero-padded tail) and silently clobbers a real block.
+
+``cache_position_modulo`` (in tokens) turns the cache into a circular buffer:
+the kernel computes ``pos % cache_position_modulo`` before resolving the
+page_table entry. Bounded-capacity allocations then work correctly under
+absolute-position addressing.
+
+Coverage:
+- Positive: round-trip a single user across multiple wrap cycles with both ops
+  and confirm PCC ≥ 0.99 vs torch reference at every step.
+- **Negative (clobbering demonstration)**: same setup WITHOUT the kwarg —
+  show that PCC collapses past the sliding window, locking in the bug as a
+  regression marker. If a future kernel change accidentally fixes it without
+  the kwarg, this test will start failing and force a re-think.
+- Validator negatives: modulo without page_table; modulo not a multiple of
+  block_size; modulo < sliding_window_size for SDPA.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _torch_sliding_ref(k_hist, v_hist, q, cur_pos, sliding_window, scale):
+    """Torch fp32 sliding-window attention reference for a single user.
+
+    ``k_hist`` / ``v_hist`` are unbounded ``[T, kv_heads, head_dim]`` tensors holding
+    every K/V written so far at their absolute logical position. Output:
+    ``[1, 1, num_q_heads, head_dim]``.
+    """
+    lo = max(0, cur_pos - sliding_window + 1)
+    k_win = k_hist[lo : cur_pos + 1].float()
+    v_win = v_hist[lo : cur_pos + 1].float()
+    q_b = q[0, 0, :, :].float()
+    repeat = q_b.shape[0] // k_win.shape[1]
+    k_rep = k_win.repeat_interleave(repeat, dim=1)
+    v_rep = v_win.repeat_interleave(repeat, dim=1)
+    scores = torch.einsum("hd,shd->hs", q_b, k_rep) * scale
+    weights = torch.softmax(scores, dim=-1)
+    out = torch.einsum("hs,shd->hd", weights, v_rep)
+    return out.unsqueeze(0).unsqueeze(0)
+
+
+def _sharded_kv_input(device, x_padded):
+    """Convert a ``(1, B=1, padded_heads, head_dim)`` torch tensor to a height-sharded
+    ttnn input matching the paged_update_cache decode-time format."""
+    num_users = x_padded.shape[1]
+    xt = ttnn.Tensor(x_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_users, device.compute_with_storage_grid_size(), True)
+    shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        [xt.volume() // xt.padded_shape[-1] // num_users, xt.padded_shape[-1]],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    return xt.to(device, mem_cfg)
+
+
+def _run_decode_walk(device, sliding_window, use_modulo_kwarg, decode_steps, scale=None):
+    """Drive a single user through ``decode_steps`` of paged_update_cache +
+    paged_scaled_dot_product_attention_decode against a bounded sliding-window cache.
+
+    Returns the list of (pos, passing, msg) PCC checks vs the torch sliding reference.
+    When ``use_modulo_kwarg`` is False, this reproduces the silent-corruption bug.
+    """
+    torch.manual_seed(0)
+
+    block_size = 32
+    sliding_blocks = sliding_window // block_size
+    max_blocks_per_req = 4 * sliding_blocks  # vLLM-style zero-pad past sliding_blocks
+
+    num_kv_heads = 1
+    num_q_heads = 1
+    head_dim = 128
+    PADDED_HEADS = 32  # paged_update_cache requires shard width == padded last dim and kv padded to TILE
+    if scale is None:
+        scale = 1.0 / (head_dim**0.5)
+
+    # Physical cache sized to hold max_blocks_per_req blocks total. Only the first
+    # sliding_blocks entries of the page_table are valid; the tail is zero-padded.
+    k_init = torch.zeros(max_blocks_per_req, num_kv_heads, block_size, head_dim).bfloat16().float()
+    v_init = torch.zeros(max_blocks_per_req, num_kv_heads, block_size, head_dim).bfloat16().float()
+    k_cache_tt = ttnn.Tensor(k_init, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    v_cache_tt = ttnn.Tensor(v_init, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.zeros(1, max_blocks_per_req, dtype=torch.int32)
+    page_table[0, :sliding_blocks] = torch.arange(sliding_blocks, dtype=torch.int32)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    k_hist = torch.zeros(decode_steps, num_kv_heads, head_dim).bfloat16().float()
+    v_hist = torch.zeros(decode_steps, num_kv_heads, head_dim).bfloat16().float()
+
+    modulo_kwargs = {"cache_position_modulo": sliding_window} if use_modulo_kwarg else {}
+
+    results = []
+    for pos in range(decode_steps):
+        K_new = torch.randn(1, 1, num_kv_heads, head_dim).bfloat16().float()
+        V_new = torch.randn(1, 1, num_kv_heads, head_dim).bfloat16().float()
+        Q = torch.randn(1, 1, num_q_heads, head_dim).bfloat16().float()
+
+        k_hist[pos, :, :] = K_new[0, 0]
+        v_hist[pos, :, :] = V_new[0, 0]
+
+        K_padded = torch.nn.functional.pad(K_new, (0, 0, 0, PADDED_HEADS - num_kv_heads))
+        V_padded = torch.nn.functional.pad(V_new, (0, 0, 0, PADDED_HEADS - num_kv_heads))
+        Kt = _sharded_kv_input(device, K_padded)
+        Vt = _sharded_kv_input(device, V_padded)
+
+        pos_tt = ttnn.Tensor(torch.tensor([pos], dtype=torch.int32), ttnn.int32).to(device)
+
+        ttnn.experimental.paged_update_cache(
+            k_cache_tt, Kt, update_idxs_tensor=pos_tt, page_table=page_table_tt, **modulo_kwargs
+        )
+        ttnn.experimental.paged_update_cache(
+            v_cache_tt, Vt, update_idxs_tensor=pos_tt, page_table=page_table_tt, **modulo_kwargs
+        )
+
+        Q_padded = torch.nn.functional.pad(Q, (0, 0, 0, PADDED_HEADS - num_q_heads))
+        Qt = ttnn.Tensor(Q_padded, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+        out_tt = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+            Qt,
+            k_cache_tt,
+            v_cache_tt,
+            cur_pos_tensor=pos_tt,
+            page_table_tensor=page_table_tt,
+            scale=scale,
+            sliding_window_size=sliding_window,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            **modulo_kwargs,
+        )
+        out_torch_padded = ttnn.to_torch(out_tt)
+        out_tt_first = out_torch_padded[..., :num_q_heads, :]
+
+        ref = _torch_sliding_ref(k_hist, v_hist, Q, pos, sliding_window, scale)
+        passing, msg = comp_pcc(ref, out_tt_first, pcc=0.99)
+        results.append((pos, passing, msg))
+
+    return results
+
+
+# ── Positive: cache_position_modulo makes bounded cache correct ────────────
+
+
+@pytest.mark.timeout(180)
+def test_bounded_sliding_kv_cache_position_modulo_round_trip(device):
+    """With ``cache_position_modulo=sliding_window`` set, the bounded cache addresses
+    correctly across multiple wrap cycles; PCC ≥ 0.99 at every step."""
+    sliding_window = 128
+    decode_steps = sliding_window * 2 + 16  # walk well past the boundary
+
+    results = _run_decode_walk(device, sliding_window, use_modulo_kwarg=True, decode_steps=decode_steps)
+
+    failing = [(p, m) for (p, ok, m) in results if not ok]
+    if failing:
+        msg = "\n".join(f"  pos={p}: {m}" for p, m in failing[:10])
+        pytest.fail(f"{len(failing)}/{decode_steps} steps failed PCC≥0.99 with cache_position_modulo set:\n{msg}")
+
+
+# ── Negative: without the kwarg, positions past sliding_window clobber block 0 ──
+
+
+@pytest.mark.timeout(180)
+def test_bounded_sliding_kv_cache_without_modulo_clobbers(device):
+    """Without ``cache_position_modulo``, positions past sliding_window route through
+    the zero-padded page_table tail and collapse onto physical block 0 — silently
+    corrupting the cache. Locks in the bug as a regression marker so anyone who
+    "fixes" it implicitly (e.g. by changing zero-padding semantics) sees this test
+    flip and re-thinks the contract.
+
+    Expected behaviour: pre-boundary positions stay near PCC 1.0; positions well past
+    the boundary tank. We assert that at least 30% of post-boundary steps fall below
+    PCC 0.99, which is conservative against bf16 noise.
+    """
+    sliding_window = 128
+    decode_steps = sliding_window * 2 + 16
+
+    results = _run_decode_walk(device, sliding_window, use_modulo_kwarg=False, decode_steps=decode_steps)
+
+    pre = [ok for (p, ok, _) in results if p < sliding_window]
+    post = [(p, ok, m) for (p, ok, m) in results if p >= sliding_window]
+
+    pre_passing = sum(pre)
+    assert pre_passing >= len(pre) * 0.95, (
+        f"Pre-boundary PCC unexpectedly poor without the kwarg: {pre_passing}/{len(pre)} passed. "
+        "If this assertion fails the test fixture itself is broken."
+    )
+
+    post_failing = sum(1 for (_, ok, _) in post if not ok)
+    assert post_failing >= len(post) * 0.3, (
+        f"Expected >=30% of post-sliding-window steps to fail PCC≥0.99 without the kwarg "
+        f"(clobbering bug should be visible); only {post_failing}/{len(post)} did. "
+        "The legacy ops may have been silently fixed — re-evaluate whether the modulo "
+        "kwarg is still needed."
+    )
+
+
+# ── Validator negatives ────────────────────────────────────────────────────
+
+
+def test_paged_update_cache_modulo_requires_page_table(device):
+    """``cache_position_modulo`` without ``page_table`` must be rejected at validation
+    (same gate as the other paged-mode-only kwargs)."""
+    torch.manual_seed(1)
+    num_users = 4
+    num_kv_heads = 1
+    max_seq_len = 256
+    head_dim = 256
+
+    cache_shape = [num_users, num_kv_heads, max_seq_len, head_dim]
+    cache_torch = torch.randn(cache_shape).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    cache_idxs_tt = ttnn.Tensor(torch.arange(num_users, dtype=torch.int32), ttnn.int32).to(device)
+
+    x = torch.randn([1, num_users, num_kv_heads, head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_kv_input(device, x_padded)
+
+    with pytest.raises(RuntimeError, match="cache_position_modulo is only supported in paged mode"):
+        ttnn.experimental.paged_update_cache(
+            cache_tt,
+            xt,
+            update_idxs_tensor=cache_idxs_tt,
+            cache_position_modulo=128,
+        )
+
+
+def test_paged_update_cache_modulo_must_be_multiple_of_block_size(device):
+    """``cache_position_modulo`` not a multiple of effective block_size must fail."""
+    torch.manual_seed(2)
+    num_users = 1
+    num_kv_heads = 1
+    block_size = 32
+    head_dim = 128
+    num_blocks = 4
+
+    cache_torch = torch.randn(num_blocks, num_kv_heads, block_size, head_dim).bfloat16().float()
+    cache_tt = ttnn.Tensor(cache_torch, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    page_table = torch.arange(num_blocks, dtype=torch.int32).reshape(num_users, num_blocks)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+    cache_idxs_tt = ttnn.Tensor(torch.zeros(num_users, dtype=torch.int32), ttnn.int32).to(device)
+
+    x = torch.randn([1, num_users, num_kv_heads, head_dim]).bfloat16().float()
+    x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
+    xt = _sharded_kv_input(device, x_padded)
+
+    with pytest.raises(
+        RuntimeError, match="cache_position_modulo .* must be a positive multiple of effective block_size"
+    ):
+        ttnn.experimental.paged_update_cache(
+            cache_tt,
+            xt,
+            update_idxs_tensor=cache_idxs_tt,
+            page_table=page_table_tt,
+            cache_position_modulo=block_size + 1,  # not a multiple of 32
+        )

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -93,12 +93,30 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
         effective_block_size,
         tt::constants::TILE_HEIGHT);
 
-    TT_FATAL(
-        input_shape[2] <= effective_block_size * page_table_shape[1],
-        "Input seq_len ({}) must fit in max_num_blocks_per_seq ({}) * block_size ({})",
-        input_shape[2],
-        page_table_shape[1],
-        effective_block_size);
+    if (args.cache_position_modulo.has_value()) {
+        const uint32_t modulo = args.cache_position_modulo.value();
+        TT_FATAL(modulo > 0, "cache_position_modulo must be > 0 when provided");
+        TT_FATAL(
+            modulo % effective_block_size == 0,
+            "cache_position_modulo ({}) must be a positive multiple of effective block_size ({}); "
+            "otherwise a wrapped position would split across blocks and the kernel can't address it.",
+            modulo,
+            effective_block_size);
+        TT_FATAL(
+            modulo <= effective_block_size * page_table_shape[1],
+            "cache_position_modulo ({}) must fit in max_num_blocks_per_seq ({}) * block_size ({})",
+            modulo,
+            page_table_shape[1],
+            effective_block_size);
+    } else {
+        // Legacy path: input must fit in the page_table address space directly.
+        TT_FATAL(
+            input_shape[2] <= effective_block_size * page_table_shape[1],
+            "Input seq_len ({}) must fit in max_num_blocks_per_seq ({}) * block_size ({})",
+            input_shape[2],
+            page_table_shape[1],
+            effective_block_size);
+    }
 
     if (tensor_args.batch_idx_tensor_opt.has_value()) {
         const auto& tensor = tensor_args.batch_idx_tensor_opt.value();
@@ -144,9 +162,9 @@ ttsl::hash::hash_t PagedFillCacheDeviceOperation::compute_program_hash(
 
     // Exclude batch_idx_fallback and noop (runtime-only).
     // Include mesh_coords (affects program factory selection).
-    // Include block_size_override (enters compile-time args).
+    // Include block_size_override and cache_position_modulo (enter compile-time args).
     return operation::hash_operation<PagedFillCacheDeviceOperation>(
-        args.mesh_coords, args.block_size_override, tensor_args, program_factory.index());
+        args.mesh_coords, args.block_size_override, args.cache_position_modulo, tensor_args, program_factory.index());
 }
 
 }  // namespace ttnn::experimental::prim
@@ -160,7 +178,8 @@ Tensor paged_fill_cache(
     const std::optional<Tensor>& batch_idx_tensor,
     uint32_t batch_idx_fallback,
     const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords,
-    std::optional<uint32_t> block_size_override) {
+    std::optional<uint32_t> block_size_override,
+    std::optional<uint32_t> cache_position_modulo) {
     using OperationType = ttnn::experimental::prim::PagedFillCacheDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{
@@ -168,6 +187,7 @@ Tensor paged_fill_cache(
         .mesh_coords = mesh_coords,
         .noop = false,
         .block_size_override = block_size_override,
+        .cache_position_modulo = cache_position_modulo,
     };
     auto tensor_args = OperationType::tensor_args_t{
         .cache_tensor = cache_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -45,6 +45,7 @@ Tensor paged_fill_cache(
     const std::optional<Tensor>& batch_idx_tensor,
     uint32_t batch_idx_fallback,
     const std::optional<std::set<ttnn::MeshCoordinate>>& mesh_coords = std::nullopt,
-    std::optional<uint32_t> block_size_override = std::nullopt);
+    std::optional<uint32_t> block_size_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation_types.hpp
@@ -16,6 +16,14 @@ struct PagedFillCacheParams {
     const bool noop = false;  // When true, kernels early exit
     // Optional per-call block_size override; see PagedUpdateCacheParams::block_size_override.
     const std::optional<uint32_t> block_size_override = std::nullopt;
+    // Optional circular-buffer capacity (in tokens) for the cache view. When set, the
+    // kernel computes ``seq_tile_id %= (cache_position_modulo / TILE_HEIGHT)`` before
+    // resolving the page_table entry, so a bounded sliding-window cache can be filled
+    // from a prefill longer than the capacity — only the last cache_position_modulo
+    // tokens survive in the cache after the writes, exactly what attention needs.
+    // Must be a multiple of the effective block_size. See
+    // PagedUpdateCacheParams::cache_position_modulo for the companion decode-side kwarg.
+    const std::optional<uint32_t> cache_position_modulo = std::nullopt;
 };
 
 struct PagedFillCacheInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -142,6 +142,11 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index, Wt};
     TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
 
+    // capacity_t (in TILE rows; 0 = unbounded/legacy) wraps seq_tile_id mod this value
+    // before page_table lookup. cache_position_modulo % effective_block_size == 0 is
+    // enforced in the validator, so the divide is exact.
+    const uint32_t capacity_t = operation_attributes.cache_position_modulo.value_or(0u) / TILE_HEIGHT;
+
     std::vector<uint32_t> writer_compile_time_args = {
         (uint32_t)src0_cb_index,
         (uint32_t)page_table_cb_index,
@@ -158,6 +163,7 @@ PagedFillCacheProgramFactory::cached_program_t PagedFillCacheProgramFactory::cre
         batch_idx_stick_size_B,        // per-element size, e.g. 4 for uint32
         batch_idx_num_elements,        // 1 = legacy single-batch, N = batched
         num_blocks_of_work_per_batch,  // num_heads * input_seq_len_t, for row_id -> batch decode
+        capacity_t,
     };
     TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
     TensorAccessorArgs(page_table_buffer).append_to(writer_compile_time_args);
@@ -341,7 +347,8 @@ PagedFillCacheMeshWorkloadFactory::cached_mesh_workload_t PagedFillCacheMeshWork
                     .batch_idx_fallback = operation_attributes.batch_idx_fallback,
                     .mesh_coords = operation_attributes.mesh_coords,
                     .noop = true,
-                    .block_size_override = operation_attributes.block_size_override};
+                    .block_size_override = operation_attributes.block_size_override,
+                    .cache_position_modulo = operation_attributes.cache_position_modulo};
                 auto cached_program =
                     PagedFillCacheProgramFactory::create(dummy_attrs, tensor_args, tensor_return_value);
                 shared_variables[single_coord_range] = std::move(cached_program.shared_variables);
@@ -390,7 +397,8 @@ void PagedFillCacheMeshWorkloadFactory::override_runtime_arguments(
             .batch_idx_fallback = operation_attributes.batch_idx_fallback,
             .mesh_coords = operation_attributes.mesh_coords,
             .noop = is_dummy,
-            .block_size_override = operation_attributes.block_size_override};
+            .block_size_override = operation_attributes.block_size_override,
+            .cache_position_modulo = operation_attributes.cache_position_modulo};
 
         ttnn::device_operation::mesh_device_operation_utils::apply_override_runtime_arguments(
             program_factory, program, shared_variables, coord_attrs, coord, tensor_args, tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -34,8 +34,11 @@ void kernel_main() {
 
     const uint32_t St = get_compile_time_arg_val(16);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
+    // 0 = legacy unbounded behavior; nonzero = wrap update_idx mod this value before
+    // page_table lookup (bounded sliding-window cache support).
+    constexpr uint32_t cache_position_modulo = get_compile_time_arg_val(18);
 
-    constexpr auto s0_args = TensorAccessorArgs<18>();
+    constexpr auto s0_args = TensorAccessorArgs<19>();
     constexpr auto index_tensor_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto page_table_args = TensorAccessorArgs<index_tensor_args.next_compile_time_args_offset()>();
 
@@ -68,11 +71,16 @@ void kernel_main() {
         cb_push_back(cb_index_id, 1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
-        const uint32_t update_idx = index_ptr[my_batch_idx];
-        if (update_idx == (uint32_t)-1) {
+        const uint32_t raw_update_idx = index_ptr[my_batch_idx];
+        if (raw_update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
             skip_update = true;
         } else {
+            // Wrap into the bounded sliding-window cache when enabled, so positions past
+            // the physical capacity are addressed correctly (cache_position_modulo is a
+            // multiple of block_size, so this preserves the intra-block offset).
+            const uint32_t update_idx =
+                cache_position_modulo > 0 ? raw_update_idx % cache_position_modulo : raw_update_idx;
             if constexpr (is_paged_cache) {
                 const auto page_table_gen = TensorAccessor(page_table_args, page_table_tensor_addr);
                 cb_reserve_back(page_table_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -49,6 +49,7 @@ void kernel_main() {
     constexpr uint32_t batch_idx_stick_size = get_compile_time_arg_val(10);  // per-element size, e.g. 4 for uint32
     constexpr uint32_t batch_idx_num_elements = get_compile_time_arg_val(11);
     constexpr uint32_t num_blocks_per_batch = get_compile_time_arg_val(12);  // num_heads * input_seq_len_t
+    constexpr uint32_t capacity_t = get_compile_time_arg_val(13);
     constexpr bool batched_fill = batch_idx_num_elements > 1;
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -63,7 +64,7 @@ void kernel_main() {
         return;  // Early exit, no work done
     }
 
-    constexpr auto s0_args = TensorAccessorArgs<13>();
+    constexpr auto s0_args = TensorAccessorArgs<14>();
     constexpr auto page_table_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto batch_idx_tensor_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 
@@ -136,6 +137,12 @@ void kernel_main() {
             cached_batch = batch_idx;
         }
 
+        // Bounded sliding-window cache: wrap the virtual tile index into the bounded
+        // capacity before the page_table lookup. capacity_t is a multiple of
+        // block_size_t (validated), so the wrap preserves intra-block layout.
+        if constexpr (capacity_t > 0) {
+            seq_tile_id %= capacity_t;
+        }
         uint32_t physical_tile_id =
             virtual_seq_tile_id_to_physical_tile_id<num_heads, block_size_t, Wt>(seq_tile_id, cur_head, page_table_ptr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
             row_within_batch = row_id;
         }
         const uint32_t cur_head = row_within_batch / num_blocks_of_work_per_head;
-        const uint32_t seq_tile_id = row_within_batch % num_blocks_of_work_per_head;
+        uint32_t seq_tile_id = row_within_batch % num_blocks_of_work_per_head;
 
         // Drop the early-prefill tiles whose final slot would be overwritten by a
         // later iteration anyway. The input CB still has to be drained so the
@@ -152,6 +152,7 @@ void kernel_main() {
             noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
             noc_async_read_barrier();
             cached_batch = batch_idx;
+        }
 
         // Bounded sliding-window cache: wrap the virtual tile index into the bounded
         // capacity before the page_table lookup. capacity_t is a multiple of

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -101,6 +101,14 @@ void kernel_main() {
     // once on the first row (cache miss) and then hits for all remaining rows;
     // batched path re-loads on batch boundaries within this core's row range.
     uint32_t cached_batch = (uint32_t)-1;
+    // Bounded sliding-window cache (capacity_t > 0): only the last capacity_t tiles
+    // of each head's input range will survive in the cache (earlier tiles would map
+    // to wrapped slots that get overwritten by later writes). Compute the skip
+    // count once so we can consume those earlier input tiles without committing
+    // them to DRAM — a strict bandwidth win for prefills longer than the bounded
+    // capacity. For prefills <= capacity_t this is 0 and the legacy path runs.
+    const uint32_t skip_tiles =
+        (capacity_t > 0 && num_blocks_of_work_per_head > capacity_t) ? (num_blocks_of_work_per_head - capacity_t) : 0;
 
     for (uint32_t row_id = start_row_num; row_id < start_row_num + num_rows; ++row_id) {
         // Decode row_id → (cur_batch, cur_head, seq_tile_id).
@@ -122,6 +130,15 @@ void kernel_main() {
         const uint32_t cur_head = row_within_batch / num_blocks_of_work_per_head;
         const uint32_t seq_tile_id = row_within_batch % num_blocks_of_work_per_head;
 
+        // Drop the early-prefill tiles whose final slot would be overwritten by a
+        // later iteration anyway. The input CB still has to be drained so the
+        // reader doesn't stall, but no NOC writes go out.
+        if (seq_tile_id < skip_tiles) {
+            cb_wait_front(cb_id_in, Wt);
+            cb_pop_front(cb_id_in, Wt);
+            continue;
+        }
+
         uint32_t batch_idx;
         if constexpr (use_batch_idx_tensor) {
             batch_idx = batch_idx_arr[batched_fill ? cur_batch : 0];
@@ -135,7 +152,6 @@ void kernel_main() {
             noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
             noc_async_read_barrier();
             cached_batch = batch_idx;
-        }
 
         // Bounded sliding-window cache: wrap the virtual tile index into the bounded
         // capacity before the page_table lookup. capacity_t is a multiple of

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -34,8 +34,11 @@ void kernel_main() {
 
     constexpr uint32_t St = get_compile_time_arg_val(15);
     uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    // 0 = legacy unbounded behavior; nonzero = wrap update_idx mod this value before
+    // page_table lookup (bounded sliding-window cache support).
+    constexpr uint32_t cache_position_modulo = get_compile_time_arg_val(17);
 
-    constexpr auto s0_args = TensorAccessorArgs<17>();
+    constexpr auto s0_args = TensorAccessorArgs<18>();
 
     constexpr uint32_t head_offset_t = Wt * St;
 
@@ -55,12 +58,17 @@ void kernel_main() {
         cb_wait_front(cb_index_id, 1);
         uint32_t index_cb_ptr = get_read_ptr(cb_index_id);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
-        const uint32_t update_idx = index_ptr[my_batch_idx];
+        const uint32_t raw_update_idx = index_ptr[my_batch_idx];
 
-        if (update_idx == (uint32_t)-1) {
+        if (raw_update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
             skip_update = true;
         } else {
+            // Wrap into the bounded sliding-window cache when enabled, so positions past
+            // the physical capacity are addressed correctly (cache_position_modulo is a
+            // multiple of block_size, so this preserves the intra-block offset).
+            const uint32_t update_idx =
+                cache_position_modulo > 0 ? raw_update_idx % cache_position_modulo : raw_update_idx;
             if constexpr (is_paged_cache) {
                 cb_wait_front(page_table_cb_id, 1);
                 uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -64,6 +64,11 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
             page_table.has_value(),
             "num_kv_heads_override is only supported in paged mode (when page_table is provided)");
     }
+    if (operation_attributes.cache_position_modulo.has_value()) {
+        TT_FATAL(
+            page_table.has_value(),
+            "cache_position_modulo is only supported in paged mode (when page_table is provided)");
+    }
 
     // Per-block element-count consistency. The program factory wires the kernel's
     // per-block stride from (num_heads, effective_block_size, input_head_dim) read off
@@ -103,6 +108,15 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
             "effective block_size ({}) must be a multiple of TILE_HEIGHT ({})",
             effective_block_size,
             tt::constants::TILE_HEIGHT);
+        if (operation_attributes.cache_position_modulo.has_value()) {
+            const uint32_t cache_position_modulo = operation_attributes.cache_position_modulo.value();
+            TT_FATAL(
+                cache_position_modulo > 0 && cache_position_modulo % effective_block_size == 0,
+                "cache_position_modulo ({}) must be a positive multiple of effective block_size ({}); "
+                "otherwise a wrapped position would split across blocks and the kernel can't address it.",
+                cache_position_modulo,
+                effective_block_size);
+        }
     } else {
         TT_FATAL(
             input_head_dim == cache_tensor.padded_shape()[-1],
@@ -279,12 +293,14 @@ ttsl::hash::hash_t PagedUpdateCacheDeviceOperation::compute_program_hash(
     // - mesh_coords: affects program factory selection
     // - block_size_override: enters compile-time args
     // - num_kv_heads_override: enters compile-time args
+    // - cache_position_modulo: enters compile-time args
     return operation::hash_operation<PagedUpdateCacheDeviceOperation>(
         args.compute_kernel_config,
         args.share_cache,
         args.mesh_coords,
         args.block_size_override,
         args.num_kv_heads_override,
+        args.cache_position_modulo,
         tensor_args,
         program_factory.index());
 }
@@ -304,7 +320,8 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
     std::optional<uint32_t> block_size_override,
-    std::optional<uint32_t> num_kv_heads_override) {
+    std::optional<uint32_t> num_kv_heads_override,
+    std::optional<uint32_t> cache_position_modulo) {
     using OperationType = ttnn::experimental::prim::PagedUpdateCacheDeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
@@ -317,7 +334,8 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
         .share_cache = share_cache_arg,
         .mesh_coords = mesh_coords,
         .block_size_override = block_size_override,
-        .num_kv_heads_override = num_kv_heads_override};
+        .num_kv_heads_override = num_kv_heads_override,
+        .cache_position_modulo = cache_position_modulo};
 
     auto tensor_args = OperationType::tensor_args_t{
         .cache_tensor = cache_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -170,12 +170,28 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
                 page_table_val.padded_shape()[0] == input_tensor.padded_shape()[1],
                 "Batch size between page_table and input_tensor must match");
         }
-        TT_FATAL(
-            page_table_val.padded_shape()[1] <= cache_tensor.padded_shape()[0],
-            "max_num_blocks_per_seq must be less than max_num_blocks: max_num_blocks_per_seq={}, "
-            "max_num_blocks={}",
-            page_table_val.padded_shape()[1],
-            cache_tensor.padded_shape()[0]);
+        if (operation_attributes.cache_position_modulo.has_value()) {
+            // Bounded-pool path (vLLM SlidingWindowSpec): page_table is right-padded
+            // out to max_model_len/block_size, but the kernel wraps positions into
+            // [0, modulo) before the page_table lookup, so the tail is never read.
+            // Only the bounded prefix needs to fit in the physical pool.
+            const uint32_t effective_block_size =
+                operation_attributes.block_size_override.value_or(cache_tensor.padded_shape()[2]);
+            const uint32_t modulo = operation_attributes.cache_position_modulo.value();
+            const uint32_t bounded_blocks_per_seq = modulo / effective_block_size;
+            TT_FATAL(
+                bounded_blocks_per_seq <= cache_tensor.padded_shape()[0],
+                "cache_position_modulo/block_size ({}) must be <= max_num_blocks ({})",
+                bounded_blocks_per_seq,
+                cache_tensor.padded_shape()[0]);
+        } else {
+            TT_FATAL(
+                page_table_val.padded_shape()[1] <= cache_tensor.padded_shape()[0],
+                "max_num_blocks_per_seq must be less than max_num_blocks: max_num_blocks_per_seq={}, "
+                "max_num_blocks={}",
+                page_table_val.padded_shape()[1],
+                cache_tensor.padded_shape()[0]);
+        }
     }
 
     // Update indices validation

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.hpp
@@ -51,6 +51,7 @@ ttnn::experimental::prim::PagedUpdateCacheDeviceOperation::tensor_return_value_t
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
     std::optional<uint32_t> block_size_override = std::nullopt,
-    std::optional<uint32_t> num_kv_heads_override = std::nullopt);
+    std::optional<uint32_t> num_kv_heads_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation_types.hpp
@@ -35,6 +35,17 @@ struct PagedUpdateCacheParams {
     // cache_num_heads * cache_block_size * cache_head_dim is enforced in
     // validate_on_program_cache_miss.
     const std::optional<uint32_t> num_kv_heads_override;
+    // Optional circular-buffer capacity (in tokens) for the cache view. When set, the
+    // kernel computes ``update_idx %= cache_position_modulo`` before resolving the
+    // page_table entry, so a bounded sliding-window cache of capacity N can be
+    // indexed by absolute positions ≥ N without falling off the page_table or
+    // collapsing to physical block 0. Required when paired with vLLM's
+    // SlidingWindowSpec, which sizes the per-layer page_table to
+    // sliding_window/block_size entries and zero-pads the rest. Must be a multiple of
+    // (effective) block_size — otherwise a wrapped position would split across blocks
+    // and the kernel can't address it. Paged-mode only (validated in
+    // validate_on_program_cache_miss).
+    const std::optional<uint32_t> cache_position_modulo;
 };
 
 struct PagedUpdateCacheInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_program_factory.cpp
@@ -162,6 +162,11 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
 
     auto* dst_buffer = cache_tensor.buffer();
 
+    // cache_position_modulo: 0 = disabled (legacy), nonzero = wrap update_idx mod this
+    // value before page_table lookup. Required when the caller's page_table is sized for
+    // a bounded sliding-window cache (vLLM SlidingWindowSpec).
+    const uint32_t cache_position_modulo = operation_attributes.cache_position_modulo.value_or(0u);
+
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)src0_cb_index,
         (std::uint32_t)src1_cb_index,
@@ -183,6 +188,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
+        cache_position_modulo,
     };
     TensorAccessorArgs(dst_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(update_idxs_tensor.has_value() ? update_idxs_tensor->buffer() : nullptr)
@@ -209,6 +215,7 @@ PagedUpdateCacheProgramFactory::cached_program_t PagedUpdateCacheProgramFactory:
         cb_pagetable_id,
         St,
         in0_sequential_mode_semaphore_id,
+        cache_position_modulo,
     };
     TensorAccessorArgs(dst_buffer).append_to(writer_compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -74,12 +74,20 @@ ttnn::Tensor paged_fill_cache(
     uint32_t batch_idx,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
-    std::optional<uint32_t> block_size_override) {
+    std::optional<uint32_t> block_size_override,
+    std::optional<uint32_t> cache_position_modulo) {
     // Note: compute_kernel_config is not used by fill_cache operation
     (void)compute_kernel_config;
 
     return ttnn::prim::paged_fill_cache(
-        cache_tensor, input_tensor, page_table, batch_idx_tensor, batch_idx, mesh_coords, block_size_override);
+        cache_tensor,
+        input_tensor,
+        page_table,
+        batch_idx_tensor,
+        batch_idx,
+        mesh_coords,
+        block_size_override,
+        cache_position_modulo);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.cpp
@@ -23,7 +23,8 @@ ttnn::Tensor paged_update_cache(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
     std::optional<uint32_t> block_size_override,
-    std::optional<uint32_t> num_kv_heads_override) {
+    std::optional<uint32_t> num_kv_heads_override,
+    std::optional<uint32_t> cache_position_modulo) {
     return ttnn::prim::paged_update_cache(
         cache_tensor,
         input_tensor,
@@ -35,7 +36,8 @@ ttnn::Tensor paged_update_cache(
         compute_kernel_config,
         mesh_coords,
         block_size_override,
-        num_kv_heads_override);
+        num_kv_heads_override,
+        cache_position_modulo);
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> paged_fused_update_cache(

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -44,6 +44,7 @@ ttnn::Tensor paged_fill_cache(
     uint32_t batch_idx,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
-    std::optional<uint32_t> block_size_override = std::nullopt);
+    std::optional<uint32_t> block_size_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -20,7 +20,8 @@ ttnn::Tensor paged_update_cache(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const std::set<ttnn::MeshCoordinate>>& mesh_coords,
     std::optional<uint32_t> block_size_override = std::nullopt,
-    std::optional<uint32_t> num_kv_heads_override = std::nullopt);
+    std::optional<uint32_t> num_kv_heads_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> paged_fused_update_cache(
     const Tensor& cache_tensor1,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -35,6 +35,14 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
          input is height-sharded with the kv-heads dim padded to TILE_HEIGHT so the
          logical count can't be inferred from the tensor.
          ``num_kv_heads * block_size * head_dim`` must be preserved across views.
+         ``cache_position_modulo`` (optional, paged mode only) makes the kernel
+         compute ``update_idx %= cache_position_modulo`` before resolving the
+         page_table entry — i.e. treats the cache as a circular buffer of that
+         many tokens. Required when the cache is sized smaller than the model's
+         max sequence length (vLLM's ``SlidingWindowSpec`` allocation pattern);
+         without it, positions past the bounded capacity collapse onto block 0
+         and silently corrupt the cache. Must be a multiple of the effective
+         ``block_size`` and ≤ ``page_table.shape[1] * block_size``.
         )doc";
 
     ttnn::bind_function<"paged_update_cache", "ttnn.experimental.">(
@@ -52,7 +60,8 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
         nb::arg("mesh_coords").noconvert() = nb::none(),
         nb::arg("block_size") = nb::none(),
-        nb::arg("num_kv_heads") = nb::none());
+        nb::arg("num_kv_heads") = nb::none(),
+        nb::arg("cache_position_modulo") = nb::none());
 
     const auto* paged_fused_update_cache_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -117,6 +117,12 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         ``head_dim`` is read from ``input_tensor.padded_shape[-1]``. ``block_size``
         defaults to ``cache_tensor.padded_shape[2]``; pass the kwarg to override it (see
         ``paged_update_cache`` for details). Per-block byte count must be preserved.
+        ``cache_position_modulo`` (optional) treats the cache as a circular buffer of
+        that many tokens: each tile write computes ``seq_tile_id %=
+        cache_position_modulo / TILE_HEIGHT`` before the page_table lookup. Lets
+        prefill writes longer than the bounded sliding-window capacity land correctly
+        (only the last ``cache_position_modulo`` tokens survive). Must be a multiple
+        of the effective ``block_size`` and ≤ ``page_table.shape[1] * block_size``.
         )doc";
 
     ttnn::bind_function<"paged_fill_cache", "ttnn.experimental.">(
@@ -131,7 +137,8 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         nb::arg("batch_idx") = 0,
         nb::arg("compute_kernel_config").noconvert() = nb::none(),
         nb::arg("mesh_coords").noconvert() = nb::none(),
-        nb::arg("block_size") = nb::none());
+        nb::arg("block_size") = nb::none(),
+        nb::arg("cache_position_modulo") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::paged_cache::detail

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -42,7 +42,13 @@ void fill_tile_zeros(uint32_t cb_id, uint32_t tile_id) {
     }
 }
 
-template <typename PageT, uint32_t num_heads, uint32_t block_size_t, uint32_t Wt>
+// capacity_t = 0 means "no wrap" (legacy / unbounded cache).  Nonzero means the cache
+// holds capacity_t tile-rows in a circular buffer; the kernel wraps seq_tile_idx
+// modulo capacity_t before resolving the page_table entry, so callers can pass
+// absolute (un-wrapped) positions even with bounded sliding-window allocations.
+// capacity_t must be a multiple of block_size_t (validated on the caller side); that
+// guarantees the wrap preserves intra-block offsets.
+template <typename PageT, uint32_t num_heads, uint32_t block_size_t, uint32_t Wt, uint32_t capacity_t = 0>
 uint32_t virtual_seq_tile_id_to_physical_tile_id(
     uint32_t seq_tile_idx, uint32_t cur_head, const volatile tt_l1_ptr PageT* const page_table_ptr) {
     // Given some index in the sequence tiles in range [0, max_seq_len_t]
@@ -50,6 +56,9 @@ uint32_t virtual_seq_tile_id_to_physical_tile_id(
     constexpr uint32_t block_stride = num_heads * block_size_t * Wt;
     const uint32_t head_offset = cur_head * block_size_t * Wt;
 
+    if constexpr (capacity_t > 0) {
+        seq_tile_idx %= capacity_t;
+    }
     const uint32_t virtual_block = seq_tile_idx / block_size_t;
     const uint32_t physical_block = static_cast<uint32_t>(page_table_ptr[virtual_block]);
     const uint32_t block_row_offset = seq_tile_idx % block_size_t;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -579,6 +579,7 @@ template <
     uint32_t barrier_threshold,
     bool is_page_table_sharded,
     bool use_mcast,
+    uint32_t capacity_t,
     typename KReaderType>
 uint64_t read_k(
     uint32_t k_chunk_tiles,
@@ -601,11 +602,18 @@ uint64_t read_k(
                 uint32_t k_write_ptr_col = k_write_ptr + row * k_tile_bytes;
                 uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
                 uint32_t physical_k_tile_id =
-                    (is_page_table_sharded)
-                        ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
-                              virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                        : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
-                              virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
+                    (is_page_table_sharded) ? virtual_seq_tile_id_to_physical_tile_id<
+                                                  uint16_t,
+                                                  num_kv_heads,
+                                                  block_size_t,
+                                                  DHt,
+                                                  capacity_t>(virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
+                                            : virtual_seq_tile_id_to_physical_tile_id<
+                                                  uint32_t,
+                                                  num_kv_heads,
+                                                  block_size_t,
+                                                  DHt,
+                                                  capacity_t>(virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
                 for (uint32_t col = 0; col < DHt; ++col) {
                     noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
                     physical_k_tile_id += 1;
@@ -658,9 +666,9 @@ uint64_t read_k(
             uint32_t virtual_k_tile_row_num = k_chunk_start_row_num + row;
             uint32_t physical_k_tile_id =
                 (is_page_table_sharded)
-                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt>(
+                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, DHt, capacity_t>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u16)
-                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt>(
+                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt, capacity_t>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < DHt; ++col) {
                 noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
@@ -688,6 +696,7 @@ template <
     uint32_t barrier_threshold,
     bool is_page_table_sharded,
     bool reuse_k,
+    uint32_t capacity_t,
     typename VReaderType>
 void read_v(
     uint32_t v_chunk_tiles,
@@ -723,9 +732,9 @@ void read_v(
             // Use vDHt for V tensor's width since V is independent
             uint32_t physical_v_tile_id =
                 (is_page_table_sharded)
-                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, vDHt>(
+                    ? virtual_seq_tile_id_to_physical_tile_id<uint16_t, num_kv_heads, block_size_t, vDHt, capacity_t>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u16)
-                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, vDHt>(
+                    : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, vDHt, capacity_t>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < vDHt; ++col) {
                 noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -52,8 +52,12 @@ void kernel_main() {
     constexpr bool q_locally_available = get_compile_time_arg_val(33) == 1;
     constexpr bool use_k_mcast = get_compile_time_arg_val(34) == 1;
     constexpr uint32_t Bmask = get_compile_time_arg_val(35);
+    // 0 = unbounded cache (legacy); nonzero = wrap virtual tile index mod this value
+    // before page_table lookup. Value is in TILE rows (= cache_position_modulo /
+    // TILE_HEIGHT). Validated to be a multiple of block_size_t at op level.
+    constexpr uint32_t capacity_t = get_compile_time_arg_val(36);
 
-    constexpr auto q_args = TensorAccessorArgs<36>();
+    constexpr auto q_args = TensorAccessorArgs<37>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -270,7 +274,8 @@ void kernel_main() {
                     k_tile_bytes,
                     barrier_threshold,
                     is_page_table_sharded,
-                    use_k_mcast>(
+                    use_k_mcast,
+                    capacity_t>(
                     k_chunk_tiles,
                     cur_head,
                     Sk_chunk_t_dynamic,
@@ -294,7 +299,8 @@ void kernel_main() {
                     v_tile_bytes,
                     barrier_threshold,
                     is_page_table_sharded,
-                    reuse_k>(
+                    reuse_k,
+                    capacity_t>(
                     v_chunk_tiles,
                     cur_head,
                     Sk_chunk_t_dynamic,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -158,6 +158,33 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(operation_attributes.num_kv_heads_override.value() > 0, "num_kv_heads_override must be > 0");
     }
 
+    if (operation_attributes.cache_position_modulo.has_value()) {
+        TT_FATAL(
+            tensor_args.page_table_tensor.has_value(),
+            "cache_position_modulo is only supported in paged mode (when page_table is provided)");
+        const uint32_t modulo = operation_attributes.cache_position_modulo.value();
+        TT_FATAL(modulo > 0, "cache_position_modulo must be > 0 when provided");
+        // Wrap must align with block boundaries (otherwise a wrapped position would split
+        // across two physical blocks and the kernel can't address it). Pull
+        // effective_block_size from the same fallback the program factory uses.
+        const uint32_t effective_block_size = operation_attributes.block_size_override.value_or(k_shape[2]);
+        TT_FATAL(
+            modulo % effective_block_size == 0,
+            "cache_position_modulo ({}) must be a multiple of effective block_size ({})",
+            modulo,
+            effective_block_size);
+        if (operation_attributes.sliding_window_size.has_value() &&
+            operation_attributes.sliding_window_size.value() > 0) {
+            TT_FATAL(
+                modulo >= operation_attributes.sliding_window_size.value(),
+                "cache_position_modulo ({}) must be >= sliding_window_size ({}); a tighter "
+                "capacity would let the SDPA attention range wrap multiple times and "
+                "double-count positions.",
+                modulo,
+                operation_attributes.sliding_window_size.value());
+        }
+    }
+
     if (operation_attributes.paged_attention) {
         // Paged attention verification
         TT_FATAL(
@@ -514,6 +541,8 @@ ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
         operation_attributes.block_size_override,
         // Enters compile-time args via num_kv_heads (parallelization grid + strides).
         operation_attributes.num_kv_heads_override,
+        // Enters compile-time args via capacity_t (per-tile page_table wrap).
+        operation_attributes.cache_position_modulo,
         tensor_args.q,
         tensor_args.k,
         tensor_args.v,
@@ -546,7 +575,8 @@ Tensor sdpa_decode(
     std::optional<bool> use_mla,
     std::optional<uint32_t> head_dim_v,
     std::optional<uint32_t> block_size_override,
-    std::optional<uint32_t> num_kv_heads_override) {
+    std::optional<uint32_t> num_kv_heads_override,
+    std::optional<uint32_t> cache_position_modulo) {
     using OperationType = SdpaDecodeDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
         .is_causal = is_causal,
@@ -563,6 +593,7 @@ Tensor sdpa_decode(
         .head_dim_v = head_dim_v,
         .block_size_override = block_size_override,
         .num_kv_heads_override = num_kv_heads_override,
+        .cache_position_modulo = cache_position_modulo,
     };
 
     auto tensor_args = OperationType::tensor_args_t{

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -131,6 +131,7 @@ Tensor sdpa_decode(
     std::optional<bool> use_mla,
     std::optional<uint32_t> head_dim_v,
     std::optional<uint32_t> block_size_override = std::nullopt,
-    std::optional<uint32_t> num_kv_heads_override = std::nullopt);
+    std::optional<uint32_t> num_kv_heads_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
@@ -40,6 +40,15 @@ struct SdpaDecodeParams {
     // small TP). Drives both the kernel's per-block stride and its head-parallel
     // reduction grid. When nullopt, falls back to K.padded_shape[1] (legacy behavior).
     std::optional<uint32_t> num_kv_heads_override = std::nullopt;
+    // Optional circular-buffer capacity (in tokens) for the K/V cache view. When set,
+    // the kernel computes ``virtual_pos %= cache_position_modulo`` before resolving the
+    // page_table entry for every tile read, so a bounded sliding-window cache of
+    // capacity N can be addressed by absolute positions ≥ N. Required for layers using
+    // vLLM's SlidingWindowSpec, which sizes the per-layer page_table to
+    // sliding_window/block_size entries and zero-pads the rest. Must be a multiple of
+    // the effective block_size and ≥ sliding_window_size when both are set. Paged-mode
+    // only (validated in validate_on_program_cache_miss).
+    std::optional<uint32_t> cache_position_modulo = std::nullopt;
 };
 
 struct SdpaDecodeInputs {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -50,6 +50,13 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
     const float scale =
         operation_attributes.scale.value_or(1.0f / std::sqrt(static_cast<float>(input_tensor_q.padded_shape()[-1])));
     const uint32_t sliding_window_size = operation_attributes.sliding_window_size.value_or(0);
+    // capacity_t is in TILE rows (= cache_position_modulo / TILE_HEIGHT); 0 = unbounded.
+    // Validator enforces cache_position_modulo % effective_block_size == 0, so the
+    // tile-aligned divide is exact. Sets the kernel's compile-time wrap modulus on
+    // every page_table lookup so a bounded sliding-window cache can be indexed by
+    // absolute positions.
+    const uint32_t cache_position_modulo = operation_attributes.cache_position_modulo.value_or(0);
+    const uint32_t capacity_t = cache_position_modulo / TILE_HEIGHT;
     const bool share_cache = operation_attributes.share_cache.value_or(false);
 
     // V tensor: use K if MLA (V is subset of K), otherwise require explicit V
@@ -665,6 +672,7 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
         static_cast<uint32_t>(q_locally_available),
         static_cast<uint32_t>(use_col_major_group_indexing),  // use_k_mcast
         Bmask,
+        capacity_t,
     };
     tt_metal::TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args_common);
     tt_metal::TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args_common);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.cpp
@@ -113,7 +113,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     std::optional<uint32_t> block_size_override,
-    std::optional<uint32_t> num_kv_heads_override) {
+    std::optional<uint32_t> num_kv_heads_override,
+    std::optional<uint32_t> cache_position_modulo) {
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
@@ -175,7 +176,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
         std::nullopt,
         std::nullopt,
         block_size_override,
-        num_kv_heads_override);
+        num_kv_heads_override,
+        cache_position_modulo);
 }
 
 ttnn::Tensor flash_multi_latent_attention_decode(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -41,7 +41,8 @@ ttnn::Tensor paged_scaled_dot_product_attention_decode(
     std::optional<operations::transformer::SDPAProgramConfig> program_config = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     std::optional<uint32_t> block_size_override = std::nullopt,
-    std::optional<uint32_t> num_kv_heads_override = std::nullopt);
+    std::optional<uint32_t> num_kv_heads_override = std::nullopt,
+    std::optional<uint32_t> cache_position_modulo = std::nullopt);
 
 ttnn::Tensor flash_multi_latent_attention_decode(
     const ttnn::Tensor& input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -101,7 +101,14 @@ void bind_sdpa_decode(nb::module_& mod) {
         // than its declared shape. Companion to block_size for HMA cross-group sharing
         // when sliding/full layers have asymmetric num_kv_heads. See
         // ttnn.experimental.paged_update_cache's kwarg of the same name.
-        nb::arg("num_kv_heads") = nb::none());
+        nb::arg("num_kv_heads") = nb::none(),
+        // cache_position_modulo (in tokens) treats the cache as a circular buffer:
+        // every page_table lookup uses cur_pos % cache_position_modulo. Required when
+        // the cache is sized for sliding-window-only allocation (vLLM
+        // SlidingWindowSpec); without it, positions past the bounded capacity collapse
+        // onto physical block 0 and silently corrupt the cache. Must be a multiple of
+        // (effective) block_size and >= sliding_window_size. Paged-mode only.
+        nb::arg("cache_position_modulo") = nb::none());
 
     ttnn::bind_function<"flash_multi_latent_attention_decode", "ttnn.transformer.">(
         mod,


### PR DESCRIPTION
## Summary

Adds a `cache_position_modulo` kwarg to `paged_update_cache`, `paged_scaled_dot_product_attention_decode`, **and `paged_fill_cache`** so callers can address a kv cache whose physical capacity is smaller than the model's max sequence length. Each kernel computes `pos % cache_position_modulo` before resolving the per-tile `page_table` lookup, turning the cache into a circular buffer on both the prefill write side and the decode read/write side.

Together with a follow-up model-side adoption, this unblocks re-enabling vLLM's `SlidingWindowSpec` in `get_kv_cache_spec` (disabled in #45184 due to the silent-corruption bug this kwarg fixes).

## Why

vLLM's hybrid kv-cache-groups manager sizes per-layer page_tables to `sliding_window/block_size` valid entries for sliding-window layers, and zero-pads them out to `max_blocks_per_req` (see `vllm-tt-plugin/.../model_runner.py::pad_block_tables`, which uses `torch.zeros`). With absolute positions, any `cur_pos >= sliding_window` lands in the zero-padded tail and the op writes/reads physical block 0 — silently clobbering whichever user owns it. Empirically reproducible: 110/144 post-boundary steps fail PCC≥0.99 in the reproducer below (PCC tanks to 0.20–0.75).

## What changed

### Op surface

```python
ttnn.experimental.paged_update_cache(
    cache, input, update_idxs_tensor=..., page_table=...,
    block_size=...,                # existing
    num_kv_heads=...,              # existing
    cache_position_modulo=...,     # NEW (paged-mode only)
)

ttnn.transformer.paged_scaled_dot_product_attention_decode(
    q, k_cache, v_cache, page_table_tensor=...,
    cur_pos_tensor=..., sliding_window_size=...,
    block_size=..., num_kv_heads=...,
    cache_position_modulo=...,     # NEW (paged-mode only)
)

ttnn.experimental.paged_fill_cache(
    cache, input, page_table,
    batch_idx=..., block_size=...,
    cache_position_modulo=...,     # NEW (prefill write-all-with-wrap)
)
```

`sliding_window_size` retains its narrow "attention mask" meaning (existing Mistral-family callers and `test_sdpa_decode_sliding_window` unchanged); `cache_position_modulo` is the orthogonal "physical capacity with wrap" concept. Validator enforces `modulo % effective_block_size == 0` and (SDPA) `modulo >= sliding_window_size`.

### Kernels

- `paged_update_cache` reader/writer: one new compile-time arg + `update_idx %= cache_position_modulo` (gated `if (cache_position_modulo > 0)`) before the existing `virtual_block_id = update_idx / block_size` math.
- `paged_sdpa_decode`: `virtual_seq_tile_id_to_physical_tile_id` in the shared `sdpa/dataflow_common.hpp` gets an optional `capacity_t` template arg (default 0 = legacy); `read_k` / `read_v` in `sdpa_decode/dataflow_common.hpp` thread it through; `reader_decode_all.cpp` reads the new compile-time arg from the program factory. Per-tile page_table lookup already supports non-contiguous physical layouts, so an attention range that straddles the wrap boundary works with no further refactor.
- `paged_fill_cache` writer (`writer_fill_cache_interleaved.cpp`): wraps `seq_tile_id` mod `capacity_t` before its local `virtual_seq_tile_id_to_physical_tile_id` helper. Same shape of change as the update_cache reader/writer.

### Files touched

```
ttnn/cpp/ttnn/operations/experimental/paged_cache/  (kernel wrap + API plumbing for update_cache AND fill_cache)
ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp  (helper)
ttnn/cpp/ttnn/operations/transformer/sdpa_decode/  (kernel wrap + API plumbing)
tests/ttnn/unit_tests/operations/sdpa/test_bounded_sliding_kv_cache.py  (new)
```

29 files across two commits.

## Tests

- `test_bounded_sliding_kv_cache_position_modulo_round_trip` — 272 decode steps (~2 full wrap cycles) against a sliding=128 / block=32 bounded cache with the kwarg set; PCC≥0.99 at every step.
- `test_bounded_sliding_kv_cache_without_modulo_clobbers` — same setup without the kwarg; asserts ≥30% of post-boundary steps fall below PCC 0.99. **Locks in the silent-corruption bug as a regression marker**: if the legacy ops ever start behaving correctly without the kwarg, this test flips and forces a re-think.
- `test_paged_fill_cache_bounded_capacity_wrap` — prefill of length `sliding_window + block_size` into a `sliding_window`-sized bounded cache; reconstructs the logical view and verifies it equals `K[p % sliding_window for largest p < prefill_len]`. PCC≥0.99.
- `test_paged_update_cache_modulo_requires_page_table` — validator gate.
- `test_paged_update_cache_modulo_must_be_multiple_of_block_size` — validator alignment check.

## Backward compatibility verified locally

All four existing suites pass unchanged (kwarg defaults to nullopt → legacy code path):

- `tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py`: 117/117 passed
- `tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py::test_sdpa_decode_sliding_window`: passed (the unbounded-cache + sliding_window_size case Mistral-family relies on)
- `tests/ttnn/unit_tests/operations/sdpa/test_paged_sdpa_decode_flexible_geometry.py`: passed
- `tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py`: passed

## Follow-ups (separate PRs)

1. **Model adoption.** Each of `gemma3 / gemma4 / gpt-oss` decode.py passes `cache_position_modulo=config.sliding_window` for sliding layers.
2. **Re-enable SlidingWindowSpec** in `HybridAttentionForCausalLM.get_kv_cache_spec` (revert #45184) once (1) lands.
3. ~~**`paged_fill_cache`** likely needs the same kwarg for prefills that span the sliding boundary; deferred since prefill's contiguous-write pattern needs separate thought (truncate vs. wrap-on-write).~~ **Done** — second commit in this PR. Semantics: write-all-with-wrap. A prefill of length `N > modulo` overwrites earlier positions during the pass and leaves the cache holding exactly the last `modulo` tokens at their wrapped slots — which is what attention needs. Redundant earlier writes are a one-time prefill cost.

## CI Status

_Workflows kicked from this branch — links below are branch-filtered Actions pages so they populate live._

- [![sanity-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![blackhole-post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![tt-metal-l2-nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/op-side-bounded-sliding-cache)

## Test plan

- [x] New positive bounded-cache test passes locally
- [x] New negative clobbering-without-kwarg test passes locally (= bug demonstrated)
- [x] Backward-compat suites all clean locally
- [ ] CI: sanity-tests
- [ ] CI: blackhole-post-commit
- [ ] CI: tt-metal-l2-nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/op-side-bounded-sliding-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/op-side-bounded-sliding-cache)
