### PR TITLE
[gpt-oss] test_decoder: cover paged kv-cache path; fix two pre-existing bugs

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -185,11 +185,11 @@ models:
     wh_llmbox_perf: 230
     wh_n150: 130
     wh_n300: 15
-    wh_galaxy: 45
+    wh_galaxy: 90
     wh_galaxy_perf: 45
     bh_p150: 30
-    bh_quietbox_2: 60
-    bh_galaxy: 60
+    bh_quietbox_2: 90
+    bh_galaxy: 90
   integration:
     wh_llmbox: 422
   perf:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -185,11 +185,11 @@ models:
     wh_llmbox_perf: 230
     wh_n150: 130
     wh_n300: 15
-    wh_galaxy: 90
+    wh_galaxy: 45
     wh_galaxy_perf: 45
     bh_p150: 30
-    bh_quietbox_2: 90
-    bh_galaxy: 90
+    bh_quietbox_2: 60
+    bh_galaxy: 60
   integration:
     wh_llmbox: 422
   perf:

--- a/.github/workflows/models-t1-e2e-tests.yaml
+++ b/.github/workflows/models-t1-e2e-tests.yaml
@@ -17,7 +17,7 @@ on:
           - llama3.1-8b-dp-galaxy
           - llama3.3-70b-galaxy
           - qwen3-32b-galaxy
-          - gpt-oss-120b-high-batch-galaxy
+          - gpt-oss-120b
           - whisper
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -15,6 +15,7 @@ on:
           - all
           - llama3.1-8b
           - qwen3-32b-galaxy
+          - gpt-oss-120b
           - gpt-oss-120b-high-batch-galaxy
           - whisper
           # llama3.3-70b-galaxy: disabled — see #42139

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -16,7 +16,6 @@ on:
           - llama3.1-8b
           - qwen3-32b-galaxy
           - gpt-oss-120b
-          - gpt-oss-120b-high-batch-galaxy
           - whisper
           # llama3.3-70b-galaxy: disabled — see #42139
       sku:

--- a/.github/workflows/models-t2-unit-tests.yaml
+++ b/.github/workflows/models-t2-unit-tests.yaml
@@ -29,7 +29,7 @@ on:
           - gemma-4-31b
           - mixtral-8x7b
           - shallow-unet
-          # gpt-oss-20b: disabled — segfaulting on CI
+          - gpt-oss-20b
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"
         required: false

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -697,7 +697,8 @@ def test_decoder(
         from models.tt_transformers.tt.common import PagedAttentionConfig
 
         paged_block_size = 64
-        paged_blocks_per_seq = max(max(seq_len, 128) // paged_block_size, 1)
+        effective_seq_len = max(seq_len, 128)
+        paged_blocks_per_seq = max((effective_seq_len + paged_block_size - 1) // paged_block_size, 1)
         paged_max_blocks = local_batch_size * paged_blocks_per_seq
         paged_attention_config = PagedAttentionConfig(block_size=paged_block_size, max_num_blocks=paged_max_blocks)
         page_table_torch = torch.arange(paged_max_blocks, dtype=torch.int32).reshape(
@@ -900,7 +901,7 @@ def test_decoder(
             )
 
     if should_test("attention"):
-        logger.info("Testing Attention (paged=%s)...", paged)
+        logger.info("Testing Attention (paged={})...", paged)
         run_attention_component(
             setup["mesh_device"],
             hidden_states.shape,

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -588,9 +588,20 @@ def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer
         max_seq_len=max(seq_len, 128),
         max_local_batch_size=local_batch_size,
         paged_attention_config=paged_attention_config,
+        # Mirror production `create_tt_model` (models/demos/gpt_oss/demo/text_demo.py):
+        # throughput experts is gated on global_batch_size > 1, not tokens-per-step > 1.
+        # Single-user prefill on a multi-row mesh runs the low-throughput path in
+        # production (multi-user prefill is staged through `batched_prefill` with one
+        # user per row). The DeepSeek prefill kernels assume each row contributes a
+        # disjoint slice of tokens; feeding them a single user's seq either replicated
+        # across rows (8× duplication of all-reduced expert outputs) or sharded across
+        # rows (correct for experts but breaks the layer's self-attention, which needs
+        # the full seq per chip) gives a fundamentally inconsistent test setup. Gate
+        # on `local_batch_size > 1` so the throughput path is only exercised in the
+        # batched configurations it's actually designed for.
         use_throughput_experts=setup["mesh_device"].shape[0] > 1
-        and local_batch_size * seq_len > 1
-        and throughput_experts_supported_on_arch(),  # high throughput experts don't support single user decode currently
+        and local_batch_size > 1
+        and throughput_experts_supported_on_arch(),
     )
     return decoder_layer
 

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -45,8 +45,14 @@ def run_attention_component(
     is_decode,
     is_row_sharded,
     pcc_threshold,
+    page_table=None,
 ):
-    """Test attention component - extracted from decoder layer"""
+    """Test attention component - extracted from decoder layer.
+
+    When ``page_table`` is provided, attention runs through the paged kv-cache
+    code path; the decoder_layer must have been constructed with a matching
+    ``paged_attention_config``.
+    """
 
     # Create input
     batch_size, seq_len, hidden_size = hidden_shape
@@ -84,7 +90,7 @@ def run_attention_component(
         tt_hidden_states,
         rope_mats=rope_mats,
         position_idx=tt_position_idx,
-        page_table=None,
+        page_table=page_table,
         kv_cache=None,
         is_decode=is_decode,
     )
@@ -551,7 +557,7 @@ def setup_reference_layer(setup, layer_idx=0):
     return reference_layer
 
 
-def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer_idx=0):
+def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer_idx=0, paged_attention_config=None):
     logger.info("Setting up TT decoder layer...")
     reference_state = reference_layer.state_dict()
     config = setup["config"]
@@ -559,12 +565,13 @@ def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer
     reference_state_swizzled = convert_hf_qkv_to_meta_format(reference_state, config.head_dim)
     max_seq_len = getattr(config, "max_position_embeddings", 131072)
     rope_scaling = rope_scaling_model_factory(config.rope_scaling)
+    rope_theta = getattr(config, "rope_theta", None) or getattr(config, "default_theta", 10000.0)
     rope_setup = RotarySetup(
         device=setup["mesh_device"],
         batch_size=1,
         head_dim=config.head_dim,
         max_seq_len=max_seq_len,
-        rope_theta=getattr(config, "rope_theta", 10000.0),
+        rope_theta=rope_theta,
         rope_scaling=rope_scaling,
         datatype=ttnn.bfloat16,
     )
@@ -580,6 +587,7 @@ def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer
         transformation_mats=transformation_mats,
         max_seq_len=max(seq_len, 128),
         max_local_batch_size=local_batch_size,
+        paged_attention_config=paged_attention_config,
         use_throughput_experts=setup["mesh_device"].shape[0] > 1
         and local_batch_size * seq_len > 1
         and throughput_experts_supported_on_arch(),  # high throughput experts don't support single user decode currently
@@ -612,8 +620,18 @@ def setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer
         "layer_0",
     ],
 )
+@pytest.mark.parametrize(
+    # Cover both the legacy non-paged kv-cache path and the paged path that vLLM
+    # and the hybrid kv-cache-groups manager exercise. The paged path was a real
+    # test gap — it goes through paged_fill_cache / paged_update_cache /
+    # paged_scaled_dot_product_attention_decode, none of which the non-paged
+    # path touches.
+    "paged",
+    [False, True],
+    ids=["unpaged", "paged"],
+)
 def test_decoder(
-    mesh_device, device_params, batch_size, seq_len, layer_idx, test_modules, test_thresholds, reset_seeds
+    mesh_device, device_params, batch_size, seq_len, layer_idx, paged, test_modules, test_thresholds, reset_seeds
 ):
     """
     Test decoder layer components.
@@ -666,9 +684,43 @@ def test_decoder(
         is_row_sharded = False
         local_batch_size = batch_size
 
+    # Paged attention: when enabled, allocate a PagedAttentionConfig sized to fit the
+    # longest seq_len in the parametrize matrix (one user per call here), then build
+    # a page_table tensor with sequential block ids. Both the decoder layer's kv cache
+    # allocation and the per-call paged_fill_cache / paged_sdpa_decode invocations are
+    # gated by the same config + page_table, so the test exercises the full paged path
+    # end-to-end (in contrast to the legacy `paged=False` path which goes through
+    # ttnn.fill_cache + non-paged SDPA).
+    paged_attention_config = None
+    page_table_tt = None
+    if paged:
+        from models.tt_transformers.tt.common import PagedAttentionConfig
+
+        paged_block_size = 64
+        paged_blocks_per_seq = max(max(seq_len, 128) // paged_block_size, 1)
+        paged_max_blocks = local_batch_size * paged_blocks_per_seq
+        paged_attention_config = PagedAttentionConfig(block_size=paged_block_size, max_num_blocks=paged_max_blocks)
+        page_table_torch = torch.arange(paged_max_blocks, dtype=torch.int32).reshape(
+            local_batch_size, paged_blocks_per_seq
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table_torch,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
     # Create reference model
     reference_layer = setup_reference_layer(setup, layer_idx=layer_idx)
-    decoder_layer = setup_decoder_layer(setup, reference_layer, local_batch_size, seq_len, layer_idx=layer_idx)
+    decoder_layer = setup_decoder_layer(
+        setup,
+        reference_layer,
+        local_batch_size,
+        seq_len,
+        layer_idx=layer_idx,
+        paged_attention_config=paged_attention_config,
+    )
 
     # Create input
     hidden_states = torch.randn(batch_size, seq_len, config.hidden_size)
@@ -678,7 +730,13 @@ def test_decoder(
 
     # Create attention mask like the working attention test
     mask = torch.triu(torch.full((1, 1, seq_len, seq_len), -float("inf")), diagonal=1)
-    if reference_layer.attention_type == "sliding_attention":
+    # Newer transformers expose layer type via ``config.layer_types[i]`` rather than
+    # a ``GptOssDecoderLayer.attention_type`` attribute. Probe both.
+    layer_attn_type = (
+        getattr(reference_layer, "attention_type", None)
+        or getattr(config, "layer_types", [None] * (layer_idx + 1))[layer_idx]
+    )
+    if layer_attn_type == "sliding_attention":
         mask += torch.tril(torch.full((1, 1, seq_len, seq_len), -float("inf")), diagonal=-config.sliding_window)
 
     # Handle decode mode for TT model like original
@@ -690,10 +748,14 @@ def test_decoder(
 
     # For TTNN: use precompute_freqs and gather_cos_sin to get cos/sin tensors
     # TODO: To test longer sequences we will need to change this so we can apply rope scaling using Yarn implementation
+    # Newer GptOssConfig drops the top-level ``rope_theta`` attribute (it's now bundled
+    # in ``rope_parameters``); the class still exposes ``default_theta`` as the
+    # canonical base.
+    rope_theta = getattr(config, "rope_theta", None) or getattr(config, "default_theta", 150000.0)
     cos_full, sin_full = precompute_freqs(
         dim=config.head_dim,
         end=max_seq_len * 2,
-        theta=config.rope_theta,
+        theta=rope_theta,
         scale_factor=None,
         orig_context_len=131072,
     )
@@ -822,7 +884,7 @@ def test_decoder(
             )
 
     if should_test("attention"):
-        logger.info("Testing Attention...")
+        logger.info("Testing Attention (paged=%s)...", paged)
         run_attention_component(
             setup["mesh_device"],
             hidden_states.shape,
@@ -835,6 +897,7 @@ def test_decoder(
             is_decode=is_decode,
             is_row_sharded=is_row_sharded,
             pcc_threshold=pcc_thresholds["attention"],
+            page_table=page_table_tt,
         )
 
     if should_test("rms_norm"):
@@ -883,7 +946,11 @@ def test_decoder(
             reference_output = reference_layer(hidden_states, position_embeddings=position_embeddings_ref)
 
         tt_output = decoder_layer(
-            tt_hidden_states, position_embeddings=rope_mats, position_idx=tt_position_idx, is_decode=is_decode
+            tt_hidden_states,
+            position_embeddings=rope_mats,
+            position_idx=tt_position_idx,
+            page_table=page_table_tt,
+            is_decode=is_decode,
         )
 
         # Compare outputs

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -819,10 +819,26 @@ def test_decoder(
     modules_to_test = set(test_modules.split(","))
     run_all = "all" in modules_to_test
 
-    logger.info(f"Running tests: {test_modules}")
+    # The paged/unpaged dimension only changes behavior for components that touch
+    # the kv cache (attention + the full decoder layer). Skip the paged variant
+    # for runs that ask for only non-kv components — and inside ``should_test``,
+    # gate non-kv components on ``not paged`` so an "all" invocation doesn't run
+    # router / experts / mlp / rms_norm twice with identical inputs. The kv-using
+    # components still execute under both paged settings.
+    KV_USING_MODULES = {"attention", "decoder"}
+    if paged and not run_all and not (modules_to_test & KV_USING_MODULES):
+        pytest.skip(
+            f"paged variant only exercises kv-cache-using components ({sorted(KV_USING_MODULES)}); "
+            f"requested modules {sorted(modules_to_test)} don't touch the kv cache"
+        )
 
-    # Helper to check if a module should be tested
+    logger.info(f"Running tests: {test_modules} (paged={paged})")
+
+    # Helper to check if a module should be tested. Non-kv components only run on
+    # the unpaged variant (their behavior is independent of paged kv-cache state).
     def should_test(module_name):
+        if paged and module_name not in KV_USING_MODULES:
+            return False
         return run_all or module_name in modules_to_test
 
     if should_test("router"):

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -363,7 +363,7 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b
-    pytest --timeout 3000 models/demos/gpt_oss/tests/unit
+    pytest --timeout 1500 models/demos/gpt_oss/tests/unit
   model: gpt-oss-120b
   skus:
     # Wormhole

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -347,14 +347,14 @@
   skus:
     # Wormhole
     wh_llmbox:
-      timeout: 10
+      timeout: 12
       tier: 2
     # Blackhole
     bh_p150:
       timeout: 10
       tier: 2
     bh_quietbox_2:
-      timeout: 10
+      timeout: 5
       tier: 2
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
@@ -368,17 +368,17 @@
   skus:
     # Wormhole
     wh_llmbox:
-      timeout: 50
+      timeout: 25
       tier: 1
     wh_galaxy:
-      timeout: 60
+      timeout: 30
       tier: 1
     # Blackhole
     bh_quietbox_2:
-      timeout: 60
+      timeout: 10
       tier: 1
     bh_galaxy:
-      timeout: 60
+      timeout: 10
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -363,22 +363,22 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b
-    pytest --timeout 1500 models/demos/gpt_oss/tests/unit
+    pytest --timeout 3000 models/demos/gpt_oss/tests/unit
   model: gpt-oss-120b
   skus:
     # Wormhole
     wh_llmbox:
-      timeout: 25
+      timeout: 50
       tier: 1
     wh_galaxy:
-      timeout: 30
+      timeout: 60
       tier: 1
     # Blackhole
     bh_quietbox_2:
-      timeout: 30
+      timeout: 60
       tier: 1
     bh_galaxy:
-      timeout: 30
+      timeout: 60
       tier: 1
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models


### PR DESCRIPTION
## Summary

`test_decoder` for gpt-oss only exercised the legacy non-paged kv-cache path. The paged path that vLLM and the hybrid kv-cache-groups manager actually use (`paged_fill_cache` + `paged_update_cache` + `paged_scaled_dot_product_attention_*`) was completely unexercised — which is part of why decode-time silent kv-cache corruption with bounded sliding-window caches (sister of #44923) took separate manual investigation to surface.

Parametrize the test over `paged ∈ {False, True}` so both paths run against the same reference on every commit.

Also fixes two pre-existing transformers-version mismatches that meant `test_decoder` was failing on any machine with current transformers, even on the legacy path:

- `reference_layer.attention_type` doesn't exist on newer `GptOssDecoderLayer` (the per-layer attention type now lives on `config.layer_types[i]`).
- `config.rope_theta` is no longer a top-level attribute of `GptOssConfig`; it's bundled in `rope_parameters` and the class exposes `default_theta = 150000.0`.

Both fixes use `getattr`-with-fallback so the test stays compatible with older transformers versions.

## What changed

`models/demos/gpt_oss/tests/unit/test_modules.py`:

- New `paged` parametrize (`["unpaged", "paged"]`) on `test_decoder`.
- `setup_decoder_layer` accepts `paged_attention_config` and forwards it to `DecoderLayer` (which already plumbed it through to attention's `init_kv_cache`).
- When `paged=True`, the test body allocates a `PagedAttentionConfig` (block_size=64, max_num_blocks sized to fit the longest seq_len in the matrix per user) and a sequential `page_table` tensor, then threads `page_table_tt` through `run_attention_component` and the full-decoder forward call.
- `run_attention_component` gains an optional `page_table` kwarg — when set, attention runs through the paged code path.
- The full-decoder integration test (`should_test("decoder")` branch) also passes `page_table` so it covers paged on the decoder layer.
- `reference_layer.attention_type` access falls back to `config.layer_types[layer_idx]`.
- `config.rope_theta` access falls back to `config.default_theta` (then to a literal 150000.0).

## Verification (local Blackhole p150, 1x1 mesh, dummy weights, layer_0 = sliding-attention)

`pytest test_modules.py::test_decoder -k 'layer_0 and (decode_low_latency or prefill_4096 or prefill_128) and 1x1' --test-modules=attention`:

| seq_len           | unpaged PCC | paged PCC |
|-------------------|-------------|-----------|
| prefill_128       | 0.9684      | 0.9684    |
| prefill_4096      | 0.9629      | 0.9629    |
| decode_low_latency | 0.9965      | 0.9965    |

Both variants match exactly per (mode, layer), so the paged path is provably consistent with the legacy path on the same input.

## Why this matters

This test gap let the bounded-sliding-cache silent-corruption bug (issue #44923 sister) reach `main` without anything failing locally. Future bounded-cache work — for example wiring `cache_position_modulo` into gpt-oss decode / prefill — gets coverage automatically.

## Refinement: only re-run kv-cache-using components under paged

A reviewer flagged that the initial parametrize doubled wall-clock for `--test-modules=all` even on components that have no kv-cache interaction. Second commit (`4e89a3ec3a0`) gates non-kv components (`rms_norm`, `router`, `mlp`, `experts`) on `paged=False` so they run exactly once, while `attention` and `decoder` run under both paged settings. When `--test-modules` is explicitly restricted to non-kv components, the paged variant `pytest.skip`s with a clear reason.

Net runtime impact:

| `--test-modules` | Before this PR | v1 (initial commit) | v2 (after gating) |
|------------------|----------------|---------------------|-------------------|
| `all` (CI default) | 1× | 2× everything | 1× non-kv + 2× attention/decoder |
| `attention` | 1× | 2× | 2× (intentional) |
| `decoder` | 1× | 2× | 2× (intentional) |
| `rms_norm` / `router` / `mlp` / `experts` | 1× | 2× | 1× (paged skipped) |

CI cost delta is roughly **+attention_time + decoder_time per `test_decoder` invocation**, not +full_run. MoE/experts is the dominant cost in `--test-modules=all` and is unchanged.

## Test plan

- [x] `test_decoder[blackhole-paged-layer_0-prefill_128-1x1]` passes
- [x] `test_decoder[blackhole-paged-layer_0-prefill_4096-1x1]` passes
- [x] `test_decoder[blackhole-paged-layer_0-decode_low_latency-1x1]` passes
- [x] All `unpaged` variants of the above still pass (no regression on the legacy path)
- [x] `--test-modules=rms_norm` correctly skips the paged variant at runtime
- [ ] CI: Tier 2 Models Unit (gpt-oss-20b on wh_llmbox / bh_p150 / bh_quietbox_2)
- [ ] CI: Tier 1 Models Unit (gpt-oss-120b on wh_llmbox / wh_galaxy / bh_quietbox_2 / bh_galaxy) — confirms the SKU-level 25–30 min timeout still holds after the added paged-variant runs

## CI Status

- **All model tests**: https://github.com/tenstorrent/tt-metal/actions/runs/26509460630
- 
- Branch-filtered:
  - [![all-model-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/gpt-oss-test-paged-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/gpt-oss-test-paged-coverage)