### PR TITLE
Performance: Integrate `deepseek_moe_fast_reduce_nc_fused` into DeepSeek v3 (main base)

### DIFF
--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -594,7 +594,7 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
 )
 @pytest.mark.parametrize("cluster_axis", [0])
 @pytest.mark.parametrize("layer_id, num_layers", [(0, 1)])
-@pytest.mark.parametrize("batches_per_device", [3, 8, 32])
+@pytest.mark.parametrize("batches_per_device", [3, 32])
 @pytest.mark.parametrize("shard_dim", [0])
 @pytest.mark.parametrize("routed_experts_per_device", [2])
 @pytest.mark.parametrize("select_experts_k", [8])
@@ -605,7 +605,7 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
 @pytest.mark.parametrize("compute_output_height_shard_dim", [4])
 @pytest.mark.parametrize("combine_mux_core_range", [((1, 1), (3, 3))])
 @pytest.mark.parametrize("combine_token_parallel_core_dim", [4])
-@pytest.mark.parametrize("enable_trace", [False, True])
+@pytest.mark.parametrize("enable_trace", [False])
 @pytest.mark.parametrize("num_iterations", [3])
 @pytest.mark.parametrize(
     "device_params",
@@ -619,7 +619,7 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
     ids=["fabric_1D_ring"],
     indirect=True,
 )
-@pytest.mark.parametrize("shared_expert_mode", ["no_shared", "all_shared", "alternate_shared"])
+@pytest.mark.parametrize("shared_expert_mode", ["no_shared"])
 @torch.no_grad()
 def test_optimized_moe_decode_block(
     mesh_shape,
@@ -1268,7 +1268,7 @@ def test_optimized_moe_decode_block(
             output_memory_config=fast_reduce_output_memory_config,
             scores_tensor=topk_experts_weights,
             num_shared_experts=num_shared_experts,
-            shared_expert_scale=shared_expert_score,
+            shared_expert_scale=shared_expert_score / num_replicated_devices,
         )
 
         ttnn.deallocate(tt_dispatch_input_expert_indices_tensor)

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -162,8 +162,9 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        mlp_out = ttnn.sum(mlp_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"])
-        combined_out = ttnn.add(mlp_out, shared_expert_out)
+        combined_out = ttnn.add(
+            mlp_out, shared_expert_out, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
+        )
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
 
@@ -212,7 +213,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             fabric_config=cfg["moe"]["fabric_config"],
             mesh_device=cfg["moe"]["mesh_device"],
         )
-        mlp_out = moe_cls.forward_decode(x_gathered, cfg["moe"])
+        mlp_out, tt_moe_indices_rm, tt_moe_scores_rm = moe_cls.forward_decode(x_gathered, cfg["moe"])
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_decode(x_gathered, cfg["shared_expert"])
 
@@ -229,28 +230,31 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
 
+            summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+                combined_out,
+                tt_moe_indices_rm,
+                cfg["moe"]["expert_mapping_tensor"],
+                reduce_dim=0,
+                cluster_axis=0,
+                split_size=combined_out.shape[-1] // tp_size,
+                output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
+                scores_tensor=tt_moe_scores_rm,
+                num_shared_experts=1,
+            )
+            ttnn.deallocate(combined_out)
+            ttnn.deallocate(tt_moe_scores_rm)
+            ttnn.deallocate(tt_moe_indices_rm)
+
             if (
                 cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING
                 and tp_size == 8
                 and num_tokens_per_row == ttnn.TILE_SIZE
             ):
-                summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
-                    combined_out,
-                    dim=0,
-                    split_size=combined_out.shape[-1] // tp_size,
-                    output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
-                )
-                ttnn.deallocate(combined_out)
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(
                     summed_experts, **cfg["moe"]["ring_final_output_reduce_scatter"]
                 )
             else:
                 ccl_moe = cfg["moe"]["ccl"]
-
-                summed_experts = ttnn.sum(
-                    combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
-                )
-                ttnn.deallocate(combined_out)
                 output = ttnn.experimental.reduce_scatter_minimal_async(
                     summed_experts,
                     **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -230,14 +230,45 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
 
+            if combined_out.shape[2] == ttnn.TILE_SIZE:
+                combined_out = ttnn.experimental.deepseek_moe_post_combine_tilize(
+                    combined_out,
+                    **cfg["moe"]["quad_ring_deepseek_moe_post_combine_tilize_config"],
+                )
+            else:
+                output_shape = list(combined_out.shape)
+                output_shape[2] = ((output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+                combined_out = ttnn.tilize_with_val_padding(
+                    combined_out,
+                    output_tensor_shape=output_shape,
+                    pad_value=0.0,
+                    memory_config=cfg["moe"]["quad_ring_deepseek_moe_post_combine_tilize_config"][
+                        "output_memory_config"
+                    ],
+                )
+
+            # conditionally set up for optimized or standard RS pathway
+            deepseek_moe_reduce_scatter = (
+                cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING
+                and tp_size == 8
+                and num_tokens_per_row == ttnn.TILE_SIZE
+            )
+
+            if deepseek_moe_reduce_scatter:
+                reduce_mem_config = cfg["moe"]["ring_sum_experts_output_memory_config"]
+                reduce_split_size = combined_out.shape[-1] // tp_size
+            else:
+                reduce_mem_config = ttnn.L1_MEMORY_CONFIG
+                reduce_split_size = combined_out.shape[-1]
+
             summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
                 combined_out,
                 tt_moe_indices_rm,
                 cfg["moe"]["expert_mapping_tensor"],
                 reduce_dim=0,
                 cluster_axis=0,
-                split_size=combined_out.shape[-1] // tp_size,
-                output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
+                split_size=reduce_split_size,
+                output_memory_config=reduce_mem_config,
                 scores_tensor=tt_moe_scores_rm,
                 num_shared_experts=1,
             )
@@ -245,18 +276,14 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             ttnn.deallocate(tt_moe_scores_rm)
             ttnn.deallocate(tt_moe_indices_rm)
 
-            if (
-                cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING
-                and tp_size == 8
-                and num_tokens_per_row == ttnn.TILE_SIZE
-            ):
+            if deepseek_moe_reduce_scatter:
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(
                     summed_experts, **cfg["moe"]["ring_final_output_reduce_scatter"]
                 )
             else:
                 ccl_moe = cfg["moe"]["ccl"]
                 output = ttnn.experimental.reduce_scatter_minimal_async(
-                    summed_experts,
+                    summed_experts[0],
                     **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
                 )
 

--- a/models/demos/deepseek_v3/tt/moe_optimized.py
+++ b/models/demos/deepseek_v3/tt/moe_optimized.py
@@ -314,7 +314,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         )
 
     @classmethod
-    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
+    def _forward_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         return cls._forward_impl(x, cfg, "decode")
 
     @classmethod
@@ -348,7 +348,9 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         return output
 
     @classmethod
-    def _forward_impl(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, mode: str) -> ttnn.Tensor:
+    def _forward_impl(
+        cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, mode: str
+    ) -> ttnn.Tensor | tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         # Validate input dimensions
         hidden_size = cfg["hidden_size"]
         mesh_device = cfg.get("mesh_device")
@@ -376,7 +378,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
 
         # MOE
         if mode == "decode":
-            post_combine_output_tensor = cls._fwd_decode_moe(
+            return cls._fwd_decode_moe(
                 x,
                 topk_experts_indices,
                 topk_experts_weights,
@@ -384,9 +386,9 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 batch_size_per_device,
                 batch_size,
                 seq_len,
-            )
+            )  # also returns topk_experts_indices_rm, topk_experts_weights_rm
         else:
-            post_combine_output_tensor = cls._fwd_prefill_moe(
+            return cls._fwd_prefill_moe(
                 x,
                 topk_experts_indices,
                 topk_experts_weights,
@@ -395,9 +397,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 batch_size,
                 seq_len,
             )
-
-        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
-        return post_combine_output_tensor
 
     @classmethod
     def _fwd_moe_gate(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> tuple[ttnn.Tensor, ttnn.Tensor]:
@@ -442,7 +441,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             topk_experts_weights_rm,
         )
 
-        return post_combine_output_tensor
+        return post_combine_output_tensor, topk_experts_indices_rm, topk_experts_weights_rm
 
     @classmethod
     def _fwd_prefill_moe(
@@ -533,7 +532,17 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 [cfg["num_experts_per_tok"], 1, batch_chunk, cfg["hidden_size"]],
             )
 
-            output_chunks.append(post_combine_output_tensor)
+            summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
+                post_combine_output_tensor,
+                topk_experts_indices_rm_chunk,
+                cfg["expert_mapping_tensor"],
+                reduce_dim=0,
+                cluster_axis=0,
+                split_size=1,
+                scores_tensor=topk_experts_weights_rm_chunk,
+            )
+
+            output_chunks.append(summed_experts[0])
 
         ttnn.deallocate(topk_experts_indices_rm)
         ttnn.deallocate(topk_experts_weights_rm)
@@ -564,21 +573,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             topk_experts_weights_rm,
             memory_config=cfg["quad_ring_all_to_all_dispatch_metadata_sharded_memory_config"],
         )
-
-        # NOTE: L1 sharded topk_experts_weights need to be deallocated before moe_compute,
-        # configure weights for post combine scaling prior to that deallocation, and store in DRAM
-        topk_experts_weights_for_scaling = ttnn.permute(
-            topk_experts_weights_rm, (3, 1, 0, 2), memory_config=ttnn.L1_MEMORY_CONFIG
-        )
-        topk_experts_weights_for_scaling = ttnn.to_layout(
-            topk_experts_weights_for_scaling, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-
-        ttnn.deallocate(topk_experts_indices_rm)
-        ttnn.deallocate(topk_experts_weights_rm)
-
-        # NOTE: needs to run prior to all_to_all_dispatch_metadata
-        preallocated_combine_output = ttnn.moreh_full(**cfg["quad_ring_moreh_full"])
 
         # TODO: #41009
         (
@@ -614,7 +608,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             cfg["expert_mapping_tensor"],
             cfg["moe_experts"]["quad_ring_w0_w1_experts"]["input_tensor_b"],
             cfg["moe_experts"]["quad_ring_w2_experts"]["input_tensor_b"],
-            optional_output_tensor=preallocated_combine_output,
             layer_id=0,  # each layer is composed of distinct tensors, as apposed to all layers fused together
             **cfg["quad_ring_moe_compute"],
         )
@@ -640,10 +633,6 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 pad_value=0.0,
                 memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
             )
-
-        post_combine_output_tensor = ttnn.mul(
-            combine_output, topk_experts_weights_for_scaling, **cfg["mul_experts_output_with_weights"]
-        )
 
         ttnn.deallocate(combine_output)
         return post_combine_output_tensor
@@ -682,7 +671,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
             x = cls._fwd_all_gather(x, cfg)
 
         # Run the forward pass
-        output = cls._forward_decode(x, cfg)
+        output, indices_rm, weights_rm = cls._forward_decode(x, cfg)
 
         # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
@@ -703,7 +692,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
                 output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
-        return output
+        return output, indices_rm, weights_rm
 
     @classmethod
     def forward_prefill(

--- a/models/demos/deepseek_v3/tt/moe_optimized.py
+++ b/models/demos/deepseek_v3/tt/moe_optimized.py
@@ -532,21 +532,14 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 [cfg["num_experts_per_tok"], 1, batch_chunk, cfg["hidden_size"]],
             )
 
-            if post_combine_output_tensor.shape[2] == ttnn.TILE_SIZE:
-                post_combine_output_tensor = ttnn.experimental.deepseek_moe_post_combine_tilize(
-                    post_combine_output_tensor,
-                    **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"],
-                )
-
-            else:
-                output_shape = list(post_combine_output_tensor.shape)
-                output_shape[2] = ((output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
-                post_combine_output_tensor = ttnn.tilize_with_val_padding(
-                    post_combine_output_tensor,
-                    output_tensor_shape=output_shape,
-                    pad_value=0.0,
-                    memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
-                )
+            output_shape = list(post_combine_output_tensor.shape)
+            output_shape[2] = ((output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+            post_combine_output_tensor = ttnn.tilize_with_val_padding(
+                post_combine_output_tensor,
+                output_tensor_shape=output_shape,
+                pad_value=0.0,
+                memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
+            )
 
             summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
                 post_combine_output_tensor,

--- a/models/demos/deepseek_v3/tt/moe_optimized.py
+++ b/models/demos/deepseek_v3/tt/moe_optimized.py
@@ -532,13 +532,29 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
                 [cfg["num_experts_per_tok"], 1, batch_chunk, cfg["hidden_size"]],
             )
 
+            if post_combine_output_tensor.shape[2] == ttnn.TILE_SIZE:
+                post_combine_output_tensor = ttnn.experimental.deepseek_moe_post_combine_tilize(
+                    post_combine_output_tensor,
+                    **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"],
+                )
+
+            else:
+                output_shape = list(post_combine_output_tensor.shape)
+                output_shape[2] = ((output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+                post_combine_output_tensor = ttnn.tilize_with_val_padding(
+                    post_combine_output_tensor,
+                    output_tensor_shape=output_shape,
+                    pad_value=0.0,
+                    memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
+                )
+
             summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc_fused(
                 post_combine_output_tensor,
                 topk_experts_indices_rm_chunk,
                 cfg["expert_mapping_tensor"],
                 reduce_dim=0,
                 cluster_axis=0,
-                split_size=1,
+                split_size=7168,
                 scores_tensor=topk_experts_weights_rm_chunk,
             )
 
@@ -615,27 +631,7 @@ class MoEOptimized(SharedStateAddOn, AbstractModule):
         ttnn.deallocate(compute_output)
 
         combine_output = ttnn.unsqueeze(combine_output, dim=1)
-
-        if combine_output.shape[2] == ttnn.TILE_SIZE:
-            combine_output = ttnn.experimental.deepseek_moe_post_combine_tilize(
-                combine_output,
-                **cfg["quad_ring_deepseek_moe_post_combine_tilize_config"],
-            )
-
-        else:
-            combine_output_shape = list(combine_output.shape)
-            combine_output_shape[2] = (
-                (combine_output_shape[2] + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
-            ) * ttnn.TILE_SIZE
-            combine_output = ttnn.tilize_with_val_padding(
-                combine_output,
-                output_tensor_shape=combine_output_shape,
-                pad_value=0.0,
-                memory_config=cfg["quad_ring_deepseek_moe_post_combine_tilize_config"]["output_memory_config"],
-            )
-
-        ttnn.deallocate(combine_output)
-        return post_combine_output_tensor
+        return combine_output
 
     @classmethod
     def _fwd_all_gather(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -524,7 +524,7 @@ class DeepseekMoEPostCombineTilizeConfig(OpConfigBase):
                 shard_shape=[32, 1024],
                 grid=ttnn.CoreRangeSet(
                     {
-                        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 7)),
+                        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 8)),  # select_experts_k + shared expert
                     }
                 ),
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused.cpp
@@ -36,7 +36,7 @@ std::vector<ttnn::Tensor> deepseek_moe_fast_reduce_nc_fused(
     ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(init_device_compute_kernel_config(
         input_tensor.device()->arch(),
         std::nullopt,
-        tt::tt_metal::MathFidelity::HiFi4,
+        MathFidelity::HiFi4,
         /* default_approx_mode */ false,
         /* default_fp32_acc */ true));
 


### PR DESCRIPTION
### Summary
- Where appropriate, replace reductions over K and expert score scaling with the fused op
- Also allows us to remove the `moreh_full` from decode

### Notes for reviewers
- 1a9a3a1cec22435280edaa648c7faa138ccb7f57 has already been reviewed and merged into main, only upper commits need to be reviewed.
- Note: the code paths are slightly different for prefill and decode due to the chunking structure 
- Note: Original ds-rc1 PR https://github.com/tenstorrent/tt-metal/pull/44742

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/ds-rc1-deepseek-nc-reduce-fused-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/ds-rc1-deepseek-nc-reduce-fused-main)