### PR TITLE
emule: Metal 2.0 JIT support (named bindings + binding-aware cache key)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -117,9 +117,11 @@ thread_local tt_emule::TileCounterArray* __emule_tc_array = nullptr;
 //                        runs on (DM count for DM kernels, active-engine count
 //                        for compute).
 //
-// __emule_my_thread_id — backs get_my_thread_id(). Same value as __processor_id
-//                        today, but kept separate for type (uint32_t vs uint8_t)
-//                        and public-API surface.
+// __emule_my_thread_id — backs get_my_thread_id(). Index of this processor within
+//                        the kernel's processor list (0-based), matching the Quasar
+//                        firmware's my_thread_id semantics. NOT the same as
+//                        __processor_id: e.g. a consumer on RISCV_1 has
+//                        __processor_id=1 but __emule_my_thread_id=0 (first consumer).
 thread_local uint8_t __processor_id = 0;
 thread_local uint8_t __emule_neo_id = 0;
 thread_local uint8_t __emule_trisc_id = 0;
@@ -274,7 +276,8 @@ struct KernelInfo {
     bool run_all_variants = false;
     std::vector<uint32_t> rt_args;
     std::vector<uint32_t> common_rt_args;
-    uint8_t processor_id = 0;
+    uint8_t processor_id = 0;  // RISC-V processor ID (mhartid); used for DFB role resolution
+    uint8_t thread_idx = 0;    // Index within this kernel's processor list → __emule_my_thread_id
     bool is_tensix = false;    // true for Tensix/compute kernels (DFB mask uses bits 8-23)
     uint32_t num_threads = 1;  // number of engines (for get_num_threads())
 };
@@ -285,6 +288,12 @@ struct DeferredCompile {
     std::unordered_map<std::string, uint32_t> named_compile_args;
     std::map<std::string, std::string> defines;
     std::string extra_inc;
+    // Metal 2.0 named-binding info — used to emit args:: / dfb:: / ta:: namespaces
+    // in the JIT wrapper so kernels that include experimental/kernel_args.h compile.
+    std::vector<std::string> named_runtime_args;           // positional RTA names
+    std::vector<std::string> named_common_runtime_args;    // positional CRTA names
+    std::map<std::string, uint32_t> dfb_accessors;         // accessor_name → logical_dfb_id
+    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;  // accessor_name → {cta_off, crta_off}
 };
 
 struct PendingKernelInfo {
@@ -294,6 +303,7 @@ struct PendingKernelInfo {
     std::vector<uint32_t> rt_args;
     std::vector<uint32_t> common_rt_args;
     uint8_t processor_id = 0;
+    uint8_t thread_idx = 0;    // Index within this kernel's processor list
     bool is_tensix = false;
     uint32_t num_threads = 1;
 };
@@ -471,6 +481,13 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
     src = std::regex_replace(
         src, l1_arg_ptr_re, "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(get_arg_val<uint32_t>$2))");
 
+    // Metal 2.0 named-arg pattern: reinterpret_cast<T*>(static_cast<uintptr_t>(get_arg(args::NAME)))
+    static const std::regex l1_named_arg_ptr_re(
+        R"(reinterpret_cast<([^>]+\*)>\s*\(\s*static_cast<uintptr_t>\s*\(\s*get_arg\s*\(\s*([^)]+)\s*\)\s*\)\s*\))");
+    src = std::regex_replace(
+        src, l1_named_arg_ptr_re,
+        "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(static_cast<uint32_t>(get_arg($2))))");
+
     std::ofstream out(out_path);
     if (!out) {
         throw std::runtime_error("preprocess_kernel_source_for_x86: cannot write " + out_path);
@@ -484,6 +501,10 @@ static std::function<void()> jit_compile_kernel(
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
     const std::map<std::string, std::string>& defines,
     const std::string& extra_include_flags,
+    const std::vector<std::string>& named_runtime_args = {},
+    const std::vector<std::string>& named_common_runtime_args = {},
+    const std::map<std::string, uint32_t>& dfb_accessors = {},
+    const std::map<std::string, std::pair<uint32_t, uint32_t>>& ta_accessors = {},
     const std::string& disk_cache_so_path_arg = "") {
     const std::string jit_inc = TT_EMULE_JIT_INCLUDE_DIR;
     const std::string parent_inc = TT_EMULE_INCLUDE_DIR;
@@ -525,6 +546,56 @@ static std::function<void()> jit_compile_kernel(
             }
         }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
+        // Emit Metal 2.0 named-binding namespaces after jit_kernel_stubs.hpp so that
+        // experimental::RtaArg / CrtaArg / CtaVal and DFBAccessor are already defined.
+        // These replace kernel_args_generated.h / kernel_bindings_generated.h from the
+        // real JIT build, allowing kernels that use args:: / dfb:: / ta:: to compile.
+        //
+        // Pull in the type headers needed by the declarations below; these are
+        // normally included by the kernel source itself, but the namespace blocks
+        // appear before the kernel #include so the types must be pre-declared here.
+        if (!named_compile_args.empty() || !named_runtime_args.empty() ||
+            !named_common_runtime_args.empty()) {
+            f << "#include \"experimental/kernel_args.h\"\n";
+        }
+        if (!dfb_accessors.empty()) {
+            f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+        }
+        if (!ta_accessors.empty()) {
+            f << "#include \"api/tensor/tensor_accessor.h\"\n";
+        }
+        if (!named_compile_args.empty() || !named_runtime_args.empty() ||
+            !named_common_runtime_args.empty()) {
+            f << "namespace args {\n";
+            for (size_t i = 0; i < named_runtime_args.size(); ++i) {
+                f << "constexpr ::experimental::RtaArg<uint32_t> " << named_runtime_args[i]
+                  << "{" << (i * sizeof(uint32_t)) << "u};\n";
+            }
+            for (size_t i = 0; i < named_common_runtime_args.size(); ++i) {
+                f << "constexpr ::experimental::CrtaArg<uint32_t> " << named_common_runtime_args[i]
+                  << "{" << (i * sizeof(uint32_t)) << "u};\n";
+            }
+            for (const auto& [name, val] : named_compile_args) {
+                f << "constexpr ::experimental::CtaVal<uint32_t> " << name << "{" << val << "u};\n";
+            }
+            f << "}  // namespace args\n";
+        }
+        if (!dfb_accessors.empty()) {
+            f << "namespace dfb {\n";
+            for (const auto& [name, id] : dfb_accessors) {
+                f << "constexpr DFBAccessor " << name << "{" << id << "u};\n";
+            }
+            f << "}  // namespace dfb\n";
+        }
+        if (!ta_accessors.empty()) {
+            f << "namespace ta {\n";
+            for (const auto& [name, offs] : ta_accessors) {
+                f << "using " << name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
+                  << offs.first << "u," << offs.second << "u>;\n";
+                f << "constexpr " << name << "_t " << name << "{};\n";
+            }
+            f << "}  // namespace ta\n";
+        }
         f << "#include \"" << patched_kernel_path << "\"\n";
         f << "extern \"C\" { void __emule_kernel_entry() { kernel_main(); } }\n";
     }
@@ -681,6 +752,7 @@ static void populate_bank_mapping(
         dram_bank_to_noc_xy[0][ch] = noc_xy;  // NOC 0
         dram_bank_to_noc_xy[1][ch] = noc_xy;  // NOC 1 (same for emulation)
         bank_to_dram_offset[ch] = static_cast<int32_t>(metal_soc.get_address_offset(ch));
+
         log_debug(
             tt::LogMetal,
             "  DRAM bank[{}]: core({},{}) noc_xy=0x{:04x} offset=0x{:x}",
@@ -942,6 +1014,22 @@ static void collect_kernels(
             auto* qck = dynamic_cast<experimental::quasar::QuasarComputeKernel*>(kernel.get());
             bool is_quasar_compute = is_tensix && (qck != nullptr);
 
+            // Collect Metal 2.0 named-binding info so the JIT wrapper can emit
+            // args:: / dfb:: / ta:: namespace declarations.
+            std::vector<std::string> named_rt_args = kernel->get_named_runtime_args();
+            std::vector<std::string> named_crta_args = kernel->get_named_common_runtime_args();
+            std::map<std::string, uint32_t> dfb_accessor_map;
+            kernel->process_dataflow_buffer_local_accessor_handles(
+                [&dfb_accessor_map](const std::string& accessor_name, uint16_t logical_dfb_id) {
+                    dfb_accessor_map[accessor_name] = logical_dfb_id;
+                });
+            std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessor_map;
+            kernel->process_tensor_binding_handles(
+                [&ta_accessor_map](
+                    const std::string& accessor_name, uint32_t cta_offset, uint32_t addr_crta_offset) {
+                    ta_accessor_map[accessor_name] = {cta_offset, addr_crta_offset};
+                });
+
             // Helper: compute cache key from a defines map (preserves upstream's sorted
             // iteration of named_compile_args and defines for key stability).
             auto compute_cache_key = [&](const std::map<std::string, std::string>& defs) -> std::string {
@@ -984,7 +1072,8 @@ static void collect_kernels(
                         g_jit_cache[key] = disk_fn;
                     } else {
                         deferred_compiles[key] =
-                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc};
+                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc,
+                                            named_rt_args, named_crta_args, dfb_accessor_map, ta_accessor_map};
                     }
                 }
             };
@@ -1023,6 +1112,7 @@ static void collect_kernels(
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                         CoreCoord logical_core(x, y);
                         auto& rt_args_data = kernel->runtime_args(logical_core);
+                        uint8_t tidx = 0;
                         for (uint8_t proc_id : procs.proc_ids) {
                             pending_core_kernels[logical_core].push_back(PendingKernelInfo{
                                 variant_cache_keys,
@@ -1030,6 +1120,7 @@ static void collect_kernels(
                                 rt_args_data,
                                 common_rt,
                                 proc_id,
+                                tidx++,
                                 is_tensix,
                                 procs.num_threads});
                         }
@@ -1059,7 +1150,10 @@ static void jit_compile_pending(
             futures.emplace_back(
                 key, std::async(std::launch::async, [&dc, cache_path, tmp_path]() {
                     auto fn = jit_compile_kernel(
-                        dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc, tmp_path);
+                        dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc,
+                        dc.named_runtime_args, dc.named_common_runtime_args,
+                        dc.dfb_accessors, dc.ta_accessors,
+                        tmp_path);
                     std::filesystem::rename(tmp_path, cache_path);
                     return fn;
                 }));
@@ -1509,7 +1603,7 @@ static void launch_cores(
                             __emule_neo_id = ki.is_tensix ? ki.processor_id : 0;
                             __emule_trisc_id = 0;
                             __emule_num_threads = ki.num_threads;
-                            __emule_my_thread_id = ki.processor_id;
+                            __emule_my_thread_id = ki.thread_idx;
 
                             log_debug(
                                 tt::LogMetal,
@@ -1635,7 +1729,7 @@ void execute_program_emulated(IDevice* device, Program& program) {
     for (auto& [logical_core, pending_list] : pending_core_kernels) {
         for (auto& pk : pending_list) {
             KernelInfo ki{
-                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.is_tensix, pk.num_threads};
+                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.thread_idx, pk.is_tensix, pk.num_threads};
             ki.variants.reserve(pk.variant_cache_keys.size());
             for (const auto& key : pk.variant_cache_keys) {
                 ki.variants.push_back(resolved_fns.at(key));

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -282,41 +282,19 @@ struct KernelInfo {
     uint32_t num_threads = 1;  // number of engines (for get_num_threads())
 };
 
-// Metal 2.0 named-binding snapshot — captured once per Kernel and threaded
-// through DeferredCompile and jit_compile_kernel. Drives both the JIT
-// wrapper's namespace emission (args::/dfb::/sem::/ta::) and the cache-key
-// suffix that distinguishes kernels sharing source/CTAs/defines but differing
-// in binding identity.
-//
-// Design note: we deliberately do NOT reuse write_kernel_bindings_generated_header
-// or write_kernel_args_generated_header from tt_metal/jit_build/genfiles.cpp.
-// Those functions are private to genfiles.cpp; exposing them would add public
-// API surface to the upstream JIT build for emulation-only needs. The cost is
-// a small amount of duplication: emit_metal2_namespaces() below MUST stay
-// text-equivalent to those two upstream generators. Re-check on every
-// Metal 2.0 host-API surface change.
-//
-// Adding a new binding kind: extend this struct, extend cache_key_suffix(),
-// extend build_metal2_snapshot(), extend emit_metal2_namespaces().
+// Captures a Metal 2.0 kernel's named bindings. Drives both the JIT wrapper's
+// namespace emission (see emit_metal2_namespaces) and the JIT cache key
+// (see cache_key_suffix). Empty for legacy kernels.
 struct Metal2BindingsSnapshot {
-    std::vector<std::string> named_runtime_args;           // RTA names, positional order
-    std::vector<std::string> named_common_runtime_args;    // CRTA names, positional order
-    std::map<std::string, uint32_t> dfb_accessors;         // accessor_name → logical_dfb_id
-    std::map<std::string, uint16_t> sem_accessors;         // accessor_name → semaphore_id
-    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;  // accessor_name → {cta_off, crta_off}
+    std::vector<std::string> named_runtime_args;
+    std::vector<std::string> named_common_runtime_args;
+    std::map<std::string, uint32_t> dfb_accessors;
+    std::map<std::string, uint16_t> sem_accessors;
+    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;
 
-    bool empty() const {
-        return named_runtime_args.empty() && named_common_runtime_args.empty() &&
-               dfb_accessors.empty() && sem_accessors.empty() && ta_accessors.empty();
-    }
-
-    // Deterministic suffix appended to the JIT cache key for Metal 2.0 kernels.
-    // Two kernels with identical sources/CTAs/defines but different binding
-    // identity (DFB IDs, semaphore IDs, RTA/CRTA name lists, TA offsets) must
-    // produce different keys; otherwise the second silently gets the first's
-    // cached .so with the wrong IDs baked in. Iteration is deterministic
-    // because dfb/sem/ta are std::map (sorted by name) and the RTA/CRTA lists
-    // come from the Kernel in positional order.
+    // Distinguishes kernels that share source/CTAs/defines but bind different
+    // IDs — without this they collide on cache key and the second silently
+    // reuses the first's .so.
     std::string cache_key_suffix() const {
         std::string s;
         for (const auto& [name, id] : dfb_accessors) {
@@ -546,9 +524,6 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
     out << src;
 }
 
-// Walks Kernel's public binding-accessor methods to build a snapshot of all
-// named bindings. Single point of truth — adding a new binding kind requires
-// extending Metal2BindingsSnapshot and adding one block here.
 static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& kernel) {
     Metal2BindingsSnapshot s;
     s.named_runtime_args = kernel.get_named_runtime_args();
@@ -564,23 +539,10 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     return s;
 }
 
-// Emits args::/dfb::/sem::/ta:: namespace blocks into the JIT wrapper .cpp,
-// replacing the kernel_args_generated.h + kernel_bindings_generated.h that
-// the real upstream JIT build pipeline writes via genfiles.cpp.
-//
-// Must stay text-equivalent to the canonical generators:
-//   tt_metal/jit_build/genfiles.cpp::write_kernel_bindings_generated_header
-//   tt_metal/jit_build/genfiles.cpp::write_kernel_args_generated_header
-//
-// Relied-upon types (must be in scope when the wrapper is compiled — they
-// come from the kernel-include surface, not from us):
-//   ::experimental::RtaArg<T>, ::experimental::CrtaArg<T>, ::experimental::CtaVal<T>
-//                                  from "experimental/kernel_args.h"
-//   DFBAccessor                    from "api/dataflow/dataflow_buffer.h"
-//   ::tensor_accessor::TensorAccessorBindingToken<CTA, CRTA>
-//                                  from "api/tensor/tensor_accessor.h"
-//   std::uint32_t                  from <cstdint>
-// If any of these are renamed/moved upstream, fix here.
+// Emits args::/dfb::/sem::/ta:: namespaces into the JIT wrapper, replacing
+// kernel_args_generated.h + kernel_bindings_generated.h that upstream's JIT
+// build produces. Must stay text-equivalent to genfiles.cpp's
+// write_kernel_{args,bindings}_generated_header.
 static void emit_metal2_namespaces(
     std::ostream& f,
     const Metal2BindingsSnapshot& s,
@@ -612,8 +574,7 @@ static void emit_metal2_namespaces(
             f << "constexpr ::experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
             crta_offset += sizeof(uint32_t);
         }
-        // Named CTAs: sort by name so wrapper text and the cache key (which
-        // sorts via std::map iteration in compute_cache_key) stay aligned.
+        // Sort CTAs for deterministic wrapper output.
         std::vector<std::pair<std::string, uint32_t>> cta_entries(
             named_compile_args.begin(), named_compile_args.end());
         std::sort(cta_entries.begin(), cta_entries.end());
@@ -695,10 +656,6 @@ static std::function<void()> jit_compile_kernel(
             }
         }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
-        // Emit Metal 2.0 named-binding namespaces (args::/dfb::/sem::/ta::)
-        // after jit_kernel_stubs.hpp. Replaces kernel_args_generated.h and
-        // kernel_bindings_generated.h from the real JIT build. See the
-        // comment on emit_metal2_namespaces() for the contract with upstream.
         emit_metal2_namespaces(f, bindings, named_compile_args);
         f << "#include \"" << patched_kernel_path << "\"\n";
         f << "extern \"C\" { void __emule_kernel_entry() { kernel_main(); } }\n";
@@ -1118,20 +1075,12 @@ static void collect_kernels(
             auto* qck = dynamic_cast<experimental::quasar::QuasarComputeKernel*>(kernel.get());
             bool is_quasar_compute = is_tensix && (qck != nullptr);
 
-            // Collect Metal 2.0 named-binding info so the JIT wrapper can emit
-            // args::/dfb::/sem::/ta:: namespace declarations. Captured once per
-            // Kernel; identical across this Kernel's TRISC variants (the cache-key
-            // suffix it produces is therefore appended to every variant key).
-            const bool is_metal2 = kernel->is_metal2_kernel();
+            // Metal 2.0 bindings — same across this Kernel's TRISC variants, so
+            // capture the cache-key suffix once and append it to every variant key.
             Metal2BindingsSnapshot bindings = build_metal2_snapshot(*kernel);
-            const std::string metal2_key_suffix = is_metal2 ? bindings.cache_key_suffix() : std::string();
+            const std::string metal2_key_suffix = bindings.cache_key_suffix();
 
-            // Helper: compute cache key from a defines map (preserves upstream's sorted
-            // iteration of named_compile_args and defines for key stability). The
-            // metal2_key_suffix captures binding identity (DFB/sem/RTA/CRTA/TA names
-            // and IDs) so two Metal 2.0 kernels sharing source/CTAs/defines but
-            // differing only in bindings produce different keys and don't collide
-            // on the cached .so.
+            // Helper: compute cache key from a defines map.
             auto compute_cache_key = [&](const std::map<std::string, std::string>& defs) -> std::string {
                 std::string key;
                 if (ksrc.source_type_ == KernelSource::FILE_PATH) {

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -282,18 +282,69 @@ struct KernelInfo {
     uint32_t num_threads = 1;  // number of engines (for get_num_threads())
 };
 
+// Metal 2.0 named-binding snapshot — captured once per Kernel and threaded
+// through DeferredCompile and jit_compile_kernel. Drives both the JIT
+// wrapper's namespace emission (args::/dfb::/sem::/ta::) and the cache-key
+// suffix that distinguishes kernels sharing source/CTAs/defines but differing
+// in binding identity.
+//
+// Design note: we deliberately do NOT reuse write_kernel_bindings_generated_header
+// or write_kernel_args_generated_header from tt_metal/jit_build/genfiles.cpp.
+// Those functions are private to genfiles.cpp; exposing them would add public
+// API surface to the upstream JIT build for emulation-only needs. The cost is
+// a small amount of duplication: emit_metal2_namespaces() below MUST stay
+// text-equivalent to those two upstream generators. Re-check on every
+// Metal 2.0 host-API surface change.
+//
+// Adding a new binding kind: extend this struct, extend cache_key_suffix(),
+// extend build_metal2_snapshot(), extend emit_metal2_namespaces().
+struct Metal2BindingsSnapshot {
+    std::vector<std::string> named_runtime_args;           // RTA names, positional order
+    std::vector<std::string> named_common_runtime_args;    // CRTA names, positional order
+    std::map<std::string, uint32_t> dfb_accessors;         // accessor_name → logical_dfb_id
+    std::map<std::string, uint16_t> sem_accessors;         // accessor_name → semaphore_id
+    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;  // accessor_name → {cta_off, crta_off}
+
+    bool empty() const {
+        return named_runtime_args.empty() && named_common_runtime_args.empty() &&
+               dfb_accessors.empty() && sem_accessors.empty() && ta_accessors.empty();
+    }
+
+    // Deterministic suffix appended to the JIT cache key for Metal 2.0 kernels.
+    // Two kernels with identical sources/CTAs/defines but different binding
+    // identity (DFB IDs, semaphore IDs, RTA/CRTA name lists, TA offsets) must
+    // produce different keys; otherwise the second silently gets the first's
+    // cached .so with the wrong IDs baked in. Iteration is deterministic
+    // because dfb/sem/ta are std::map (sorted by name) and the RTA/CRTA lists
+    // come from the Kernel in positional order.
+    std::string cache_key_suffix() const {
+        std::string s;
+        for (const auto& [name, id] : dfb_accessors) {
+            s += ":dfb:" + name + "=" + std::to_string(id);
+        }
+        for (const auto& [name, id] : sem_accessors) {
+            s += ":sem:" + name + "=" + std::to_string(id);
+        }
+        for (const auto& [name, offs] : ta_accessors) {
+            s += ":ta:" + name + "=" + std::to_string(offs.first) + "," + std::to_string(offs.second);
+        }
+        for (const auto& name : named_runtime_args) {
+            s += ":rta:" + name;
+        }
+        for (const auto& name : named_common_runtime_args) {
+            s += ":crta:" + name;
+        }
+        return s;
+    }
+};
+
 struct DeferredCompile {
     std::string src_path;
     std::vector<uint32_t> compile_args;
     std::unordered_map<std::string, uint32_t> named_compile_args;
     std::map<std::string, std::string> defines;
     std::string extra_inc;
-    // Metal 2.0 named-binding info — used to emit args:: / dfb:: / ta:: namespaces
-    // in the JIT wrapper so kernels that include experimental/kernel_args.h compile.
-    std::vector<std::string> named_runtime_args;           // positional RTA names
-    std::vector<std::string> named_common_runtime_args;    // positional CRTA names
-    std::map<std::string, uint32_t> dfb_accessors;         // accessor_name → logical_dfb_id
-    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;  // accessor_name → {cta_off, crta_off}
+    Metal2BindingsSnapshot bindings;
 };
 
 struct PendingKernelInfo {
@@ -495,16 +546,114 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
     out << src;
 }
 
+// Walks Kernel's public binding-accessor methods to build a snapshot of all
+// named bindings. Single point of truth — adding a new binding kind requires
+// extending Metal2BindingsSnapshot and adding one block here.
+static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& kernel) {
+    Metal2BindingsSnapshot s;
+    s.named_runtime_args = kernel.get_named_runtime_args();
+    s.named_common_runtime_args = kernel.get_named_common_runtime_args();
+    kernel.process_dataflow_buffer_local_accessor_handles(
+        [&s](const std::string& name, uint16_t id) { s.dfb_accessors[name] = id; });
+    kernel.process_semaphore_local_accessor_handles(
+        [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
+    kernel.process_tensor_binding_handles(
+        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off) {
+            s.ta_accessors[name] = {cta_off, addr_crta_off};
+        });
+    return s;
+}
+
+// Emits args::/dfb::/sem::/ta:: namespace blocks into the JIT wrapper .cpp,
+// replacing the kernel_args_generated.h + kernel_bindings_generated.h that
+// the real upstream JIT build pipeline writes via genfiles.cpp.
+//
+// Must stay text-equivalent to the canonical generators:
+//   tt_metal/jit_build/genfiles.cpp::write_kernel_bindings_generated_header
+//   tt_metal/jit_build/genfiles.cpp::write_kernel_args_generated_header
+//
+// Relied-upon types (must be in scope when the wrapper is compiled — they
+// come from the kernel-include surface, not from us):
+//   ::experimental::RtaArg<T>, ::experimental::CrtaArg<T>, ::experimental::CtaVal<T>
+//                                  from "experimental/kernel_args.h"
+//   DFBAccessor                    from "api/dataflow/dataflow_buffer.h"
+//   ::tensor_accessor::TensorAccessorBindingToken<CTA, CRTA>
+//                                  from "api/tensor/tensor_accessor.h"
+//   std::uint32_t                  from <cstdint>
+// If any of these are renamed/moved upstream, fix here.
+static void emit_metal2_namespaces(
+    std::ostream& f,
+    const Metal2BindingsSnapshot& s,
+    const std::unordered_map<std::string, uint32_t>& named_compile_args) {
+    const bool has_args = !s.named_runtime_args.empty() || !s.named_common_runtime_args.empty() ||
+                          !named_compile_args.empty();
+    if (has_args) {
+        f << "#include \"experimental/kernel_args.h\"\n";
+    }
+    if (!s.dfb_accessors.empty()) {
+        f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+    }
+    if (!s.sem_accessors.empty()) {
+        f << "#include <cstdint>\n";
+    }
+    if (!s.ta_accessors.empty()) {
+        f << "#include \"api/tensor/tensor_accessor.h\"\n";
+    }
+
+    if (has_args) {
+        f << "namespace args {\n";
+        uint32_t rta_offset = 0;
+        for (const auto& name : s.named_runtime_args) {
+            f << "constexpr ::experimental::RtaArg<uint32_t> " << name << "{" << rta_offset << "};\n";
+            rta_offset += sizeof(uint32_t);
+        }
+        uint32_t crta_offset = 0;
+        for (const auto& name : s.named_common_runtime_args) {
+            f << "constexpr ::experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
+            crta_offset += sizeof(uint32_t);
+        }
+        // Named CTAs: sort by name so wrapper text and the cache key (which
+        // sorts via std::map iteration in compute_cache_key) stay aligned.
+        std::vector<std::pair<std::string, uint32_t>> cta_entries(
+            named_compile_args.begin(), named_compile_args.end());
+        std::sort(cta_entries.begin(), cta_entries.end());
+        for (const auto& [name, value] : cta_entries) {
+            f << "constexpr ::experimental::CtaVal<uint32_t> " << name << "{" << value << "u};\n";
+        }
+        f << "}  // namespace args\n";
+    }
+    if (!s.dfb_accessors.empty()) {
+        f << "namespace dfb {\n";
+        for (const auto& [name, id] : s.dfb_accessors) {
+            f << "constexpr DFBAccessor " << name << "{" << id << "};\n";
+        }
+        f << "}  // namespace dfb\n";
+    }
+    if (!s.sem_accessors.empty()) {
+        f << "namespace sem {\n";
+        for (const auto& [name, id] : s.sem_accessors) {
+            f << "constexpr std::uint32_t " << name << " = " << id << "u;\n";
+        }
+        f << "}  // namespace sem\n";
+    }
+    if (!s.ta_accessors.empty()) {
+        f << "namespace ta {\n";
+        for (const auto& [name, offs] : s.ta_accessors) {
+            f << "using " << name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
+              << offs.first << "u, " << offs.second << "u>;\n";
+            f << "constexpr " << name << "_t " << name << "{};\n";
+        }
+        f << "}  // namespace ta\n";
+    }
+}
+
 static std::function<void()> jit_compile_kernel(
     const std::string& kernel_src_path,
     const std::vector<uint32_t>& compile_args,
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
     const std::map<std::string, std::string>& defines,
     const std::string& extra_include_flags,
-    const std::vector<std::string>& named_runtime_args = {},
-    const std::vector<std::string>& named_common_runtime_args = {},
-    const std::map<std::string, uint32_t>& dfb_accessors = {},
-    const std::map<std::string, std::pair<uint32_t, uint32_t>>& ta_accessors = {},
+    const Metal2BindingsSnapshot& bindings = {},
     const std::string& disk_cache_so_path_arg = "") {
     const std::string jit_inc = TT_EMULE_JIT_INCLUDE_DIR;
     const std::string parent_inc = TT_EMULE_INCLUDE_DIR;
@@ -546,56 +695,11 @@ static std::function<void()> jit_compile_kernel(
             }
         }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
-        // Emit Metal 2.0 named-binding namespaces after jit_kernel_stubs.hpp so that
-        // experimental::RtaArg / CrtaArg / CtaVal and DFBAccessor are already defined.
-        // These replace kernel_args_generated.h / kernel_bindings_generated.h from the
-        // real JIT build, allowing kernels that use args:: / dfb:: / ta:: to compile.
-        //
-        // Pull in the type headers needed by the declarations below; these are
-        // normally included by the kernel source itself, but the namespace blocks
-        // appear before the kernel #include so the types must be pre-declared here.
-        if (!named_compile_args.empty() || !named_runtime_args.empty() ||
-            !named_common_runtime_args.empty()) {
-            f << "#include \"experimental/kernel_args.h\"\n";
-        }
-        if (!dfb_accessors.empty()) {
-            f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-        }
-        if (!ta_accessors.empty()) {
-            f << "#include \"api/tensor/tensor_accessor.h\"\n";
-        }
-        if (!named_compile_args.empty() || !named_runtime_args.empty() ||
-            !named_common_runtime_args.empty()) {
-            f << "namespace args {\n";
-            for (size_t i = 0; i < named_runtime_args.size(); ++i) {
-                f << "constexpr ::experimental::RtaArg<uint32_t> " << named_runtime_args[i]
-                  << "{" << (i * sizeof(uint32_t)) << "u};\n";
-            }
-            for (size_t i = 0; i < named_common_runtime_args.size(); ++i) {
-                f << "constexpr ::experimental::CrtaArg<uint32_t> " << named_common_runtime_args[i]
-                  << "{" << (i * sizeof(uint32_t)) << "u};\n";
-            }
-            for (const auto& [name, val] : named_compile_args) {
-                f << "constexpr ::experimental::CtaVal<uint32_t> " << name << "{" << val << "u};\n";
-            }
-            f << "}  // namespace args\n";
-        }
-        if (!dfb_accessors.empty()) {
-            f << "namespace dfb {\n";
-            for (const auto& [name, id] : dfb_accessors) {
-                f << "constexpr DFBAccessor " << name << "{" << id << "u};\n";
-            }
-            f << "}  // namespace dfb\n";
-        }
-        if (!ta_accessors.empty()) {
-            f << "namespace ta {\n";
-            for (const auto& [name, offs] : ta_accessors) {
-                f << "using " << name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
-                  << offs.first << "u," << offs.second << "u>;\n";
-                f << "constexpr " << name << "_t " << name << "{};\n";
-            }
-            f << "}  // namespace ta\n";
-        }
+        // Emit Metal 2.0 named-binding namespaces (args::/dfb::/sem::/ta::)
+        // after jit_kernel_stubs.hpp. Replaces kernel_args_generated.h and
+        // kernel_bindings_generated.h from the real JIT build. See the
+        // comment on emit_metal2_namespaces() for the contract with upstream.
+        emit_metal2_namespaces(f, bindings, named_compile_args);
         f << "#include \"" << patched_kernel_path << "\"\n";
         f << "extern \"C\" { void __emule_kernel_entry() { kernel_main(); } }\n";
     }
@@ -1015,23 +1119,19 @@ static void collect_kernels(
             bool is_quasar_compute = is_tensix && (qck != nullptr);
 
             // Collect Metal 2.0 named-binding info so the JIT wrapper can emit
-            // args:: / dfb:: / ta:: namespace declarations.
-            std::vector<std::string> named_rt_args = kernel->get_named_runtime_args();
-            std::vector<std::string> named_crta_args = kernel->get_named_common_runtime_args();
-            std::map<std::string, uint32_t> dfb_accessor_map;
-            kernel->process_dataflow_buffer_local_accessor_handles(
-                [&dfb_accessor_map](const std::string& accessor_name, uint16_t logical_dfb_id) {
-                    dfb_accessor_map[accessor_name] = logical_dfb_id;
-                });
-            std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessor_map;
-            kernel->process_tensor_binding_handles(
-                [&ta_accessor_map](
-                    const std::string& accessor_name, uint32_t cta_offset, uint32_t addr_crta_offset) {
-                    ta_accessor_map[accessor_name] = {cta_offset, addr_crta_offset};
-                });
+            // args::/dfb::/sem::/ta:: namespace declarations. Captured once per
+            // Kernel; identical across this Kernel's TRISC variants (the cache-key
+            // suffix it produces is therefore appended to every variant key).
+            const bool is_metal2 = kernel->is_metal2_kernel();
+            Metal2BindingsSnapshot bindings = build_metal2_snapshot(*kernel);
+            const std::string metal2_key_suffix = is_metal2 ? bindings.cache_key_suffix() : std::string();
 
             // Helper: compute cache key from a defines map (preserves upstream's sorted
-            // iteration of named_compile_args and defines for key stability).
+            // iteration of named_compile_args and defines for key stability). The
+            // metal2_key_suffix captures binding identity (DFB/sem/RTA/CRTA/TA names
+            // and IDs) so two Metal 2.0 kernels sharing source/CTAs/defines but
+            // differing only in bindings produce different keys and don't collide
+            // on the cached .so.
             auto compute_cache_key = [&](const std::map<std::string, std::string>& defs) -> std::string {
                 std::string key;
                 if (ksrc.source_type_ == KernelSource::FILE_PATH) {
@@ -1053,6 +1153,7 @@ static void collect_kernels(
                 for (const auto& [k, v] : defs) {
                     key += ":" + k + "=" + v;
                 }
+                key += metal2_key_suffix;
                 return key;
             };
 
@@ -1072,8 +1173,7 @@ static void collect_kernels(
                         g_jit_cache[key] = disk_fn;
                     } else {
                         deferred_compiles[key] =
-                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc,
-                                            named_rt_args, named_crta_args, dfb_accessor_map, ta_accessor_map};
+                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc, bindings};
                     }
                 }
             };
@@ -1151,9 +1251,7 @@ static void jit_compile_pending(
                 key, std::async(std::launch::async, [&dc, cache_path, tmp_path]() {
                     auto fn = jit_compile_kernel(
                         dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc,
-                        dc.named_runtime_args, dc.named_common_runtime_args,
-                        dc.dfb_accessors, dc.ta_accessors,
-                        tmp_path);
+                        dc.bindings, tmp_path);
                     std::filesystem::rename(tmp_path, cache_path);
                     return fn;
                 }));

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -286,11 +286,20 @@ struct KernelInfo {
 // namespace emission (see emit_metal2_namespaces) and the JIT cache key
 // (see cache_key_suffix). Empty for legacy kernels.
 struct Metal2BindingsSnapshot {
+    // TA bindings are kept in insertion order (matches genfiles.cpp's vector);
+    // their CRTA position drives the get_common_vararg offset.
+    struct TaEntry {
+        std::string name;
+        uint32_t cta_offset;
+        uint32_t addr_crta_offset;
+    };
+
+    bool is_metal2 = false;
     std::vector<std::string> named_runtime_args;
     std::vector<std::string> named_common_runtime_args;
     std::map<std::string, uint32_t> dfb_accessors;
     std::map<std::string, uint16_t> sem_accessors;
-    std::map<std::string, std::pair<uint32_t, uint32_t>> ta_accessors;
+    std::vector<TaEntry> ta_accessors;
 
     // Distinguishes kernels that share source/CTAs/defines but bind different
     // IDs — without this they collide on cache key and the second silently
@@ -303,8 +312,9 @@ struct Metal2BindingsSnapshot {
         for (const auto& [name, id] : sem_accessors) {
             s += ":sem:" + name + "=" + std::to_string(id);
         }
-        for (const auto& [name, offs] : ta_accessors) {
-            s += ":ta:" + name + "=" + std::to_string(offs.first) + "," + std::to_string(offs.second);
+        for (const auto& ta : ta_accessors) {
+            s += ":ta:" + ta.name + "=" + std::to_string(ta.cta_offset) + "," +
+                 std::to_string(ta.addr_crta_offset);
         }
         for (const auto& name : named_runtime_args) {
             s += ":rta:" + name;
@@ -526,6 +536,7 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
 
 static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& kernel) {
     Metal2BindingsSnapshot s;
+    s.is_metal2 = kernel.is_metal2_kernel();
     s.named_runtime_args = kernel.get_named_runtime_args();
     s.named_common_runtime_args = kernel.get_named_common_runtime_args();
     kernel.process_dataflow_buffer_local_accessor_handles(
@@ -534,7 +545,7 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
         [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
     kernel.process_tensor_binding_handles(
         [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off) {
-            s.ta_accessors[name] = {cta_off, addr_crta_off};
+            s.ta_accessors.push_back({name, cta_off, addr_crta_off});
         });
     return s;
 }
@@ -599,12 +610,26 @@ static void emit_metal2_namespaces(
     }
     if (!s.ta_accessors.empty()) {
         f << "namespace ta {\n";
-        for (const auto& [name, offs] : s.ta_accessors) {
-            f << "using " << name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
-              << offs.first << "u, " << offs.second << "u>;\n";
-            f << "constexpr " << name << "_t " << name << "{};\n";
+        for (const auto& ta : s.ta_accessors) {
+            f << "using " << ta.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
+              << ta.cta_offset << "u, " << ta.addr_crta_offset << "u>;\n";
+            f << "constexpr " << ta.name << "_t " << ta.name << "{};\n";
         }
         f << "}  // namespace ta\n";
+    }
+
+    // Vararg helpers — always emitted for Metal 2.0 kernels (mirrors
+    // genfiles.cpp). The CRTA buffer layout is [user-named CRTAs,
+    // TensorBinding addresses, varargs], so get_common_vararg's base skips
+    // past both the named CRTAs and the binding section.
+    if (s.is_metal2) {
+        const uint32_t named_rta_words = static_cast<uint32_t>(s.named_runtime_args.size());
+        const uint32_t named_crta_words =
+            static_cast<uint32_t>(s.named_common_runtime_args.size() + s.ta_accessors.size());
+        f << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { "
+          << "return get_arg_val<uint32_t>(" << named_rta_words << " + idx); }\n";
+        f << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { "
+          << "return get_common_arg_val<uint32_t>(" << named_crta_words << " + idx); }\n";
     }
 }
 


### PR DESCRIPTION
## Summary

Adds Metal 2.0 named-binding kernel support to the tt-emule out-of-tree JIT compile path. Without this, every Metal 2.0 kernel (anything referencing `args::*`, `dfb::*`, `sem::*`, `ta::*`) fails to JIT-compile under emulation, because the emule JIT writes its own kernel wrapper instead of going through `jit_build_genfiles_kernel_include` / `triscs_src` and therefore never produces the `kernel_bindings_generated.h` / `kernel_args_generated.h` headers those names resolve against.


## Approach

Self-contained in the emulated program runner:

- **`Metal2BindingsSnapshot`** — captures a Kernel's named bindings (RTA/CRTA names, DFB/sem/TA accessor maps) by walking the Kernel's already-public `process_*_handles` / `get_named_*_args` methods. One snapshot per Kernel; identical across TRISC variants.
- **`emit_metal2_namespaces()`** — inline-writes the `args::` / `dfb::` / `sem::` / `ta::` namespace blocks into the JIT wrapper `.cpp` before the kernel `#include`. Text-equivalent to the canonical generators in `tt_metal/jit_build/genfiles.cpp` (`write_kernel_{bindings,args}_generated_header`); a comment marks that contract.
- **Cache-key suffix** — `Metal2BindingsSnapshot::cache_key_suffix()` extends the JIT cache key with the binding identity (`:dfb:NAME=ID:sem:NAME=ID:ta:NAME=CTA,CRTA:rta:NAME:crta:NAME`). Two Metal 2.0 kernels sharing source/CTAs/defines but binding different IDs now produce distinct keys; otherwise the second silently reused the first's cached `.so` with the wrong IDs baked in. Empty (no-op) for legacy kernels.
- **L1 pointer regex** in `preprocess_kernel_source_for_x86()` for the Metal 2.0 named-arg pattern: `reinterpret_cast<T*>(static_cast<uintptr_t>(get_arg(args::NAME)))` → routed through `__emule_local_l1_to_ptr`. Fixes RISC-V atomic tests that previously SEGFAULTed dereferencing raw firmware L1 offsets as host pointers.

## Why inline emission instead of reusing `genfiles.cpp`

`tt_metal/jit_build/genfiles.cpp` already has `write_kernel_bindings_generated_header` and `write_kernel_args_generated_header` that produce the same content — but they live in an anonymous namespace. Reusing them would mean promoting two functions into `genfiles.hpp`'s public API surface for an emulation-only need. We chose to absorb the cost on the emulation side instead: the inline emission stays text-equivalent to the upstream generators, with the contract documented at the call site.

## Test plan

Verified against tt-emule (out-of-tree consumer) across three parallel CI matrix jobs:

- [x] **wormhole**: 31 passed, 9 failed (all known: Tier-5b BF16 reductions)
- [x] **blackhole**: 20 passed, 0 failed
- [x] **quasar**: 105 passed, 9 failed (all known: DFB topologies exceeding the 6-user-DM hardware limit)
- [x] Builds clean against `origin/main` (cherry-picks applied without conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-uplift)