### PR TITLE
Group norm interface fix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -139,9 +139,6 @@ def test_group_norm_sharded_ex_external_cb_gap(device, specify_grid):
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
 
@@ -178,7 +175,6 @@ def test_group_norm_sharded_ex_external_cb_gap(device, specify_grid):
         input_tensor,
         num_groups=num_groups,
         epsilon=eps,
-        input_mask=input_mask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1097,62 +1097,6 @@ def test_group_norm_negative_tests(
         )
 
 
-@pytest.mark.skip(
-    reason="Public input_mask/negative_mask removed in interface fix #45292: input_mask is now "
-    "deprecated/ignored and the mask is created internally, so the old user-mask validation no longer applies."
-)
-def test_group_norm_rejects_host_input_mask(device):
-    input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
-    input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
-
-    with pytest.raises(RuntimeError, match="Input mask must be on device"):
-        ttnn.group_norm(
-            input_tensor,
-            num_groups=32,
-            input_mask=input_mask,
-            core_grid=ttnn.CoreGrid(y=1, x=1),
-            inplace=False,
-        )
-
-
-@pytest.mark.skip(
-    reason="Public input_mask/negative_mask removed in interface fix #45292: negative_mask is no longer a "
-    "public kwarg and the mask is created internally, so the old user-mask validation no longer applies."
-)
-def test_group_norm_rejects_host_negative_mask(device):
-    grid_size = ttnn.CoreGrid(y=1, x=1)
-    torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)
-    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, 32 * 32, 320)
-    input_tensor = ttnn.from_torch(
-        input_tensor,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    input_mask = ttnn.create_group_norm_input_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16)
-    input_mask = ttnn.to_device(input_mask, device)
-    negative_mask = ttnn.create_group_norm_input_negative_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16)
-
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    shard_spec = ttnn.ShardSpec(shard_grid, (32 * 32, 320), ttnn.ShardOrientation.ROW_MAJOR)
-    sharded_mem_config = ttnn.MemoryConfig(
-        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
-    )
-    input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
-
-    with pytest.raises(RuntimeError, match="Negative mask must be on device"):
-        ttnn.group_norm(
-            input_tensor,
-            num_groups=32,
-            input_mask=input_mask,
-            negative_mask=negative_mask,
-            memory_config=sharded_mem_config,
-            core_grid=grid_size,
-        )
-
-
 @pytest.mark.parametrize("N, C, H, W, num_groups", DRAM_GRID_SIZE_SHAPES)
 @pytest.mark.parametrize("specify_grid", [True])
 def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -157,10 +157,6 @@ def test_group_norm_with_height_sharded(device, N, C, H, W, num_groups, use_welf
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
 
@@ -192,7 +188,6 @@ def test_group_norm_with_height_sharded(device, N, C, H, W, num_groups, use_welf
     output_tensor = ttnn.group_norm(
         input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
@@ -252,10 +247,6 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
-    # input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # gamma/beta
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
@@ -289,7 +280,6 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
     output_tensor = ttnn.group_norm(
         input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
@@ -352,10 +342,6 @@ def test_group_norm_with_block_sharded_v2_8x8_grid(device, N, C, H, W, num_group
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # gamma/beta
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
@@ -389,7 +375,6 @@ def test_group_norm_with_block_sharded_v2_8x8_grid(device, N, C, H, W, num_group
     output_tensor = ttnn.group_norm(
         input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
@@ -455,10 +440,6 @@ def test_group_norm_with_block_sharded_v2_8x8_grid_tile_layout(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    # input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # gamma/beta
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
@@ -492,7 +473,6 @@ def test_group_norm_with_block_sharded_v2_8x8_grid_tile_layout(
     output_tensor = ttnn.group_norm(
         input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
@@ -614,15 +594,10 @@ def run_sdxl_base_group_norm_test(
         device=device,
     )
 
-    # Generate input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, core_grid.x, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # Execute ttnn group_norm
     tt_output_tensor = ttnn.group_norm(
         tt_input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         memory_config=tt_input_tensor.memory_config(),
         core_grid=core_grid if specify_grid else None,
         inplace=inplace,
@@ -719,15 +694,10 @@ def test_sdxl_base_group_norm_bh(device, input_shape, specify_grid, perf_test_mo
         device=device,
     )
 
-    # Generate input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, core_grid.x, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # Execute ttnn group_norm
     tt_output_tensor = ttnn.group_norm(
         tt_input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
         memory_config=tt_input_tensor.memory_config(),
         core_grid=core_grid if specify_grid else None,
         inplace=inplace,
@@ -794,15 +764,6 @@ def test_sdxl_base_group_norm_negative_mask(device, input_shape, specify_grid=Tr
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
-    # Generate input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.x, ttnn.DataType.BFLOAT8_B)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
-    input_negative_mask_tensor = ttnn.create_group_norm_input_negative_mask(
-        C, num_groups, grid_size.x, ttnn.DataType.BFLOAT8_B
-    )
-    input_negative_mask_tensor = ttnn.to_device(input_negative_mask_tensor, device)
-
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.x)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.x)
 
@@ -835,8 +796,6 @@ def test_sdxl_base_group_norm_negative_mask(device, input_shape, specify_grid=Tr
     tt_output_tensor = ttnn.group_norm(
         tt_input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
-        negative_mask=input_negative_mask_tensor,
         memory_config=sharded_mem_config,
         core_grid=grid_size if specify_grid else None,
         weight=gamma_t,
@@ -883,10 +842,6 @@ def test_group_norm_compute_config(device, N, C, H, W, num_groups, specify_grid)
     torch_output_tensor = torch.nn.functional.group_norm(torch_input_tensor, num_groups)
     torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
 
-    # Generate input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y, ttnn.DataType.BFLOAT16)
-    tt_input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-
     # Generate shard config
     grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
@@ -910,7 +865,6 @@ def test_group_norm_compute_config(device, N, C, H, W, num_groups, specify_grid)
         tt_output_tensor = ttnn.group_norm(
             tt_input_tensor,
             num_groups=num_groups,
-            input_mask=tt_input_mask_tensor,
             memory_config=sharded_mem_config,
             core_grid=grid_size if specify_grid else None,
             compute_kernel_config=compute_config,
@@ -981,21 +935,13 @@ def test_group_norm_oft(device, N, C, H, W, num_groups, shard, eps, use_negative
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    # Generate input mask
+    # Generate gamma/beta tensors
     if shard == "HS":
         grid_x = grid_size.x * grid_size.y
         grid_y = 1
     else:
         grid_x = grid_size.x
         grid_y = grid_size.y
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_y, ttnn.DataType.BFLOAT16)
-    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
-    if use_negative_mask:
-        input_nmask_tensor = ttnn.create_group_norm_input_negative_mask(C, num_groups, grid_y, ttnn.DataType.BFLOAT16)
-        input_nmask_tensor = ttnn.to_device(input_nmask_tensor, device)
-    else:
-        input_nmask_tensor = None
-    # Generate gamma/beta tensors
     gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_y)
     beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_y)
 
@@ -1033,8 +979,6 @@ def test_group_norm_oft(device, N, C, H, W, num_groups, shard, eps, use_negative
     output_tensor = ttnn.group_norm(
         input_tensor,
         num_groups=num_groups,
-        input_mask=input_mask_tensor,
-        negative_mask=input_nmask_tensor,
         weight=gamma_t,
         bias=beta_t,
         memory_config=sharded_mem_config,
@@ -1222,13 +1166,13 @@ def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid)
     torch_output = torch.nn.functional.group_norm(torch_input, num_groups, weight=torch_weight, bias=torch_bias)
     torch_output = torch_output.permute(0, 2, 3, 1).view(N, 1, H * W, C)
 
-    [gamma_t, beta_t], input_mask = ttnn.dram_group_norm_params_from_torch(
+    [gamma_t, beta_t] = ttnn.dram_group_norm_params_from_torch(
         [torch_weight.float(), torch_bias.float()],
         C,
         num_groups,
         device,
         core_grid=grid_size,
-        return_mask=True,
+        return_mask=False,
     )
 
     tt_input = torch_input.permute(0, 2, 3, 1).view(N, 1, H * W, C)
@@ -1244,7 +1188,6 @@ def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid)
     tt_output = ttnn.group_norm(
         tt_input,
         num_groups=num_groups,
-        input_mask=input_mask,
         weight=gamma_t,
         bias=beta_t,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -1289,10 +1232,6 @@ def test_group_norm_optional_weight_bias(
         num_groups=num_groups,
         input_nhw=N * H * W,
     )
-
-    num_virtual_cols = ttnn.operations.normalization.dram_group_norm_virtual_columns(grid_size, C, num_groups)
-    input_mask = ttnn.create_group_norm_input_mask(C, num_groups, num_virtual_cols, ttnn.bfloat16)
-    input_mask = ttnn.to_device(input_mask, device)
 
     torch_input = torch.rand((N, C, H, W), dtype=torch.bfloat16)
     torch_weight = torch.rand((C,), dtype=torch.bfloat16) if has_weight else None
@@ -1345,7 +1284,6 @@ def test_group_norm_optional_weight_bias(
         tt_input,
         num_groups=num_groups,
         epsilon=epsilon,
-        input_mask=input_mask,
         weight=gamma_t,
         bias=beta_t,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1097,6 +1097,10 @@ def test_group_norm_negative_tests(
         )
 
 
+@pytest.mark.skip(
+    reason="Public input_mask/negative_mask removed in interface fix #45292: input_mask is now "
+    "deprecated/ignored and the mask is created internally, so the old user-mask validation no longer applies."
+)
 def test_group_norm_rejects_host_input_mask(device):
     input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
     input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
@@ -1111,6 +1115,10 @@ def test_group_norm_rejects_host_input_mask(device):
         )
 
 
+@pytest.mark.skip(
+    reason="Public input_mask/negative_mask removed in interface fix #45292: negative_mask is no longer a "
+    "public kwarg and the mask is created internally, so the old user-mask validation no longer applies."
+)
 def test_group_norm_rejects_host_negative_mask(device):
     grid_size = ttnn.CoreGrid(y=1, x=1)
     torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -265,6 +265,11 @@ TensorSpec GroupNormDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 
+    // A pre-allocated output fixes the spec; the op writes into it rather than allocating.
+    if (tensor_args.optional_output.has_value()) {
+        return tensor_args.optional_output->tensor_spec();
+    }
+
     return std::visit(
         [&](const auto& program_config) -> spec_return_value_t {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
@@ -293,6 +298,11 @@ Tensor GroupNormDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
 
+    // Reuse a pre-allocated output if the caller provided one (no second allocation).
+    if (tensor_args.optional_output.has_value()) {
+        return tensor_args.optional_output.value();
+    }
+
     return std::visit(
         [&](const auto& program_config) -> tensor_return_value_t {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
@@ -320,7 +330,8 @@ Tensor group_norm(
     std::optional<Tensor> beta,
     std::optional<Tensor> input_mask,
     std::optional<Tensor> negative_mask,
-    std::optional<Tensor> reciprocals) {
+    std::optional<Tensor> reciprocals,
+    std::optional<Tensor> optional_output) {
     if (negative_mask.has_value()) {
         TT_FATAL(
             negative_mask.value().storage_type() == StorageType::DEVICE,
@@ -345,7 +356,8 @@ Tensor group_norm(
         .beta = std::move(beta),
         .input_mask = std::move(input_mask),
         .negative_mask = std::move(negative_mask),
-        .reciprocals = std::move(reciprocals)};
+        .reciprocals = std::move(reciprocals),
+        .optional_output = std::move(optional_output)};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.hpp
@@ -66,6 +66,7 @@ Tensor group_norm(
     std::optional<Tensor> beta,
     std::optional<Tensor> input_mask,
     std::optional<Tensor> negative_mask,
-    std::optional<Tensor> reciprocals);
+    std::optional<Tensor> reciprocals,
+    std::optional<Tensor> optional_output = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
@@ -55,6 +55,11 @@ struct GroupNormInputs {
     std::optional<Tensor> input_mask;
     std::optional<Tensor> negative_mask;
     std::optional<Tensor> reciprocals;
+    // Pre-allocated output. When set, the op writes into this buffer instead of allocating a new
+    // one (see create_output_tensors / compute_output_specs). The ttnn::group_norm wrapper uses
+    // this to allocate the output up front so it can make an exact L1-fit decision before
+    // dispatch. Hashed by spec only (no buffer address), so it is program-cache safe.
+    std::optional<Tensor> optional_output;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -232,7 +232,7 @@ uint32_t compute_sharded_gn_l1_footprint(
     // Flags decide which CBs are actually allocated, matching the factory's conditionals.
     const uint32_t tile_width = input.tensor_spec().tile().get_width();
     const bool reader_repack_output = (input.shard_spec().value().shape[1] % tile_width) != 0;
-    const bool untilize_out = output_spec.layout() == ttnn::Layout::ROW_MAJOR;
+    const bool untilize_out = output_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR;
 
     uint32_t footprint = cb.total(
         with_negative_mask,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -7,6 +7,10 @@
 #include <limits>
 #include <algorithm>
 
+#include <tt-metalium/device.hpp>                // tt::tt_metal::IDevice
+#include <tt-metalium/tt_backend_api_types.hpp>  // tt::DataFormat, tt::tile_size
+#include <ttnn/tensor/types.hpp>                 // tt::tt_metal::datatype_to_dataformat_converter
+
 namespace ttnn::prim {
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
@@ -100,6 +104,154 @@ std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size
     }
 
     return {max_tile_span, num_groups_before_start_again_at_tile_beginning};
+}
+
+uint32_t GroupNormShardedStaticCbSizes::total(
+    bool with_negative_mask,
+    bool untilize_out,
+    bool has_gamma,
+    bool has_beta,
+    bool has_input_mask,
+    bool reader_repack_output,
+    bool use_welford) const {
+    uint32_t t = 0;
+    t += in_CB_size;  // c_1 tilized input
+    // Non-negative-mask path keeps a second copy for untilize-out (c_30); negative-mask path
+    // replaces it with the (smaller) negative-mask CB (c_14).
+    t += with_negative_mask ? in_negative_mask_CB_size : (untilize_out ? in_CB_size : 0u);
+    t += in2_CB_size;  // c_2 scaler
+    t += in3_CB_size;  // c_3 eps
+    if (!use_welford) {
+        t += in2_CB_size;  // c_4 scaler-c
+    }
+    if (has_gamma) {
+        t += in5_CB_size;  // c_5
+    }
+    if (has_beta) {
+        t += in6_CB_size;  // c_6
+    }
+    if (has_input_mask) {
+        t += in_mask_CB_size;  // c_7
+    }
+    if (reader_repack_output) {
+        t += repack_CB_size;  // c_11/c_12
+    }
+    t += x_CB_size;           // c_13
+    t += ex_partial_CB_size;  // c_8
+    if (!use_welford) {
+        t += single_tile_size;  // c_10 ex_external
+    }
+    t += ex_global_CB_size;  // c_9/c_15
+    t += ex2pe_CB_size;      // c_17
+    t += single_tile_size;   // c_26 ones
+    return t;
+}
+
+GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
+    const ttnn::Tensor& input,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    bool use_welford,
+    uint32_t num_groups) {
+    // Mirror the factory's intermediate derivations exactly (see
+    // groupnorm_sharded_program_factory.cpp) so the sizes are byte-identical to what it
+    // allocates. find_max_tile_span uses the default tile_width to match the factory.
+    const auto& shard_spec = input.shard_spec().value();
+    const uint32_t tile_height = input.tensor_spec().tile().get_height();
+    const uint32_t tile_width = input.tensor_spec().tile().get_width();
+
+    const uint32_t per_core_M = shard_spec.shape[0];
+    const uint32_t per_core_N = shard_spec.shape[1];
+    const uint32_t per_core_Mt = per_core_M / tile_height;
+    const uint32_t per_core_Nt = (per_core_N + tile_width - 1) / tile_width;
+
+    const auto& shape = input.padded_shape();
+    const uint32_t num_batches = shape[0];
+    const uint32_t W = shape[3];
+    const uint32_t H = shape[2] * num_batches;
+    const uint32_t group_size = W / num_groups;
+
+    const uint32_t num_shards_r = H / per_core_M;
+    const uint32_t num_batches_per_core = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
+    const uint32_t num_shards_c = W / per_core_N;
+    const uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
+
+    const auto [block_wt, num_groups_per_reset] = find_max_tile_span(per_core_N, group_size);
+    (void)num_groups_per_reset;
+    const uint32_t block_ht = per_core_Mt / num_batches_per_core;
+    const uint32_t interm_block_tiles = block_ht * block_wt;
+    const uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
+
+    // Tile sizes by data format. The op fixes the compute (intermediate) format to bf16, and
+    // the input/negative masks are bf16; gamma/beta share one CB format (gamma's, overridden by
+    // beta's when beta is present), matching the factory's gamma_beta_cb_data_format.
+    const tt::DataFormat in_fmt = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    constexpr tt::DataFormat bf16_fmt = tt::DataFormat::Float16_b;
+    const uint32_t in_ts = tt::tile_size(in_fmt);
+    const uint32_t ts = tt::tile_size(bf16_fmt);
+
+    tt::DataFormat gamma_beta_fmt = bf16_fmt;
+    if (gamma_dtype.has_value()) {
+        gamma_beta_fmt = tt::tt_metal::datatype_to_dataformat_converter(*gamma_dtype);
+    }
+    if (beta_dtype.has_value()) {
+        gamma_beta_fmt = tt::tt_metal::datatype_to_dataformat_converter(*beta_dtype);
+    }
+    const uint32_t gamma_beta_ts = tt::tile_size(gamma_beta_fmt);
+
+    GroupNormShardedStaticCbSizes s;
+    s.in_CB_size = in0_block_tiles * in_ts;
+    s.in2_CB_size = ts * (use_welford ? 3u : 1u);
+    s.in3_CB_size = ts;
+    s.in5_CB_size = per_core_Nt * gamma_beta_ts;
+    s.in6_CB_size = per_core_Nt * gamma_beta_ts;
+    s.in_mask_CB_size = block_wt * ts * (use_welford ? num_groups_per_core : 2u);
+    s.in_negative_mask_CB_size = block_wt * ts * 2u;
+    s.repack_CB_size = per_core_Nt * in_ts * 2u;
+    s.x_CB_size = ts * (use_welford ? 1u : interm_block_tiles);
+    s.ex_partial_CB_size = ts * (use_welford ? 2u : 1u);
+    s.ex_global_CB_size = s.ex_partial_CB_size * (use_welford ? num_groups_per_core : 1u);
+    s.ex2pe_CB_size = use_welford ? ts * num_groups_per_core : s.ex_partial_CB_size;
+    s.single_tile_size = ts;
+    return s;
+}
+
+uint32_t compute_sharded_gn_l1_footprint(
+    const ttnn::Tensor& input,
+    const ttnn::TensorSpec& output_spec,
+    const tt::tt_metal::IDevice& device,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    bool has_input_mask,
+    bool with_negative_mask,
+    bool use_welford,
+    bool inplace,
+    uint32_t num_groups) {
+    const auto cb = compute_sharded_gn_static_cb_sizes(input, gamma_dtype, beta_dtype, use_welford, num_groups);
+
+    // Flags decide which CBs are actually allocated, matching the factory's conditionals.
+    const uint32_t tile_width = input.tensor_spec().tile().get_width();
+    const bool reader_repack_output = (input.shard_spec().value().shape[1] % tile_width) != 0;
+    const bool untilize_out = output_spec.layout() == ttnn::Layout::ROW_MAJOR;
+
+    uint32_t footprint = cb.total(
+        with_negative_mask,
+        untilize_out,
+        gamma_dtype.has_value(),
+        beta_dtype.has_value(),
+        has_input_mask,
+        reader_repack_output,
+        use_welford);
+
+    // Beyond the static CB region added above, the output buffer is the only other new L1 the op
+    // allocates — and only when it lands in L1 and isn't computed in place. Its size is exact:
+    // taken from the output spec's own per-bank computation, not estimated.
+    const bool output_allocates_l1 =
+        !inplace && output_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1;
+    if (output_allocates_l1) {
+        footprint += static_cast<uint32_t>(output_spec.compute_consumed_memory_bytes_per_bank(device));
+    }
+    return footprint;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -6,12 +6,86 @@
 
 #include <vector>
 #include <cstdint>
+#include <optional>
 
 #include <tt-metalium/core_coord.hpp>
+#include "ttnn/tensor/tensor.hpp"  // ttnn::Tensor, ttnn::TensorSpec, tt::tt_metal::DataType
+
+namespace tt::tt_metal {
+class IDevice;
+}
 
 namespace ttnn::prim {
 
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
+
+// Per-core byte sizes of the statically-allocated circular buffers used by the sharded
+// group-norm program factory. These are the CBs that grow upward from l1_base; the in0
+// (c_0) and output (c_16) CBs are bound to existing tensor buffers and are therefore NOT
+// part of this set. Computed once by compute_sharded_gn_static_cb_sizes() and consumed
+// BOTH by the program factory (to create the CBs) AND by the op-level L1 sizing helpers,
+// so the factory and any size computation can never disagree. To add or resize a static
+// CB, change compute_sharded_gn_static_cb_sizes() — the single source of truth.
+struct GroupNormShardedStaticCbSizes {
+    uint32_t in_CB_size = 0;                // c_1  tilized input (and c_30 untilize-out copy)
+    uint32_t in2_CB_size = 0;               // c_2  scaler (and c_4 scaler-c when !welford)
+    uint32_t in3_CB_size = 0;               // c_3  eps
+    uint32_t in5_CB_size = 0;               // c_5  gamma
+    uint32_t in6_CB_size = 0;               // c_6  beta
+    uint32_t in_mask_CB_size = 0;           // c_7  input mask
+    uint32_t in_negative_mask_CB_size = 0;  // c_14 negative mask
+    uint32_t repack_CB_size = 0;            // c_11/c_12 repack
+    uint32_t x_CB_size = 0;                 // c_13 x
+    uint32_t ex_partial_CB_size = 0;        // c_8  ex_partial
+    uint32_t ex_global_CB_size = 0;         // c_9/c_15 ex_global
+    uint32_t ex2pe_CB_size = 0;             // c_17 ex2pe
+    uint32_t single_tile_size = 0;          // c_10 ex_external and c_26 ones
+
+    // Total per-core L1 occupied by the static CB region, matching exactly what the factory
+    // allocates for the given configuration. `with_negative_mask` selects the negative-mask
+    // CB (c_14) in place of the untilize-out copy (c_30). The flags mirror the factory's own
+    // conditionals so the same CBs are counted here and created there.
+    uint32_t total(
+        bool with_negative_mask,
+        bool untilize_out,
+        bool has_gamma,
+        bool has_beta,
+        bool has_input_mask,
+        bool reader_repack_output,
+        bool use_welford) const;
+};
+
+// Single source of truth for the static-CB sizes above. `input` must be the sharded input
+// tensor; gamma/beta dtypes are optional (absent => not present). Assumes the op's fixed
+// conventions: bf16 compute data format and bf16 input/negative masks.
+GroupNormShardedStaticCbSizes compute_sharded_gn_static_cb_sizes(
+    const ttnn::Tensor& input,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    bool use_welford,
+    uint32_t num_groups);
+
+// Exact per-core L1 (bytes) that running sharded group_norm ADDS to the device:
+//   (1) the statically-allocated CB region — which INCLUDES the gamma, beta, input-mask and
+//       negative-mask CBs (those are scratch CBs the op allocates), and
+//   (2) the output buffer, only when it is a fresh L1 allocation (L1 and not in place).
+// NOT counted: buffers that already exist before the op runs — the input, the reciprocals LUT,
+// and the gamma/beta/input-mask SOURCE tensors (the c_5/c_6/c_7 CBs are counted, but the
+// tensors feeding them are not) — nor any other tensor resident elsewhere in L1. No estimates:
+// the CB region reuses compute_sharded_gn_static_cb_sizes(), and the output size comes from the
+// output spec's own per-bank computation. This does NOT answer "will it fit" — that also depends
+// on every other live L1 tensor and on where the allocator places the output (see the dispatch path).
+uint32_t compute_sharded_gn_l1_footprint(
+    const ttnn::Tensor& input,
+    const ttnn::TensorSpec& output_spec,
+    const tt::tt_metal::IDevice& device,
+    std::optional<tt::tt_metal::DataType> gamma_dtype,
+    std::optional<tt::tt_metal::DataType> beta_dtype,
+    bool has_input_mask,
+    bool with_negative_mask,
+    bool use_welford,
+    bool inplace,
+    uint32_t num_groups);
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -314,41 +314,33 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // block size for in0 (tensor a)
     uint32_t in0_block_tiles = per_core_Nt * per_core_Mt;
     uint32_t in0_CB_size = a.buffer()->aligned_size_per_bank();  // use buffer size to handle both RM and Tile
-    uint32_t in_CB_size = in0_block_tiles * in_single_tile_size;
-    // in2 - scaler
-    uint32_t in2_CB_size = single_tile_size * (use_welford ? 3 : 1);
-    // in3 - eps
-    uint32_t in3_CB_size = single_tile_size;
-    // gamma
+
+    // Statically-allocated CB sizes come from a single shared helper so this factory and the
+    // op-level L1 sizing helpers can never disagree about how much L1 the CBs consume. To add
+    // or resize a static CB, edit compute_sharded_gn_static_cb_sizes() — the single source of
+    // truth.
+    const GroupNormShardedStaticCbSizes static_cb = compute_sharded_gn_static_cb_sizes(
+        a,
+        gamma.has_value() ? std::make_optional(gamma.value().dtype()) : std::nullopt,
+        beta.has_value() ? std::make_optional(beta.value().dtype()) : std::nullopt,
+        use_welford,
+        num_groups);
+    // Static CB byte sizes are read directly from `static_cb` at each CB descriptor below, so
+    // this factory and the op-level L1 sizing helpers can never disagree. Only the per-core tile
+    // counts (gamma/beta and input mask) and the output CB size are kept as locals, since they are
+    // not part of the shared static-CB helper.
     uint32_t gamma_beta_num_cols_tile_per_core = per_core_Nt;
-    uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
-    // beta
-    uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
-    // input mask
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
-    uint32_t in_mask_CB_size =
-        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2);  // double buffer
-    // negative mask
-    uint32_t in_negative_mask_CB_size = block_wt * in_negative_mask_single_tile_size * 2;  // double buffer
-    // repack cb
-    uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;  // double buffer
-    // itermediate buffers
-    uint32_t interm_block_tiles = block_ht * block_wt;
-    uint32_t x_CB_size = single_tile_size * (use_welford ? 1 : interm_block_tiles);
-    // In welford, we both store mean and var here, so double the size
-    uint32_t ex_partial_CB_size = single_tile_size * (use_welford ? 2 : 1);
-    uint32_t ex_global_CB_size = ex_partial_CB_size * (use_welford ? num_groups_per_core : 1);  // the final result Ex
-    uint32_t ex2pe_CB_size = use_welford ? single_tile_size * num_groups_per_core : ex_partial_CB_size;
     // output buffer size
     uint32_t out_CB_size = in0_block_tiles * out_single_tile_size;
 
     log_debug(tt::LogOp, "per_core_Nt: {}", per_core_Nt);
     log_debug(tt::LogOp, "per_core_Mt: {}", per_core_Mt);
     log_debug(tt::LogOp, "in0_CB_size: {}", in0_CB_size);
-    log_debug(tt::LogOp, "in_CB_size: {}", in_CB_size);
+    log_debug(tt::LogOp, "in_CB_size: {}", static_cb.in_CB_size);
     log_debug(tt::LogOp, "gamma_beta_num_cols_tile_per_core: {}", gamma_beta_num_cols_tile_per_core);
-    log_debug(tt::LogOp, "in5_CB_size: {}", in5_CB_size);
-    log_debug(tt::LogOp, "repack_CB_size: {}", repack_CB_size);
+    log_debug(tt::LogOp, "in5_CB_size: {}", static_cb.in5_CB_size);
+    log_debug(tt::LogOp, "repack_CB_size: {}", static_cb.repack_CB_size);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -896,11 +888,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     };
     if (!negative_mask.has_value()) {
         // in - stores tilized input
-        desc.cbs.push_back(make_in_cb_desc(in_CB_size));
+        desc.cbs.push_back(make_in_cb_desc(static_cb.in_CB_size));
         if (untilize_out) {
             constexpr uint32_t out_cb_index = tt::CBIndex::c_30;
             desc.cbs.push_back(CBDescriptor{
-                .total_size = in_CB_size,
+                .total_size = static_cb.in_CB_size,
                 .core_ranges = all_cores,
                 .format_descriptors = {{CBFormatDescriptor{
                     .buffer_index = static_cast<uint8_t>(out_cb_index),
@@ -912,12 +904,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     } else {
         // in - stores tilized input
         // tilized in is overlapped with it
-        desc.cbs.push_back(make_in_cb_desc(in_CB_size));
+        desc.cbs.push_back(make_in_cb_desc(static_cb.in_CB_size));
     }
     // in2 scaler - for partial Ex
     constexpr uint32_t in2_cb_index = tt::CBIndex::c_2;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = in2_CB_size,
+        .total_size = static_cb.in2_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in2_cb_index),
@@ -928,7 +920,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // in3 eps
     constexpr uint32_t in3_cb_index = tt::CBIndex::c_3;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = in3_CB_size,
+        .total_size = static_cb.in3_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(in3_cb_index),
@@ -940,7 +932,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (!use_welford) {
         constexpr uint32_t in4_cb_index = tt::CBIndex::c_4;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in2_CB_size,
+            .total_size = static_cb.in2_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in4_cb_index),
@@ -953,7 +945,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (gamma.has_value()) {
         constexpr uint32_t in5_cb_index = tt::CBIndex::c_5;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in5_CB_size,
+            .total_size = static_cb.in5_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in5_cb_index),
@@ -966,7 +958,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (beta.has_value()) {
         constexpr uint32_t in6_cb_index = tt::CBIndex::c_6;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in6_CB_size,
+            .total_size = static_cb.in6_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in6_cb_index),
@@ -979,7 +971,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (input_mask.has_value()) {
         constexpr uint32_t in_mask_cb_index = tt::CBIndex::c_7;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in_mask_CB_size,
+            .total_size = static_cb.in_mask_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in_mask_cb_index),
@@ -992,7 +984,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     if (negative_mask.has_value()) {
         constexpr uint32_t in_negative_mask_cb_index = tt::CBIndex::c_14;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = in_negative_mask_CB_size,
+            .total_size = static_cb.in_negative_mask_CB_size,
             .core_ranges = all_cores,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(in_negative_mask_cb_index),
@@ -1005,7 +997,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         constexpr uint32_t repack_cb_index = tt::CBIndex::c_11;
         constexpr uint32_t repack_out_cb_index = tt::CBIndex::c_12;
         desc.cbs.push_back(CBDescriptor{
-            .total_size = repack_CB_size,
+            .total_size = static_cb.repack_CB_size,
             .core_ranges = all_cores,
             .format_descriptors =
                 {{CBFormatDescriptor{
@@ -1023,7 +1015,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // x
     constexpr uint32_t x_cb_index = tt::CBIndex::c_13;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = x_CB_size,
+        .total_size = static_cb.x_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(x_cb_index),
@@ -1035,7 +1027,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // ex_partial
     constexpr uint32_t ex_cb_partial_index = tt::CBIndex::c_8;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex_partial_CB_size,
+        .total_size = static_cb.ex_partial_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(ex_cb_partial_index),
@@ -1062,7 +1054,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     constexpr uint32_t ex_cb_index = tt::CBIndex::c_9;
     constexpr uint32_t ex_global_cb_index = tt::CBIndex::c_15;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex_global_CB_size,
+        .total_size = static_cb.ex_global_CB_size,
         .core_ranges = all_cores,
         .format_descriptors =
             {{CBFormatDescriptor{
@@ -1080,7 +1072,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // ex2pe
     constexpr uint32_t cb_ex2pe_index = tt::CBIndex::c_17;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = ex2pe_CB_size,
+        .total_size = static_cb.ex2pe_CB_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_ex2pe_index),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -4,14 +4,16 @@
 
 #include "groupnorm.hpp"
 #include "device/groupnorm_device_operation.hpp"
+#include "device/groupnorm_program_utils.hpp"
 #include "groupnorm_grid_utils.hpp"
 #include "groupnorm_input_mask.hpp"
 
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 
-#include <stdexcept>
-#include <string_view>
+#include <tt-metalium/allocator.hpp>
+
+#include <optional>
 
 namespace {
 
@@ -229,14 +231,9 @@ Tensor group_norm(
         input_tensor.storage_type() == StorageType::DEVICE,
         "Invalid input tensor storage type: Input tensor must be on device. (storage type={})",
         input_tensor.storage_type());
-    if (input_mask.has_value()) {
-        TT_FATAL(
-            input_mask->storage_type() == StorageType::DEVICE,
-            "Input mask must be on device, got storage type: {}",
-            input_mask->storage_type());
-        TT_FATAL(input_mask->buffer() != nullptr, "Input mask must be allocated in buffers on device!");
-        TT_FATAL(input_tensor.device() == input_mask->device(), "Input and input mask tensors must be on same device");
-    }
+    // Note: input_mask is no longer a public parameter; the mask is created internally (always
+    // on-device, always allocated) and validated in the device op's validate(). The user-mask
+    // validation that #46162 added here is therefore obsolete on this interface.
     const auto arch = input_tensor.device()->arch();
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;
@@ -371,8 +368,55 @@ Tensor group_norm(
         const bool negative_mask_applicable =
             input_tensor.layout() == Layout::ROW_MAJOR && effective_output_layout == Layout::ROW_MAJOR;
 
-        // First attempt: run without negative mask (better performance)
-        try {
+        // Allocate the output up front (reusing the op's own create_output_tensors, so the spec
+        // can't drift) so that lowest_occupied_compute_l1_address() reflects it exactly. We then
+        // decide whether the cheaper no-negative-mask CBs fit with NO prediction about where the
+        // allocator placed the output. The pre-allocated output is handed to the prim op via
+        // optional_output, so it is not allocated a second time.
+        const ttnn::prim::GroupNormParams output_alloc_params{
+            .eps = epsilon,
+            .num_groups = static_cast<uint32_t>(num_groups),
+            .output_mem_config = output_mem_config,
+            .program_config = program_config,
+            .compute_kernel_config = kernel_config_val,
+            .use_welford = use_welford};
+        const ttnn::Tensor output = ttnn::prim::GroupNormDeviceOperation::create_output_tensors(
+            output_alloc_params, ttnn::prim::GroupNormInputs{.input = input_tensor});
+
+        // Exact L1-fit check: the CBs grow up from l1_base; the output (now allocated) is already
+        // counted in lowest_occupied. So the no-negative-mask CBs fit iff
+        //   l1_base + static_cb_total <= lowest_occupied.
+        // CB sizes come from the same helper the program factory uses, so they match what the
+        // factory will allocate. NOTE: this is exact under the default LOCKSTEP allocator; under
+        // the experimental HYBRID per-core allocator (or if another stream allocates L1 between
+        // here and dispatch) per-core occupancy can diverge from this single value, and the
+        // framework's dispatch-time check in program.cpp remains the ground truth.
+        const bool needs_negative_mask = negative_mask_applicable && [&] {
+            const uint32_t l1_base =
+                input_tensor.device()->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+            const auto lowest_occupied = input_tensor.device()->lowest_occupied_compute_l1_address();
+            const uint32_t lowest_l1 = lowest_occupied.value_or(input_tensor.buffer()->address());
+
+            const auto cb_sizes = ttnn::prim::compute_sharded_gn_static_cb_sizes(
+                input_tensor,
+                gamma.has_value() ? std::make_optional(gamma->dtype()) : std::nullopt,
+                beta.has_value() ? std::make_optional(beta->dtype()) : std::nullopt,
+                use_welford,
+                static_cast<uint32_t>(num_groups));
+            const uint32_t tile_w = input_tensor.tensor_spec().tile().get_width();
+            const bool reader_repack_output = (input_tensor.shard_spec().value().shape[1] % tile_w) != 0;
+            const uint32_t cb_total = cb_sizes.total(
+                /*with_negative_mask=*/false,
+                /*untilize_out=*/effective_output_layout == Layout::ROW_MAJOR,
+                /*has_gamma=*/gamma.has_value(),
+                /*has_beta=*/beta.has_value(),
+                /*has_input_mask=*/true,
+                reader_repack_output,
+                use_welford);
+            return l1_base + cb_total > lowest_l1;
+        }();
+
+        if (!needs_negative_mask) {
             return ttnn::prim::group_norm(
                 input_tensor,
                 epsilon,
@@ -385,15 +429,10 @@ Tensor group_norm(
                 beta,
                 mask,
                 std::nullopt,
-                reciprocals);
-        } catch (const std::runtime_error& e) {
-            const bool is_l1_clash = std::string_view(e.what()).find("clash") != std::string_view::npos;
-            if (!negative_mask_applicable || !is_l1_clash) {
-                throw;
-            }
+                reciprocals,
+                output);
         }
 
-        // Fallback: retry with negative mask to relax L1 CB constraints
         ttnn::Tensor neg_mask =
             operations::normalization::get_negative_mask_tensor(input_tensor, core_grid.value(), num_groups);
         return ttnn::prim::group_norm(
@@ -408,7 +447,8 @@ Tensor group_norm(
             beta,
             mask,
             neg_mask,
-            reciprocals);
+            reciprocals,
+            output);
     }
     // When the user did not pin a core grid, defer num_out_blocks to the program
     // factory's heuristic via the -1 sentinel (see GroupNormMultiCoreProgramConfig).

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -10,6 +10,9 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 
+#include <stdexcept>
+#include <string_view>
+
 namespace {
 
 using ttnn::operations::normalization::compute_num_virtual_cols;
@@ -96,48 +99,57 @@ int64_t get_group_norm_cores_across_channel(
 
 namespace ttnn::operations::normalization {
 
-ttnn::Tensor get_mask_tensor(
-    const ttnn::Tensor& input_tensor,
-    const std::optional<ttnn::Tensor>& input_mask,
-    const std::optional<ttnn::Tensor>& negative_mask,
-    const CoreGrid& core_grid,
-    const int num_groups) {
-    ttnn::Tensor mask = input_mask.value_or(ttnn::Tensor());
-    if (!input_mask.has_value() and !negative_mask.has_value()) {
-        // create input mask
-        int64_t num_channel = input_tensor.padded_shape()[-1];
-        int64_t num_cores_across_channel;
-        if (input_tensor.memory_config().buffer_type() == BufferType::L1) {
-            const auto mem_layout = input_tensor.memory_config().memory_layout();
-            const auto shard_spec = input_tensor.memory_config().shard_spec();
-            std::optional<ShardOrientation> shard_orientation = std::nullopt;
-            if (shard_spec.has_value()) {
-                shard_orientation = shard_spec->orientation;
-            }
-            num_cores_across_channel = get_group_norm_cores_across_channel(mem_layout, core_grid, shard_orientation);
-        } else {
-            uint32_t num_virtual_cols =
-                compute_num_virtual_cols(core_grid.x, num_groups, static_cast<uint32_t>(num_channel));
-            TT_FATAL(
-                num_virtual_cols > 0,
-                "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
-                "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
-                "and num_groups % nvc == 0.",
-                core_grid.x,
-                num_groups,
-                num_channel);
-            num_cores_across_channel = static_cast<int64_t>(num_virtual_cols);
+static int64_t compute_num_cores_across_channel(
+    const ttnn::Tensor& input_tensor, const CoreGrid& core_grid, const int num_groups) {
+    int64_t num_channel = input_tensor.padded_shape()[-1];
+    if (input_tensor.memory_config().buffer_type() == BufferType::L1) {
+        const auto mem_layout = input_tensor.memory_config().memory_layout();
+        const auto shard_spec = input_tensor.memory_config().shard_spec();
+        std::optional<ShardOrientation> shard_orientation = std::nullopt;
+        if (shard_spec.has_value()) {
+            shard_orientation = shard_spec->orientation;
         }
-        mask = create_group_norm_input_mask(
-            num_channel,
+        return get_group_norm_cores_across_channel(mem_layout, core_grid, shard_orientation);
+    } else {
+        uint32_t num_virtual_cols =
+            compute_num_virtual_cols(core_grid.x, num_groups, static_cast<uint32_t>(num_channel));
+        TT_FATAL(
+            num_virtual_cols > 0,
+            "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
+            "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
+            "and num_groups % nvc == 0.",
+            core_grid.x,
             num_groups,
-            num_cores_across_channel,
-            tt::tt_metal::DataType::BFLOAT16,
-            input_tensor.tensor_spec().tile().get_height(),
-            input_tensor.tensor_spec().tile().get_width());
-        mask = mask.to_device(input_tensor.device());
+            num_channel);
+        return static_cast<int64_t>(num_virtual_cols);
     }
-    return mask;
+}
+
+ttnn::Tensor get_mask_tensor(const ttnn::Tensor& input_tensor, const CoreGrid& core_grid, const int num_groups) {
+    int64_t num_channel = input_tensor.padded_shape()[-1];
+    int64_t num_cores_across_channel = compute_num_cores_across_channel(input_tensor, core_grid, num_groups);
+    ttnn::Tensor mask = create_group_norm_input_mask(
+        num_channel,
+        num_groups,
+        num_cores_across_channel,
+        tt::tt_metal::DataType::BFLOAT16,
+        input_tensor.tensor_spec().tile().get_height(),
+        input_tensor.tensor_spec().tile().get_width());
+    return mask.to_device(input_tensor.device());
+}
+
+ttnn::Tensor get_negative_mask_tensor(
+    const ttnn::Tensor& input_tensor, const CoreGrid& core_grid, const int num_groups) {
+    int64_t num_channel = input_tensor.padded_shape()[-1];
+    int64_t num_cores_across_channel = compute_num_cores_across_channel(input_tensor, core_grid, num_groups);
+    ttnn::Tensor neg_mask = create_group_norm_input_negative_mask(
+        num_channel,
+        num_groups,
+        num_cores_across_channel,
+        tt::tt_metal::DataType::BFLOAT16,
+        input_tensor.tensor_spec().tile().get_height(),
+        input_tensor.tensor_spec().tile().get_width());
+    return neg_mask.to_device(input_tensor.device());
 }
 
 }  // namespace ttnn::operations::normalization
@@ -148,7 +160,6 @@ Tensor group_norm(
     const Tensor& input_tensor,
     const int num_groups,
     const float epsilon,
-    const std::optional<Tensor>& input_mask,
     const std::optional<Tensor>& weight,
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& reciprocals,
@@ -159,7 +170,6 @@ Tensor group_norm(
     std::optional<Layout> output_layout,
     std::optional<int> num_out_blocks,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<Tensor>& negative_mask,
     bool use_welford) {
     if (input_tensor.layout() == Layout::TILE and inplace.has_value()) {
         TT_FATAL(
@@ -347,17 +357,46 @@ Tensor group_norm(
         validate_dram_grid(core_grid.value(), W, Ht, num_groups, input_padded_shape[0]);
     }
 
-    // auto generate mask tensor if both input_mask and negative_mask are not provided
-    ttnn::Tensor mask = operations::normalization::get_mask_tensor(
-        input_tensor, input_mask, negative_mask, core_grid.value(), num_groups);
+    ttnn::Tensor mask = operations::normalization::get_mask_tensor(input_tensor, core_grid.value(), num_groups);
 
     if (input_tensor.is_sharded()) {
+        const Layout effective_output_layout = output_layout.value_or(input_tensor.layout());
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {
             .compute_with_storage_grid_size = core_grid.value().to_CoreCoord(),
             .im_data_format = DataType::BFLOAT16,
             .out_data_format = DataType::BFLOAT16,
             .inplace = inplace.value_or(false),
-            .output_layout = output_layout.value_or(input_tensor.layout())};
+            .output_layout = effective_output_layout};
+
+        // negative_mask reduces L1 CB usage at a small perf cost; only valid for ROW_MAJOR in/out
+        const bool negative_mask_applicable =
+            input_tensor.layout() == Layout::ROW_MAJOR && effective_output_layout == Layout::ROW_MAJOR;
+
+        // First attempt: run without negative mask (better performance)
+        try {
+            return ttnn::prim::group_norm(
+                input_tensor,
+                epsilon,
+                static_cast<uint32_t>(num_groups),
+                output_mem_config,
+                program_config,
+                kernel_config_val,
+                use_welford,
+                gamma,
+                beta,
+                mask,
+                std::nullopt,
+                reciprocals);
+        } catch (const std::runtime_error& e) {
+            const bool is_l1_clash = std::string_view(e.what()).find("clash") != std::string_view::npos;
+            if (!negative_mask_applicable || !is_l1_clash) {
+                throw;
+            }
+        }
+
+        // Fallback: retry with negative mask to relax L1 CB constraints
+        ttnn::Tensor neg_mask =
+            operations::normalization::get_negative_mask_tensor(input_tensor, core_grid.value(), num_groups);
         return ttnn::prim::group_norm(
             input_tensor,
             epsilon,
@@ -369,7 +408,7 @@ Tensor group_norm(
             gamma,
             beta,
             mask,
-            negative_mask,
+            neg_mask,
             reciprocals);
     }
     // When the user did not pin a core grid, defer num_out_blocks to the program
@@ -393,7 +432,7 @@ Tensor group_norm(
         gamma,
         beta,
         mask,
-        negative_mask,
+        std::nullopt,
         reciprocals);
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -171,6 +171,7 @@ Tensor group_norm(
     std::optional<Layout> output_layout,
     std::optional<int> num_out_blocks,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<Tensor>& /*negative_mask*/,
     bool use_welford) {
     if (input_tensor.layout() == Layout::TILE and inplace.has_value()) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -110,19 +110,17 @@ static int64_t compute_num_cores_across_channel(
             shard_orientation = shard_spec->orientation;
         }
         return get_group_norm_cores_across_channel(mem_layout, core_grid, shard_orientation);
-    } else {
-        uint32_t num_virtual_cols =
-            compute_num_virtual_cols(core_grid.x, num_groups, static_cast<uint32_t>(num_channel));
-        TT_FATAL(
-            num_virtual_cols > 0,
-            "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
-            "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
-            "and num_groups % nvc == 0.",
-            core_grid.x,
-            num_groups,
-            num_channel);
-        return static_cast<int64_t>(num_virtual_cols);
     }
+    uint32_t num_virtual_cols = compute_num_virtual_cols(core_grid.x, num_groups, static_cast<uint32_t>(num_channel));
+    TT_FATAL(
+        num_virtual_cols > 0,
+        "group_norm: Cannot determine num_virtual_cols for core_grid x={}, num_groups={}, "
+        "num_channels={}. num_virtual_cols must satisfy (num_channels / nvc) % TILE_SIZE == 0 "
+        "and num_groups % nvc == 0.",
+        core_grid.x,
+        num_groups,
+        num_channel);
+    return static_cast<int64_t>(num_virtual_cols);
 }
 
 ttnn::Tensor get_mask_tensor(const ttnn::Tensor& input_tensor, const CoreGrid& core_grid, const int num_groups) {
@@ -162,6 +160,7 @@ Tensor group_norm(
     const float epsilon,
     const std::optional<Tensor>& weight,
     const std::optional<Tensor>& bias,
+    const std::optional<Tensor>& /*input_mask*/,
     const std::optional<Tensor>& reciprocals,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DataType> /*dtype*/,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -17,6 +17,7 @@ Tensor group_norm(
     float epsilon,
     const std::optional<Tensor>& weight = std::nullopt,
     const std::optional<Tensor>& bias = std::nullopt,
+    const std::optional<Tensor>& input_mask = std::nullopt,  // Deprecated: ignored, will be removed soon
     const std::optional<Tensor>& reciprocals = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> dtype = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -15,7 +15,6 @@ Tensor group_norm(
     const Tensor& input_tensor,
     int num_groups,
     float epsilon,
-    const std::optional<Tensor>& input_mask = std::nullopt,
     const std::optional<Tensor>& weight = std::nullopt,
     const std::optional<Tensor>& bias = std::nullopt,
     const std::optional<Tensor>& reciprocals = std::nullopt,
@@ -26,7 +25,6 @@ Tensor group_norm(
     std::optional<Layout> output_layout = std::nullopt,
     std::optional<int> num_out_blocks = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    const std::optional<Tensor>& negative_mask = std::nullopt,
     bool use_welford = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -26,6 +26,7 @@ Tensor group_norm(
     std::optional<Layout> output_layout = std::nullopt,
     std::optional<int> num_out_blocks = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    const std::optional<Tensor>& negative_mask = std::nullopt,  // Deprecated: ignored, will be removed soon
     bool use_welford = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -56,6 +56,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 epsilon (float): Defaults to 1e-12.
                 weight (ttnn.Tensor, optional): Gamma (scale) parameter for the affine transformation. When omitted, no scaling is applied. Defaults to `None`.
                 bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
+                input_mask (ttnn.Tensor, optional): Deprecated. This argument is ignored and will be removed soon. The mask is now created automatically. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (ttnn.DataType, optional): Defaults to `None`.
                 core_grid (CoreGrid, optional): Defaults to `None`.
@@ -123,6 +124,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("epsilon") = 1e-12,
         nb::arg("weight") = nb::none(),
         nb::arg("bias") = nb::none(),
+        nb::arg("input_mask") = nb::none(),
         nb::arg("reciprocals") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("dtype") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -57,6 +57,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 weight (ttnn.Tensor, optional): Gamma (scale) parameter for the affine transformation. When omitted, no scaling is applied. Defaults to `None`.
                 bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
                 input_mask (ttnn.Tensor, optional): Deprecated. This argument is ignored and will be removed soon. The mask is now created automatically. Defaults to `None`.
+                negative_mask (ttnn.Tensor, optional): Deprecated. This argument is ignored and will be removed soon. The mask is now created automatically. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (ttnn.DataType, optional): Defaults to `None`.
                 core_grid (CoreGrid, optional): Defaults to `None`.
@@ -133,6 +134,7 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("output_layout") = nb::none(),
         nb::arg("num_out_blocks") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("negative_mask") = nb::none(),
         nb::arg("use_welford") = false);
     mod.def(
         "create_group_norm_input_mask",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -54,7 +54,6 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
             Keyword args:
                 num_groups (int): Number of groups to split the tensor's channels into.
                 epsilon (float): Defaults to 1e-12.
-                input_mask (ttnn.Tensor, optional): Defaults to `None`. When processing the inputs, the mask is used to only look at the elements of the current group.
                 weight (ttnn.Tensor, optional): Gamma (scale) parameter for the affine transformation. When omitted, no scaling is applied. Defaults to `None`.
                 bias (ttnn.Tensor, optional): Beta (shift) parameter for the affine transformation. When omitted, no shift is applied. Defaults to `None`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
@@ -64,7 +63,6 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
                 output_layout (ttnn.Layout, optional): Defaults to `None`.
                 num_out_blocks (int, optional): For non-sharded (interleaved) inputs, splits the per-core output height (``block_h``, in tiles) into ``num_out_blocks`` chunks so each iteration uses less SRAM, at the cost of performance. Ignored for sharded inputs. Should only be set if needed to relieve SRAM pressure. Accepted explicit values are ``-1`` (use the built-in auto-heuristic) or a chunk count in range ``[1, block_h]``. Defaults to `None`, whose meaning depends on :attr:`core_grid` (non-sharded inputs only): when :attr:`core_grid` is also `None` (auto-selected), ``num_out_blocks`` is determined automatically using the same auto-heuristic as ``-1``, and passing an explicit ``num_out_blocks`` in that case is rejected. When :attr:`core_grid` is provided and ``num_out_blocks`` is `None` (default), ``num_out_blocks`` defaults to ``1`` (no chunking).
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Compute kernel configuration for the op. Defaults to `None`.
-                negative_mask (ttnn.Tensor, optional): Defaults to `None`. Can be used only in row-major sharded input/output tensors. Used to reduce the number of CB's used in the sharded version of the kernel by overlapping the CB's used for tilized input and output. (The kernel is in fact row major variant, but is internally tilizing RM into tilized inputs).
                 use_welford (bool, optional): Defaults to `False`. If `True`, the Welford's algorithm is used to compute the mean and variance.
                 reciprocals (ttnn.Tensor, optional): Defaults to `None`. FP32 tensor containing pre-computed reciprocal values. Only valid when ``use_welford`` is True. Must be sharded to L1 using the legacy ``ShardSpec`` representation, with the shard grid matching the compute :attr:`core_grid`. Interleaved tensors and ``NdShardSpec`` sharding are currently not supported for the :attr:`reciprocals` tensor.
 
@@ -123,7 +121,6 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("num_groups"),
         nb::arg("epsilon") = 1e-12,
-        nb::arg("input_mask") = nb::none(),
         nb::arg("weight") = nb::none(),
         nb::arg("bias") = nb::none(),
         nb::arg("reciprocals") = nb::none(),
@@ -134,7 +131,6 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("output_layout") = nb::none(),
         nb::arg("num_out_blocks") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("negative_mask") = nb::none(),
         nb::arg("use_welford") = false);
     mod.def(
         "create_group_norm_input_mask",


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
[FEATURE] Remove input masks from GN (Group Normalization) interface

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #31778

Removes `input_mask` and `negative_mask` from the public GN (Group Normalization) op API to simplify usage and reduce boilerplate for callers.

Previously, users had to supply these masks manually. This change moves mask management into the op itself
[link](https://github.com/tenstorrent/tt-metal/issues/31778)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/GN_interface_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/GN_interface_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/GN_interface_fix)