### PR TITLE
Fix Moreh simulator op failures

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -478,8 +478,8 @@ def test_moreh_bias_backward_fp32(shapes, device):
     torch_output.backward(torch_output_grad.float())
     ## test for equivalance
     rtol = atol = 0.1
-    tt_bias_grad_fp32_cpu = tt_bias_grad_fp32.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(bias_shape).to_torch()
-    tt_bias_grad_cpu = tt_bias_grad.cpu().to(ttnn.ROW_MAJOR_LAYOUT).unpad_from_tile(bias_shape).to_torch()
+    tt_bias_grad_fp32_cpu = ttnn.to_torch(tt_bias_grad_fp32)
+    tt_bias_grad_cpu = ttnn.to_torch(tt_bias_grad)
     passing, output_pcc = comp_allclose_and_pcc(
         torch_bias_fp32.grad, tt_bias_grad_fp32_cpu, pcc=0.98, rtol=rtol, atol=atol
     )

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -25,6 +25,7 @@ void kernel_main() {
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {
             cb_c2.wait_front(onetile);
+            cb_c16.reserve_back(onetile);
             ACQ();
             mul_tiles_bcast<BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, 0, 0, 0);
             pack_tile(0, tt::CBIndex::c_16);
@@ -35,6 +36,7 @@ void kernel_main() {
 
         if (has_other_grad) {
             cb_c1.wait_front(onetile);
+            cb_c17.reserve_back(onetile);
             ACQ();
             mul_tiles_bcast<BroadcastType::SCALAR>(tt::CBIndex::c_1, tt::CBIndex::c_0, 0, 0, 0);
             pack_tile(0, tt::CBIndex::c_17);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.cpp
@@ -12,6 +12,20 @@
 
 namespace ttnn {
 
+namespace {
+
+ttnn::SmallVector<int64_t> get_reduce_dims(const Tensor& tensor) {
+    ttnn::SmallVector<int64_t> reduce_dims;
+    const auto rank = tensor.logical_shape().rank();
+    reduce_dims.reserve(rank);
+    for (uint32_t i = 0; i < rank; ++i) {
+        reduce_dims.push_back(i);
+    }
+    return reduce_dims;
+}
+
+}  // namespace
+
 Tensor moreh_nll_loss(
     const Tensor& input_tensor,
     const Tensor& target_tensor,
@@ -39,7 +53,13 @@ Tensor moreh_nll_loss(
             memory_config,
             compute_kernel_config_val);
 
-        moreh_sum(step1_result, std::nullopt, false, divisor_tensor, memory_config, compute_kernel_config_val);
+        moreh_sum(
+            step1_result,
+            get_reduce_dims(step1_result),
+            false,
+            divisor_tensor,
+            memory_config,
+            compute_kernel_config_val);
 
         const Tensor& step2_result = prim::moreh_nll_loss_step2(
             input_tensor,
@@ -51,7 +71,13 @@ Tensor moreh_nll_loss(
             ignore_index,
             memory_config,
             compute_kernel_config_val);
-        return moreh_sum(step2_result, std::nullopt, false, output_tensor, memory_config, compute_kernel_config_val);
+        return moreh_sum(
+            step2_result,
+            get_reduce_dims(step2_result),
+            false,
+            output_tensor,
+            memory_config,
+            compute_kernel_config_val);
     }
     if (reduction == SUM) {
         const Tensor& step2_result = prim::moreh_nll_loss_step2(
@@ -64,7 +90,13 @@ Tensor moreh_nll_loss(
             ignore_index,
             memory_config,
             compute_kernel_config_val);
-        return moreh_sum(step2_result, std::nullopt, false, output_tensor, memory_config, compute_kernel_config_val);
+        return moreh_sum(
+            step2_result,
+            get_reduce_dims(step2_result),
+            false,
+            output_tensor,
+            memory_config,
+            compute_kernel_config_val);
     }
 
     return prim::moreh_nll_loss_step2(


### PR DESCRIPTION
## Summary
- reserve output CB space before packing in `moreh_dot_backward`
- pass explicit reduce dimensions to `moreh_sum` in `moreh_nll_loss`
- use `ttnn.to_torch` for the Moreh linear bias-grad reference conversion

## Notes
This PR intentionally excludes local cumsum/batchnorm edits already covered on `main`, unrelated tolerance-only changes, and local debug artifacts.

## Validation
- Patch prepared against `origin/main` (`231c7223899cc1c42763498a13a3bee138decb78`).
- Current TTNN op CI BH rerun is still in progress on the local dirty tree that includes these Moreh changes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/moreh)