### PR TITLE
[skip ci] Fix: mpi interface selection logic on exabox scripts

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -27,8 +27,7 @@ Optional:
                                             (Kubernetes CNI, flannel, docker) being selected by MPI
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
-    --log-file <path>                       Log file path (default: recover_YYYYMMDD_HHMMSS.log)
-                                            ANSI color codes and carriage returns are stripped in the log
+    --output <directory>                     Output directory for log files (default: recover-logs)
 
     --cabling-descriptor-path <path>        Path to cabling descriptor file (4x32 only, overrides --config default)
                                             (default: /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto)
@@ -63,7 +62,7 @@ SEND_TRAFFIC=true
 CHECK=false
 MPI_IF="ens5f0np0"
 MPI_EXTRA_ARGS=()
-LOG_FILE=""
+OUTPUT_DIR="recover-logs"
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -162,12 +161,12 @@ while [[ $# -gt 0 ]]; do
             MPI_EXTRA_ARGS+=("${_extra[@]}")
             shift 2
             ;;
-        --log-file)
+        --output)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --log-file requires a non-empty value"
+                echo "Error: --output requires a non-empty value"
                 exit 1
             fi
-            LOG_FILE="$2"
+            OUTPUT_DIR="$2"
             shift 2
             ;;
         --cabling-descriptor-path)
@@ -220,8 +219,9 @@ if [[ "$SKIP_RESET" == true && "$SKIP_VALIDATION" == true ]]; then
     exit 1
 fi
 
-# Set default log file name after parsing (captures actual start time)
-[[ -z "$LOG_FILE" ]] && LOG_FILE="recover_$(date +%Y%m%d_%H%M%S).log"
+# Set log file path inside output directory (captures actual start time)
+mkdir -p "$OUTPUT_DIR"
+LOG_FILE="$OUTPUT_DIR/recover_$(date +%Y%m%d_%H%M%S).log"
 
 # Redirect all output: terminal sees colors, log file gets ANSI/CR stripped
 exec > >(tee >(sed 's/\x1b\[[0-9;]*[mJKHABCDfsuGMF]//g; s/\r//g' > "$LOG_FILE")) 2>&1
@@ -288,6 +288,7 @@ echo "Send traffic: $SEND_TRAFFIC"
 echo "Sleep after reset: ${SLEEP_DURATION}s"
 echo "Skip reset: $SKIP_RESET"
 echo "Skip validation: $SKIP_VALIDATION"
+echo "Output directory: $OUTPUT_DIR"
 echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -321,7 +321,9 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
     if [[ -n "$DOCKER_IMAGE" ]]; then
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
+            --mpi-interface "$MPI_IF" \
             --volume /data/scaleout_configs \
+            "${MPI_EXTRA_ARGS[@]}" \
             --host "$HOSTS" \
             ./build/tools/scaleout/run_cluster_validation \
             "${VALIDATION_ARGS[@]}"

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -15,6 +15,7 @@ Optional:
     --output <directory>                Output directory for log files (default: dispatch_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file
                                         (default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto)
+    --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
     --help                              Display this help message and exit
 
 Example:
@@ -28,6 +29,7 @@ HOSTS=""
 DOCKER_IMAGE=""
 OUTPUT_DIR="dispatch_test_logs"
 MESH_GRAPH_DESC_PATH="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
+MPI_IF="ens5f0np0"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -61,6 +63,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MESH_GRAPH_DESC_PATH="$2"
+            shift 2
+            ;;
+        --mpi-if)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --mpi-if requires a non-empty value"
+                exit 1
+            fi
+            MPI_IF="$2"
             shift 2
             ;;
         --help)
@@ -102,6 +112,7 @@ echo "Using hosts: $HOSTS"
 echo "Using docker image: $DOCKER_IMAGE"
 echo "Output directory: $OUTPUT_DIR"
 echo "Mesh graph descriptor: $MESH_GRAPH_DESC_PATH"
+echo "MPI interface: $MPI_IF"
 echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
@@ -109,6 +120,7 @@ echo ""
 ./tools/scaleout/exabox/mpi-docker \
     --image "$DOCKER_IMAGE" \
     --empty-entrypoint \
+    --mpi-interface "$MPI_IF" \
     --host "$HOSTS" \
     -x TT_MESH_ID=0 \
     -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -23,6 +23,9 @@ Optional:
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
+    --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
+    --mpi-args <args>                   Extra arguments passed directly to mpirun (quoted string)
+                                        e.g. --mpi-args "--tag-output"
     --help                              Display this help message and exit
 
 Example:
@@ -44,6 +47,8 @@ MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
 TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
 FILTER=""
+MPI_IF="ens5f0np0"
+MPI_EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -118,6 +123,23 @@ while [[ $# -gt 0 ]]; do
             FILTER="$2"
             shift 2
             ;;
+        --mpi-if)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --mpi-if requires a non-empty value"
+                exit 1
+            fi
+            MPI_IF="$2"
+            shift 2
+            ;;
+        --mpi-args)
+            if [[ -z "$2" ]]; then
+                echo "Error: --mpi-args requires a non-empty value"
+                exit 1
+            fi
+            read -ra _extra <<< "$2"
+            MPI_EXTRA_ARGS+=("${_extra[@]}")
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -174,6 +196,10 @@ echo "Test config: $TEST_CONFIG"
 if [[ -n "$FILTER" ]]; then
     echo "Filter: $FILTER"
 fi
+echo "MPI interface: $MPI_IF"
+if [[ "${#MPI_EXTRA_ARGS[@]}" -gt 0 ]]; then
+    echo "MPI extra args: ${MPI_EXTRA_ARGS[*]}"
+fi
 echo "Log file: $LOG_FILE"
 echo "=========================================="
 echo ""
@@ -201,7 +227,8 @@ if [[ "$DOCKER_IMAGE" == "none" ]]; then
         mpirun-ulfm \
             --tag-output \
             --mca plm_ssh_args "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
-            --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
             --bind-to none \
             --host "$SINGLE_HOST" \
             -np 1 \
@@ -213,7 +240,8 @@ if [[ "$DOCKER_IMAGE" == "none" ]]; then
         mpirun-ulfm \
             --tag-output \
             --mca plm_ssh_args "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
-            --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
             --bind-to none \
             --host "$HOSTS" \
             -np 1 \
@@ -244,6 +272,8 @@ elif [[ "$CONFIG" == "4x8" ]]; then
 
     ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
         --empty-entrypoint \
+        --mpi-interface "$MPI_IF" \
+        "${MPI_EXTRA_ARGS[@]}" \
         --bind-to none \
         --host "$SINGLE_HOST" \
         -np 1 \
@@ -254,6 +284,8 @@ elif [[ "$CONFIG" == "4x8" ]]; then
 else
     ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
         --empty-entrypoint \
+        --mpi-interface "$MPI_IF" \
+        "${MPI_EXTRA_ARGS[@]}" \
         --bind-to none \
         --host "$HOSTS" \
         -np 1 \

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -26,6 +26,9 @@ Optional:
                                             /data/scaleout_configs is mounted by default; each host path
                                             is mounted at the same path inside the container
     --rerun-on-retrain                      Rerun validation when Ethernet links are retrained
+    --mpi-if <interface>                    Network interface for MPI TCP transport (default: ens5f0np0)
+    --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
+                                            e.g. --mpi-args "--tag-output"
     --help                                  Display this help message and exit
 
 Example:
@@ -46,6 +49,8 @@ FACTORY_DESCRIPTOR_PATH=""
 OUTPUT_DIR="validation_output"
 EXTRA_VOLUMES=(/data/scaleout_configs)
 RERUN_ON_RETRAIN=false
+MPI_IF="ens5f0np0"
+MPI_EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -125,6 +130,23 @@ while [[ $# -gt 0 ]]; do
             RERUN_ON_RETRAIN=true
             shift
             ;;
+        --mpi-if)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --mpi-if requires a non-empty value"
+                exit 1
+            fi
+            MPI_IF="$2"
+            shift 2
+            ;;
+        --mpi-args)
+            if [[ -z "$2" ]]; then
+                echo "Error: --mpi-args requires a non-empty value"
+                exit 1
+            fi
+            read -ra _extra <<< "$2"
+            MPI_EXTRA_ARGS+=("${_extra[@]}")
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -169,7 +191,8 @@ run_cluster_validation() {
 
     if [[ $DOCKER_IMAGE == "none" ]]; then
         mpirun --host "$HOSTS" \
-            --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
             --tag-output \
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
@@ -179,7 +202,9 @@ run_cluster_validation() {
     else
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
+            --mpi-interface "$MPI_IF" \
             "${volume_args[@]}" \
+            "${MPI_EXTRA_ARGS[@]}" \
             --host "$HOSTS" \
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
@@ -201,7 +226,8 @@ run_board_reset() {
 
     # Run reset
     mpirun --host "$host_list" \
-        --mca btl_tcp_if_exclude docker0,lo,tailscale0 \
+        --mca btl_tcp_if_include "$MPI_IF" \
+        "${MPI_EXTRA_ARGS[@]}" \
         --tag-output \
         bash -c 'tt-smi -glx_reset > /dev/null 2>&1; echo "RESET_EXIT_CODE=$?"' > "$output_file"
     mpirun_exit_code=$?
@@ -251,6 +277,10 @@ if [[ -n "$FACTORY_DESCRIPTOR_PATH" ]]; then
 else
     echo "Cabling descriptor path: $CABLING_DESCRIPTOR_PATH"
     echo "Deployment descriptor path: $DEPLOYMENT_DESCRIPTOR_PATH"
+fi
+echo "MPI interface: $MPI_IF"
+if [[ "${#MPI_EXTRA_ARGS[@]}" -gt 0 ]]; then
+    echo "MPI extra args: ${MPI_EXTRA_ARGS[*]}"
 fi
 echo "Number of iterations: $ITERATIONS"
 echo "Output directory: $OUTPUT_DIR"


### PR DESCRIPTION
### PR Category
FIX: mpi interface selection for data transfer between hosts on exabox scripts
Issue: [MPI communication fails due to network interface picking logic](https://tenstorrent.atlassian.net/browse/DCAMP-595)

### Summary
The `run_validation.sh`, `run_fabric_tests.sh`, and `recover.sh` scripts used `--mca btl_tcp_if_exclude docker0,lo,tailscale0` to configure which network interface MPI uses for data transfer between hosts. This exclusion-based approach was fragile as it only avoids a few known interfaces but doesn't guarantee the correct physical NIC is selected. On hosts with additional virtual interfaces, MPI could silently pick the wrong one causing inter-host communication failures during test runs.

#### What's changed
- Replaced the exclusion approach with an explicit inclusion across all three scripts and their mpi-docker code paths
- Added `--mpi-if <interface>` and `--mpi-args <args>` arguments to all three scripts, consistent with the same change already merged to `recover.sh` in PR #45115 
- The interface override works for both direct mpirun/mpirun-ulfm calls and the inner mpi-docker calls
