### PR TITLE
Use row-wise split for fast_reduce sub-core grids

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -139,7 +139,8 @@ FastReduceNCProgramFactory::cached_program_t FastReduceNCProgramFactory::create(
             divide_by_shards
                 ? dspec.core_groups_tuple()
                 : (use_sub_core_grids
-                       ? tt::tt_metal::split_work_to_cores(*operation_attributes.sub_core_grids, num_output_tiles)
+                       ? tt::tt_metal::split_work_to_cores(
+                             *operation_attributes.sub_core_grids, num_output_tiles, /*row_wise=*/true)
                        : tt::tt_metal::split_work_to_cores(grid, num_output_tiles, /*row_wise=*/true));
     num_cols_per_core_group_1 *= shard_factor;
     num_cols_per_core_group_2 *= shard_factor;


### PR DESCRIPTION
## Summary
- passes row_wise=true when splitting fast_reduce work across explicit sub-core grids
- keeps the sub-core-grid path aligned with the normal grid split path

## Validation
- isolated one-file patch against current origin/main
- git diff --check for the touched fast_reduce file

This is split out from the local simulator TTNN-op sweep cleanup.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/fast-reduce-subcore-row-wise-20260526)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/fast-reduce-subcore-row-wise-20260526)