### PR TITLE
Disable realtime profiler on simulator

### DIFF
--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -120,6 +120,14 @@ RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* devi
         return {};
     }
 
+    if (cluster.get_target_device_type() == tt::TargetDevice::Simulator) {
+        log_debug(
+            tt::LogMetal,
+            "Real-time profiler disabled on device {}: target is simulator.",
+            device_id);
+        return {};
+    }
+
     if (!device->is_mmio_capable()) {
         log_debug(
             tt::LogMetal,


### PR DESCRIPTION
## Summary
- skip realtime profiler setup when the target device type is simulator
- avoids trying to use profiler socket/MMIO plumbing that is not available in ttsim flows

## Validation
- isolated one-file patch against current origin/main
- git diff --check for the touched profiler file

This is split out from the local simulator TTNN-op sweep cleanup.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/disable-realtime-profiler-on-sim-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/disable-realtime-profiler-on-sim-20260526)