### PR TITLE
Lingjunw/qwen35 27b automodel deprecation

### DIFF
--- a/models/common/llama_models.py
+++ b/models/common/llama_models.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Union
 import torch
 from PIL import Image
 from pydantic import BaseModel, validator
-from transformers import AutoModelForVision2Seq, AutoProcessor, pipeline
+from transformers import AutoModelForImageTextToText, AutoProcessor, pipeline
 
 
 class Role(Enum):
@@ -185,7 +185,7 @@ class GeneratorChat:
 class GeneratorText:
     def __init__(self, model_name):
         self.processor = AutoProcessor.from_pretrained(model_name)
-        self.model = AutoModelForVision2Seq.from_pretrained(model_name)
+        self.model = AutoModelForImageTextToText.from_pretrained(model_name)
 
     def text_completion(
         self,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2942,12 +2942,12 @@ class ModelArgs:
         return self.model_config
 
     def get_hf_model_cls(self):
-        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoModelForVision2Seq
+        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
         if not self.is_multimodal:
             return AutoModelForCausalLM
 
-        for model_cls in (AutoModelForVision2Seq, AutoModelForImageTextToText):
+        for model_cls in (AutoModelForImageTextToText,):
             if type(self.hf_config) in model_cls._model_mapping:
                 return model_cls
 


### PR DESCRIPTION
This PR updates depreciated `AutoModelForVision2Seq` with `AutoModelForImageTextToText` since we're bumping tt-metal to `transformers > 5`