### PR TITLE
Refactor weights, state dict loading and attention delegation

### DIFF
--- a/models/demos/qwen35_27b/tt/attention.py
+++ b/models/demos/qwen35_27b/tt/attention.py
@@ -12,11 +12,19 @@ Differences from standard tt_transformers Attention:
 5. Separate K/V projections (not fused QKV)
 """
 
+import os
+
 import torch
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-from models.demos.qwen35_27b.tt.model_config import create_prefill_matmul_program_config
+from models.demos.qwen35_27b.tt.model_config import (
+    _replicate,
+    _shard_w,
+    create_prefill_matmul_program_config,
+    prepare_attn_qg,
+    replicate_kv_weight,
+)
 from models.demos.qwen35_27b.tt.rope import apply_partial_rope_decode, apply_partial_rope_prefill, get_prefill_rot_mats
 from models.tt_transformers.tt.ccl import tt_all_reduce
 
@@ -84,8 +92,57 @@ class Qwen35Attention(LightweightModule):
         self.v_caches = None
         self._kv_update_shard_cfg = args.kv_update_shard_cfg
 
-        # Weights set later via set_weights()
-        self.tw = self._load_weights(state_dict, layer_num, mesh_device, weight_cache_path)
+        self.tw = {}
+        cache_dir = str(weight_cache_path / "attention_mesh")
+        os.makedirs(cache_dir, exist_ok=True)
+        tp = args.num_devices
+        p = f"layers.{layer_num}."
+        ld = os.path.join(cache_dir, f"layer_{layer_num:02d}")
+        os.makedirs(ld, exist_ok=True)
+        qg_reordered = prepare_attn_qg(state_dict, p, args.n_heads, args.head_dim, tp)
+        self.tw["wqkv"] = _shard_w(
+            qg_reordered,
+            mesh_device,
+            dim=-1,
+            memory_config=args.attn_qg_weight_memcfg,
+            cache_path=os.path.join(ld, "wqkv"),
+        )
+        k_weight = state_dict[p + "attention.wk.weight"]
+        v_weight = state_dict[p + "attention.wv.weight"]
+        if args.kv_replication:
+            k_weight = replicate_kv_weight(k_weight, args.n_kv_heads, tp, args.head_dim)
+            v_weight = replicate_kv_weight(v_weight, args.n_kv_heads, tp, args.head_dim)
+        self.tw["wk"] = _shard_w(
+            k_weight,
+            mesh_device,
+            dim=-1,
+            memory_config=args.attn_k_weight_memcfg,
+            cache_path=os.path.join(ld, "wk"),
+        )
+        self.tw["wv"] = _shard_w(
+            v_weight,
+            mesh_device,
+            dim=-1,
+            memory_config=args.attn_v_weight_memcfg,
+            cache_path=os.path.join(ld, "wv"),
+        )
+        self.tw["wo"] = _shard_w(
+            state_dict[p + "attention.wo.weight"],
+            mesh_device,
+            dim=0,
+            memory_config=args.attn_wo_weight_memcfg,
+            cache_path=os.path.join(ld, "wo"),
+        )
+        self.tw["q_norm"] = _replicate(
+            state_dict[p + "attention.q_norm.weight"],
+            mesh_device,
+            os.path.join(ld, "q_norm"),
+        )
+        self.tw["k_norm"] = _replicate(
+            state_dict[p + "attention.k_norm.weight"],
+            mesh_device,
+            os.path.join(ld, "k_norm"),
+        )
 
     def _load_weights(self, state_dict, layer_num, mesh_device, weight_cache_path):
         if isinstance(state_dict, dict) and "wqkv" in state_dict:

--- a/models/demos/qwen35_27b/tt/gdn.py
+++ b/models/demos/qwen35_27b/tt/gdn.py
@@ -26,7 +26,15 @@ from models.demos.qwen35_27b.tt.gdn_kernel.gdn_kernel_op import (
     gdn_prefill_fused,
     gdn_recurrence_fused_inplace,
 )
-from models.demos.qwen35_27b.tt.model_config import create_prefill_matmul_program_config
+from models.demos.qwen35_27b.tt.model_config import (
+    GDN_CONV_KERNEL_SIZE,
+    _replicate,
+    _shard_small,
+    _shard_w,
+    create_prefill_matmul_program_config,
+    prepare_conv_taps,
+    prepare_gdn_qkv,
+)
 from models.tt_transformers.tt.ccl import tt_all_reduce
 
 
@@ -118,7 +126,92 @@ class TtGatedDeltaNet(LightweightModule):
 
         self.compute_cfg = args.compute_kernel_config_hifi2
 
-        self.tw = self._load_weights(state_dict, layer_num, mesh_device, weight_cache_path)
+        self.tw = {}
+        # Fused QKV+Z weight
+        p = f"layers.{layer_num}."
+        cache_dir = str(weight_cache_path / "attention_mesh")
+        tp = args.num_devices
+        ld = _os.path.join(cache_dir, f"layer_{layer_num:02d}")
+        _os.makedirs(ld, exist_ok=True)
+        qkv_reordered = prepare_gdn_qkv(state_dict, p, tp)
+        z_weight = state_dict[p + "linear_attn.in_proj_z.weight"]
+        qkv_per = args.gdn_qkv_dim_tp
+        z_per = args.gdn_z_dim_tp
+        fused_parts = []
+        for d in range(tp):
+            fused_parts.append(
+                torch.cat(
+                    [
+                        qkv_reordered[d * qkv_per : (d + 1) * qkv_per, :],
+                        z_weight[d * z_per : (d + 1) * z_per, :],
+                    ],
+                    dim=0,
+                )
+            )
+        qkvz_fused = torch.cat(fused_parts, dim=0)
+        self.tw["qkvz"] = _shard_w(
+            qkvz_fused,
+            mesh_device,
+            dim=-1,
+            memory_config=args.gdn_qkvz_weight_memcfg,
+            cache_path=_os.path.join(ld, "qkvz"),
+        )
+
+        # Fused A+B projection: concat per-device shards of A and B
+        a_w = state_dict[p + "linear_attn.in_proj_a.weight"]
+        b_w = state_dict[p + "linear_attn.in_proj_b.weight"]
+        a_per = args.gdn_nv_tp
+        b_per = args.gdn_nv_tp
+        ab_parts = []
+        for d in range(tp):
+            ab_parts.append(
+                torch.cat(
+                    [
+                        a_w[d * a_per : (d + 1) * a_per, :],
+                        b_w[d * b_per : (d + 1) * b_per, :],
+                    ],
+                    dim=0,
+                )
+            )
+        ab_fused = torch.cat(ab_parts, dim=0)
+        self.tw["ab"] = _shard_w(
+            ab_fused,
+            mesh_device,
+            dim=-1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_path=_os.path.join(ld, "ab"),
+        )
+
+        # Output projection (row-parallel)
+        self.tw["out"] = _shard_w(
+            state_dict[p + "linear_attn.out_proj.weight"],
+            mesh_device,
+            dim=0,
+            memory_config=args.gdn_out_weight_memcfg,
+            cache_path=_os.path.join(ld, "out"),
+        )
+
+        # Per-head params
+        self.tw["A_log"] = _shard_small(
+            state_dict[p + "linear_attn.A_log"].float(),
+            mesh_device,
+            _os.path.join(ld, "A_log"),
+        )
+        self.tw["dt_bias"] = _shard_small(
+            state_dict[p + "linear_attn.dt_bias"].float(),
+            mesh_device,
+            _os.path.join(ld, "dt_bias"),
+        )
+        self.tw["norm_w"] = _replicate(
+            state_dict[p + "linear_attn.norm.weight"].float(),
+            mesh_device,
+            _os.path.join(ld, "norm_w"),
+        )
+        # Conv taps
+        taps = prepare_conv_taps(state_dict, p, tp)
+        self.tw["conv_taps"] = [
+            _shard_small(taps[j], mesh_device, _os.path.join(ld, f"conv_tap_{j}")) for j in range(GDN_CONV_KERNEL_SIZE)
+        ]
 
         # Mutable state buffers (conv + recurrence)
         self.conv_states = None
@@ -136,6 +229,7 @@ class TtGatedDeltaNet(LightweightModule):
         # Chunkwise prefill masks (pre-computed once, reused across layers/calls)
         self.chunk_size = args.gdn_chunk_size
         self._chunk_masks = create_chunk_masks(self.chunk_size, mesh_device)
+        self._precompute_constants()
 
     def _load_weights(self, state_dict, layer_num, mesh_device, weight_cache_path):
         if isinstance(state_dict, dict) and "qkvz" in state_dict:

--- a/models/demos/qwen35_27b/tt/model.py
+++ b/models/demos/qwen35_27b/tt/model.py
@@ -22,20 +22,7 @@ from loguru import logger
 import ttnn
 from models.demos.qwen35_27b.tt.attention import Qwen35Attention
 from models.demos.qwen35_27b.tt.gdn import TtGatedDeltaNet
-from models.demos.qwen35_27b.tt.model_config import (
-    ATTN_CHUNK_SIZE,
-    GDN_CHUNK_SIZE,
-    GDN_CONV_KERNEL_SIZE,
-    Qwen35ModelArgs,
-    _replicate,
-    _shard_small,
-    _shard_w,
-    load_qwen35_state_dict,
-    prepare_attn_qg,
-    prepare_conv_taps,
-    prepare_gdn_qkv,
-    replicate_kv_weight,
-)
+from models.demos.qwen35_27b.tt.model_config import ATTN_CHUNK_SIZE, GDN_CHUNK_SIZE, Qwen35ModelArgs
 from models.demos.qwen35_27b.tt.rope import Qwen35PartialRopeSetup
 from models.tt_transformers.tt.model import Transformer as TTTransformer
 from models.tt_transformers.tt.model_config import Mode
@@ -62,6 +49,13 @@ class Transformer(TTTransformer):
         prefetcher=None,
     ):
         # Build with Qwen35Attention as default, then swap GDN layers after
+
+        def attention_wrapper(**kwargs):
+            if args.layer_types[kwargs["layer_num"]] == "linear_attention":
+                return TtGatedDeltaNet(**kwargs)
+            else:
+                return Qwen35Attention(**kwargs)
+
         super().__init__(
             args=args,
             dtype=dtype,
@@ -70,181 +64,10 @@ class Transformer(TTTransformer):
             weight_cache_path=weight_cache_path,
             paged_attention_config=paged_attention_config,
             use_paged_kv_cache=use_paged_kv_cache,
-            attention_class=Qwen35Attention,
+            attention_class=attention_wrapper,
             rope_setup_class=Qwen35PartialRopeSetup,
             prefetcher=prefetcher,
         )
-
-        # Replace attention on linear_attention layers with TtGatedDeltaNet
-        for i in range(args.n_layers):
-            if args.layer_types[i] == "linear_attention":
-                self.layers[i].attention = TtGatedDeltaNet(
-                    mesh_device=mesh_device,
-                    tt_ccl=self.tt_ccl,
-                    args=args,
-                    state_dict=state_dict,
-                    weight_cache_path=weight_cache_path,
-                    layer_num=i,
-                    dtype=dtype,
-                    transformation_mats=self.trans_mats_dict,
-                    configuration=args,
-                    paged_attention_config=paged_attention_config,
-                    use_paged_kv_cache=use_paged_kv_cache,
-                    prefetcher=prefetcher,
-                )
-
-        # Load attention-specific mesh weights and wire them up
-        cache_dir = str(weight_cache_path / "attention_mesh")
-        self._load_and_wire_attention_weights(state_dict, mesh_device, cache_dir, args)
-
-    def _load_and_wire_attention_weights(self, state_dict, mesh, cache_dir, args):
-        """Load attention mesh tensors and call set_weights() on each layer's attention."""
-        os.makedirs(cache_dir, exist_ok=True)
-        tp = args.num_devices
-
-        for i in range(args.n_layers):
-            layer_type = args.layer_types[i]
-            p = f"layers.{i}."
-            ld = os.path.join(cache_dir, f"layer_{i:02d}")
-            os.makedirs(ld, exist_ok=True)
-            tw = {}
-
-            if layer_type == "full_attention":
-                qg_reordered = prepare_attn_qg(state_dict, p, args.n_heads, args.head_dim, tp)
-                tw["wqkv"] = _shard_w(
-                    qg_reordered,
-                    mesh,
-                    dim=-1,
-                    memory_config=args.attn_qg_weight_memcfg,
-                    cache_path=os.path.join(ld, "wqkv"),
-                )
-                k_weight = state_dict[p + "attention.wk.weight"]
-                v_weight = state_dict[p + "attention.wv.weight"]
-                if args.kv_replication:
-                    k_weight = replicate_kv_weight(k_weight, args.n_kv_heads, tp, args.head_dim)
-                    v_weight = replicate_kv_weight(v_weight, args.n_kv_heads, tp, args.head_dim)
-                tw["wk"] = _shard_w(
-                    k_weight,
-                    mesh,
-                    dim=-1,
-                    memory_config=args.attn_k_weight_memcfg,
-                    cache_path=os.path.join(ld, "wk"),
-                )
-                tw["wv"] = _shard_w(
-                    v_weight,
-                    mesh,
-                    dim=-1,
-                    memory_config=args.attn_v_weight_memcfg,
-                    cache_path=os.path.join(ld, "wv"),
-                )
-                tw["wo"] = _shard_w(
-                    state_dict[p + "attention.wo.weight"],
-                    mesh,
-                    dim=0,
-                    memory_config=args.attn_wo_weight_memcfg,
-                    cache_path=os.path.join(ld, "wo"),
-                )
-                tw["q_norm"] = _replicate(
-                    state_dict[p + "attention.q_norm.weight"],
-                    mesh,
-                    os.path.join(ld, "q_norm"),
-                )
-                tw["k_norm"] = _replicate(
-                    state_dict[p + "attention.k_norm.weight"],
-                    mesh,
-                    os.path.join(ld, "k_norm"),
-                )
-                self.layers[i].attention.set_weights(tw)
-                logger.info(f"  Layer {i:2d}/{args.n_layers} (full_attention) weights loaded")
-
-            elif layer_type == "linear_attention":
-                # Fused QKV+Z weight
-                qkv_reordered = prepare_gdn_qkv(state_dict, p, tp)
-                z_weight = state_dict[p + "linear_attn.in_proj_z.weight"]
-                qkv_per = args.gdn_qkv_dim_tp
-                z_per = args.gdn_z_dim_tp
-                fused_parts = []
-                for d in range(tp):
-                    fused_parts.append(
-                        torch.cat(
-                            [
-                                qkv_reordered[d * qkv_per : (d + 1) * qkv_per, :],
-                                z_weight[d * z_per : (d + 1) * z_per, :],
-                            ],
-                            dim=0,
-                        )
-                    )
-                qkvz_fused = torch.cat(fused_parts, dim=0)
-                tw["qkvz"] = _shard_w(
-                    qkvz_fused,
-                    mesh,
-                    dim=-1,
-                    memory_config=args.gdn_qkvz_weight_memcfg,
-                    cache_path=os.path.join(ld, "qkvz"),
-                )
-
-                # Fused A+B projection: concat per-device shards of A and B
-                a_w = state_dict[p + "linear_attn.in_proj_a.weight"]
-                b_w = state_dict[p + "linear_attn.in_proj_b.weight"]
-                a_per = args.gdn_nv_tp
-                b_per = args.gdn_nv_tp
-                ab_parts = []
-                for d in range(tp):
-                    ab_parts.append(
-                        torch.cat(
-                            [
-                                a_w[d * a_per : (d + 1) * a_per, :],
-                                b_w[d * b_per : (d + 1) * b_per, :],
-                            ],
-                            dim=0,
-                        )
-                    )
-                ab_fused = torch.cat(ab_parts, dim=0)
-                tw["ab"] = _shard_w(
-                    ab_fused,
-                    mesh,
-                    dim=-1,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    cache_path=os.path.join(ld, "ab"),
-                )
-
-                # Output projection (row-parallel)
-                tw["out"] = _shard_w(
-                    state_dict[p + "linear_attn.out_proj.weight"],
-                    mesh,
-                    dim=0,
-                    memory_config=args.gdn_out_weight_memcfg,
-                    cache_path=os.path.join(ld, "out"),
-                )
-
-                # Per-head params
-                tw["A_log"] = _shard_small(
-                    state_dict[p + "linear_attn.A_log"].float(),
-                    mesh,
-                    os.path.join(ld, "A_log"),
-                )
-                tw["dt_bias"] = _shard_small(
-                    state_dict[p + "linear_attn.dt_bias"].float(),
-                    mesh,
-                    os.path.join(ld, "dt_bias"),
-                )
-                tw["norm_w"] = _replicate(
-                    state_dict[p + "linear_attn.norm.weight"].float(),
-                    mesh,
-                    os.path.join(ld, "norm_w"),
-                )
-
-                # Conv taps
-                taps = prepare_conv_taps(state_dict, p, tp)
-                tw["conv_taps"] = [
-                    _shard_small(taps[j], mesh, os.path.join(ld, f"conv_tap_{j}")) for j in range(GDN_CONV_KERNEL_SIZE)
-                ]
-
-                self.layers[i].attention.set_weights(tw)
-                logger.info(f"  Layer {i:2d}/{args.n_layers} (linear_attention) weights loaded")
-
-            else:
-                logger.warning(f"  Layer {i:2d}: unknown type '{layer_type}'")
 
     # ── L1 State Management ────────────────────────────────────────────
 
@@ -670,11 +493,12 @@ def create_qwen35_model(
     if not os.environ.get("HF_MODEL"):
         os.environ["HF_MODEL"] = model_path
 
-    logger.info("Loading Qwen3.5 state dict...")
-    state_dict = load_qwen35_state_dict(model_path)
+    # logger.info("Loading Qwen3.5 state dict...")
+    # state_dict = load_qwen35_state_dict(model_path)
 
     logger.info("Creating Qwen35ModelArgs...")
     args = Qwen35ModelArgs(mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len)
+    state_dict = args.load_state_dict()
 
     if n_layers is not None:
         logger.info(f"Overriding n_layers: {args.n_layers} -> {n_layers} (layer_types: {args.layer_types[:n_layers]})")

--- a/models/demos/qwen35_27b/tt/model_config.py
+++ b/models/demos/qwen35_27b/tt/model_config.py
@@ -466,7 +466,7 @@ def prepare_attn_qg(sd, prefix, n_heads, head_dim, tp):
     ShardTensorToMesh(dim=-1) on the transposed weight naturally groups contiguous heads
     per device, preserving the per-head [Q, gate] layout expected by forward_decode.
     """
-    return sd[prefix + "attention.wqkv.weight"]
+    return sd[prefix + "attention.wq.weight"]
 
 
 def prepare_conv_taps(sd, prefix, tp):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2942,12 +2942,12 @@ class ModelArgs:
         return self.model_config
 
     def get_hf_model_cls(self):
-        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoModelForVision2Seq
+        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
         if not self.is_multimodal:
             return AutoModelForCausalLM
 
-        for model_cls in (AutoModelForVision2Seq, AutoModelForImageTextToText):
+        for model_cls in (AutoModelForImageTextToText,):
             if type(self.hf_config) in model_cls._model_mapping:
                 return model_cls
 


### PR DESCRIPTION


### Summary
Changes made:

- refactored state dict and model weights loading to call tt-transformers methods
- added attention wrappers to switch between gdn and gated attention at runtime instead of post initialization fixing
-  attention weight initialization delegated to individual layers instead of monkey patching in model layer


### Notes for reviewers
need transformers uplift prior to main merging