### PR TITLE
DS Prefill :: Dispatch performance improvement

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -236,12 +236,12 @@ _DISPATCH_PERF_PARAMS = [
         "test_ttnn_dispatch",
         "linear",
         2,
-        4_108_262,
+        4_068_188,
         "",
         dtype_filter="bf16_out",
     ),
     _perf_param(
-        "dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 3_683_084, "", dtype_filter="bf16_out"
+        "dispatch", "test_prefill_dispatch.py", "test_ttnn_dispatch", "ring", 2, 2_652_427, "", dtype_filter="bf16_out"
     ),
 ]
 _COMBINE_PERF_PARAMS = [

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -24,7 +24,7 @@ def test_deepseek_v3_mla_perf_loudbox():
     """
     run_mla_perf_with_approximation(
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=8_952_745,
+        expected_ns_2x4=8_255_885,
         model_name_2x4="deepseek_v3_mla_lb_2x4",
         subdir="deepseek_v3_mla",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -38,7 +38,7 @@ def test_deepseek_v3_mla_perf_galaxy():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
-        expected_device_perf_ns_per_iteration=15_427_562,
+        expected_device_perf_ns_per_iteration=14_719_306,
         subdir="deepseek_v3_mla",
         model_name="deepseek_v3_mla_glx_8x4",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -43,7 +43,7 @@ def test_deepseek_v3_moe_perf_loudbox():
         expected_ns_8x1=102_298_878,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=94_929_326,
+        expected_ns_2x4=92_289_763,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -40,10 +40,10 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        expected_ns_8x1=102_298_878,
+        expected_ns_8x1=29_185_788,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=92_289_763,
+        expected_ns_2x4=39_194_517,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -40,7 +40,7 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        expected_ns_8x1=29_185_788,
+        expected_ns_8x1=36_272_143,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
         expected_ns_2x4=39_194_517,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -54,7 +54,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            107_554_551,
+            104_390_120,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -44,7 +44,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-8x4 and layer3 and gate_device and no_ref and isl_25k and not fabric2d-'",
-            130_873_080,
+            73_644_850,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer3_moe",
             1,
@@ -54,7 +54,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            61_188_063,
+            58_852_515,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,
@@ -87,8 +87,8 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            75_467_194,  # Recalibrated 2026-06-05 on bh_loudbox bh-lb-02 (post-main-rebase): ~38% speedup from
-            "deepseek_v3_prefill_block",  # #45189 (unified_routed_expert_ffn), matching the fabric2d-mesh-8x4 layer3 recalibration.
+            72_625_506,
+            "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe_fabric2d",
             1,
             1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -54,7 +54,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            104_390_120,
+            61_188_063,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -11,8 +11,9 @@ and TtRoutedExpert (which processes the tokens after they arrive).
 
 For each token and each of its top-k experts, the dispatch kernel:
   1. Looks up which destination device hosts that expert via the expert_dispatch_table.
-  2. Reads the write position (global_dispatch_offset) for this source device and expert
-     from tt_expert_offsets (produced by TtMoERoutingSetup).
+  2. Reads the starting write position for this source device and expert from
+     tt_expert_offsets (global_dispatch_offsets, produced by TtMoERoutingSetup), then
+     advances a running per-expert counter from it as tokens are packed.
   3. Writes the token embedding into the destination device's local dispatch buffer at that
      position: locally via NOC if the expert is on the same device, or remotely via fabric
      if it is on a different device in the dispatch group.
@@ -66,6 +67,7 @@ class TtDispatchModule(LightweightModule):
         topology: ttnn.Topology = ttnn.Topology.Linear,
         fp8_output: bool = False,
         subdevice_id=None,
+        num_untilizers_per_sender: int = 2,
     ):
         """
         Initialize dispatch module with configuration parameters.
@@ -87,6 +89,7 @@ class TtDispatchModule(LightweightModule):
             num_links: Number of fabric links for remote token writes.
             topology: Fabric topology for remote token writes.
             fp8_output: Output dtype for the dispatched buffer.
+            num_untilizers_per_sender: Number of untilizer cores per sender (any N >= 1).
         """
         if fp8_output and "blackhole" not in ttnn.get_arch_name():
             raise ValueError("fp8_output requires Blackhole hardware")
@@ -104,6 +107,9 @@ class TtDispatchModule(LightweightModule):
         self.topology = topology
         self.fp8_output = fp8_output
         self.subdevice_id = subdevice_id
+        if num_untilizers_per_sender < 1:
+            raise ValueError(f"num_untilizers_per_sender must be >= 1; got {num_untilizers_per_sender}")
+        self.num_untilizers_per_sender = num_untilizers_per_sender
 
     @staticmethod
     def shard_expert_offsets(
@@ -227,7 +233,7 @@ class TtDispatchModule(LightweightModule):
                 Shape per device: (1, 1, max_dispatch_buffer_token_size, emb_dim)
                 Token at index i belongs to the expert whose region covers index i; regions are
                 TILE_HEIGHT-aligned and laid out by the expert region offsets from offset_cumsum.
-            metadata: Per-token metadata written alongside dispatched_buffer.
+            metadata: Per-token routing metadata written alongside dispatched_buffer.
                 Shape per device: (1, 1, max_dispatch_buffer_token_size, metadata_len=5),
                 int32, ROW_MAJOR.
                 Fields per token: [linearized_mesh_coord, token_idx, topk_idx, routed_expert, weight].
@@ -267,6 +273,7 @@ class TtDispatchModule(LightweightModule):
             topology=self.topology,
             use_fp8_dispatch=self.fp8_output,
             subdevice_id=self.subdevice_id,
+            num_untilizers_per_sender=self.num_untilizers_per_sender,
         )
 
         if tt_dispatched_buffer.dtype == ttnn.uint8:

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -107,8 +107,8 @@ class TtDispatchModule(LightweightModule):
         self.topology = topology
         self.fp8_output = fp8_output
         self.subdevice_id = subdevice_id
-        if num_untilizers_per_sender < 1:
-            raise ValueError(f"num_untilizers_per_sender must be >= 1; got {num_untilizers_per_sender}")
+        # num_untilizers_per_sender >= 1 is validated on the device op side
+        # (DispatchDeviceOperation::validate_on_program_cache_miss).
         self.num_untilizers_per_sender = num_untilizers_per_sender
 
     @staticmethod

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -141,7 +141,7 @@
 - name: t3k_DeepSeek_PREFILL_OP_TESTS
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check)) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and not test_dispatch_combine_l1_small_semaphores" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check and not fabric2d)) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and not test_dispatch_combine_l1_small_semaphores" || exit_code=$?
     exit $exit_code
   skus:
     wh_llmbox:

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -64,6 +64,11 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         !operation_attributes.output_mem_config.is_sharded(),
         "Output memory config must be DRAM interleaved, not sharded");
+
+    TT_FATAL(
+        operation_attributes.num_untilizers_per_sender >= 1,
+        "num_untilizers_per_sender must be >= 1; got {}.",
+        operation_attributes.num_untilizers_per_sender);
 }
 
 void DispatchDeviceOperation::validate_on_program_cache_hit(
@@ -154,7 +159,8 @@ prefill_dispatch(
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
     bool use_l1_small_for_semaphores,
-    bool use_fp8_dispatch) {
+    bool use_fp8_dispatch,
+    uint32_t num_untilizers_per_sender) {
     using OperationType = ttnn::operations::experimental::deepseek_prefill::dispatch::DispatchDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
@@ -170,7 +176,8 @@ prefill_dispatch(
             .output_mem_config = memory_config,
             .worker_core_range_set = worker_core_range_set,
             .use_l1_small_for_semaphores = use_l1_small_for_semaphores,
-            .use_fp8_dispatch = use_fp8_dispatch},
+            .use_fp8_dispatch = use_fp8_dispatch,
+            .num_untilizers_per_sender = num_untilizers_per_sender},
         OperationType::tensor_args_t{
             .input_tensor = input_tensor,
             .weights_tensor = weights_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -64,11 +64,6 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         !operation_attributes.output_mem_config.is_sharded(),
         "Output memory config must be DRAM interleaved, not sharded");
-
-    TT_FATAL(
-        operation_attributes.num_untilizers_per_sender >= 1,
-        "num_untilizers_per_sender must be >= 1; got {}.",
-        operation_attributes.num_untilizers_per_sender);
 }
 
 void DispatchDeviceOperation::validate_on_program_cache_hit(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.hpp
@@ -62,5 +62,6 @@ prefill_dispatch(
     const ttnn::MemoryConfig& memory_config,
     const CoreRangeSet& worker_core_range_set,
     bool use_l1_small_for_semaphores = false,
-    bool use_fp8_dispatch = false);
+    bool use_fp8_dispatch = false,
+    uint32_t num_untilizers_per_sender = 2);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -87,7 +87,8 @@ void create_tensor_cb(
 
 namespace {
 
-// Tile-layout path: TILE inputs, fused untilize across sender + idle cores.
+// Tile-layout path: TILE inputs, fused untilize across N untilize cores per sender
+// (num_untilizers_per_sender, u1..uN); sender is fabric-only.
 tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
@@ -109,6 +110,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
+    uint32_t num_untilizers = operation_attributes.num_untilizers_per_sender;
     log_debug(
         tt::LogOp,
         "Creating prefill dispatch program (tile layout) for mesh coordinate: ({}, {}) with topology: {} num_links: {}",
@@ -152,8 +154,10 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     uint32_t num_cores = effective_num_links;
 
-    // ==================== Core layout: senders + idle groups ====================
+    // ==================== Core layout: senders + untilize cores ====================
     // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
+    // Each sender owns num_untilizers consecutive untilize cores (u1..uN): cores are
+    // laid out [sender, u1, ..., uN] consecutively along x per sender group.
     uint32_t sender_row_y = subdevice_cores.at(0).y;
     std::vector<CoreCoord> all_row_cores;
     for (const auto& core : subdevice_cores) {
@@ -165,76 +169,54 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
 
     uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
+    uint32_t cores_per_sender = 1 + num_untilizers;  // 1 sender + N untilize cores (u1..uN)
     TT_FATAL(
-        total_row_cores > num_cores,
-        "Same-row has only {} cores for {} senders — need at least one idle core per sender",
+        total_row_cores >= cores_per_sender * num_cores,
+        "Same-row has only {} cores for {} senders — need {} cores per sender (>= {} required)",
         total_row_cores,
-        num_cores);
-
-    // Divide total_row_cores into num_cores groups.
-    // Within each group: center core = sender, surrounding cores = that sender's idle cores.
-    uint32_t base_group_size = total_row_cores / num_cores;
-    uint32_t extra_groups = total_row_cores % num_cores;
+        num_cores,
+        cores_per_sender,
+        cores_per_sender * num_cores);
 
     std::vector<CoreCoord> sender_cores;
     sender_cores.reserve(num_cores);
-    std::vector<std::vector<CoreCoord>> sender_idle_groups(num_cores);
-    std::vector<CoreCoord> all_idle_cores;
-    std::vector<uint32_t> idle_sender_map;
+    std::vector<std::vector<CoreCoord>> sender_untilize_groups(num_cores);
+    std::vector<CoreCoord> all_untilize_cores;
+    all_untilize_cores.reserve(num_cores * num_untilizers);
+    std::vector<uint32_t> untilize_sender_map;
+    untilize_sender_map.reserve(num_cores * num_untilizers);
 
-    {
-        uint32_t pos = 0;
-        for (uint32_t s = 0; s < num_cores; s++) {
-            uint32_t group_size = base_group_size + (s >= num_cores - extra_groups ? 1 : 0);
-            uint32_t sender_offset = group_size / 2;
-            for (uint32_t j = 0; j < group_size; j++, pos++) {
-                if (j == sender_offset) {
-                    sender_cores.push_back(all_row_cores[pos]);
-                } else {
-                    sender_idle_groups[s].push_back(all_row_cores[pos]);
-                    all_idle_cores.push_back(all_row_cores[pos]);
-                    idle_sender_map.push_back(s);
-                }
-            }
+    for (uint32_t s = 0; s < num_cores; s++) {
+        sender_cores.push_back(all_row_cores[cores_per_sender * s]);
+        for (uint32_t u = 0; u < num_untilizers; u++) {
+            CoreCoord uc = all_row_cores[cores_per_sender * s + 1 + u];
+            sender_untilize_groups[s].push_back(uc);
+            all_untilize_cores.push_back(uc);
+            untilize_sender_map.push_back(s);
         }
     }
 
-    uint32_t num_idle_cores = static_cast<uint32_t>(all_idle_cores.size());
-    TT_FATAL(
-        num_idle_cores >= num_cores,
-        "Same-row has only {} idle cores for {} senders — need at least one idle core per sender",
-        num_idle_cores,
-        num_cores);
+    uint32_t num_untilize_cores = static_cast<uint32_t>(all_untilize_cores.size());
 
-    // Build sender_core_grid and idle_core_grid CoreRangeSets
+    // Build sender_core_grid and untilize_core_grid CoreRangeSets
     std::set<CoreRange> sender_ranges_set;
     for (const auto& sc : sender_cores) {
         sender_ranges_set.insert(CoreRange(sc));
     }
     auto sender_core_grid = CoreRangeSet(sender_ranges_set);
 
-    std::set<CoreRange> idle_ranges_set;
-    for (const auto& ic : all_idle_cores) {
-        idle_ranges_set.insert(CoreRange(ic));
+    std::set<CoreRange> untilize_ranges_set;
+    for (const auto& ic : all_untilize_cores) {
+        untilize_ranges_set.insert(CoreRange(ic));
     }
-    CoreRangeSet idle_core_grid(idle_ranges_set);
-
-    // Combined grid for shared semaphores
-    std::set<CoreRange> sender_and_idle_ranges;
-    for (const auto& cr : sender_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    for (const auto& cr : idle_core_grid.ranges()) {
-        sender_and_idle_ranges.insert(cr);
-    }
-    CoreRangeSet sender_and_idle_grid(sender_and_idle_ranges);
+    CoreRangeSet untilize_core_grid(untilize_ranges_set);
 
     log_debug(
         tt::LogOp,
-        "Dispatch program: num_links: {} num_cores(senders): {} num_idle_cores: {} tokens_per_device: {}",
+        "Dispatch program: num_links: {} num_cores(senders): {} num_untilize_cores: {} tokens_per_device: {}",
         num_links,
         num_cores,
-        num_idle_cores,
+        num_untilize_cores,
         tokens_per_device);
 
     constexpr uint32_t read_batch_size = 32;
@@ -242,60 +224,80 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     uint32_t total_batches = (tokens_per_device + read_batch_size - 1) / read_batch_size;
 
-    // ==================== Semaphores for inter-core sync ====================
-    // ProgramDescriptor semaphores carry an explicit `.id` field — legacy
-    // CreateSemaphore() auto-assigned the next available ID per core, so we
-    // mirror that with a monotonic counter.  Every semaphore here is created on
-    // the same sender_and_idle_grid, so a single counter trivially guarantees
-    // per-core uniqueness.
+    // ==================== Semaphores ====================
+    // Per-entry credit, each kept on the consumer's L1 (producer NOC-incs):
+    //   data_avail  (sender L1, init=0):                untilize → sender, "entry ready".
+    //   space_avail (untilize L1, init=writer_cb_size): sender → untilize, "slot freed".
+    constexpr uint32_t writer_cb_size = read_batch_size;  // 32 slots — one batch deep
     uint32_t next_sema_id = 0;
-    auto add_sema = [&](const CoreRangeSet& crs) -> uint32_t {
+    auto add_sema = [&](const CoreRangeSet& crs, uint32_t init_val = 0) -> uint32_t {
         uint32_t id = next_sema_id++;
         desc.semaphores.push_back(tt::tt_metal::SemaphoreDescriptor{
-            .id = id, .core_type = tt::CoreType::WORKER, .core_ranges = crs, .initial_value = 0});
+            .id = id, .core_type = tt::CoreType::WORKER, .core_ranges = crs, .initial_value = init_val});
         return id;
     };
-    // One data_ready + one start semaphore per sender (created on sender+idle grid)
-    std::vector<uint32_t> data_ready_semaphore_ids;
-    std::vector<uint32_t> start_semaphore_ids;
-    data_ready_semaphore_ids.reserve(num_cores);
-    start_semaphore_ids.reserve(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        data_ready_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
-        start_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
-    }
-    // addr_ready semaphore: sender signals idle cores after writing receive buffer address
-    auto addr_ready_semaphore_id = add_sema(sender_and_idle_grid);
-    // addr_value semaphore: holds the sender's c_18 L1 address (written via noc_async_write)
-    auto addr_value_semaphore_id = add_sema(sender_and_idle_grid);
-    // mbox_ready semaphore (per sender): idle cores signal this after NOC-writing their mailbox address.
-    // Sender waits for count == num_idle_cores_in_group before reading its own scratch buffer.
-    std::vector<uint32_t> mbox_ready_semaphore_ids;
-    mbox_ready_semaphore_ids.reserve(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        mbox_ready_semaphore_ids.push_back(add_sema(sender_and_idle_grid));
-    }
-    // mbox_scratch_addr semaphore: sender writes its route-table scratch base address here and
-    // multicasts it to idle cores alongside addr_ready.  Idle cores read it after addr_ready fires,
-    // then NOC-write their mailbox L1 address into the sender's scratch slot (core_id * 4 offset).
-    auto mbox_scratch_addr_semaphore_id = add_sema(sender_and_idle_grid);
 
-    // ==================== Circular Buffers for IDLE cores ====================
+    std::vector<uint32_t> data_avail_semaphore_ids(num_untilizers);
+    for (uint32_t s = 0; s < num_untilizers; s++) {
+        data_avail_semaphore_ids[s] = add_sema(sender_core_grid);
+    }
+    auto space_avail_semaphore_id = add_sema(untilize_core_grid, writer_cb_size);
+    auto addr_ready_semaphore_id = add_sema(untilize_core_grid);
+    auto cross_addr_semaphore_id = add_sema(untilize_core_grid);
+    auto turn_semaphore_id = add_sema(untilize_core_grid);
+
+    // ==================== Circular Buffers for untilize cores ====================
+    // Routing decisions and offsets[] live on the untilize core — sender is fabric-only.
     // c_0: tiled input stripe (reader → compute)
     detail::create_tensor_cb(
         desc,
-        idle_core_grid,
+        untilize_core_grid,
         input_tensor,
         /*buffering_factor=*/16,
         /*cb_id=*/tt::CBIndex::c_0,
-        "idle_input_scratch");
+        "untilize_input_scratch");
+    // c_1: indices scratch (untilize reader does per-batch DRAM reads)
+    detail::create_tensor_cb(
+        desc,
+        untilize_core_grid,
+        indices_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_1,
+        "untilize_indices_scratch");
+    // c_2: weights scratch
+    detail::create_tensor_cb(
+        desc,
+        untilize_core_grid,
+        weights_tensor,
+        /*buffering_factor=*/read_batch_size,
+        /*cb_id=*/tt::CBIndex::c_2,
+        "untilize_weights_scratch");
+    // c_3: offsets (full tensor, mutated in place per batch as the shared running counter).
+    // The owner untilize core (local_core_id==0) loads expert_offsets[] here once at startup;
+    // non-owners leave it uninitialized and pull/push the owner's copy under the baton each
+    // batch (see reader_untilize_dispatch.cpp). One copy per core — no extra scratch.
+    detail::create_tensor_cb(
+        desc,
+        untilize_core_grid,
+        offsets_tensor,
+        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
+        /*cb_id=*/tt::CBIndex::c_3,
+        "untilize_offsets_tensor");
+    // c_9: dispatch_table (full tensor, loaded once at startup)
+    detail::create_tensor_cb(
+        desc,
+        untilize_core_grid,
+        dispatch_table_tensor,
+        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
+        /*cb_id=*/tt::CBIndex::c_9,
+        "untilize_dispatch_table_tensor");
     // c_10: signal CB (reader → compute)
     {
         uint32_t signal_page_size = l1_alignment;
         constexpr uint32_t signal_buffering = 2;
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
             .total_size = signal_buffering * signal_page_size,
-            .core_ranges = idle_core_grid,
+            .core_ranges = untilize_core_grid,
             .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
                 .data_format = tt::DataFormat::UInt32,
@@ -304,169 +306,119 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         });
     }
     // c_11: untilize output (compute → writer)
-    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
+    // Double-buffered at batch granularity: two slots of read_batch_size tokens so compute can
+    // pack the next batch while the writer is still draining the previous one.
     detail::create_tensor_cb(
         desc,
-        idle_core_grid,
+        untilize_core_grid,
         output_tensor,
-        /*buffering_factor=*/read_batch_size,
+        /*buffering_factor=*/2 * read_batch_size,
         /*cb_id=*/tt::CBIndex::c_11,
-        "idle_untilize_output");
-    // c_12: route table mailbox (sender writes before start_semaphore; writer reads after)
-    // Layout: [entry_count u32] [entry_0..N × 6 u32s each]
+        "untilize_untilize_output");
+    // c_13: metadata scratch (untilize writer builds metadata here before NOC-writing).
+    detail::create_tensor_cb(
+        desc,
+        untilize_core_grid,
+        metadata_tensor,
+        /*buffering_factor=*/(read_batch_size * operation_attributes.num_experts_per_tok) + 1,
+        /*cb_id=*/tt::CBIndex::c_13,
+        "untilize_metadata_scratch");
+    // c_15: route_info scratch (16B = l1_alignment). Untilize writer builds the 4-u32
+    // route_info entry [route, distance, page_idx, 0] here, then NOC-writes the whole
+    // block as a single noc_async_write to the sender's c_4 slot (replaces 4× inline_dw).
     {
-        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
-        uint32_t mailbox_page_size = tt::round_up(
-            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
-            l1_alignment);
+        uint32_t route_info_scratch_size = l1_alignment;
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = mailbox_page_size,
-            .core_ranges = idle_core_grid,
+            .total_size = route_info_scratch_size,
+            .core_ranges = untilize_core_grid,
             .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_12),
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_15),
                 .data_format = tt::DataFormat::UInt32,
-                .page_size = mailbox_page_size,
+                .page_size = route_info_scratch_size,
             }}},
         });
     }
-    // c_13: metadata scratch (idle writer builds metadata here before NOC-writing to DRAM)
-    detail::create_tensor_cb(
-        desc,
-        idle_core_grid,
-        metadata_tensor,
-        /*buffering_factor=*/1,
-        /*cb_id=*/tt::CBIndex::c_13,
-        "idle_metadata_scratch");
+    // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
+    // Layout: [entry_count u32][padding to 32B][entries × 8 u32 each]
+    {
+        constexpr uint32_t plan_entry_u32s = 8;
+        uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;
+        uint32_t plan_page_size = tt::round_up(
+            32u + max_plan_entries * plan_entry_u32s * static_cast<uint32_t>(sizeof(uint32_t)), l1_alignment);
+        constexpr uint32_t plan_buffering = 2;
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = plan_buffering * plan_page_size,
+            .core_ranges = untilize_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_14),
+                .data_format = tt::DataFormat::UInt32,
+                .page_size = plan_page_size,
+            }}},
+        });
+    }
 
     // ==================== Circular Buffers for SENDER cores ====================
-    // c_0: tiled input stripe for self-untilize (reader → compute on sender)
-    // Double-buffered blocks of 8 tiles (compute processes 8 at a time)
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        input_tensor,
-        /*buffering_factor=*/16,
-        /*cb_id=*/tt::CBIndex::c_0,
-        "sender_input_scratch");
-    // c_10: signal CB for self-untilize (reader → compute on sender)
+    // Direct-consume pipeline on sender: one writer-CB set (route_info, payload, metadata)
+    // per untilizer. Set s is fed by the untilizer with local_core_id == s; the sender
+    // writer (RISCV_0) polls all N sets round-robin. Untilize cores NOC-write per-entry
+    // directly into the relevant set (addresses learned via the boot-time handshake).
+    //
+    // CB index layout: set 0 keeps the legacy c_4/c_5/c_6, set 1 keeps c_16/c_17/c_18, and
+    // further sets take consecutive free indices from c_19 up. Large N runs out of CB indices
+    // and CB creation asserts — that is the intended "breaks if too many" behaviour.
+    std::vector<std::array<uint32_t, 3>> writer_cb_ids(num_untilizers);  // {route, payload, metadata}
     {
-        uint32_t signal_page_size = l1_alignment;
-        constexpr uint32_t signal_buffering = 2;
-        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = signal_buffering * signal_page_size,
-            .core_ranges = sender_core_grid,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
-                .data_format = tt::DataFormat::UInt32,
-                .page_size = signal_page_size,
-            }}},
-        });
-    }
-    // c_1: indices scratch
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        indices_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_1,
-        "indices_scratch");
-    // c_2: weights scratch
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        weights_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_2,
-        "weights_scratch");
-    // c_3: offsets (full tensor)
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        offsets_tensor,
-        /*buffering_factor=*/detail::get_num_pages(offsets_tensor),
-        /*cb_id=*/tt::CBIndex::c_3,
-        "offsets_tensor");
-
-    // c_4, c_5, c_6: reader→writer CBs for (route_info, payload, metadata) per remote entry.
-    // The reader pushes all three per entry in lockstep, so small buffering (2) suffices
-    // for the writer to drain concurrently. No large buffering needed.
-    {
-        constexpr uint32_t rw_buffering = 2;
-
         uint32_t route_info_page_size = l1_alignment;
-        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = rw_buffering * route_info_page_size,
-            .core_ranges = sender_core_grid,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
-                .data_format = tt::DataFormat::UInt8,
-                .page_size = route_info_page_size,
-            }}},
-        });
+        uint32_t next_free_cb = static_cast<uint32_t>(tt::CBIndex::c_19);
+        for (uint32_t s = 0; s < num_untilizers; s++) {
+            std::array<uint32_t, 3> ids;
+            if (s == 0) {
+                ids = {
+                    static_cast<uint32_t>(tt::CBIndex::c_4),
+                    static_cast<uint32_t>(tt::CBIndex::c_5),
+                    static_cast<uint32_t>(tt::CBIndex::c_6)};
+            } else if (s == 1) {
+                ids = {
+                    static_cast<uint32_t>(tt::CBIndex::c_16),
+                    static_cast<uint32_t>(tt::CBIndex::c_17),
+                    static_cast<uint32_t>(tt::CBIndex::c_18)};
+            } else {
+                ids = {next_free_cb, next_free_cb + 1, next_free_cb + 2};
+                next_free_cb += 3;
+            }
+            writer_cb_ids[s] = ids;
 
-        detail::create_tensor_cb(
-            desc,
-            sender_core_grid,
-            output_tensor,
-            /*buffering_factor=*/rw_buffering,
-            /*cb_id=*/tt::CBIndex::c_5,
-            "payload_for_writer");
-
-        detail::create_tensor_cb(
-            desc,
-            sender_core_grid,
-            metadata_tensor,
-            /*buffering_factor=*/rw_buffering,
-            /*cb_id=*/tt::CBIndex::c_6,
-            "metadata_for_writer");
-    }
-
-    // c_7: metadata_temp (reader-only, for constructing metadata locally)
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        metadata_tensor,
-        /*buffering_factor=*/1,
-        /*cb_id=*/tt::CBIndex::c_7,
-        "metadata_temp_buffer");
-    // c_9: dispatch_table (full tensor)
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        dispatch_table_tensor,
-        /*buffering_factor=*/detail::get_num_pages(dispatch_table_tensor),
-        /*cb_id=*/tt::CBIndex::c_9,
-        "dispatch_table_tensor");
-    // c_18: receive buffer for untilized data from idle cores (also sender self-untilize output)
-    // FP8 path: pack_untilize converts BF16 tiles → FP8 row-major; page size is one aligned FP8 row.
-    detail::create_tensor_cb(
-        desc,
-        sender_core_grid,
-        output_tensor,
-        /*buffering_factor=*/read_batch_size,
-        /*cb_id=*/tt::CBIndex::c_18,
-        "receive_untilized");
-    // c_19: route table scratch (sender builds local-expert route table here before NOC-writing to idle)
-    {
-        uint32_t max_route_entries = read_batch_size * operation_attributes.num_experts_per_tok;
-        uint32_t mailbox_page_size = tt::round_up(
-            static_cast<uint32_t>(sizeof(uint32_t)) + max_route_entries * 6 * static_cast<uint32_t>(sizeof(uint32_t)),
-            l1_alignment);
-        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = mailbox_page_size,
-            .core_ranges = sender_core_grid,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_19),
-                .data_format = tt::DataFormat::UInt32,
-                .page_size = mailbox_page_size,
-            }}},
-        });
+            // route_info CB (UInt32, one L1_ALIGNMENT page per slot).
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = writer_cb_size * route_info_page_size,
+                .core_ranges = sender_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(ids[0]),
+                    .data_format = tt::DataFormat::UInt32,
+                    .page_size = route_info_page_size,
+                }}},
+            });
+            detail::create_tensor_cb(
+                desc,
+                sender_core_grid,
+                output_tensor,
+                /*buffering_factor=*/writer_cb_size,
+                /*cb_id=*/static_cast<tt::CBIndex>(ids[1]),
+                "payload_for_writer_" + std::to_string(s));
+            detail::create_tensor_cb(
+                desc,
+                sender_core_grid,
+                metadata_tensor,
+                /*buffering_factor=*/writer_cb_size,
+                /*cb_id=*/static_cast<tt::CBIndex>(ids[2]),
+                "metadata_for_writer_" + std::to_string(s));
+        }
     }
 
     const auto [neighbors, directions] =
         ccl::common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
 
-    // c_8: packet header CB for fabric sends
+    // c_8: packet header CB for fabric sends (sender-only)
     if (operation_attributes.num_links > 0) {
         constexpr uint32_t num_packet_headers = 2;
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
@@ -501,10 +453,10 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     log_debug(
         tt::LogOp, "Fabric max packet size: {} bytes, L1 alignment: {} bytes", fabric_max_packet_size, l1_alignment);
 
-    // ==================== Compile-time args shared by sender reader and writer ====================
+    // ==================== Compile-time args for the sender writer kernel ====================
     std::vector<uint32_t> compile_time_args = {
         // CB IDs (10)
-        static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (used by sender reader for self-untilize)
+        static_cast<uint32_t>(tt::CBIndex::c_0),  // cb_input_id (row-major path only)
         static_cast<uint32_t>(tt::CBIndex::c_1),  // cb_indices_id
         static_cast<uint32_t>(tt::CBIndex::c_2),  // cb_weights_id
         static_cast<uint32_t>(tt::CBIndex::c_3),  // cb_offsets_id
@@ -591,50 +543,24 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         fabric_defines["AXIS"] = std::to_string(operation_attributes.axis.value());
     }
 
-    // ==================== Per-sender reader kernels ====================
-    // Each sender gets its own reader kernel with per-sender idle core count baked in.
-    auto reader_defines = fabric_defines;
-    reader_defines["IS_TILE_LAYOUT"] = "1";
-    std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
-    reader_kernel_ids.reserve(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
-        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
-        auto per_sender_compile_args = compile_time_args;
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id (receive buf)
-        per_sender_compile_args.push_back(
-            detail::get_aligned_page_size(output_tensor));  // aligned_row_major_input_page_size
-        per_sender_compile_args.push_back(k_s);             // num_idle_cores
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_10));  // cb_signal_id
-        per_sender_compile_args.push_back(total_workers);                             // total_workers
-        per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_19));  // cb_route_table_scratch_id
+    // ==================== Sender writer kernel ====================
+    // Tile-layout: no sender reader RISC.
+    // Writes tokens and metadata via fabric to destination.
+    auto writer_defines = fabric_defines;
+    writer_defines["IS_TILE_LAYOUT"] = "1";
 
-        CoreRangeSet single_sender_core({CoreRange(sender_cores[s])});
-        tt::tt_metal::KernelDescriptor reader_kd;
-        reader_kd.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
-            "reader_dispatch.cpp";
-        reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-        reader_kd.core_ranges = single_sender_core;
-        reader_kd.compile_time_args = std::move(per_sender_compile_args);
-        reader_kd.defines = {reader_defines.begin(), reader_defines.end()};
-        reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
-        };
-        reader_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
-        desc.kernels.push_back(std::move(reader_kd));
-    }
+    std::vector<uint32_t> writer_compile_time_args = compile_time_args;
+    writer_compile_time_args.push_back(writer_cb_size);  // sender writer CB depth
+    writer_compile_time_args.push_back(num_untilizers);  // N: sizes the kernel's per-ring arrays
 
-    // ==================== Sender writer kernel (shared across all senders) ====================
     tt::tt_metal::KernelDescriptor writer_kd;
     writer_kd.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
         "writer_dispatch.cpp";
     writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
     writer_kd.core_ranges = sender_core_grid;
-    writer_kd.compile_time_args = compile_time_args;
-    writer_kd.defines = {fabric_defines.begin(), fabric_defines.end()};
+    writer_kd.compile_time_args = std::move(writer_compile_time_args);
+    writer_kd.defines = {writer_defines.begin(), writer_defines.end()};
     writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
         .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
         .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
@@ -642,125 +568,141 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     tt::tt_metal::KernelHandle writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
     desc.kernels.push_back(std::move(writer_kd));
 
-    // ==================== Idle core kernels ====================
-    // Reader and writer kernels run on the two data-movement RISCs of each idle core
-    // so that DRAM reads for the next batch overlap with the NOC write of the previous
-    // batch to the owning sender's receive buffer.
+    // ==================== Untilize core kernels ====================
+    // Reader (RISCV_1): routing decisions, DRAM reads for input/indices/weights/offsets/dispatch_table,
+    //                   publishes per-batch route plan to writer via c_14.
+    // Writer (RISCV_0): drains c_14 plan, executes local DRAM writes for the local path and direct
+    //                   NOC writes into the owning sender's writer-CB set for local_core_id (set s)
+    //                   for the cross-device path.  Per-entry handshake via data_avail / space_avail.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
     std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
-    reader_untilize_kernel_ids.reserve(num_idle_cores);
-    writer_untilize_kernel_ids.reserve(num_idle_cores);
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
-        uint32_t k_s = static_cast<uint32_t>(sender_idle_groups[s].size());
-        // Compute local core_id within this sender's idle group
-        uint32_t local_core_id = 0;
-        for (uint32_t g = 0; g < k_s; g++) {
-            if (sender_idle_groups[s][g] == all_idle_cores[j]) {
-                local_core_id = g;
-                break;
-            }
-        }
+    reader_untilize_kernel_ids.reserve(num_untilize_cores);
+    writer_untilize_kernel_ids.reserve(num_untilize_cores);
+    for (uint32_t j = 0; j < num_untilize_cores; j++) {
+        uint32_t s = untilize_sender_map[j];
+        // Each sender owns num_untilizers cores; they split batches round-robin by local_core_id
+        // (batch i handled by core i % total_workers) and share one offsets[] counter via a baton.
+        uint32_t local_core_id = j % num_untilizers;
+        uint32_t total_workers = num_untilizers;
 
-        uint32_t total_workers = k_s + 1;  // idle cores + sender itself
-
-        // Reader compile args (DRAM-read side)
-        std::vector<uint32_t> idle_reader_compile_args = {
-            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_input_id
-            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-            (uint32_t)hidden_size,
-            detail::get_aligned_page_size(input_tensor),  // aligned_input_page_size
-            total_batches,
-            local_core_id,  // core_id within sender group
-            total_workers,  // batch stride (idle cores + sender)
+        // ===== Reader compile args =====
+        std::vector<uint32_t> untilize_reader_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_0),               // 0: cb_input_id
+            static_cast<uint32_t>(tt::CBIndex::c_10),              // 1: cb_signal_id
+            (uint32_t)hidden_size,                                 // 2
+            detail::get_aligned_page_size(input_tensor),           // 3: aligned_input_page_size
+            total_batches,                                         // 4
+            local_core_id,                                         // 5
+            total_workers,                                         // 6
+            static_cast<uint32_t>(tt::CBIndex::c_1),               // 7: cb_indices_id
+            static_cast<uint32_t>(tt::CBIndex::c_2),               // 8: cb_weights_id
+            static_cast<uint32_t>(tt::CBIndex::c_3),               // 9: cb_offsets_id
+            static_cast<uint32_t>(tt::CBIndex::c_9),               // 10: cb_dispatch_table_id
+            static_cast<uint32_t>(tt::CBIndex::c_14),              // 11: cb_plan_id
+            read_batch_size,                                       // 12
+            detail::get_aligned_page_size(indices_tensor),         // 13
+            detail::get_aligned_page_size(weights_tensor),         // 14
+            detail::get_aligned_page_size(offsets_tensor),         // 15
+            detail::get_aligned_page_size(dispatch_table_tensor),  // 16
+            detail::get_num_pages(offsets_tensor),                 // 17: offsets_pages
+            detail::get_num_pages(dispatch_table_tensor),          // 18: dispatch_table_pages
+            operation_attributes.num_experts_per_tok,              // 19
+            operation_attributes.num_routed_experts,               // 20: n_routed_experts
+            operation_attributes.max_dispatch_buffer_token_size,   // 21
+            s,                                                     // 22: dispatch_core_idx
+            num_cores,                                             // 23: num_dispatch_cores
+            mesh_view.num_devices(),                               // 24: num_devices
+            mesh_view.num_rows(),                                  // 25
+            mesh_view.num_cols(),                                  // 26
+            linearized_mesh_coord,                                 // 27
+            static_cast<uint32_t>(topology),                       // 28
         };
-        // Append TensorAccessorArgs for input tensor only
-        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(idle_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(weights_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(offsets_tensor.buffer()).append_to(untilize_reader_compile_args);
+        tt::tt_metal::TensorAccessorArgs(dispatch_table_tensor.buffer()).append_to(untilize_reader_compile_args);
 
-        // Writer compile args (NOC-write side)
-        std::vector<uint32_t> idle_writer_compile_args = {
-            static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
-            read_batch_size,
-            detail::get_aligned_page_size(output_tensor),  // aligned_output_page_size
-            total_batches,
-            local_core_id,
-            total_workers,
-            // New: direct-DRAM-write support
-            static_cast<uint32_t>(tt::CBIndex::c_12),        // cb_mailbox_id
-            static_cast<uint32_t>(tt::CBIndex::c_13),        // cb_metadata_scratch_id
-            detail::get_aligned_page_size(metadata_tensor),  // aligned_metadata_page_size
-            operation_attributes.num_experts_per_tok,
-            linearized_mesh_coord,
+        // ===== Writer compile args =====
+        std::vector<uint32_t> untilize_writer_compile_args = {
+            static_cast<uint32_t>(tt::CBIndex::c_11),                    // 0: cb_untilize_id
+            read_batch_size,                                             // 1
+            detail::get_aligned_page_size(output_tensor),                // 2: aligned_output_page_size
+            total_batches,                                               // 3
+            local_core_id,                                               // 4
+            total_workers,                                               // 5
+            static_cast<uint32_t>(tt::CBIndex::c_13),                    // 6: cb_metadata_scratch_id
+            detail::get_aligned_page_size(metadata_tensor),              // 7: aligned_metadata_page_size
+            static_cast<uint32_t>(tt::CBIndex::c_14),                    // 8: cb_plan_id
+            linearized_mesh_coord,                                       // 9
+            l1_alignment,                                                // 10: route_info slot stride
+            writer_cb_size,                                              // 11: sender writer CB size
+            static_cast<uint32_t>(tt::CBIndex::c_15),                    // 12: cb_route_info_scratch_id
+            read_batch_size * operation_attributes.num_experts_per_tok,  // 13: meta_scratch_slots
         };
-        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(idle_writer_compile_args);
-        tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(idle_writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(untilize_writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(metadata_tensor.buffer()).append_to(untilize_writer_compile_args);
 
-        CoreRangeSet single_idle_core({CoreRange(all_idle_cores[j])});
-        tt::tt_metal::KernelDescriptor idle_reader_kd;
-        idle_reader_kd.kernel_source =
+        auto untilize_kernel_defines = fabric_defines;  // carries AXIS define if set
+
+        CoreRangeSet single_untilize_core({CoreRange(all_untilize_cores[j])});
+        tt::tt_metal::KernelDescriptor untilize_reader_kd;
+        untilize_reader_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
             "reader_untilize_dispatch.cpp";
-        idle_reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-        idle_reader_kd.core_ranges = single_idle_core;
-        idle_reader_kd.compile_time_args = std::move(idle_reader_compile_args);
-        idle_reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        untilize_reader_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        untilize_reader_kd.core_ranges = single_untilize_core;
+        untilize_reader_kd.compile_time_args = std::move(untilize_reader_compile_args);
+        untilize_reader_kd.defines = {untilize_kernel_defines.begin(), untilize_kernel_defines.end()};
+        untilize_reader_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
         };
         reader_untilize_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
-        desc.kernels.push_back(std::move(idle_reader_kd));
+        desc.kernels.push_back(std::move(untilize_reader_kd));
 
-        tt::tt_metal::KernelDescriptor idle_writer_kd;
-        idle_writer_kd.kernel_source =
+        tt::tt_metal::KernelDescriptor untilize_writer_kd;
+        untilize_writer_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/"
             "writer_untilize_dispatch.cpp";
-        idle_writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-        idle_writer_kd.core_ranges = single_idle_core;
-        idle_writer_kd.compile_time_args = std::move(idle_writer_compile_args);
-        idle_writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+        untilize_writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        untilize_writer_kd.core_ranges = single_untilize_core;
+        untilize_writer_kd.compile_time_args = std::move(untilize_writer_compile_args);
+        untilize_writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::detail::preferred_noc_for_dram_write(mesh_device->arch()),
         };
         writer_untilize_kernel_ids.push_back(static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size()));
-        desc.kernels.push_back(std::move(idle_writer_kd));
+        desc.kernels.push_back(std::move(untilize_writer_kd));
     }
 
-    // Compute kernel on idle cores
+    // Compute kernel on untilize cores
     {
-        tt::tt_metal::KernelDescriptor idle_compute_kd;
-        idle_compute_kd.kernel_source =
+        tt::tt_metal::KernelDescriptor untilize_compute_kd;
+        untilize_compute_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
             "untilize_dispatch.cpp";
-        idle_compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-        idle_compute_kd.core_ranges = idle_core_grid;
-        idle_compute_kd.compile_time_args = {
+        untilize_compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        untilize_compute_kd.core_ranges = untilize_core_grid;
+        untilize_compute_kd.compile_time_args = {
             static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
             static_cast<uint32_t>(tt::CBIndex::c_11),  // cb_untilize_id
             static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
             (uint32_t)hidden_size,
             read_batch_size,
         };
-        idle_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
-        desc.kernels.push_back(std::move(idle_compute_kd));
-    }
-
-    // Compute kernel on sender cores for self-untilize (output goes to c_18)
-    {
-        tt::tt_metal::KernelDescriptor sender_compute_kd;
-        sender_compute_kd.kernel_source =
-            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
-            "untilize_dispatch.cpp";
-        sender_compute_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-        sender_compute_kd.core_ranges = sender_core_grid;
-        sender_compute_kd.compile_time_args = {
-            static_cast<uint32_t>(tt::CBIndex::c_10),  // cb_signal_id
-            static_cast<uint32_t>(tt::CBIndex::c_18),  // cb_untilize_id (reuse receive buffer)
-            static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
-            (uint32_t)hidden_size,
-            read_batch_size,
+        untilize_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = MathFidelity::HiFi4,
+            // Blackhole requires the DEST register in 32-bit mode whenever any CB on the core uses
+            // an 8-bit float format (Fp8_e4m3). The FP8 dispatch path reinterprets UINT8 CBs as
+            // Fp8_e4m3, so fp32_dest_acc_en must be enabled there.
+            .fp32_dest_acc_en = operation_attributes.use_fp8_dispatch,
+            // 32-bit DEST halves pack_untilize block capacity: half-sync 32-bit allows only 4
+            // tiles, but pack_untilize_block uses block_ct_dim=8. Full-sync 32-bit restores the
+            // 8-tile budget so the block still fits. Only needed on the FP8 (32-bit) path.
+            .dst_full_sync_en = operation_attributes.use_fp8_dispatch,
         };
-        sender_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
-        desc.kernels.push_back(std::move(sender_compute_kd));
+        desc.kernels.push_back(std::move(untilize_compute_kd));
     }
 
     // ==================== Pre-compute NOC coordinates ====================
@@ -768,31 +710,6 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     for (const auto& sc : sender_cores) {
         auto noc_coord = mesh_device->virtual_core_from_logical_core(sc, tt::CoreType::WORKER);
         sender_noc_coords.emplace_back(noc_coord.x, noc_coord.y);
-    }
-
-    // Per-sender multicast/idle info
-    struct SenderIdleCfg {
-        std::vector<std::pair<uint32_t, uint32_t>> idle_noc_coords;
-        uint32_t mcast_x_start = 0, mcast_y_start = 0, mcast_x_end = 0, mcast_y_end = 0;
-    };
-    std::vector<SenderIdleCfg> sender_idle_cfgs(num_cores);
-    for (uint32_t s = 0; s < num_cores; s++) {
-        bool first = true;
-        for (const auto& ic : sender_idle_groups[s]) {
-            auto noc = mesh_device->virtual_core_from_logical_core(ic, tt::CoreType::WORKER);
-            uint32_t nx = (uint32_t)noc.x, ny = (uint32_t)noc.y;
-            sender_idle_cfgs[s].idle_noc_coords.emplace_back(nx, ny);
-            if (first) {
-                sender_idle_cfgs[s].mcast_x_start = sender_idle_cfgs[s].mcast_x_end = nx;
-                sender_idle_cfgs[s].mcast_y_start = sender_idle_cfgs[s].mcast_y_end = ny;
-                first = false;
-            } else {
-                sender_idle_cfgs[s].mcast_x_start = std::min(sender_idle_cfgs[s].mcast_x_start, nx);
-                sender_idle_cfgs[s].mcast_x_end = std::max(sender_idle_cfgs[s].mcast_x_end, nx);
-                sender_idle_cfgs[s].mcast_y_start = std::min(sender_idle_cfgs[s].mcast_y_start, ny);
-                sender_idle_cfgs[s].mcast_y_end = std::max(sender_idle_cfgs[s].mcast_y_end, ny);
-            }
-        }
     }
 
     // ==================== Runtime args for sender cores ====================
@@ -838,35 +755,32 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     uint32_t core_idx = 0;
     for (const auto& sender_core : sender_cores) {
-        std::vector<uint32_t> reader_runtime_args = base_runtime_args;
+        // This sender's N untilizers, ordered by local_core_id: group[s] has local_core_id == s
+        // (all_untilize_cores is built sender-major, so j = s*num_untilizers + u → local id u).
+        const auto& group = sender_untilize_groups[core_idx];
+
         std::vector<uint32_t> writer_runtime_args = base_runtime_args;
+        writer_runtime_args[11] = core_idx;  // dispatch_core_idx
 
-        reader_runtime_args[11] = core_idx;  // dispatch_core_idx
-        writer_runtime_args[11] = core_idx;
-
-        // Writer-only: exit semaphore address (separate from init_semaphore to avoid
-        // init/exit reuse race where a fast peer's exit-inc lands during the post-init
-        // set(0) window).
+        // Writer-only: exit semaphore address (avoids init/exit reuse race).
         writer_runtime_args.push_back((uint32_t)exit_semaphore.address());
 
-        // Inter-core sync args for reader
-        reader_runtime_args.push_back(data_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(start_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(addr_ready_semaphore_id);
-        reader_runtime_args.push_back(addr_value_semaphore_id);
-        reader_runtime_args.push_back(mbox_ready_semaphore_ids[core_idx]);
-        reader_runtime_args.push_back(mbox_scratch_addr_semaphore_id);
-
-        // Pass NOC coords of this sender's idle cores (for per-batch unicast start signal)
-        for (const auto& [noc_x, noc_y] : sender_idle_cfgs[core_idx].idle_noc_coords) {
-            reader_runtime_args.push_back(noc_x);
-            reader_runtime_args.push_back(noc_y);
+        // ===== Sender writer (tile-layout): handshake + per-entry fabric send + credit =====
+        // Shared single-id semaphores (one per-core slot on each untilizer): pushed once.
+        writer_runtime_args.push_back(addr_ready_semaphore_id);
+        writer_runtime_args.push_back(cross_addr_semaphore_id);
+        writer_runtime_args.push_back(space_avail_semaphore_id);
+        // Per-ring group s: {route_cb, payload_cb, metadata_cb, untilize_noc_x, untilize_noc_y,
+        // data_avail_id}. The kernel reads exactly num_untilizers such groups.
+        for (uint32_t s = 0; s < num_untilizers; s++) {
+            auto u_noc = mesh_device->virtual_core_from_logical_core(group[s], tt::CoreType::WORKER);
+            writer_runtime_args.push_back(writer_cb_ids[s][0]);
+            writer_runtime_args.push_back(writer_cb_ids[s][1]);
+            writer_runtime_args.push_back(writer_cb_ids[s][2]);
+            writer_runtime_args.push_back((uint32_t)u_noc.x);
+            writer_runtime_args.push_back((uint32_t)u_noc.y);
+            writer_runtime_args.push_back(data_avail_semaphore_ids[s]);
         }
-        // Bounding box for multicast of addr_value / addr_ready to the idle group
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_start);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_start);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_x_end);
-        reader_runtime_args.push_back(sender_idle_cfgs[core_idx].mcast_y_end);
 
         if (operation_attributes.num_links > 0) {
             uint32_t core_link = core_idx % num_links;
@@ -896,47 +810,66 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             }
         }
 
-        desc.kernels[reader_kernel_ids[core_idx]].emplace_runtime_args(
-            sender_core, promote_rt_args_with_buffer_bindings(reader_runtime_args));
         desc.kernels[writer_kernel_id].emplace_runtime_args(
             sender_core, promote_rt_args_with_buffer_bindings(writer_runtime_args));
         core_idx++;
     }
 
-    // ==================== Runtime args for idle cores ====================
-    // The sender's c_18 L1 address is communicated at runtime: sender uses noc_async_write
-    // to copy it to each idle core's addr_value_sem, then signals addr_ready_sem.
-    // Reader only needs the input tensor address; writer owns the sender-sync semaphores
-    // and NOC coords.
-    for (uint32_t j = 0; j < num_idle_cores; j++) {
-        uint32_t s = idle_sender_map[j];
+    // ==================== Runtime args for untilize cores ====================
+    // Reader: tensor base addresses + token range (Buffer* slots → BufferBindings on cache hit).
+    // Writer: sender NOC coords + addr-handshake + data_avail/space_avail semaphores + output/metadata buffers.
+    //   writer-CB set per local_core_id: 0 → c_4/c_5/c_6, 1 → c_16/c_17/c_18, rest → c_19+.
+    for (uint32_t j = 0; j < num_untilize_cores; j++) {
+        uint32_t s = untilize_sender_map[j];
 
-        // Idle reader: only RT arg is the input tensor base address — pushed as
-        // Buffer* so the framework records a BufferBinding.
-        tt::tt_metal::KernelDescriptor::RTArgList idle_reader_rt_args;
-        idle_reader_rt_args.push_back(input_tensor.buffer());
-        desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(all_idle_cores[j], idle_reader_rt_args);
+        // Reader RT args
+        tt::tt_metal::KernelDescriptor::RTArgList untilize_reader_rt_args;
+        untilize_reader_rt_args.push_back(input_tensor.buffer());
+        untilize_reader_rt_args.push_back(indices_tensor.buffer());
+        untilize_reader_rt_args.push_back(weights_tensor.buffer());
+        untilize_reader_rt_args.push_back(offsets_tensor.buffer());
+        untilize_reader_rt_args.push_back(dispatch_table_tensor.buffer());
+        untilize_reader_rt_args.push_back(0u);                           // token_start_idx
+        untilize_reader_rt_args.push_back((uint32_t)tokens_per_device);  // token_end_idx
+        // Baton-ring offset sync: owner (group[0]) holds the shared offsets[]; the next core
+        // in the ring ((local_u_id+1) % num_untilizers) receives the baton after this batch.
+        {
+            const auto& group = sender_untilize_groups[s];
+            uint32_t local_u_id = j % num_untilizers;
+            CoreCoord owner_core = group[0];
+            CoreCoord next_core = group[(local_u_id + 1) % num_untilizers];
+            auto owner_noc = mesh_device->virtual_core_from_logical_core(owner_core, tt::CoreType::WORKER);
+            auto next_noc = mesh_device->virtual_core_from_logical_core(next_core, tt::CoreType::WORKER);
+            untilize_reader_rt_args.push_back((uint32_t)owner_noc.x);
+            untilize_reader_rt_args.push_back((uint32_t)owner_noc.y);
+            untilize_reader_rt_args.push_back((uint32_t)next_noc.x);
+            untilize_reader_rt_args.push_back((uint32_t)next_noc.y);
+            untilize_reader_rt_args.push_back(turn_semaphore_id);
+        }
+        desc.kernels[reader_untilize_kernel_ids[j]].emplace_runtime_args(
+            all_untilize_cores[j], untilize_reader_rt_args);
 
-        // Idle writer: output_tensor (slot 6) and metadata_tensor (slot 7) are
-        // pushed as Buffer*; all other slots are plain uint32_t.
-        tt::tt_metal::KernelDescriptor::RTArgList idle_writer_rt_args;
-        idle_writer_rt_args.push_back(data_ready_semaphore_ids[s]);
-        idle_writer_rt_args.push_back(start_semaphore_ids[s]);
-        idle_writer_rt_args.push_back(sender_noc_coords[s].first);
-        idle_writer_rt_args.push_back(sender_noc_coords[s].second);
-        idle_writer_rt_args.push_back(addr_ready_semaphore_id);
-        idle_writer_rt_args.push_back(addr_value_semaphore_id);
-        idle_writer_rt_args.push_back(output_tensor.buffer());
-        idle_writer_rt_args.push_back(metadata_tensor.buffer());
-        idle_writer_rt_args.push_back(mbox_ready_semaphore_ids[s]);
-        idle_writer_rt_args.push_back(mbox_scratch_addr_semaphore_id);
-        desc.kernels[writer_untilize_kernel_ids[j]].emplace_runtime_args(all_idle_cores[j], idle_writer_rt_args);
+        // Writer RT args. addr_ready / cross_addr / space_avail are shared single-id semaphores
+        // (this untilizer uses its own per-core slot at each); data_avail is this ring's private
+        // id (the sender waits on its matching slot). Arg order unchanged from the kernel's view.
+        uint32_t local_u_id = j % num_untilizers;
+        tt::tt_metal::KernelDescriptor::RTArgList untilize_writer_rt_args;
+        untilize_writer_rt_args.push_back(sender_noc_coords[s].first);
+        untilize_writer_rt_args.push_back(sender_noc_coords[s].second);
+        untilize_writer_rt_args.push_back(addr_ready_semaphore_id);
+        untilize_writer_rt_args.push_back(cross_addr_semaphore_id);
+        untilize_writer_rt_args.push_back(data_avail_semaphore_ids[local_u_id]);
+        untilize_writer_rt_args.push_back(space_avail_semaphore_id);
+        untilize_writer_rt_args.push_back(output_tensor.buffer());
+        untilize_writer_rt_args.push_back(metadata_tensor.buffer());
+        desc.kernels[writer_untilize_kernel_ids[j]].emplace_runtime_args(
+            all_untilize_cores[j], untilize_writer_rt_args);
     }
 
     return desc;
 }
 
-// Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no idle cores.
+// Row-major path: ROW_MAJOR inputs, single reader kernel per sender, no untilize cores.
 tt::tt_metal::ProgramDescriptor create_at_row_major(
     const DispatchParams& operation_attributes,
     const MeshCoordinate& mesh_coordinate,
@@ -1065,7 +998,7 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
             .core_ranges = sender_core_grid,
             .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_4),
-                .data_format = tt::DataFormat::UInt8,
+                .data_format = tt::DataFormat::UInt32,
                 .page_size = route_info_page_size,
             }}},
         });
@@ -1101,7 +1034,7 @@ tt::tt_metal::ProgramDescriptor create_at_row_major(
 
     // c_8: packet header CB for fabric sends (writer-only)
     if (operation_attributes.num_links > 0) {
-        constexpr uint32_t num_packet_headers = 2;  // unicast + metadata
+        constexpr uint32_t num_packet_headers = 2;
         auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
         uint32_t packet_header_cb_size = num_packet_headers * packet_header_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dispatch_device_operation.hpp"
+#include "kernels/dataflow/dispatch_plan.hpp"  // PlanHeader / PlanEntry layout (host sizes the plan CB from these)
 #include <algorithm>
 #include <array>
 #include <utility>
@@ -342,12 +343,12 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     }
     // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
     // Layout (PlanHeader + PlanEntry[]) is defined in kernels/dataflow/dispatch_plan.hpp:
-    // [PlanHeader: 32B][PlanEntry × 9 u32 (36B) each].
+    // [PlanHeader: 32B][PlanEntry: 48B each] (both alignas(16)). Sized straight from sizeof so the
+    // page size always tracks the structs.
     {
-        constexpr uint32_t plan_entry_u32s = 9;
         uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;
         uint32_t plan_page_size = tt::round_up(
-            32u + max_plan_entries * plan_entry_u32s * static_cast<uint32_t>(sizeof(uint32_t)), l1_alignment);
+            static_cast<uint32_t>(sizeof(PlanHeader) + max_plan_entries * sizeof(PlanEntry)), l1_alignment);
         constexpr uint32_t plan_buffering = 2;
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
             .total_size = plan_buffering * plan_page_size,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -343,7 +343,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     }
     // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
     // Layout (PlanHeader + PlanEntry[]) is defined in kernels/dataflow/dispatch_plan.hpp:
-    // [PlanHeader: 32B][PlanEntry: 48B each] (both alignas(16)). Sized straight from sizeof so the
+    // [PlanHeader: 16B][PlanEntry: 48B each] (both alignas(16)). Sized straight from sizeof so the
     // page size always tracks the structs.
     {
         uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -325,8 +325,9 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         /*cb_id=*/tt::CBIndex::c_13,
         "untilize_metadata_scratch");
     // c_15: route_info scratch (16B = l1_alignment). Untilize writer builds the 4-u32
-    // route_info entry [route, distance, page_idx, 0] here, then NOC-writes the whole
+    // route_info entry [route, distance, page_idx, dst_chip] here, then NOC-writes the whole
     // block as a single noc_async_write to the sender's c_4 slot (replaces 4× inline_dw).
+    // dst_chip is the linearized dest device index used by the sender's 2D fabric route.
     {
         uint32_t route_info_scratch_size = l1_alignment;
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
@@ -341,9 +342,9 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     }
     // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
     // Layout (PlanHeader + PlanEntry[]) is defined in kernels/dataflow/dispatch_plan.hpp:
-    // [PlanHeader: 32B][PlanEntry × 8 u32 (32B) each].
+    // [PlanHeader: 32B][PlanEntry × 9 u32 (36B) each].
     {
-        constexpr uint32_t plan_entry_u32s = 8;
+        constexpr uint32_t plan_entry_u32s = 9;
         uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;
         uint32_t plan_page_size = tt::round_up(
             32u + max_plan_entries * plan_entry_u32s * static_cast<uint32_t>(sizeof(uint32_t)), l1_alignment);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -111,6 +111,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
     uint32_t num_untilizers = operation_attributes.num_untilizers_per_sender;
+    TT_FATAL(num_untilizers >= 1, "num_untilizers_per_sender must be >= 1; got {}.", num_untilizers);
     log_debug(
         tt::LogOp,
         "Creating prefill dispatch program (tile layout) for mesh coordinate: ({}, {}) with topology: {} num_links: {}",
@@ -339,7 +340,8 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         });
     }
     // c_14: per-batch route plan (reader RISC → writer RISC, on same untilize core).
-    // Layout: [entry_count u32][padding to 32B][entries × 8 u32 each]
+    // Layout (PlanHeader + PlanEntry[]) is defined in kernels/dataflow/dispatch_plan.hpp:
+    // [PlanHeader: 32B][PlanEntry × 8 u32 (32B) each].
     {
         constexpr uint32_t plan_entry_u32s = 8;
         uint32_t max_plan_entries = read_batch_size * operation_attributes.num_experts_per_tok;
@@ -762,7 +764,9 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         std::vector<uint32_t> writer_runtime_args = base_runtime_args;
         writer_runtime_args[11] = core_idx;  // dispatch_core_idx
 
-        // Writer-only: exit semaphore address (avoids init/exit reuse race).
+        // Writer-only: exit semaphore address (separate from init_semaphore to avoid
+        // init/exit reuse race where a fast peer's exit-inc lands during the post-init
+        // set(0) window).
         writer_runtime_args.push_back((uint32_t)exit_semaphore.address());
 
         // ===== Sender writer (tile-layout): handshake + per-entry fabric send + credit =====

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_types.hpp
@@ -29,6 +29,7 @@ struct DispatchParams {
     CoreRangeSet worker_core_range_set;
     bool use_l1_small_for_semaphores = false;
     bool use_fp8_dispatch = false;
+    uint32_t num_untilizers_per_sender = 2;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dispatch_group_size",
@@ -43,7 +44,8 @@ struct DispatchParams {
         "output_mem_config",
         "worker_core_range_set",
         "use_l1_small_for_semaphores",
-        "use_fp8_dispatch");
+        "use_fp8_dispatch",
+        "num_untilizers_per_sender");
 
     auto attribute_values() const {
         return std::forward_as_tuple(
@@ -59,7 +61,8 @@ struct DispatchParams {
             output_mem_config,
             worker_core_range_set,
             use_l1_small_for_semaphores,
-            use_fp8_dispatch);
+            use_fp8_dispatch,
+            num_untilizers_per_sender);
     };
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -22,8 +22,8 @@
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 // Compile-time args:
-//   0: cb_signal_id    - CB for reader->compute signaling (c_17)
-//   1: cb_untilize_id  - CB for compute untilized output (c_18)
+//   0: cb_signal_id    - CB for reader->compute signaling (c_10)
+//   1: cb_untilize_id  - CB for compute untilized output (c_11)
 //   2: cb_in_id        - CB for untilize input tile data (c_0)
 //   3: hidden_size     - hidden dimension (e.g., 7168)
 //   4: read_batch_size - number of rows per untilize batch (32)
@@ -42,16 +42,16 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_in_id, cb_untilize_id);
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
 
-    uint32_t batch_counter = 0;
-
     while (true) {
         cb_reserve_back(cb_untilize_id, read_batch_size);
+
         cb_wait_front(cb_signal_id, 1);
         uint32_t val = read_tile_value(cb_signal_id, 0, 0);
         cb_pop_front(cb_signal_id, 1);
         if (val == ROUTE_INFO_SENTINEL) {
             break;
         }
+
         for (uint32_t block = 0; block < num_blocks; block++) {
             cb_wait_front(cb_in_id, block_ct_dim);
             pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
@@ -59,8 +59,6 @@ void kernel_main() {
         }
 
         cb_push_back(cb_untilize_id, read_batch_size);
-
-        batch_counter++;
     }
     pack_untilize_uninit(cb_untilize_id);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
@@ -25,7 +25,7 @@ struct PlanHeader {
     uint32_t reserved[7];
 };
 
-// 32-byte (8 × u32) routing entry.
+// 36-byte (9 × u32) routing entry.
 struct PlanEntry {
     uint32_t flags;    // PLAN_FLAG_* bits (bit 0 = is_local, bit 31 = end sentinel)
     uint32_t token_t;  // offset within the batch (0 .. read_batch_size - 1)
@@ -34,9 +34,10 @@ struct PlanEntry {
     uint32_t token_idx;  // global token index, for metadata
     int16_t weight;      // routing weight (signed); packed low 16 bits of the legacy [5] word
     uint16_t k;          // top-k slot;                 packed high 16 bits of the legacy [5] word
-    uint32_t route;      // cross-device only
-    uint32_t distance;   // cross-device only
+    uint32_t route;      // cross-device only (1D EDM index)
+    uint32_t distance;   // cross-device only (1D hop count)
+    uint32_t dst_chip;   // cross-device only (linearized dest device index; consumed by the 2D fabric route)
 };
 
 static_assert(sizeof(PlanHeader) == 8 * sizeof(uint32_t), "PlanHeader must be 32 bytes");
-static_assert(sizeof(PlanEntry) == 8 * sizeof(uint32_t), "PlanEntry must be 32 bytes");
+static_assert(sizeof(PlanEntry) == 9 * sizeof(uint32_t), "PlanEntry must be 36 bytes");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Per-batch route plan shared between the dispatch untilize reader and writer kernels.
+// The reader builds one plan page per batch; the writer drains it. Both sides view the
+// same L1 page through these structs (no magic offsets / hand-packed bit fields).
+//
+// Page layout (one CB page per batch):
+//   [ PlanHeader (32 B) ][ PlanEntry[0] ][ PlanEntry[1] ] ... [ PlanEntry[entry_count-1] ]
+//
+// End-of-plan sentinel page: entry_count == 0 and entries[0].flags has PLAN_FLAG_END set.
+
+// flags bits
+constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;       // entry targets the local device
+constexpr uint32_t PLAN_FLAG_END = 0x80000000u;  // end-of-plan sentinel (first entry of final page)
+
+// 32-byte page header; entries follow immediately after.
+struct PlanHeader {
+    uint32_t entry_count;
+    uint32_t reserved[7];
+};
+
+// 32-byte (8 × u32) routing entry.
+struct PlanEntry {
+    uint32_t flags;    // PLAN_FLAG_* bits (bit 0 = is_local, bit 31 = end sentinel)
+    uint32_t token_t;  // offset within the batch (0 .. read_batch_size - 1)
+    uint32_t routed_expert;
+    uint32_t page_idx;   // destination DRAM page (local + remote)
+    uint32_t token_idx;  // global token index, for metadata
+    int16_t weight;      // routing weight (signed); packed low 16 bits of the legacy [5] word
+    uint16_t k;          // top-k slot;                 packed high 16 bits of the legacy [5] word
+    uint32_t route;      // cross-device only
+    uint32_t distance;   // cross-device only
+};
+
+static_assert(sizeof(PlanHeader) == 8 * sizeof(uint32_t), "PlanHeader must be 32 bytes");
+static_assert(sizeof(PlanEntry) == 8 * sizeof(uint32_t), "PlanEntry must be 32 bytes");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
@@ -11,7 +11,11 @@
 // same L1 page through these structs (no magic offsets / hand-packed bit fields).
 //
 // Page layout (one CB page per batch):
-//   [ PlanHeader (32 B) ][ PlanEntry[0] ][ PlanEntry[1] ] ... [ PlanEntry[entry_count-1] ]
+//   [ PlanHeader (32 B) ][ PlanEntry[0] (48 B) ][ PlanEntry[1] (48 B) ] ... [ PlanEntry[entry_count-1] ]
+//
+// Both structs are alignas(16): the page base (CB write ptr) is 16B-aligned, the header is a
+// multiple of 16B, and each entry is a multiple of 16B — so every entry starts on a 16B boundary
+// and no field can ever straddle a 16B L1 line, no matter how the layout evolves.
 //
 // End-of-plan sentinel page: entry_count == 0 and entries[0].flags has PLAN_FLAG_END set.
 
@@ -19,25 +23,39 @@
 constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;       // entry targets the local device
 constexpr uint32_t PLAN_FLAG_END = 0x80000000u;  // end-of-plan sentinel (first entry of final page)
 
-// 32-byte page header; entries follow immediately after.
-struct PlanHeader {
+// 32-byte page header (already a multiple of 16B); entries follow immediately after.
+struct alignas(16) PlanHeader {
     uint32_t entry_count;
     uint32_t reserved[7];
 };
 
-// 36-byte (9 × u32) routing entry.
-struct PlanEntry {
+// Routing entry: 9 × u32 of payload, alignas(16) rounds sizeof up to 48 B (12 B trailing pad)
+// so every entry starts on a 16B L1 line boundary.
+//
+// NOTE: every field is a 32-bit word and the struct is built directly in L1 by the reader.
+// Baby-RISC (BRISC/NCRISC) sub-word stores to L1 — `sh` (half-word) / `sb` (byte) — are
+// unreliable on Blackhole (unaligned half-words corrupt / drop a byte across the 16B boundary;
+// only aligned 32-bit `sw` stores are safe). So weight (signed) + k (top-k slot) are packed
+// into a single 32-bit word `weight_k` and written/read via the helpers below — never as
+// separate 16-bit fields.
+struct alignas(16) PlanEntry {
     uint32_t flags;    // PLAN_FLAG_* bits (bit 0 = is_local, bit 31 = end sentinel)
     uint32_t token_t;  // offset within the batch (0 .. read_batch_size - 1)
     uint32_t routed_expert;
     uint32_t page_idx;   // destination DRAM page (local + remote)
     uint32_t token_idx;  // global token index, for metadata
-    int16_t weight;      // routing weight (signed); packed low 16 bits of the legacy [5] word
-    uint16_t k;          // top-k slot;                 packed high 16 bits of the legacy [5] word
+    uint32_t weight_k;   // packed: low 16 bits = int16_t routing weight, high 16 bits = uint16_t top-k slot
     uint32_t route;      // cross-device only (1D EDM index)
     uint32_t distance;   // cross-device only (1D hop count)
     uint32_t dst_chip;   // cross-device only (linearized dest device index; consumed by the 2D fabric route)
 };
 
-static_assert(sizeof(PlanHeader) == 8 * sizeof(uint32_t), "PlanHeader must be 32 bytes");
-static_assert(sizeof(PlanEntry) == 9 * sizeof(uint32_t), "PlanEntry must be 36 bytes");
+static_assert(sizeof(PlanHeader) == 32, "PlanHeader must be 32 bytes");
+static_assert(alignof(PlanHeader) == 16, "PlanHeader must be 16B-aligned");
+static_assert(sizeof(PlanEntry) == 48, "PlanEntry must be 48 bytes (9 u32 + 12B pad for 16B alignment)");
+static_assert(alignof(PlanEntry) == 16, "PlanEntry must be 16B-aligned");
+
+// weight (signed) + k packed into one 32-bit word so the reader emits a single aligned L1 store.
+inline uint32_t pack_weight_k(int16_t weight, uint16_t k) { return ((uint32_t)(uint16_t)weight) | ((uint32_t)k << 16); }
+inline int16_t unpack_weight(uint32_t weight_k) { return (int16_t)(weight_k & 0xFFFFu); }
+inline uint16_t unpack_k(uint32_t weight_k) { return (uint16_t)(weight_k >> 16); }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp
@@ -11,7 +11,7 @@
 // same L1 page through these structs (no magic offsets / hand-packed bit fields).
 //
 // Page layout (one CB page per batch):
-//   [ PlanHeader (32 B) ][ PlanEntry[0] (48 B) ][ PlanEntry[1] (48 B) ] ... [ PlanEntry[entry_count-1] ]
+//   [ PlanHeader (16 B) ][ PlanEntry[0] (48 B) ][ PlanEntry[1] (48 B) ] ... [ PlanEntry[entry_count-1] ]
 //
 // Both structs are alignas(16): the page base (CB write ptr) is 16B-aligned, the header is a
 // multiple of 16B, and each entry is a multiple of 16B — so every entry starts on a 16B boundary
@@ -19,18 +19,22 @@
 //
 // End-of-plan sentinel page: entry_count == 0 and entries[0].flags has PLAN_FLAG_END set.
 
+// L1 access granularity both structs are aligned to, so no field ever straddles an L1 line and
+// every entry starts on an L1 boundary. Defined locally (not pulled from noc_params.h) because
+// that macro differs between host and kernel includes of this shared header.
+constexpr uint32_t PLAN_L1_ALIGNMENT = 16;
+
 // flags bits
 constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;       // entry targets the local device
 constexpr uint32_t PLAN_FLAG_END = 0x80000000u;  // end-of-plan sentinel (first entry of final page)
 
-// 32-byte page header (already a multiple of 16B); entries follow immediately after.
-struct alignas(16) PlanHeader {
+// Page header (alignas rounds sizeof up to PLAN_L1_ALIGNMENT); entries follow immediately after.
+struct alignas(PLAN_L1_ALIGNMENT) PlanHeader {
     uint32_t entry_count;
-    uint32_t reserved[7];
 };
 
-// Routing entry: 9 × u32 of payload, alignas(16) rounds sizeof up to 48 B (12 B trailing pad)
-// so every entry starts on a 16B L1 line boundary.
+// Routing entry: 9 × u32 of payload, alignas rounds sizeof up to 48 B (12 B trailing pad)
+// so every entry starts on an L1 line boundary.
 //
 // NOTE: every field is a 32-bit word and the struct is built directly in L1 by the reader.
 // Baby-RISC (BRISC/NCRISC) sub-word stores to L1 — `sh` (half-word) / `sb` (byte) — are
@@ -38,7 +42,7 @@ struct alignas(16) PlanHeader {
 // only aligned 32-bit `sw` stores are safe). So weight (signed) + k (top-k slot) are packed
 // into a single 32-bit word `weight_k` and written/read via the helpers below — never as
 // separate 16-bit fields.
-struct alignas(16) PlanEntry {
+struct alignas(PLAN_L1_ALIGNMENT) PlanEntry {
     uint32_t flags;    // PLAN_FLAG_* bits (bit 0 = is_local, bit 31 = end sentinel)
     uint32_t token_t;  // offset within the batch (0 .. read_batch_size - 1)
     uint32_t routed_expert;
@@ -50,10 +54,10 @@ struct alignas(16) PlanEntry {
     uint32_t dst_chip;   // cross-device only (linearized dest device index; consumed by the 2D fabric route)
 };
 
-static_assert(sizeof(PlanHeader) == 32, "PlanHeader must be 32 bytes");
-static_assert(alignof(PlanHeader) == 16, "PlanHeader must be 16B-aligned");
+static_assert(sizeof(PlanHeader) == PLAN_L1_ALIGNMENT, "PlanHeader must be 1 u32 padded up to PLAN_L1_ALIGNMENT");
+static_assert(alignof(PlanHeader) == PLAN_L1_ALIGNMENT, "PlanHeader must be PLAN_L1_ALIGNMENT-aligned");
 static_assert(sizeof(PlanEntry) == 48, "PlanEntry must be 48 bytes (9 u32 + 12B pad for 16B alignment)");
-static_assert(alignof(PlanEntry) == 16, "PlanEntry must be 16B-aligned");
+static_assert(alignof(PlanEntry) == PLAN_L1_ALIGNMENT, "PlanEntry must be PLAN_L1_ALIGNMENT-aligned");
 
 // weight (signed) + k packed into one 32-bit word so the reader emits a single aligned L1 store.
 inline uint32_t pack_weight_k(int16_t weight, uint16_t k) { return ((uint32_t)(uint16_t)weight) | ((uint32_t)k << 16); }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -3,12 +3,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Sender RISCV_1 kernel — row-major path only.
+// Reader kernel for the row-major dispatch path — runs on the sender core's
+// RISCV_1, paired with writer_dispatch.cpp on RISCV_0.  (The tile-layout path
+// uses untilize cores instead and has no sender-side reader kernel.)
 //
-// This kernel is created only on the row-major dispatch path; the tile-layout path
-// runs without a reader kernel
+// Streams row-major input/indices/weights from DRAM and, per routed token, either
+// writes it straight to local DRAM or hands (route_info, payload, metadata) to the
+// writer for a fabric send to the destination device.
 //
-// Reads input/indices/weights and builds (route_info, payload, metadata)
+// Tokens [token_start_idx, token_end_idx) are processed in batches of
+// read_batch_size.  Reads are pipelined: the next batch's DRAM reads are issued
+// before the current batch's write barrier so the read and write NOC channels
+// overlap.  (The input/indices/weights scratch is a single region reused per
+// batch, not a FIFO — see the reservation note below.)
+//
+// Startup: load offsets[] (per-expert DRAM page allocators) and the read-only
+// dispatch_table[] (expert → destination chip, or -1) into local L1 scratch.
+//
+// For each batch, for each (token, top-k expert) routed to this dispatch core:
+//   - Allocate a destination DRAM page from offsets[expert]; if the dispatch
+//     buffer is full, bump the counter and drop the token (prevents OOB writes).
+//   - Local (expert maps to this device): write payload + metadata directly to
+//     local DRAM.
+//   - Cross-device: push route_info (route/distance/page), payload, and metadata
+//     to the writer CBs; the writer forwards them over the fabric.
+//
+// After the last batch: push ROUTE_INFO_SENTINEL to the writer so it stops.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
@@ -216,6 +236,8 @@ void kernel_main() {
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
                 uint32_t routed_expert = (uint32_t)indices[k];
 
+                // Skip experts not owned by this dispatch core (low bits of the expert id
+                // select the dispatch core) and experts the table maps nowhere (-1).
                 if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
                     continue;
                 }
@@ -225,6 +247,7 @@ void kernel_main() {
                     continue;
                 }
                 auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
+                // Allocate this token's destination DRAM page from the expert's counter.
                 auto& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
                     // Token would overflow the dispatch buffer - skip to prevent
@@ -234,8 +257,12 @@ void kernel_main() {
                 }
                 auto page_idx = offset;
 
+                // Local: expert lives on this device — write payload + metadata straight to DRAM.
                 if (expert_chip == linearized_mesh_coord) {
                     {
+                        // Metadata layout (5 × int32): [src chip, global token idx, top-k slot,
+                        // routed expert, routing weight].  Staged in scratch, then written to the
+                        // same DRAM page index as the payload.
                         volatile tt_l1_ptr int32_t* metadata =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
                         metadata[0] = linearized_mesh_coord;
@@ -250,6 +277,9 @@ void kernel_main() {
                         batch_did_local_write = true;
                     }
                 } else {
+                    // Cross-device: stage route_info, payload and metadata into the writer's CBs;
+                    // the writer (RISCV_0) forwards them over the fabric.  route/distance tell the
+                    // fabric writer where to send.
                     if constexpr (is_1d_topology<topology>()) {
                         uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
                         uint32_t distance =
@@ -316,7 +346,8 @@ void kernel_main() {
         }
     }
 
-    // Sentinel: row-major sender reader still drives the local writer through c_4 sentinel.
+    // Teardown: all batches done — push a ROUTE_INFO_SENTINEL route_info entry so the writer
+    // (RISCV_0) knows no more tokens are coming and stops forwarding / exits.
     cb_reserve_back(cb_route_info_id, 1);
     volatile tt_l1_ptr uint32_t* sentinel_route_info =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -2,6 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//
+// Sender RISCV_1 kernel — row-major path only.
+//
+// This kernel is created only on the row-major dispatch path; the tile-layout path
+// runs without a reader kernel
+//
+// Reads input/indices/weights and builds (route_info, payload, metadata)
+
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -81,7 +89,7 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(45);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(46);
 
-    // Batch configuration (index 47)
+    // Batch configuration (indices 47)
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(47);
 
     // Total dispatch buffer token capacity (shared across all local experts).
@@ -96,25 +104,6 @@ void kernel_main() {
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
-
-#ifdef IS_TILE_LAYOUT
-    // Reader-only compile-time args (appended after TensorAccessorArgs)
-    constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset());
-    constexpr uint32_t aligned_row_major_input_page_size =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 1);
-    constexpr uint32_t num_idle_cores =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 2);
-    constexpr uint32_t cb_signal_id = get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 3);
-    constexpr uint32_t total_workers =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 4);
-    constexpr uint32_t cb_route_table_scratch_id =
-        get_compile_time_arg_val(dispatch_table_args.next_compile_time_args_offset() + 5);
-
-    constexpr uint32_t tiles_per_row = hidden_size / 32;
-    constexpr uint32_t writer_page_size = aligned_row_major_input_page_size;
-#else
-    constexpr uint32_t writer_page_size = aligned_input_page_size;
-#endif
 
     // ===== Runtime Args =====
     uint32_t rt_args = 0;
@@ -133,43 +122,6 @@ void kernel_main() {
     uint32_t num_dispatch_cores = get_arg_val<uint32_t>(rt_args++);
     uint32_t core_mask = num_dispatch_cores - 1;
 
-#ifdef IS_TILE_LAYOUT
-    // Inter-core sync args
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-
-    volatile tt_l1_ptr uint32_t* data_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(data_ready_semaphore_id));
-    uint32_t start_sem_l1_offset = get_semaphore(start_semaphore_id);
-    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
-    uint32_t addr_value_sem_l1_offset = get_semaphore(addr_value_semaphore_id);
-
-    // Read per-idle-core NOC addresses for per-batch start signaling (unicast)
-    // x/y kept separately to build idle_mailbox_noc_addrs after the mbox_ready rendezvous.
-    uint64_t idle_start_noc_addrs[num_idle_cores];
-    uint32_t idle_noc_xs[num_idle_cores];
-    uint32_t idle_noc_ys[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
-        idle_noc_xs[c] = get_arg_val<uint32_t>(rt_args++);
-        idle_noc_ys[c] = get_arg_val<uint32_t>(rt_args++);
-        idle_start_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], start_sem_l1_offset);
-    }
-
-    // Bounding box covering all idle cores in this sender's group (for multicast)
-    uint32_t mcast_x_start = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_y_start = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_x_end = get_arg_val<uint32_t>(rt_args++);
-    uint32_t mcast_y_end = get_arg_val<uint32_t>(rt_args++);
-    uint64_t mcast_addr_value_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_value_sem_l1_offset);
-    uint64_t mcast_addr_ready_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, addr_ready_sem_l1_offset);
-#endif
-
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
@@ -185,24 +137,14 @@ void kernel_main() {
     constexpr uint32_t device_stride = 1;
 #endif
 
-#ifdef IS_TILE_LAYOUT
-    DPRINT_DISPATCH(
-        "Reader kernel: tokens=[{},{}] dispatch_core={}/{} num_idle_cores={}\n",
-        token_start_idx,
-        token_end_idx,
-        dispatch_core_idx,
-        num_dispatch_cores,
-        num_idle_cores);
-#else
     DPRINT_DISPATCH(
         "Reader kernel: tokens=[{},{}] dispatch_core={}/{}\n",
         token_start_idx,
         token_end_idx,
         dispatch_core_idx,
         num_dispatch_cores);
-#endif
 
-    // Read offsets into local scratch
+    // Read offsets tensor into local scratch
     const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
     cb_reserve_back(cb_offsets_id, offsets_pages);
     uint32_t offsets_base_addr = get_write_ptr(cb_offsets_id);
@@ -231,13 +173,6 @@ void kernel_main() {
     uint32_t indices_base = get_write_ptr(cb_indices_id);
     cb_reserve_back(cb_weights_id, read_batch_size);
     uint32_t weights_base = get_write_ptr(cb_weights_id);
-
-#ifdef IS_TILE_LAYOUT
-    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
-    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
-    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, aligned_output_page_size);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, aligned_metadata_page_size);
-#else
     cb_reserve_back(cb_input_id, read_batch_size);
     uint32_t input_base = get_write_ptr(cb_input_id);
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address);
@@ -245,56 +180,10 @@ void kernel_main() {
     const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address);
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
-#endif
 
     cb_reserve_back(cb_metadata_temp_id, 1);
     uint32_t metadata_temp_addr = get_write_ptr(cb_metadata_temp_id);
 
-#ifdef IS_TILE_LAYOUT
-    uint32_t untilize_base = get_write_ptr(cb_untilize_id);
-    uint32_t rt_scratch_base = get_write_ptr(cb_route_table_scratch_id);
-
-    // Multicast two addresses to all idle cores in this sender's group before signaling addr_ready:
-    //   1. receive buffer address (c_18 base) → idle cores write untilized data here
-    //   2. route-table scratch base → idle cores NOC-write their mailbox L1 address into
-    //      slot [core_id * 4] of this buffer so the sender can read it locally (no NOC read).
-    volatile tt_l1_ptr uint32_t* addr_value_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr_value_sem_l1_offset);
-    *addr_value_ptr = untilize_base;
-    noc_async_write_multicast(addr_value_sem_l1_offset, mcast_addr_value_noc_addr, sizeof(uint32_t), num_idle_cores);
-
-    uint32_t mbox_scratch_addr_sem_l1_offset = get_semaphore(mbox_scratch_addr_semaphore_id);
-    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mbox_scratch_addr_sem_l1_offset);
-    *mbox_scratch_addr_ptr = rt_scratch_base;
-    uint64_t mcast_mbox_scratch_noc_addr =
-        get_noc_multicast_addr(mcast_x_start, mcast_y_start, mcast_x_end, mcast_y_end, mbox_scratch_addr_sem_l1_offset);
-    noc_async_write_multicast(
-        mbox_scratch_addr_sem_l1_offset, mcast_mbox_scratch_noc_addr, sizeof(uint32_t), num_idle_cores);
-    noc_async_write_barrier();
-    noc_semaphore_inc_multicast(mcast_addr_ready_noc_addr, 1, num_idle_cores);
-    noc_async_atomic_barrier();
-
-    // Wait for all idle cores to NOC-write their mailbox L1 addresses into rt_scratch_base.
-    // Because idle cores use noc_inline_dw_write (ordered before noc_semaphore_inc on the NOC),
-    // each slot is guaranteed to be visible in local L1 once mbox_ready reaches num_idle_cores.
-    volatile tt_l1_ptr uint32_t* mbox_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_ready_semaphore_id));
-    noc_semaphore_wait(mbox_ready_sem_ptr, num_idle_cores);
-    noc_semaphore_set(mbox_ready_sem_ptr, 0);
-
-    // Read idle mailbox addresses directly from own L1 scratch — no NOC reads needed.
-    volatile tt_l1_ptr uint32_t* rt_scratch_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
-    uint64_t idle_mailbox_noc_addrs[num_idle_cores];
-    for (uint32_t c = 0; c < num_idle_cores; c++) {
-        idle_mailbox_noc_addrs[c] = get_noc_addr(idle_noc_xs[c], idle_noc_ys[c], rt_scratch_ptr[c]);
-    }
-
-    // Self-untilize setup: TensorAccessor for reading tiles from DRAM
-    const auto self_input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
-    constexpr uint32_t block_ct_dim = 8;
-    constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
-#else
     // Prefetch first batch of DRAM reads
     uint32_t first_batch_end =
         (token_start_idx + read_batch_size < token_end_idx) ? token_start_idx + read_batch_size : token_end_idx;
@@ -307,9 +196,7 @@ void kernel_main() {
         }
         noc_async_read_barrier();
     }
-#endif
 
-    // ===== Unified batch loop =====
     uint32_t total_batches = (token_end_idx - token_start_idx + read_batch_size - 1) / read_batch_size;
     for (uint32_t B = 0; B < total_batches; B++) {
         uint32_t batch_start = token_start_idx + B * read_batch_size;
@@ -318,135 +205,9 @@ void kernel_main() {
         uint32_t batch_count = batch_end - batch_start;
         bool batch_did_local_write = false;
 
-#ifdef IS_TILE_LAYOUT
-        // Batch prep: delegate to idle core, or self-untilize locally.
-        uint32_t C = B % total_workers;
-
-        if (C < num_idle_cores) {
-            // ---- Worker-batch: delegate to idle core C ----
-            // Read indices/weights before building the route table so routing
-            // decisions are known before we signal the idle core.
-            for (uint32_t t = 0; t < batch_count; t++) {
-                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
-            }
-            noc_async_read_barrier();
-
-            // Build local-expert route table into the route table scratch CB.
-            // Only LOCAL entries go in the mailbox; cross-device entries are
-            // handled by the sender's main routing loop as normal.
-            // We track per-expert offset increments locally to mirror the main
-            // loop without touching the shared offsets[] array.
-            uint32_t local_offset_delta[n_routed_experts] = {};
-            volatile tt_l1_ptr uint32_t* rt = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(rt_scratch_base);
-            uint32_t entry_count = 0;
-            bool has_non_local = false;
-
-            for (uint32_t t = 0; t < batch_count; t++) {
-                tt_l1_ptr uint16_t* indices_t =
-                    reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
-                tt_l1_ptr uint16_t* weights_t =
-                    reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
-                for (uint32_t k = 0; k < num_experts_per_tok; k++) {
-                    uint32_t routed_expert = (uint32_t)indices_t[k];
-                    if ((routed_expert & core_mask) != dispatch_core_idx) {
-                        continue;
-                    }
-                    auto expert_chip_og = expert_dispatch_table[routed_expert];
-                    if (expert_chip_og == -1) {
-                        continue;
-                    }
-                    // Mirror offset++ from main loop (covers both overflow and valid paths)
-                    uint32_t effective_offset = offsets[routed_expert] + local_offset_delta[routed_expert];
-                    local_offset_delta[routed_expert]++;
-
-                    if (effective_offset >= max_dispatch_buffer_token_size) {
-                        continue;
-                    }
-                    auto expert_chip = device_begin_idx + expert_chip_og * device_stride;
-                    if (expert_chip != linearized_mesh_coord) {
-                        has_non_local = true;
-                        continue;  // cross-device: sender handles in main routing loop
-                    }
-                    auto page_idx = effective_offset;
-
-                    uint32_t base = 1 + entry_count * 6;
-                    rt[base + 0] = t;
-                    rt[base + 1] = (uint32_t)page_idx;
-                    rt[base + 2] = batch_start + t;
-                    rt[base + 3] = k;
-                    rt[base + 4] = (uint32_t)routed_expert;
-                    rt[base + 5] = (uint32_t)(int32_t)(int16_t)weights_t[k];
-                    entry_count++;
-                }
-            }
-            // High bit signals the idle core whether to bulk-send back to us.
-            rt[0] = entry_count | (has_non_local ? 0x80000000u : 0u);
-
-            // Write route table to idle core's mailbox, then signal start.
-            uint32_t mailbox_write_bytes = sizeof(uint32_t) + entry_count * 6 * sizeof(uint32_t);
-            noc_async_write(rt_scratch_base, idle_mailbox_noc_addrs[C], mailbox_write_bytes);
-            noc_async_write_barrier();
-
-            noc_semaphore_inc(idle_start_noc_addrs[C], 1);
-            noc_async_atomic_barrier();
-
-            // Only wait if the idle core will actually send data back.
-            if (has_non_local) {
-                DPRINT_DISPATCH("Waiting for idle core {} batch {}\n", C, B);
-                noc_semaphore_wait(data_ready_sem_ptr, 1);
-                noc_semaphore_set(data_ready_sem_ptr, 0);
-                DPRINT_DISPATCH("Got batch {} from idle core {}\n", B, C);
-            }
-        } else {
-            // ---- Self-batch: read tiles, untilize locally, no NOC transfer ----
-            DPRINT_DISPATCH("Self-untilize batch {}\n", B);
-            uint32_t tile_base_page = B * tiles_per_row;
-
-            // Signal compute to untilize (before streaming tiles so compute is ready)
-            cb_reserve_back(cb_signal_id, 1);
-            volatile tt_l1_ptr uint32_t* signal_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-            signal_ptr[0] = 0x00000000;
-            cb_push_back(cb_signal_id, 1);
-
-            // Stream tiles in blocks of 8 — compute consumes each block as it arrives
-            for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
-                cb_reserve_back(cb_input_id, block_ct_dim);
-                uint32_t blk_write_ptr = get_write_ptr(cb_input_id);
-                uint32_t blk_start = tile_base_page + blk * block_ct_dim;
-                for (uint32_t col = 0; col < block_ct_dim; col++) {
-                    noc_async_read_page(
-                        blk_start + col, self_input_addr_gen, blk_write_ptr + col * aligned_input_page_size);
-                }
-                noc_async_read_barrier();
-                cb_push_back(cb_input_id, block_ct_dim);
-            }
-
-            // Overlap reads with compute
-            for (uint32_t t = 0; t < batch_count; t++) {
-                noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
-                noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
-            }
-
-            // Wait for compute to finish (it writes untilized data into cb_untilize_id / c_18)
-            cb_wait_front(cb_untilize_id, read_batch_size);
-            noc_async_read_barrier();
-            DPRINT_DISPATCH("Self-untilize batch {} done\n", B);
-        }
-#endif
-
-        // ---- Common inner token loop ----
-#ifdef IS_TILE_LAYOUT
-        bool is_delegated_batch = (C < num_idle_cores);
-#endif
         for (uint32_t t = 0; t < batch_count; t++) {
             uint32_t token_idx = batch_start + t;
-#ifdef IS_TILE_LAYOUT
-            uint32_t token_input_addr = untilize_base + t * writer_page_size;
-#else
             uint32_t token_input_addr = input_base + t * aligned_input_page_size;
-#endif
             tt_l1_ptr uint16_t* indices =
                 reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
             tt_l1_ptr uint16_t* weights =
@@ -474,11 +235,6 @@ void kernel_main() {
                 auto page_idx = offset;
 
                 if (expert_chip == linearized_mesh_coord) {
-#ifdef IS_TILE_LAYOUT
-                    // For delegated batches the idle core's writer kernel handles
-                    // local DRAM writes directly; skip them here.
-                    if (!is_delegated_batch)
-#endif
                     {
                         volatile tt_l1_ptr int32_t* metadata =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_temp_addr);
@@ -514,7 +270,7 @@ void kernel_main() {
 
                         cb_reserve_back(cb_payload_for_writer_id, 1);
                         uint32_t payload_dst = get_write_ptr(cb_payload_for_writer_id);
-                        noc_async_read(get_noc_addr(token_input_addr), payload_dst, writer_page_size);
+                        noc_async_read(get_noc_addr(token_input_addr), payload_dst, aligned_input_page_size);
                         noc_async_read_barrier();
                         cb_push_back(cb_payload_for_writer_id, 1);
 
@@ -534,15 +290,6 @@ void kernel_main() {
             }
         }
 
-#ifdef IS_TILE_LAYOUT
-        if (batch_did_local_write) {
-            noc_async_write_barrier();
-        }
-        // Release CB after self-batch so compute can reuse it next time
-        if (C >= num_idle_cores) {
-            cb_pop_front(cb_untilize_id, read_batch_size);
-        }
-#else
         // Issue next batch DRAM reads BEFORE write barrier to overlap read/write NOC channels
         uint32_t next_batch_start = batch_start + read_batch_size;
         bool has_next_batch = (next_batch_start < token_end_idx);
@@ -567,25 +314,15 @@ void kernel_main() {
         if (has_next_batch) {
             noc_async_read_barrier();
         }
-#endif
     }
 
-#ifdef IS_TILE_LAYOUT
-    // Signal compute to exit
-    cb_reserve_back(cb_signal_id, 1);
-    volatile tt_l1_ptr uint32_t* signal_sentinel =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
-    signal_sentinel[0] = ROUTE_INFO_SENTINEL;
-    cb_push_back(cb_signal_id, 1);
-#endif
-
-    // Push sentinel to signal writer that all dispatches are done
+    // Sentinel: row-major sender reader still drives the local writer through c_4 sentinel.
     cb_reserve_back(cb_route_info_id, 1);
-    volatile tt_l1_ptr uint32_t* route_info =
+    volatile tt_l1_ptr uint32_t* sentinel_route_info =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_route_info_id));
-    route_info[0] = ROUTE_INFO_SENTINEL;
-    route_info[1] = 0;
-    route_info[2] = 0;
-    route_info[3] = 0;
+    sentinel_route_info[0] = ROUTE_INFO_SENTINEL;
+    sentinel_route_info[1] = 0;
+    sentinel_route_info[2] = 0;
+    sentinel_route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -3,22 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Reader kernel for idle (worker) cores in the dispatch op.
-// Pairs with writer_untilize_dispatch.cpp running on the other data-movement
-// RISC — this kernel focuses on streaming tiled input from DRAM so the writer
-// can overlap NOC-writes to the owning sender with the next batch's reads.
-//
-// Token batches are distributed round-robin across total_workers (k_s idle
-// cores + the sender itself). Core i processes batches i, i+total_workers, …
-//
-// For each assigned batch:
-//   1. Signal compute to start untilizing this batch (cb_signal_id).
-//   2. Read tiled input stripe from DRAM → cb_input_id, block_ct_dim tiles at a time.
-//
+// Reader kernel for untilizer cores.
+// Reads input, indices, weights and builds a per-batch routing plan.
+// Building the routing plan requires for the untilizer cores turn
+// to modify the offsets[] tensor.
+// Repeats this process until all batches are processed.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 
 #define ENABLE_DISPATCH_DEBUG 0
 #if ENABLE_DISPATCH_DEBUG
@@ -28,8 +23,25 @@
 #endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
+constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
+constexpr uint32_t PLAN_ENTRY_U32S = 8;
+
+// Plan entry layout (8 u32 = 32 bytes):
+//   [0] flags (bit 0: is_local, bit 31: end-of-plan sentinel)
+//   [1] token_t           (offset in c_11 batch — 0..read_batch_size-1)
+//   [2] routed_expert
+//   [3] page_idx          (DRAM page for local + remote)
+//   [4] token_idx         (global token index, for metadata)
+//   [5] (k << 16) | (weight & 0xFFFF)
+//   [6] route             (cross-device only)
+//   [7] distance          (cross-device only)
+//
+// Page layout: [entry_count u32][padding][entries...]
 
 void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
     // ===== Compile-time args =====
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(1);
@@ -38,21 +50,142 @@ void kernel_main() {
     constexpr uint32_t total_batches = get_compile_time_arg_val(4);
     constexpr uint32_t core_id = get_compile_time_arg_val(5);
     constexpr uint32_t total_workers = get_compile_time_arg_val(6);
-    constexpr auto input_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t cb_indices_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_weights_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_offsets_id = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_dispatch_table_id = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(11);
+
+    constexpr uint32_t read_batch_size = get_compile_time_arg_val(12);
+    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t aligned_weights_page_size = get_compile_time_arg_val(14);
+    constexpr uint32_t aligned_offsets_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t aligned_dispatch_table_page_size = get_compile_time_arg_val(16);
+
+    constexpr uint32_t offsets_pages = get_compile_time_arg_val(17);
+    constexpr uint32_t dispatch_table_pages = get_compile_time_arg_val(18);
+
+    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(19);
+    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(20);
+    constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(21);
+    constexpr uint32_t dispatch_core_idx = get_compile_time_arg_val(22);
+    constexpr uint32_t num_dispatch_cores = get_compile_time_arg_val(23);
+    constexpr uint32_t core_mask = num_dispatch_cores - 1;
+    // Batches are assigned round-robin (batch i -> core i % total_workers); all cores
+    // grow offsets[] left-to-right from the single shared owner copy under the baton.
+
+    constexpr uint32_t num_devices = get_compile_time_arg_val(24);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(25);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(26);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(27);
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(28);
+
+    constexpr auto input_args = TensorAccessorArgs<29>();
+    constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
+    constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+    constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
+    constexpr auto dispatch_table_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t tiles_per_row = hidden_size / 32;
     constexpr uint32_t block_ct_dim = 8;
     constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
 
+#ifdef AXIS
+    constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
+    constexpr uint32_t row = linearized_mesh_coord / mesh_cols;
+    constexpr uint32_t col = linearized_mesh_coord % mesh_cols;
+    constexpr uint32_t device_begin_idx = axis == ReplicateGroup::COLS ? col : row * mesh_cols;
+    constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
+#else
+    constexpr ReplicateGroup axis = ReplicateGroup::NONE;
+    constexpr uint32_t device_begin_idx = 0;
+    constexpr uint32_t device_stride = 1;
+#endif
+
     // ===== Runtime args =====
-    uint32_t input_tensor_address = get_arg_val<uint32_t>(0);
+    uint32_t rt_idx = 0;
+    uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t weights_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t offsets_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t dispatch_table_tensor_address = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t token_start_idx = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t token_end_idx = get_arg_val<uint32_t>(rt_idx++);
+    // Baton-ring offset sync: offsets[] live only on the owner (core_id==0) of this
+    // sender group. Every core pulls/pushes the shared offsets[] under a baton that
+    // circulates in global batch order (core (b+1)%W signaled after batch b).
+    uint32_t owner_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t owner_noc_y = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t next_noc_x = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t next_noc_y = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t turn_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
 
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, aligned_input_page_size);
+    const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, aligned_indices_page_size);
+    const auto weights_addr_gen = TensorAccessor(weights_args, weights_tensor_address, aligned_weights_page_size);
+    const auto offsets_addr_gen = TensorAccessor(offsets_args, offsets_tensor_address);
+    const auto dispatch_table_addr_gen = TensorAccessor(dispatch_table_args, dispatch_table_tensor_address);
 
+    // ===== Startup: load offsets[] (owner only) and dispatch_table[] into local L1 =====
+    // offsets[] is a single shared counter array living on the owner (core_id==0) of this
+    // sender group. The owner loads tt_expert_offsets[] from DRAM; non-owners leave their
+    // local copy uninitialized and pull the owner's copy under the baton (per-batch loop).
+    // dispatch_table[] is read-only -> every core keeps its own copy.
+    constexpr bool IS_OWNER = (core_id == 0);
+    cb_reserve_back(cb_offsets_id, offsets_pages);
+    uint32_t offsets_base_addr = get_write_ptr(cb_offsets_id);
+    if constexpr (IS_OWNER) {
+        for (uint32_t i = 0; i < offsets_pages; i++) {
+            noc_async_read_page(i, offsets_addr_gen, offsets_base_addr + i * aligned_offsets_page_size);
+        }
+    }
+    cb_reserve_back(cb_dispatch_table_id, dispatch_table_pages);
+    uint32_t dispatch_table_base_addr = get_write_ptr(cb_dispatch_table_id);
+    for (uint32_t i = 0; i < dispatch_table_pages; i++) {
+        noc_async_read_page(
+            i, dispatch_table_addr_gen, dispatch_table_base_addr + i * aligned_dispatch_table_page_size);
+    }
+    noc_async_read_barrier();
+    tt_l1_ptr uint32_t* offsets = reinterpret_cast<tt_l1_ptr uint32_t*>(offsets_base_addr);
+    tt_l1_ptr int32_t* expert_dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_base_addr);
+
+    // ===== Baton-ring setup =====
+    // Each core waits on its own turn semaphore (local poll) and signals the next core's
+    // semaphore after finishing its batch. The owner seeds its own semaphore to 1 so the
+    // very first batch (batch 0, always owned by core 0) does not block.
+    const uint32_t offsets_bytes = offsets_pages * aligned_offsets_page_size;
+    volatile tt_l1_ptr uint32_t* turn_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(turn_semaphore_id));
+    uint64_t owner_offsets_noc_addr = get_noc_addr(owner_noc_x, owner_noc_y, offsets_base_addr);
+    uint64_t next_turn_sem_noc_addr = get_noc_addr(next_noc_x, next_noc_y, get_semaphore(turn_semaphore_id));
+    if constexpr (IS_OWNER) {
+        noc_semaphore_set(turn_sem_ptr, 1);
+    }
+    uint32_t turn_expected = 1;  // per-core baton counter; +1 for each batch this core handles
+    DPRINT_DISPATCH(
+        "[R s={} c={}] startup done; owner={} total_batches={} total_workers={}\n",
+        (uint32_t)dispatch_core_idx,
+        (uint32_t)core_id,
+        (uint32_t)IS_OWNER,
+        (uint32_t)total_batches,
+        (uint32_t)total_workers);
+
+    // ===== Indices / weights scratch (overwritten per batch, single page slot used) =====
+    cb_reserve_back(cb_indices_id, read_batch_size);
+    uint32_t indices_base = get_write_ptr(cb_indices_id);
+    cb_reserve_back(cb_weights_id, read_batch_size);
+    uint32_t weights_base = get_write_ptr(cb_weights_id);
+
+    // ===== Per-batch loop — this core handles batches core_id, core_id+total_workers, ... =====
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
         uint32_t tile_base_page = batch_idx * tiles_per_row;
+        uint32_t batch_start = batch_idx * read_batch_size;
+        uint32_t batch_end =
+            (batch_start + read_batch_size < token_end_idx) ? batch_start + read_batch_size : token_end_idx;
+        uint32_t batch_count = batch_end - batch_start;
 
-        // 1. Signal compute to untilize this batch (before streaming tiles so compute is ready)
+        // 1. Signal compute to start untilizing this batch
         cb_reserve_back(cb_signal_id, 1);
         volatile tt_l1_ptr uint32_t* signal_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
@@ -70,12 +203,137 @@ void kernel_main() {
             noc_async_read_barrier();
             cb_push_back(cb_input_id, block_ct_dim);
         }
+
+        // 3. Read this batch's indices and weights pages
+        for (uint32_t t = 0; t < batch_count; t++) {
+            noc_async_read_page(batch_start + t, indices_addr_gen, indices_base + t * aligned_indices_page_size);
+            noc_async_read_page(batch_start + t, weights_addr_gen, weights_base + t * aligned_weights_page_size);
+        }
+        noc_async_read_barrier();
+
+        // 4. Build per-batch route plan into c_14.
+        DPRINT_DISPATCH(
+            "[R s={} c={}] b={} reserving plan slot (blocks on writer drain)\n",
+            (uint32_t)dispatch_core_idx,
+            (uint32_t)core_id,
+            batch_idx);
+        cb_reserve_back(cb_plan_id, 1);
+        uint32_t plan_addr = get_write_ptr(cb_plan_id);
+        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
+        uint32_t entry_count = 0;
+        uint32_t entry_off = 8;  // entries start at u32 offset 8 (32B header)
+
+        DPRINT_DISPATCH(
+            "[R s={} c={}] b={} WAIT baton (turn_sem>={}, have={})\n",
+            (uint32_t)dispatch_core_idx,
+            (uint32_t)core_id,
+            batch_idx,
+            turn_expected,
+            (uint32_t)(*turn_sem_ptr));
+        noc_semaphore_wait_min(turn_sem_ptr, turn_expected);
+        DPRINT_DISPATCH("[R s={} c={}] b={} GOT baton\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id, batch_idx);
+        turn_expected++;
+        if constexpr (!IS_OWNER) {
+            noc_async_read(owner_offsets_noc_addr, offsets_base_addr, offsets_bytes);
+            noc_async_read_barrier();
+        }
+
+        for (uint32_t t = 0; t < batch_count; t++) {
+            tt_l1_ptr uint16_t* indices_t =
+                reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
+            tt_l1_ptr uint16_t* weights_t =
+                reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
+            uint32_t token_idx = batch_start + t;
+
+            for (uint32_t k = 0; k < num_experts_per_tok; k++) {
+                int32_t routed_expert = indices_t[k];
+                if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
+                    continue;
+                }
+                int32_t expert_chip_og = expert_dispatch_table[routed_expert];
+                if (expert_chip_og == -1) {
+                    continue;
+                }
+
+                // Single shared counter, all cores grow left-to-right from offsets[e].
+                uint32_t& offset = offsets[routed_expert];
+                if (offset >= max_dispatch_buffer_token_size) {
+                    offset++;
+                    continue;
+                }
+                uint32_t page_idx = offset++;
+
+                uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
+                bool is_local = (expert_chip == linearized_mesh_coord);
+                int16_t weight = (int16_t)weights_t[k];
+
+                uint32_t base = entry_off;
+                plan[base + 0] = is_local ? PLAN_FLAG_LOCAL : 0;
+                plan[base + 1] = t;
+                plan[base + 2] = (uint32_t)routed_expert;
+                plan[base + 3] = page_idx;
+                plan[base + 4] = token_idx;
+                plan[base + 5] = (k << 16) | ((uint32_t)(uint16_t)weight);
+
+                if (!is_local) {
+                    if constexpr (is_1d_topology<topology>()) {
+                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                        uint32_t distance =
+                            manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                        plan[base + 6] = route;
+                        plan[base + 7] = distance;
+                    } else {
+                        plan[base + 6] = 0;
+                        plan[base + 7] = 0;
+                    }
+                } else {
+                    plan[base + 6] = 0;
+                    plan[base + 7] = 0;
+                }
+
+                entry_count++;
+                entry_off += PLAN_ENTRY_U32S;
+            }
+        }
+
+        if constexpr (!IS_OWNER) {
+            noc_async_write(offsets_base_addr, owner_offsets_noc_addr, offsets_bytes);
+            noc_async_write_barrier();
+        }
+        if (batch_idx + 1 < total_batches) {
+            noc_semaphore_inc(next_turn_sem_noc_addr, 1);
+            DPRINT_DISPATCH(
+                "[R s={} c={}] b={} RELEASE baton -> signaled next (entries={})\n",
+                (uint32_t)dispatch_core_idx,
+                (uint32_t)core_id,
+                batch_idx,
+                entry_count);
+        } else {
+            DPRINT_DISPATCH(
+                "[R s={} c={}] b={} RELEASE baton -> LAST batch, no signal (entries={})\n",
+                (uint32_t)dispatch_core_idx,
+                (uint32_t)core_id,
+                batch_idx,
+                entry_count);
+        }
+
+        plan[0] = entry_count;
+        cb_push_back(cb_plan_id, 1);
     }
 
-    // Send sentinel to compute to break out of its loop
+    DPRINT_DISPATCH("[R s={} c={}] loop DONE -> pushing sentinels\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id);
+    // Send sentinel to compute so it breaks out of its loop
     cb_reserve_back(cb_signal_id, 1);
     volatile tt_l1_ptr uint32_t* signal_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
     signal_ptr[0] = ROUTE_INFO_SENTINEL;
     cb_push_back(cb_signal_id, 1);
+
+    // Push end-of-plan sentinel for the writer so it forwards ROUTE_INFO_SENTINEL to sender.
+    cb_reserve_back(cb_plan_id, 1);
+    uint32_t sentinel_addr = get_write_ptr(cb_plan_id);
+    volatile tt_l1_ptr uint32_t* sentinel_plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sentinel_addr);
+    sentinel_plan[0] = 0;  // entry_count
+    sentinel_plan[8] = PLAN_FLAG_END;
+    cb_push_back(cb_plan_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -3,17 +3,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Reader kernel for untilizer cores.
-// Reads input, indices, weights and builds a per-batch routing plan.
-// Building the routing plan requires for the untilizer cores turn
-// to modify the offsets[] tensor.
-// Repeats this process until all batches are processed.
+// Reader kernel for the untilize cores in the tile-layout dispatch path.
+// Runs on the reader RISC of each untilize core, paired with
+// writer_untilize_dispatch.cpp on the other data-movement RISC: this kernel
+// streams tiled input for compute to untilize and builds the per-batch route
+// plan, while the writer drains the previous batch's plan and issues the NOC
+// writes.
+//
+// Token batches are distributed round-robin across total_workers untilize cores:
+// core i processes batches i, i+total_workers, …
+//
+// Shared state — offsets[] (per-expert DRAM page allocators) is a single counter
+// array owned by core 0 of each sender group.  Cores take turns mutating it under
+// a baton ring (turn semaphore) that circulates in global batch order: a core
+// pulls the owner's offsets[], appends its batch's allocations, writes them back,
+// then hands the baton to the next core.  dispatch_table[] is read-only, so every
+// core keeps its own copy.
+//
+// For each assigned batch:
+//   1. Signal compute to start untilizing this batch (cb_signal_id).
+//   2. Stream the tiled input stripe from DRAM → cb_input_id, block_ct_dim tiles
+//      at a time, for compute to untilize.
+//   3. Read this batch's indices and weights pages from DRAM.
+//   4. Take the baton, then build the route plan into cb_plan_id: for each
+//      (token, top-k) routed to this dispatch core, allocate a DRAM page from
+//      offsets[expert] (drop if the dispatch buffer is full), classify it local
+//      vs cross-device (computing route/distance for the latter), and append a
+//      PlanEntry.  Write offsets[] back and release the baton.
+//
+// After the last batch: push an end-of-plan sentinel — ROUTE_INFO_SENTINEL to
+// compute (cb_signal_id) and a zero-entry sentinel plan page to the writer.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp"
 
 #define ENABLE_DISPATCH_DEBUG 0
 #if ENABLE_DISPATCH_DEBUG
@@ -23,21 +49,9 @@
 #endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
-constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
-constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
-constexpr uint32_t PLAN_ENTRY_U32S = 8;
 
-// Plan entry layout (8 u32 = 32 bytes):
-//   [0] flags (bit 0: is_local, bit 31: end-of-plan sentinel)
-//   [1] token_t           (offset in c_11 batch — 0..read_batch_size-1)
-//   [2] routed_expert
-//   [3] page_idx          (DRAM page for local + remote)
-//   [4] token_idx         (global token index, for metadata)
-//   [5] (k << 16) | (weight & 0xFFFF)
-//   [6] route             (cross-device only)
-//   [7] distance          (cross-device only)
-//
-// Page layout: [entry_count u32][padding][entries...]
+// Plan page layout (PlanHeader + PlanEntry[]) is defined in dispatch_plan.hpp and shared
+// with the writer kernel.
 
 void kernel_main() {
     using namespace ttnn::operations::ccl::common;
@@ -219,9 +233,10 @@ void kernel_main() {
             batch_idx);
         cb_reserve_back(cb_plan_id, 1);
         uint32_t plan_addr = get_write_ptr(cb_plan_id);
-        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
+        volatile tt_l1_ptr PlanHeader* plan = reinterpret_cast<volatile tt_l1_ptr PlanHeader*>(plan_addr);
+        volatile tt_l1_ptr PlanEntry* entries =
+            reinterpret_cast<volatile tt_l1_ptr PlanEntry*>(plan_addr + sizeof(PlanHeader));
         uint32_t entry_count = 0;
-        uint32_t entry_off = 8;  // entries start at u32 offset 8 (32B header)
 
         DPRINT_DISPATCH(
             "[R s={} c={}] b={} WAIT baton (turn_sem>={}, have={})\n",
@@ -245,8 +260,12 @@ void kernel_main() {
                 reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
             uint32_t token_idx = batch_start + t;
 
+            // Walk this token's top-k experts; emit a plan entry for each one routed to this
+            // dispatch core (after the ownership / mapping / capacity filters below).
             for (uint32_t k = 0; k < num_experts_per_tok; k++) {
                 int32_t routed_expert = indices_t[k];
+                // Skip experts not owned by this dispatch core (low bits of the expert id
+                // select the dispatch core), and experts the table maps nowhere (-1).
                 if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
                     continue;
                 }
@@ -255,7 +274,10 @@ void kernel_main() {
                     continue;
                 }
 
-                // Single shared counter, all cores grow left-to-right from offsets[e].
+                // Allocate this token's destination DRAM page from the expert's counter.
+                // Single shared counter; all cores grow it left-to-right from offsets[e].
+                // If the dispatch buffer for this expert is full, still bump the counter
+                // (so capacity accounting stays consistent) but drop the token — no entry.
                 uint32_t& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
                     offset++;
@@ -267,32 +289,30 @@ void kernel_main() {
                 bool is_local = (expert_chip == linearized_mesh_coord);
                 int16_t weight = (int16_t)weights_t[k];
 
-                uint32_t base = entry_off;
-                plan[base + 0] = is_local ? PLAN_FLAG_LOCAL : 0;
-                plan[base + 1] = t;
-                plan[base + 2] = (uint32_t)routed_expert;
-                plan[base + 3] = page_idx;
-                plan[base + 4] = token_idx;
-                plan[base + 5] = (k << 16) | ((uint32_t)(uint16_t)weight);
+                volatile tt_l1_ptr PlanEntry* entry = &entries[entry_count];
+                entry->flags = is_local ? PLAN_FLAG_LOCAL : 0;
+                entry->token_t = t;
+                entry->routed_expert = (uint32_t)routed_expert;
+                entry->page_idx = page_idx;
+                entry->token_idx = token_idx;
+                entry->weight = weight;
+                entry->k = (uint16_t)k;
 
                 if (!is_local) {
                     if constexpr (is_1d_topology<topology>()) {
-                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
-                        uint32_t distance =
+                        entry->route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
+                        entry->distance =
                             manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
-                        plan[base + 6] = route;
-                        plan[base + 7] = distance;
                     } else {
-                        plan[base + 6] = 0;
-                        plan[base + 7] = 0;
+                        entry->route = 0;
+                        entry->distance = 0;
                     }
                 } else {
-                    plan[base + 6] = 0;
-                    plan[base + 7] = 0;
+                    entry->route = 0;
+                    entry->distance = 0;
                 }
 
                 entry_count++;
-                entry_off += PLAN_ENTRY_U32S;
             }
         }
 
@@ -317,23 +337,28 @@ void kernel_main() {
                 entry_count);
         }
 
-        plan[0] = entry_count;
+        plan->entry_count = entry_count;
         cb_push_back(cb_plan_id, 1);
     }
 
+    // Teardown: all batches done — push the two end-of-stream sentinels this core's
+    // consumers wait on.
     DPRINT_DISPATCH("[R s={} c={}] loop DONE -> pushing sentinels\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id);
-    // Send sentinel to compute so it breaks out of its loop
+    // (1) Sentinel value to compute so it breaks out of its untilize loop.
     cb_reserve_back(cb_signal_id, 1);
     volatile tt_l1_ptr uint32_t* signal_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_signal_id));
     signal_ptr[0] = ROUTE_INFO_SENTINEL;
     cb_push_back(cb_signal_id, 1);
 
-    // Push end-of-plan sentinel for the writer so it forwards ROUTE_INFO_SENTINEL to sender.
+    // (2) Zero-entry end-of-plan page to the writer (entry_count == 0, entries[0].flags ==
+    //     PLAN_FLAG_END) so it stops draining and forwards ROUTE_INFO_SENTINEL to the sender.
     cb_reserve_back(cb_plan_id, 1);
     uint32_t sentinel_addr = get_write_ptr(cb_plan_id);
-    volatile tt_l1_ptr uint32_t* sentinel_plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sentinel_addr);
-    sentinel_plan[0] = 0;  // entry_count
-    sentinel_plan[8] = PLAN_FLAG_END;
+    volatile tt_l1_ptr PlanHeader* sentinel_plan = reinterpret_cast<volatile tt_l1_ptr PlanHeader*>(sentinel_addr);
+    volatile tt_l1_ptr PlanEntry* sentinel_entries =
+        reinterpret_cast<volatile tt_l1_ptr PlanEntry*>(sentinel_addr + sizeof(PlanHeader));
+    sentinel_plan->entry_count = 0;
+    sentinel_entries[0].flags = PLAN_FLAG_END;
     cb_push_back(cb_plan_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -297,6 +297,10 @@ void kernel_main() {
                 entry->token_idx = token_idx;
                 entry->weight = weight;
                 entry->k = (uint16_t)k;
+                // Linearized destination device index. Under 1D it is unused by the fabric writer
+                // (route/distance drive the send); under 2D it is the only routing input — the
+                // writer recomputes the EDM direction and (mesh,chip) header from it.
+                entry->dst_chip = expert_chip;
 
                 if (!is_local) {
                     if constexpr (is_1d_topology<topology>()) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -295,8 +295,8 @@ void kernel_main() {
                 entry->routed_expert = (uint32_t)routed_expert;
                 entry->page_idx = page_idx;
                 entry->token_idx = token_idx;
-                entry->weight = weight;
-                entry->k = (uint16_t)k;
+                // Single aligned 32-bit store: baby-RISC sub-word L1 stores are unreliable on BH.
+                entry->weight_k = pack_weight_k(weight, (uint16_t)k);
                 // Linearized destination device index. Under 1D it is unused by the fabric writer
                 // (route/distance drive the send); under 2D it is the only routing input — the
                 // writer recomputes the EDM direction and (mesh,chip) header from it.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -2,6 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//
+// Sender RISCV_0 kernel — fabric writer.
+//
+// Tile layout (IS_TILE_LAYOUT): sends tokens and metadata via fabric to dst.
+// Reads tokens and metadata from corresponding untilizer CBs.
+//
+// Row-major layout (no IS_TILE_LAYOUT): standard cb_wait_front / cb_pop_front on
+// c_4 / c_5 / c_6 pushed by the row-major sender reader.
+//
+
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -64,11 +74,6 @@ void kernel_main() {
     // Operation parameters (indices 24-30)
     constexpr uint32_t num_devices = get_compile_time_arg_val(24);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(25);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(26);
-    constexpr uint32_t n_routed_experts = get_compile_time_arg_val(27);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(28);
-    constexpr uint32_t metadata_len = get_compile_time_arg_val(29);
-    constexpr uint32_t tokens_per_device = get_compile_time_arg_val(30);
 
     // Mesh information (indices 31-35)
     constexpr uint32_t src_mesh_id = get_compile_time_arg_val(31);
@@ -92,9 +97,6 @@ void kernel_main() {
     constexpr uint32_t num_links = get_compile_time_arg_val(45);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(46);
 
-    // Batch configuration (index 47) — read_batch_size not used by writer
-    // Index 48 — max_dispatch_buffer_token_size (used by reader only)
-
     // TensorAccessorArgs for all 7 tensors (starting at index 49)
     constexpr auto input_args = TensorAccessorArgs<49>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
@@ -103,6 +105,13 @@ void kernel_main() {
     constexpr auto output_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<metadata_args.next_compile_time_args_offset()>();
+
+#ifdef IS_TILE_LAYOUT
+    constexpr uint32_t writer_extra_args_base = dispatch_table_args.next_compile_time_args_offset();
+    constexpr uint32_t writer_cb_size = get_compile_time_arg_val(writer_extra_args_base + 0);
+    constexpr uint32_t num_untilizers = get_compile_time_arg_val(writer_extra_args_base + 1);
+    constexpr uint32_t route_info_slot_stride = l1_alignment;
+#endif
 
     // ===== Runtime Args =====
     size_t rt_args_idx = 0;
@@ -125,6 +134,27 @@ void kernel_main() {
     // pair on dispatch_devices==2 (mesh-2x4 column pair). Mirrors the combine fix.
     uint32_t exit_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
 
+#ifdef IS_TILE_LAYOUT
+    uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t cross_addr_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t space_avail_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+    uint32_t ring_route_cb[num_untilizers];
+    uint32_t ring_payload_cb[num_untilizers];
+    uint32_t ring_meta_cb[num_untilizers];
+    uint32_t ring_noc_x[num_untilizers];
+    uint32_t ring_noc_y[num_untilizers];
+    uint32_t ring_data_avail_id[num_untilizers];
+    for (uint32_t s = 0; s < num_untilizers; s++) {
+        ring_route_cb[s] = get_arg_val<uint32_t>(rt_args_idx++);
+        ring_payload_cb[s] = get_arg_val<uint32_t>(rt_args_idx++);
+        ring_meta_cb[s] = get_arg_val<uint32_t>(rt_args_idx++);
+        ring_noc_x[s] = get_arg_val<uint32_t>(rt_args_idx++);
+        ring_noc_y[s] = get_arg_val<uint32_t>(rt_args_idx++);
+        ring_data_avail_id[s] = get_arg_val<uint32_t>(rt_args_idx++);
+    }
+#endif
+
 #ifdef AXIS
     constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
     constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
@@ -138,6 +168,27 @@ void kernel_main() {
         dispatch_core_idx,
         num_dispatch_cores,
         dispatch_devices);
+
+#ifdef IS_TILE_LAYOUT
+    uint32_t ring_route_base[num_untilizers];
+    uint32_t ring_payload_base[num_untilizers];
+    uint32_t ring_meta_base[num_untilizers];
+    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
+    uint32_t cross_addr_sem_l1_offset = get_semaphore(cross_addr_semaphore_id);
+    for (uint32_t s = 0; s < num_untilizers; s++) {
+        ring_route_base[s] = get_write_ptr(ring_route_cb[s]);
+        ring_payload_base[s] = get_write_ptr(ring_payload_cb[s]);
+        ring_meta_base[s] = get_write_ptr(ring_meta_cb[s]);
+        uint64_t mailbox = get_noc_addr(ring_noc_x[s], ring_noc_y[s], cross_addr_sem_l1_offset);
+        noc_inline_dw_write(mailbox + 0 * sizeof(uint32_t), ring_route_base[s]);
+        noc_inline_dw_write(mailbox + 1 * sizeof(uint32_t), ring_payload_base[s]);
+        noc_inline_dw_write(mailbox + 2 * sizeof(uint32_t), ring_meta_base[s]);
+        noc_async_write_barrier();  // all three addresses must land before addr_ready wakes untilizer s
+        noc_semaphore_inc(get_noc_addr(ring_noc_x[s], ring_noc_y[s], addr_ready_sem_l1_offset), 1);
+        noc_async_atomic_barrier();
+        DPRINT_DISPATCH("Sender writer: addr handshake done ring={} u=({},{})\n", s, ring_noc_x[s], ring_noc_y[s]);
+    }
+#endif
 
 #ifdef DEST_CHIP_ID
     constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
@@ -175,7 +226,70 @@ void kernel_main() {
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
-    // Sentinel-terminated fabric send loop
+#ifdef IS_TILE_LAYOUT
+    volatile tt_l1_ptr uint32_t* ring_data_avail_ptr[num_untilizers];
+    uint64_t ring_space_avail_noc[num_untilizers];
+    uint32_t consumed[num_untilizers];
+    bool done[num_untilizers];
+    uint32_t num_done = 0;
+    uint32_t space_avail_sem_l1_offset = get_semaphore(space_avail_semaphore_id);
+    for (uint32_t s = 0; s < num_untilizers; s++) {
+        ring_data_avail_ptr[s] = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(ring_data_avail_id[s]));
+        ring_space_avail_noc[s] = get_noc_addr(ring_noc_x[s], ring_noc_y[s], space_avail_sem_l1_offset);
+        consumed[s] = 0;
+        done[s] = false;
+    }
+
+    DPRINT_DISPATCH("[SND] drain loop start (rings={})\n", num_untilizers);
+
+    while (num_done < num_untilizers) {
+        for (uint32_t s = 0; s < num_untilizers; s++) {
+            if (done[s]) {
+                continue;
+            }
+            if (*ring_data_avail_ptr[s] >= consumed[s] + 1) {
+                uint32_t slot = consumed[s] % writer_cb_size;
+                volatile tt_l1_ptr uint32_t* route_info =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ring_route_base[s] + slot * route_info_slot_stride);
+                if (route_info[0] == ROUTE_INFO_SENTINEL) {
+                    done[s] = true;
+                    num_done++;
+                    DPRINT_DISPATCH("[SND] ring={} SENTINEL (consumed={})\n", s, consumed[s]);
+                } else {
+                    uint32_t distance = route_info[1];
+                    uint32_t page_idx = route_info[2];
+                    uint32_t payload_addr = ring_payload_base[s] + slot * aligned_output_page_size;
+                    uint32_t metadata_addr = ring_meta_base[s] + slot * aligned_metadata_page_size;
+                    DPRINT_DISPATCH("ring={} send: route={} page={}\n", s, route_info[0], page_idx);
+#ifdef DEST_CHIP_ID
+                    fabric_set_unicast_route<false>(
+                        (volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+                    fabric_send_noc_unicast<fabric_max_packet_size>(
+                        output_addr_gen,
+                        fabric_connections[route_info[0]],
+                        unicast_packet_header,
+                        payload_addr,
+                        page_idx,
+                        (int)aligned_output_page_size,
+                        l1_alignment);
+                    fabric_send_noc_unicast<fabric_max_packet_size>(
+                        metadata_addr_gen,
+                        fabric_connections[route_info[0]],
+                        unicast_packet_header,
+                        metadata_addr,
+                        page_idx,
+                        (int)aligned_metadata_page_size,
+                        l1_alignment);
+                    noc_async_writes_flushed();
+#endif
+                    noc_semaphore_inc<true>(ring_space_avail_noc[s], 1);
+                    consumed[s]++;
+                }
+            }
+        }
+    }
+#else
+    // ===== Row-major path: standard CB protocol on c_4/c_5/c_6 pushed by the sender reader.
     while (true) {
         cb_wait_front(cb_route_info_id, 1);
         volatile tt_l1_ptr uint32_t* route_info =
@@ -244,49 +358,45 @@ void kernel_main() {
             page_idx,
             (int)aligned_metadata_page_size,
             l1_alignment);
-        noc_async_writes_flushed();  // Ensure payload+metadata departed L1 before freeing CB slots
 
+        noc_async_writes_flushed();
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);
         cb_pop_front(cb_metadata_for_writer_id, 1);
     }
+#endif
 
 #ifdef DEST_CHIP_ID
-    // Defensive: drain any pending local NOC writes before fabric atomic-inc traffic,
-    // so the exit-sem signal cannot reach peers ahead of the last metadata/payload writes.
-    noc_async_write_barrier();
+        // Defensive: drain any pending local NOC writes before fabric atomic-inc traffic,
+        // so the exit-sem signal cannot reach peers ahead of the last metadata/payload writes.
+        noc_async_write_barrier();
 
-    // Exit semaphore exchange - uses a dedicated semaphore (exit_semaphore_address) and
-    // the dedicated sem_packet_header. flush=true (vs the init handshake which uses the
-    // default flush=false): the EDM on the receiver holds this atomic-inc until our prior
-    // fabric writes (payload + metadata) to that chip have committed there. Without it the
-    // small atomic-inc packet can overtake the larger data writes on B's local NOC and the
-    // peer would observe sem-reached-threshold before the data has landed in DRAM. At init
-    // there are no prior writes to order against, so flush=false saves one EDM round-trip
-    // check.
-    {
-        const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
-        send_init_semaphore_to_configured_targets<
-            linearized_mesh_coord,
-            topology,
-            src_chip_id,
-            mesh_rows,
-            mesh_cols,
-            axis,
-            num_devices>(
-            fabric_connections,
-            sem_packet_header,
-            dest_chip_ids,
-            dest_mesh_ids,
-            exit_noc_semaphore_addr,
-            /*flush=*/true);
+        {
+            const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
+            send_init_semaphore_to_configured_targets<
+                linearized_mesh_coord,
+                topology,
+                src_chip_id,
+                mesh_rows,
+                mesh_cols,
+                axis,
+                num_devices>(
+                fabric_connections,
+                sem_packet_header,
+                dest_chip_ids,
+                dest_mesh_ids,
+                exit_noc_semaphore_addr,
+                /*flush=*/true);
 
-        volatile tt_l1_ptr uint32_t* exit_sem_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(exit_semaphore_address);
-        noc_semaphore_wait(exit_sem_ptr, dispatch_devices - 1);
-        noc_semaphore_set(exit_sem_ptr, 0);
-    }
+            volatile tt_l1_ptr uint32_t* exit_sem_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(exit_semaphore_address);
+            DPRINT_DISPATCH(
+                "[SND] drain DONE; WAIT exit_sem=={} (have={})\n", dispatch_devices - 1, (uint32_t)(*exit_sem_ptr));
+            noc_semaphore_wait(exit_sem_ptr, dispatch_devices - 1);
+            DPRINT_DISPATCH("[SND] exit handshake done\n");
+            noc_semaphore_set(exit_sem_ptr, 0);
+        }
 
     // send_init_semaphore_to_configured_targets's portable helper uses
     // fabric_unicast_noc_unicast_atomic_inc (linear/api.h), which calls

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -256,19 +256,40 @@ void kernel_main() {
                     num_done++;
                     DPRINT_DISPATCH("[SND] ring={} SENTINEL (consumed={})\n", s, consumed[s]);
                 } else {
+                    uint32_t route = route_info[0];
                     uint32_t distance = route_info[1];
                     uint32_t page_idx = route_info[2];
+                    uint32_t dst_chip_index = route_info[3];
                     uint32_t payload_addr = ring_payload_base[s] + slot * aligned_output_page_size;
                     uint32_t metadata_addr = ring_meta_base[s] + slot * aligned_metadata_page_size;
-                    DPRINT_DISPATCH("ring={} send: route={} page={}\n", s, route_info[0], page_idx);
+                    DPRINT_DISPATCH("ring={} send: route={} page={}\n", s, route, page_idx);
 #ifdef DEST_CHIP_ID
-                    fabric_set_unicast_route<false>(
-                        (volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+                    // route_info layout (written by writer_untilize_dispatch): [0]=route (1D EDM
+                    // index), [1]=distance_hops, [2]=page_idx, [3]=dst_chip_index (2D). Mirrors the
+                    // row-major path: under 2D the 1D-style route_info[0] doesn't match the physical
+                    // EDM index, so recompute the direction and the (mesh, chip) header from the dest.
+                    ccl_routing_utils::line_unicast_route_info_t pkt_route_info{};
+                    uint32_t fabric_route;
+                    if constexpr (
+                        std::is_same_v<PACKET_HEADER_TYPE, tt::tt_fabric::HybridMeshPacketHeader> ||
+                        std::is_same_v<PACKET_HEADER_TYPE, tt::tt_fabric::UDMHybridMeshPacketHeader>) {
+                        pkt_route_info.dst_chip_id = dest_chip_ids[dst_chip_index];
+                        pkt_route_info.dst_mesh_id = dest_mesh_ids[dst_chip_index];
+                        // TODO(#46174): drop the private tt_fabric_api.h dependency once
+                        // RoutingPlaneConnectionManager exposes a portable (mesh, chip) -> slot lookup.
+                        fabric_route = static_cast<uint32_t>(get_next_hop_router_direction(
+                            dest_mesh_ids[dst_chip_index], dest_chip_ids[dst_chip_index]));
+                    } else {
+                        pkt_route_info.distance_in_hops = static_cast<uint16_t>(distance);
+                        fabric_route = route;
+                    }
 
                     // Send payload
+                    ccl_routing_utils::fabric_set_line_unicast_route(
+                        pkt_hdr_for_route_helper(unicast_packet_header), pkt_route_info);
                     fabric_send_noc_unicast<fabric_max_packet_size>(
                         output_addr_gen,
-                        fabric_connections[route_info[0]],
+                        fabric_connections[fabric_route],
                         unicast_packet_header,
                         payload_addr,
                         page_idx,
@@ -276,9 +297,11 @@ void kernel_main() {
                         l1_alignment);
 
                     // Send metadata
+                    ccl_routing_utils::fabric_set_line_unicast_route(
+                        pkt_hdr_for_route_helper(unicast_packet_header), pkt_route_info);
                     fabric_send_noc_unicast<fabric_max_packet_size>(
                         metadata_addr_gen,
-                        fabric_connections[route_info[0]],
+                        fabric_connections[fabric_route],
                         unicast_packet_header,
                         metadata_addr,
                         page_idx,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_dispatch.cpp
@@ -264,6 +264,8 @@ void kernel_main() {
 #ifdef DEST_CHIP_ID
                     fabric_set_unicast_route<false>(
                         (volatile tt_l1_ptr LowLatencyPacketHeader*)unicast_packet_header, distance);
+
+                    // Send payload
                     fabric_send_noc_unicast<fabric_max_packet_size>(
                         output_addr_gen,
                         fabric_connections[route_info[0]],
@@ -272,6 +274,8 @@ void kernel_main() {
                         page_idx,
                         (int)aligned_output_page_size,
                         l1_alignment);
+
+                    // Send metadata
                     fabric_send_noc_unicast<fabric_max_packet_size>(
                         metadata_addr_gen,
                         fabric_connections[route_info[0]],
@@ -280,7 +284,7 @@ void kernel_main() {
                         page_idx,
                         (int)aligned_metadata_page_size,
                         l1_alignment);
-                    noc_async_writes_flushed();
+                    noc_async_writes_flushed();  // Ensure payload+metadata departed L1 before freeing CB slots
 #endif
                     noc_semaphore_inc<true>(ring_space_avail_noc[s], 1);
                     consumed[s]++;
@@ -359,7 +363,7 @@ void kernel_main() {
             (int)aligned_metadata_page_size,
             l1_alignment);
 
-        noc_async_writes_flushed();
+        noc_async_writes_flushed();  // Ensure payload+metadata departed L1 before freeing CB slots
 #endif
 
         cb_pop_front(cb_payload_for_writer_id, 1);
@@ -372,6 +376,14 @@ void kernel_main() {
         // so the exit-sem signal cannot reach peers ahead of the last metadata/payload writes.
         noc_async_write_barrier();
 
+        // Exit semaphore exchange - uses a dedicated semaphore (exit_semaphore_address) and
+        // the dedicated sem_packet_header. flush=true (vs the init handshake which uses the
+        // default flush=false): the EDM on the receiver holds this atomic-inc until our prior
+        // fabric writes (payload + metadata) to that chip have committed there. Without it the
+        // small atomic-inc packet can overtake the larger data writes on B's local NOC and the
+        // peer would observe sem-reached-threshold before the data has landed in DRAM. At init
+        // there are no prior writes to order against, so flush=false saves one EDM round-trip
+        // check.
         {
             const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
             send_init_semaphore_to_configured_targets<
@@ -407,6 +419,6 @@ void kernel_main() {
     // (and atomics, defensively) have completed before we close.
     noc_async_full_barrier();
 
-    close_direction_connections(directions, fabric_connections);
+        close_direction_connections(directions, fabric_connections);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -3,26 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Writer kernel for idle (worker) cores in the dispatch op.
-// Runs on the data-movement RISC opposite the reader so that the reader can
-// prefetch the next batch's DRAM tiles into cb_input_id while this kernel is
-// waiting for compute / the owning sender and performing the NOC write.
+// Untilize core RISCV_0 — data movement.
 //
-// Each idle core is permanently bound to ONE sender core (its owning sender).
-// Token batches are distributed round-robin across total_workers (k_s idle
-// cores + the sender itself).  Core i processes batches i, i+total_workers, …
-//
-// For each assigned batch:
-//   1. Wait for compute to finish (cb_wait_front on cb_untilize_id).
-//   2. Wait for the owning sender's "send now" signal (start_semaphore).
-//      The sender also writes a route table to cb_mailbox_id before signaling,
-//      so the table is ready to read immediately after the semaphore fires.
-//   3. For each local route entry in the mailbox: write output data and metadata
-//      directly to DRAM using NOC1, bypassing the sender entirely.
-//   4. Bulk-write the full untilized batch to the sender's receive buffer so
-//      the sender can forward cross-device tokens via the fabric writer.
-//   5. Signal the sender that data has landed (data_ready_semaphore).
-//   6. Release the untilize CB (cb_pop_front).
+// Responsible for writing tokens to local DRAM or
+// delegate them to the sender core if fabric write is needed.
 //
 
 #include <cstdint>
@@ -36,6 +20,12 @@
 #define DPRINT_DISPATCH(...)
 #endif
 
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
+constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
+constexpr uint32_t PLAN_ENTRY_U32S = 8;
+constexpr uint32_t TRID_NON_LOCAL_WRITE = 1;
+
 void kernel_main() {
     // ===== Compile-time args =====
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
@@ -44,137 +34,211 @@ void kernel_main() {
     constexpr uint32_t total_batches = get_compile_time_arg_val(3);
     constexpr uint32_t core_id = get_compile_time_arg_val(4);
     constexpr uint32_t total_workers = get_compile_time_arg_val(5);
-    // New: direct-DRAM-write support
-    constexpr uint32_t cb_mailbox_id = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(7);
-    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(8);
-    constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(9);
-    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(10);
-    constexpr auto output_args = TensorAccessorArgs<11>();
-    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
-    constexpr uint32_t total_transfer_size = read_batch_size * aligned_output_page_size;
+    constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(6);
+    constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_plan_id = get_compile_time_arg_val(8);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(9);
+
+    // Per-entry CB protocol on sender side (sender writer CBs, writer_cb_size slots deep).
+    constexpr uint32_t route_info_slot_stride = get_compile_time_arg_val(10);    // l1_alignment
+    constexpr uint32_t writer_cb_size = get_compile_time_arg_val(11);            // = read_batch_size = 32
+    constexpr uint32_t cb_route_info_scratch_id = get_compile_time_arg_val(12);  // 16B local scratch
+    constexpr uint32_t meta_scratch_slots = get_compile_time_arg_val(13);
+
+    constexpr auto output_args = TensorAccessorArgs<14>();
+    constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
 
     // ===== Runtime args =====
     uint32_t rt_idx = 0;
-    uint32_t data_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t start_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_idx++);
     uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_idx++);
     uint32_t addr_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t addr_value_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    // New:
+    uint32_t cross_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t data_avail_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
+    uint32_t space_avail_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
     uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_idx++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t mbox_ready_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
-    uint32_t mbox_scratch_addr_semaphore_id = get_arg_val<uint32_t>(rt_idx++);
 
-    uint64_t sender_data_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
-    volatile tt_l1_ptr uint32_t* start_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(start_semaphore_id));
+    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
+    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
-    // ===== Startup: receive buffer address exchange (existing) =====
+    // ===== Startup: wait for sender to multicast c_4/c_5/c_6 L1 base addresses =====
     volatile tt_l1_ptr uint32_t* addr_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_ready_semaphore_id));
     noc_semaphore_wait(addr_ready_sem_ptr, 1);
     noc_semaphore_set(addr_ready_sem_ptr, 0);
-    volatile tt_l1_ptr uint32_t* addr_value_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_value_semaphore_id));
-    uint32_t sender_receive_buf_l1_addr = *addr_value_ptr;
-    uint64_t sender_receive_buf_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_receive_buf_l1_addr);
 
-    // ===== Startup: NOC-write mailbox L1 address into sender's scratch slot =====
-    // addr_ready also signals that the sender has multicast its rt_scratch_base into the
-    // mbox_scratch_addr semaphore slot on every core.  We read it here, then use
-    // noc_inline_dw_write to push our mailbox address into the sender's scratch buffer at
-    // slot [core_id * 4].  noc_inline_dw_write is ordered before the subsequent
-    // noc_semaphore_inc on the NOC, so the sender's local L1 read is safe after mbox_ready fires.
-    uint32_t mailbox_l1_addr = get_write_ptr(cb_mailbox_id);
-    volatile tt_l1_ptr uint32_t* mbox_scratch_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(mbox_scratch_addr_semaphore_id));
-    uint32_t sender_scratch_base = *mbox_scratch_addr_ptr;
-    uint64_t sender_scratch_slot_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, sender_scratch_base + core_id * sizeof(uint32_t));
-    noc_inline_dw_write(sender_scratch_slot_noc_addr, mailbox_l1_addr);
-    noc_async_write_barrier();  // ensure mailbox L1 addr has landed before atomic wakes sender
-    uint64_t sender_mbox_ready_noc_addr =
-        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(mbox_ready_semaphore_id));
-    noc_semaphore_inc(sender_mbox_ready_noc_addr, 1);
-    noc_async_atomic_barrier();
+    // All three base addresses arrive packed in the single mailbox slot (words [0],[1],[2]).
+    volatile tt_l1_ptr uint32_t* cross_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(cross_addr_semaphore_id));
+    uint32_t sender_c4_l1_addr = cross_addr_ptr[0];
+    uint32_t sender_c5_l1_addr = cross_addr_ptr[1];
+    uint32_t sender_c6_l1_addr = cross_addr_ptr[2];
 
-    // ===== Addr gens for direct DRAM writes =====
-    const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
+    uint64_t sender_c4_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c4_l1_addr);
+    uint64_t sender_c5_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c5_l1_addr);
+    uint64_t sender_c6_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c6_l1_addr);
+    uint64_t sender_data_avail_noc_addr =
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_avail_semaphore_id));
+
+    volatile tt_l1_ptr uint32_t* space_avail_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(space_avail_semaphore_id));
+
     uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
+    uint32_t xdev_metadata_scratch_addr = metadata_scratch_addr + meta_scratch_slots * aligned_metadata_page_size;
+    uint32_t route_info_scratch_addr = get_write_ptr(cb_route_info_scratch_id);
+    volatile tt_l1_ptr uint32_t* route_info_scratch =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(route_info_scratch_addr);
+    uint32_t produced_count = 0;
+    uint32_t local_count = 0;
 
+    DPRINT_DISPATCH(
+        "Writer untilize: handshake done c4={} c5={} c6={}\n", sender_c4_l1_addr, sender_c5_l1_addr, sender_c6_l1_addr);
+
+    // ===== Per-batch loop — drains the route plan published by the reader RISC =====
     for (uint32_t batch_idx = core_id; batch_idx < total_batches; batch_idx += total_workers) {
-        // 1. Wait for compute to finish untilizing this batch
+        // Wait for compute to finish untilizing this batch
         cb_wait_front(cb_untilize_id, read_batch_size);
-
-        // 2. Wait for the sender's "send now" signal
-        //    The sender writes the route table to cb_mailbox_id before incrementing this semaphore,
-        //    so the table is guaranteed to be visible once we clear the semaphore.
-        noc_semaphore_wait(start_sem_ptr, 1);
-        noc_semaphore_set(start_sem_ptr, 0);
 
         uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
 
-        // 3. Write local-expert tokens directly to DRAM (NOC1), skipping the sender.
-        //    Mailbox layout: [entry_count | has_non_local_flag (u32)] [entry_0..entry_N]
-        //    Each entry: token_t, page_idx, token_idx, k, routed_expert, weight (6 × u32)
-        //    High bit of mbox[0]: 1 = cross-device tokens exist → must bulk-send back to sender.
-        //                         0 = all local → skip bulk-send entirely.
-        volatile tt_l1_ptr uint32_t* mbox = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mailbox_l1_addr);
-        uint32_t raw = mbox[0];
-        bool has_non_local = (raw & 0x80000000u) != 0;
-        uint32_t entry_count = raw & 0x7FFFFFFFu;
-        for (uint32_t e = 0; e < entry_count; e++) {
-            uint32_t base = 1 + e * 6;
-            uint32_t token_t = mbox[base + 0];
-            uint32_t page_idx = mbox[base + 1];
-            int32_t token_idx = (int32_t)mbox[base + 2];
-            int32_t k = (int32_t)mbox[base + 3];
-            int32_t routed_exp = (int32_t)mbox[base + 4];
-            int16_t weight = (int16_t)mbox[base + 5];
+        // Wait for reader to publish the per-batch route plan
+        cb_wait_front(cb_plan_id, 1);
+        uint32_t plan_addr = get_read_ptr(cb_plan_id);
+        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
+        uint32_t entry_count = plan[0];
+        DPRINT_DISPATCH(
+            "[W c={}] b={} draining plan entries={} produced_so_far={}\n",
+            (uint32_t)core_id,
+            batch_idx,
+            entry_count,
+            produced_count);
 
-            uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
+        {
+            for (uint32_t e = 0; e < entry_count; e++) {
+                uint32_t base = 8 + e * PLAN_ENTRY_U32S;
+                uint32_t flags = plan[base + 0];
+                uint32_t token_t = plan[base + 1];
+                uint32_t routed_expert = plan[base + 2];
+                uint32_t page_idx = plan[base + 3];
+                uint32_t token_idx = plan[base + 4];
+                uint32_t kw = plan[base + 5];
+                uint32_t k = kw >> 16;
+                int16_t weight = (int16_t)(kw & 0xFFFF);
 
-            noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
+                bool is_local = (flags & PLAN_FLAG_LOCAL) != 0;
 
-            volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(metadata_scratch_addr);
-            meta[0] = (int32_t)linearized_mesh_coord;
-            meta[1] = token_idx;
-            meta[2] = k;
-            meta[3] = routed_exp;
-            meta[4] = (int32_t)weight;
-            noc_async_write_page(page_idx, metadata_addr_gen, metadata_scratch_addr);
-            noc_async_writes_flushed();
-        }
+                if (is_local) {
+                    //  Local: NOC1 write payload + metadata directly to DRAM.
+                    //  No in-loop flush — payload source (src_addr) is unique per token,
+                    //  and metadata source rotates through meta_scratch_slots ring slots.
+                    //  Single noc_async_writes_flushed() at batch end covers reuse.
+                    noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                    uint32_t meta_addr =
+                        metadata_scratch_addr + (local_count % meta_scratch_slots) * aligned_metadata_page_size;
+                    volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(meta_addr);
+                    meta[0] = (int32_t)linearized_mesh_coord;
+                    meta[1] = (int32_t)token_idx;
+                    meta[2] = (int32_t)k;
+                    meta[3] = (int32_t)routed_expert;
+                    meta[4] = (int32_t)weight;
+                    noc_async_write_page(page_idx, metadata_addr_gen, meta_addr);
+                    local_count++;
+                } else {
+                    uint32_t route = plan[base + 6];
+                    uint32_t distance = plan[base + 7];
 
-        // 4. Bulk-write full untilized batch to sender's receive buffer (cross-device tokens).
-        //    Skipped entirely when all tokens are local — no round-trip to sender needed.
-        if (has_non_local) {
-            uint32_t off = 0;
-            while (off < total_transfer_size) {
-                uint32_t chunk = (total_transfer_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
-                                     ? (uint32_t)NOC_MAX_BURST_SIZE
-                                     : (total_transfer_size - off);
-                noc_async_write(untilize_read_ptr + off, sender_receive_buf_noc_addr + off, chunk);
-                off += chunk;
+                    // Per-entry credit: wait until the sender has fabric-sent the slot we're
+                    // about to overwrite (sender writer inc's space_avail once per slot freed).
+                    DPRINT_DISPATCH(
+                        "[W c={}] b={} WAIT space_avail>={} (have={}) for xdev entry route={}\n",
+                        (uint32_t)core_id,
+                        batch_idx,
+                        produced_count + 1,
+                        (uint32_t)(*space_avail_sem_ptr),
+                        route);
+                    noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+
+                    uint32_t slot = produced_count % writer_cb_size;
+
+                    // Build route_info (4 × u32) in local scratch, send as one NOC write.
+                    route_info_scratch[0] = route;
+                    route_info_scratch[1] = distance;
+                    route_info_scratch[2] = page_idx;
+                    route_info_scratch[3] = 0;
+                    uint64_t c4_slot = sender_c4_base_noc_addr + slot * route_info_slot_stride;
+                    noc_async_write_one_packet_with_trid(
+                        route_info_scratch_addr, c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
+
+                    // Payload: chunk to NOC_MAX_BURST_SIZE packets, each tagged with TRID.
+                    uint64_t c5_slot = sender_c5_base_noc_addr + slot * aligned_output_page_size;
+                    uint32_t off = 0;
+                    while (off < aligned_output_page_size) {
+                        uint32_t chunk = (aligned_output_page_size - off > (uint32_t)NOC_MAX_BURST_SIZE)
+                                             ? (uint32_t)NOC_MAX_BURST_SIZE
+                                             : (aligned_output_page_size - off);
+                        noc_async_write_one_packet_with_trid(
+                            src_addr + off, c5_slot + off, chunk, TRID_NON_LOCAL_WRITE);
+                        off += chunk;
+                    }
+
+                    volatile tt_l1_ptr int32_t* meta =
+                        reinterpret_cast<volatile tt_l1_ptr int32_t*>(xdev_metadata_scratch_addr);
+                    meta[0] = (int32_t)linearized_mesh_coord;
+                    meta[1] = (int32_t)token_idx;
+                    meta[2] = (int32_t)k;
+                    meta[3] = (int32_t)routed_expert;
+                    meta[4] = (int32_t)weight;
+                    uint64_t c6_slot = sender_c6_base_noc_addr + slot * aligned_metadata_page_size;
+                    noc_async_write_one_packet_with_trid(
+                        xdev_metadata_scratch_addr, c6_slot, aligned_metadata_page_size, TRID_NON_LOCAL_WRITE);
+
+                    // Wait only on this entry's cross-device writes — in-flight local
+                    // DRAM writes are tagged-out by TRID and keep flying.
+                    noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+
+                    noc_semaphore_inc<true>(sender_data_avail_noc_addr, 1);
+
+                    produced_count++;
+                }
             }
-            noc_async_write_barrier();
-
-            // 5. Signal the sender that all data has landed
-            noc_semaphore_inc(sender_data_ready_noc_addr, 1);
-            noc_async_atomic_barrier();
         }
 
-        // 6. Release untilize CB
+        // Drain all local NOC writes issued during this batch before the scratch ring or
+        // untilize CB get reused. Cross-device entries already barriered per-entry.
+        noc_async_writes_flushed();
+        local_count = 0;
+
+        cb_pop_front(cb_plan_id, 1);
         cb_pop_front(cb_untilize_id, read_batch_size);
     }
-    // Ensure all in-flight NOC traffic has landed before kernel exit. The all-local path only
-    // calls noc_async_writes_flushed (departure-from-source); without this barrier its
-    // noc_async_write_page DRAM writes can still be in flight at program end.
+
+    // After the last data entry: write ROUTE_INFO_SENTINEL as one final entry into the
+    // next slot. Must wait for space_avail like any regular entry.
+    cb_wait_front(cb_plan_id, 1);
+    cb_pop_front(cb_plan_id, 1);
+
+    DPRINT_DISPATCH(
+        "[W c={}] loop DONE; WAIT space_avail>={} (have={}) to send SENTINEL\n",
+        (uint32_t)core_id,
+        produced_count + 1,
+        (uint32_t)(*space_avail_sem_ptr));
+    noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+    DPRINT_DISPATCH("[W c={}] sending SENTINEL (produced total={})\n", (uint32_t)core_id, produced_count);
+
+    uint32_t sentinel_slot = produced_count % writer_cb_size;
+    route_info_scratch[0] = ROUTE_INFO_SENTINEL;
+    route_info_scratch[1] = 0;
+    route_info_scratch[2] = 0;
+    route_info_scratch[3] = 0;
+    uint64_t sentinel_c4_slot = sender_c4_base_noc_addr + sentinel_slot * route_info_slot_stride;
+    noc_async_write_one_packet_with_trid(
+        route_info_scratch_addr, sentinel_c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
+    noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
+    noc_semaphore_inc(sender_data_avail_noc_addr, 1);
+
+    // noc_async_full_barrier flushes everything in-flight (including the inc) before exit.
     noc_async_full_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -3,15 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Untilize core RISCV_0 — data movement.
+// Writer kernel for the untilize cores in the tile-layout dispatch path.
+// Runs on RISCV_0 (data movement) of each untilize core, opposite the reader
+// RISC on the same core: the reader builds the next batch's route plan while
+// this kernel drains the current one and performs the NOC writes.
 //
-// Responsible for writing tokens to local DRAM or
-// delegate them to the sender core if fabric write is needed.
+// Token batches are distributed round-robin across total_workers untilize cores:
+// core i processes batches i, i+total_workers, …  Each untilize core is bound to
+// ONE sender core (fabric-only) that forwards its cross-device tokens.
+//
+// Startup handshake:
+//   Wait for the owning sender to multicast its c_4/c_5/c_6 receive-buffer L1
+//   base addresses (addr_ready_semaphore), then read them from the cross-addr
+//   mailbox.  c_4 = route_info slots, c_5 = payload slots, c_6 = metadata slots.
+//
+// For each assigned batch:
+//   1. Wait for compute to finish untilizing this batch (cb_wait_front on
+//      cb_untilize_id).
+//   2. Wait for the reader RISC to publish this batch's route plan (cb_wait_front
+//      on cb_plan_id), then read it as PlanHeader + PlanEntry[] (layout shared
+//      with the reader via dispatch_plan.hpp).
+//   3. For each plan entry:
+//        - Local (PLAN_FLAG_LOCAL): NOC-write the token payload and its metadata
+//          straight to local DRAM, bypassing the sender.  Sources are unique per
+//          token / ring-rotated, so a single flush at batch end covers reuse.
+//        - Cross-device: wait for a per-entry credit (space_avail; the sender
+//          frees one slot per fabric send), then write route_info, payload and
+//          metadata into the sender's c_4/c_5/c_6 slot (TRID-tagged, barriered
+//          per entry) and bump the sender's data_avail semaphore so it forwards
+//          the token over the fabric.
+//   4. Flush outstanding local writes, then release the plan and untilize CBs
+//      (cb_pop_front).
+//
+// After the last batch: drain the reader's end-of-plan sentinel page, send
+// ROUTE_INFO_SENTINEL to the sender (so it stops forwarding), and full-barrier
+// before exit.
 //
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp"
 
 #define ENABLE_DISPATCH_DEBUG 0
 #if ENABLE_DISPATCH_DEBUG
@@ -21,9 +53,6 @@
 #endif
 
 constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
-constexpr uint32_t PLAN_FLAG_LOCAL = 0x1u;
-constexpr uint32_t PLAN_FLAG_END = 0x80000000u;
-constexpr uint32_t PLAN_ENTRY_U32S = 8;
 constexpr uint32_t TRID_NON_LOCAL_WRITE = 1;
 
 void kernel_main() {
@@ -63,7 +92,13 @@ void kernel_main() {
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address);
     const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address);
 
-    // ===== Startup: wait for sender to multicast c_4/c_5/c_6 L1 base addresses =====
+    // ===== Startup handshake: receive the owning sender's receive-buffer base addresses =====
+    // The sender owns three L1 receive buffers this untilizer fabric-feeds — c_4 (route_info),
+    // c_5 (payload), c_6 (metadata) — whose L1 base addresses are only known at runtime.  The
+    // sender packs all three into our cross_addr mailbox slot, then increments addr_ready.  The
+    // sender barriers those address writes before the inc, so once addr_ready fires the packed
+    // addresses are already in our local L1 and the read below is safe.  We reset addr_ready to 0
+    // so the slot is clean for the next program launch.
     volatile tt_l1_ptr uint32_t* addr_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_ready_semaphore_id));
     noc_semaphore_wait(addr_ready_sem_ptr, 1);
@@ -76,15 +111,26 @@ void kernel_main() {
     uint32_t sender_c5_l1_addr = cross_addr_ptr[1];
     uint32_t sender_c6_l1_addr = cross_addr_ptr[2];
 
+    // Pre-compute NOC addresses for the sender's three receive buffers and its data_avail
+    // semaphore.  A cross-device entry writes route_info/payload/metadata into these slots,
+    // then bumps data_avail to tell the sender one slot is ready to forward over the fabric.
     uint64_t sender_c4_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c4_l1_addr);
     uint64_t sender_c5_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c5_l1_addr);
     uint64_t sender_c6_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c6_l1_addr);
     uint64_t sender_data_avail_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_avail_semaphore_id));
 
+    // space_avail lives in our local L1; the sender increments it remotely once per slot it has
+    // finished forwarding.  We poll it as a per-entry credit (wait for produced_count+1) before
+    // overwriting a slot, so the sender's in-flight fabric send is never clobbered.
     volatile tt_l1_ptr uint32_t* space_avail_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(space_avail_semaphore_id));
 
+    // Metadata scratch layout: [meta_scratch_slots local ring slots][1 trailing cross-device slot].
+    // Local entries rotate through the ring so consecutive DRAM writes overlap; cross-device entries
+    // stage into the single trailing slot (xdev_metadata_scratch_addr) before the NOC write to c_6.
+    // route_info_scratch is a tiny local buffer where the 4×u32 route_info word group is assembled
+    // before being pushed to the sender's c_4 in one NOC write.
     uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
     uint32_t xdev_metadata_scratch_addr = metadata_scratch_addr + meta_scratch_slots * aligned_metadata_page_size;
     uint32_t route_info_scratch_addr = get_write_ptr(cb_route_info_scratch_id);
@@ -106,8 +152,10 @@ void kernel_main() {
         // Wait for reader to publish the per-batch route plan
         cb_wait_front(cb_plan_id, 1);
         uint32_t plan_addr = get_read_ptr(cb_plan_id);
-        volatile tt_l1_ptr uint32_t* plan = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(plan_addr);
-        uint32_t entry_count = plan[0];
+        volatile tt_l1_ptr PlanHeader* plan = reinterpret_cast<volatile tt_l1_ptr PlanHeader*>(plan_addr);
+        volatile tt_l1_ptr PlanEntry* entries =
+            reinterpret_cast<volatile tt_l1_ptr PlanEntry*>(plan_addr + sizeof(PlanHeader));
+        uint32_t entry_count = plan->entry_count;
         DPRINT_DISPATCH(
             "[W c={}] b={} draining plan entries={} produced_so_far={}\n",
             (uint32_t)core_id,
@@ -116,17 +164,20 @@ void kernel_main() {
             produced_count);
 
         {
+            // Drain every entry the reader recorded for this batch.  Each entry decodes to one
+            // untilized token; flags selects its destination: local DRAM here, or staged into the
+            // sender's receive buffers for the sender to forward over the fabric.
             for (uint32_t e = 0; e < entry_count; e++) {
-                uint32_t base = 8 + e * PLAN_ENTRY_U32S;
-                uint32_t flags = plan[base + 0];
-                uint32_t token_t = plan[base + 1];
-                uint32_t routed_expert = plan[base + 2];
-                uint32_t page_idx = plan[base + 3];
-                uint32_t token_idx = plan[base + 4];
-                uint32_t kw = plan[base + 5];
-                uint32_t k = kw >> 16;
-                int16_t weight = (int16_t)(kw & 0xFFFF);
+                volatile tt_l1_ptr PlanEntry* entry = &entries[e];
+                uint32_t flags = entry->flags;
+                uint32_t token_t = entry->token_t;
+                uint32_t routed_expert = entry->routed_expert;
+                uint32_t page_idx = entry->page_idx;
+                uint32_t token_idx = entry->token_idx;
+                uint32_t k = entry->k;
+                int16_t weight = entry->weight;
 
+                // Payload source: this token's untilized row inside the compute output CB.
                 uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;
                 bool is_local = (flags & PLAN_FLAG_LOCAL) != 0;
 
@@ -136,6 +187,9 @@ void kernel_main() {
                     //  and metadata source rotates through meta_scratch_slots ring slots.
                     //  Single noc_async_writes_flushed() at batch end covers reuse.
                     noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                    // Per-token metadata layout (5 × int32): [src chip, global token idx, top-k
+                    // slot, routed expert, routing weight].  Built into the next ring slot, then
+                    // written to the same DRAM page index as the payload.
                     uint32_t meta_addr =
                         metadata_scratch_addr + (local_count % meta_scratch_slots) * aligned_metadata_page_size;
                     volatile tt_l1_ptr int32_t* meta = reinterpret_cast<volatile tt_l1_ptr int32_t*>(meta_addr);
@@ -147,8 +201,12 @@ void kernel_main() {
                     noc_async_write_page(page_idx, metadata_addr_gen, meta_addr);
                     local_count++;
                 } else {
-                    uint32_t route = plan[base + 6];
-                    uint32_t distance = plan[base + 7];
+                    // Cross-device: stage this token into one sender slot as three NOC writes —
+                    // route_info (c_4), payload (c_5), metadata (c_6) — then signal data_avail so
+                    // the sender forwards it over the fabric.  route/distance tell the sender's
+                    // fabric writer where to send.
+                    uint32_t route = entry->route;
+                    uint32_t distance = entry->distance;
 
                     // Per-entry credit: wait until the sender has fabric-sent the slot we're
                     // about to overwrite (sender writer inc's space_avail once per slot freed).
@@ -184,6 +242,8 @@ void kernel_main() {
                         off += chunk;
                     }
 
+                    // Metadata: same 5 × int32 layout as the local path, staged in the dedicated
+                    // cross-device scratch slot, then written to the sender's c_6 slot.
                     volatile tt_l1_ptr int32_t* meta =
                         reinterpret_cast<volatile tt_l1_ptr int32_t*>(xdev_metadata_scratch_addr);
                     meta[0] = (int32_t)linearized_mesh_coord;
@@ -215,10 +275,14 @@ void kernel_main() {
         cb_pop_front(cb_untilize_id, read_batch_size);
     }
 
-    // After the last data entry: write ROUTE_INFO_SENTINEL as one final entry into the
-    // next slot. Must wait for space_avail like any regular entry.
+    // Teardown: the reader pushes one extra end-of-plan sentinel page after the last batch.
+    // Consume it (its entry_count is 0, so nothing was drained above for it).
     cb_wait_front(cb_plan_id, 1);
     cb_pop_front(cb_plan_id, 1);
+
+    // Then send ROUTE_INFO_SENTINEL as one final route_info entry into the next sender slot.
+    // It takes a real slot, so wait for a space_avail credit just like any data entry; the
+    // sender treats this sentinel as "no more tokens from this untilizer" and stops forwarding.
 
     DPRINT_DISPATCH(
         "[W c={}] loop DONE; WAIT space_avail>={} (have={}) to send SENTINEL\n",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -207,6 +207,7 @@ void kernel_main() {
                     // fabric writer where to send.
                     uint32_t route = entry->route;
                     uint32_t distance = entry->distance;
+                    uint32_t dst_chip = entry->dst_chip;
 
                     // Per-entry credit: wait until the sender has fabric-sent the slot we're
                     // about to overwrite (sender writer inc's space_avail once per slot freed).
@@ -222,10 +223,12 @@ void kernel_main() {
                     uint32_t slot = produced_count % writer_cb_size;
 
                     // Build route_info (4 × u32) in local scratch, send as one NOC write.
+                    // [3]=dst_chip carries the linearized dest device index for the sender's 2D
+                    // fabric route (ignored under 1D, where [0]=route/[1]=distance drive the send).
                     route_info_scratch[0] = route;
                     route_info_scratch[1] = distance;
                     route_info_scratch[2] = page_idx;
-                    route_info_scratch[3] = 0;
+                    route_info_scratch[3] = dst_chip;
                     uint64_t c4_slot = sender_c4_base_noc_addr + slot * route_info_slot_stride;
                     noc_async_write_one_packet_with_trid(
                         route_info_scratch_addr, c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -174,8 +174,9 @@ void kernel_main() {
                 uint32_t routed_expert = entry->routed_expert;
                 uint32_t page_idx = entry->page_idx;
                 uint32_t token_idx = entry->token_idx;
-                uint32_t k = entry->k;
-                int16_t weight = entry->weight;
+                uint32_t weight_k = entry->weight_k;
+                uint32_t k = unpack_k(weight_k);
+                int16_t weight = unpack_weight(weight_k);
 
                 // Payload source: this token's untilized row inside the compute output CB.
                 uint32_t src_addr = untilize_read_ptr + token_t * aligned_output_page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -30,7 +30,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<uint32_t> num_links,
     std::optional<tt::tt_fabric::Topology> topology,
     bool use_l1_small_for_semaphores,
-    bool use_fp8_dispatch) {
+    bool use_fp8_dispatch,
+    uint32_t num_untilizers_per_sender) {
     auto* mesh_device = input_tensor.device();
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
@@ -75,7 +76,8 @@ std::array<ttnn::Tensor, 2> dispatch(
         memory_config_,
         subdevice_core_range_set,
         use_l1_small_for_semaphores,
-        use_fp8_dispatch);
+        use_fp8_dispatch,
+        num_untilizers_per_sender);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -31,7 +31,8 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<uint32_t> num_links = 1,
     std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
     bool use_l1_small_for_semaphores = false,
-    bool use_fp8_dispatch = false);
+    bool use_fp8_dispatch = false,
+    uint32_t num_untilizers_per_sender = 2);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -69,8 +69,13 @@ void bind_dispatch(nb::module_& mod) {
                 Defaults to 1.
             topology (ttnn.Topology, optional): Fabric topology for remote writes.
                 Defaults to Linear.
-            fp8_output (bool, optional): Output dtype for the dispatched buffer.
-                Defaults to False.
+            use_l1_small_for_semaphores (bool, optional): Allocate the workload's
+                GlobalSemaphores in L1_SMALL instead of L1. Defaults to False.
+            use_fp8_dispatch (bool, optional): Pack the dispatched buffer as Fp8_e4m3
+                (DRAM allocated as UINT8). Requires TILE input layout, not supported on
+                Wormhole_B0. Defaults to False.
+            num_untilizers_per_sender (int, optional): Number of untilize cores per
+                sender on the tile-layout path.
 
         Returns:
             Tuple[ttnn.Tensor, ttnn.Tensor]:
@@ -100,7 +105,8 @@ void bind_dispatch(nb::module_& mod) {
         nb::arg("num_links") = 1,
         nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
         nb::arg("use_l1_small_for_semaphores") = false,
-        nb::arg("use_fp8_dispatch") = false);
+        nb::arg("use_fp8_dispatch") = false,
+        nb::arg("num_untilizers_per_sender") = 2);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch::detail


### PR DESCRIPTION
- This PR improves performance for the dispatch module
- Idea was to improve fabric usage ; we have to send tokens and metadata via fabric, and we can't control its speed ( we are bounded by fabric speed ) -> we want to utilize it as much as possible to minimize the op time
- Changes that were made:

1. Removed the logic where the sender core acted as an untilize core since that created a gap in fabric sends
2. Removed reader kernel from the sender core ; now, there is only a writer core on the sender that is responsible for fabric sends ; removing the reader kernel also mean't moving the routing plan creation logic on the untilizer cores
3. The offset tensor can be only changed by one untilize core at a time - the offset tensor lives just on one untilizer core ; untilizer core waits for its time slice to build the routing plan and change this offsets tensor ; untilizer cores get access to the offset tensor in round robin fashion. 
4. There are num_untilize_cores cb's with 16 slots on the sender where the untilizer cores write the payload and metadata
5. The number of untilize cores can now be parametrized - for some models maybe a different number would be ideal - for deepseek it is 2

## Perf improvement table

- ## !!! -*Tested on LB with FW that has same BW speed as GLX - fabric1d*

- It is expected for ring configuration to have much bigger gain than linear configuration ; linear configuration on it's edge devices already had > 80% fabric utilization since the fabric writes were long enough for the untilizer cores to prepare data for the next batch ; on ring, fabric writes were much faster resulting in lower fabric usage ; batchN was finished with fabric sends before compute managed to prepare the batchN+1 data

| Configuration            | Optimized (μs) | Main (μs)  | Gain (%) |
| ------------------------ | -------------: | ---------: | -------: |
| linear-8-1link-fp8_out   |       6,535.15 |   6,743.51 |    3.09% |
| linear-8-2link-fp8_out   |       3,357.13 |   3,522.60 |    4.70% |
| ring-8-1link-fp8_out     |       3,285.45 |   4,461.48 |   26.36% |
| ring-8-2link-fp8_out     |       1,736.08 |   2,866.99 |   39.45% |
| linear-8-1link-bf16_out  |      10,007.13 |  10,131.29 |    1.23% |
| linear-8-2link-bf16_out  |       5,082.91 |   5,192.51 |    2.11% |
| ring-8-1link-bf16_out    |       4,572.28 |   5,616.13 |   18.59% |
| ring-8-2link-bf16_out    |       2,472.73 |   3,533.24 |   30.02% |

## Tracy view of the fabric usage
- This was ran on ring-2link, bf16_out since it is the best example to see how there are no gaps now
### Before
<img width="1889" height="55" alt="image" src="https://github.com/user-attachments/assets/42dcc814-b156-45d5-8196-214dae4cf7e2" />

### After
<img width="1848" height="119" alt="image" src="https://github.com/user-attachments/assets/ec9de189-c424-4e34-8213-fe3958c08557" />

## Fabric usage % improvement tables

- For each device, for each sender, we can see how much more % it is utilized
<details>
<summary><code>linear-8-1link-bf16_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 92.64%      | 67.72%  |
| 1      | 0        | 95.01%      | 76.06%  |
| 2      | 0        | 96.54%      | 82.47%  |
| 3      | 0        | 96.51%      | 82.96%  |
| 4      | 0        | 92.73%      | 68.58%  |
| 5      | 0        | 94.94%      | 76.46%  |
| 6      | 0        | 96.45%      | 82.15%  |
| 7      | 0        | 96.35%      | 82.79%  |

</details>

<details>
<summary><code>linear-8-1link-fp8_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 89.65%      | 63.74%  |
| 1      | 0        | 92.55%      | 70.44%  |
| 2      | 0        | 94.65%      | 76.75%  |
| 3      | 0        | 94.69%      | 77.43%  |
| 4      | 0        | 89.71%      | 64.59%  |
| 5      | 0        | 92.32%      | 69.81%  |
| 6      | 0        | 94.51%      | 76.87%  |
| 7      | 0        | 94.40%      | 77.13%  |

</details>

<details>
<summary><code>linear-8-2link-bf16_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 93.23%      | 54.61%  |
| 0      | 1        | 93.08%      | 56.16%  |
| 1      | 0        | 95.06%      | 62.97%  |
| 1      | 1        | 95.04%      | 64.65%  |
| 2      | 0        | 96.52%      | 68.84%  |
| 2      | 1        | 96.61%      | 70.35%  |
| 3      | 0        | 96.52%      | 70.80%  |
| 3      | 1        | 96.62%      | 71.17%  |
| 4      | 0        | 92.82%      | 57.36%  |
| 4      | 1        | 92.80%      | 58.38%  |
| 5      | 0        | 94.81%      | 64.01%  |
| 5      | 1        | 94.84%      | 62.91%  |
| 6      | 0        | 96.28%      | 69.59%  |
| 6      | 1        | 96.20%      | 70.09%  |
| 7      | 0        | 96.23%      | 71.54%  |
| 7      | 1        | 96.12%      | 72.38%  |

</details>

<details>
<summary><code>linear-8-2link-fp8_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 89.93%      | 51.17%  |
| 0      | 1        | 89.93%      | 53.34%  |
| 1      | 0        | 92.63%      | 56.41%  |
| 1      | 1        | 92.56%      | 57.67%  |
| 2      | 0        | 94.65%      | 60.91%  |
| 2      | 1        | 94.82%      | 62.39%  |
| 3      | 0        | 94.74%      | 62.92%  |
| 3      | 1        | 94.88%      | 64.39%  |
| 4      | 0        | 89.63%      | 53.06%  |
| 4      | 1        | 89.53%      | 53.90%  |
| 5      | 0        | 92.10%      | 57.26%  |
| 5      | 1        | 92.15%      | 57.19%  |
| 6      | 0        | 94.30%      | 60.94%  |
| 6      | 1        | 94.10%      | 61.93%  |
| 7      | 0        | 94.25%      | 63.84%  |
| 7      | 1        | 94.04%      | 64.23%  |

</details>

<details>
<summary><code>ring-8-1link-bf16_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 92.17%      | 64.83%  |
| 1      | 0        | 92.23%      | 65.17%  |
| 2      | 0        | 92.44%      | 64.83%  |
| 3      | 0        | 92.37%      | 64.98%  |
| 4      | 0        | 92.13%      | 65.45%  |
| 5      | 0        | 92.06%      | 64.85%  |
| 6      | 0        | 92.18%      | 64.54%  |
| 7      | 0        | 92.12%      | 65.61%  |

</details>

<details>
<summary><code>ring-8-1link-fp8_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 89.22%      | 62.84%  |
| 1      | 0        | 89.27%      | 63.33%  |
| 2      | 0        | 89.57%      | 63.24%  |
| 3      | 0        | 89.48%      | 63.06%  |
| 4      | 0        | 89.14%      | 63.32%  |
| 5      | 0        | 89.11%      | 63.13%  |
| 6      | 0        | 89.06%      | 62.70%  |
| 7      | 0        | 89.05%      | 63.38%  |

</details>

<details>
<summary><code>ring-8-2link-bf16_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 92.78%      | 51.37%  |
| 0      | 1        | 92.59%      | 52.60%  |
| 1      | 0        | 92.21%      | 52.54%  |
| 1      | 1        | 92.27%      | 54.73%  |
| 2      | 0        | 92.69%      | 53.39%  |
| 2      | 1        | 92.61%      | 54.10%  |
| 3      | 0        | 92.93%      | 52.02%  |
| 3      | 1        | 93.18%      | 52.21%  |
| 4      | 0        | 92.25%      | 52.24%  |
| 4      | 1        | 92.21%      | 53.05%  |
| 5      | 0        | 92.30%      | 51.83%  |
| 5      | 1        | 92.47%      | 51.34%  |
| 6      | 0        | 92.08%      | 52.16%  |
| 6      | 1        | 91.88%      | 53.39%  |
| 7      | 0        | 92.03%      | 51.44%  |
| 7      | 1        | 91.94%      | 52.14%  |

</details>

<details>
<summary><code>ring-8-2link-fp8_out</code></summary>

| Device | Sender # | Optimized % | Main %  |
| -----: | -------: | ----------: | ------: |
| 0      | 0        | 89.60%      | 50.15%  |
| 0      | 1        | 89.48%      | 52.44%  |
| 1      | 0        | 89.44%      | 50.68%  |
| 1      | 1        | 89.41%      | 53.01%  |
| 2      | 0        | 89.75%      | 51.58%  |
| 2      | 1        | 89.73%      | 52.46%  |
| 3      | 0        | 89.82%      | 51.29%  |
| 3      | 1        | 89.93%      | 52.02%  |
| 4      | 0        | 89.05%      | 51.44%  |
| 4      | 1        | 89.06%      | 52.53%  |
| 5      | 0        | 89.05%      | 50.88%  |
| 5      | 1        | 89.20%      | 50.90%  |
| 6      | 0        | 88.72%      | 50.62%  |
| 6      | 1        | 88.66%      | 51.83%  |
| 7      | 0        | 88.69%      | 50.59%  |
| 7      | 1        | 88.70%      | 52.10%  |

</details>

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [ ] [![L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [ ] [![Demo SP Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nostojic/dispatch_two_untilizers)

#### Model tests

- [ ] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [ ] [![t3k-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_two_untilizers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_two_untilizers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_two_untilizers)