### PR TITLE
[tt-train - bug fix] Separate stdout and stderr streams when generating training logs

### DIFF
--- a/tt-train/scripts/run_models.py
+++ b/tt-train/scripts/run_models.py
@@ -56,7 +56,7 @@ def run_and_save_log(cmd: list[str], log_path: Path) -> int:
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=None,
             text=True,
         )
         for line in proc.stdout:


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
CI has been failing with tt-train model runs since [May 23](https://github.com/tenstorrent/tt-metal/actions/runs/26326209323/job/77504713447) due to log parsing errors. The cause is a recent change in tt-metal that produces a large number of warnings from kernel compilation during the initial runtime. These warnings get embedded into the log output of the training run, causing the parser to break.

A simple fix would be to separate the stdout and stderr streams, since the warnings are always part of stderr. This way, the warnings would still be displayed in the CI logs but would not be piped to the log file. In the future, implementing a [structured logging scheme](https://github.com/tenstorrent/tt-metal/issues/41315) would be ideal.

### CI Status
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/fix-log-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/fix-log-output)