### PR TITLE
deepseek_v3: update BLOCK_TILES_W consumers in hf_model_utils.py

### DIFF
--- a/models/demos/deepseek_v3/utils/hf_model_utils.py
+++ b/models/demos/deepseek_v3/utils/hf_model_utils.py
@@ -364,14 +364,14 @@ def _default_quad_ring_shard_maps(
     *,
     num_cores: int = 12,
 ) -> tuple[list[int], list[tuple[int, int]]]:
-    from ttnn.experimental.moe_compute_utils import BLOCK_TILES_W, _shard_tiles, _w2_shard_tiles
+    from ttnn.experimental.moe_compute_utils import W2_TILES_PER_A2A_ITER_W, _shard_tiles, _w2_shard_tiles
 
     import ttnn
 
     hidden_tiles = hidden_size // ttnn.TILE_SIZE
     intermediate_tiles = intermediate_size // ttnn.TILE_SIZE
     max_w2_tiles = (hidden_tiles + num_cores - 1) // num_cores
-    groups_per_core = (max_w2_tiles + BLOCK_TILES_W - 1) // BLOCK_TILES_W
+    groups_per_core = (max_w2_tiles + W2_TILES_PER_A2A_ITER_W - 1) // W2_TILES_PER_A2A_ITER_W
 
     w0_w1_shard_map = []
     w2_shard_map = []
@@ -379,8 +379,8 @@ def _default_quad_ring_shard_maps(
         w0_w1_shard_map.append(_shard_tiles(intermediate_tiles, ring_pos, num_cores))
 
         w2_tiles = _w2_shard_tiles(hidden_tiles, ring_pos, intermediate_tiles, num_cores)
-        last_group_tiles = w2_tiles - (groups_per_core - 1) * BLOCK_TILES_W
-        last_group_pad_tiles = groups_per_core * BLOCK_TILES_W - w2_tiles
+        last_group_tiles = w2_tiles - (groups_per_core - 1) * W2_TILES_PER_A2A_ITER_W
+        last_group_pad_tiles = groups_per_core * W2_TILES_PER_A2A_ITER_W - w2_tiles
         w2_shard_map.append((last_group_tiles, last_group_pad_tiles))
 
     return w0_w1_shard_map, w2_shard_map


### PR DESCRIPTION
## Summary

- PR #44195 split `BLOCK_TILES_W` (in `ttnn._experimental.moe_compute_utils`) into two distinct named constants `W0_W1_BLOCK_TILES_W` and `W2_TILES_PER_A2A_ITER_W` to mirror the kernel-side naming in `moe_ring_common.h`.
- `models/demos/deepseek_v3/utils/hf_model_utils.py::_default_quad_ring_shard_maps` was missed in the consumer sweep at the time; it still imports the now-removed `BLOCK_TILES_W`.
- This patch updates the import and the 3 usage sites (lines 374, 382, 383) to `W2_TILES_PER_A2A_ITER_W`. The semantics are W2-specific in all four references (`max_w2_tiles`, `w2_tiles`, `w2_shard_map`), so `W2_TILES_PER_A2A_ITER_W` is the structurally-correct name (matches the same usage pattern in `moe_compute_utils.py::get_weight_core_shard_maps`). 
- Currently all of those variables has the same value 4 anyway.

## Test plan

- [ ] `pytest models/demos/deepseek_v3/tests/test_hf_model_utils.py::test_default_quad_ring_shard_maps_match_legacy_deepseek_layout -v` no longer ImportErrors on `BLOCK_TILES_W`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/moe_compute_patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/moe_compute_patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/moe_compute_patch)