### PR TITLE
[DCAMP-649] exabox: forward run_cluster_validation flags via --validation-args

### DIFF
--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -239,11 +239,19 @@ source python_env/bin/activate
 
 Look for `All Detected Links are healthy` in the output. If you see `could not access or execute an executable`, see [Recovery Script Fails](./TROUBLESHOOTING.md#recovery-script-fails-with-could-not-access-or-execute-an-executable).
 
+**Tolerating missing cables:** by default, recovery fails if any expected cable is missing — either with `Encountered unrecoverable state` after 5 retrain attempts, or by early-exiting after a successful retrain without sending traffic. To validate the rest of the cluster when one or more cables are down, forward `--min-connections N` (relaxed mode, ASIC pair passes if it has at least N connections) via `--validation-args` and/or pass `--rerun-on-retrain` (rerun validation after a successful retrain so traffic actually runs).
+
+```bash
+./tools/scaleout/exabox/recover.sh --hosts <hosts> --validation-args "--min-connections 3" --rerun-on-retrain
+```
+
+Any other `run_cluster_validation` flag (e.g. `--hard-fail`, `--print-connectivity`, `--log-ethernet-metrics`) can be forwarded via `--validation-args`.
+
 ## Troubleshooting
 
 **Machine reboots during test**: If your machine reboots mid-test, the tests keep running on the other machines. You'll need to manually kill them or wait for them to timeout.
 
-**Missing connections** (`Channel/Port Connections found in FSD but missing in GSD`): Check cables are seated, verify you're using the right FSD file.
+**Missing connections** (`Channel/Port Connections found in FSD but missing in GSD`): Check cables are seated, verify you're using the right FSD file. If you only need to validate the rest of the cluster while a known cable is down, rerun with `--validation-args "--min-connections N"` and/or `--rerun-on-retrain` (see [Quick Health Check](#quick-health-check-for-developers)).
 
 **Timeouts** (`Timeout (10000 ms) waiting for physical cores`): Usually a transient issue. Issue a cluster-level reset (do NOT power cycle). If the issue persists, contact syseng in the `#exabox-infra` Slack channel. Power cycling should only be done in coordination with cluster managers (infra and cloud teams).
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -36,7 +36,21 @@ Optional:
     --factory-descriptor-path <path>        Path to factory system descriptor file (overrides --config defaults;
                                             when provided, cabling and deployment descriptors are ignored)
                                             (8x16 default: /data/scaleout_configs/5xBH_8x16_intrapod/fsd.textproto)
+    --rerun-on-retrain                      Rerun validation when Ethernet links are retrained
+                                            (the underlying tool early-exits after a successful retrain without sending
+                                            traffic; this reruns it to actually validate the cluster)
+    --validation-args <args>                Extra arguments passed verbatim to run_cluster_validation (quoted string)
+                                            e.g. --validation-args "--min-connections 2 --hard-fail"
+                                            Use this for any run_cluster_validation flag (relaxed validation, strict
+                                            failure, connectivity prints, metrics logging, etc.)
     --help                                  Display this help message and exit
+
+================================================================================
+To see the full list of run_cluster_validation flags forwardable via
+--validation-args, run (no cluster needed, --hosts is not required):
+
+    $0 --use-docker <image> --validation-args "--help"
+================================================================================
 
 Example:
     $0 --hosts bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08
@@ -63,6 +77,8 @@ CHECK=false
 MPI_IF="ens5f0np0"
 MPI_EXTRA_ARGS=()
 OUTPUT_DIR="recover-logs"
+RERUN_ON_RETRAIN=false
+VALIDATION_EXTRA_ARGS=()
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -193,6 +209,23 @@ while [[ $# -gt 0 ]]; do
             FACTORY_DESCRIPTOR_PATH="$2"
             shift 2
             ;;
+        --rerun-on-retrain)
+            if [[ -n "$2" ]] && [[ "$2" != --* ]]; then
+                echo "Error: --rerun-on-retrain does not accept a value"
+                exit 1
+            fi
+            RERUN_ON_RETRAIN=true
+            shift
+            ;;
+        --validation-args)
+            if [[ -z "$2" ]]; then
+                echo "Error: --validation-args requires a non-empty value"
+                exit 1
+            fi
+            read -ra _extra <<< "$2"
+            VALIDATION_EXTRA_ARGS+=("${_extra[@]}")
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -204,6 +237,21 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
     esac
+done
+
+# If the operator forwarded --help / -h through --validation-args, just print
+# run_cluster_validation --help from the docker image and exit. Short-circuits
+# before --hosts validation since no cluster operation is performed.
+for _arg in "${VALIDATION_EXTRA_ARGS[@]}"; do
+    if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
+        if [[ -z "$DOCKER_IMAGE" ]]; then
+            echo "Error: --validation-args \"--help\" requires --use-docker <image>"
+            echo "Example: $0 --use-docker <ghcr-image> --validation-args \"--help\""
+            exit 1
+        fi
+        exec docker run --rm --entrypoint='' "$DOCKER_IMAGE" \
+            ./build/tools/scaleout/run_cluster_validation --help
+    fi
 done
 
 # Validate required arguments
@@ -290,6 +338,10 @@ echo "Skip reset: $SKIP_RESET"
 echo "Skip validation: $SKIP_VALIDATION"
 echo "Output directory: $OUTPUT_DIR"
 echo "Log file: $LOG_FILE"
+echo "Rerun on retrain: $RERUN_ON_RETRAIN"
+if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
+    echo "Extra validation args: ${VALIDATION_EXTRA_ARGS[*]}"
+fi
 echo "=========================================="
 echo ""
 
@@ -316,26 +368,41 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
         VALIDATION_ARGS+=(--send-traffic)
     fi
     VALIDATION_ARGS+=(--num-iterations "$NUM_ITERATIONS")
+    if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
+        VALIDATION_ARGS+=("${VALIDATION_EXTRA_ARGS[@]}")
+    fi
+
+    run_cluster_validation() {
+        if [[ -n "$DOCKER_IMAGE" ]]; then
+            ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+                --empty-entrypoint \
+                --mpi-interface "$MPI_IF" \
+                --volume /data/scaleout_configs \
+                "${MPI_EXTRA_ARGS[@]}" \
+                --host "$HOSTS" \
+                ./build/tools/scaleout/run_cluster_validation \
+                "${VALIDATION_ARGS[@]}"
+        else
+            mpirun --host "$HOSTS" \
+                --mca btl_tcp_if_include "$MPI_IF" \
+                "${MPI_EXTRA_ARGS[@]}" \
+                --tag-output \
+                ./build/tools/scaleout/run_cluster_validation \
+                "${VALIDATION_ARGS[@]}"
+        fi
+    }
 
     echo ""
     echo "Running cluster validation..."
-    if [[ -n "$DOCKER_IMAGE" ]]; then
-        ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
-            --empty-entrypoint \
-            --mpi-interface "$MPI_IF" \
-            --volume /data/scaleout_configs \
-            "${MPI_EXTRA_ARGS[@]}" \
-            --host "$HOSTS" \
-            ./build/tools/scaleout/run_cluster_validation \
-            "${VALIDATION_ARGS[@]}"
-    else
-        mpirun --host "$HOSTS" \
-            --mca btl_tcp_if_include "$MPI_IF" \
-            "${MPI_EXTRA_ARGS[@]}" \
-            --tag-output \
-            ./build/tools/scaleout/run_cluster_validation \
-            "${VALIDATION_ARGS[@]}"
+    VALIDATION_LOG=$(mktemp)
+    run_cluster_validation 2>&1 | tee "$VALIDATION_LOG"
+
+    if [[ "$RERUN_ON_RETRAIN" == true ]] && grep -q "Ethernet Links were Retrained" "$VALIDATION_LOG"; then
+        echo ""
+        echo "Ethernet links were retrained — rerunning validation to issue traffic..."
+        run_cluster_validation
     fi
+    rm -f "$VALIDATION_LOG"
 else
     echo "Skipping validation (--skip-validation)"
 fi

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -29,7 +29,18 @@ Optional:
     --mpi-if <interface>                    Network interface for MPI TCP transport (default: ens5f0np0)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
+    --validation-args <args>                Extra arguments passed verbatim to run_cluster_validation (quoted string)
+                                            e.g. --validation-args "--min-connections 2 --hard-fail"
+                                            Use this for any run_cluster_validation flag (relaxed validation, strict
+                                            failure, connectivity prints, metrics logging, etc.)
     --help                                  Display this help message and exit
+
+================================================================================
+To see the full list of run_cluster_validation flags forwardable via
+--validation-args, run (no cluster needed, --hosts is not required):
+
+    $0 --image <image> --validation-args "--help"
+================================================================================
 
 Example:
     $0 --hosts bh-glx-c01u02,bh-glx-c01u08,bh-glx-c02u02,bh-glx-c02u08 \\
@@ -51,6 +62,7 @@ EXTRA_VOLUMES=(/data/scaleout_configs)
 RERUN_ON_RETRAIN=false
 MPI_IF="ens5f0np0"
 MPI_EXTRA_ARGS=()
+VALIDATION_EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -147,6 +159,15 @@ while [[ $# -gt 0 ]]; do
             MPI_EXTRA_ARGS+=("${_extra[@]}")
             shift 2
             ;;
+        --validation-args)
+            if [[ -z "$2" ]]; then
+                echo "Error: --validation-args requires a non-empty value"
+                exit 1
+            fi
+            read -ra _extra <<< "$2"
+            VALIDATION_EXTRA_ARGS+=("${_extra[@]}")
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -158,6 +179,21 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
     esac
+done
+
+# If the operator forwarded --help / -h through --validation-args, just print
+# run_cluster_validation --help from the docker image and exit. Short-circuits
+# before --hosts validation since no cluster operation is performed.
+for _arg in "${VALIDATION_EXTRA_ARGS[@]}"; do
+    if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
+        if [[ -z "$DOCKER_IMAGE" ]]; then
+            echo "Error: --validation-args \"--help\" requires --image <docker-image>"
+            echo "Example: $0 --image <ghcr-image> --validation-args \"--help\""
+            exit 1
+        fi
+        exec docker run --rm --entrypoint='' "$DOCKER_IMAGE" \
+            ./build/tools/scaleout/run_cluster_validation --help
+    fi
 done
 
 # Validate required arguments
@@ -196,6 +232,7 @@ run_cluster_validation() {
             --tag-output \
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
+            "${VALIDATION_EXTRA_ARGS[@]}" \
             --send-traffic \
             --num-iterations 10 \
             --output-path "$validation_output_path"
@@ -208,6 +245,7 @@ run_cluster_validation() {
             --host "$HOSTS" \
             ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
+            "${VALIDATION_EXTRA_ARGS[@]}" \
             --send-traffic \
             --num-iterations 10 \
             --output-path "$validation_output_path"
@@ -284,6 +322,9 @@ if [[ "${#MPI_EXTRA_ARGS[@]}" -gt 0 ]]; then
 fi
 echo "Number of iterations: $ITERATIONS"
 echo "Output directory: $OUTPUT_DIR"
+if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
+    echo "Extra validation args: ${VALIDATION_EXTRA_ARGS[*]}"
+fi
 echo ""
 
 # Create output directory if it doesn't exist and resolve to an absolute path so


### PR DESCRIPTION
### Issue
https://tenstorrent.atlassian.net/browse/DCAMP-649

### PR Category
Feature

### Summary
Recovery fails when a cable is missing: `run_cluster_validation` either throws "unrecoverable state" after 5 retrain attempts, or early-exits without traffic on a successful retrain. Adds `--rerun-on-retrain` to recover.sh and `--validation-args "<args>"` to both wrappers — generic pass-through to run_cluster_validation (e.g. `--validation-args "--min-connections 2 --hard-fail"`). Mirrors the existing `--mpi-args` pattern, so future flags don't need wrapper plumbing. `--validation-args "--help"` short-circuits to a wrapper-mediated `docker run --help` so operators can discover forwardable flags without leaving the script.

### Notes for reviewers
- Wrappers + README only; no C++ change.
- No local-build dependency. The `--validation-args "--help"` short-circuit uses the image already passed via `--use-docker` / `--image`.
- Convention: use `--validation-args` for any future run_cluster_validation flag unless it needs script-side behavior.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/min_connections_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/min_connections_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/min_connections_validation)