### PR TITLE
[gpt-oss-120b][tier-1] Fix dropdown, set throttle, and add --skip-model-load to CI run

### DIFF
--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -103,6 +103,7 @@ jobs:
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        MLPERF_READ_ONLY: ${{ inputs.mlperf-read-only }} # used by GPT-OSS 120B to toggle --skip-model-load
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/models-t1-e2e-tests.yaml
+++ b/.github/workflows/models-t1-e2e-tests.yaml
@@ -62,11 +62,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-      mlperf-read-only:
+      mlperf-write-access:
         required: false
         type: boolean
-        default: true
-        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access)"
+        default: false
+        description: "Enable read-write access to /mnt/MLPerf (e.g. to regenerate tensor cache). Default is read-only."
 
 permissions:
   packages: write
@@ -120,5 +120,5 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       model: ${{ needs.resolve-skus.outputs.model }}
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      mlperf-read-only: ${{ inputs.mlperf-write-access != true }}
       tier: "1"

--- a/.github/workflows/models-t1-e2e-tests.yaml
+++ b/.github/workflows/models-t1-e2e-tests.yaml
@@ -17,7 +17,7 @@ on:
           - llama3.1-8b-dp-galaxy
           - llama3.3-70b-galaxy
           - qwen3-32b-galaxy
-          - gpt-oss-120b-high-batch-galaxy
+          - gpt-oss-120b
           - whisper
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -15,7 +15,7 @@ on:
           - all
           - llama3.1-8b
           - qwen3-32b-galaxy
-          - gpt-oss-120b-high-batch-galaxy
+          - gpt-oss-120b
           - whisper
           # llama3.3-70b-galaxy: disabled — see #42139
       sku:

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -61,11 +61,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-      mlperf-read-only:
+      mlperf-write-access:
         required: false
         type: boolean
-        default: true
-        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access)"
+        default: false
+        description: "Enable read-write access to /mnt/MLPerf (e.g. to regenerate tensor cache). Default is read-only."
 
 permissions:
   packages: write
@@ -119,5 +119,5 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       model: ${{ needs.resolve-skus.outputs.model }}
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
+      mlperf-read-only: ${{ inputs.mlperf-write-access != true }}
       tier: "1"

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -103,6 +103,7 @@ jobs:
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        MLPERF_READ_ONLY: ${{ inputs.mlperf-read-only }} # used by GPT-OSS 120B to toggle --skip-model-load
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/models/demos/gpt_oss/tt/common.py
+++ b/models/demos/gpt_oss/tt/common.py
@@ -50,8 +50,9 @@ def create_tt_model(
         gpt_oss_model_args.hf_config.num_hidden_layers = num_layers
         gpt_oss_model_args.n_layers = num_layers
 
-    # Avoid loading state_dict for every DP model
-    if not state_dict:
+    # Avoid loading state_dict for every DP model. An empty dict is intentional
+    # when --skip-model-load is used.
+    if state_dict is None:
         state_dict = gpt_oss_model_args.load_state_dict(
             weights_path=gpt_oss_model_args.model_path,
             dummy_weights=gpt_oss_model_args.dummy_weights,

--- a/models/demos/gpt_oss/tt/experts_throughput/weights.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/weights.py
@@ -876,36 +876,37 @@ def create_fused_moe_gpt_config(
     # Device d (row-major: d = row * mesh_cols + col) owns experts [d*E : (d+1)*E].
     # Weights are organized as [rows*num_cores, cols*L, ...] and sharded via
     # ShardTensor2dMesh(dims=(0, 1)) so each device gets [num_cores, L, ...].
-    if "gate_up_proj" in state_dict:
-        gate_up_all = state_dict["gate_up_proj"]  # [num_experts, K, 2N]
-        w0_all = gate_up_all[..., ::2].contiguous().float()  # [num_experts, K, N]
-        w1_all = gate_up_all[..., 1::2].contiguous().float()  # [num_experts, K, N]
-    else:
-        w0_all = state_dict["gate_proj"].contiguous().float()
-        w1_all = state_dict["up_proj"].contiguous().float()
-    w2_all = state_dict["down_proj"].contiguous().float()  # [num_experts, N, K]
+    if state_dict:
+        if "gate_up_proj" in state_dict:
+            gate_up_all = state_dict["gate_up_proj"]  # [num_experts, K, 2N]
+            w0_all = gate_up_all[..., ::2].contiguous().float()  # [num_experts, K, N]
+            w1_all = gate_up_all[..., 1::2].contiguous().float()  # [num_experts, K, N]
+        else:
+            w0_all = state_dict["gate_proj"].contiguous().float()
+            w1_all = state_dict["up_proj"].contiguous().float()
+        w2_all = state_dict["down_proj"].contiguous().float()  # [num_experts, N, K]
 
-    # --- Extract bias tensors ---
-    if "gate_up_proj_bias" in state_dict:
-        gate_up_bias = state_dict["gate_up_proj_bias"]
-        b0_all = gate_up_bias[..., ::2].contiguous().float()  # [num_experts, N]
-        b1_all = gate_up_bias[..., 1::2].contiguous().float()  # [num_experts, N]
-    elif "gate_up_proj" in state_dict:
-        b0_all = torch.zeros(w0_all.shape[0], N, dtype=torch.float32)
-        b1_all = torch.zeros(w1_all.shape[0], N, dtype=torch.float32)
-    else:
-        b0_all = state_dict.get("gate_proj_bias", torch.zeros(w0_all.shape[0], N)).contiguous().float()
-        b1_all = state_dict.get("up_proj_bias", torch.zeros(w1_all.shape[0], N)).contiguous().float()
-    b2_all = state_dict.get("down_proj_bias", torch.zeros(w2_all.shape[0], K)).contiguous().float()
+        # --- Extract bias tensors ---
+        if "gate_up_proj_bias" in state_dict:
+            gate_up_bias = state_dict["gate_up_proj_bias"]
+            b0_all = gate_up_bias[..., ::2].contiguous().float()  # [num_experts, N]
+            b1_all = gate_up_bias[..., 1::2].contiguous().float()  # [num_experts, N]
+        elif "gate_up_proj" in state_dict:
+            b0_all = torch.zeros(w0_all.shape[0], N, dtype=torch.float32)
+            b1_all = torch.zeros(w1_all.shape[0], N, dtype=torch.float32)
+        else:
+            b0_all = state_dict.get("gate_proj_bias", torch.zeros(w0_all.shape[0], N)).contiguous().float()
+            b1_all = state_dict.get("up_proj_bias", torch.zeros(w1_all.shape[0], N)).contiguous().float()
+        b2_all = state_dict.get("down_proj_bias", torch.zeros(w2_all.shape[0], K)).contiguous().float()
 
-    # Reshape biases: [num_experts, dim] -> [num_experts, 1, dim] for tile row (32-row padding)
-    # Pad to 32 rows (one tile row): [num_experts, 32, dim]
-    b0_all = b0_all.unsqueeze(1)  # [num_experts, 1, N]
-    b0_all = torch.nn.functional.pad(b0_all, (0, 0, 0, 31), "constant", 0.0)  # [num_experts, 32, N]
-    b1_all = b1_all.unsqueeze(1)
-    b1_all = torch.nn.functional.pad(b1_all, (0, 0, 0, 31), "constant", 0.0)
-    b2_all = b2_all.unsqueeze(1)
-    b2_all = torch.nn.functional.pad(b2_all, (0, 0, 0, 31), "constant", 0.0)  # [num_experts, 32, K]
+        # Reshape biases: [num_experts, dim] -> [num_experts, 1, dim] for tile row (32-row padding)
+        # Pad to 32 rows (one tile row): [num_experts, 32, dim]
+        b0_all = b0_all.unsqueeze(1)  # [num_experts, 1, N]
+        b0_all = torch.nn.functional.pad(b0_all, (0, 0, 0, 31), "constant", 0.0)  # [num_experts, 32, N]
+        b1_all = b1_all.unsqueeze(1)
+        b1_all = torch.nn.functional.pad(b1_all, (0, 0, 0, 31), "constant", 0.0)
+        b2_all = b2_all.unsqueeze(1)
+        b2_all = torch.nn.functional.pad(b2_all, (0, 0, 0, 31), "constant", 0.0)  # [num_experts, 32, K]
 
     # --- Prepare fused kernel weights (DRAM HEIGHT_SHARDED) ---
     ring2cores = _build_ring2cores(mesh_device)
@@ -924,25 +925,29 @@ def create_fused_moe_gpt_config(
     # ShardTensor2dMesh(dims=(0, 1)) gives each device [num_cores, L, E, groups, K, tile].
     mesh_cols = total_devices // ring_devices
     experts_per_cluster = config.num_experts // mesh_cols
-    w0_w1_rows = []
-    w2_rows = []
-    for r in range(ring_devices):
-        w0_w1_cols = []
-        w2_cols = []
-        for c in range(mesh_cols):
-            start = c * experts_per_cluster + r * E
-            w0_d = w0_all[start : start + E].unsqueeze(0)  # [1, E, K, N]
-            w1_d = w1_all[start : start + E].unsqueeze(0)  # [1, E, K, N]
-            w2_d = w2_all[start : start + E].unsqueeze(0)  # [1, E, N, K]
-            b0_d = b0_all[start : start + E].unsqueeze(0)  # [1, E, 32, N]
-            b1_d = b1_all[start : start + E].unsqueeze(0)  # [1, E, 32, N]
-            b2_d = b2_all[start : start + E].unsqueeze(0)  # [1, E, 32, K]
-            w0_w1_cols.append(_prepare_w0_b0_w1_b1_tensor(w0_d, b0_d, w1_d, b1_d, L, E, K, N, ring2cores))
-            w2_cols.append(_prepare_w2_b2_tensor(w2_d, b2_d, L, E, N, K, ring2cores))
-        w0_w1_rows.append(torch.cat(w0_w1_cols, dim=1))  # cat cols on dim 1
-        w2_rows.append(torch.cat(w2_cols, dim=1))
-    torch_w0_w1 = torch.cat(w0_w1_rows, dim=0)  # cat rows on dim 0
-    torch_w2 = torch.cat(w2_rows, dim=0)
+    if state_dict:
+        w0_w1_rows = []
+        w2_rows = []
+        for r in range(ring_devices):
+            w0_w1_cols = []
+            w2_cols = []
+            for c in range(mesh_cols):
+                start = c * experts_per_cluster + r * E
+                w0_d = w0_all[start : start + E].unsqueeze(0)  # [1, E, K, N]
+                w1_d = w1_all[start : start + E].unsqueeze(0)  # [1, E, K, N]
+                w2_d = w2_all[start : start + E].unsqueeze(0)  # [1, E, N, K]
+                b0_d = b0_all[start : start + E].unsqueeze(0)  # [1, E, 32, N]
+                b1_d = b1_all[start : start + E].unsqueeze(0)  # [1, E, 32, N]
+                b2_d = b2_all[start : start + E].unsqueeze(0)  # [1, E, 32, K]
+                w0_w1_cols.append(_prepare_w0_b0_w1_b1_tensor(w0_d, b0_d, w1_d, b1_d, L, E, K, N, ring2cores))
+                w2_cols.append(_prepare_w2_b2_tensor(w2_d, b2_d, L, E, N, K, ring2cores))
+            w0_w1_rows.append(torch.cat(w0_w1_cols, dim=1))  # cat cols on dim 1
+            w2_rows.append(torch.cat(w2_cols, dim=1))
+        torch_w0_w1 = torch.cat(w0_w1_rows, dim=0)  # cat rows on dim 0
+        torch_w2 = torch.cat(w2_rows, dim=0)
+    else:
+        torch_w0_w1 = None
+        torch_w2 = None
 
     K_bias = K + 32  # K + 1 bias tile row (32 rows)
     w0_w1_mem_config = ttnn.MemoryConfig(

--- a/models/demos/gpt_oss/tt/topk.py
+++ b/models/demos/gpt_oss/tt/topk.py
@@ -49,8 +49,11 @@ class TopKRouter:
         self.top_k = hf_config.num_experts_per_tok
         self.num_experts = hf_config.num_local_experts
         self.hidden_dim = hf_config.hidden_size
+        self.tensor_cache_path = tensor_cache_path
+        torch_weight = state_dict["weight"].transpose(0, 1) if state_dict else None
+        torch_bias = state_dict["bias"].unsqueeze(0) if state_dict else None
         self.weight = ttnn.as_tensor(
-            state_dict["weight"].transpose(0, 1),
+            torch_weight,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat16,
@@ -58,7 +61,7 @@ class TopKRouter:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         self.bias = ttnn.as_tensor(
-            state_dict["bias"].unsqueeze(0),
+            torch_bias,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat16,
@@ -87,7 +90,7 @@ class TopKRouter:
         # Keep the original unsharded bias for fused op initialization
         # (ttnn.as_tensor shards self.bias across the mesh, but the fused op
         # needs the full [1, num_experts] bias replicated on every device)
-        if self.use_fused_op:
+        if self.use_fused_op and state_dict:
             self._bias_torch = state_dict["bias"].unsqueeze(0).to(torch.bfloat16)
         else:
             self._bias_torch = None
@@ -97,16 +100,20 @@ class TopKRouter:
         mesh_mapper = ttnn.ReplicateTensorToMesh(device) if isinstance(device, ttnn.MeshDevice) else None
 
         if self._fused_bias is None:
-            # Use the original unsharded bias (self._bias_torch is [1, num_experts])
-            # and broadcast to [B, num_experts] so every tile row has the bias vector.
-            bias_bcast = self._bias_torch.expand(B, -1).contiguous()
-            self._fused_bias = ttnn.from_torch(
+            if self._bias_torch is not None:
+                # Use the original unsharded bias (self._bias_torch is [1, num_experts])
+                # and broadcast to [B, num_experts] so every tile row has the bias vector.
+                bias_bcast = self._bias_torch.expand(B, -1).contiguous()
+            else:
+                bias_bcast = None
+            self._fused_bias = ttnn.as_tensor(
                 bias_bcast,
                 dtype=ttnn.bfloat16,
                 device=device,
                 layout=ttnn.TILE_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 mesh_mapper=mesh_mapper,
+                cache_file_name=get_cache_file_name(self.tensor_cache_path, f"fused_bias_B{B}"),
             )
 
     def __call__(self, hidden_states, use_throughput_experts):

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -434,7 +434,7 @@
 - name: GPT-OSS 120B e2e tests
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
-    export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/
+    export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ TT_MM_THROTTLE_PERF=2
     pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500
   model: gpt-oss-120b
   skus:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -435,7 +435,11 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ TT_MM_THROTTLE_PERF=2
-    pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500
+    # Tensor cache is pre-built on the NAS — skip loading model weights by default.
+    # Check mlperf-write-access in the workflow to load weights and regenerate the cache.
+    SKIP_MODEL_LOAD="--skip-model-load"
+    [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
+    pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500 $SKIP_MODEL_LOAD
   model: gpt-oss-120b
   skus:
     wh_galaxy_perf:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -362,7 +362,7 @@
 - name: GPT-OSS 120B unit tests
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
-    export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b
+    export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b TT_MM_THROTTLE_PERF=2
     pytest --timeout 1500 models/demos/gpt_oss/tests/unit
   model: gpt-oss-120b
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -363,7 +363,11 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b TT_MM_THROTTLE_PERF=2
-    pytest --timeout 1500 models/demos/gpt_oss/tests/unit
+    # Tensor cache is pre-built on the NAS — skip loading model weights by default.
+    # Check mlperf-write-access in the workflow to load weights and regenerate the cache.
+    SKIP_MODEL_LOAD="--skip-model-load"
+    [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
+    pytest --timeout 1500 models/demos/gpt_oss/tests/unit $SKIP_MODEL_LOAD
   model: gpt-oss-120b
   skus:
     # Wormhole


### PR DESCRIPTION
## Summary

**PR:** https://github.com/tenstorrent/tt-metal/pull/45301

This PR bundles three fixes for the GPT-OSS 120B tier-1 e2e and unit test pipelines:

### 1. Fix workflow dispatch dropdown names
The model key in the test matrix was renamed to `gpt-oss-120b` but the `workflow_dispatch` dropdowns in `models-t1-e2e-tests.yaml` and `models-t1-unit-tests.yaml` still had the old `gpt-oss-120b-high-batch-galaxy` value. The pipeline filter does a substring match, so manual runs on gpt-oss-120b were silently skipped.

### 2. Set `TT_MM_THROTTLE_PERF=2`
GPT-OSS 120B was experiencing matmul hangs in tier-1 runs. Setting `TT_MM_THROTTLE_PERF=2` resolves these by throttling matmul performance.

### 3. Add `--skip-model-load` (saves ~5 min per run)
The tensor cache for GPT-OSS 120B is pre-built on the NAS — loading ~120B model weights from scratch on every CI run is unnecessary. Adding `--skip-model-load` by default skips weight loading and reads directly from the tensor cache, saving **~5 minutes per run**.

Everyone debugging tier-1 failures will see a direct improvement in iteration time since model loading is no longer a mandatory step.

**Model code fix** (`common.py`, `weights.py`, `topk.py`): Several code paths mishandled an empty `{}` state dict (treating it as falsy or crashing on missing keys). Fixed to check `is None` / `if state_dict:` explicitly so `{}` is the valid "no weights" signal.

**Pipeline changes:**
- Replaces `mlperf-read-only: true` (checked by default) with `mlperf-write-access: false` (unchecked by default) in the tier-1 dispatch inputs — unchecked = read-only = `--skip-model-load` automatically applied.
- The impl workflows forward the mount mode as `MLPERF_READ_ONLY` into the container env.
- GPT-OSS 120B test commands read `MLPERF_READ_ONLY` and conditionally pass `--skip-model-load`.

**To regenerate the tensor cache:** check **mlperf-write-access** in the workflow dispatch UI — this mounts `/mnt/MLPerf` read-write and loads model weights so fresh cache files can be written.

## CI runs

- [ ] [(Tier 1) Models E2E — gpt-oss-120b on wh_galaxy_perf](https://github.com/tenstorrent/tt-metal/actions/runs/26501795091)
- [ ] [(Tier 1) Models Unit — gpt-oss-120b on wh_galaxy](https://github.com/tenstorrent/tt-metal/actions/runs/26501834977)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=divanovic/gpt-oss-120b-t1-e2e-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:divanovic/gpt-oss-120b-t1-e2e-fixes)