### PR TITLE
[Bug fix] ttnn.reshape: auto-derive shard_spec + H/W grid lock-in + over-pad warnings

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_reshape.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_reshape.py
@@ -400,3 +400,189 @@ def test_reshape_cross_strategy(device, input_shape, output_shape, case_id, in_s
     tt_output = ttnn.reshape(tt_input, output_shape, memory_config=out_memcfg)
     actual = ttnn.to_torch(tt_output)
     _assert_reshape(torch_output, actual, ttnn.bfloat16)
+
+
+# Reshape on a sharded TILE input must keep the input shard grid. The per-core
+# shape may round up to tile alignment, but the grid itself must never be
+# silently shrunk.
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape, expected_out_shard_shape",
+    [
+        # 64 cores, phys_h=320 -> per-core 5 rows padded up to 32 (6.4x waste).
+        ((640, 32), (320, 64), [32, 64]),
+        # Same setup with phys_h=160 -> per-core 3 rows padded to 32 (10x waste).
+        ((640, 32), (160, 128), [32, 128]),
+    ],
+    ids=["overpad_320", "deeper_overpad_160"],
+)
+def test_reshape_height_sharded_preserves_input_grid_when_alignment_wastes(
+    device, input_shape, output_shape, expected_out_shard_shape
+):
+    """Reshape on a HEIGHT_SHARDED TILE input must preserve the input grid and
+    round each per-core shape up to tile alignment, even when phys_h/num_cores
+    is not already tile-aligned. Data must match torch bit-for-bit on bf16.
+    """
+    core_grid_size = device.compute_with_storage_grid_size()
+    if core_grid_size.x < 8 or core_grid_size.y < 8:
+        pytest.skip("requires at least 8x8 core grid")
+
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
+
+    # 64 cores, phys_h=input_shape[0] tile-aligned -> shard_h = 32 per core.
+    input_shard_shape = [32, input_shape[1]]
+    in_shard_spec = ttnn.ShardSpec(grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=in_shard_spec
+    )
+
+    torch.manual_seed(0)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output = torch_input.reshape(output_shape)
+
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_memcfg
+    )
+
+    tt_output = ttnn.reshape(tt_input, output_shape)
+
+    out_memcfg = tt_output.memory_config()
+    assert (
+        out_memcfg.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    ), f"reshape changed output memory layout to {out_memcfg.memory_layout} (expected HEIGHT_SHARDED)"
+    assert (
+        out_memcfg.shard_spec.grid == grid
+    ), f"reshape silently changed the output shard grid ({grid} -> {out_memcfg.shard_spec.grid})"
+    assert (
+        list(out_memcfg.shard_spec.shape) == expected_out_shard_shape
+    ), f"output per-core shard shape {list(out_memcfg.shard_spec.shape)} != expected {expected_out_shard_shape}"
+
+    actual = ttnn.to_torch(tt_output).to(torch.bfloat16)
+    _assert_reshape(torch_output, actual, ttnn.bfloat16)
+
+
+def test_reshape_width_sharded_preserves_input_grid_when_alignment_wastes(device):
+    """Symmetric WIDTH_SHARDED case: the input grid must be preserved and the
+    per-core width rounded up to tile alignment.
+    """
+    core_grid_size = device.compute_with_storage_grid_size()
+    if core_grid_size.x < 8 or core_grid_size.y < 8:
+        pytest.skip("requires at least 8x8 core grid")
+
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})
+
+    # 8 cores, phys (32, 256) -> shard_w = 32 per core (clean).
+    input_shape = (32, 256)
+    input_shard_shape = [32, 32]
+    in_shard_spec = ttnn.ShardSpec(grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, buffer_type=ttnn.BufferType.L1, shard_spec=in_shard_spec
+    )
+
+    # phys_w=32 on 8 cores -> per-core 4 cols padded to 32 (8x waste).
+    output_shape = (256, 32)
+    expected_out_shard_shape = [256, 32]
+
+    torch.manual_seed(0)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output = torch_input.reshape(output_shape)
+
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_memcfg
+    )
+
+    tt_output = ttnn.reshape(tt_input, output_shape)
+
+    out_memcfg = tt_output.memory_config()
+    assert (
+        out_memcfg.memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    ), f"reshape changed output memory layout to {out_memcfg.memory_layout} (expected WIDTH_SHARDED)"
+    assert (
+        out_memcfg.shard_spec.grid == grid
+    ), f"reshape silently changed the output shard grid ({grid} -> {out_memcfg.shard_spec.grid})"
+    assert (
+        list(out_memcfg.shard_spec.shape) == expected_out_shard_shape
+    ), f"output per-core shard shape {list(out_memcfg.shard_spec.shape)} != expected {expected_out_shard_shape}"
+
+    actual = ttnn.to_torch(tt_output).to(torch.bfloat16)
+    _assert_reshape(torch_output, actual, ttnn.bfloat16)
+
+
+# Auto-derive shard_spec: caller pins the output layout but leaves shard_spec
+# unset. reshape should reuse the input's shard_spec as the seed grid rather
+# than raising "Shard spec has no value".
+
+
+@pytest.mark.parametrize(
+    "layout_name, in_shard_shape, in_grid_xy, input_shape, output_shape, expected_out_shard_shape",
+    [
+        # HEIGHT: phys_h=3584 on 56 cores -> ceil(3584/56)=64, rounded to tile -> 64 rows per core.
+        ("HEIGHT_SHARDED", [32, 64], (7, 6), (1, 1, 1792, 64), (1, 1, 3584, 32), [64, 32]),
+        # WIDTH: phys_w=128 on 8 cores -> ceil(128/8)=16, rounded to tile -> 32 cols per core.
+        ("WIDTH_SHARDED", [32, 32], (7, 0), (1, 1, 32, 256), (1, 1, 64, 128), [64, 32]),
+        # BLOCK: phys (128,512) on 4x4 -> find_best_n_1d keeps full 4x4 -> 32x128 per core.
+        ("BLOCK_SHARDED", [64, 64], (3, 3), (1, 1, 256, 256), (1, 1, 128, 512), [32, 128]),
+    ],
+    ids=["height", "width", "block"],
+)
+def test_reshape_sharded_memory_config_without_shard_spec_autoderives_from_input(
+    device, layout_name, in_shard_shape, in_grid_xy, input_shape, output_shape, expected_out_shard_shape
+):
+    """Public API: ttnn.reshape(t, shape, memory_config=MemoryConfig(layout, L1))
+    (no shard_spec) must succeed by seeding from the input's shard_spec and
+    derive a valid output shard_spec. Data must match torch bit-for-bit.
+    """
+    core_grid_size = device.compute_with_storage_grid_size()
+    if core_grid_size.x <= in_grid_xy[0] or core_grid_size.y <= in_grid_xy[1]:
+        pytest.skip(f"requires at least {in_grid_xy[0] + 1}x{in_grid_xy[1] + 1} core grid")
+
+    layout = getattr(ttnn.TensorMemoryLayout, layout_name)
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(*in_grid_xy))})
+    in_shard_spec = ttnn.ShardSpec(grid, in_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in_memcfg = ttnn.MemoryConfig(layout, buffer_type=ttnn.BufferType.L1, shard_spec=in_shard_spec)
+
+    torch.manual_seed(0)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output = torch_input.reshape(output_shape)
+
+    tt_input = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in_memcfg
+    )
+
+    out_memcfg_no_spec = ttnn.MemoryConfig(layout, buffer_type=ttnn.BufferType.L1)
+    assert out_memcfg_no_spec.shard_spec is None, "test setup: out_memcfg should not carry a shard_spec"
+
+    tt_output = ttnn.reshape(tt_input, output_shape, memory_config=out_memcfg_no_spec)
+
+    out_memcfg = tt_output.memory_config()
+    assert out_memcfg.is_sharded(), "auto-derived output should remain sharded"
+    assert out_memcfg.memory_layout == layout, f"layout changed to {out_memcfg.memory_layout}"
+    assert out_memcfg.shard_spec is not None, "auto-derived output must have a shard_spec"
+    assert out_memcfg.shard_spec.grid == grid, "auto-derived output should reuse the input grid"
+    assert (
+        list(out_memcfg.shard_spec.shape) == expected_out_shard_shape
+    ), f"derived shard shape {list(out_memcfg.shard_spec.shape)} != expected {expected_out_shard_shape}"
+
+    actual = ttnn.to_torch(tt_output).to(torch.bfloat16)
+    _assert_reshape(torch_output, actual, ttnn.bfloat16)
+
+
+def test_reshape_layout_only_sharded_output_without_input_shard_spec_fails(device):
+    """Interleaved input + layout-only sharded output memory_config must TT_FATAL
+    with an actionable message when no input shard_spec is available to seed from.
+    """
+    torch_input = torch.randn(1, 1, 256, 256, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1)
+    assert out_mc.shard_spec is None
+
+    with pytest.raises(RuntimeError, match="no input_shard_spec is available"):
+        ttnn.reshape(tt_input, (1, 1, 512, 128), memory_config=out_mc)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -72,18 +72,34 @@ static bool has_inner_2d_tile_padding(const ttnn::Shape& shape) {
 // Returns a sharded output MemoryConfig, or INTERLEAVED if no valid grid exists.
 // Callers must check is_sharded() before calling interleaved_to_sharded.
 //
-// `explicit_memory_config` indicates the caller explicitly passed `memory_config` to the
-// public reshape API (vs. defaulting to the input tensor's). When true, the supplied spec
-// is honored as-is provided it tile-aligns and its grid covers the output's physical
-// shape (over-cover allowed). This lets a model lock in the layout its downstream ops are
-// tuned for; if the supplied spec does not cover the output we fall through to the
-// derivation logic below.
+// `explicit_memory_config`: caller passed `memory_config` to the public API; honor
+// a supplied BLOCK spec when tile-aligned and its grid covers the output.
+//
+// `input_shard_spec`: when `memory_config` is sharded but has no shard_spec, seed
+// derivation from the input tensor's spec (layout should match the input).
 MemoryConfig recompute_shard_spec_for_output(
-    const MemoryConfig& memory_config, const TensorSpec& output_shape, bool explicit_memory_config = false) {
+    const MemoryConfig& memory_config,
+    const TensorSpec& output_shape,
+    bool explicit_memory_config = false,
+    const std::optional<tt::tt_metal::ShardSpec>& input_shard_spec = std::nullopt) {
+    // Auto-derive: caller asked for a sharded output but didn't pin a shard_spec. Seed
+    // from input_shard_spec (typically the input tensor's) and re-enter; on the
+    // recursion the layout/buffer_type from the caller is preserved while the grid
+    // comes from the input.
+    if (!memory_config.shard_spec().has_value() && input_shard_spec.has_value()) {
+        MemoryConfig seeded{memory_config.memory_layout(), memory_config.buffer_type(), input_shard_spec.value()};
+        return recompute_shard_spec_for_output(seeded, output_shape, explicit_memory_config, std::nullopt);
+    }
+
     auto output_mem_config = memory_config;
-    TT_FATAL(memory_config.shard_spec().has_value(), "Shard spec has no value");
-    const auto& input_shard_spec = memory_config.shard_spec().value();
-    auto orientation = input_shard_spec.orientation;
+    TT_FATAL(
+        memory_config.shard_spec().has_value(),
+        "ttnn.reshape: sharded output memory_config (layout={}) was supplied without a shard_spec, "
+        "and no input_shard_spec is available (input is likely interleaved). Either provide a "
+        "shard_spec on memory_config or omit memory_config to inherit it from the input tensor.",
+        memory_config.memory_layout());
+    const auto& source_shard_spec = memory_config.shard_spec().value();
+    auto orientation = source_shard_spec.orientation;
 
     auto alignment = output_shape.page_config().get_recommended_shard_shape_alignment(output_shape.data_type());
     uint32_t align_h = alignment.size() >= 2 ? alignment[-2] : 1;
@@ -93,14 +109,14 @@ MemoryConfig recompute_shard_spec_for_output(
 
     // Reject non-rectangular grids; bounding_box() would silently include extra cores.
     // TODO: search for a rectangular sub-grid inside the input before falling back.
-    auto input_bbox = input_shard_spec.grid.bounding_box();
-    if (input_bbox.size() != input_shard_spec.grid.num_cores()) {
+    auto input_bbox = source_shard_spec.grid.bounding_box();
+    if (input_bbox.size() != source_shard_spec.grid.num_cores()) {
         log_warning(
             tt::LogOp,
             "ttnn.reshape: input shard grid is non-rectangular "
             "(bbox cores={}, grid cores={}); falling back to INTERLEAVED",
             input_bbox.size(),
-            input_shard_spec.grid.num_cores());
+            source_shard_spec.grid.num_cores());
         return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
     }
 
@@ -113,7 +129,7 @@ MemoryConfig recompute_shard_spec_for_output(
     // grid covers the output's physical extent. Lets callers preserve a layout their
     // downstream ops are tuned for, even when our derived sub-grid would be smaller.
     if (explicit_memory_config && layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        const auto& shard_shape = input_shard_spec.shape;
+        const auto& shard_shape = source_shard_spec.shape;
         uint32_t shard_h = shard_shape[0];
         uint32_t shard_w = shard_shape[1];
         bool is_rm = (orientation == ShardOrientation::ROW_MAJOR);
@@ -149,15 +165,55 @@ MemoryConfig recompute_shard_spec_for_output(
         CoreCoord new_end =
             is_rm ? CoreCoord{start.x + nx - 1, start.y + ny - 1} : CoreCoord{start.x + ny - 1, start.y + nx - 1};
         output_mem_config = output_shape.block_sharded(CoreRange{start, new_end}, orientation).memory_config();
-    } else if (layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        // Pass the full input grid through unchanged. Sub-grid search (picking a smaller
-        // rectangular subset for tile alignment) silently shrinks the shard grid and
-        // caused UFLD V2 PCC regression by changing the shard layout that downstream
-        // ops read from; let height_sharded() handle alignment internally instead.
-        output_mem_config = output_shape.height_sharded(input_shard_spec.grid, orientation).memory_config();
-    } else if (layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        // Pass the full input grid through unchanged (see HEIGHT_SHARDED comment above).
-        output_mem_config = output_shape.width_sharded(input_shard_spec.grid, orientation).memory_config();
+    } else if (layout == TensorMemoryLayout::HEIGHT_SHARDED || layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        const bool is_height = (layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        const uint32_t num_cores = source_shard_spec.grid.num_cores();
+        const uint32_t phys_dim = is_height ? phys_h : phys_w;
+
+        // Degenerate inputs cannot form a valid sharded spec; fall back to INTERLEAVED
+        // (mirrors the BLOCK_SHARDED safety net above).
+        if (num_cores == 0 || phys_dim == 0) {
+            log_warning(
+                tt::LogOp,
+                "ttnn.reshape: cannot form valid {} spec for output "
+                "(phys_{}={}, num_cores={}); falling back to INTERLEAVED",
+                layout,
+                is_height ? 'h' : 'w',
+                phys_dim,
+                num_cores);
+            return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
+        }
+
+        // Preserve the input grid; height/width_sharded() rounds the per-core shape up
+        // to tile alignment without changing the grid itself.
+        output_mem_config = is_height ? output_shape.height_sharded(source_shard_spec.grid, orientation).memory_config()
+                                      : output_shape.width_sharded(source_shard_spec.grid, orientation).memory_config();
+
+        // Warn when each core's shard slot is much larger than the data slice it actually backs.
+        // 4x threshold skips the benign 2x case (e.g. 16-row data in a 32-row tile slot) and
+        // only flags genuinely over-padded shards (e.g. UFLD V2's ~6.4x case).
+        constexpr uint32_t kOverpadWarnThreshold = 4;
+        if (output_mem_config.shard_spec().has_value()) {
+            const auto& out_shape = output_mem_config.shard_spec().value().shape;
+            const uint32_t shard_dim = is_height ? out_shape[0] : out_shape[1];
+            const uint32_t data_per_core = (phys_dim + num_cores - 1) / num_cores;
+            if (data_per_core > 0 && shard_dim >= kOverpadWarnThreshold * data_per_core) {
+                log_warning(
+                    tt::LogOp,
+                    "ttnn.reshape: {} output per-core shard ({} {}) is {}x its per-core data "
+                    "slice ({} {}) for phys_{}={} on {} cores. Per-core L1 is dominated by "
+                    "padding; consider a smaller core grid or INTERLEAVED.",
+                    layout,
+                    shard_dim,
+                    is_height ? "rows" : "cols",
+                    shard_dim / data_per_core,
+                    data_per_core,
+                    is_height ? "rows" : "cols",
+                    is_height ? 'h' : 'w',
+                    phys_dim,
+                    num_cores);
+            }
+        }
     } else {
         TT_FATAL(
             false, "Unsupported memory layout {}: expected BLOCK_SHARDED, HEIGHT_SHARDED, or WIDTH_SHARDED", layout);
@@ -190,7 +246,11 @@ ttnn::Tensor perform_reshape_on_2D_RM(
 
     if (memory_config.is_sharded()) {
         TT_FATAL(!sub_core_grid.has_value(), "Sharded reshape does not support sub core grid specification\n");
-        auto output_mem_config = recompute_shard_spec_for_output(memory_config, temp_tensor2.tensor_spec());
+        auto output_mem_config = recompute_shard_spec_for_output(
+            memory_config,
+            temp_tensor2.tensor_spec(),
+            /*explicit_memory_config=*/false,
+            tensor.memory_config().shard_spec());
         if (output_mem_config.is_sharded()) {
             return ttnn::interleaved_to_sharded(temp_tensor2, output_mem_config, std::nullopt);
         }
@@ -376,7 +436,10 @@ ttnn::Tensor reshape_tiled(
             output_tensor_3d = ttnn::typecast(output_tensor_3d, tensor.dtype());
             if (memory_config.is_sharded()) {
                 auto output_mem_config = detail::recompute_shard_spec_for_output(
-                    memory_config, output_tensor_3d.tensor_spec(), explicit_memory_config);
+                    memory_config,
+                    output_tensor_3d.tensor_spec(),
+                    explicit_memory_config,
+                    tensor.memory_config().shard_spec());
                 if (output_mem_config.is_sharded()) {
                     output_tensor_3d = ttnn::interleaved_to_sharded(output_tensor_3d, output_mem_config, std::nullopt);
                 }
@@ -397,12 +460,12 @@ ttnn::Tensor reshape_tiled(
                     interleaved_output_mem_config,
                     requested_shape_3d,
                     requested_padded_shape_3d));
-            target_output_mem_config =
-                detail::recompute_shard_spec_for_output(memory_config, interleaved_output_spec, explicit_memory_config);
+            target_output_mem_config = detail::recompute_shard_spec_for_output(
+                memory_config, interleaved_output_spec, explicit_memory_config, tensor.memory_config().shard_spec());
         }
 
-        // Defensive: if recompute fell back to INTERLEAVED while input is sharded,
-        // convert the input first so prim::reshape_view gets matching layouts.
+        // If recompute fell back to INTERLEAVED, un-shard the input so
+        // prim::reshape_view sees matching layouts.
         if (tensor3d.memory_config().is_sharded() && !target_output_mem_config.is_sharded()) {
             MemoryConfig interleaved_input{TensorMemoryLayout::INTERLEAVED, tensor3d.memory_config().buffer_type()};
             tensor3d = ttnn::sharded_to_interleaved(tensor3d, interleaved_input, std::nullopt);
@@ -466,8 +529,8 @@ ttnn::Tensor reshape_tiled(
         tt::tt_metal::TensorSpec synthetic_spec(requested_shape_3d, synthetic_layout);
 
         // Recompute the shard spec for the output tensor shape
-        updated_mem_config =
-            detail::recompute_shard_spec_for_output(updated_mem_config, synthetic_spec, explicit_memory_config);
+        updated_mem_config = detail::recompute_shard_spec_for_output(
+            updated_mem_config, synthetic_spec, explicit_memory_config, tensor.memory_config().shard_spec());
     }
 
     auto output_tensor_3d = ttnn::prim::reshape_view(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -87,7 +87,7 @@ MemoryConfig recompute_shard_spec_for_output(
     // layout and buffer_type are preserved; the full ShardSpec (grid, orientation, and
     // per-core shape) comes from the input and will be re-derived for the output shape.
     if (!memory_config.shard_spec().has_value() && input_shard_spec.has_value()) {
-        MemoryConfig seeded{memory_config.memory_layout(), memory_config.buffer_type(), input_shard_spec.value()};
+        MemoryConfig seeded{memory_config.memory_layout(), memory_config.buffer_type(), input_shard_spec};
         // Layout-only request: re-derive shard_spec for output_shape; skip BLOCK explicit override.
         return recompute_shard_spec_for_output(seeded, output_shape, /*explicit_memory_config=*/false, std::nullopt);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -83,14 +83,14 @@ MemoryConfig recompute_shard_spec_for_output(
     bool explicit_memory_config = false,
     const std::optional<tt::tt_metal::ShardSpec>& input_shard_spec = std::nullopt) {
     // Auto-derive: caller asked for a sharded output but didn't pin a shard_spec. Seed
-    // from input_shard_spec (typically the input tensor's) and re-enter; on the
-    // recursion the layout/buffer_type from the caller is preserved while the grid
-    // comes from the input.
+    // from input_shard_spec (typically the input tensor's) and re-enter. The caller's
+    // layout and buffer_type are preserved; the full ShardSpec (grid, orientation, and
+    // per-core shape) comes from the input and will be re-derived for the output shape.
     if (!memory_config.shard_spec().has_value() && input_shard_spec.has_value()) {
         MemoryConfig seeded{memory_config.memory_layout(), memory_config.buffer_type(), input_shard_spec.value()};
-        return recompute_shard_spec_for_output(seeded, output_shape, explicit_memory_config, std::nullopt);
+        // Layout-only request: re-derive shard_spec for output_shape; skip BLOCK explicit override.
+        return recompute_shard_spec_for_output(seeded, output_shape, /*explicit_memory_config=*/false, std::nullopt);
     }
-
     auto output_mem_config = memory_config;
     TT_FATAL(
         memory_config.shard_spec().has_value(),
@@ -107,13 +107,19 @@ MemoryConfig recompute_shard_spec_for_output(
     auto phys_h = output_shape.physical_shape().height();
     auto phys_w = output_shape.physical_shape().width();
 
+    // bounding_box() TT_FATALs on an empty grid; guard before calling it.
+    if (source_shard_spec.grid.num_cores() == 0) {
+        log_warning(tt::LogOp, "ttnn.reshape: shard grid is empty; falling back to INTERLEAVED");
+        return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
+    }
+
     // Reject non-rectangular grids; bounding_box() would silently include extra cores.
     // TODO: search for a rectangular sub-grid inside the input before falling back.
     auto input_bbox = source_shard_spec.grid.bounding_box();
     if (input_bbox.size() != source_shard_spec.grid.num_cores()) {
         log_warning(
             tt::LogOp,
-            "ttnn.reshape: input shard grid is non-rectangular "
+            "ttnn.reshape: shard grid is non-rectangular "
             "(bbox cores={}, grid cores={}); falling back to INTERLEAVED",
             input_bbox.size(),
             source_shard_spec.grid.num_cores());
@@ -170,17 +176,13 @@ MemoryConfig recompute_shard_spec_for_output(
         const uint32_t num_cores = source_shard_spec.grid.num_cores();
         const uint32_t phys_dim = is_height ? phys_h : phys_w;
 
-        // Degenerate inputs cannot form a valid sharded spec; fall back to INTERLEAVED
-        // (mirrors the BLOCK_SHARDED safety net above).
-        if (num_cores == 0 || phys_dim == 0) {
+        // phys_dim == 0 cannot form a valid sharded spec; fall back to INTERLEAVED.
+        if (phys_dim == 0) {
             log_warning(
                 tt::LogOp,
-                "ttnn.reshape: cannot form valid {} spec for output "
-                "(phys_{}={}, num_cores={}); falling back to INTERLEAVED",
+                "ttnn.reshape: cannot form valid {} spec for output (phys_{}=0); falling back to INTERLEAVED",
                 layout,
-                is_height ? 'h' : 'w',
-                phys_dim,
-                num_cores);
+                is_height ? 'h' : 'w');
             return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
         }
 
@@ -197,7 +199,7 @@ MemoryConfig recompute_shard_spec_for_output(
             const auto& out_shape = output_mem_config.shard_spec().value().shape;
             const uint32_t shard_dim = is_height ? out_shape[0] : out_shape[1];
             const uint32_t data_per_core = (phys_dim + num_cores - 1) / num_cores;
-            if (data_per_core > 0 && shard_dim >= kOverpadWarnThreshold * data_per_core) {
+            if (data_per_core > 0 && shard_dim / data_per_core >= kOverpadWarnThreshold) {
                 log_warning(
                     tt::LogOp,
                     "ttnn.reshape: {} output per-core shard ({} {}) is {}x its per-core data "

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -107,12 +107,6 @@ MemoryConfig recompute_shard_spec_for_output(
     auto phys_h = output_shape.physical_shape().height();
     auto phys_w = output_shape.physical_shape().width();
 
-    // bounding_box() TT_FATALs on an empty grid; guard before calling it.
-    if (source_shard_spec.grid.num_cores() == 0) {
-        log_warning(tt::LogOp, "ttnn.reshape: shard grid is empty; falling back to INTERLEAVED");
-        return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
-    }
-
     // Reject non-rectangular grids; bounding_box() would silently include extra cores.
     // TODO: search for a rectangular sub-grid inside the input before falling back.
     auto input_bbox = source_shard_spec.grid.bounding_box();
@@ -175,16 +169,6 @@ MemoryConfig recompute_shard_spec_for_output(
         const bool is_height = (layout == TensorMemoryLayout::HEIGHT_SHARDED);
         const uint32_t num_cores = source_shard_spec.grid.num_cores();
         const uint32_t phys_dim = is_height ? phys_h : phys_w;
-
-        // phys_dim == 0 cannot form a valid sharded spec; fall back to INTERLEAVED.
-        if (phys_dim == 0) {
-            log_warning(
-                tt::LogOp,
-                "ttnn.reshape: cannot form valid {} spec for output (phys_{}=0); falling back to INTERLEAVED",
-                layout,
-                is_height ? 'h' : 'w');
-            return MemoryConfig{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
-        }
 
         // Preserve the input grid; height/width_sharded() rounds the per-core shape up
         // to tile alignment without changing the grid itself.

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -43,7 +43,7 @@ void bind_reshape_view_operation(nb::module_& mod) {
                 * shape: Shape of tensor.
 
             Keyword Args:
-                * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config
+                * :attr:`memory_config`: Memory Config of the output tensor. Default is to match input tensor memory config. If ``memory_config`` specifies a sharded layout without ``shard_spec``, the input tensor's ``shard_spec`` is used as the seed grid (layout should match the input).
                 * :attr:`pad_value` (number): Value to pad the output tensor. Default is 0
                 * :attr:`reshape_tile_mode` (TileReshapeMapMode): Advanced option. Set to RECREATE to recompute and reallocate the mapping tensor. This may alleviate DRAM fragmentation but is slow. Default is CACHE. This keyword is named :attr:`reshape_tile_mode` on all overloads; the small-vector (tuple/list) shape overload previously used the name ``recreate_mapping_tensor`` for the same option—update callers to ``reshape_tile_mode``.
                 * :attr:`sub_core_grids` (CoreRangeSet, optional): Specifies sub-core grid ranges for advanced core selection control. Default uses all the cores in the device.


### PR DESCRIPTION
## Summary

Closes [#43113](https://github.com/tenstorrent/tt-metal/issues/43113).

Follow-up to the sharded-tiled reshape work in [#42543](https://github.com/tenstorrent/tt-metal/pull/42543). This PR hardens `recompute_shard_spec_for_output` for `HEIGHT_SHARDED` / `WIDTH_SHARDED` outputs and fixes a public-API crash when callers pass a sharded output `memory_config` without a `shard_spec`.

**Default behavior is unchanged for existing callers** that already pass a full sharded `memory_config` (layout + `shard_spec`) or omit `memory_config` entirely. Two intentional differences:

- **Fix:** layout-only sharded `memory_config` (no `shard_spec`) no longer crashes when the input tensor is sharded; we auto-derive from the input's `shard_spec`.
- **Observability:** over-padded H/W shard slots (≥ 4× per-core data) may emit `log_warning(tt::LogOp, ...)` in logs. No functional change.

The input shard grid is still preserved; per-core shard shapes may round up to tile alignment internally, but the grid itself is never silently shrunk. This deliberately does **not** repeat the sub-grid search from commit `598d4b9` (reverted in `1150515675e`) that caused the UFLD V2 PCC regression.

## Problem

1. **Grid preservation contract was untested.** After the UFLD V2 revert, `HEIGHT_SHARDED` / `WIDTH_SHARDED` branches pass the full input grid through unchanged and let `height_sharded()` / `width_sharded()` tile-align per-core shapes. That is the behavior models like UFLD V2 depend on, but nothing in the test suite locked it in.

2. **Public API crash on layout-only sharded output config.** Python allows:
   ```python
   out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1)
   ttnn.reshape(tt_input, new_shape, memory_config=out_mc)  # out_mc.shard_spec is None
   ```
   This previously crashed with `TT_FATAL: Shard spec has no value` even when the input tensor had a usable `shard_spec`.

## What this PR does

### 1. Preserve input grid on H/W sharded reshape (regression lock-in)

- `HEIGHT_SHARDED` / `WIDTH_SHARDED` branches pass the **full input grid** through unchanged.
- `height_sharded()` / `width_sharded()` round per-core shapes up to tile alignment without changing the grid.
- New tests assert grid preservation and bit-exact data correctness for over-padded cases (e.g. phys_h=320 on 64 cores → 32-row tile slots).

### 2. Over-pad observability on H/W sharded reshape

- When a per-core shard slot is **≥ 4×** its per-core data slice, emit `log_warning(tt::LogOp, ...)`.
- 4× threshold skips benign 2× tile-alignment padding; flags genuine waste (e.g. UFLD V2 ~6.4×).
- No functional change — logs only.

### 3. Auto-derive output `shard_spec` from input when caller pins layout only

- `recompute_shard_spec_for_output(..., input_shard_spec=...)` accepts the input tensor's `shard_spec` when the caller's output `memory_config` has a sharded layout but no `shard_spec`.
- All four call sites pass `tensor.memory_config().shard_spec()`.
- Enables `ttnn.reshape(t, shape, memory_config=MemoryConfig(HEIGHT/WIDTH/BLOCK_SHARDED, L1))` without crashing when the input is sharded with the **same layout**.
- Auto-derive reuses the input grid under the caller's layout; cross-layout layout-only requests are the caller's responsibility to validate.
- If neither the caller nor the input has a `shard_spec` (e.g. interleaved input → sharded output request), we keep a `TT_FATAL` with an actionable message.

### Pipeline Updates

- [x] (Blackhole) e2e tests - Passed as in main
- [x] Sanity tests  - passed
- [x] (Runtime) Sanity Tests - passed
- [x] Blackhole post-commit tests - Passed as in main
- [x] T3K - Passed as in main
- [x] Nightly L2 - Passed as in main
- [x] All model test - Passed as in main
- [x] Single card - Passed as in main
- [x] Galaxy - Passed as in main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/reshape_shard_grid_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/reshape_shard_grid_fix)