### PR TITLE
[MeshTensor Integration] layernorm op

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -70,6 +70,11 @@ bool CB_can_fit_in_L1(
     return sum < l1_size * 0.95;
 }
 
+uint32_t get_buffer_aligned_size_per_bank(const MeshTensor& t) {
+    return static_cast<uint32_t>(
+        t.mesh_buffer().get_reference_buffer()->aligned_size_per_bank());  // aligned_size_per_bank() -> DeviceAddr
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -198,13 +203,11 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
          num_tile_rows_per_core_group_2] = split_work_to_cores(requested_cores, num_tile_rows, true /* row_wise */);
 
     // Use passed-in reciprocal LUT tensor if using Welford
-    std::optional<Tensor> recip_tensor = std::nullopt;
+    const auto recip = as_optional_mesh_tensor(tensor_args.recip_tensor);
     uint32_t reciprocal_CB_size_bytes = 0;
     if (use_welford) {
-        TT_FATAL(tensor_args.recip_tensor.has_value(), "Reciprocal tensor not provided for Welford layernorm");
-        recip_tensor = tensor_args.recip_tensor;
-        reciprocal_CB_size_bytes =
-            recip_tensor->mesh_tensor().mesh_buffer().get_reference_buffer()->aligned_size_per_bank();
+        TT_FATAL(recip.has_value(), "Reciprocal tensor not provided for Welford layernorm");
+        reciprocal_CB_size_bytes = get_buffer_aligned_size_per_bank(*recip);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -832,7 +835,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             .buffer_index = tt::CBIndex::c_25,
             .data_format = reciprocal_cb_data_format,
             .page_size = reciprocal_CB_size_bytes});
-        recip_cb_desc.tensor = &recip_tensor.value().mesh_tensor();
+        recip_cb_desc.buffer = recip->mesh_buffer().get_reference_buffer();
         program_descriptor.cbs.push_back(std::move(recip_cb_desc));
     }
     return program_descriptor;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -544,8 +544,6 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
                    ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp"
                    : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp");
 
-    // Build kernel descriptors up-front so we can register runtime args (with MeshTensor
-    // buffer bindings) directly inside the per-core loop via emplace_runtime_args.
     KernelDescriptor reader_kernel_desc;
     reader_kernel_desc.kernel_source = reader_kernel_path;
     reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -128,7 +128,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
     IDevice* device = a.device();
-    auto dst_addr = output.buffer()->address();
+    auto dst_addr = output.mesh_tensor().address();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -184,10 +184,10 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         inb_single_tile_size = tt::tile_size(inb_data_format);
     }
 
-    auto a_addr = a.buffer()->address();
-    auto b_dram_addr = b ? b.value().buffer()->address() : 0;
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
+    auto a_addr = a.mesh_tensor().address();
+    auto b_dram_addr = b ? b.value().mesh_tensor().address() : 0;
+    auto gamma_dram_addr = gamma.has_value() ? gamma.value().mesh_tensor().address() : 0;
+    auto beta_dram_addr = beta.has_value() ? beta.value().mesh_tensor().address() : 0;
 
     uint32_t num_tile_rows = NC * Ht;
 
@@ -208,7 +208,8 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     if (use_welford) {
         TT_FATAL(tensor_args.recip_tensor.has_value(), "Reciprocal tensor not provided for Welford layernorm");
         recip_tensor = tensor_args.recip_tensor;
-        reciprocal_CB_size_bytes = recip_tensor->buffer()->aligned_size_per_bank();
+        reciprocal_CB_size_bytes =
+            recip_tensor->mesh_tensor().mesh_buffer().get_reference_buffer()->aligned_size_per_bank();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -355,10 +356,18 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         reader_compile_time_args.push_back((std::uint32_t)use_welford);
     }
     reader_compile_time_args.push_back(W);
-    tt::tt_metal::TensorAccessorArgs(a.buffer()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(b ? b->buffer() : nullptr).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(gamma ? gamma->buffer() : nullptr).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(beta ? beta->buffer() : nullptr).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a.mesh_tensor()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(
+        b ? ttsl::optional_reference<const MeshTensor>(b->mesh_tensor()) : ttsl::optional_reference<const MeshTensor>{})
+        .append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(
+        gamma ? ttsl::optional_reference<const MeshTensor>(gamma->mesh_tensor())
+              : ttsl::optional_reference<const MeshTensor>{})
+        .append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(
+        beta ? ttsl::optional_reference<const MeshTensor>(beta->mesh_tensor())
+             : ttsl::optional_reference<const MeshTensor>{})
+        .append_to(reader_compile_time_args);
 
     if (input_is_row_major) {
         // For rm_input readers: element size of input tensor for address stride calculations
@@ -375,7 +384,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
 
     // Build compile time args for writer kernel
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)block_size};
-    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
     if (input_is_row_major) {
         // RM writer needs elem_size to compute per-row NOC write sizes
         writer_compile_time_args.push_back(static_cast<uint32_t>(output.element_size()));
@@ -829,7 +838,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             .buffer_index = tt::CBIndex::c_25,
             .data_format = reciprocal_cb_data_format,
             .page_size = reciprocal_CB_size_bytes});
-        recip_cb_desc.buffer = recip_tensor.value().buffer();
+        recip_cb_desc.tensor = &recip_tensor.value().mesh_tensor();
         program_descriptor.cbs.push_back(std::move(recip_cb_desc));
     }
     return program_descriptor;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -128,7 +128,6 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
     IDevice* device = a.device();
-    auto dst_addr = output.mesh_tensor().address();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -183,11 +182,6 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         inb_data_format = tt::tt_metal::datatype_to_dataformat_converter(b.value().dtype());
         inb_single_tile_size = tt::tile_size(inb_data_format);
     }
-
-    auto a_addr = a.mesh_tensor().address();
-    auto b_dram_addr = b ? b.value().mesh_tensor().address() : 0;
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().mesh_tensor().address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().mesh_tensor().address() : 0;
 
     uint32_t num_tile_rows = NC * Ht;
 
@@ -557,18 +551,51 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
                    ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_welford.cpp"
                    : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp");
 
+    // Build kernel descriptors up-front so we can register runtime args (with MeshTensor
+    // buffer bindings) directly inside the per-core loop via emplace_runtime_args.
+    KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source = reader_kernel_path;
+    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = cb_named_args;
+    reader_kernel_desc.defines = reader_defines;
+    reader_kernel_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source = input_is_row_major
+                                           ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+                                             "writer_unary_interleaved_start_id_blocked_rm_output.cpp"
+                                           : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
+                                             "writer_unary_interleaved_start_id_blocked.cpp";
+    writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = writer_compile_time_args;
+    writer_kernel_desc.named_compile_time_args = cb_named_args;
+    writer_kernel_desc.config = WriterConfigDescriptor{};
+
+    KernelDescriptor compute_kernel_desc;
+    compute_kernel_desc.kernel_source = compute_kernel_path;
+    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kernel_desc.core_ranges = all_cores;
+    compute_kernel_desc.compile_time_args = compute_args;
+    compute_kernel_desc.named_compile_time_args = cb_named_args;
+    compute_kernel_desc.defines = compute_defines;
+    compute_kernel_desc.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .dst_full_sync_en = dst_full_sync_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx_mode};
+
+    reader_kernel_desc.runtime_args.reserve(num_cores);
+    writer_kernel_desc.runtime_args.reserve(num_cores);
+    compute_kernel_desc.runtime_args.reserve(num_cores);
+
     // Build per-core runtime args
     uint32_t curr_row = 0;
     auto bfloat_one_value = bfloat16(1);
     uint32_t packed_one_value = pack_two_bfloat16_into_uint32({bfloat_one_value, bfloat_one_value});
-
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
-    KernelDescriptor::RuntimeArgs compute_runtime_args;
-
-    reader_runtime_args.reserve(num_cores);
-    writer_runtime_args.reserve(num_cores);
-    compute_runtime_args.reserve(num_cores);
 
     // Iterate over active cores
     auto all_core_coords = corerange_to_cores(all_cores, num_cores, true);
@@ -592,30 +619,48 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
             (use_welford_and_not_rms_norm && large_tensor_needed) || (use_row_major_kernel && !input_is_row_major);
         const uint32_t reader_start = using_legacy_tile_reader ? tile_offset : curr_row;
 
-        std::vector<uint32_t> reader_args = {
-            a_addr,
-            num_tile_rows_per_core,
-            Wt,
-            reader_start,
-            packed_one_value,
-            std::bit_cast<uint32_t>(eps),
-            gamma_dram_addr,
-            beta_dram_addr,
-            b_dram_addr};
-        if (input_is_row_major) {
-            reader_args.push_back(H_logical);
+        // Reader: optional gamma/beta/b pass a MeshTensor ref when present, 0u sentinel when absent
+        // (the kernel reads slot==0 as "no tensor"). The variant in RTArgList accepts uint32_t and
+        // MeshTensor refs interchangeably.
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(a.mesh_tensor());               // slot 0: src DRAM addr
+        reader_args.push_back(num_tile_rows_per_core);        // slot 1
+        reader_args.push_back(Wt);                            // slot 2
+        reader_args.push_back(reader_start);                  // slot 3
+        reader_args.push_back(packed_one_value);              // slot 4
+        reader_args.push_back(std::bit_cast<uint32_t>(eps));  // slot 5
+        if (gamma.has_value()) {
+            reader_args.push_back(gamma->mesh_tensor());  // slot 6: gamma addr
+        } else {
+            reader_args.push_back(0u);
         }
+        if (beta.has_value()) {
+            reader_args.push_back(beta->mesh_tensor());  // slot 7: beta addr
+        } else {
+            reader_args.push_back(0u);
+        }
+        if (b.has_value()) {
+            reader_args.push_back(b->mesh_tensor());  // slot 8: b addr
+        } else {
+            reader_args.push_back(0u);
+        }
+        if (input_is_row_major) {
+            reader_args.push_back(H_logical);  // slot 9 (RM only)
+        }
+        reader_kernel_desc.emplace_runtime_args(core, reader_args);
 
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
         // For the RM output writer arg[3] is start_tile_row (starting tile-row index for this core),
         // not the flat tile offset, because the RM writer computes row addresses directly.
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
-        std::vector<uint32_t> writer_args = {dst_addr, Wt, num_tile_rows_per_core, writer_start};
         if (input_is_row_major) {
-            writer_args.push_back(H_logical);  // arg[4]
+            writer_kernel_desc.emplace_runtime_args(
+                core, {output.mesh_tensor(), Wt, num_tile_rows_per_core, writer_start, H_logical});
+        } else {
+            writer_kernel_desc.emplace_runtime_args(
+                core, {output.mesh_tensor(), Wt, num_tile_rows_per_core, writer_start});
         }
-        writer_runtime_args.emplace_back(core, std::move(writer_args));
-        compute_runtime_args.emplace_back(core, std::vector<uint32_t>{num_tile_rows_per_core});
+
+        compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});
 
         curr_row += num_tile_rows_per_core;
     }
@@ -624,49 +669,8 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //                      Build ProgramDescriptor
     ////////////////////////////////////////////////////////////////////////////
     ProgramDescriptor program_descriptor;
-
-    // Build KernelDescriptor for reader kernel
-    KernelDescriptor reader_kernel_desc;
-    reader_kernel_desc.kernel_source = reader_kernel_path;
-    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_kernel_desc.core_ranges = all_cores;
-    reader_kernel_desc.compile_time_args = reader_compile_time_args;
-    reader_kernel_desc.named_compile_time_args = cb_named_args;
-    reader_kernel_desc.defines = reader_defines;
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    reader_kernel_desc.config = ReaderConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
-
-    // Build KernelDescriptor for writer kernel
-    KernelDescriptor writer_kernel_desc;
-    writer_kernel_desc.kernel_source = input_is_row_major
-                                           ? "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
-                                             "writer_unary_interleaved_start_id_blocked_rm_output.cpp"
-                                           : "ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/"
-                                             "writer_unary_interleaved_start_id_blocked.cpp";
-    writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_kernel_desc.core_ranges = all_cores;
-    writer_kernel_desc.compile_time_args = writer_compile_time_args;
-    writer_kernel_desc.named_compile_time_args = cb_named_args;
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
-    writer_kernel_desc.config = WriterConfigDescriptor{};
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
-
-    // Build KernelDescriptor for compute kernel
-    KernelDescriptor compute_kernel_desc;
-    compute_kernel_desc.kernel_source = compute_kernel_path;
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_kernel_desc.core_ranges = all_cores;
-    compute_kernel_desc.compile_time_args = compute_args;
-    compute_kernel_desc.named_compile_time_args = cb_named_args;
-    compute_kernel_desc.defines = compute_defines;
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args);
-    compute_kernel_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .dst_full_sync_en = dst_full_sync_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-        .math_approx_mode = math_approx_mode};
     program_descriptor.kernels.push_back(std::move(compute_kernel_desc));
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "ttnn/operations/normalization/layernorm/device/layernorm_common.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation_types.hpp"
@@ -80,11 +81,11 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
     // Extract from operation_attributes and tensor_args
-    const auto& a = tensor_args.input;
-    const auto& b = tensor_args.residual_input_tensor;
-    const auto& gamma = tensor_args.weight;
-    const auto& beta = tensor_args.bias;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.input.mesh_tensor();
+    const auto b = as_optional_mesh_tensor(tensor_args.residual_input_tensor);
+    const auto gamma = as_optional_mesh_tensor(tensor_args.weight);
+    const auto beta = as_optional_mesh_tensor(tensor_args.bias);
+    const auto& output = tensor_return_value.mesh_tensor();
     bool rms_norm = operation_attributes.norm_type == LayerNormType::RMSNORM;
     float eps = operation_attributes.eps;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;
@@ -127,7 +128,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
     //                       Device Setup
     //////////////////////////////////////////////////////////////////////////
     // This should allocate a DRAM buffer on the device
-    IDevice* device = a.device();
+    IDevice* device = &a.mutable_device();
 
     ////////////////////////////////////////////////////////////////////////////
     //                Circular Buffer Data Format Setup
@@ -278,7 +279,7 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         im2_t * single_tile_size,
         reciprocal_CB_size_bytes,
         in_rm_size + out_rm_size,
-        a.device()->l1_size_per_core());
+        a.device().l1_size_per_core());
     // For input_is_row_major we also allow large_tensor_needed (same L1 logic applies).
     // use_row_major_kernel (row-major gamma/beta) still skips large_tensor check as before.
     if (!use_row_major_kernel || input_is_row_major) {
@@ -350,35 +351,27 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         reader_compile_time_args.push_back((std::uint32_t)use_welford);
     }
     reader_compile_time_args.push_back(W);
-    tt::tt_metal::TensorAccessorArgs(a.mesh_tensor()).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(
-        b ? ttsl::optional_reference<const MeshTensor>(b->mesh_tensor()) : ttsl::optional_reference<const MeshTensor>{})
-        .append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(
-        gamma ? ttsl::optional_reference<const MeshTensor>(gamma->mesh_tensor())
-              : ttsl::optional_reference<const MeshTensor>{})
-        .append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(
-        beta ? ttsl::optional_reference<const MeshTensor>(beta->mesh_tensor())
-             : ttsl::optional_reference<const MeshTensor>{})
-        .append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(gamma).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(beta).append_to(reader_compile_time_args);
 
     if (input_is_row_major) {
         // For rm_input readers: element size of input tensor for address stride calculations
         reader_compile_time_args.push_back(static_cast<uint32_t>(a.element_size()));
     } else if (gamma.has_value() and gamma.value().layout() == Layout::ROW_MAJOR) {
         auto gamma_stick_size = gamma.value().padded_shape()[-1] * gamma.value().element_size();
-        reader_compile_time_args.push_back(gamma_stick_size);
+        reader_compile_time_args.push_back(static_cast<uint32_t>(gamma_stick_size));
     } else if (beta.has_value() and beta.value().layout() == Layout::ROW_MAJOR) {
         auto beta_stick_size = beta.value().padded_shape()[-1] * beta.value().element_size();
-        reader_compile_time_args.push_back(beta_stick_size);
+        reader_compile_time_args.push_back(static_cast<uint32_t>(beta_stick_size));
     } else {
         reader_compile_time_args.push_back(tile_size(datatype_to_dataformat_converter(a.dtype())));
     }
 
     // Build compile time args for writer kernel
     std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)block_size};
-    tt::tt_metal::TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
     if (input_is_row_major) {
         // RM writer needs elem_size to compute per-row NOC write sizes
         writer_compile_time_args.push_back(static_cast<uint32_t>(output.element_size()));
@@ -623,24 +616,24 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         // (the kernel reads slot==0 as "no tensor"). The variant in RTArgList accepts uint32_t and
         // MeshTensor refs interchangeably.
         KernelDescriptor::RTArgList reader_args;
-        reader_args.push_back(a.mesh_tensor());               // slot 0: src DRAM addr
+        reader_args.push_back(a);                             // slot 0: src DRAM addr
         reader_args.push_back(num_tile_rows_per_core);        // slot 1
         reader_args.push_back(Wt);                            // slot 2
         reader_args.push_back(reader_start);                  // slot 3
         reader_args.push_back(packed_one_value);              // slot 4
         reader_args.push_back(std::bit_cast<uint32_t>(eps));  // slot 5
         if (gamma.has_value()) {
-            reader_args.push_back(gamma->mesh_tensor());  // slot 6: gamma addr
+            reader_args.push_back(*gamma);  // slot 6: gamma addr
         } else {
             reader_args.push_back(0u);
         }
         if (beta.has_value()) {
-            reader_args.push_back(beta->mesh_tensor());  // slot 7: beta addr
+            reader_args.push_back(*beta);  // slot 7: beta addr
         } else {
             reader_args.push_back(0u);
         }
         if (b.has_value()) {
-            reader_args.push_back(b->mesh_tensor());  // slot 8: b addr
+            reader_args.push_back(*b);  // slot 8: b addr
         } else {
             reader_args.push_back(0u);
         }
@@ -654,10 +647,9 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         const uint32_t writer_start = input_is_row_major ? curr_row : tile_offset;
         if (input_is_row_major) {
             writer_kernel_desc.emplace_runtime_args(
-                core, {output.mesh_tensor(), Wt, num_tile_rows_per_core, writer_start, H_logical});
+                core, {output, Wt, num_tile_rows_per_core, writer_start, H_logical});
         } else {
-            writer_kernel_desc.emplace_runtime_args(
-                core, {output.mesh_tensor(), Wt, num_tile_rows_per_core, writer_start});
+            writer_kernel_desc.emplace_runtime_args(core, {output, Wt, num_tile_rows_per_core, writer_start});
         }
 
         compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_per_core});

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "ttnn/operations/normalization/layernorm/device/layernorm_common.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_device_operation_types.hpp"
@@ -57,12 +58,12 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     }
 
     // Extract from operation_attributes and tensor_args
-    const auto& a = tensor_args.input;
-    const auto& b = tensor_args.residual_input_tensor;
-    const auto& gamma = tensor_args.weight;
-    const auto& beta = tensor_args.bias;
-    const auto& stats = tensor_args.stats;
-    auto& output = tensor_return_value;
+    const auto& a = tensor_args.input.mesh_tensor();
+    const auto b = as_optional_mesh_tensor(tensor_args.residual_input_tensor);
+    const auto gamma = as_optional_mesh_tensor(tensor_args.weight);
+    const auto beta = as_optional_mesh_tensor(tensor_args.bias);
+    const auto stats = as_optional_mesh_tensor(tensor_args.stats);
+    const auto& output = tensor_return_value.mesh_tensor();
     bool rms_norm = operation_attributes.norm_type == LayerNormType::RMSNORM;
     bool is_pre_all_gather = operation_attributes.distributed_norm_stage == DistributedLayerNormStage::PRE_ALL_GATHER;
     bool is_post_all_gather = operation_attributes.distributed_norm_stage == DistributedLayerNormStage::POST_ALL_GATHER;
@@ -100,7 +101,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     ////////////////////////////////////////////////////////////////////////////
     //                            Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    IDevice* device = a.device();
+    IDevice* device = &a.mutable_device();
 
     // convert data format
     tt::DataFormat in_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
@@ -152,10 +153,6 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         storage_core_noc_x.push_back((std::uint32_t)device->worker_core_from_logical_core(core).x);
         storage_core_noc_y.push_back((std::uint32_t)device->worker_core_from_logical_core(core).y);
     }
-
-    // get sharded addr
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().mesh_tensor().address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().mesh_tensor().address() : 0;
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -238,7 +235,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         use_welford,
         skip_write_back,
         operation_attributes.fused_activation,
-        tensor_return_value.dtype());
+        output.dtype());
 
     // Get kernel paths using helper
     bool use_row_major_kernel = (gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR) ||
@@ -277,15 +274,15 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .legacy_rsqrt = legacy_rsqrt,
         .gamma_cb_data_format = gamma_cb_data_format,
         .beta_cb_data_format = beta_cb_data_format,
-        .gamma_buffer = gamma.has_value() ? gamma.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr,
-        .beta_buffer = beta.has_value() ? beta.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr,
+        .gamma_tensor = gamma,
+        .beta_tensor = beta,
         .gamma_is_row_major = gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR,
         .beta_is_row_major = beta.has_value() && beta.value().layout() == Layout::ROW_MAJOR,
         .gamma_stick_size = gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR
-                                ? gamma.value().padded_shape()[-1] * gamma.value().element_size()
+                                ? static_cast<uint32_t>(gamma.value().padded_shape()[-1] * gamma.value().element_size())
                                 : 0,
         .beta_stick_size = beta.has_value() && beta.value().layout() == Layout::ROW_MAJOR
-                               ? beta.value().padded_shape()[-1] * beta.value().element_size()
+                               ? static_cast<uint32_t>(beta.value().padded_shape()[-1] * beta.value().element_size())
                                : 0,
         .eps = eps,
         .per_core_recip_lut_size = block_w,
@@ -330,8 +327,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .packed_cinv_value_one = pack_two_bfloat16_into_uint32({bfloat_cinv_one, bfloat_cinv_one}),
         .packed_winv_value = pack_two_bfloat16_into_uint32({bfloat_winv, bfloat_winv}),
         .eps_u = eps_u,
-        .gamma_dram_addr = gamma_dram_addr,
-        .beta_dram_addr = beta_dram_addr,
+        .gamma_tensor = gamma,
+        .beta_tensor = beta,
         .single_tile_size = single_tile_size,
         .out_single_tile_size = out_single_tile_size,
         .block_wt = block_wt,
@@ -394,74 +391,71 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     //   CB 16 is intermediate (no buffer), CB 17 is the final resharded output
     // Otherwise:
     //   CB 16 is the output, CB 17 is not used
-    Buffer* output_buffer = nullptr;
-    Buffer* output_reshard_buffer = nullptr;
+    ttsl::optional_reference<const MeshTensor> output_tensor;
+    ttsl::optional_reference<const MeshTensor> output_reshard_tensor;
     if (is_post_all_gather && !skip_write_back) {
-        // Resharding case: CB 17 needs the output buffer
-        output_reshard_buffer = output.buffer();
+        // Resharding case: CB 17 needs the output tensor
+        output_reshard_tensor = output;
     } else {
-        // Normal case: CB 16 needs the output buffer
-        output_buffer = output.buffer();
+        // Normal case: CB 16 needs the output tensor
+        output_tensor = output;
     }
 
-    CBConfig cb_config;
-    cb_config.in0_CB_size = cb_sizes.in0_CB_size;
-    cb_config.in1_CB_size = cb_sizes.in1_CB_size;
-    cb_config.in2_CB_size = cb_sizes.in2_CB_size;
-    cb_config.in3_CB_size = cb_sizes.in3_CB_size;
-    cb_config.in5_CB_size = cb_sizes.in5_CB_size;
-    cb_config.in6_CB_size = cb_sizes.in6_CB_size;
-    cb_config.x_CB_size = cb_sizes.x_CB_size;
-    cb_config.xmm_CB_size = cb_sizes.xmm_CB_size;
-    cb_config.ex_partial_CB_size = cb_sizes.ex_partial_CB_size;
-    cb_config.ex_CB_size = cb_sizes.ex_CB_size;
-    cb_config.ex_external_CB_size = cb_sizes.ex_external_CB_size;
-    cb_config.ex_global_CB_size = cb_sizes.ex_global_CB_size;
-    cb_config.ex2pe_CB_size = cb_sizes.ex2pe_CB_size;
-    cb_config.out_CB_size = cb_sizes.out_CB_size;
-    cb_config.out_reshard_CB_size = cb_sizes.out_reshard_CB_size;
-    cb_config.stats_cb_size = cb_sizes.stats_cb_size;
-    cb_config.stats_reduced_cb_size = cb_sizes.stats_reduced_cb_size;
-    cb_config.reciprocal_CB_size_bytes = reciprocal_CB_size_bytes;
-    cb_config.in_data_format = in_data_format;
-    cb_config.cb_data_format = cb_data_format;
-    cb_config.out_data_format = out_data_format;
-    cb_config.gamma_cb_data_format = gamma_cb_data_format;
-    cb_config.beta_cb_data_format = beta_cb_data_format;
-    cb_config.stats_cb_data_format = stats_cb_data_format;
-    cb_config.reciprocal_cb_data_format = reciprocal_cb_data_format;
-    cb_config.in_single_tile_size = in_single_tile_size;
-    cb_config.single_tile_size = single_tile_size;
-    cb_config.out_single_tile_size = out_single_tile_size;
-    cb_config.gamma_single_tile_size = gamma_single_tile_size;
-    cb_config.beta_single_tile_size = beta_single_tile_size;
-    cb_config.stats_single_tile_size = stats_single_tile_size;
-    cb_config.bfloat16_tile_size = bfloat16_tile_size;
-    cb_config.a_buffer = a.buffer();
-    cb_config.b_buffer = b.has_value() ? b.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
-    cb_config.gamma_buffer =
-        gamma.has_value() ? gamma.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
-    cb_config.beta_buffer =
-        beta.has_value() ? beta.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
-    cb_config.stats_buffer =
-        stats.has_value() ? stats.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
-    cb_config.recip_buffer =
-        recip_tensor.has_value() ? recip_tensor.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
-    cb_config.output_buffer = output_buffer;
-    cb_config.output_reshard_buffer = output_reshard_buffer;
-    cb_config.has_b = b.has_value();
-    cb_config.has_gamma = gamma.has_value();
-    cb_config.has_beta = beta.has_value();
-    cb_config.rms_norm = rms_norm;
-    cb_config.use_welford = use_welford;
-    cb_config.is_pre_all_gather = is_pre_all_gather;
-    cb_config.is_post_all_gather = is_post_all_gather;
-    cb_config.skip_write_back = skip_write_back;
-    // Enable the welford-fp32 alias only when the SrcA-routed transpose_wh_tile would
-    // otherwise truncate Float32 input to TF32. Restricting to !rms_norm because
-    // RMSNorm doesn't use Welford in this kernel path.
-    cb_config.welford_fp32_alias =
-        use_welford && !rms_norm && in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en;
+    CBConfig cb_config{
+        .in0_CB_size = cb_sizes.in0_CB_size,
+        .in1_CB_size = cb_sizes.in1_CB_size,
+        .in2_CB_size = cb_sizes.in2_CB_size,
+        .in3_CB_size = cb_sizes.in3_CB_size,
+        .in5_CB_size = cb_sizes.in5_CB_size,
+        .in6_CB_size = cb_sizes.in6_CB_size,
+        .x_CB_size = cb_sizes.x_CB_size,
+        .xmm_CB_size = cb_sizes.xmm_CB_size,
+        .ex_partial_CB_size = cb_sizes.ex_partial_CB_size,
+        .ex_CB_size = cb_sizes.ex_CB_size,
+        .ex_external_CB_size = cb_sizes.ex_external_CB_size,
+        .ex_global_CB_size = cb_sizes.ex_global_CB_size,
+        .ex2pe_CB_size = cb_sizes.ex2pe_CB_size,
+        .out_CB_size = cb_sizes.out_CB_size,
+        .out_reshard_CB_size = cb_sizes.out_reshard_CB_size,
+        .stats_cb_size = cb_sizes.stats_cb_size,
+        .stats_reduced_cb_size = cb_sizes.stats_reduced_cb_size,
+        .reciprocal_CB_size_bytes = reciprocal_CB_size_bytes,
+        .in_data_format = in_data_format,
+        .cb_data_format = cb_data_format,
+        .out_data_format = out_data_format,
+        .gamma_cb_data_format = gamma_cb_data_format,
+        .beta_cb_data_format = beta_cb_data_format,
+        .stats_cb_data_format = stats_cb_data_format,
+        .reciprocal_cb_data_format = reciprocal_cb_data_format,
+        .in_single_tile_size = in_single_tile_size,
+        .single_tile_size = single_tile_size,
+        .out_single_tile_size = out_single_tile_size,
+        .gamma_single_tile_size = gamma_single_tile_size,
+        .beta_single_tile_size = beta_single_tile_size,
+        .stats_single_tile_size = stats_single_tile_size,
+        .bfloat16_tile_size = bfloat16_tile_size,
+        .a_tensor = a,
+        .b_tensor = b,
+        .gamma_tensor = gamma,
+        .beta_tensor = beta,
+        .stats_tensor = stats,
+        .recip_tensor = as_optional_mesh_tensor(recip_tensor),
+        .output_tensor = output_tensor,
+        .output_reshard_tensor = output_reshard_tensor,
+        .has_b = b.has_value(),
+        .has_gamma = gamma.has_value(),
+        .has_beta = beta.has_value(),
+        .rms_norm = rms_norm,
+        .use_welford = use_welford,
+        .is_pre_all_gather = is_pre_all_gather,
+        .is_post_all_gather = is_post_all_gather,
+        .skip_write_back = skip_write_back,
+        // Enable the welford-fp32 alias only when the SrcA-routed transpose_wh_tile would
+        // otherwise truncate Float32 input to TF32. Restricting to !rms_norm because
+        // RMSNorm doesn't use Welford in this kernel path.
+        .welford_fp32_alias =
+            use_welford && !rms_norm && in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en,
+    };
 
     add_cb_descriptors(program_descriptor, core_ranges, all_worker_and_storage_cores, cb_config);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -27,12 +27,24 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+uint32_t get_buffer_aligned_size_per_bank(const MeshTensor& t) {
+    return static_cast<uint32_t>(
+        t.mesh_buffer().get_reference_buffer()->aligned_size_per_bank());  // aligned_size_per_bank() -> DeviceAddr
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descriptor(
     const LayerNormParams& operation_attributes,
     const LayerNormInputs& tensor_args,
     Tensor& tensor_return_value,
     const std::optional<CoreRangeSet>& core_range_set) {
     using namespace sharded_layernorm_helpers;
+    using namespace CMAKE_UNIQUE_NAMESPACE;
 
     // For sharded layernorm, core ranges are derived from tensor shard spec.
     // If core_range_set is provided, validate that shard spec cores are within it.
@@ -166,13 +178,11 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     }
 
     // Reciprocal LUT for Welford
-    std::optional<Tensor> recip_tensor = std::nullopt;
+    const auto recip = as_optional_mesh_tensor(tensor_args.recip_tensor);
     uint32_t reciprocal_CB_size_bytes = 0;
     if (use_welford) {
-        TT_FATAL(tensor_args.recip_tensor.has_value(), "Reciprocal tensor not provided for Welford layernorm");
-        recip_tensor = tensor_args.recip_tensor;
-        reciprocal_CB_size_bytes =
-            recip_tensor->mesh_tensor().mesh_buffer().get_reference_buffer()->aligned_size_per_bank();
+        TT_FATAL(recip.has_value(), "Reciprocal tensor not provided for Welford layernorm");
+        reciprocal_CB_size_bytes = get_buffer_aligned_size_per_bank(*recip);
     }
 
     // Compute CB sizes using helper
@@ -439,7 +449,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .gamma_tensor = gamma,
         .beta_tensor = beta,
         .stats_tensor = stats,
-        .recip_tensor = as_optional_mesh_tensor(recip_tensor),
+        .recip_tensor = recip,
         .output_tensor = output_tensor,
         .output_reshard_tensor = output_reshard_tensor,
         .has_b = b.has_value(),
@@ -453,8 +463,7 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         // Enable the welford-fp32 alias only when the SrcA-routed transpose_wh_tile would
         // otherwise truncate Float32 input to TF32. Restricting to !rms_norm because
         // RMSNorm doesn't use Welford in this kernel path.
-        .welford_fp32_alias =
-            use_welford && !rms_norm && in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en,
+        .welford_fp32_alias = use_welford && !rms_norm && in_data_format == tt::DataFormat::Float32 && fp32_dest_acc_en,
     };
 
     add_cb_descriptors(program_descriptor, core_ranges, all_worker_and_storage_cores, cb_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core_sharded.cpp
@@ -154,8 +154,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     }
 
     // get sharded addr
-    auto gamma_dram_addr = gamma.has_value() ? gamma.value().buffer()->address() : 0;
-    auto beta_dram_addr = beta.has_value() ? beta.value().buffer()->address() : 0;
+    auto gamma_dram_addr = gamma.has_value() ? gamma.value().mesh_tensor().address() : 0;
+    auto beta_dram_addr = beta.has_value() ? beta.value().mesh_tensor().address() : 0;
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -174,7 +174,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     if (use_welford) {
         TT_FATAL(tensor_args.recip_tensor.has_value(), "Reciprocal tensor not provided for Welford layernorm");
         recip_tensor = tensor_args.recip_tensor;
-        reciprocal_CB_size_bytes = recip_tensor->buffer()->aligned_size_per_bank();
+        reciprocal_CB_size_bytes =
+            recip_tensor->mesh_tensor().mesh_buffer().get_reference_buffer()->aligned_size_per_bank();
     }
 
     // Compute CB sizes using helper
@@ -276,8 +277,8 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
         .legacy_rsqrt = legacy_rsqrt,
         .gamma_cb_data_format = gamma_cb_data_format,
         .beta_cb_data_format = beta_cb_data_format,
-        .gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr,
-        .beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr,
+        .gamma_buffer = gamma.has_value() ? gamma.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr,
+        .beta_buffer = beta.has_value() ? beta.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr,
         .gamma_is_row_major = gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR,
         .beta_is_row_major = beta.has_value() && beta.value().layout() == Layout::ROW_MAJOR,
         .gamma_stick_size = gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR
@@ -437,11 +438,15 @@ tt::tt_metal::ProgramDescriptor LayerNormShardedProgramFactory::create_descripto
     cb_config.stats_single_tile_size = stats_single_tile_size;
     cb_config.bfloat16_tile_size = bfloat16_tile_size;
     cb_config.a_buffer = a.buffer();
-    cb_config.b_buffer = b.has_value() ? b.value().buffer() : nullptr;
-    cb_config.gamma_buffer = gamma.has_value() ? gamma.value().buffer() : nullptr;
-    cb_config.beta_buffer = beta.has_value() ? beta.value().buffer() : nullptr;
-    cb_config.stats_buffer = stats.has_value() ? stats.value().buffer() : nullptr;
-    cb_config.recip_buffer = recip_tensor.has_value() ? recip_tensor.value().buffer() : nullptr;
+    cb_config.b_buffer = b.has_value() ? b.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
+    cb_config.gamma_buffer =
+        gamma.has_value() ? gamma.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
+    cb_config.beta_buffer =
+        beta.has_value() ? beta.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
+    cb_config.stats_buffer =
+        stats.has_value() ? stats.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
+    cb_config.recip_buffer =
+        recip_tensor.has_value() ? recip_tensor.value().mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr;
     cb_config.output_buffer = output_buffer;
     cb_config.output_reshard_buffer = output_reshard_buffer;
     cb_config.has_b = b.has_value();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -50,22 +50,19 @@ void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_
 
 std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
 get_cb_data_formats(
-    const Tensor& output,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& beta,
-    const std::optional<const Tensor>& stats,
+    const MeshTensor& output,
+    ttsl::optional_reference<const MeshTensor> gamma,
+    ttsl::optional_reference<const MeshTensor> beta,
+    ttsl::optional_reference<const MeshTensor> stats,
     bool fp32_dest_acc_en) {
     tt::DataFormat out_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     tt::DataFormat cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat gamma_cb_data_format = gamma.has_value()
-                                              ? tt::tt_metal::datatype_to_dataformat_converter(gamma.value().dtype())
-                                              : tt::DataFormat::Float16_b;
-    tt::DataFormat beta_cb_data_format = beta.has_value()
-                                             ? tt::tt_metal::datatype_to_dataformat_converter(beta.value().dtype())
-                                             : tt::DataFormat::Float16_b;
-    tt::DataFormat stats_cb_data_format = stats.has_value()
-                                              ? tt::tt_metal::datatype_to_dataformat_converter(stats.value().dtype())
-                                              : tt::DataFormat::Float16_b;
+    tt::DataFormat gamma_cb_data_format =
+        gamma.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(gamma->dtype()) : tt::DataFormat::Float16_b;
+    tt::DataFormat beta_cb_data_format =
+        beta.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(beta->dtype()) : tt::DataFormat::Float16_b;
+    tt::DataFormat stats_cb_data_format =
+        stats.has_value() ? tt::tt_metal::datatype_to_dataformat_converter(stats->dtype()) : tt::DataFormat::Float16_b;
     tt::DataFormat reciprocal_cb_data_format = tt::DataFormat::Float32;
     return {
         out_data_format,
@@ -109,7 +106,7 @@ uint32_t get_num_blocks(bool mcast_1d, bool row_wise, CoreCoord grid_size, const
 // Grid and worker distribution
 //////////////////////////////////////////////////////////////////////////////
 
-GridParams GridParams::compute(const Tensor& input, uint32_t block_ht, CoreCoord compute_with_storage_grid_size) {
+GridParams GridParams::compute(const MeshTensor& input, uint32_t block_ht, CoreCoord compute_with_storage_grid_size) {
     auto spec = input.shard_spec().value();
     const uint32_t tile_height = input.tensor_spec().tile().get_height();
     uint32_t M = input.physical_volume() / input.padded_shape()[-1];
@@ -680,8 +677,8 @@ CompileTimeArgs CompileTimeArgs::build(const CompileTimeArgsContext& ctx) {
         (uint32_t)ctx.has_beta,
         ctx.block_wt,
         (uint32_t)ctx.use_welford};
-    tt::tt_metal::TensorAccessorArgs(ctx.gamma_buffer).append_to(args.writer_sender);
-    tt::tt_metal::TensorAccessorArgs(ctx.beta_buffer).append_to(args.writer_sender);
+    tt::tt_metal::TensorAccessorArgs(ctx.gamma_tensor).append_to(args.writer_sender);
+    tt::tt_metal::TensorAccessorArgs(ctx.beta_tensor).append_to(args.writer_sender);
 
     // Writer receiver compile time args
     args.writer_receiver = {
@@ -690,8 +687,8 @@ CompileTimeArgs CompileTimeArgs::build(const CompileTimeArgsContext& ctx) {
         (uint32_t)ctx.has_beta,
         ctx.block_wt,
         (uint32_t)ctx.use_welford};
-    tt::tt_metal::TensorAccessorArgs(ctx.gamma_buffer).append_to(args.writer_receiver);
-    tt::tt_metal::TensorAccessorArgs(ctx.beta_buffer).append_to(args.writer_receiver);
+    tt::tt_metal::TensorAccessorArgs(ctx.gamma_tensor).append_to(args.writer_receiver);
+    tt::tt_metal::TensorAccessorArgs(ctx.beta_tensor).append_to(args.writer_receiver);
 
     // Add stick size for row-major gamma/beta
     if (ctx.gamma_is_row_major) {
@@ -894,7 +891,9 @@ void add_kernel_descriptors(
     writer_sender_kernel_desc.compile_time_args = std::move(kernel_config.writer_sender_ct_args);
     writer_sender_kernel_desc.named_compile_time_args = writer_cb_named_args;
     writer_sender_kernel_desc.defines = kernel_config.writer_defines;
-    writer_sender_kernel_desc.runtime_args = std::move(kernel_config.writer_sender_rt_args);
+    for (auto& [core, args] : kernel_config.writer_sender_rt_args) {
+        writer_sender_kernel_desc.emplace_runtime_args(core, args);
+    }
     writer_sender_kernel_desc.config = DataMovementConfigDescriptor{
         .processor = DataMovementProcessor::RISCV_1,
         .noc = kernel_config.writer_noc,
@@ -910,7 +909,9 @@ void add_kernel_descriptors(
         writer_receiver_kernel_desc.compile_time_args = std::move(kernel_config.writer_receiver_ct_args);
         writer_receiver_kernel_desc.named_compile_time_args = writer_cb_named_args;
         writer_receiver_kernel_desc.defines = std::move(kernel_config.writer_defines);
-        writer_receiver_kernel_desc.runtime_args = std::move(kernel_config.writer_receiver_rt_args);
+        for (auto& [core, args] : kernel_config.writer_receiver_rt_args) {
+            writer_receiver_kernel_desc.emplace_runtime_args(core, args);
+        }
         writer_receiver_kernel_desc.config = DataMovementConfigDescriptor{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = kernel_config.writer_noc,
@@ -981,13 +982,13 @@ void add_cb_descriptors(
                                  uint8_t buffer_index,
                                  tt::DataFormat data_format,
                                  uint32_t page_size,
-                                 Buffer* buffer = nullptr) {
+                                 ttsl::optional_reference<const MeshTensor> tensor = {}) {
         CBDescriptor cb_desc;
         cb_desc.total_size = total_size;
         cb_desc.core_ranges = core_ranges;
         cb_desc.format_descriptors.push_back(
             CBFormatDescriptor{.buffer_index = buffer_index, .data_format = data_format, .page_size = page_size});
-        cb_desc.buffer = buffer;
+        cb_desc.tensor = tensor.has_value() ? &*tensor : nullptr;
         return cb_desc;
     };
 
@@ -1003,7 +1004,7 @@ void add_cb_descriptors(
             tt::CBIndex::c_0,
             cb_config.in_data_format,
             cb_config.in_single_tile_size,
-            cb_config.a_buffer);
+            cb_config.a_tensor);
         if (cb_config.welford_fp32_alias && !cb_config.has_b) {
             cb0_desc.format_descriptors.push_back(CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_29),
@@ -1021,7 +1022,7 @@ void add_cb_descriptors(
             tt::CBIndex::c_1,
             cb_config.in_data_format,
             cb_config.in_single_tile_size,
-            cb_config.b_buffer));
+            cb_config.b_tensor));
         if (cb_config.is_pre_all_gather) {
             program_descriptor.cbs.push_back(make_cb_descriptor(
                 cb_config.in1_CB_size,
@@ -1029,7 +1030,7 @@ void add_cb_descriptors(
                 tt::CBIndex::c_14,
                 cb_config.in_data_format,
                 cb_config.in_single_tile_size,
-                cb_config.a_buffer));
+                cb_config.a_tensor));
         }
     }
 
@@ -1182,7 +1183,7 @@ void add_cb_descriptors(
             .buffer_index = tt::CBIndex::c_25,
             .data_format = cb_config.reciprocal_cb_data_format,
             .page_size = cb_config.reciprocal_CB_size_bytes});
-        recip_cb_desc.buffer = cb_config.recip_buffer;
+        recip_cb_desc.tensor = cb_config.recip_tensor.has_value() ? &*cb_config.recip_tensor : nullptr;
         program_descriptor.cbs.push_back(std::move(recip_cb_desc));
     }
 
@@ -1195,7 +1196,7 @@ void add_cb_descriptors(
             .buffer_index = tt::CBIndex::c_7,
             .data_format = cb_config.stats_cb_data_format,
             .page_size = cb_config.stats_single_tile_size});
-        stats_cb_desc.buffer = cb_config.stats_buffer;
+        stats_cb_desc.tensor = cb_config.stats_tensor.has_value() ? &*cb_config.stats_tensor : nullptr;
         program_descriptor.cbs.push_back(std::move(stats_cb_desc));
 
         // CB 21: cb_stats_reduced
@@ -1223,7 +1224,7 @@ void add_cb_descriptors(
             tt::CBIndex::c_16,
             cb_config.out_data_format,
             cb_config.out_single_tile_size,
-            cb_config.output_buffer));
+            cb_config.output_tensor));
     } else {
         program_descriptor.cbs.push_back(make_cb_descriptor(
             cb_config.out_CB_size,
@@ -1231,7 +1232,7 @@ void add_cb_descriptors(
             tt::CBIndex::c_16,
             cb_config.out_data_format,
             cb_config.out_single_tile_size,
-            cb_config.output_buffer));
+            cb_config.output_tensor));
     }
 
     // CB 17: output reshard (if is_post_all_gather and not skip_write_back)
@@ -1242,7 +1243,7 @@ void add_cb_descriptors(
             tt::CBIndex::c_17,
             cb_config.out_data_format,
             cb_config.out_single_tile_size,
-            cb_config.output_reshard_buffer));
+            cb_config.output_reshard_tensor));
     }
 }
 
@@ -1480,12 +1481,12 @@ std::vector<uint32_t> build_write_back_args(
     return args;
 }
 
-std::vector<uint32_t> build_writer_args(
+KernelDescriptor::RTArgList build_writer_args(
     const CoreIndices& idx,
     const RuntimeArgsContext& ctx,
     const std::vector<uint32_t>& write_back_args,
     bool is_all_to_all) {
-    std::vector<uint32_t> args;
+    KernelDescriptor::RTArgList args;
 
     if (is_all_to_all) {
         if (ctx.grid.use_two_stage_reduce && idx.width_index >= ctx.workers.num_cores_all_to_all_first_stage) {
@@ -1498,11 +1499,19 @@ std::vector<uint32_t> build_writer_args(
     }
     args.push_back(ctx.packed_winv_value);
     args.push_back(ctx.eps_u);
-    args.push_back(ctx.gamma_dram_addr);
-    args.push_back(ctx.beta_dram_addr);
+    if (ctx.gamma_tensor.has_value()) {
+        args.push_back(*ctx.gamma_tensor);
+    } else {
+        args.push_back(0u);
+    }
+    if (ctx.beta_tensor.has_value()) {
+        args.push_back(*ctx.beta_tensor);
+    } else {
+        args.push_back(0u);
+    }
     args.push_back(idx.gamma_tile_start_id);
     args.push_back(idx.beta_tile_start_id);
-    args.insert(args.end(), write_back_args.begin(), write_back_args.end());
+    args.append(write_back_args);
     return args;
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -988,7 +988,11 @@ void add_cb_descriptors(
         cb_desc.core_ranges = core_ranges;
         cb_desc.format_descriptors.push_back(
             CBFormatDescriptor{.buffer_index = buffer_index, .data_format = data_format, .page_size = page_size});
-        cb_desc.tensor = tensor.has_value() ? &*tensor : nullptr;
+        // Resolve to a Buffer* rather than binding the MeshTensor directly: the experimental
+        // fusion op caches this descriptor and only refreshes CBs backed by `buffer` (see
+        // compute_cb_io_tensor_map / patch_stale_descriptor). A `tensor` binding would never be
+        // patched and would dangle on a fusion cache hit. Tensor::buffer() == this same buffer.
+        cb_desc.buffer = tensor.has_value() ? tensor->mesh_buffer().get_reference_buffer() : nullptr;
         return cb_desc;
     };
 
@@ -1183,7 +1187,8 @@ void add_cb_descriptors(
             .buffer_index = tt::CBIndex::c_25,
             .data_format = cb_config.reciprocal_cb_data_format,
             .page_size = cb_config.reciprocal_CB_size_bytes});
-        recip_cb_desc.tensor = cb_config.recip_tensor.has_value() ? &*cb_config.recip_tensor : nullptr;
+        recip_cb_desc.buffer =
+            cb_config.recip_tensor.has_value() ? cb_config.recip_tensor->mesh_buffer().get_reference_buffer() : nullptr;
         program_descriptor.cbs.push_back(std::move(recip_cb_desc));
     }
 
@@ -1196,7 +1201,8 @@ void add_cb_descriptors(
             .buffer_index = tt::CBIndex::c_7,
             .data_format = cb_config.stats_cb_data_format,
             .page_size = cb_config.stats_single_tile_size});
-        stats_cb_desc.tensor = cb_config.stats_tensor.has_value() ? &*cb_config.stats_tensor : nullptr;
+        stats_cb_desc.buffer =
+            cb_config.stats_tensor.has_value() ? cb_config.stats_tensor->mesh_buffer().get_reference_buffer() : nullptr;
         program_descriptor.cbs.push_back(std::move(stats_cb_desc));
 
         // CB 21: cb_stats_reduced

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.hpp
@@ -34,10 +34,10 @@ void assert_subblock_compute_config_compatible(bool dst_full_sync_en, bool fp32_
 
 std::tuple<tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat, tt::DataFormat>
 get_cb_data_formats(
-    const Tensor& output,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& beta,
-    const std::optional<const Tensor>& stats,
+    const MeshTensor& output,
+    ttsl::optional_reference<const MeshTensor> gamma,
+    ttsl::optional_reference<const MeshTensor> beta,
+    ttsl::optional_reference<const MeshTensor> stats,
     bool fp32_dest_acc_en);
 
 //////////////////////////////////////////////////////////////////////////////
@@ -55,7 +55,7 @@ struct GridParams {
     bool use_mcast = false;
     bool use_two_stage_reduce = false;
 
-    static GridParams compute(const Tensor& input, uint32_t block_ht, CoreCoord compute_with_storage_grid_size);
+    static GridParams compute(const MeshTensor& input, uint32_t block_ht, CoreCoord compute_with_storage_grid_size);
 };
 
 // Struct to hold worker distribution parameters
@@ -224,9 +224,9 @@ struct CompileTimeArgsContext {
     tt::DataFormat gamma_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat beta_cb_data_format = tt::DataFormat::Float16_b;
 
-    // Tensor buffers for TensorAccessorArgs
-    Buffer* gamma_buffer = nullptr;
-    Buffer* beta_buffer = nullptr;
+    // Tensors for TensorAccessorArgs
+    ttsl::optional_reference<const MeshTensor> gamma_tensor;
+    ttsl::optional_reference<const MeshTensor> beta_tensor;
 
     // For row-major gamma/beta
     bool gamma_is_row_major = false;
@@ -286,8 +286,8 @@ struct KernelConfig {
     KernelDescriptor::RuntimeArgs reader_sender_rt_args;
     KernelDescriptor::RuntimeArgs reader_receiver_all_to_all_rt_args;
     KernelDescriptor::RuntimeArgs reader_receiver_rt_args;
-    KernelDescriptor::RuntimeArgs writer_sender_rt_args;
-    KernelDescriptor::RuntimeArgs writer_receiver_rt_args;
+    std::vector<std::pair<CoreCoord, KernelDescriptor::RTArgList>> writer_sender_rt_args;
+    std::vector<std::pair<CoreCoord, KernelDescriptor::RTArgList>> writer_receiver_rt_args;
     KernelDescriptor::RuntimeArgs compute_all_to_all_rt_args;
     KernelDescriptor::RuntimeArgs compute_not_all_to_all_rt_args;
 
@@ -346,15 +346,15 @@ struct CBConfig {
     uint32_t stats_single_tile_size = 0;
     uint32_t bfloat16_tile_size = 0;
 
-    // Buffers
-    Buffer* a_buffer = nullptr;
-    Buffer* b_buffer = nullptr;
-    Buffer* gamma_buffer = nullptr;
-    Buffer* beta_buffer = nullptr;
-    Buffer* stats_buffer = nullptr;
-    Buffer* recip_buffer = nullptr;
-    Buffer* output_buffer = nullptr;          // CB 16 output buffer
-    Buffer* output_reshard_buffer = nullptr;  // CB 17 resharded output buffer
+    // Tensors
+    const MeshTensor& a_tensor;
+    ttsl::optional_reference<const MeshTensor> b_tensor;
+    ttsl::optional_reference<const MeshTensor> gamma_tensor;
+    ttsl::optional_reference<const MeshTensor> beta_tensor;
+    ttsl::optional_reference<const MeshTensor> stats_tensor;
+    ttsl::optional_reference<const MeshTensor> recip_tensor;
+    ttsl::optional_reference<const MeshTensor> output_tensor;          // CB 16 output tensor
+    ttsl::optional_reference<const MeshTensor> output_reshard_tensor;  // CB 17 resharded output tensor
 
     // Flags
     bool has_b = false;
@@ -408,9 +408,9 @@ struct RuntimeArgsContext {
     uint32_t packed_winv_value = 0;
     uint32_t eps_u = 0;
 
-    // Addresses
-    uint32_t gamma_dram_addr = 0;
-    uint32_t beta_dram_addr = 0;
+    // Optional tensor bindings (resolved to Buffer* at emplace_runtime_args time)
+    ttsl::optional_reference<const MeshTensor> gamma_tensor;
+    ttsl::optional_reference<const MeshTensor> beta_tensor;
 
     // Tile and block info
     uint32_t single_tile_size = 0;
@@ -452,8 +452,8 @@ struct RuntimeArgsResult {
     KernelDescriptor::RuntimeArgs reader_sender;
     KernelDescriptor::RuntimeArgs reader_receiver_all_to_all;
     KernelDescriptor::RuntimeArgs reader_receiver;
-    KernelDescriptor::RuntimeArgs writer_sender;
-    KernelDescriptor::RuntimeArgs writer_receiver;
+    std::vector<std::pair<CoreCoord, KernelDescriptor::RTArgList>> writer_sender;
+    std::vector<std::pair<CoreCoord, KernelDescriptor::RTArgList>> writer_receiver;
     KernelDescriptor::RuntimeArgs compute_all_to_all;
     KernelDescriptor::RuntimeArgs compute_not_all_to_all;
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Mechanical migration of the `layernorm` op family program factories
to the `MeshTensor`/`MeshBuffer` APIs.

Candidate program factories (2, before pre-filtering):

- normalization/layernorm/device

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure. It
is closely modelled on `ttnn::Tensor` — the two share very similar
semantics and are designed to be drop-in interchangeable where
appropriate.

The motivation for Runtime Tensor is that it lets the runtime capture
the shape and sharding information of the true storage data structure.
That information is plumbed through `TensorAccessorArgs` and is
critical for the upcoming Metal 2.0 refactoring: gen 2 hardware needs
to understand the shape and sharding of device memory directly.

Runtime Tensor is not meant to replace `ttnn::Tensor` outright. This
PR replaces `ttnn::Tensor` usage in program factories specifically,
where Runtime Tensor is the most appropriate abstraction level.
(`MeshTensor` — the type you will see in the diff — is the
device-side part of Runtime Tensor.)

#### This refactoring

- **Primary goal:** ensure ops leverage Runtime Tensor so we no longer
  lose shape and sharding information when passing `Buffer` into
  runtime / compile arguments (notably into `TensorAccessorArgs`).
- **Secondary goal:** complete the migration away from single-device
  data classes now that the rest of our infrastructure is
  multi-device-aware (`Buffer` → `MeshTensor`).

#### Risk

This migration should carry minimal regression risk: it is a
type-substitution refactor, not a behavioural change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-layernorm) (fails in reshape, assuming flakyness as all other pipelines succeeded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-layernorm)