### PR TITLE
[API Cleanup] Structural API cleanup of Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -132,14 +132,14 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .entry_size = entry_size_a,
         .num_entries = num_entries_a,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .alias_with = {"dfb_b"},
+        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}},
     };
     DataflowBufferSpec dfb_b{
         .unique_id = "dfb_b",
         .entry_size = entry_size_b,
         .num_entries = num_entries_b,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .alias_with = {"dfb_a"},
+        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}},
     };
 
     KernelSpec producer{
@@ -347,7 +347,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .alias_with = {"dfb_alias"},
+        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_alias"}},
     };
     DataflowBufferSpec dfb_alias_spec{
         .unique_id = "dfb_alias",
@@ -355,7 +355,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .alias_with = {"dfb_borrowed"},
+        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_borrowed"}},
     };
 
     KernelSpec producer{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -132,14 +132,14 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .entry_size = entry_size_a,
         .num_entries = num_entries_a,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}},
+        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}},
     };
     DataflowBufferSpec dfb_b{
         .unique_id = "dfb_b",
         .entry_size = entry_size_b,
         .num_entries = num_entries_b,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}},
+        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}},
     };
 
     KernelSpec producer{
@@ -347,7 +347,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_alias"}},
+        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_alias"}},
     };
     DataflowBufferSpec dfb_alias_spec{
         .unique_id = "dfb_alias",
@@ -355,7 +355,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_borrowed"}},
+        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_borrowed"}},
     };
 
     KernelSpec producer{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -143,54 +143,64 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
     };
 
     KernelSpec producer{
-        .unique_id   = "producer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .unique_id = "producer",
+        .source = ALIAS_PRODUCER_KERNEL,
         .num_threads = num_producers,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_a", .local_accessor_name = "out_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_b", .local_accessor_name = "out_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
-            {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_producer_a", epp_a},
-            {"num_entries_per_producer_b", epp_b},
-            {"num_producers",              static_cast<uint32_t>(num_producers)},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_a",
+                 .local_accessor_name = "out_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_b",
+                 .local_accessor_name = "out_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
+                {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_producer_a", epp_a},
+                {"num_entries_per_producer_b", epp_b},
+                {"num_producers", static_cast<uint32_t>(num_producers)},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
     KernelSpec consumer{
-        .unique_id   = "consumer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .unique_id = "consumer",
+        .source = ALIAS_CONSUMER_KERNEL,
         .num_threads = num_consumers,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_a", .local_accessor_name = "in_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_b", .local_accessor_name = "in_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
-            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_consumer_a", epc_a},
-            {"num_entries_per_consumer_b", epc_b},
-            {"num_consumers",              static_cast<uint32_t>(num_consumers)},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_a",
+                 .local_accessor_name = "in_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_b",
+                 .local_accessor_name = "in_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+                {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_consumer_a", epc_a},
+                {"num_entries_per_consumer_b", epc_b},
+                {"num_consumers", static_cast<uint32_t>(num_consumers)},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 
@@ -349,57 +359,67 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
     };
 
     KernelSpec producer{
-        .unique_id   = "producer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_PRODUCER_KERNEL},
+        .unique_id = "producer",
+        .source = ALIAS_PRODUCER_KERNEL,
         .num_threads = 1,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "out_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "out_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "in_tensor_a",  .accessor_name = "src_a"},
-            {.tensor_parameter_name = "in_tensor_b",  .accessor_name = "src_b"},
-            // ring_tensor must be bound to at least one kernel even though the
-            // kernel doesn't access it directly (required by TensorParameter rules).
-            {.tensor_parameter_name = "ring_tensor",  .accessor_name = "ring"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_producer_a", epp},
-            {"num_entries_per_producer_b", epp},
-            {"num_producers",              1u},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_borrowed",
+                 .local_accessor_name = "out_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_alias",
+                 .local_accessor_name = "out_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::PRODUCER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "in_tensor_a", .accessor_name = "src_a"},
+                {.tensor_parameter_name = "in_tensor_b", .accessor_name = "src_b"},
+                // ring_tensor must be bound to at least one kernel even though the
+                // kernel doesn't access it directly (required by TensorParameter rules).
+                {.tensor_parameter_name = "ring_tensor", .accessor_name = "ring"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_producer_a", epp},
+                {"num_entries_per_producer_b", epp},
+                {"num_producers", 1u},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = producer_cfg,
     };
 
     KernelSpec consumer{
-        .unique_id   = "consumer",
-        .source      = KernelSpec::SourceFilePath{ALIAS_CONSUMER_KERNEL},
+        .unique_id = "consumer",
+        .source = ALIAS_CONSUMER_KERNEL,
         .num_threads = 1,
-        .dfb_bindings = {
-            {.dfb_spec_name = "dfb_borrowed", .local_accessor_name = "in_a",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-            {.dfb_spec_name = "dfb_alias", .local_accessor_name = "in_b",
-             .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
-             .access_pattern = DFBAccessPattern::STRIDED},
-        },
-        .tensor_bindings = {
-            {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
-            {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
-        },
-        .compile_time_arg_bindings = {
-            {"num_entries_per_consumer_a", epc},
-            {"num_entries_per_consumer_b", epc},
-            {"num_consumers",              1u},
-        },
-        .runtime_arguments_schema = {.named_runtime_args =
-            {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
+        .dfb_bindings =
+            {
+                {.dfb_spec_name = "dfb_borrowed",
+                 .local_accessor_name = "in_a",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+                {.dfb_spec_name = "dfb_alias",
+                 .local_accessor_name = "in_b",
+                 .endpoint_type = KernelSpec::DFBEndpointType::CONSUMER,
+                 .access_pattern = DFBAccessPattern::STRIDED},
+            },
+        .tensor_bindings =
+            {
+                {.tensor_parameter_name = "out_tensor_a", .accessor_name = "dst_a"},
+                {.tensor_parameter_name = "out_tensor_b", .accessor_name = "dst_b"},
+            },
+        .compile_time_arg_bindings =
+            {
+                {"num_entries_per_consumer_a", epc},
+                {"num_entries_per_consumer_b", epc},
+                {"num_consumers", 1u},
+            },
+        .runtime_arguments_schema =
+            {.named_runtime_args = {"chunk_offset_a", "chunk_offset_b", "entries_per_core_a", "entries_per_core_b"}},
         .config_spec = consumer_cfg,
     };
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -132,14 +132,14 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
         .entry_size = entry_size_a,
         .num_entries = num_entries_a,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}},
+        .advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}},
     };
     DataflowBufferSpec dfb_b{
         .unique_id = "dfb_b",
         .entry_size = entry_size_b,
         .num_entries = num_entries_b,
         .data_format_metadata = tt::DataFormat::Float16_b,
-        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}},
+        .advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_a"}},
     };
 
     KernelSpec producer{
@@ -347,7 +347,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_alias"}},
+        .advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_alias"}},
     };
     DataflowBufferSpec dfb_alias_spec{
         .unique_id = "dfb_alias",
@@ -355,7 +355,7 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
         .num_entries = num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = "ring_tensor",
-        .advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_borrowed"}},
+        .advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_borrowed"}},
     };
 
     KernelSpec producer{

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -110,7 +110,7 @@ void run_borrowed_memory_dfb_program(
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("producer", static_cast<uint8_t>(cfg.num_producers))
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer_spec.source = KernelSpec::SourceFilePath{DFB_PRODUCER_KERNEL};
+    producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_arg_bindings = {
         {"num_entries_per_producer", entries_per_producer},
         {"implicit_sync",            implicit_sync},
@@ -133,7 +133,7 @@ void run_borrowed_memory_dfb_program(
         consumer_spec = (arch == ARCH::QUASAR)
             ? MakeMinimalComputeKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalComputeKernel("consumer");
-        consumer_spec.source = KernelSpec::SourceFilePath{DFB_TENSIX_CONSUMER_KERNEL};
+        consumer_spec.source = DFB_TENSIX_CONSUMER_KERNEL;
         consumer_spec.compile_time_arg_bindings = {
             {"num_entries_per_consumer", entries_per_consumer},
         };
@@ -142,7 +142,7 @@ void run_borrowed_memory_dfb_program(
         consumer_spec = (arch == ARCH::QUASAR)
             ? MakeMinimalDMKernel("consumer", static_cast<uint8_t>(cfg.num_consumers))
             : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-        consumer_spec.source = KernelSpec::SourceFilePath{DFB_DM_CONSUMER_KERNEL};
+        consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
         consumer_spec.compile_time_arg_bindings = {
             {"num_entries_per_consumer", entries_per_consumer},
             {"blocked_consumer",         static_cast<uint32_t>(is_all ? 1u : 0u)},
@@ -277,7 +277,7 @@ void run_update_address_test(
     KernelSpec producer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("producer")
         : MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer_spec.source = KernelSpec::SourceFilePath{DFB_PRODUCER_KERNEL};
+    producer_spec.source = DFB_PRODUCER_KERNEL;
     producer_spec.compile_time_arg_bindings = {
         {"num_entries_per_producer", num_entries},
         {"implicit_sync",            implicit_sync},
@@ -293,7 +293,7 @@ void run_update_address_test(
     KernelSpec consumer_spec = (arch == ARCH::QUASAR)
         ? MakeMinimalDMKernel("consumer")
         : MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer_spec.source = KernelSpec::SourceFilePath{DFB_DM_CONSUMER_KERNEL};
+    consumer_spec.source = DFB_DM_CONSUMER_KERNEL;
     consumer_spec.compile_time_arg_bindings = {
         {"num_entries_per_consumer", num_entries},
         {"blocked_consumer",         0u},

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -243,8 +243,8 @@ void run_single_dfb_program(
         producer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = PRODUCER,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -269,8 +269,8 @@ void run_single_dfb_program(
         producer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = PRODUCER,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -288,8 +288,8 @@ void run_single_dfb_program(
         consumer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = CONSUMER,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -315,8 +315,8 @@ void run_single_dfb_program(
         consumer_spec = experimental::metal2_host_api::KernelSpec{
             .unique_id = CONSUMER,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
             .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
@@ -658,8 +658,8 @@ void run_concurrent_dfbs_program(
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = producer_name,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -691,8 +691,8 @@ void run_concurrent_dfbs_program(
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = consumer_name,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -815,8 +815,8 @@ void run_concurrent_tensix_dm_dfbs_program(
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_seq_producer.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings = {{"num_entries_per_producer", entries_per_dfb}},
@@ -866,8 +866,8 @@ void run_concurrent_tensix_dm_dfbs_program(
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = consumer_name,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp",
             .num_threads = 1,
             .dfb_bindings = {{
                 .dfb_spec_name = dfb_name,
@@ -1040,8 +1040,8 @@ void run_sequential_dfbs_program(
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp",
         .num_threads = num_producers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings =
@@ -1061,8 +1061,8 @@ void run_sequential_dfbs_program(
     experimental::metal2_host_api::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp",
         .num_threads = num_consumers,
         .compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}},
         .compile_time_arg_bindings =
@@ -1247,8 +1247,8 @@ void run_in_dfb_out_dfb_program(
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = static_cast<uint8_t>(dm2tensix_config.num_producers),
         .dfb_bindings = {{
             .dfb_spec_name = IN_DFB,
@@ -1280,8 +1280,8 @@ void run_in_dfb_out_dfb_program(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {
@@ -1306,8 +1306,8 @@ void run_in_dfb_out_dfb_program(
     experimental::metal2_host_api::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
         .num_threads = static_cast<uint8_t>(tensix2dm_config.num_consumers),
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -1962,8 +1962,8 @@ static void run_intra_tensix_dfb_program(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp",
         .num_threads = static_cast<uint8_t>(num_threads),
         .dfb_bindings =
             {
@@ -2107,8 +2107,8 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     experimental::metal2_host_api::KernelSpec dm_producer_spec{
         .unique_id = DM_PRODUCER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = REMAPPER_DFB,
@@ -2143,8 +2143,8 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp",
         .num_threads = static_cast<uint8_t>(num_neos),
         .dfb_bindings =
             {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -245,7 +245,7 @@ void run_single_dfb_program(
             .source =
 
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
-            .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
+            .num_threads = dfb_config.num_producers,
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "out",
@@ -271,7 +271,7 @@ void run_single_dfb_program(
             .source =
 
                 "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_producer.cpp",
-            .num_threads = static_cast<uint8_t>(dfb_config.num_producers),
+            .num_threads = dfb_config.num_producers,
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "out",
@@ -290,7 +290,7 @@ void run_single_dfb_program(
             .source =
 
                 "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
-            .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
+            .num_threads = dfb_config.num_consumers,
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "in",
@@ -317,7 +317,7 @@ void run_single_dfb_program(
             .source =
 
                 "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
-            .num_threads = static_cast<uint8_t>(dfb_config.num_consumers),
+            .num_threads = dfb_config.num_consumers,
             .dfb_bindings = {{
                 .dfb_spec_name = DFB_NAME,
                 .local_accessor_name = "in",
@@ -1249,7 +1249,7 @@ void run_in_dfb_out_dfb_program(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
-        .num_threads = static_cast<uint8_t>(dm2tensix_config.num_producers),
+        .num_threads = dm2tensix_config.num_producers,
         .dfb_bindings = {{
             .dfb_spec_name = IN_DFB,
             .local_accessor_name = "out",
@@ -1308,7 +1308,7 @@ void run_in_dfb_out_dfb_program(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp",
-        .num_threads = static_cast<uint8_t>(tensix2dm_config.num_consumers),
+        .num_threads = tensix2dm_config.num_consumers,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
             .local_accessor_name = "in",
@@ -1964,7 +1964,7 @@ static void run_intra_tensix_dfb_program(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp",
-        .num_threads = static_cast<uint8_t>(num_threads),
+        .num_threads = num_threads,
         .dfb_bindings =
             {
                 {
@@ -2145,7 +2145,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4A) {
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp",
-        .num_threads = static_cast<uint8_t>(num_neos),
+        .num_threads = num_neos,
         .dfb_bindings =
             {
                 {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -128,9 +128,7 @@ inline DataflowBufferSpec MakeMinimalDFB(
 
 // Helper to create a minimal valid WorkUnitSpec
 inline WorkUnitSpec MakeMinimalWorkUnit(
-    const std::string& name,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes,
-    const std::vector<KernelSpecName>& kernels) {
+    const std::string& name, const Nodes& nodes, const std::vector<KernelSpecName>& kernels) {
     return WorkUnitSpec{
         .unique_id = name,
         .kernels = kernels,

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -76,7 +76,7 @@ inline constexpr const char* MINIMAL_KERNEL_SOURCE = "void kernel_main() {}";
 // Placement is stated on WorkUnitSpec; pass node sets to MakeMinimalWorkUnit instead.
 
 // Helper to create a minimal valid KernelSpec for data movement (Gen2/Quasar)
-inline KernelSpec MakeMinimalDMKernel(const std::string& name, int num_threads = 1) {
+inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint32_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
@@ -107,7 +107,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
 }
 
 // Helper to create a minimal valid KernelSpec for compute
-inline KernelSpec MakeMinimalComputeKernel(const std::string& name, int num_threads = 1) {
+inline KernelSpec MakeMinimalComputeKernel(const std::string& name, uint32_t num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -76,7 +76,7 @@ inline constexpr const char* MINIMAL_KERNEL_SOURCE = "void kernel_main() {}";
 // Placement is stated on WorkUnitSpec; pass node sets to MakeMinimalWorkUnit instead.
 
 // Helper to create a minimal valid KernelSpec for data movement (Gen2/Quasar)
-inline KernelSpec MakeMinimalDMKernel(const std::string& name, uint8_t num_threads = 1) {
+inline KernelSpec MakeMinimalDMKernel(const std::string& name, int num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
@@ -107,7 +107,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
 }
 
 // Helper to create a minimal valid KernelSpec for compute
-inline KernelSpec MakeMinimalComputeKernel(const std::string& name, uint8_t num_threads = 1) {
+inline KernelSpec MakeMinimalComputeKernel(const std::string& name, int num_threads = 1) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -61,7 +61,7 @@ using test_helpers::ScopedSlowDispatchOverride;
 
 // Shorthand for the per-node-override vararg type (needed at call sites because
 // std::optional<T> can't be brace-init from an initializer-list of T's elements).
-using NumVarargsPerNode = KernelSpec::RuntimeArgSchema::NumVarargsPerNode;
+using NumVarargsPerNode = KernelSpecAdvancedOptions::NumVarargsPerNode;
 
 // ============================================================================
 // Test Fixtures
@@ -103,8 +103,8 @@ inline ProgramSpec MakeSpecWithRTAs(const NodeCoord& /*node*/, size_t num_per_no
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Set the RTA schema on the dm_kernel (first kernel)
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = num_per_node_rtas;
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = num_common_rtas;
+    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
 
     // compute_kernel has no RTAs (defaults: 0 / 0)
 
@@ -121,12 +121,12 @@ inline ProgramSpec MakeSpecWithBothKernelRTAs(
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // dm_kernel RTAs
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = dm_per_node_rtas;
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = dm_common_rtas;
+    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = dm_per_node_rtas, .num_common_runtime_varargs = dm_common_rtas};
 
     // compute_kernel RTAs
-    spec.kernels[1].runtime_arguments_schema.num_runtime_varargs = compute_per_node_rtas;
-    spec.kernels[1].runtime_arguments_schema.num_common_runtime_varargs = compute_common_rtas;
+    spec.kernels[1].advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = compute_per_node_rtas, .num_common_runtime_varargs = compute_common_rtas};
 
     return spec;
 }
@@ -543,8 +543,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
-    producer.runtime_arguments_schema.num_runtime_varargs = 2;
-    producer.runtime_arguments_schema.num_common_runtime_varargs = 1;
+    producer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
 
     // consumer has no varargs (defaults)
 
@@ -589,7 +588,7 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
-    producer.runtime_arguments_schema.num_runtime_varargs = 2;
+    producer.advanced_options.emplace().num_runtime_varargs = 2;
     // consumer has no varargs (defaults)
 
     // Single DFB spanning all nodes
@@ -756,7 +755,8 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "vararg_differing_counts";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
+    kernel.advanced_options.emplace().num_runtime_varargs_per_node =
+        KernelSpecAdvancedOptions::NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -787,7 +787,8 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     // Nodes a and b share count 3 (declared via a NodeRangeSet entry).
     // Node c has count 5 (declared via a NodeCoord entry).
-    kernel.runtime_arguments_schema.num_runtime_varargs_per_node = NumVarargsPerNode{{ab, 3}, {node_c, 5}};
+    kernel.advanced_options.emplace().num_runtime_varargs_per_node =
+        KernelSpecAdvancedOptions::NumVarargsPerNode{{ab, 3}, {node_c, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -814,9 +815,11 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
     ProgramSpec spec;
     spec.program_id = "vararg_scalar_with_sparse_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // default for unlisted nodes
-    kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
-        NumVarargsPerNode{{node_c, 5}};  // node_c is the exception
+    kernel.advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = 2,  // default for unlisted nodes
+        .num_runtime_varargs_per_node =
+            KernelSpecAdvancedOptions::NumVarargsPerNode{{node_c, 5}},  // node_c is the exception
+    };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -846,9 +849,11 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
     ProgramSpec spec;
     spec.program_id = "vararg_zero_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.runtime_arguments_schema.num_runtime_varargs = 3;
-    kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
-        NumVarargsPerNode{{node_b, 0}};  // node_b: no varargs despite scalar default
+    kernel.advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = 3,
+        .num_runtime_varargs_per_node =
+            KernelSpecAdvancedOptions::NumVarargsPerNode{{node_b, 0}},  // node_b: no varargs despite scalar default
+    };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -867,10 +872,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
     // migration where nothing has been upgraded to named args yet.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 1;
-    spec.kernels[1].runtime_arguments_schema.num_runtime_varargs = 2;
-    spec.kernels[1].runtime_arguments_schema.num_common_runtime_varargs = 2;
+    spec.kernels[0].advanced_options =
+        KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
+    spec.kernels[1].advanced_options =
+        KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 2};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
@@ -889,7 +894,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     ProgramSpec spec;
     spec.program_id = "vararg_missing_node";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.runtime_arguments_schema.num_runtime_varargs = 2;  // uniform across both nodes
+    kernel.advanced_options.emplace().num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -909,7 +914,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
     NodeCoord node{0, 0};
     NodeCoord wrong_node{3, 3};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 1;
+    spec.kernels[0].advanced_options.emplace().num_runtime_varargs = 1;
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
@@ -949,7 +954,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
+    spec.kernels[0].advanced_options.emplace().num_runtime_varargs = 3;
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
@@ -1129,8 +1134,8 @@ protected:
 inline ProgramSpec MakeGen1SpecWithRTAs(const NodeCoord& /*node*/, size_t num_per_node_rtas, size_t num_common_rtas) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = num_per_node_rtas;
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = num_common_rtas;
+    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
 
     // kernels[1] has no varargs (defaults)
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -609,7 +609,7 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
-    producer.advanced_options.emplace().num_runtime_varargs = 2;
+    producer.advanced_options.num_runtime_varargs = 2;
     // consumer has no varargs (defaults)
 
     // Single DFB spanning all nodes
@@ -782,7 +782,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     ProgramSpec spec;
     spec.program_id = "vararg_differing_counts";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.advanced_options.emplace().num_runtime_varargs_per_node =
+    kernel.advanced_options.num_runtime_varargs_per_node =
         KernelAdvancedOptions::NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
@@ -817,7 +817,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     // Nodes a and b share count 3 (declared via a NodeRangeSet entry).
     // Node c has count 5 (declared via a NodeCoord entry).
-    kernel.advanced_options.emplace().num_runtime_varargs_per_node =
+    kernel.advanced_options.num_runtime_varargs_per_node =
         KernelAdvancedOptions::NumVarargsPerNode{{ab, 3}, {node_c, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
@@ -931,7 +931,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
     ProgramSpec spec;
     spec.program_id = "vararg_missing_node";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.advanced_options.emplace().num_runtime_varargs = 2;  // uniform across both nodes
+    kernel.advanced_options.num_runtime_varargs = 2;  // uniform across both nodes
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -955,7 +955,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
     NodeCoord node{0, 0};
     NodeCoord wrong_node{3, 3};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].advanced_options.emplace().num_runtime_varargs = 1;
+    spec.kernels[0].advanced_options.num_runtime_varargs = 1;
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
@@ -998,7 +998,7 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arguments_schema.named_runtime_args = {"input_ptr"};
-    spec.kernels[0].advanced_options.emplace().num_runtime_varargs = 3;
+    spec.kernels[0].advanced_options.num_runtime_varargs = 3;
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -1552,7 +1552,7 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_InterleavedAcceptsDifferentS
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1575,7 +1575,7 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_DTypeMismatchStillFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1604,7 +1604,7 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_RankMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // rank-2 shape {1, 32}
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1670,7 +1670,7 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_ShardedSetWritesShapeIntoCRT
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding =
         MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1696,7 +1696,7 @@ TEST_F(ProgramRunParamsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape)
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding =
         MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1749,7 +1749,7 @@ TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_AcceptsDifferentLogicalSha
     TensorParameter binding{
         .unique_id = "input_tensor",
         .spec = declared_spec,
-        .match_padded_shape_only = true,
+        .advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true},
     };
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -1781,7 +1781,7 @@ TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_PaddedShapeMismatchFails) 
     TensorParameter binding{
         .unique_id = "input_tensor",
         .spec = declared_spec,
-        .match_padded_shape_only = true,
+        .advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true},
     };
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -1810,7 +1810,7 @@ TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
-    binding.match_padded_shape_only = true;
+    binding.advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1873,8 +1873,8 @@ TEST_F(ProgramRunParamsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
-    binding.match_padded_shape_only = true;
-    binding.dynamic_tensor_shape = true;
+    binding.advanced_options =
+        TensorParameterAdvancedOptions{.match_padded_shape_only = true, .dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -61,7 +61,7 @@ using test_helpers::ScopedSlowDispatchOverride;
 
 // Shorthand for the per-node-override vararg type (needed at call sites because
 // std::optional<T> can't be brace-init from an initializer-list of T's elements).
-using NumVarargsPerNode = KernelSpecAdvancedOptions::NumVarargsPerNode;
+using NumVarargsPerNode = KernelAdvancedOptions::NumVarargsPerNode;
 
 // ============================================================================
 // Test Fixtures
@@ -103,8 +103,8 @@ inline ProgramSpec MakeSpecWithRTAs(const NodeCoord& /*node*/, size_t num_per_no
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Set the RTA schema on the dm_kernel (first kernel)
-    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
-        .num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
+    spec.kernels[0].advanced_options =
+        KernelAdvancedOptions{.num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
 
     // compute_kernel has no RTAs (defaults: 0 / 0)
 
@@ -121,11 +121,11 @@ inline ProgramSpec MakeSpecWithBothKernelRTAs(
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // dm_kernel RTAs
-    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
-        .num_runtime_varargs = dm_per_node_rtas, .num_common_runtime_varargs = dm_common_rtas};
+    spec.kernels[0].advanced_options =
+        KernelAdvancedOptions{.num_runtime_varargs = dm_per_node_rtas, .num_common_runtime_varargs = dm_common_rtas};
 
     // compute_kernel RTAs
-    spec.kernels[1].advanced_options = KernelSpecAdvancedOptions{
+    spec.kernels[1].advanced_options = KernelAdvancedOptions{
         .num_runtime_varargs = compute_per_node_rtas, .num_common_runtime_varargs = compute_common_rtas};
 
     return spec;
@@ -558,7 +558,7 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     auto consumer = MakeMinimalDMKernel("consumer");
 
     // Throw in some varargs (the normal kind, not the weird per-node override kind)
-    producer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
+    producer.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
 
     // consumer has no varargs (defaults)
 
@@ -783,7 +783,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     spec.program_id = "vararg_differing_counts";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
     kernel.advanced_options.emplace().num_runtime_varargs_per_node =
-        KernelSpecAdvancedOptions::NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
+        KernelAdvancedOptions::NumVarargsPerNode{{node_a, 2}, {node_b, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -818,7 +818,7 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     // Nodes a and b share count 3 (declared via a NodeRangeSet entry).
     // Node c has count 5 (declared via a NodeCoord entry).
     kernel.advanced_options.emplace().num_runtime_varargs_per_node =
-        KernelSpecAdvancedOptions::NumVarargsPerNode{{ab, 3}, {node_c, 5}};
+        KernelAdvancedOptions::NumVarargsPerNode{{ab, 3}, {node_c, 5}};
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -848,10 +848,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
     ProgramSpec spec;
     spec.program_id = "vararg_scalar_with_sparse_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.advanced_options = KernelSpecAdvancedOptions{
+    kernel.advanced_options = KernelAdvancedOptions{
         .num_runtime_varargs = 2,  // default for unlisted nodes
         .num_runtime_varargs_per_node =
-            KernelSpecAdvancedOptions::NumVarargsPerNode{{node_c, 5}},  // node_c is the exception
+            KernelAdvancedOptions::NumVarargsPerNode{{node_c, 5}},  // node_c is the exception
     };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", all_nodes, {"dm_kernel"})};
@@ -885,10 +885,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
     ProgramSpec spec;
     spec.program_id = "vararg_zero_override";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.advanced_options = KernelSpecAdvancedOptions{
+    kernel.advanced_options = KernelAdvancedOptions{
         .num_runtime_varargs = 3,
         .num_runtime_varargs_per_node =
-            KernelSpecAdvancedOptions::NumVarargsPerNode{{node_b, 0}},  // node_b: no varargs despite scalar default
+            KernelAdvancedOptions::NumVarargsPerNode{{node_b, 0}},  // node_b: no varargs despite scalar default
     };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
@@ -911,10 +911,8 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
     // migration where nothing has been upgraded to named args yet.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
-    spec.kernels[0].advanced_options =
-        KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
-    spec.kernels[1].advanced_options =
-        KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 2};
+    spec.kernels[0].advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
+    spec.kernels[1].advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 2};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunParams params;
@@ -1183,8 +1181,8 @@ protected:
 inline ProgramSpec MakeGen1SpecWithRTAs(const NodeCoord& /*node*/, size_t num_per_node_rtas, size_t num_common_rtas) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
-    spec.kernels[0].advanced_options = KernelSpecAdvancedOptions{
-        .num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
+    spec.kernels[0].advanced_options =
+        KernelAdvancedOptions{.num_runtime_varargs = num_per_node_rtas, .num_common_runtime_varargs = num_common_rtas};
 
     // kernels[1] has no varargs (defaults)
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_params.cpp
@@ -139,8 +139,11 @@ inline ProgramRunParams::KernelRunParams MakeKernelRunParams(
     const std::vector<uint32_t>& common_args) {
     return ProgramRunParams::KernelRunParams{
         .kernel_spec_name = kernel_name,
-        .runtime_varargs = {{node, per_node_args}},
-        .common_runtime_varargs = common_args,
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node, per_node_args}},
+                .common_runtime_varargs = common_args,
+            },
     };
 }
 
@@ -170,8 +173,11 @@ TEST_F(ProgramRunParamsTestQuasar, UnknownKernelNameFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "nonexistent_kernel",
-        .runtime_varargs = {},
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {},
+                .common_runtime_varargs = {},
+            },
     });
 
     EXPECT_THAT(
@@ -189,8 +195,11 @@ TEST_F(ProgramRunParamsTestQuasar, InvalidNodeForKernelFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{wrong_node, {1, 2}}},  // Wrong node!
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{wrong_node, {1, 2}}},  // Wrong node!
+                .common_runtime_varargs = {},
+            },
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -292,8 +301,11 @@ TEST_F(ProgramRunParamsTestQuasar, MissingNodeRTAsFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {},  // Missing node RTAs!
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {},  // Missing node RTAs!
+                .common_runtime_varargs = {},
+            },
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -368,8 +380,11 @@ TEST_F(ProgramRunParamsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{node, {1, 2}}, {node, {3, 4}}},  // Duplicate node!
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node, {1, 2}}, {node, {3, 4}}},  // Duplicate node!
+                .common_runtime_varargs = {},
+            },
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 
@@ -563,13 +578,19 @@ TEST_F(ProgramRunParamsTestQuasar, SetRunParamsSucceeds_MultiNodeKernel) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "producer",
-        .runtime_varargs = {{node0, {10, 20}}, {node1, {30, 40}}},
-        .common_runtime_varargs = {100},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node0, {10, 20}}, {node1, {30, 40}}},
+                .common_runtime_varargs = {100},
+            },
     });
     params.kernel_run_params.push_back({
         .kernel_spec_name = "consumer",
-        .runtime_varargs = {{node0, {}}, {node1, {}}},
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node0, {}}, {node1, {}}},
+                .common_runtime_varargs = {},
+            },
     });
 
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
@@ -607,13 +628,19 @@ TEST_F(ProgramRunParamsTestQuasar, MultiNode_MissingOneNodeFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "producer",
-        .runtime_varargs = {{node0, {10, 20}}},  // Missing node1!
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node0, {10, 20}}},  // Missing node1!
+                .common_runtime_varargs = {},
+            },
     });
     params.kernel_run_params.push_back({
         .kernel_spec_name = "consumer",
-        .runtime_varargs = {{node0, {}}, {node1, {}}},
-        .common_runtime_varargs = {},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node0, {}}, {node1, {}}},
+                .common_runtime_varargs = {},
+            },
     });
 
     EXPECT_THAT(
@@ -764,7 +791,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{node_a, {10, 20}}, {node_b, {100, 200, 300, 400, 500}}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node_a, {10, 20}}, {node_b, {100, 200, 300, 400, 500}}},
+            },
     });
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
 }
@@ -796,7 +826,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds)
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{node_a, {1, 2, 3}}, {node_b, {10, 20, 30}}, {node_c, {100, 200, 300, 400, 500}}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node_a, {1, 2, 3}}, {node_b, {10, 20, 30}}, {node_c, {100, 200, 300, 400, 500}}},
+            },
     });
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
 }
@@ -827,11 +860,14 @@ TEST_F(ProgramRunParamsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs =
-            {
-                {node_a, {1, 2}},                     // scalar default (2 args)
-                {node_b, {10, 20}},                   // scalar default (2 args)
-                {node_c, {100, 200, 300, 400, 500}},  // override (5 args)
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs =
+                    {
+                        {node_a, {1, 2}},                     // scalar default (2 args)
+                        {node_b, {10, 20}},                   // scalar default (2 args)
+                        {node_c, {100, 200, 300, 400, 500}},  // override (5 args)
+                    },
             },
     });
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
@@ -862,7 +898,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{node_a, {1, 2, 3}}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node_a, {1, 2, 3}}},
+            },
     });
     EXPECT_NO_THROW(SetProgramRunParameters(program, params));
 }
@@ -901,7 +940,11 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
 
     ProgramRunParams params;
     params.kernel_run_params.push_back({
-        .kernel_spec_name = "dm_kernel", .runtime_varargs = {{node_a, {10, 20}}},  // node_b missing!
+        .kernel_spec_name = "dm_kernel",
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node_a, {10, 20}}},  // node_b missing!
+            },
     });
     EXPECT_THAT(
         [&] { SetProgramRunParameters(program, params); },
@@ -920,7 +963,10 @@ TEST_F(ProgramRunParamsTestQuasar, VarargOnlyUnknownNodeFails) {
     ProgramRunParams params;
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
-        .runtime_varargs = {{wrong_node, {42}}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{wrong_node, {42}}},
+            },
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
     EXPECT_THAT(
@@ -961,7 +1007,10 @@ TEST_F(ProgramRunParamsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
     params.kernel_run_params.push_back({
         .kernel_spec_name = "dm_kernel",
         .named_runtime_args = {{.node = node, .args = {{"input_ptr", 0x1000}}}},
-        .runtime_varargs = {{node, {7, 8, 9}}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs = {{node, {7, 8, 9}}},
+            },
     });
     params.kernel_run_params.push_back(MakeKernelRunParams("compute_kernel", node, {}, {}));
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3222,8 +3222,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
     // DFB_A: 512 * 8 = 4096 bytes, DFB_B: 256 * 8 = 2048 bytes — different totals → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/8);
-    dfb_a.alias_with = {"dfb_b"};
-    dfb_b.alias_with = {"dfb_a"};
+    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     const NodeCoord node{0, 0};
     auto spec = MakeAliasProgramSpec(node, dfb_a, dfb_b);
@@ -3238,7 +3238,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
     // DFB_A lists DFB_B but DFB_B does not list DFB_A — clique violation → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
-    dfb_a.alias_with = {"dfb_b"};
+    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
     // dfb_b.alias_with intentionally left empty
 
     const NodeCoord node{0, 0};
@@ -3264,8 +3264,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.alias_with = {"dfb_b"};
-    dfb_b.alias_with = {"dfb_a"};
+    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
@@ -3294,8 +3294,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.alias_with = {"dfb_b"};
-    dfb_b.alias_with = {"dfb_a"};
+    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer_a = MakeMinimalDMKernel("producer_a");
     KernelSpec consumer_a = MakeMinimalDMKernel("consumer_a");
@@ -3326,8 +3326,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/16, /*num_entries=*/2);
-    dfb_a.alias_with = {"dfb_b"};
-    dfb_b.alias_with = {"dfb_a"};
+    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
     dfb_a.borrowed_from = "borrowed_tensor";
     // dfb_b.borrowed_from intentionally left unset
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1531,7 +1531,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
     spec.program_id = "self_loop_inter";
 
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.advanced_options = KernelSpecAdvancedOptions{
+    compute.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTER}}};
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1558,7 +1558,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnDMKernelFails) {
 
     auto producer = MakeMinimalDMKernel("producer");
     // Misapplied: self-loop scope entries are valid only on compute kernels.
-    producer.advanced_options = KernelSpecAdvancedOptions{
+    producer.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
     auto consumer = MakeMinimalDMKernel("consumer");
 
@@ -1583,7 +1583,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: there is no DFB named "ghost" in the spec.
-    compute.advanced_options = KernelSpecAdvancedOptions{
+    compute.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "ghost", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1609,7 +1609,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnNonSelfLoopedDFBFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: the kernel only produces; it does not self-loop the DFB.
-    compute.advanced_options = KernelSpecAdvancedOptions{
+    compute.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
     auto dm_consumer = MakeMinimalDMKernel("dm_consumer");
 
@@ -1636,7 +1636,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSelfLoopScopeEntriesFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Two entries for the same DFB on the same kernel.
-    compute.advanced_options = KernelSpecAdvancedOptions{
+    compute.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes =
             {
                 {.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA},
@@ -1712,7 +1712,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
     spec.program_id = "self_loop_explicit_intra";
 
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.advanced_options = KernelSpecAdvancedOptions{
+    compute.advanced_options = KernelAdvancedOptions{
         .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1885,8 +1885,7 @@ TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add runtime args schema
-    spec.kernels[0].advanced_options =
-        KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 2};
+    spec.kernels[0].advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 2};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -1901,9 +1900,9 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     ProgramSpec spec;
     spec.program_id = "vararg_overlap_test";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.advanced_options = KernelSpecAdvancedOptions{
+    kernel.advanced_options = KernelAdvancedOptions{
         .num_runtime_varargs_per_node =
-            KernelSpecAdvancedOptions::NumVarargsPerNode{{both, 3}, {node_a, 3}},  // node_a listed twice
+            KernelAdvancedOptions::NumVarargsPerNode{{both, 3}, {node_a, 3}},  // node_a listed twice
     };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
@@ -2354,7 +2353,7 @@ TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
 
 TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
     // Named RTAs + CRTAs via designated initializers; vararg counts now live on
-    // KernelSpecAdvancedOptions (see VarargCountsOnAdvancedOptions below).
+    // KernelAdvancedOptions (see VarargCountsOnAdvancedOptions below).
     KernelSpec::RuntimeArgSchema schema{
         .named_runtime_args = {"input_ptr", "output_ptr"},
         .named_common_runtime_args = {"tile_count"},
@@ -2365,8 +2364,8 @@ TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
 }
 
 TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
-    // Scalar vararg counts via designated initializers on KernelSpecAdvancedOptions.
-    KernelSpecAdvancedOptions adv{
+    // Scalar vararg counts via designated initializers on KernelAdvancedOptions.
+    KernelAdvancedOptions adv{
         .num_runtime_varargs = 4,
         .num_common_runtime_varargs = 2,
     };
@@ -2378,8 +2377,8 @@ TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
 
 TEST(AggregateSpecTypes, VarargPerNodeOverrideOnAdvancedOptions) {
     // Per-node override path (advanced): ensure designated-init through std::optional works.
-    using NumVarargsPerNode = KernelSpecAdvancedOptions::NumVarargsPerNode;
-    KernelSpecAdvancedOptions adv{
+    using NumVarargsPerNode = KernelAdvancedOptions::NumVarargsPerNode;
+    KernelAdvancedOptions adv{
         .num_runtime_varargs_per_node = NumVarargsPerNode{{NodeCoord{0, 0}, 4}, {NodeCoord{1, 0}, 7}},
     };
 
@@ -3235,8 +3234,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
     // DFB_A: 512 * 8 = 4096 bytes, DFB_B: 256 * 8 = 2048 bytes — different totals → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/8);
-    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_a"}};
 
     const NodeCoord node{0, 0};
     auto spec = MakeAliasProgramSpec(node, dfb_a, dfb_b);
@@ -3251,7 +3250,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
     // DFB_A lists DFB_B but DFB_B does not list DFB_A — clique violation → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
-    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}};
     // dfb_b.alias_with intentionally left empty
 
     const NodeCoord node{0, 0};
@@ -3277,8 +3276,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
@@ -3307,8 +3306,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer_a = MakeMinimalDMKernel("producer_a");
     KernelSpec consumer_a = MakeMinimalDMKernel("consumer_a");
@@ -3339,8 +3338,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/16, /*num_entries=*/2);
-    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBAdvancedOptions{.alias_with = {"dfb_a"}};
     dfb_a.borrowed_from = "borrowed_tensor";
     // dfb_b.borrowed_from intentionally left unset
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1885,8 +1885,8 @@ TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add runtime args schema
-    spec.kernels[0].runtime_arguments_schema.num_runtime_varargs = 3;
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 2;
+    spec.kernels[0].advanced_options =
+        KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 2};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -1894,7 +1894,6 @@ TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
 TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     // Rule: overlapping entries in num_runtime_varargs_per_node are an error, even when
     // their counts agree. Overlap suggests a user mistake.
-    using NumVarargsPerNode = KernelSpec::RuntimeArgSchema::NumVarargsPerNode;
     NodeCoord node_a{0, 0};
     NodeCoord node_b{1, 0};
     NodeRangeSet both{std::vector<NodeRange>{NodeRange{node_a, node_a}, NodeRange{node_b, node_b}}};
@@ -1902,8 +1901,10 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
     ProgramSpec spec;
     spec.program_id = "vararg_overlap_test";
     auto kernel = MakeMinimalDMKernel("dm_kernel");
-    kernel.runtime_arguments_schema.num_runtime_varargs_per_node =
-        NumVarargsPerNode{{both, 3}, {node_a, 3}};  // node_a listed twice
+    kernel.advanced_options = KernelSpecAdvancedOptions{
+        .num_runtime_varargs_per_node =
+            KernelSpecAdvancedOptions::NumVarargsPerNode{{both, 3}, {node_a, 3}},  // node_a listed twice
+    };
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", both, {"dm_kernel"})};
 
@@ -2352,31 +2353,39 @@ TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
 }
 
 TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
-    // Named RTAs + CRTAs + scalar vararg counts, all via designated initializers.
+    // Named RTAs + CRTAs via designated initializers; vararg counts now live on
+    // KernelSpecAdvancedOptions (see VarargCountsOnAdvancedOptions below).
     KernelSpec::RuntimeArgSchema schema{
         .named_runtime_args = {"input_ptr", "output_ptr"},
         .named_common_runtime_args = {"tile_count"},
-        .num_runtime_varargs = 4,
-        .num_common_runtime_varargs = 2,
     };
 
     EXPECT_EQ(schema.named_runtime_args.size(), 2u);
     EXPECT_EQ(schema.named_common_runtime_args.size(), 1u);
-    EXPECT_EQ(schema.num_runtime_varargs, 4u);
-    EXPECT_EQ(schema.num_common_runtime_varargs, 2u);
-    EXPECT_FALSE(schema.num_runtime_varargs_per_node.has_value());
 }
 
-TEST(AggregateSpecTypes, RuntimeArgSchemaPerNodeOverrideDesignatedInitializers) {
+TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
+    // Scalar vararg counts via designated initializers on KernelSpecAdvancedOptions.
+    KernelSpecAdvancedOptions adv{
+        .num_runtime_varargs = 4,
+        .num_common_runtime_varargs = 2,
+    };
+
+    EXPECT_EQ(adv.num_runtime_varargs, 4u);
+    EXPECT_EQ(adv.num_common_runtime_varargs, 2u);
+    EXPECT_FALSE(adv.num_runtime_varargs_per_node.has_value());
+}
+
+TEST(AggregateSpecTypes, VarargPerNodeOverrideOnAdvancedOptions) {
     // Per-node override path (advanced): ensure designated-init through std::optional works.
-    using NumVarargsPerNode = KernelSpec::RuntimeArgSchema::NumVarargsPerNode;
-    KernelSpec::RuntimeArgSchema schema{
+    using NumVarargsPerNode = KernelSpecAdvancedOptions::NumVarargsPerNode;
+    KernelSpecAdvancedOptions adv{
         .num_runtime_varargs_per_node = NumVarargsPerNode{{NodeCoord{0, 0}, 4}, {NodeCoord{1, 0}, 7}},
     };
 
-    ASSERT_TRUE(schema.num_runtime_varargs_per_node.has_value());
-    EXPECT_EQ(schema.num_runtime_varargs_per_node->size(), 2u);
-    EXPECT_EQ(schema.num_runtime_varargs, 0u);  // scalar left at default in this example
+    ASSERT_TRUE(adv.num_runtime_varargs_per_node.has_value());
+    EXPECT_EQ(adv.num_runtime_varargs_per_node->size(), 2u);
+    EXPECT_EQ(adv.num_runtime_varargs, 0u);  // scalar left at default in this example
 }
 
 TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
@@ -3112,7 +3121,7 @@ TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
     // Section 1: named CRTAs on the DM kernel.
     spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"foo", "bar"};
     // Section 3: vararg CRTAs on the DM kernel.
-    spec.kernels[0].runtime_arguments_schema.num_common_runtime_varargs = 3;
+    spec.kernels[0].advanced_options.emplace().num_common_runtime_varargs = 3;
 
     // Section 2: two bindings — one plain (1 word), one sharded+dynamic_tensor_shape
     // (1 word + tensor_shape_in_pages rank words).

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -966,7 +966,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
     SemaphoreSpec sem;
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
-    sem.initial_value = 1;
+    sem.advanced_options = SemaphoreAdvancedOptions{.initial_value = 1};
     spec.semaphores = {sem};
 
     EXPECT_THAT(
@@ -2409,11 +2409,12 @@ TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
     SemaphoreSpec sem{
         .unique_id = "my_semaphore",
         .target_nodes = NodeCoord{0, 0},
-        .initial_value = 7,
+        .advanced_options = SemaphoreAdvancedOptions{.initial_value = 7},
     };
 
     EXPECT_EQ(sem.unique_id, "my_semaphore");
-    EXPECT_EQ(sem.initial_value, 7u);
+    ASSERT_TRUE(sem.advanced_options.has_value());
+    EXPECT_EQ(sem.advanced_options->initial_value, 7u);
 }
 
 TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
@@ -2744,7 +2745,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     SemaphoreSpec sem;
     sem.unique_id = "sem_0";
     sem.target_nodes = NodeCoord{0, 0};
-    sem.initial_value = 3;
+    sem.advanced_options = SemaphoreAdvancedOptions{.initial_value = 3};
     spec.semaphores = {sem};
 
     spec.kernels[0].semaphore_bindings = {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2372,18 +2372,17 @@ TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
 
     EXPECT_EQ(adv.num_runtime_varargs, 4u);
     EXPECT_EQ(adv.num_common_runtime_varargs, 2u);
-    EXPECT_FALSE(adv.num_runtime_varargs_per_node.has_value());
+    EXPECT_TRUE(adv.num_runtime_varargs_per_node.empty());
 }
 
 TEST(AggregateSpecTypes, VarargPerNodeOverrideOnAdvancedOptions) {
-    // Per-node override path (advanced): ensure designated-init through std::optional works.
+    // Per-node override path (advanced): ensure designated-init works.
     using NumVarargsPerNode = KernelAdvancedOptions::NumVarargsPerNode;
     KernelAdvancedOptions adv{
         .num_runtime_varargs_per_node = NumVarargsPerNode{{NodeCoord{0, 0}, 4}, {NodeCoord{1, 0}, 7}},
     };
 
-    ASSERT_TRUE(adv.num_runtime_varargs_per_node.has_value());
-    EXPECT_EQ(adv.num_runtime_varargs_per_node->size(), 2u);
+    EXPECT_EQ(adv.num_runtime_varargs_per_node.size(), 2u);
     EXPECT_EQ(adv.num_runtime_varargs, 0u);  // scalar left at default in this example
 }
 
@@ -2412,8 +2411,7 @@ TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
     };
 
     EXPECT_EQ(sem.unique_id, "my_semaphore");
-    ASSERT_TRUE(sem.advanced_options.has_value());
-    EXPECT_EQ(sem.advanced_options->initial_value, 7u);
+    EXPECT_EQ(sem.advanced_options.initial_value, 7u);
 }
 
 TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
@@ -3121,7 +3119,7 @@ TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
     // Section 1: named CRTAs on the DM kernel.
     spec.kernels[0].runtime_arguments_schema.named_common_runtime_args = {"foo", "bar"};
     // Section 3: vararg CRTAs on the DM kernel.
-    spec.kernels[0].advanced_options.emplace().num_common_runtime_varargs = 3;
+    spec.kernels[0].advanced_options.num_common_runtime_varargs = 3;
 
     // Section 2: two bindings — one plain (1 word), one sharded+dynamic_tensor_shape
     // (1 word + tensor_shape_in_pages rank words).

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2995,7 +2995,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
         TensorParameter tp{
             .unique_id = "input_tensor",
             .spec = tt::tt_metal::TensorSpec(std::move(shape), std::move(tensor_layout)),
-            .dynamic_tensor_shape = true,
+            .advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true},
         };
         spec.tensor_parameters = {tp};
         BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -3021,7 +3021,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShap
     auto make_spec = [](const tt::tt_metal::Shape& shape, bool dynamic) {
         ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
         auto tp = MakeShardedTensorParameter("input_tensor", shape, {32, 32}, /*num_cores=*/2);
-        tp.dynamic_tensor_shape = dynamic;
+        tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = dynamic};
         spec.tensor_parameters = {tp};
         BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
         return spec;
@@ -3055,7 +3055,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlot
     // directly to be robust against BDS-internal flattening conventions.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto tp = MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, 2);
-    tp.dynamic_tensor_shape = true;
+    tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {tp};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -3077,7 +3077,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFie
     // demotion, so num_runtime_field_crta_words should remain zero.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto tp = MakeMinimalTensorParameter("input_tensor");
-    tp.dynamic_tensor_shape = true;
+    tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {tp};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -3116,7 +3116,7 @@ TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
     auto plain_tp = MakeMinimalTensorParameter("plain_tensor");
     auto dyn_tp =
         MakeShardedTensorParameter("dyn_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    dyn_tp.dynamic_tensor_shape = true;
+    dyn_tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {plain_tp, dyn_tp};
     BindTensorParameterToKernel(spec.kernels[0], "plain_tensor", "plain_ta");
     BindTensorParameterToKernel(spec.kernels[0], "dyn_tensor", "dyn_ta");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1531,8 +1531,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelInterScopeFails) {
     spec.program_id = "self_loop_inter";
 
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTER});
+    compute.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTER}}};
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -1558,8 +1558,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnDMKernelFails) {
 
     auto producer = MakeMinimalDMKernel("producer");
     // Misapplied: self-loop scope entries are valid only on compute kernels.
-    producer.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
+    producer.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
     auto consumer = MakeMinimalDMKernel("consumer");
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1583,8 +1583,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeReferencingUnknownDFBFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: there is no DFB named "ghost" in the spec.
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "ghost", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
+    compute.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "ghost", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -1609,8 +1609,8 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopScopeOnNonSelfLoopedDFBFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Misapplied: the kernel only produces; it does not self-loop the DFB.
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
+    compute.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
     auto dm_consumer = MakeMinimalDMKernel("dm_consumer");
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -1636,10 +1636,13 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSelfLoopScopeEntriesFails) {
 
     auto compute = MakeMinimalComputeKernel("compute");
     // Two entries for the same DFB on the same kernel.
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
+    compute.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes =
+            {
+                {.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA},
+                {.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA},
+            },
+    };
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -1709,8 +1712,8 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelExplicitIntraSucceeds) {
     spec.program_id = "self_loop_explicit_intra";
 
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.dfb_compute_self_loop_scopes.push_back(
-        {.dfb_spec_name = "dfb", .scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA});
+    compute.advanced_options = KernelSpecAdvancedOptions{
+        .dfb_compute_self_loop_scopes = {{.dfb_spec_name = "dfb", .scope = DFBComputeSelfLoopScope::Scope::INTRA}}};
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3234,8 +3234,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
     // DFB_A: 512 * 8 = 4096 bytes, DFB_B: 256 * 8 = 2048 bytes — different totals → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/8);
-    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     const NodeCoord node{0, 0};
     auto spec = MakeAliasProgramSpec(node, dfb_a, dfb_b);
@@ -3250,7 +3250,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
     // DFB_A lists DFB_B but DFB_B does not list DFB_A — clique violation → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
-    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
     // dfb_b.alias_with intentionally left empty
 
     const NodeCoord node{0, 0};
@@ -3276,8 +3276,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer = MakeMinimalDMKernel("producer_kernel");
     KernelSpec consumer = MakeMinimalDMKernel("consumer_kernel");
@@ -3306,8 +3306,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/512, /*num_entries=*/8);
-    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
 
     KernelSpec producer_a = MakeMinimalDMKernel("producer_a");
     KernelSpec consumer_a = MakeMinimalDMKernel("consumer_a");
@@ -3338,8 +3338,8 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
 
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/16, /*num_entries=*/2);
-    dfb_a.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_b"}};
-    dfb_b.advanced_options = DataflowBufferSpecAdvancedOptions{.alias_with = {"dfb_a"}};
+    dfb_a.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_b"}};
+    dfb_b.advanced_options = DFBSpecAdvancedOptions{.alias_with = {"dfb_a"}};
     dfb_a.borrowed_from = "borrowed_tensor";
     // dfb_b.borrowed_from intentionally left unset
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -103,12 +103,12 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
-    producer.advanced_options.emplace().num_runtime_varargs = 3;
+    producer.advanced_options.num_runtime_varargs = 3;
 
     // Consumer: NCRISC reads DFB → DRAM
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.emplace().num_runtime_varargs = 3;
+    consumer.advanced_options.num_runtime_varargs = 3;
 
     // DFB: both kernels bind it, with different local accessor names
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries);
@@ -373,7 +373,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // verbatim (positional varargs only).
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.emplace().num_runtime_varargs = 3;
+    consumer.advanced_options.num_runtime_varargs = 3;
 
     auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
     out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -575,12 +575,12 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // Producer (BRISC): reads input tensor via TA binding, pushes to DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp";
-    producer.advanced_options.emplace().num_runtime_varargs = 1;
+    producer.advanced_options.num_runtime_varargs = 1;
 
     // Consumer (NCRISC): pops from DFB, writes output tensor via TA binding
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.emplace().num_runtime_varargs = 1;
+    consumer.advanced_options.num_runtime_varargs = 1;
 
     // DFB connecting the two kernels
     auto dfb = MakeMinimalDFB("input_dfb", page_size, num_dfb_entries);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -132,23 +132,29 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "producer",
-            .runtime_varargs =
-                {{node,
-                  {
-                      input_buffer->address(),
-                      0u,  // bank_id (single-page buffer → bank 0)
-                      num_transfers,
-                  }}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs =
+                        {{node,
+                          {
+                              input_buffer->address(),
+                              0u,  // bank_id (single-page buffer → bank 0)
+                              num_transfers,
+                          }}},
+                },
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
-            .runtime_varargs =
-                {{node,
-                  {
-                      output_buffer->address(),
-                      0u,  // bank_id
-                      num_transfers,
-                  }}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs =
+                        {{node,
+                          {
+                              output_buffer->address(),
+                              0u,  // bank_id
+                              num_transfers,
+                          }}},
+                },
         },
     };
     SetProgramRunParameters(program, params);
@@ -278,15 +284,21 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
             .kernel_spec_name = "producer",
             .named_runtime_args = {{.node = node, .args = {{"src_addr", input_buffer->address()}}}},
             .named_common_runtime_args = {{"num_entries", num_transfers}},
-            .runtime_varargs = {{node, {kProducerRta0, kProducerRta1, kProducerRta2}}},
-            .common_runtime_varargs = {kProducerCrta0},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {kProducerRta0, kProducerRta1, kProducerRta2}}},
+                    .common_runtime_varargs = {kProducerCrta0},
+                },
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
             .named_runtime_args = {{.node = node, .args = {{"dst_addr", output_buffer->address()}}}},
             .named_common_runtime_args = {{"num_entries", num_transfers}},
-            .runtime_varargs = {{node, {kConsumerRta0, kConsumerRta1}}},
-            .common_runtime_varargs = {kConsumerCrta0},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {kConsumerRta0, kConsumerRta1}}},
+                    .common_runtime_varargs = {kConsumerCrta0},
+                },
         },
     };
     SetProgramRunParameters(program, params);
@@ -393,12 +405,18 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
             .kernel_spec_name = "compute",
             .named_runtime_args = {{.node = node, .args = {{"input_offset", kInputOffset}}}},
             .named_common_runtime_args = {{"num_tiles", num_transfers}},
-            .runtime_varargs = {{node, {kVararg0, kVararg1}}},
-            .common_runtime_varargs = {kCommonVararg0},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {kVararg0, kVararg1}}},
+                    .common_runtime_varargs = {kCommonVararg0},
+                },
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
-            .runtime_varargs = {{node, {output_buffer->address(), 0u, num_transfers}}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {output_buffer->address(), 0u, num_transfers}}},
+                },
         },
     };
     SetProgramRunParameters(program, params);
@@ -594,11 +612,17 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "producer",
-            .runtime_varargs = {{node, {num_pages}}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {num_pages}}},
+                },
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "consumer",
-            .runtime_varargs = {{node, {num_pages}}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {num_pages}}},
+                },
         },
     };
     params.tensor_args = {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -103,12 +103,12 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
-    producer.runtime_arguments_schema.num_runtime_varargs = 3;
+    producer.advanced_options.emplace().num_runtime_varargs = 3;
 
     // Consumer: NCRISC reads DFB → DRAM
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.runtime_arguments_schema.num_runtime_varargs = 3;
+    consumer.advanced_options.emplace().num_runtime_varargs = 3;
 
     // DFB: both kernels bind it, with different local accessor names
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries);
@@ -234,8 +234,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp";
     producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
     producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
-    producer.runtime_arguments_schema.num_runtime_varargs = 3;
-    producer.runtime_arguments_schema.num_common_runtime_varargs = 1;
+    producer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
     producer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads DFB → DRAM. Uses default `args` namespace, 1 named RTA,
@@ -245,8 +244,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
     consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
-    consumer.runtime_arguments_schema.num_runtime_varargs = 2;
-    consumer.runtime_arguments_schema.num_common_runtime_varargs = 1;
+    consumer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
     consumer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries_in_dfb);
@@ -356,15 +354,14 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
     compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
     compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
-    compute.runtime_arguments_schema.num_runtime_varargs = 2;
-    compute.runtime_arguments_schema.num_common_runtime_varargs = 1;
+    compute.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
     compute.compile_time_arg_bindings = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
     // verbatim (positional varargs only).
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.runtime_arguments_schema.num_runtime_varargs = 3;
+    consumer.advanced_options.emplace().num_runtime_varargs = 3;
 
     auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
     out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
@@ -560,12 +557,12 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // Producer (BRISC): reads input tensor via TA binding, pushes to DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp";
-    producer.runtime_arguments_schema.num_runtime_varargs = 1;
+    producer.advanced_options.emplace().num_runtime_varargs = 1;
 
     // Consumer (NCRISC): pops from DFB, writes output tensor via TA binding
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp";
-    consumer.runtime_arguments_schema.num_runtime_varargs = 1;
+    consumer.advanced_options.emplace().num_runtime_varargs = 1;
 
     // DFB connecting the two kernels
     auto dfb = MakeMinimalDFB("input_dfb", page_size, num_dfb_entries);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -102,14 +102,12 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
     // Producer: BRISC reads from DRAM → DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp";
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // Consumer: NCRISC reads DFB → DRAM
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     // DFB: both kernels bind it, with different local accessor names
@@ -233,8 +231,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // Producer: BRISC reads DRAM → DFB. 1 named RTA, 1 named CRTA, 2 named CTAs, 3 RTA
     // varargs, 1 CRTA vararg.
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp";
     producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
     producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
     producer.runtime_arguments_schema.num_runtime_varargs = 3;
@@ -245,8 +242,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     // 1 named CRTA, 2 named CTAs, 2 RTA varargs (note: different count from producer —
     // this verifies the named_rta_words offset is baked per-kernel), 1 CRTA vararg.
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
     consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
     consumer.runtime_arguments_schema.num_runtime_varargs = 2;
@@ -357,8 +353,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // Compute kernel: produces out_dfb. The kernel under test — exercises every
     // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
     auto compute = MakeMinimalComputeKernel("compute");
-    compute.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp"};
+    compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
     compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
     compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
     compute.runtime_arguments_schema.num_runtime_varargs = 2;
@@ -368,8 +363,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
     // verbatim (positional varargs only).
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source =
-        KernelSpec::SourceFilePath{"tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 3;
 
     auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
@@ -464,8 +458,8 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     KernelSpec producer{
         .unique_id = "producer",
         .source =
-            KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
         .config_spec =
@@ -479,8 +473,8 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     KernelSpec consumer{
         .unique_id = "consumer",
         .source =
-            KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
         .config_spec =
@@ -565,14 +559,12 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 
     // Producer (BRISC): reads input tensor via TA binding, pushes to DFB
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
-    producer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp"};
+    producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp";
     producer.runtime_arguments_schema.num_runtime_varargs = 1;
 
     // Consumer (NCRISC): pops from DFB, writes output tensor via TA binding
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
-    consumer.source = KernelSpec::SourceFilePath{
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp"};
+    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.num_runtime_varargs = 1;
 
     // DFB connecting the two kernels

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -240,7 +240,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     producer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp";
     producer.runtime_arguments_schema.named_runtime_args = {"src_addr"};
     producer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
-    producer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
+    producer.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 3, .num_common_runtime_varargs = 1};
     producer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads DFB → DRAM. Uses default `args` namespace, 1 named RTA,
@@ -250,7 +250,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp";
     consumer.runtime_arguments_schema.named_runtime_args = {"dst_addr"};
     consumer.runtime_arguments_schema.named_common_runtime_args = {"num_entries"};
-    consumer.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
+    consumer.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
     consumer.compile_time_arg_bindings = {{"bank_id", 0}, {"entry_size", entry_size}};
 
     auto dfb = MakeMinimalDFB("loopback_dfb", entry_size, num_entries_in_dfb);
@@ -366,7 +366,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
     compute.runtime_arguments_schema.named_runtime_args = {"input_offset"};
     compute.runtime_arguments_schema.named_common_runtime_args = {"num_tiles"};
-    compute.advanced_options = KernelSpecAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
+    compute.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
     compute.compile_time_arg_bindings = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
 
     // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -253,8 +253,8 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = L1_DFB,
@@ -270,8 +270,8 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = L1_DFB,
@@ -449,8 +449,8 @@ bool reader_datacopy_writer(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -466,8 +466,8 @@ bool reader_datacopy_writer(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp",
         .num_threads = num_threads,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -483,8 +483,8 @@ bool reader_datacopy_writer(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp",
         .num_threads = num_threads,
         .dfb_bindings =
             {{

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -92,14 +92,14 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
 
     if (is_quasar) {
         auto spec = MakeMinimalDMKernel("dm_barrier_kernel", static_cast<uint8_t>(expected_num_threads));
-        spec.source = KernelSpec::SourceFilePath{kKernelPath};
+        spec.source = kKernelPath;
         spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
         kernel_configs.push_back({"dm_barrier_kernel", spec, make_layout(l1_base, kRounds)});
         work_unit_kernel_names = {"dm_barrier_kernel"};
     } else {
         auto make_gen1 = [&](const std::string& name, tt::tt_metal::DataMovementProcessor proc, uint32_t layout_base) {
             auto spec = MakeMinimalGen1DMKernel(name, proc);
-            spec.source = KernelSpec::SourceFilePath{kKernelPath};
+            spec.source = kKernelPath;
             spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
             return KernelConfig{name, spec, make_layout(layout_base, kRounds)};
         };

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -94,7 +94,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     std::vector<std::string> work_unit_kernel_names;
 
     if (is_quasar) {
-        auto spec = MakeMinimalDMKernel("dm_barrier_kernel", static_cast<uint8_t>(expected_num_threads));
+        auto spec = MakeMinimalDMKernel("dm_barrier_kernel", expected_num_threads);
         spec.source = kKernelPath;
         spec.advanced_options.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
         kernel_configs.push_back({"dm_barrier_kernel", spec, make_layout(l1_base, kRounds)});

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -96,14 +96,14 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     if (is_quasar) {
         auto spec = MakeMinimalDMKernel("dm_barrier_kernel", static_cast<uint8_t>(expected_num_threads));
         spec.source = kKernelPath;
-        spec.advanced_options.emplace().num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
+        spec.advanced_options.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
         kernel_configs.push_back({"dm_barrier_kernel", spec, make_layout(l1_base, kRounds)});
         work_unit_kernel_names = {"dm_barrier_kernel"};
     } else {
         auto make_gen1 = [&](const std::string& name, tt::tt_metal::DataMovementProcessor proc, uint32_t layout_base) {
             auto spec = MakeMinimalGen1DMKernel(name, proc);
             spec.source = kKernelPath;
-            spec.advanced_options.emplace().num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
+            spec.advanced_options.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
             return KernelConfig{name, spec, make_layout(layout_base, kRounds)};
         };
         kernel_configs.push_back(make_gen1("brisc_barrier_kernel", tt::tt_metal::DataMovementProcessor::RISCV_0, l1_base));

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -54,16 +54,19 @@ ProgramRunParams::KernelRunParams make_run_params(
     const KernelSpecName& kernel_name, const NodeCoord& node, const ScratchLayout& layout, uint32_t rounds, uint32_t skew_iters) {
     return ProgramRunParams::KernelRunParams{
         .kernel_spec_name = kernel_name,
-        .runtime_varargs =
-            {{node,
-              {
-                  layout.arrivals_addr,
-                  layout.observed_addr,
-                  layout.post_addr,
-                  rounds,
-                  skew_iters,
-                  layout.total_words,
-              }}},
+        .advanced_options =
+            AdvancedKernelRunParams{
+                .runtime_varargs =
+                    {{node,
+                      {
+                          layout.arrivals_addr,
+                          layout.observed_addr,
+                          layout.post_addr,
+                          rounds,
+                          skew_iters,
+                          layout.total_words,
+                      }}},
+            },
     };
 }
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -93,14 +93,14 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     if (is_quasar) {
         auto spec = MakeMinimalDMKernel("dm_barrier_kernel", static_cast<uint8_t>(expected_num_threads));
         spec.source = kKernelPath;
-        spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
+        spec.advanced_options.emplace().num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
         kernel_configs.push_back({"dm_barrier_kernel", spec, make_layout(l1_base, kRounds)});
         work_unit_kernel_names = {"dm_barrier_kernel"};
     } else {
         auto make_gen1 = [&](const std::string& name, tt::tt_metal::DataMovementProcessor proc, uint32_t layout_base) {
             auto spec = MakeMinimalGen1DMKernel(name, proc);
             spec.source = kKernelPath;
-            spec.runtime_arguments_schema.num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
+            spec.advanced_options.emplace().num_runtime_varargs_per_node = {{node, kKernelArgsCount}};
             return KernelConfig{name, spec, make_layout(layout_base, kRounds)};
         };
         kernel_configs.push_back(make_gen1("brisc_barrier_kernel", tt::tt_metal::DataMovementProcessor::RISCV_0, l1_base));

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -138,12 +138,12 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
             "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
         .num_threads = num_threads,
         .compiler_options = {.defines = dm_defines},
-        .runtime_arguments_schema =
-            {
+        .config_spec = dm_cfg,
+        .advanced_options =
+            experimental::metal2_host_api::KernelSpecAdvancedOptions{
                 .num_runtime_varargs = num_unique_rt_args,
                 .num_common_runtime_varargs = common_rtas ? num_unique_rt_args : 0u,
             },
-        .config_spec = dm_cfg,
     };
 
     experimental::metal2_host_api::WorkUnitSpec wu{
@@ -216,15 +216,15 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                 "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
             .num_threads = static_cast<uint8_t>(dm_processors_per_kernel),
             .compiler_options = {.defines = defines_vec},
-            .runtime_arguments_schema =
-                {
-                    .num_runtime_varargs = num_runtime_args,
-                    .num_common_runtime_varargs = common_rtas ? num_runtime_args : 0,
-                },
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{
                     .gen2_data_movement_config =
                         experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+            .advanced_options =
+                experimental::metal2_host_api::KernelSpecAdvancedOptions{
+                    .num_runtime_varargs = num_runtime_args,
+                    .num_common_runtime_varargs = common_rtas ? static_cast<size_t>(num_runtime_args) : size_t{0},
+                },
         });
         wu_kernel_names.push_back(kernel_names[k]);
     }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -134,8 +134,8 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
     experimental::metal2_host_api::KernelSpec kernel_spec{
         .unique_id = KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
         .num_threads = num_threads,
         .compiler_options = {.defines = dm_defines},
         .runtime_arguments_schema =
@@ -212,8 +212,8 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = kernel_names[k],
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
             .num_threads = static_cast<uint8_t>(dm_processors_per_kernel),
             .compiler_options = {.defines = defines_vec},
             .runtime_arguments_schema =

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -129,7 +129,7 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
         .gen2_data_movement_config = experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{},
     };
     const bool is_quasar = MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
-    const uint8_t num_threads = is_quasar ? static_cast<uint8_t>(kQuasarNumUserDms) : uint8_t{1};
+    const uint32_t num_threads = is_quasar ? kQuasarNumUserDms : 1u;
 
     experimental::metal2_host_api::KernelSpec kernel_spec{
         .unique_id = KERNEL,
@@ -214,7 +214,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
             .source =
 
                 "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel_2_0.cpp",
-            .num_threads = static_cast<uint8_t>(dm_processors_per_kernel),
+            .num_threads = dm_processors_per_kernel,
             .compiler_options = {.defines = defines_vec},
             .config_spec =
                 experimental::metal2_host_api::DataMovementConfiguration{

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -1002,8 +1002,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTASharedL1Address) {
     experimental::metal2_host_api::ProgramRunParams params;
     params.kernel_run_params = {{
         .kernel_spec_name = kernel_names[0],
-        .runtime_varargs = {{core, std::vector<uint32_t>(common_rtas.size(), 0)}},
-        .common_runtime_varargs = common_rtas,
+        .advanced_options =
+            experimental::metal2_host_api::AdvancedKernelRunParams{
+                .runtime_varargs = {{core, std::vector<uint32_t>(common_rtas.size(), 0)}},
+                .common_runtime_varargs = common_rtas,
+            },
     }};
     experimental::metal2_host_api::SetProgramRunParameters(program, params);
 
@@ -1041,8 +1044,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
         all_crtas[i] = kernel_crtas;
         params.kernel_run_params.push_back({
             .kernel_spec_name = kernel_names[i],
-            .runtime_varargs = {{core, std::vector<uint32_t>(base_crtas.size(), 0)}},
-            .common_runtime_varargs = kernel_crtas,
+            .advanced_options =
+                experimental::metal2_host_api::AdvancedKernelRunParams{
+                    .runtime_varargs = {{core, std::vector<uint32_t>(base_crtas.size(), 0)}},
+                    .common_runtime_varargs = kernel_crtas,
+                },
         });
     }
     experimental::metal2_host_api::SetProgramRunParameters(program, params);

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -140,7 +140,7 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
         .compiler_options = {.defines = dm_defines},
         .config_spec = dm_cfg,
         .advanced_options =
-            experimental::metal2_host_api::KernelSpecAdvancedOptions{
+            experimental::metal2_host_api::KernelAdvancedOptions{
                 .num_runtime_varargs = num_unique_rt_args,
                 .num_common_runtime_varargs = common_rtas ? num_unique_rt_args : 0u,
             },
@@ -221,7 +221,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
                     .gen2_data_movement_config =
                         experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
             .advanced_options =
-                experimental::metal2_host_api::KernelSpecAdvancedOptions{
+                experimental::metal2_host_api::KernelAdvancedOptions{
                     .num_runtime_varargs = num_runtime_args,
                     .num_common_runtime_varargs = common_rtas ? static_cast<size_t>(num_runtime_args) : size_t{0},
                 },

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -55,8 +55,8 @@ bool run_l2_flush_test(
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp"},
+
+            "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {
@@ -147,8 +147,8 @@ bool run_l1_dcache_test(
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp"},
+
+            "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_addrgen/test_addrgen_example.cpp
@@ -37,7 +37,7 @@ bool run_addrgen_test(
 
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings =
             {{"src_stride_en", src_stride_en},

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -37,7 +37,7 @@ static void run_kernel(
 
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings = std::move(compile_time_arg_bindings),
         .config_spec =

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_im2col/test_im2col_example.cpp
@@ -33,7 +33,7 @@ bool run_im2col_test(
 
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = 1,
         .compile_time_arg_bindings = {{"num_of_addresses", num_of_addresses}},
         .config_spec =

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -84,7 +84,7 @@ static void RunTest(
             virtual_core = device->worker_core_from_logical_core(logical_core);
             experimental::metal2_host_api::KernelSpec assert_kernel_spec{
                 .unique_id = ASSERT_KERNEL_NAME,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel},
+                .source = kernel,
                 .runtime_arguments_schema = {.named_runtime_args = {"a", "b", "assert_type", "hw_assert_cause"}},
             };
             switch (processor.processor_class) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -80,7 +80,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     std::vector<experimental::metal2_host_api::KernelSpecName> kernel_names;
     std::vector<experimental::metal2_host_api::ProgramRunParams::KernelRunParams> kernel_run_params;
     auto add_dm_kernel =
-        [&](const char* name, uint8_t num_threads, std::optional<tt::tt_metal::DataMovementProcessor> gen1_processor) {
+        [&](const char* name, uint32_t num_threads, std::optional<tt::tt_metal::DataMovementProcessor> gen1_processor) {
             // Always provide both gen1 and gen2 configs; the runtime picks the one matching the
             // current arch. The unused config is ignored on the other arch.
             auto gen1_proc = gen1_processor.value_or(tt::tt_metal::DataMovementProcessor::RISCV_0);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -96,7 +96,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             };
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = name,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+                .source = path_metal2,
                 .num_threads = num_threads,
                 .runtime_arguments_schema = {.named_common_runtime_args = {"wait_cycles"}},
                 .config_spec = dm_cfg,
@@ -120,7 +120,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         constexpr const char* COMPUTE_KERNEL_NAME = "pause_compute";
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = COMPUTE_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+            .source = path_metal2,
             .num_threads = 1,
             .runtime_arguments_schema = {.named_common_runtime_args = {"wait_cycles"}},
             .config_spec = experimental::metal2_host_api::ComputeConfiguration{},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -145,7 +145,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
 
         experimental::metal2_host_api::KernelSpec dm_spec{
             .unique_id = DM_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+            .source = rta_crta_kernel_path,
             .num_threads = 1,
             .compile_time_arg_bindings = {{"l1_scratch_addr", l1_unreserved_base}},
             .config_spec =
@@ -156,7 +156,7 @@ TEST_F(RTATestFixture, SentinelPatternHandlingAndMissingRTADetection) {
         };
         experimental::metal2_host_api::KernelSpec compute_spec{
             .unique_id = COMPUTE_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+            .source = rta_crta_kernel_path,
             .num_threads = 1,
             .compile_time_arg_bindings = {{"l1_scratch_addr", compute_scratch_addr}},
             .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
@@ -272,7 +272,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
 
     experimental::metal2_host_api::KernelSpec dm_spec{
         .unique_id = DM_KERNEL_NAME,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+        .source = rta_crta_kernel_path,
         .num_threads = is_quasar ? static_cast<uint8_t>(num_dms_) : uint8_t{1},
         .runtime_arguments_schema =
             {.num_runtime_varargs = default_rtas.size(), .num_common_runtime_varargs = default_crtas.size()},
@@ -395,7 +395,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
     experimental::metal2_host_api::KernelSpec kspec{
         .unique_id = OOB_KERNEL_NAME,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+        .source = rta_crta_kernel_path,
         .compiler_options = {.defines = m2_defines},
         .runtime_arguments_schema = schema,
     };
@@ -468,7 +468,7 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
     constexpr const char* MULTI_DM_KERNEL_NAME = "multi_dm_oob";
     experimental::metal2_host_api::KernelSpec dm_spec{
         .unique_id = MULTI_DM_KERNEL_NAME,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{rta_crta_kernel_path},
+        .source = rta_crta_kernel_path,
         .num_threads = static_cast<uint8_t>(num_dms_),
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -274,9 +274,12 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
         .unique_id = DM_KERNEL_NAME,
         .source = rta_crta_kernel_path,
         .num_threads = is_quasar ? static_cast<uint8_t>(num_dms_) : uint8_t{1},
-        .runtime_arguments_schema =
-            {.num_runtime_varargs = default_rtas.size(), .num_common_runtime_varargs = default_crtas.size()},
         .config_spec = dm_cfg,
+        .advanced_options =
+            experimental::metal2_host_api::KernelSpecAdvancedOptions{
+                .num_runtime_varargs = default_rtas.size(),
+                .num_common_runtime_varargs = default_crtas.size(),
+            },
     };
     if (is_quasar) {
         dm_spec.compile_time_arg_bindings = {{"dm_id", 0}, {"l1_scratch_addr", l1_unreserved_base}};
@@ -386,18 +389,18 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
     // RTA test reads index == default_rtas.size() (one past the end), so the kernel must declare
     // exactly default_rtas.size() varargs to make that access OOB.
-    experimental::metal2_host_api::KernelSpec::RuntimeArgSchema schema;
+    experimental::metal2_host_api::KernelSpecAdvancedOptions adv_opts;
     if (params.test_rta) {
-        schema.num_runtime_varargs = default_rtas.size();
+        adv_opts.num_runtime_varargs = default_rtas.size();
     } else {
-        schema.num_common_runtime_varargs = default_crtas.size();
+        adv_opts.num_common_runtime_varargs = default_crtas.size();
     }
 
     experimental::metal2_host_api::KernelSpec kspec{
         .unique_id = OOB_KERNEL_NAME,
         .source = rta_crta_kernel_path,
         .compiler_options = {.defines = m2_defines},
-        .runtime_arguments_schema = schema,
+        .advanced_options = adv_opts,
     };
     if (params.processor_class == HalProcessorClassType::DM) {
         if (is_quasar) {
@@ -473,11 +476,14 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
         .compile_time_arg_bindings = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},
-        .runtime_arguments_schema = {.num_runtime_varargs = default_rtas.size()},
         .config_spec =
             experimental::metal2_host_api::DataMovementConfiguration{
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
+        .advanced_options =
+            experimental::metal2_host_api::KernelSpecAdvancedOptions{
+                .num_runtime_varargs = default_rtas.size(),
+            },
     };
     experimental::metal2_host_api::WorkUnitSpec wu{
         .unique_id = "main",

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -273,7 +273,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
     experimental::metal2_host_api::KernelSpec dm_spec{
         .unique_id = DM_KERNEL_NAME,
         .source = rta_crta_kernel_path,
-        .num_threads = is_quasar ? static_cast<uint8_t>(num_dms_) : uint8_t{1},
+        .num_threads = is_quasar ? num_dms_ : 1u,
         .config_spec = dm_cfg,
         .advanced_options =
             experimental::metal2_host_api::KernelAdvancedOptions{
@@ -408,7 +408,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
     };
     if (params.processor_class == HalProcessorClassType::DM) {
         if (is_quasar) {
-            kspec.num_threads = static_cast<uint8_t>(num_dms_);
+            kspec.num_threads = num_dms_;
             kspec.compile_time_arg_bindings = {{"dm_id", 0}};
         } else {
             kspec.num_threads = 1;
@@ -476,7 +476,7 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
     experimental::metal2_host_api::KernelSpec dm_spec{
         .unique_id = MULTI_DM_KERNEL_NAME,
         .source = rta_crta_kernel_path,
-        .num_threads = static_cast<uint8_t>(num_dms_),
+        .num_threads = num_dms_,
         .compiler_options =
             {.defines = {{"MAX_RTA_IDX", std::to_string(default_rtas.size())}, {"TEST_MULTI_DM_RTA", "1"}}},
         .compile_time_arg_bindings = {{"num_dms", num_dms_}, {"l1_sync_addr", l1_unreserved_base}},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -303,14 +303,19 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
         experimental::metal2_host_api::ProgramRunParams params;
         experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{
             .kernel_spec_name = DM_KERNEL_NAME,
-            .common_runtime_varargs = default_crtas,
+            .advanced_options =
+                experimental::metal2_host_api::AdvancedKernelRunParams{
+                    .common_runtime_varargs = default_crtas,
+                },
         };
         for (const auto& c : core_range1) {
-            krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+            krp.advanced_options->runtime_varargs.push_back(
+                {experimental::metal2_host_api::NodeCoord{c}, default_rtas});
         }
         if (!is_quasar) {
             for (const auto& c : core_range2) {
-                krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, rtas_range2});
+                krp.advanced_options->runtime_varargs.push_back(
+                    {experimental::metal2_host_api::NodeCoord{c}, rtas_range2});
             }
         }
         params.kernel_run_params = {krp};
@@ -438,12 +443,14 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
     experimental::metal2_host_api::ProgramRunParams params_m2;
     experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = OOB_KERNEL_NAME};
+    krp.advanced_options.emplace();
     if (params.test_rta) {
         for (const auto& c : core_range) {
-            krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+            krp.advanced_options->runtime_varargs.push_back(
+                {experimental::metal2_host_api::NodeCoord{c}, default_rtas});
         }
     } else {
-        krp.common_runtime_varargs = default_crtas;
+        krp.advanced_options->common_runtime_varargs = default_crtas;
     }
     params_m2.kernel_run_params = {krp};
     experimental::metal2_host_api::SetProgramRunParameters(program, params_m2);
@@ -499,8 +506,9 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
 
     experimental::metal2_host_api::ProgramRunParams params;
     experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = MULTI_DM_KERNEL_NAME};
+    krp.advanced_options.emplace();
     for (const auto& c : core_range) {
-        krp.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+        krp.advanced_options->runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
     }
     params.kernel_run_params = {krp};
     experimental::metal2_host_api::SetProgramRunParameters(program, params);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -309,12 +309,11 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
                 },
         };
         for (const auto& c : core_range1) {
-            krp.advanced_options->runtime_varargs.push_back(
-                {experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+            krp.advanced_options.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
         }
         if (!is_quasar) {
             for (const auto& c : core_range2) {
-                krp.advanced_options->runtime_varargs.push_back(
+                krp.advanced_options.runtime_varargs.push_back(
                     {experimental::metal2_host_api::NodeCoord{c}, rtas_range2});
             }
         }
@@ -443,14 +442,12 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
     experimental::metal2_host_api::ProgramRunParams params_m2;
     experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = OOB_KERNEL_NAME};
-    krp.advanced_options.emplace();
     if (params.test_rta) {
         for (const auto& c : core_range) {
-            krp.advanced_options->runtime_varargs.push_back(
-                {experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+            krp.advanced_options.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
         }
     } else {
-        krp.advanced_options->common_runtime_varargs = default_crtas;
+        krp.advanced_options.common_runtime_varargs = default_crtas;
     }
     params_m2.kernel_run_params = {krp};
     experimental::metal2_host_api::SetProgramRunParameters(program, params_m2);
@@ -506,9 +503,8 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
 
     experimental::metal2_host_api::ProgramRunParams params;
     experimental::metal2_host_api::ProgramRunParams::KernelRunParams krp{.kernel_spec_name = MULTI_DM_KERNEL_NAME};
-    krp.advanced_options.emplace();
     for (const auto& c : core_range) {
-        krp.advanced_options->runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
+        krp.advanced_options.runtime_varargs.push_back({experimental::metal2_host_api::NodeCoord{c}, default_rtas});
     }
     params.kernel_run_params = {krp};
     experimental::metal2_host_api::SetProgramRunParameters(program, params);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_runtime_args_known_garbage.cpp
@@ -276,7 +276,7 @@ TEST_F(RTATestFixture, CorrectArgDispatchAndPayloadValidation) {
         .num_threads = is_quasar ? static_cast<uint8_t>(num_dms_) : uint8_t{1},
         .config_spec = dm_cfg,
         .advanced_options =
-            experimental::metal2_host_api::KernelSpecAdvancedOptions{
+            experimental::metal2_host_api::KernelAdvancedOptions{
                 .num_runtime_varargs = default_rtas.size(),
                 .num_common_runtime_varargs = default_crtas.size(),
             },
@@ -394,7 +394,7 @@ TEST_P(RTAAssertTest, OutOfBoundsArgAccessDetection) {
 
     // RTA test reads index == default_rtas.size() (one past the end), so the kernel must declare
     // exactly default_rtas.size() varargs to make that access OOB.
-    experimental::metal2_host_api::KernelSpecAdvancedOptions adv_opts;
+    experimental::metal2_host_api::KernelAdvancedOptions adv_opts;
     if (params.test_rta) {
         adv_opts.num_runtime_varargs = default_rtas.size();
     } else {
@@ -488,7 +488,7 @@ TEST_F(RTATestFixture, QuasarMultiDMOutOfBoundsArgDetection) {
                 .gen2_data_movement_config =
                     experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{}},
         .advanced_options =
-            experimental::metal2_host_api::KernelSpecAdvancedOptions{
+            experimental::metal2_host_api::KernelAdvancedOptions{
                 .num_runtime_varargs = default_rtas.size(),
             },
     };

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -236,7 +236,7 @@ void RunTestOnCore(
             .gen2_data_movement_config =
                 experimental::metal2_host_api::DataMovementConfiguration::Gen2DataMovementConfig{},
         };
-        uint8_t num_threads = is_quasar ? 6 : 1;
+        uint32_t num_threads = is_quasar ? 6u : 1u;
         if (!is_quasar) {
             noc = static_cast<int>(gen1_noc);
         }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -242,7 +242,7 @@ void RunTestOnCore(
         }
         experimental::metal2_host_api::KernelSpec dm_spec{
             .unique_id = DRAM_COPY_KERNEL_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_metal2},
+            .source = kernel_metal2,
             .num_threads = num_threads,
             .compiler_options = {.defines = defines},
             .compile_time_arg_bindings = cta_bindings,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -87,7 +87,7 @@ void RunOneTest(
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = name,
                 .source = path_metal2,
-                .num_threads = static_cast<uint8_t>(dms_per_kernel),
+                .num_threads = dms_per_kernel,
                 .compile_time_arg_bindings = {{"usage", free}},
                 .config_spec =
                     experimental::metal2_host_api::DataMovementConfiguration{

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -86,7 +86,7 @@ void RunOneTest(
             std::string name = fmt::format("dm_{}", i);
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = name,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+                .source = path_metal2,
                 .num_threads = static_cast<uint8_t>(dms_per_kernel),
                 .compile_time_arg_bindings = {{"usage", free}},
                 .config_spec =
@@ -99,7 +99,7 @@ void RunOneTest(
         constexpr const char* COMPUTE_NAME = "compute";
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = COMPUTE_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+            .source = path_metal2,
             // One thread per Neo (Quasar Tensix has 4) so the compute kernel fans out across
             // all Neos; each Neo internally runs the kernel on its 4 TRISCs.
             .num_threads = 4,
@@ -117,7 +117,7 @@ void RunOneTest(
             auto noc = (type_idx == 1) ? tt::tt_metal::NOC::RISCV_1_default : tt::tt_metal::NOC::RISCV_0_default;
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = name,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+                .source = path_metal2,
                 .num_threads = 1,
                 .compile_time_arg_bindings = {{"usage", free}},
                 .config_spec =
@@ -131,7 +131,7 @@ void RunOneTest(
         constexpr const char* COMPUTE_NAME = "compute";
         kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
             .unique_id = COMPUTE_NAME,
-            .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{path_metal2},
+            .source = path_metal2,
             .num_threads = 1,
             .compile_time_arg_bindings = {{"usage", free}},
             .config_spec = experimental::metal2_host_api::ComputeConfiguration{},

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -80,7 +80,7 @@ void RunTest(
 
     experimental::metal2_host_api::KernelSpec producer_spec{
         .unique_id = PRODUCER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = NUM_PRODUCERS,
         .compiler_options = {.defines = {{"DFB_PRODUCER", "1"}}},
         .dfb_bindings = {{
@@ -102,7 +102,7 @@ void RunTest(
     uint32_t entries_per_consumer = use_remapper ? NUM_ENTRIES_PER_DFB : NUM_ENTRIES_PER_CONSUMER;
     experimental::metal2_host_api::KernelSpec consumer_spec{
         .unique_id = CONSUMER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+        .source = kernel_path,
         .num_threads = NUM_CONSUMERS,
         .dfb_bindings = {{
             .dfb_spec_name = TILE_COUNTER_DFB,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -99,7 +99,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     std::vector<experimental::metal2_host_api::KernelSpecName> kernel_names;
     std::vector<experimental::metal2_host_api::ProgramRunParams::KernelRunParams> kernel_run_params;
     auto add_dm_kernel =
-        [&](const char* name, uint8_t num_threads, std::optional<tt::tt_metal::DataMovementProcessor> gen1_processor) {
+        [&](const char* name, uint32_t num_threads, std::optional<tt::tt_metal::DataMovementProcessor> gen1_processor) {
             // Always provide both gen1 and gen2 configs; the runtime picks the one matching the
             // current arch. The unused config is ignored on the other arch.
             auto gen1_proc = gen1_processor.value_or(tt::tt_metal::DataMovementProcessor::RISCV_0);
@@ -139,7 +139,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
         .unique_id = COMPUTE_KERNEL_NAME,
         .source = kernel_path_metal2,
         // Quasar Tensix has 4 Neos so the compute kernel fans out across all of them; WH/BH has 1 TRISC group.
-        .num_threads = static_cast<uint8_t>(is_quasar ? 4 : 1),
+        .num_threads = is_quasar ? 4u : 1u,
         .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
         .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
     });

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -115,7 +115,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
             };
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = name,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path_metal2},
+                .source = kernel_path_metal2,
                 .num_threads = num_threads,
                 .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},
                 .config_spec = dm_cfg,
@@ -137,7 +137,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     }
     kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
         .unique_id = COMPUTE_KERNEL_NAME,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path_metal2},
+        .source = kernel_path_metal2,
         // Quasar Tensix has 4 Neos so the compute kernel fans out across all of them; WH/BH has 1 TRISC group.
         .num_threads = static_cast<uint8_t>(is_quasar ? 4 : 1),
         .runtime_arguments_schema = {.named_common_runtime_args = {"sync_flag_addr"}},

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -253,7 +253,7 @@ static void matmul_tile_block(
 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{cfg.reader_kernel},
+        .source = cfg.reader_kernel,
         .num_threads = 1,
         .dfb_bindings =
             {{
@@ -292,8 +292,8 @@ static void matmul_tile_block(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
@@ -339,7 +339,7 @@ static void matmul_tile_block(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{cfg.compute_kernel},
+        .source = cfg.compute_kernel,
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -316,8 +316,8 @@ void run_single_core_broadcast(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {{
@@ -347,8 +347,8 @@ void run_single_core_broadcast(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -370,8 +370,8 @@ void run_single_core_broadcast(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/broadcast_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/broadcast_2_0.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = defines_vec},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -115,8 +115,8 @@ void run_single_core_copy_block_matmul_partials(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = SRC0_DFB,
@@ -139,8 +139,8 @@ void run_single_core_copy_block_matmul_partials(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
@@ -168,8 +168,8 @@ void run_single_core_copy_block_matmul_partials(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -83,8 +83,8 @@ static vector<uint32_t> run_mxfp4_typecast(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -103,8 +103,8 @@ static vector<uint32_t> run_mxfp4_typecast(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -123,8 +123,8 @@ static vector<uint32_t> run_mxfp4_typecast(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {{

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -436,8 +436,8 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_six_input.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_six_input.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {dfb_binding(INP0_DFB, DFBEndpoint::PRODUCER),
@@ -470,8 +470,7 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
 
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{"tt_metal/kernels/dataflow/writer_unary.cpp"},
+        .source = "tt_metal/kernels/dataflow/writer_unary.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -490,8 +489,8 @@ bool single_core_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>&
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/reconfig_quasar.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/reconfig_quasar.cpp",
         .num_threads = 1,
         .dfb_bindings =
             {dfb_binding(INP0_DFB, DFBEndpoint::CONSUMER),

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -362,7 +362,7 @@ void run_single_core_reduce_program(
 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{reader_kernel_path},
+        .source = reader_kernel_path,
         .num_threads = 1,
         .compiler_options = {.defines = reader_defines},
         .dfb_bindings =
@@ -394,8 +394,8 @@ void run_single_core_reduce_program(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
@@ -417,8 +417,7 @@ void run_single_core_reduce_program(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{get_compute_kernel_name(test_config.reduce_dim)},
+        .source = get_compute_kernel_name(test_config.reduce_dim),
         .num_threads = 1,
         .compiler_options = {.defines = build_reduce_defines(test_config)},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -232,8 +232,8 @@ bool run_sfpu_all_same_buffer(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = IN_DFB,
@@ -254,8 +254,8 @@ bool run_sfpu_all_same_buffer(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -281,8 +281,8 @@ bool run_sfpu_all_same_buffer(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_sfpu_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_sfpu_2_0.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = std::move(compute_defines)},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -307,8 +307,8 @@ bool single_core_binary(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_2_0.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =
@@ -346,8 +346,8 @@ bool single_core_binary(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUT_DFB,
@@ -369,8 +369,8 @@ bool single_core_binary(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_2_0.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = defines},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -195,8 +195,8 @@ void run_single_core_transpose(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -219,8 +219,8 @@ void run_single_core_transpose(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -251,7 +251,7 @@ void run_single_core_transpose(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{compute_kernel_path},
+        .source = compute_kernel_path,
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -324,9 +324,7 @@ void run_single_core_unary_broadcast_quasar(
 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n_2_0.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = SRC_DFB,
@@ -348,9 +346,7 @@ void run_single_core_unary_broadcast_quasar(
 
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = DST_DFB,
@@ -375,9 +371,7 @@ void run_single_core_unary_broadcast_quasar(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast.cpp"},
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -257,7 +257,7 @@ void run_single_core_tilize_program(
 
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{reader_kernel_path},
+        .source = reader_kernel_path,
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -278,8 +278,8 @@ void run_single_core_tilize_program(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -329,7 +329,7 @@ void run_single_core_tilize_program(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{compute_kernel},
+        .source = compute_kernel,
         .num_threads = 1,
         .compiler_options = {.defines = compute_defines},
         .dfb_bindings =
@@ -779,8 +779,8 @@ static void run_quasar_tilize_untilize_test(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -799,8 +799,8 @@ static void run_quasar_tilize_untilize_test(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -849,7 +849,7 @@ static void run_quasar_tilize_untilize_test(
 
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
-        .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{compute_kernel},
+        .source = compute_kernel,
         .num_threads = 1,
         .dfb_bindings =
             {{

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -125,8 +125,8 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp",
         .num_threads = static_cast<uint8_t>(p.num_threads),
         .dfb_bindings =
             {{.dfb_spec_name = SRC0_DFB,
@@ -151,8 +151,8 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp",
         .num_threads = static_cast<uint8_t>(p.num_threads),
         .dfb_bindings =
             {{.dfb_spec_name = DST_DFB,
@@ -168,8 +168,8 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp",
         .num_threads = static_cast<uint8_t>(p.num_threads),
         .dfb_bindings =
             {{.dfb_spec_name = SRC0_DFB,

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -127,7 +127,7 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp",
-        .num_threads = static_cast<uint8_t>(p.num_threads),
+        .num_threads = p.num_threads,
         .dfb_bindings =
             {{.dfb_spec_name = SRC0_DFB,
               .local_accessor_name = "src0",
@@ -153,7 +153,7 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp",
-        .num_threads = static_cast<uint8_t>(p.num_threads),
+        .num_threads = p.num_threads,
         .dfb_bindings =
             {{.dfb_spec_name = DST_DFB,
               .local_accessor_name = "dst",
@@ -170,7 +170,7 @@ experimental::metal2_host_api::ProgramSpec build_bmm_program_spec(
         .source =
 
             "tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp",
-        .num_threads = static_cast<uint8_t>(p.num_threads),
+        .num_threads = p.num_threads,
         .dfb_bindings =
             {{.dfb_spec_name = SRC0_DFB,
               .local_accessor_name = "src0",

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -65,8 +65,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = id,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp"},
+
+                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1.cpp",
             .num_threads = 1,
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =
@@ -84,8 +84,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = id,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp"},
+
+                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram.cpp",
             .num_threads = 1,
             .semaphore_bindings = {{.semaphore_spec_name = "sem", .accessor_name = "sem"}},
             .runtime_arguments_schema =

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -70,8 +70,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = unique_id,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_tls_check.cpp"},
+
+                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_tls_check.cpp",
             .num_threads = num_threads,
             .compile_time_arg_bindings = {{"kernel_id", kernel_id}},
             .runtime_arguments_schema =
@@ -308,8 +308,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     experimental::metal2_host_api::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/simple_tls_check.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/simple_tls_check.cpp",
         .num_threads = QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER,
         .runtime_arguments_schema =
             {

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -66,7 +66,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
 
     // Three kernels split 6 user DMs as 3 + 2 + 1 to mirror the original 4 + 3 + 1 split
     // (preserving the "shared kernel binary across multiple DMs" + "single-DM kernel" mix).
-    auto make_dm_kernel_spec = [](const char* unique_id, uint32_t kernel_id, uint8_t num_threads) {
+    auto make_dm_kernel_spec = [](const char* unique_id, uint32_t kernel_id, uint32_t num_threads) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = unique_id,
             .source =

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -51,8 +51,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = id,
             .source =
-                experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                    "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints_2_0.cpp"},
+
+                "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints_2_0.cpp",
             .num_threads = num_threads,
             .compile_time_arg_bindings = {{"l1_address", l1_addr}},
             .runtime_arguments_schema =

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -47,7 +47,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     constexpr const char* KERNEL_2 = "kernel_2";
     constexpr const char* KERNEL_3 = "kernel_3";
 
-    auto make_dm_kernel_spec = [](const char* id, uint8_t num_threads, uint32_t l1_addr) {
+    auto make_dm_kernel_spec = [](const char* id, uint32_t num_threads, uint32_t l1_addr) {
         return experimental::metal2_host_api::KernelSpec{
             .unique_id = id,
             .source =

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -82,8 +82,8 @@ static void run_pack_relu_test(
     experimental::metal2_host_api::KernelSpec reader_spec{
         .unique_id = READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = INPUT_DFB,
@@ -102,8 +102,8 @@ static void run_pack_relu_test(
     experimental::metal2_host_api::KernelSpec writer_spec{
         .unique_id = WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp",
         .num_threads = 1,
         .dfb_bindings = {{
             .dfb_spec_name = OUTPUT_DFB,
@@ -122,8 +122,8 @@ static void run_pack_relu_test(
     experimental::metal2_host_api::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp"},
+
+            "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_2_0.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"PACK_RELU", "1"}}},
         .dfb_bindings =

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -52,8 +52,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     experimental::metal2_host_api::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 4,
         .runtime_arguments_schema =
             {
@@ -128,8 +128,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     experimental::metal2_host_api::KernelSpec compute_kernel_spec{
         .unique_id = COMPUTE_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 1,
         .runtime_arguments_schema =
             {
@@ -184,8 +184,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
     experimental::metal2_host_api::KernelSpec compute_kernel_spec_1{
         .unique_id = COMPUTE_KERNEL_1,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 1,
         .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
     };
@@ -193,8 +193,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
     experimental::metal2_host_api::KernelSpec compute_kernel_spec_2{
         .unique_id = COMPUTE_KERNEL_2,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
         .num_threads = 2,
         .config_spec = experimental::metal2_host_api::ComputeConfiguration{},
     };

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -64,8 +64,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     experimental::metal2_host_api::KernelSpec dm_reader_spec{
         .unique_id = DM_READER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem0", .accessor_name = "sem"}},
         .runtime_arguments_schema =
@@ -81,8 +81,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     experimental::metal2_host_api::KernelSpec dm_transform_spec{
         .unique_id = DM_TRANSFORM,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"OUTGOING_SEM", "1"}, {"INCOMING_SEM", "1"}}},
         .semaphore_bindings =
@@ -105,8 +105,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     experimental::metal2_host_api::KernelSpec dm_writer_spec{
         .unique_id = DM_WRITER,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem1", .accessor_name = "sem"}},
         .runtime_arguments_schema =
@@ -225,8 +225,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     experimental::metal2_host_api::KernelSpec dm_transform_0_spec{
         .unique_id = DM_TRANSFORM_0,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"OUTGOING_SEM", "1"}}},
         .semaphore_bindings = {{.semaphore_spec_name = "sem_core_0", .accessor_name = "sem_out"}},
@@ -245,8 +245,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     experimental::metal2_host_api::KernelSpec dm_writer_0_spec{
         .unique_id = DM_WRITER_0,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"INCREMENT_REMOTE_SEM", "1"}}},
         .semaphore_bindings =
@@ -268,8 +268,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     experimental::metal2_host_api::KernelSpec dm_reader_1_spec{
         .unique_id = DM_READER_1,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}},
         .semaphore_bindings =
@@ -290,8 +290,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     experimental::metal2_host_api::KernelSpec dm_transform_1_spec{
         .unique_id = DM_TRANSFORM_1,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
         .num_threads = 1,
         .compiler_options = {.defines = {{"INCOMING_SEM", "1"}, {"OUTGOING_SEM", "1"}}},
         .semaphore_bindings =
@@ -314,8 +314,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     experimental::metal2_host_api::KernelSpec dm_writer_1_spec{
         .unique_id = DM_WRITER_1,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = "sem1_core_1", .accessor_name = "sem"}},
         .runtime_arguments_schema =

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -90,7 +90,7 @@ protected:
             const std::string DM_KERNEL = "dm_kernel";
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = DM_KERNEL,
-                .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+                .source = kernel_path,
                 .num_threads = static_cast<uint8_t>(num_dms_),
                 .compiler_options = {.defines = defines_vec},
                 .runtime_arguments_schema = {.named_runtime_args = {"l1_counter_addr", "increment_times"}},
@@ -106,7 +106,7 @@ protected:
                 const std::string name = "dm_kernel_" + std::to_string(dm_id);
                 kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                     .unique_id = name,
-                    .source = experimental::metal2_host_api::KernelSpec::SourceFilePath{kernel_path},
+                    .source = kernel_path,
                     .num_threads = 1,
                     .compiler_options = {.defines = defines_vec},
                     .runtime_arguments_schema = {.named_runtime_args = {"l1_counter_addr", "increment_times"}},

--- a/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
+++ b/tests/tt_metal/tt_metal/test_riscv_atomics.cpp
@@ -91,7 +91,7 @@ protected:
             kernel_specs.push_back(experimental::metal2_host_api::KernelSpec{
                 .unique_id = DM_KERNEL,
                 .source = kernel_path,
-                .num_threads = static_cast<uint8_t>(num_dms_),
+                .num_threads = num_dms_,
                 .compiler_options = {.defines = defines_vec},
                 .runtime_arguments_schema = {.named_runtime_args = {"l1_counter_addr", "increment_times"}},
                 .config_spec =

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -53,8 +53,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     experimental::metal2_host_api::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
         .source =
-            experimental::metal2_host_api::KernelSpec::SourceFilePath{
-                OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp"},
+
+            OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
         .num_threads = 2,
         .runtime_arguments_schema =
             {

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -162,8 +162,8 @@ void run_strided_dfb_copy_test(
     writer.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", output_cta_str});
 
     // Runtime varargs: [0]=base_addr, [1]=total_pages
-    reader.runtime_arguments_schema.num_runtime_varargs = 2;
-    writer.runtime_arguments_schema.num_runtime_varargs = 2;
+    reader.advanced_options.emplace().num_runtime_varargs = 2;
+    writer.advanced_options.emplace().num_runtime_varargs = 2;
 
     // DFB: one entry per page, pipelined depth = num_dfb_entries.
     // data_format_metadata must be set — set_dfb_tile_dims calls get_tile_size() unconditionally

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -184,11 +184,17 @@ void run_strided_dfb_copy_test(
     run_params.kernel_run_params = {
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "reader",
-            .runtime_varargs = {{node, {input_buffer->address(), total_pages}}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {input_buffer->address(), total_pages}}},
+                },
         },
         ProgramRunParams::KernelRunParams{
             .kernel_spec_name = "writer",
-            .runtime_varargs = {{node, {output_buffer->address(), total_pages}}},
+            .advanced_options =
+                AdvancedKernelRunParams{
+                    .runtime_varargs = {{node, {output_buffer->address(), total_pages}}},
+                },
         },
     };
     SetProgramRunParameters(program, run_params);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -162,8 +162,8 @@ void run_strided_dfb_copy_test(
     writer.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", output_cta_str});
 
     // Runtime varargs: [0]=base_addr, [1]=total_pages
-    reader.advanced_options.emplace().num_runtime_varargs = 2;
-    writer.advanced_options.emplace().num_runtime_varargs = 2;
+    reader.advanced_options.num_runtime_varargs = 2;
+    writer.advanced_options.num_runtime_varargs = 2;
 
     // DFB: one entry per page, pipelined depth = num_dfb_entries.
     // data_format_metadata must be set — set_dfb_tile_dims calls get_tile_size() unconditionally

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -156,8 +156,8 @@ void run_strided_dfb_copy_test(
     kernel_builder_fn(reader, writer);
 
     // Inject CTA define so TensorAccessorArgs<0, 0>() resolves at compile time
-    reader.source = KernelSpec::SourceFilePath{kReaderKernelPath};
-    writer.source = KernelSpec::SourceFilePath{kWriterKernelPath};
+    reader.source = kReaderKernelPath;
+    writer.source = kWriterKernelPath;
     reader.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", input_cta_str});
     writer.compiler_options.defines.push_back({"KERNEL_COMPILE_TIME_ARGS", output_cta_str});
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -96,6 +96,7 @@ struct KernelAdvancedOptions {
     // TODO: This feature is truly bizarre. It will be removed from the API once
     //       existing uses are refactored to avoid it.
     using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;
+    [[deprecated("Per-node-vararg-count feature is deprecated and will be removed.")]]
     std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -180,6 +181,7 @@ struct SemaphoreAdvancedOptions {
     // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
     // NOTE: Runtime wants to deprecate this feature for ALL architectures.
     //       When remote DFB becomes available, non-zero initial values will be removed.
+    [[deprecated("Non-zero semaphore initialization is deprecated and will be removed.")]]
     uint32_t initial_value = 0;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -44,6 +44,28 @@ using DFBSpecName = std::string;
 // (TODO: comments in this header to be revisited with Audrey after structural
 // changes land.)
 
+// Self-loop DFBs on compute kernels (niche use case).
+// This applies only to compute kernels that bind BOTH the producer and consumer
+// endpoints of the same DFB (self-loop).
+//
+// The compute kernel threads can communicate via the DFB in two topologies:
+//
+//   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
+//         (no cross-thread communication). This is the common case.
+//   INTER (inter-thread): Within the kernel, some threads produce data for other
+//          threads to consume.
+//
+// Only the INTRA case is currently supported. INTER will trigger a validation error.
+// There are currently no known use cases for an INTER-thread self-loop. This option
+// is present in the API for completeness, to surface any use cases that may arise.
+struct DFBComputeSelfLoopScope {
+    DFBSpecName dfb_spec_name;
+    enum class Scope { INTRA, INTER };
+    Scope scope = Scope::INTRA;
+    // If the INTER case were enabled, we would need an additional field to describe
+    // the inter-thread communication pattern here.
+};
+
 struct KernelSpecAdvancedOptions {
     // (Optional) Per-node thread count specification.
     // The default threading is KernelSpec::num_threads. However, you may override
@@ -54,6 +76,9 @@ struct KernelSpecAdvancedOptions {
     using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
+
+    // Self-loop DFBs on compute kernels — see DFBComputeSelfLoopScope above.
+    std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
 };
 
 struct DataflowBufferSpecAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -47,7 +47,7 @@ struct KernelAdvancedOptions {
     //       (It's an open question if we EVER want to support it.)
     //       It is included here just as a placeholder for use case feedback.
     //       Attempting to use it will trigger a runtime error.
-    using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
+    using NodeSpecificThreadCount = std::pair<Nodes, uint32_t>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     NodeSpecificThreadCounts node_specific_thread_counts;
 
@@ -78,12 +78,12 @@ struct KernelAdvancedOptions {
     //--------------------------------
     // Number of runtime varargs for the kernel.
     // Set the vararg values (per node) via ProgramRunParams.
-    size_t num_runtime_varargs = 0;
+    uint32_t num_runtime_varargs = 0;
 
     // Number of common runtime varargs for the kernel.
     // Set the vararg values via ProgramRunParams.
     // (The same argument values are broadcast to every node the kernel runs on.)
-    size_t num_common_runtime_varargs = 0;
+    uint32_t num_common_runtime_varargs = 0;
 
     // Per-node runtime vararg-count override.
     // In very rare cases a kernel needs a DIFFERENT number of runtime varargs on
@@ -91,7 +91,7 @@ struct KernelAdvancedOptions {
     // not listed default to num_runtime_varargs.
     // TODO: This feature is truly bizarre. It will be removed from the API once
     //       existing uses are refactored to avoid it.
-    using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;
+    using NumVarargsPerNode = std::vector<std::pair<Nodes, uint32_t>>;
     [[deprecated("Per-node-vararg-count feature is deprecated and will be removed.")]]
     NumVarargsPerNode num_runtime_varargs_per_node;
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -37,7 +37,7 @@ using DFBSpecName = std::string;
 // main Spec, NOT here.
 //
 // The std::optional wrapper + explicit type name at the use site
-// (e.g. `.advanced_options = KernelSpecAdvancedOptions{.foo = bar}`) is
+// (e.g. `.advanced_options = KernelAdvancedOptions{.foo = bar}`) is
 // intentional: it puts a small ergonomic speed bump in front of reaching into
 // this bucket on autopilot.
 //
@@ -66,7 +66,7 @@ struct DFBComputeSelfLoopScope {
     // the inter-thread communication pattern here.
 };
 
-struct KernelSpecAdvancedOptions {
+struct KernelAdvancedOptions {
     // (Optional) Per-node thread count specification.
     // The default threading is KernelSpec::num_threads. However, you may override
     // this on a per-node basis.
@@ -104,7 +104,7 @@ struct KernelSpecAdvancedOptions {
     std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
 };
 
-struct DFBSpecAdvancedOptions {
+struct DFBAdvancedOptions {
     // Alias two or more DFBs.
     // Aliased DFBs are logically distinct, but physically share the same backing memory.
     // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
@@ -119,7 +119,7 @@ struct DFBSpecAdvancedOptions {
 
 struct AdvancedKernelRunParams {
     // Unnamed runtime argument "varargs" (companion to the vararg schema declared
-    // on KernelSpecAdvancedOptions). Specified per-node; length can vary per-node.
+    // on KernelAdvancedOptions). Specified per-node; length can vary per-node.
     // (Slated for eventual removal in favor of typed array runtime args.)
     struct NodeVarargs {
         NodeCoord node;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+//------------------------------------------------------------
+// Advanced options for Metal 2.0 specs
+//------------------------------------------------------------
+//
+// Each Metal 2.0 Spec (KernelSpec, DataflowBufferSpec, TensorParameter, ...) may
+// carry a std::optional<*AdvancedOptions> field at the end of the struct. The
+// *AdvancedOptions struct holds members that meet ONE OR MORE of the following:
+//
+//   - Niche use case (most users will never set it).
+//   - Not safe by construction (footgun disguised as a feature).
+//   - Placeholder for feedback (unstable; may move or disappear based on real usage).
+//   - Slated for removal (kept only because a replacement does not yet exist;
+//     should carry [[deprecated]] with a message stating the removal plan).
+//
+// Members that are merely "advanced but mainstream" — production-ready features
+// most users will not need but that work safely and predictably — stay on the
+// main Spec, NOT here.
+//
+// The std::optional wrapper + explicit type name at the use site
+// (e.g. `.advanced_options = KernelSpecAdvancedOptions{.foo = bar}`) is
+// intentional: it puts a small ergonomic speed bump in front of reaching into
+// this bucket on autopilot.
+//
+// (TODO: comments in this header to be revisited with Audrey after structural
+// changes land.)
+
+struct KernelSpecAdvancedOptions {
+    // No fields yet — populated as features migrate in.
+};
+
+struct DataflowBufferSpecAdvancedOptions {
+    // No fields yet — populated as features migrate in.
+};
+
+struct TensorParameterAdvancedOptions {
+    // No fields yet — populated as features migrate in.
+};
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -4,7 +4,15 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 namespace tt::tt_metal::experimental::metal2_host_api {
+
+// Forward-declare *Name typedefs that AdvancedOptions members reference.
+// Each is also declared in its owning spec header; C++ permits redeclaration
+// of identical typedefs in the same namespace.
+using DFBSpecName = std::string;
 
 //------------------------------------------------------------
 // Advanced options for Metal 2.0 specs
@@ -37,7 +45,16 @@ struct KernelSpecAdvancedOptions {
 };
 
 struct DataflowBufferSpecAdvancedOptions {
-    // No fields yet — populated as features migrate in.
+    // Alias two or more DFBs.
+    // Aliased DFBs are logically distinct, but physically share the same backing memory.
+    // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
+    //
+    // Rules for aliased DFBs:
+    //   - Every DFB in the alias group must list every other member as an alias
+    //   - Aliased DFBs must have the same total size (num_entries * entry_size).
+    //   - All members must target the same node set
+    //     (derived from their bound kernels' WorkUnitSpecs).
+    std::vector<DFBSpecName> alias_with;
 };
 
 struct TensorParameterAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -104,7 +104,7 @@ struct KernelSpecAdvancedOptions {
     std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
 };
 
-struct DataflowBufferSpecAdvancedOptions {
+struct DFBSpecAdvancedOptions {
     // Alias two or more DFBs.
     // Aliased DFBs are logically distinct, but physically share the same backing memory.
     // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
@@ -115,6 +115,23 @@ struct DataflowBufferSpecAdvancedOptions {
     //   - All members must target the same node set
     //     (derived from their bound kernels' WorkUnitSpecs).
     std::vector<DFBSpecName> alias_with;
+};
+
+struct AdvancedKernelRunParams {
+    // Unnamed runtime argument "varargs" (companion to the vararg schema declared
+    // on KernelSpecAdvancedOptions). Specified per-node; length can vary per-node.
+    // (Slated for eventual removal in favor of typed array runtime args.)
+    struct NodeVarargs {
+        NodeCoord node;
+        std::vector<uint32_t> args;
+    };
+    std::vector<NodeVarargs> runtime_varargs;
+
+    // Unnamed common runtime argument "varargs" — broadcast to every node the kernel
+    // runs on. Companion to num_common_runtime_varargs in the schema.
+    // (Slated for eventual removal in favor of typed array common runtime args.)
+    using CommonVarargs = std::vector<uint32_t>;
+    CommonVarargs common_runtime_varargs;
 };
 
 struct TensorParameterAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -79,6 +79,29 @@ struct KernelSpecAdvancedOptions {
 
     // Self-loop DFBs on compute kernels — see DFBComputeSelfLoopScope above.
     std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
+
+    // Runtime varargs: dynamic RTAs.
+    // Some kernels are designed to take a variable number of arguments — e.g. N
+    // arguments representing the dimensions of an N-dimensional tensor, where N
+    // is passed to the kernel as a CTA. Varargs are accessed positionally since
+    // the kernel does not know how many to expect. Set the vararg values per
+    // node via ProgramRunParams.
+    // (Slated for eventual removal in favor of typed array runtime args.)
+    size_t num_runtime_varargs = 0;
+
+    // Common runtime varargs: dynamic CRTAs.
+    // Like runtime varargs, but the same values are broadcast to every node the
+    // kernel runs on.
+    // (Slated for eventual removal in favor of typed array common runtime args.)
+    size_t num_common_runtime_varargs = 0;
+
+    // Per-node vararg-count override.
+    // In very rare cases a kernel needs a DIFFERENT number of runtime varargs on
+    // different nodes. Each entry pairs a node set with its vararg count; nodes
+    // not listed default to num_runtime_varargs.
+    // TODO: This feature is truly bizarre. Investigate removing it from the API.
+    using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;
+    std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
 };
 
 struct DataflowBufferSpecAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -32,82 +32,116 @@ using DFBSpecName = std::string;
 //   - Slated for removal (kept only because a replacement does not yet exist;
 //     should carry [[deprecated]] with a message stating the removal plan).
 //
-// Members that are merely "advanced but mainstream" — production-ready features
-// most users will not need but that work safely and predictably — stay on the
-// main Spec, NOT here.
+// NOTE: Features that are "advanced" but mainstream and core to the API
+//       belong on the primary Spec. *AdvancedOptions features are limited
+//       to those that are truly niche, unsafe, or unstable.
 //
-// The std::optional wrapper + explicit type name at the use site
-// (e.g. `.advanced_options = KernelAdvancedOptions{.foo = bar}`) is
-// intentional: it puts a small ergonomic speed bump in front of reaching into
-// this bucket on autopilot.
-//
-// (TODO: comments in this header to be revisited with Audrey after structural
-// changes land.)
-
-// Self-loop DFBs on compute kernels (niche use case).
-// This applies only to compute kernels that bind BOTH the producer and consumer
-// endpoints of the same DFB (self-loop).
-//
-// The compute kernel threads can communicate via the DFB in two topologies:
-//
-//   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
-//         (no cross-thread communication). This is the common case.
-//   INTER (inter-thread): Within the kernel, some threads produce data for other
-//          threads to consume.
-//
-// Only the INTRA case is currently supported. INTER will trigger a validation error.
-// There are currently no known use cases for an INTER-thread self-loop. This option
-// is present in the API for completeness, to surface any use cases that may arise.
-struct DFBComputeSelfLoopScope {
-    DFBSpecName dfb_spec_name;
-    enum class Scope { INTRA, INTER };
-    Scope scope = Scope::INTRA;
-    // If the INTER case were enabled, we would need an additional field to describe
-    // the inter-thread communication pattern here.
-};
+// Use the features in *AdvancedOptions with caution!
+// The header comments for each field describe which category it falls into,
+// and any special considerations for use.
 
 struct KernelAdvancedOptions {
-    // (Optional) Per-node thread count specification.
-    // The default threading is KernelSpec::num_threads. However, you may override
-    // this on a per-node basis.
-    // NOTE: This feature is currently unsupported. It's an open question if we EVER
-    //       want to support it. Here as a placeholder; specifying it will trigger a
-    //       runtime error.
+    ////////////////////////////////////////////////////////////////////////////////
+    // Per-node thread count (Gen2)
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // The default kernel threading is specified by KernelSpec::num_threads.
+    // However, you may override this on a per-node basis.
+    //
+    // NOTE: This feature is currently UNSUPPORTED!
+    //       (It's an open question if we EVER want to support it.)
+    //       It is included here just as a placeholder for use case feedback.
+    //       Attempting to use it will trigger a runtime error.
     using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 
-    // Self-loop DFBs on compute kernels — see DFBComputeSelfLoopScope above.
-    std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
+    ////////////////////////////////////////////////////////////////////////////////
+    // Varargs
+    ////////////////////////////////////////////////////////////////////////////////
 
-    // Runtime varargs: dynamic RTAs.
-    // Some kernels are designed to take a variable number of arguments — e.g. N
-    // arguments representing the dimensions of an N-dimensional tensor, where N
-    // is passed to the kernel as a CTA. Varargs are accessed positionally since
-    // the kernel does not know how many to expect. Set the vararg values per
-    // node via ProgramRunParams.
-    // (Slated for eventual removal in favor of typed array runtime args.)
+    // In Metal 2.0, kernel arguments are NAMED parameters declared in the KernelSpec.
+    // However, until typed kernel argument support is available, certain advanced use
+    // cases require a VARIABLE number of arguments. e.g.:
+    //   - N runtime arguments, representing the size of an N-dimensional tensor
+    //   - a kernel that accepts a variadic number of tensor arguments
+    //
+    // Varargs must be accessed POSITIONALLY in the kernel code.
+    //
+    // The vararg schema below is a temporary mechanism to support these use cases.
+    // It will later be deprecated and replaced by std::array typed arguments.
+
+    //--------------------------------
+    // Compile time varargs
+    //--------------------------------
+    // TODO: This is currently unimplemented.
+    //       However, certain variadic kernels require this workaround.
+
+    //--------------------------------
+    // Runtime varargs
+    //--------------------------------
+    // Number of runtime varargs for the kernel.
+    // Set the vararg values (per node) via ProgramRunParams.
     size_t num_runtime_varargs = 0;
 
-    // Common runtime varargs: dynamic CRTAs.
-    // Like runtime varargs, but the same values are broadcast to every node the
-    // kernel runs on.
-    // (Slated for eventual removal in favor of typed array common runtime args.)
+    // Number of common runtime varargs for the kernel.
+    // Set the vararg values via ProgramRunParams.
+    // (The same argument values are broadcast to every node the kernel runs on.)
     size_t num_common_runtime_varargs = 0;
 
-    // Per-node vararg-count override.
+    // Per-node runtime vararg-count override.
     // In very rare cases a kernel needs a DIFFERENT number of runtime varargs on
     // different nodes. Each entry pairs a node set with its vararg count; nodes
     // not listed default to num_runtime_varargs.
-    // TODO: This feature is truly bizarre. Investigate removing it from the API.
+    // TODO: This feature is truly bizarre. It will be removed from the API once
+    //       existing uses are refactored to avoid it.
     using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;
     std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Multi-threaded self-loop DFBs on compute kernels
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Self-loop DFBs on compute kernels (niche use case).
+    // This applies only to compute kernels that bind BOTH the producer and consumer
+    // endpoints of the same DFB (self-loop).
+    //
+    // The compute kernel threads can communicate via the DFB in two topologies:
+    //
+    //   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
+    //         (no cross-thread communication). This is the common case.
+    //   INTER (inter-thread): Within the kernel, some threads produce data for other
+    //          threads to consume.
+    //
+    // Only the INTRA case is currently supported. INTER will trigger a validation error.
+    // There are currently no known use cases for an INTER-thread self-loop. This option
+    // is present in the API for completeness, to surface any use cases that may arise.
+    struct DFBComputeSelfLoopScope {
+        DFBSpecName dfb_spec_name;
+        enum class Scope { INTRA, INTER };
+        Scope scope = Scope::INTRA;
+        // If the INTER case were enabled, we would need an additional field to describe
+        // the inter-thread communication pattern here.
+    };
+    // Self-loop DFBs on compute kernels — see DFBComputeSelfLoopScope above.
+    std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
 };
 
+// (Convenience alias for type)
+using DFBComputeSelfLoopScope = KernelAdvancedOptions::DFBComputeSelfLoopScope;
+
 struct DFBAdvancedOptions {
+    ////////////////////////////////////////////////////////////////////////////////
+    // Aliased DFBs
+    ////////////////////////////////////////////////////////////////////////////////
+
     // Alias two or more DFBs.
     // Aliased DFBs are logically distinct, but physically share the same backing memory.
-    // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
+    // This is an advanced feature for memory use optimization in niche use cases.
+    //
+    // CAUTION:
+    // Aliased DFBs offer NO guarantees against data clobbering!
+    // This feature is unsafe in most circumstances; kernel logic must ensure safety.
     //
     // Rules for aliased DFBs:
     //   - Every DFB in the alias group must list every other member as an alias
@@ -118,24 +152,31 @@ struct DFBAdvancedOptions {
 };
 
 struct AdvancedKernelRunParams {
-    // Unnamed runtime argument "varargs" (companion to the vararg schema declared
-    // on KernelAdvancedOptions). Specified per-node; length can vary per-node.
-    // (Slated for eventual removal in favor of typed array runtime args.)
+    ////////////////////////////////////////////////////////////////////////////////
+    // Varargs
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Unnamed runtime argument "varargs"
+    // (Companion to the vararg schema declared on KernelAdvancedOptions).
+    // Specified per-node; length can vary per-node (as declared in schema).
     struct NodeVarargs {
         NodeCoord node;
         std::vector<uint32_t> args;
     };
     std::vector<NodeVarargs> runtime_varargs;
 
-    // Unnamed common runtime argument "varargs" — broadcast to every node the kernel
-    // runs on. Companion to num_common_runtime_varargs in the schema.
-    // (Slated for eventual removal in favor of typed array common runtime args.)
+    // Unnamed common runtime argument "varargs"
+    // (Companion to num_common_runtime_varargs in the schema.)
+    // Broadcast to every node the kernel runs on.
     using CommonVarargs = std::vector<uint32_t>;
     CommonVarargs common_runtime_varargs;
 };
 
 struct SemaphoreAdvancedOptions {
-    // Initial value
+    ////////////////////////////////////////////////////////////////////////////////
+    // Non-zero initial value
+    ////////////////////////////////////////////////////////////////////////////////
+
     // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
     // NOTE: Runtime wants to deprecate this feature for ALL architectures.
     //       When remote DFB becomes available, non-zero initial values will be removed.
@@ -143,11 +184,16 @@ struct SemaphoreAdvancedOptions {
 };
 
 struct TensorParameterAdvancedOptions {
+    ////////////////////////////////////////////////////////////////////////////////
+    // TensorSpec match relaxation options
+    ////////////////////////////////////////////////////////////////////////////////
+
     // By default, the MeshTensor argument provided at execution time must
-    // EXACTLY match the TensorParameter's declared TensorSpec. The options
-    // below relax this match requirement in particular ways.
+    // EXACTLY match the TensorParameter's declared TensorSpec.
+    // The options here relax this match requirement in particular ways.
     //
-    // NOTE: These options are UNSAFE if set to true; most kernels will not function
+    // CAUTION:
+    // These options are UNSAFE if set to true; most kernels will not function
     // correctly if the tensor argument's spec deviates from the declared spec.
     // Use with caution and ensure that your kernel logic is compatible.
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -14,8 +14,7 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // Forward-declare *Name typedefs that AdvancedOptions members reference.
-// Each is also declared in its owning spec header; C++ permits redeclaration
-// of identical typedefs in the same namespace.
+// (Each is also declared in its owning spec header.)
 using DFBSpecName = std::string;
 
 //------------------------------------------------------------
@@ -76,6 +75,7 @@ struct KernelAdvancedOptions {
     //--------------------------------
     // TODO: This is currently unimplemented.
     //       However, certain variadic kernels require this workaround.
+    //       (#45388 tracks the implementation of this feature.)
 
     //--------------------------------
     // Runtime varargs

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -4,8 +4,12 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 
 namespace tt::tt_metal::experimental::metal2_host_api {
 
@@ -41,7 +45,15 @@ using DFBSpecName = std::string;
 // changes land.)
 
 struct KernelSpecAdvancedOptions {
-    // No fields yet — populated as features migrate in.
+    // (Optional) Per-node thread count specification.
+    // The default threading is KernelSpec::num_threads. However, you may override
+    // this on a per-node basis.
+    // NOTE: This feature is currently unsupported. It's an open question if we EVER
+    //       want to support it. Here as a placeholder; specifying it will trigger a
+    //       runtime error.
+    using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
+    using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
+    std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 };
 
 struct DataflowBufferSpecAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -134,6 +134,14 @@ struct AdvancedKernelRunParams {
     CommonVarargs common_runtime_varargs;
 };
 
+struct SemaphoreAdvancedOptions {
+    // Initial value
+    // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
+    // NOTE: Runtime wants to deprecate this feature for ALL architectures.
+    //       When remote DFB becomes available, non-zero initial values will be removed.
+    uint32_t initial_value = 0;
+};
+
 struct TensorParameterAdvancedOptions {
     // By default, the MeshTensor argument provided at execution time must
     // EXACTLY match the TensorParameter's declared TensorSpec. The options

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -22,22 +21,19 @@ using DFBSpecName = std::string;
 //------------------------------------------------------------
 //
 // Each Metal 2.0 Spec (KernelSpec, DataflowBufferSpec, TensorParameter, ...) may
-// carry a std::optional<*AdvancedOptions> field at the end of the struct. The
-// *AdvancedOptions struct holds members that meet ONE OR MORE of the following:
+// carry a *AdvancedOptions field at the end of its struct.
+// Features in "advanced options" are one (or more) of:
 //
-//   - Niche use case (most users will never set it).
-//   - Not safe by construction (footgun disguised as a feature).
-//   - Placeholder for feedback (unstable; may move or disappear based on real usage).
-//   - Slated for removal (kept only because a replacement does not yet exist;
-//     should carry [[deprecated]] with a message stating the removal plan).
+//   - Not safe by construction (requires extreme caution to use correctly)
+//   - Extremely niche (only relevant to a tiny fraction of use cases)
+//   - Unstable / experimental
 //
 // NOTE: Features that are "advanced" but mainstream and core to the API
 //       belong on the primary Spec. *AdvancedOptions features are limited
 //       to those that are truly niche, unsafe, or unstable.
 //
-// Use the features in *AdvancedOptions with caution!
-// The header comments for each field describe which category it falls into,
-// and any special considerations for use.
+// Use the advanced options with caution!
+// The header comments for each field describe special considerations for use.
 
 struct KernelAdvancedOptions {
     ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +49,7 @@ struct KernelAdvancedOptions {
     //       Attempting to use it will trigger a runtime error.
     using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
-    std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
+    NodeSpecificThreadCounts node_specific_thread_counts;
 
     ////////////////////////////////////////////////////////////////////////////////
     // Varargs
@@ -97,7 +93,7 @@ struct KernelAdvancedOptions {
     //       existing uses are refactored to avoid it.
     using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;
     [[deprecated("Per-node-vararg-count feature is deprecated and will be removed.")]]
-    std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
+    NumVarargsPerNode num_runtime_varargs_per_node;
 
     ////////////////////////////////////////////////////////////////////////////////
     // Multi-threaded self-loop DFBs on compute kernels

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -41,7 +41,29 @@ struct DataflowBufferSpecAdvancedOptions {
 };
 
 struct TensorParameterAdvancedOptions {
-    // No fields yet — populated as features migrate in.
+    // By default, the MeshTensor argument provided at execution time must
+    // EXACTLY match the TensorParameter's declared TensorSpec. The options
+    // below relax this match requirement in particular ways.
+    //
+    // NOTE: These options are UNSAFE if set to true; most kernels will not function
+    // correctly if the tensor argument's spec deviates from the declared spec.
+    // Use with caution and ensure that your kernel logic is compatible.
+
+    // Permit tensor arguments whose logical_shape differs from the declared shape.
+    // The argument's padded_shape must still match exactly.
+    // Effects:
+    //  - Validation checks are relaxed
+    //  - TensorAccessor configuration is completely unchanged
+    bool match_padded_shape_only = false;
+
+    // Permit tensor arguments with dynamic logical shape.
+    // The argument's logical_shape AND padded_shape may differ from the declared shape.
+    // Effects:
+    //  - Validation checks are relaxed
+    //  - For an interleaved tensor, TensorAccessor configuration is unchanged
+    //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
+    //    argument's actual shape. (Shape becomes an implicit runtime argument.)
+    bool dynamic_tensor_shape = false;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
@@ -14,9 +14,9 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 
 struct ComputeConfiguration {
     // Tensix hardware resource configuration for compute kernels.
-    // Gen1 and Gen2 configurations are identical.
-    //
-    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
+    // (Common to all Tenstorrent accelerators.)
+
+    // The Tensix Engine pipeline consists of Unpack, Math, and Pack stages.
     // There are two math engines:
     //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
     //    writes to the Dest register file (16- or 32-bit, configurable).

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_configuration.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/base_types.hpp>  // For MathFidelity, UnpackToDestMode (global scope)
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+struct ComputeConfiguration {
+    // Tensix hardware resource configuration for compute kernels.
+    // Gen1 and Gen2 configurations are identical.
+    //
+    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
+    // There are two math engines:
+    //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
+    //    writes to the Dest register file (16- or 32-bit, configurable).
+    //  - SFPU runs SIMD transcendentals. It can only access Dest.
+    // The fields below configure this pipeline.
+
+    // Number of multiply passes the FPU runs to use more mantissa bits
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+
+    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
+    bool fp32_dest_acc_en = false;
+
+    // Dest register sync mode:
+    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
+    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
+    bool dst_full_sync_en = false;
+
+    // Pack-side precision tweak for the Bfp8 block-float format.
+    // (Affects how exponents are reconciled when converting Dest contents to Bfp8)
+    bool bfp8_pack_precise = false;
+
+    // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
+    bool math_approx_mode = false;
+
+    // Per-DFB choice of how the unpacker delivers data into the math stage:
+    //   Default          — unpack via SrcA/B regs (~19-bit elements; full FPU access)
+    //   UnpackToDestFp32 — unpack via Dest regs with full FP32 precision (SFPU only)
+    //
+    // This choice matters only when ALL of the following hold for the DFB binding:
+    //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
+    //   2. The DFB's data format is Float32.
+    //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
+    //
+    // You MUST provide an unpack_to_dest_mode entry for the DFB if these conditions hold;
+    // failing to do so will trigger an error. Otherwise, supplying an entry is optional
+    // and only Default is accepted.
+    using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
+    std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
+};
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -13,7 +13,8 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 struct DataMovementConfiguration {
-    // The DM configuration is different for Gen1 and Gen2.
+    // Data movement resource configuration for DM kernels.
+    // NOTE: The DM configuration is different for Gen1 and Gen2.
 
     struct Gen1DataMovementConfig {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/kernel_types.hpp>  // For DataMovementProcessor, NOC, etc.
+
+namespace tt::tt_metal::experimental::metal2_host_api {
+
+struct DataMovementConfiguration {
+    // The DM configuration is different for Gen1 and Gen2.
+
+    struct Gen1DataMovementConfig {
+        tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
+        tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
+        tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
+    };
+    std::optional<Gen1DataMovementConfig> gen1_data_movement_config = std::nullopt;
+
+    struct Gen2DataMovementConfig {
+        // Opt-out of DFB implicit sync (on a per-DFB basis)
+        //  - Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
+        //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
+        //  - This feature is mainly for debug purposes, or for backwards-compatible code style.
+        // Any bound DFB not listed here will use implicit sync by default.
+        std::vector<DFBSpecName> disable_implicit_sync_for;
+    };
+    std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
+};
+
+}  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -93,7 +93,7 @@ struct DataflowBufferSpec {
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////
-    std::optional<DFBSpecAdvancedOptions> advanced_options = std::nullopt;
+    std::optional<DFBAdvancedOptions> advanced_options = std::nullopt;
 };
 
 // NOTE: Remote DataflowBuffer is not yet supported!

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -93,7 +93,7 @@ struct DataflowBufferSpec {
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////
-    std::optional<DataflowBufferSpecAdvancedOptions> advanced_options = std::nullopt;
+    std::optional<DFBSpecAdvancedOptions> advanced_options = std::nullopt;
 };
 
 // NOTE: Remote DataflowBuffer is not yet supported!

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/tile.hpp>
@@ -105,6 +106,11 @@ struct DataflowBufferSpec {
     //     (derived from their bound kernels' WorkUnitSpecs).
     using DFBIdentifiers = std::vector<DFBSpecName>;
     DFBIdentifiers alias_with;  // empty vector means no aliasing
+
+    //////////////////////////////
+    // Advanced options (see advanced_options.hpp)
+    //////////////////////////////
+    std::optional<DataflowBufferSpecAdvancedOptions> advanced_options = std::nullopt;
 };
 
 // NOTE: Remote DataflowBuffer is not yet supported!

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -93,7 +93,7 @@ struct DataflowBufferSpec {
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////
-    std::optional<DFBAdvancedOptions> advanced_options = std::nullopt;
+    DFBAdvancedOptions advanced_options;
 };
 
 // NOTE: Remote DataflowBuffer is not yet supported!

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -19,11 +19,6 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a DataflowBufferSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* INPUT_DFB = "input_dfb";
-//   DataflowBufferSpec{.unique_id = INPUT_DFB, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
 using DFBSpecName = std::string;
 
 // DataflowBuffer endpoint access patterns:

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -71,7 +71,7 @@ struct DataflowBufferSpec {
     std::optional<tt::tt_metal::Tile> tile_format_metadata = std::nullopt;
 
     //////////////////////////////
-    // Advanced options
+    // Backing memory
     //////////////////////////////
 
     // Build DFB on borrowed memory.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -90,18 +90,6 @@ struct DataflowBufferSpec {
     // (TODO: this should become std::variant<TensorParameterName, BufferParameterName>.)
     std::optional<TensorParameterName> borrowed_from = std::nullopt;
 
-    // Alias two or more DFBs
-    // Aliased DFBs are logically distinct, but physically share the same backing memory.
-    // Aliased DFBs offer NO guarantees against data clobbering; kernel logic must ensure safety.
-    //
-    // Rules for aliased DFBs:
-    //   - Every DFB in the alias group must list every other member as an alias
-    //   - Aliased DFBs must have the same total size (num_entries * entry_size).
-    //   - All members must target the same node set
-    //     (derived from their bound kernels' WorkUnitSpecs).
-    using DFBIdentifiers = std::vector<DFBSpecName>;
-    DFBIdentifiers alias_with;  // empty vector means no aliasing
-
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -70,14 +70,6 @@ struct KernelSpec {
     // Number of kernel threads
     int num_threads = 1;
 
-    // (Optional) Per-node thread count specification
-    // The default threading is num_threads. However, you may override this on a per-node basis.
-    // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
-    //       Here as a placeholder; specifying it will trigger a runtime error.
-    using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
-    using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
-    std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
-
     // Kernel type (methods)
     bool is_dm_kernel() const { return std::holds_alternative<DataMovementConfiguration>(config_spec); }
     bool is_compute_kernel() const { return std::holds_alternative<ComputeConfiguration>(config_spec); }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -12,6 +12,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
@@ -298,6 +299,11 @@ struct KernelSpec {
         // the inter-thread communication pattern here.
     };
     std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
+
+    //////////////////////////////////////////////////////////////////////////////
+    // Advanced options (see advanced_options.hpp)
+    //////////////////////////////////////////////////////////////////////////////
+    std::optional<KernelSpecAdvancedOptions> advanced_options = std::nullopt;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -140,7 +140,6 @@ struct KernelSpec {
     // The default threading is num_threads. However, you may override this on a per-node basis.
     // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
     //       Here as a placeholder; specifying it will trigger a runtime error.
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
     using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -191,34 +191,6 @@ struct KernelSpec {
     ConfigSpec config_spec;
 
     //////////////////////////////////////////////////////////////////////////////
-    // Advanced options / niche use cases
-    //////////////////////////////////////////////////////////////////////////////
-
-    // Niche use case: Self-loop DFBs on compute kernels only
-    // This applies only to compute kernels that bind BOTH the producer and consumer
-    // endpoints of the same DFB (self-loop).
-    //
-    // The compute kernel threads can communicate via the DFB in two topologies:
-    //
-    //   INTRA (intra-thread): Each kernel thread uses the DFB in its own self-loop.
-    //         (no cross-thread communication). This is the common case.
-    //   INTER (inter-thread): Within the kernel, some threads produce data for other
-    //          threads to consume.
-    //
-    // Only the INTRA case is currently supported. INTER will trigger a validation error.
-    // There are currently no known use cases for an INTER-thread self-loop. This option
-    // is present in the API for completeness, to surface any use cases that may arise.
-    //
-    struct DFBComputeSelfLoopScope {
-        DFBSpecName dfb_spec_name;
-        enum class Scope { INTRA, INTER };
-        Scope scope = Scope::INTRA;
-        // If the INTER case were enabled, we would need an additional field to describe
-        // the inter-thread communication pattern here.
-    };
-    std::vector<DFBComputeSelfLoopScope> dfb_compute_self_loop_scopes;
-
-    //////////////////////////////////////////////////////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////////////////////////////////////////////////////
     std::optional<KernelSpecAdvancedOptions> advanced_options = std::nullopt;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <filesystem>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -148,10 +147,10 @@ struct KernelSpec {
     //
     // For vararg-style positional RTAs/CRTAs, see KernelAdvancedOptions.
     struct RuntimeArgSchema {
-        // Named RTAs: names in declaration order. Must be unique valid C++ identifiers.
+        // Runtime argument names (must be unique, valid C++ identifiers.)
         std::vector<std::string> named_runtime_args;
 
-        // Named CRTAs: names in declaration order. Must be unique valid C++ identifiers.
+        // Common runtime argument names (must be unique, valid C++ identifiers.)
         std::vector<std::string> named_common_runtime_args;
     };
     RuntimeArgSchema runtime_arguments_schema{};
@@ -165,7 +164,7 @@ struct KernelSpec {
     //////////////////////////////////////////////////////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////////////////////////////////////////////////////
-    std::optional<KernelAdvancedOptions> advanced_options = std::nullopt;
+    KernelAdvancedOptions advanced_options;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -13,80 +13,14 @@
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
+#include <tt-metalium/experimental/metal2_host_api/compute_configuration.hpp>
+#include <tt-metalium/experimental/metal2_host_api/data_movement_configuration.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
-#include <tt-metalium/base_types.hpp>    // For MathFidelity, UnpackToDestMode (global scope)
-#include <tt-metalium/kernel_types.hpp>  // For DataMovementProcessor, NOC, etc.
 
 namespace tt::tt_metal::experimental::metal2_host_api {
-
-struct ComputeConfiguration {
-    // Tensix hardware resource configuration for compute kernels.
-    // Gen1 and Gen2 configurations are identical.
-    //
-    // The Tensix Engine is a 3-stage pipeline (Unpack → Math → Pack).
-    // There are two math engines:
-    //  - FPU reads operands from the SrcA / SrcB register files (~19-bit),
-    //    writes to the Dest register file (16- or 32-bit, configurable).
-    //  - SFPU runs SIMD transcendentals. It can only access Dest.
-    // The fields below configure this pipeline.
-
-    // Number of multiply passes the FPU runs to use more mantissa bits
-    MathFidelity math_fidelity = MathFidelity::HiFi4;
-
-    // Configure Dest register to hold 32-bit elements (instead of the default 16-bit)
-    bool fp32_dest_acc_en = false;
-
-    // Dest register sync mode:
-    //   false (Half) — Dest is split in half; math and pack pipeline (double-buffered)
-    //   true  (Full) — Dest is one buffer; twice the capacity, no math/pack overlap
-    bool dst_full_sync_en = false;
-
-    // Pack-side precision tweak for the Bfp8 block-float format.
-    // (Affects how exponents are reconciled when converting Dest contents to Bfp8)
-    bool bfp8_pack_precise = false;
-
-    // Select fast-and-approximate vs slow-and-precise variants of SFPU transcendentals
-    bool math_approx_mode = false;
-
-    // Per-DFB choice of how the unpacker delivers data into the math stage:
-    //   Default          — unpack via SrcA/B regs (~19-bit elements; full FPU access)
-    //   UnpackToDestFp32 — unpack via Dest regs with full FP32 precision (SFPU only)
-    //
-    // This choice matters only when ALL of the following hold for the DFB binding:
-    //   1. The kernel is the consumer endpoint (unpacking data into the kernel)
-    //   2. The DFB's data format is Float32.
-    //   3. fp32_dest_acc_en is true (Dest must be 32-bit-wide to hold FP32).
-    //
-    // You MUST provide an unpack_to_dest_mode entry for the DFB if these conditions hold;
-    // failing to do so will trigger an error. Otherwise, supplying an entry is optional
-    // and only Default is accepted.
-    using UnpackToDestModeEntry = std::pair<DFBSpecName, tt::tt_metal::UnpackToDestMode>;
-    std::vector<UnpackToDestModeEntry> unpack_to_dest_mode;
-};
-
-struct DataMovementConfiguration {
-    // The DM configuration is different for Gen1 and Gen2.
-
-    struct Gen1DataMovementConfig {
-        tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
-        tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
-        tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
-    };
-    std::optional<Gen1DataMovementConfig> gen1_data_movement_config = std::nullopt;
-
-    struct Gen2DataMovementConfig {
-        // Opt-out of DFB implicit sync (on a per-DFB basis)
-        //  - Implicit sync enables streamlined kernel-side syntax, but triggers ISR handling.
-        //  - Use this control to revert to legacy explicit sync APIs (for specific bound DFBs).
-        //  - This feature is mainly for debug purposes, or for backwards-compatible code style.
-        // Any bound DFB not listed here will use implicit sync by default.
-        std::vector<DFBSpecName> disable_implicit_sync_for;
-    };
-    std::optional<Gen2DataMovementConfig> gen2_data_movement_config = std::nullopt;
-};
 
 // A name identifying a KernelSpec within a ProgramSpec.
 using KernelSpecName = std::string;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -146,7 +146,7 @@ struct KernelSpec {
     // Named RTAs/CRTAs: referenced by name in kernel code via `args::<name>`.
     // (Currently, only uint32_t type is supported.)
     //
-    // For vararg-style positional RTAs/CRTAs, see KernelSpecAdvancedOptions.
+    // For vararg-style positional RTAs/CRTAs, see KernelAdvancedOptions.
     struct RuntimeArgSchema {
         // Named RTAs: names in declaration order. Must be unique valid C++ identifiers.
         std::vector<std::string> named_runtime_args;
@@ -165,7 +165,7 @@ struct KernelSpec {
     //////////////////////////////////////////////////////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////////////////////////////////////////////////////
-    std::optional<KernelSpecAdvancedOptions> advanced_options = std::nullopt;
+    std::optional<KernelAdvancedOptions> advanced_options = std::nullopt;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -143,44 +143,16 @@ struct KernelSpec {
     // Schema for runtime arguments (RTA) and common runtime arguments (CRTA)
     // (The VALUES of these arguments are set as ProgramRunParams.)
     //
-    // Two mechanisms are supported per kernel:
-    //   - Named RTAs/CRTAs: referenced by name in kernel code via `args::<name>`.
-    //     (Currently, only uint32_t type is supported.)
-    //   - Vararg RTAs/CRTAs: positional, variable-count, always uint32_t.
-    //     Indexed from 0 in kernel code via `get_vararg(idx)` / `get_common_vararg(idx)`.
-    //     Vararg indices are stable across schema changes (e.g., moving a named arg from RTA→CRTA).
+    // Named RTAs/CRTAs: referenced by name in kernel code via `args::<name>`.
+    // (Currently, only uint32_t type is supported.)
+    //
+    // For vararg-style positional RTAs/CRTAs, see KernelSpecAdvancedOptions.
     struct RuntimeArgSchema {
         // Named RTAs: names in declaration order. Must be unique valid C++ identifiers.
         std::vector<std::string> named_runtime_args;
 
         // Named CRTAs: names in declaration order. Must be unique valid C++ identifiers.
         std::vector<std::string> named_common_runtime_args;
-
-        //----------------------
-        // Advanced options
-
-        // Runtime varargs: dynamic RTAs
-        // Some kernels are designed to take a variable number of arguments.
-        //  e.g. N arguments representing the dimensions of an N-dimensional tensor,
-        //       where N is passed to the kernel as a CTA.
-        // Varargs are accessed positionally, since the kernel does not know how many to expect.
-        // The vararg schema specifies the number of RTA varargs for this kernel.
-        // Use ProgramRunParams to set the vararg values (per node).
-        size_t num_runtime_varargs = 0;
-
-        // Per-node vararg number override: different per-node vararg counts
-        // In very rare cases, the kernel running on different nodes requires a DIFFERENT
-        // number of varargs on different nodes.
-        // Use num_runtime_varargs_per_node to override the number of varargs.
-        // Any kernel target node not specified in the override defaults to num_runtime_varargs.
-        using NumVarargsPerNode = std::vector<std::pair<Nodes, size_t>>;  // {nodes, num_varargs}
-        std::optional<NumVarargsPerNode> num_runtime_varargs_per_node = std::nullopt;
-        // TODO: This feature is truly bizarre. Investigate removing it from the API.
-
-        // Common runtime varargs: dynamic number of CRTAs
-        // These are similar to runtime varargs. However, when specifying the argument values
-        // (in ProgramRunParams), all nodes of the kernel receive the common values.
-        size_t num_common_runtime_varargs = 0;
     };
     RuntimeArgSchema runtime_arguments_schema{};
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -122,28 +122,26 @@ struct KernelSpec {
     KernelSpecName unique_id;
 
     // Kernel source: either a path to a source file, or the source code itself.
-    // (Force callers to choose explicitly between path and inline code.)
-    struct SourceFilePath {
-        std::filesystem::path path;
-    };
+    // String literals bind directly to the path variant alternative; wrap inline
+    // source code with SourceCode{...}.
     struct SourceCode {
         std::string code;
     };
-    std::variant<SourceFilePath, SourceCode> source;
+    std::variant<std::filesystem::path, SourceCode> source;
 
     // NOTE: The kernel's target node set is a DERIVED property, based on the
     //       WorkUnitSpec(s) that include this kernel.
 
     // Kernel threading:
     // Number of kernel threads
-    uint8_t num_threads = 1;
+    int num_threads = 1;
 
     // (Optional) Per-node thread count specification
     // The default threading is num_threads. However, you may override this on a per-node basis.
     // NOTE: This feature is currently unsupported. It's an open question if we EVER want to support it.
     //       Here as a placeholder; specifying it will trigger a runtime error.
     using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
-    using NodeSpecificThreadCount = std::pair<Nodes, uint8_t>;  // {node_set, num_threads}
+    using NodeSpecificThreadCount = std::pair<Nodes, int>;  // {node_set, num_threads}
     using NodeSpecificThreadCounts = std::vector<NodeSpecificThreadCount>;
     std::optional<NodeSpecificThreadCounts> node_specific_thread_counts = std::nullopt;
 
@@ -173,11 +171,11 @@ struct KernelSpec {
     // DFB bindings
     // Declares that this kernel requires a DFB resource (declared at the ProgramSpec level)
     // The kernel constructs the accessor via DataflowBufferAccessor(dfb::<local_accessor_name>)
-    enum class DFBEndpointType { PRODUCER, CONSUMER, RELAY };
+    enum class DFBEndpointType { PRODUCER, CONSUMER };
     struct DFBBinding {
         DFBSpecName dfb_spec_name;        // identify the DFB within the ProgramSpec
         std::string local_accessor_name;  // DFB accessor name (used in the kernel source code)
-        DFBEndpointType endpoint_type;    // producer, consumer, or relay
+        DFBEndpointType endpoint_type;    // producer or consumer
         DFBAccessPattern access_pattern = DFBAccessPattern::STRIDED;  // strided, all, or blocked
     };
     std::vector<DFBBinding> dfb_bindings;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -89,11 +89,6 @@ struct DataMovementConfiguration {
 };
 
 // A name identifying a KernelSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* READER_KERNEL = "reader";
-//   KernelSpec{.unique_id = READER_KERNEL, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
 using KernelSpecName = std::string;
 
 // A KernelSpec is a descriptor for a Tenstorrent kernel:

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -67,7 +67,7 @@ struct KernelSpec {
 
     // Kernel threading:
     // Number of kernel threads
-    int num_threads = 1;
+    uint32_t num_threads = 1;
 
     // Kernel type (methods)
     bool is_dm_kernel() const { return std::holds_alternative<DataMovementConfiguration>(config_spec); }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
@@ -19,6 +19,8 @@
 // A "node" is a NOC endpoint with an x,y address - a block in the accelerator grid.
 // This header provides type aliases for the new "Node" terminology.
 
+#include <variant>
+
 #include <tt-metalium/core_coord.hpp>
 
 namespace tt::tt_metal::experimental::metal2_host_api {
@@ -27,6 +29,9 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 using NodeCoord = tt::tt_metal::CoreCoord;
 using NodeRange = tt::tt_metal::CoreRange;
 using NodeRangeSet = tt::tt_metal::CoreRangeSet;
+
+// A set of nodes specified as a single point, range, or range set.
+using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
 
 // Function aliases: Node terminology equivalents
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -51,7 +51,7 @@ struct ProgramRunParams {
         std::unordered_map<std::string, uint32_t> named_common_runtime_args;
 
         // Advanced options (see advanced_options.hpp).
-        // Companion to KernelSpecAdvancedOptions on the schema side; holds
+        // Companion to KernelAdvancedOptions on the schema side; holds
         // unnamed-vararg RTA/CRTA values.
         std::optional<AdvancedKernelRunParams> advanced_options = std::nullopt;
     };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -53,7 +53,7 @@ struct ProgramRunParams {
         // Advanced options (see advanced_options.hpp).
         // Companion to KernelAdvancedOptions on the schema side; holds
         // unnamed-vararg RTA/CRTA values.
-        std::optional<AdvancedKernelRunParams> advanced_options = std::nullopt;
+        AdvancedKernelRunParams advanced_options;
     };
     // KernelRunParams must be specified for ALL kernels in the ProgramSpec.
     std::vector<KernelRunParams> kernel_run_params;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_params.hpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
@@ -49,18 +50,10 @@ struct ProgramRunParams {
         // Every arg in this kernel's RuntimeArgSchema::named_common_runtime_args must be set.
         std::unordered_map<std::string, uint32_t> named_common_runtime_args;
 
-        // Unnamed runtime argument "varargs"
-        // (these are specified per-node; length can vary per-node)
-        struct NodeVarargs {
-            NodeCoord node;
-            std::vector<uint32_t> args;
-        };
-        std::vector<NodeVarargs> runtime_varargs;
-
-        // Unnamed common runtime argument "varargs"
-        // (common to all nodes on which the kernel runs)
-        using CommonVarargs = std::vector<uint32_t>;
-        CommonVarargs common_runtime_varargs;
+        // Advanced options (see advanced_options.hpp).
+        // Companion to KernelSpecAdvancedOptions on the schema side; holds
+        // unnamed-vararg RTA/CRTA values.
+        std::optional<AdvancedKernelRunParams> advanced_options = std::nullopt;
     };
     // KernelRunParams must be specified for ALL kernels in the ProgramSpec.
     std::vector<KernelRunParams> kernel_run_params;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -40,7 +40,7 @@ struct WorkUnitSpec {
     std::vector<KernelSpecName> kernels;
 
     // The set of nodes configured by this WorkUnitSpec.
-    std::variant<NodeCoord, NodeRange, NodeRangeSet> target_nodes;
+    Nodes target_nodes;
 };
 
 // A ProgramSpec describes the immutable properties of a Program:

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -19,15 +19,9 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a ProgramSpec within a MeshWorkload.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* MATMUL_PROGRAM = "matmul";
-//   ProgramSpec{.program_id = MATMUL_PROGRAM, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
 using ProgramSpecName = std::string;
 
 // A name identifying a WorkUnitSpec within a ProgramSpec.
-// CONVENTION: define names as `constexpr const char*` constants (see above).
 using WorkUnitSpecName = std::string;
 
 //------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -39,7 +38,7 @@ struct SemaphoreSpec {
     //////////////////////////////////////////////////////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////////////////////////////////////////////////////
-    std::optional<SemaphoreAdvancedOptions> advanced_options = std::nullopt;
+    SemaphoreAdvancedOptions advanced_options;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -15,11 +15,6 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a SemaphoreSpec within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* DONE_FLAG = "done_flag";
-//   SemaphoreSpec{.unique_id = DONE_FLAG, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
 using SemaphoreSpecName = std::string;
 
 // A SemaphoreSpec is a descriptor for a Tenstorrent semaphore,

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -35,15 +35,10 @@ struct SemaphoreSpec {
     // Target nodes
     Nodes target_nodes;
 
-    //////////////////////////////
-    // Advanced options
-    //////////////////////////////
-
-    // Initial value
-    // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
-    // NOTE: Runtime wants to deprecate this feature for ALL architectures.
-    //       When remote DFB becomes available, non-zero initial values will be removed.
-    uint32_t initial_value = 0;
+    //////////////////////////////////////////////////////////////////////////////
+    // Advanced options (see advanced_options.hpp)
+    //////////////////////////////////////////////////////////////////////////////
+    std::optional<SemaphoreAdvancedOptions> advanced_options = std::nullopt;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -44,12 +44,6 @@ struct SemaphoreSpec {
     // NOTE: Runtime wants to deprecate this feature for ALL architectures.
     //       When remote DFB becomes available, non-zero initial values will be removed.
     uint32_t initial_value = 0;
-
-    // Backing memory
-    // NOTE: Register-backed semaphores are a Gen2-only hardware feature.
-    //       They are not yet supported; TBD whether we will ever support them.
-    enum class SemaphoreMemoryType { L1, Register };
-    SemaphoreMemoryType memory_type = SemaphoreMemoryType::L1;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 
 namespace tt::tt_metal::experimental::metal2_host_api {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -33,7 +33,6 @@ struct SemaphoreSpec {
     SemaphoreSpecName unique_id;
 
     // Target nodes
-    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
     Nodes target_nodes;
 
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -25,36 +25,6 @@ struct TensorParameter {
     // Single-device tensor layout
     tt::tt_metal::TensorSpec spec;
 
-    ///////////////////////////////////////////////////////////////////
-    // Advanced options
-    ///////////////////////////////////////////////////////////////////
-
-    // By default, the MeshTensor argument provided at execution time must
-    // EXACTLY match the TensorParameter's declared TensorSpec. The advanced
-    // options below relax this match requirement in particular ways.
-    //
-    // NOTE: These options are UNSAFE if set to true; most kernels will not function
-    // correctly if the tensor argument's spec deviates from the declared spec.
-    // Use with caution and ensure that your kernel logic is compatible.
-
-    // Permit tensor arguments whose logical_shape differs from the declared shape.
-    // The argument's padded_shape must still match exactly.
-    // Effects:
-    //  - Validation checks are relaxed
-    //  - TensorAccessor configuration is completely unchanged
-    bool match_padded_shape_only = false;
-
-    // Permit tensor arguments with dynamic logical shape.
-    // The argument's logical_shape AND padded_shape may differ from the declared shape.
-    // Effects:
-    //  - Validation checks are relaxed
-    //  - For an interleaved tensor, TensorAccessor configuration is unchanged
-    //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
-    //    argument's actual shape. (Shape becomes an implicit runtime argument.)
-    bool dynamic_tensor_shape = false;
-
-    // Additional relaxation options will be added in the future.
-
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -13,11 +13,6 @@
 namespace tt::tt_metal::experimental::metal2_host_api {
 
 // A name identifying a TensorParameter within a ProgramSpec.
-//
-// CONVENTION: define names as `constexpr const char*` constants, e.g.:
-//   constexpr const char* INPUT_TENSOR = "input_tensor";
-//   TensorParameter{.unique_id = INPUT_TENSOR, ...};
-// Reusing a single constant helps catch typos and errors at compile time.
 using TensorParameterName = std::string;
 
 // A TensorParameter is used to declare that a Program operates on a MeshTensor

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 
 namespace tt::tt_metal::experimental::metal2_host_api {
@@ -57,6 +59,11 @@ struct TensorParameter {
     bool dynamic_tensor_shape = false;
 
     // Additional relaxation options will be added in the future.
+
+    //////////////////////////////
+    // Advanced options (see advanced_options.hpp)
+    //////////////////////////////
+    std::optional<TensorParameterAdvancedOptions> advanced_options = std::nullopt;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
@@ -28,7 +27,7 @@ struct TensorParameter {
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////
-    std::optional<TensorParameterAdvancedOptions> advanced_options = std::nullopt;
+    TensorParameterAdvancedOptions advanced_options;
 };
 
 }  // namespace tt::tt_metal::experimental::metal2_host_api

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -24,6 +24,19 @@ namespace tt::tt_metal::experimental::metal2_host_api {
 // Type alias for readability
 using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 
+// Helpers for vararg-value access (now living on AdvancedKernelRunParams).
+const std::vector<AdvancedKernelRunParams::NodeVarargs>& kernel_runtime_varargs(
+    const ProgramRunParams::KernelRunParams& kp) {
+    static const std::vector<AdvancedKernelRunParams::NodeVarargs> empty;
+    return kp.advanced_options.has_value() ? kp.advanced_options->runtime_varargs : empty;
+}
+
+const AdvancedKernelRunParams::CommonVarargs& kernel_common_runtime_varargs(
+    const ProgramRunParams::KernelRunParams& kp) {
+    static const AdvancedKernelRunParams::CommonVarargs empty;
+    return kp.advanced_options.has_value() ? kp.advanced_options->common_runtime_varargs : empty;
+}
+
 // Internal validation function - validates a TensorArg list against the Program's TensorParameters.
 // Shared by SetProgramRunParameters (full path) and UpdateTensorArgs (partial path).
 //   - No duplicate tensor_parameter_name entries
@@ -148,7 +161,7 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 
         // Validate vararg RTA counts per node
         std::unordered_set<NodeCoord> nodes_with_vararg_params;
-        for (const auto& [node_coord, args] : kernel_params.runtime_varargs) {
+        for (const auto& [node_coord, args] : kernel_runtime_varargs(kernel_params)) {
             auto [it_node, node_inserted] = nodes_with_vararg_params.insert(node_coord);
             TT_FATAL(
                 node_inserted,
@@ -189,11 +202,11 @@ void ValidateProgramRunParams(const Program& program, const ProgramRunParams& pa
 
         // Validate vararg CRTA count
         TT_FATAL(
-            kernel_params.common_runtime_varargs.size() == schema->num_common_runtime_varargs,
+            kernel_common_runtime_varargs(kernel_params).size() == schema->num_common_runtime_varargs,
             "Kernel '{}' expects {} vararg common runtime args, but {} were provided",
             kernel_name,
             schema->num_common_runtime_varargs,
-            kernel_params.common_runtime_varargs.size());
+            kernel_common_runtime_varargs(kernel_params).size());
 
         // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
         const auto& named_rta_names = schema->named_runtime_args;
@@ -489,7 +502,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
 
         // Build a node -> vararg-values-span lookup.
         std::unordered_map<NodeCoord, const std::vector<uint32_t>*> varargs_by_node;
-        for (const auto& [node, args] : kernel_params.runtime_varargs) {
+        for (const auto& [node, args] : kernel_runtime_varargs(kernel_params)) {
             varargs_by_node[node] = &args;
         }
 
@@ -546,7 +559,7 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
         std::vector<uint32_t> combined_crtas;
         combined_crtas.reserve(
             schema->named_common_runtime_args.size() + binding_section_words +
-            kernel_params.common_runtime_varargs.size());
+            kernel_common_runtime_varargs(kernel_params).size());
         for (const auto& name : schema->named_common_runtime_args) {
             auto v_it = kernel_params.named_common_runtime_args.find(name);
             TT_FATAL(
@@ -568,8 +581,8 @@ void SetProgramRunParameters(Program& program, const ProgramRunParams& params) {
         }
         combined_crtas.insert(
             combined_crtas.end(),
-            kernel_params.common_runtime_varargs.begin(),
-            kernel_params.common_runtime_varargs.end());
+            kernel_common_runtime_varargs(kernel_params).begin(),
+            kernel_common_runtime_varargs(kernel_params).end());
 
         // Set common runtime args
         // TODO: Why on earth does SetCommonRuntimeArgs() only work the first time??

--- a/tt_metal/impl/metal2_host_api/program_run_params.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_params.cpp
@@ -27,14 +27,12 @@ using KernelRTASchema = detail::ProgramImpl::KernelRTASchema;
 // Helpers for vararg-value access (now living on AdvancedKernelRunParams).
 const std::vector<AdvancedKernelRunParams::NodeVarargs>& kernel_runtime_varargs(
     const ProgramRunParams::KernelRunParams& kp) {
-    static const std::vector<AdvancedKernelRunParams::NodeVarargs> empty;
-    return kp.advanced_options.has_value() ? kp.advanced_options->runtime_varargs : empty;
+    return kp.advanced_options.runtime_varargs;
 }
 
 const AdvancedKernelRunParams::CommonVarargs& kernel_common_runtime_varargs(
     const ProgramRunParams::KernelRunParams& kp) {
-    static const AdvancedKernelRunParams::CommonVarargs empty;
-    return kp.advanced_options.has_value() ? kp.advanced_options->common_runtime_varargs : empty;
+    return kp.advanced_options.common_runtime_varargs;
 }
 
 // Internal validation function - validates a TensorArg list against the Program's TensorParameters.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -181,6 +181,12 @@ const std::vector<DFBSpecName>& dfb_alias_with(const DataflowBufferSpec& dfb) {
     return dfb.advanced_options.has_value() ? dfb.advanced_options->alias_with : empty;
 }
 
+// Helper: return a kernel's dfb-compute-self-loop-scopes list (empty if not set in advanced_options).
+const std::vector<DFBComputeSelfLoopScope>& kernel_self_loop_scopes(const KernelSpec& kernel) {
+    static const std::vector<DFBComputeSelfLoopScope> empty;
+    return kernel.advanced_options.has_value() ? kernel.advanced_options->dfb_compute_self_loop_scopes : empty;
+}
+
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
 // They are used verbatim in the generated kernel source code.
 // TODO: Move this to ttsl in a follow up PR
@@ -1101,12 +1107,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // unordered_set), so iteration order — and any resulting error message — is
             // deterministic across runs.
             auto scope_for_kernel = [&](const KernelSpec* k) {
-                for (const auto& entry : k->dfb_compute_self_loop_scopes) {
+                for (const auto& entry : kernel_self_loop_scopes(*k)) {
                     if (entry.dfb_spec_name == dfb.unique_id) {
                         return entry.scope;
                     }
                 }
-                return KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA;
+                return DFBComputeSelfLoopScope::Scope::INTRA;
             };
             const KernelSpec* first_kernel = endpoints.producers.front().kernel;
             const auto first_scope = scope_for_kernel(first_kernel);
@@ -1296,7 +1302,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // (bind it as both producer and consumer).
     // All misapplications fail loudly here for the benefit of users (especially AI users).
     for (const KernelSpec& kernel : spec.kernels) {
-        if (kernel.dfb_compute_self_loop_scopes.empty()) {
+        if (kernel_self_loop_scopes(kernel).empty()) {
             continue;
         }
         TT_FATAL(
@@ -1306,7 +1312,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.unique_id);
 
         std::unordered_set<DFBSpecName> seen_dfb_names;
-        for (const auto& entry : kernel.dfb_compute_self_loop_scopes) {
+        for (const auto& entry : kernel_self_loop_scopes(kernel)) {
             TT_FATAL(
                 seen_dfb_names.insert(entry.dfb_spec_name).second,
                 "KernelSpec '{}' has duplicate dfb_compute_self_loop_scopes entries for DFB '{}'.",
@@ -1340,7 +1346,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 entry.dfb_spec_name);
 
             TT_FATAL(
-                entry.scope != KernelSpec::DFBComputeSelfLoopScope::Scope::INTER,
+                entry.scope != DFBComputeSelfLoopScope::Scope::INTER,
                 "KernelSpec '{}' specifies INTER scope for self-looped DFB '{}'. INTER scope is "
                 "not yet supported by the runtime.",
                 kernel.unique_id,
@@ -2045,14 +2051,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     }();
     std::optional<experimental::dfb::TensixScope> tensix_scope;
     if (is_self_loop && producer->is_compute_kernel()) {
-        auto user_scope = KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA;
-        for (const auto& entry : producer->dfb_compute_self_loop_scopes) {
+        auto user_scope = DFBComputeSelfLoopScope::Scope::INTRA;
+        for (const auto& entry : kernel_self_loop_scopes(*producer)) {
             if (entry.dfb_spec_name == dfb_spec->unique_id) {
                 user_scope = entry.scope;
                 break;
             }
         }
-        tensix_scope = (user_scope == KernelSpec::DFBComputeSelfLoopScope::Scope::INTRA)
+        tensix_scope = (user_scope == DFBComputeSelfLoopScope::Scope::INTRA)
                            ? experimental::dfb::TensixScope::INTRA
                            : experimental::dfb::TensixScope::INTER;  // currently blocked in validation
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -153,7 +153,7 @@ inline bool is_gen1_arch() {
     return arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE;
 }
 
-NodeRangeSet to_node_range_set(const std::variant<NodeCoord, NodeRange, NodeRangeSet>& nodes) {
+NodeRangeSet to_node_range_set(const Nodes& nodes) {
     return std::visit(
         [](const auto& n) -> NodeRangeSet {
             using T = std::decay_t<decltype(n)>;
@@ -169,9 +169,7 @@ NodeRangeSet to_node_range_set(const std::variant<NodeCoord, NodeRange, NodeRang
         nodes);
 }
 
-bool nodes_intersect(
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& a,
-    const std::variant<NodeCoord, NodeRange, NodeRangeSet>& b) {
+bool nodes_intersect(const Nodes& a, const Nodes& b) {
     NodeRangeSet a_set = to_node_range_set(a);
     NodeRangeSet b_set = to_node_range_set(b);
     return a_set.intersects(b_set);
@@ -525,7 +523,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
     // No need for dispatch-specific checks (and dispatch-specific error messages confuse users)
     const CoreCoord compute_grid = tt::get_compute_grid_size(env_impl, chip_id, num_hw_cqs, dispatch_core_config);
 
-    auto check_target_nodes = [&](const std::variant<NodeCoord, NodeRange, NodeRangeSet>& target_nodes,
+    auto check_target_nodes = [&](const Nodes& target_nodes,
                                   std::string_view entity_type,
                                   std::string_view entity_name) {
         const NodeRangeSet range_set = to_node_range_set(target_nodes);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1793,7 +1793,8 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     // tensors the CTA payload never carried tensor_shape in the first place (and
     // the device-side accessor doesn't read it), so the flag is a pure host-side
     // validation loosening and has no effect on the CTA/CRTA layout.
-    const bool dyn_shape = tensor_parameter.dynamic_tensor_shape && is_sharded;
+    const bool dyn_shape = tensor_parameter.advanced_options.has_value() &&
+                           tensor_parameter.advanced_options->dynamic_tensor_shape && is_sharded;
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -2414,11 +2415,12 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Register TensorParameters with the program for ValidateProgramRunParams to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {
+        const bool dyn_shape =
+            tensor_parameter.advanced_options.has_value() && tensor_parameter.advanced_options->dynamic_tensor_shape;
+        const bool match_padded_only =
+            tensor_parameter.advanced_options.has_value() && tensor_parameter.advanced_options->match_padded_shape_only;
         program_impl->register_tensor_parameter(
-            tensor_parameter.unique_id,
-            tensor_parameter.spec,
-            tensor_parameter.dynamic_tensor_shape,
-            tensor_parameter.match_padded_shape_only);
+            tensor_parameter.unique_id, tensor_parameter.spec, dyn_shape, match_padded_only);
     }
 
     // Create DataflowBuffers and build name -> ID map.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -175,6 +175,12 @@ bool nodes_intersect(const Nodes& a, const Nodes& b) {
     return a_set.intersects(b_set);
 }
 
+// Helper: return a DFB's alias-with list (empty vector if not set in advanced_options).
+const std::vector<DFBSpecName>& dfb_alias_with(const DataflowBufferSpec& dfb) {
+    static const std::vector<DFBSpecName> empty;
+    return dfb.advanced_options.has_value() ? dfb.advanced_options->alias_with : empty;
+}
+
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
 // They are used verbatim in the generated kernel source code.
 // TODO: Move this to ttsl in a follow up PR
@@ -1194,7 +1200,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         // The "extended group" of a DFB is its alias_with plus the DFB itself. Two DFBs
         // are in the same alias group iff their extended groups are equal.
         auto extended_group = [](const DataflowBufferSpec& d) {
-            std::set<DFBSpecName> s(d.alias_with.begin(), d.alias_with.end());
+            std::set<DFBSpecName> s(dfb_alias_with(d).begin(), dfb_alias_with(d).end());
             s.insert(d.unique_id);
             return s;
         };
@@ -1202,7 +1208,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         // Pre-pass: every name in every alias_with must refer to a real DFB and must not
         // be self-referential.
         for (const auto& dfb : spec.dataflow_buffers) {
-            for (const auto& alias_name : dfb.alias_with) {
+            for (const auto& alias_name : dfb_alias_with(dfb)) {
                 TT_FATAL(
                     collected.dfb_by_name.contains(alias_name),
                     "DFB '{}' lists unknown alias '{}' in alias_with",
@@ -1213,14 +1219,14 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
 
         for (const auto& dfb : spec.dataflow_buffers) {
-            if (dfb.alias_with.empty()) {
+            if (dfb_alias_with(dfb).empty()) {
                 continue;
             }
             const size_t total_size_a = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
             const auto group_a = extended_group(dfb);
             const auto& nodes_a = collected.dfb_node_set.at(dfb.unique_id);
 
-            for (const auto& alias_name : dfb.alias_with) {
+            for (const auto& alias_name : dfb_alias_with(dfb)) {
                 const DataflowBufferSpec* alias_spec = collected.dfb_by_name.at(alias_name);
 
                 // Rule 1: full clique declaration.
@@ -2461,11 +2467,11 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
             if (handled_as_secondary.contains(dfb_spec.unique_id)) {
                 continue;
             }
-            if (dfb_spec.alias_with.empty()) {
+            if (dfb_alias_with(dfb_spec).empty()) {
                 continue;
             }
             const uint32_t primary_id = dfb_name_to_id.at(dfb_spec.unique_id);
-            for (const auto& alias_name : dfb_spec.alias_with) {
+            for (const auto& alias_name : dfb_alias_with(dfb_spec)) {
                 if (handled_as_secondary.contains(alias_name)) {
                     continue;
                 }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -587,8 +587,10 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     // Validate no per-node thread maps are used (not yet implemented)
     for (const auto& kernel : spec.kernels) {
+        const bool has_node_specific =
+            kernel.advanced_options.has_value() && kernel.advanced_options->node_specific_thread_counts.has_value();
         TT_FATAL(
-            !kernel.node_specific_thread_counts.has_value(),
+            !has_node_specific,
             "KernelSpec '{}' specifies node_specific_thread_counts, but per-node thread counts are not implemented.",
             kernel.unique_id);
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1372,12 +1372,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //////////////////////////////////
 
     for (const auto& sem : spec.semaphores) {
+        const uint32_t init_value = sem.advanced_options.has_value() ? sem.advanced_options->initial_value : 0u;
         if (is_gen2_arch()) {
             TT_FATAL(
-                sem.initial_value == 0,
+                init_value == 0,
                 "SemaphoreSpec '{}' has initial_value={} but only zero is supported on Quasar",
                 sem.unique_id,
-                sem.initial_value);
+                init_value);
         }
     }
 
@@ -2495,8 +2496,10 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     SemaphoreNameToIdMap semaphore_name_to_id;
     for (const auto& semaphore_spec : spec.semaphores) {
         const SemaphoreSpecName& semaphore_name = semaphore_spec.unique_id;
+        const uint32_t init_value =
+            semaphore_spec.advanced_options.has_value() ? semaphore_spec.advanced_options->initial_value : 0u;
         uint32_t sem_id = program_impl->create_semaphore(
-            to_node_range_set(semaphore_spec.target_nodes), semaphore_spec.initial_value, CoreType::WORKER);
+            to_node_range_set(semaphore_spec.target_nodes), init_value, CoreType::WORKER);
         program_impl->register_semaphore_spec_name(semaphore_name, sem_id);
         semaphore_name_to_id[semaphore_name] = sem_id;
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -175,16 +175,14 @@ bool nodes_intersect(const Nodes& a, const Nodes& b) {
     return a_set.intersects(b_set);
 }
 
-// Helper: return a DFB's alias-with list (empty vector if not set in advanced_options).
+// Helper: return a DFB's alias-with list.
 const std::vector<DFBSpecName>& dfb_alias_with(const DataflowBufferSpec& dfb) {
-    static const std::vector<DFBSpecName> empty;
-    return dfb.advanced_options.has_value() ? dfb.advanced_options->alias_with : empty;
+    return dfb.advanced_options.alias_with;
 }
 
-// Helper: return a kernel's dfb-compute-self-loop-scopes list (empty if not set in advanced_options).
+// Helper: return a kernel's dfb-compute-self-loop-scopes list.
 const std::vector<DFBComputeSelfLoopScope>& kernel_self_loop_scopes(const KernelSpec& kernel) {
-    static const std::vector<DFBComputeSelfLoopScope> empty;
-    return kernel.advanced_options.has_value() ? kernel.advanced_options->dfb_compute_self_loop_scopes : empty;
+    return kernel.advanced_options.dfb_compute_self_loop_scopes;
 }
 
 // Local accessor names for kernel resource bindings must be valid C++ identifiers
@@ -593,8 +591,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     // Validate no per-node thread maps are used (not yet implemented)
     for (const auto& kernel : spec.kernels) {
-        const bool has_node_specific =
-            kernel.advanced_options.has_value() && kernel.advanced_options->node_specific_thread_counts.has_value();
+        const bool has_node_specific = !kernel.advanced_options.node_specific_thread_counts.empty();
         TT_FATAL(
             !has_node_specific,
             "KernelSpec '{}' specifies node_specific_thread_counts, but per-node thread counts are not implemented.",
@@ -1372,7 +1369,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //////////////////////////////////
 
     for (const auto& sem : spec.semaphores) {
-        const uint32_t init_value = sem.advanced_options.has_value() ? sem.advanced_options->initial_value : 0u;
+        const uint32_t init_value = sem.advanced_options.initial_value;
         if (is_gen2_arch()) {
             TT_FATAL(
                 init_value == 0,
@@ -1808,8 +1805,7 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     // tensors the CTA payload never carried tensor_shape in the first place (and
     // the device-side accessor doesn't read it), so the flag is a pure host-side
     // validation loosening and has no effect on the CTA/CRTA layout.
-    const bool dyn_shape = tensor_parameter.advanced_options.has_value() &&
-                           tensor_parameter.advanced_options->dynamic_tensor_shape && is_sharded;
+    const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape && is_sharded;
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -2430,10 +2426,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Register TensorParameters with the program for ValidateProgramRunParams to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {
-        const bool dyn_shape =
-            tensor_parameter.advanced_options.has_value() && tensor_parameter.advanced_options->dynamic_tensor_shape;
-        const bool match_padded_only =
-            tensor_parameter.advanced_options.has_value() && tensor_parameter.advanced_options->match_padded_shape_only;
+        const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape;
+        const bool match_padded_only = tensor_parameter.advanced_options.match_padded_shape_only;
         program_impl->register_tensor_parameter(
             tensor_parameter.unique_id, tensor_parameter.spec, dyn_shape, match_padded_only);
     }
@@ -2496,8 +2490,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     SemaphoreNameToIdMap semaphore_name_to_id;
     for (const auto& semaphore_spec : spec.semaphores) {
         const SemaphoreSpecName& semaphore_name = semaphore_spec.unique_id;
-        const uint32_t init_value =
-            semaphore_spec.advanced_options.has_value() ? semaphore_spec.advanced_options->initial_value : 0u;
+        const uint32_t init_value = semaphore_spec.advanced_options.initial_value;
         uint32_t sem_id = program_impl->create_semaphore(
             to_node_range_set(semaphore_spec.target_nodes), init_value, CoreType::WORKER);
         program_impl->register_semaphore_spec_name(semaphore_name, sem_id);
@@ -2632,12 +2625,9 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         runtime_schema.named_common_runtime_args = user_named_crtas;
 
         // Varargs schema now lives on KernelAdvancedOptions.
-        const size_t num_runtime_varargs =
-            kernel_spec.advanced_options.has_value() ? kernel_spec.advanced_options->num_runtime_varargs : 0;
-        const size_t num_common_runtime_varargs =
-            kernel_spec.advanced_options.has_value() ? kernel_spec.advanced_options->num_common_runtime_varargs : 0;
-        const bool has_per_node_override = kernel_spec.advanced_options.has_value() &&
-                                           kernel_spec.advanced_options->num_runtime_varargs_per_node.has_value();
+        const size_t num_runtime_varargs = kernel_spec.advanced_options.num_runtime_varargs;
+        const size_t num_common_runtime_varargs = kernel_spec.advanced_options.num_common_runtime_varargs;
+        const bool has_per_node_override = !kernel_spec.advanced_options.num_runtime_varargs_per_node.empty();
 
         if (num_runtime_varargs > 0) {
             for (const NodeRange& range : node_ranges.ranges()) {
@@ -2648,7 +2638,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         }
         if (has_per_node_override) {
             std::unordered_set<NodeCoord> seen_overrides;
-            for (const auto& [nodes_spec, num_varargs] : *kernel_spec.advanced_options->num_runtime_varargs_per_node) {
+            for (const auto& [nodes_spec, num_varargs] : kernel_spec.advanced_options.num_runtime_varargs_per_node) {
                 const NodeRangeSet expanded = to_node_range_set(nodes_spec);
                 for (const NodeRange& range : expanded.ranges()) {
                     for (const NodeCoord& node : range) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2631,7 +2631,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // addr_crta_offset; SetProgramRunParameters uses BOTH to assemble the per-enqueue CRTA buffer.
         runtime_schema.named_common_runtime_args = user_named_crtas;
 
-        // Varargs schema now lives on KernelSpecAdvancedOptions.
+        // Varargs schema now lives on KernelAdvancedOptions.
         const size_t num_runtime_varargs =
             kernel_spec.advanced_options.has_value() ? kernel_spec.advanced_options->num_runtime_varargs : 0;
         const size_t num_common_runtime_varargs =

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1620,7 +1620,7 @@ private:
 // Constraint score for sorting: higher = more constrained (RISC cores should be assigned earlier)
 int ConstraintScore(const KernelSpec* k, const NodeRangeSet& kernel_nodes) {
     int node_count = static_cast<int>(kernel_nodes.num_cores());
-    int thread_count = k->num_threads;
+    int thread_count = static_cast<int>(k->num_threads);
     return (node_count * 100) + thread_count;  // nodes dominate, threads break ties
 }
 
@@ -2231,7 +2231,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
 
     return experimental::quasar::QuasarDataMovementConfig{
-        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
+        .num_threads_per_cluster = kernel_spec.num_threads,
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
@@ -2254,7 +2254,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         BuildUnpackToDestModeVector(compute_config.unpack_to_dest_mode, dfb_name_to_id);
 
     return experimental::quasar::QuasarComputeConfig{
-        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
+        .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = compute_config.math_fidelity,
         .fp32_dest_acc_en = compute_config.fp32_dest_acc_en,
         .dst_full_sync_en = compute_config.dst_full_sync_en,
@@ -2625,8 +2625,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         runtime_schema.named_common_runtime_args = user_named_crtas;
 
         // Varargs schema now lives on KernelAdvancedOptions.
-        const size_t num_runtime_varargs = kernel_spec.advanced_options.num_runtime_varargs;
-        const size_t num_common_runtime_varargs = kernel_spec.advanced_options.num_common_runtime_varargs;
+        const uint32_t num_runtime_varargs = kernel_spec.advanced_options.num_runtime_varargs;
+        const uint32_t num_common_runtime_varargs = kernel_spec.advanced_options.num_common_runtime_varargs;
         const bool has_per_node_override = !kernel_spec.advanced_options.num_runtime_varargs_per_node.empty();
 
         if (num_runtime_varargs > 0) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1358,10 +1358,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //////////////////////////////////
 
     for (const auto& sem : spec.semaphores) {
-        TT_FATAL(
-            sem.memory_type == SemaphoreSpec::SemaphoreMemoryType::L1,
-            "SemaphoreSpec '{}' uses non-L1 memory type, which is not yet supported",
-            sem.unique_id);
         if (is_gen2_arch()) {
             TT_FATAL(
                 sem.initial_value == 0,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2081,10 +2081,10 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .entry_size = dfb_spec->entry_size,
         .num_entries = dfb_spec->num_entries,
         .producer_risc_mask = producer_risc_mask,
-        .num_producers = producer->num_threads,
+        .num_producers = static_cast<uint8_t>(producer->num_threads),
         .pap = producer_access_pattern,
         .consumer_risc_mask = consumer_risc_mask,
-        .num_consumers = consumer->num_threads,
+        .num_consumers = static_cast<uint8_t>(consumer->num_threads),
         .cap = consumer_access_pattern,
         .enable_producer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.producers),
         .enable_consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers),
@@ -2104,9 +2104,9 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
     return std::visit(
         [&](const auto& src) -> KernelSource {
             using T = std::decay_t<decltype(src)>;
-            if constexpr (std::is_same_v<T, KernelSpec::SourceFilePath>) {
-                TT_FATAL(!src.path.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
-                return KernelSource(src.path.string(), KernelSource::SourceType::FILE_PATH);
+            if constexpr (std::is_same_v<T, std::filesystem::path>) {
+                TT_FATAL(!src.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
+                return KernelSource(src.string(), KernelSource::SourceType::FILE_PATH);
             } else if constexpr (std::is_same_v<T, KernelSpec::SourceCode>) {
                 TT_FATAL(!src.code.empty(), "KernelSpec '{}' has empty inline source code", kernel_spec.unique_id);
                 return KernelSource(src.code, KernelSource::SourceType::SOURCE_CODE);
@@ -2225,7 +2225,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
     TT_FATAL(kernel_spec.is_dm_kernel(), "Expected a DM kernel");
 
     return experimental::quasar::QuasarDataMovementConfig{
-        .num_threads_per_cluster = kernel_spec.num_threads,
+        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
         .compile_args = {},  // only named_compile_args is used
         .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_arg_bindings),
@@ -2248,7 +2248,7 @@ experimental::quasar::QuasarComputeConfig MakeQuasarComputeConfig(
         BuildUnpackToDestModeVector(compute_config.unpack_to_dest_mode, dfb_name_to_id);
 
     return experimental::quasar::QuasarComputeConfig{
-        .num_threads_per_cluster = kernel_spec.num_threads,
+        .num_threads_per_cluster = static_cast<uint32_t>(kernel_spec.num_threads),
         .math_fidelity = compute_config.math_fidelity,
         .fp32_dest_acc_en = compute_config.fp32_dest_acc_en,
         .dst_full_sync_en = compute_config.dst_full_sync_en,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2627,16 +2627,25 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // (via tensor_binding_handles) and its slot offsets are baked into each binding handle's
         // addr_crta_offset; SetProgramRunParameters uses BOTH to assemble the per-enqueue CRTA buffer.
         runtime_schema.named_common_runtime_args = user_named_crtas;
-        if (user_schema.num_runtime_varargs > 0) {
+
+        // Varargs schema now lives on KernelSpecAdvancedOptions.
+        const size_t num_runtime_varargs =
+            kernel_spec.advanced_options.has_value() ? kernel_spec.advanced_options->num_runtime_varargs : 0;
+        const size_t num_common_runtime_varargs =
+            kernel_spec.advanced_options.has_value() ? kernel_spec.advanced_options->num_common_runtime_varargs : 0;
+        const bool has_per_node_override = kernel_spec.advanced_options.has_value() &&
+                                           kernel_spec.advanced_options->num_runtime_varargs_per_node.has_value();
+
+        if (num_runtime_varargs > 0) {
             for (const NodeRange& range : node_ranges.ranges()) {
                 for (const NodeCoord& node : range) {
-                    runtime_schema.num_runtime_varargs_per_node[node] = user_schema.num_runtime_varargs;
+                    runtime_schema.num_runtime_varargs_per_node[node] = num_runtime_varargs;
                 }
             }
         }
-        if (user_schema.num_runtime_varargs_per_node.has_value()) {
+        if (has_per_node_override) {
             std::unordered_set<NodeCoord> seen_overrides;
-            for (const auto& [nodes_spec, num_varargs] : *user_schema.num_runtime_varargs_per_node) {
+            for (const auto& [nodes_spec, num_varargs] : *kernel_spec.advanced_options->num_runtime_varargs_per_node) {
                 const NodeRangeSet expanded = to_node_range_set(nodes_spec);
                 for (const NodeRange& range : expanded.ranges()) {
                     for (const NodeCoord& node : range) {
@@ -2658,7 +2667,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                 }
             }
         }
-        runtime_schema.num_common_runtime_varargs = user_schema.num_common_runtime_varargs;
+        runtime_schema.num_common_runtime_varargs = num_common_runtime_varargs;
         program_impl->register_kernel_rta_schema(kernel_spec.unique_id, runtime_schema);
     }
 


### PR DESCRIPTION
## PR Category
API cleanup
(call-site breaking, but no semantic changes)

## Summary
This is a structural "cleanup" of the experimental Metal 2.0 host APIs. (I'll follow it up with the "naming things" cleanup.) The cleanup goal is improve ergonomics, usability, AI author usability, and add extensibility/maintainability. This is all based on observations from the first real-world uses of Metal 2.0 in ops porting experiments.

**There are no API semantic changes in this PR**. (Most just moving stuff around.)
But, there are numerous small syntax changes that affect use sites. 

### Advanced Options
The headline change in this PR is to create the "`*AdvancedOptions` sub-structs. This segregates the primary, mainstream API surface from the descriptor fields that are niche, unsafe-by-construction, temporary shims, or genuinely experimental functionality. This change makes the main API surface easier to understand, and also gives us a mechanism to add experimental API extensions in the future.

**Features I moved into `*AdvancedOptions`:**
 - Kernel varargs (gross, will be deprecated in favor of `std::array` args later)
 - Kernel node-specific thread counts (this is a speculative placeholder, unimplemented)
 - DFB compute self-loop multi-threaded controls (INTER/INTRA, a speculative placeholder, only partly supported)
 - DFB aliasing (_highly_ unsafe, ninja-only feature)
 - Semaphore initial value (slated for deprecation)
 - TensorParameter "relaxations" (usafe, also current API is a shim... we'll be tinkering with this one)

**Speculative (unimplemented) placeholders that I deleted instead:**
 - `SemaphoreMemoryType` (Gen2 register-based semaphores, if implemented, would likely use a different control)
 - RELAY `DFBEndpointType` (this was for the yet-unimplemented remote DFB, it appears prominently in the main API, and it just confuses everyone who sees it... human and AI alike)

### Other structural cleanups

A few other minor structural changes:

 - `kernel_spec.hpp` was getting unwieldy, so I moved the compute and DM config objects into their own headers.
 - Moved the repeated `Nodes` declaration into node_coords.hpp
 - Drop the unnecessary `SourceFilePath` wrapper
 - I removed the comments insisting that an AI use a  `const char * BLAH` everywhere. (Looked odd at use sites, and Claude decided it wasn't useful after all.)
 - Clean up unnecessary `std::optional`s
 - Clean up mismatched int types

### Propagating the API changes

The changes above required some corresponding tweaks to the `impl`. 

The bulk of the blast radius comes from mechanically propagating the necessary changes through all the Metal 2.0 use sites in the codebase (all of them tests in `tt_metal/tests`). 

### Notes for reviewers
I was careful to build this unwieldy PR stepwise for reviewability.
Each commit applies a distinct, bite-sized structural fixup.

The easiest way to review is to focus just on the PR description list exclusively.
If you study the code, easiest way is one isolated commit at a time.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/structural-api-changes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/structural-api-changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/structural-api-changes)