### PR TITLE
Support indexed ND-sharded KV in ring joint SDPA

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -242,6 +242,7 @@ MODEL_CONFIGS = generate_model_configs(MESH_CONFIG)
 # Accuracy threshold constants
 DEFAULT_PCC_THRESHOLD = 0.994
 DEFAULT_RMSE_THRESHOLD = 0.05
+NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 
 from tests.nightly.sdpa_perf_utils import (
     ARCH_CONSTANTS,
@@ -264,7 +265,7 @@ def fa_rand(*shape):
     return normal_1 + normal_2 * bernoulli
 
 
-def torch_joint_sdpa_reference(q, k, v, joint_q, joint_k, joint_v, is_causal=False):
+def torch_sdpa_reference(q, k, v, is_causal=False):
     """
     Memory-efficient PyTorch reference for ring joint attention.
 
@@ -275,14 +276,8 @@ def torch_joint_sdpa_reference(q, k, v, joint_q, joint_k, joint_v, is_causal=Fal
     SEQ_CHUNK = 4096
     HEAD_CHUNK = 16
 
-    main_seq_len = q.size(2)
-
-    combined_q = torch.cat([q, joint_q], dim=2)
-    combined_k = torch.cat([k, joint_k], dim=2)
-    combined_v = torch.cat([v, joint_v], dim=2)
-
-    B, H, total_seq, _ = combined_q.shape
-    Dv = combined_v.shape[-1]
+    B, H, total_seq, _ = q.shape
+    Dv = v.shape[-1]
 
     def take_heads(t, h_start, h_end):
         # MLA broadcasts a single KV head across all Q heads via expand (no copy).
@@ -292,18 +287,18 @@ def torch_joint_sdpa_reference(q, k, v, joint_q, joint_k, joint_v, is_causal=Fal
 
     if total_seq <= SEQ_CHUNK and H <= HEAD_CHUNK:
         attn_out = torch.nn.functional.scaled_dot_product_attention(
-            combined_q,
-            take_heads(combined_k, 0, H),
-            take_heads(combined_v, 0, H),
+            q,
+            take_heads(k, 0, H),
+            take_heads(v, 0, H),
             is_causal=is_causal,
         )
     else:
-        attn_out = torch.empty(B, H, total_seq, Dv, dtype=combined_q.dtype)
+        attn_out = torch.empty(B, H, total_seq, Dv, dtype=q.dtype)
         for h_start in range(0, H, HEAD_CHUNK):
             h_end = min(h_start + HEAD_CHUNK, H)
-            q_heads = combined_q[:, h_start:h_end]
-            k_heads = take_heads(combined_k, h_start, h_end)
-            v_heads = take_heads(combined_v, h_start, h_end)
+            q_heads = q[:, h_start:h_end]
+            k_heads = take_heads(k, h_start, h_end)
+            v_heads = take_heads(v, h_start, h_end)
             for seq_start in range(0, total_seq, SEQ_CHUNK):
                 seq_end = min(seq_start + SEQ_CHUNK, total_seq)
                 q_chunk = q_heads[:, :, seq_start:seq_end]
@@ -318,7 +313,21 @@ def torch_joint_sdpa_reference(q, k, v, joint_q, joint_k, joint_v, is_causal=Fal
                     out = torch.nn.functional.scaled_dot_product_attention(q_chunk, k_heads, v_heads)
                 attn_out[:, h_start:h_end, seq_start:seq_end] = out
 
-    return attn_out[:, :, :main_seq_len], attn_out[:, :, main_seq_len:]
+    return attn_out
+
+
+def nd_sharded_dram_memory_config(device, head_dim):
+    num_dram_banks = device.dram_grid_size().x
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(num_dram_banks)
+    ]
+    nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, head_dim],
+        grid=ttnn.CoreRangeSet(core_ranges),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    return ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=nd_shard_spec)
 
 
 # ============================================================================
@@ -377,6 +386,80 @@ def generate_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, Mode
 def create_global_semaphores(mesh_device, cores, initial_value):
     """Create global semaphore handles for CCL coordination."""
     return [ttnn.create_global_semaphore(mesh_device, cores, initial_value) for _ in range(2)]
+
+
+def to_balanced_growing_cache_layout(src_full, sp_size, chunk_size, last_uploaded_chunk):
+    """Pack a growing chunked K/V cache into the per-device slab layout expected by ring joint SDPA.
+
+    "Balanced" here names the chunked cache storage layout, not the causal zigzag work balancing
+    controlled by the is_balanced flag.
+    """
+    n_populated = last_uploaded_chunk + 1
+    slab_rows = chunk_size // sp_size
+    K_local_curr = n_populated * slab_rows
+    populated_len = n_populated * chunk_size
+    b, nh, _, d = src_full.shape
+    perm = torch.zeros(b, nh, populated_len, d, dtype=src_full.dtype, device=src_full.device)
+    for dev in range(sp_size):
+        for chunk in range(n_populated):
+            local_start = dev * K_local_curr + chunk * slab_rows
+            global_start = chunk * chunk_size + dev * slab_rows
+            perm[:, :, local_start : local_start + slab_rows, :] = src_full[
+                :, :, global_start : global_start + slab_rows, :
+            ]
+    return perm
+
+
+def call_sdpa(
+    tt_q,
+    tt_k,
+    tt_v,
+    logical_n,
+    is_causal,
+    is_balanced,
+    p_buf_k,
+    p_buf_v,
+    program_config,
+    compute_kernel_config,
+    ccl_semaphore_handles,
+    num_links,
+    sp_axis,
+    mesh_device,
+    topology,
+    worker_sub_device_id,
+    ccl_column,
+    *,
+    scale=None,
+    cache_batch_idx=None,
+):
+    tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+        tt_q,
+        tt_k,
+        tt_v,
+        None,
+        None,
+        None,
+        persistent_output_buffer_k=p_buf_k,
+        persistent_output_buffer_v=p_buf_v,
+        joint_strategy="rear",
+        logical_n=logical_n,
+        is_causal=is_causal,
+        is_balanced=is_balanced,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        dim=2,
+        multi_device_global_semaphore=ccl_semaphore_handles,
+        num_links=num_links,
+        cluster_axis=sp_axis,
+        mesh_device=mesh_device,
+        topology=topology,
+        subdevice_id=worker_sub_device_id,
+        ccl_core_grid_offset=(ccl_column, 0),
+        use_column_major_ccl=True,
+        scale=scale,
+        cache_batch_idx=cache_batch_idx,
+    )
+    return tt_out
 
 
 def run_ring_joint_sdpa(
@@ -474,8 +557,6 @@ def run_ring_joint_sdpa(
     sp_axis = 1  # Column axis for sequence parallel (ring axis)
     tp_axis = 0  # Row axis for tensor parallel (head axis)
 
-    joint_seq_len = 0  # Use empty joint sequence (WAN 2.2 compatible)
-
     if mesh_config.sp_size < 2:
         pytest.skip(f"Ring joint attention requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
 
@@ -523,11 +604,6 @@ def run_ring_joint_sdpa(
         Q = fa_rand(b, nhq, sq, d_q)
         K = fa_rand(b, nhk, sq, d_k)
         V = fa_rand(b, nhv, sq, d_v)
-
-        # Joint tensors - Use dummy tensors like WAN 2.2 (empty sequence, zero-filled)
-        joint_Q = torch.zeros((b, nhq, joint_seq_len, d_q), dtype=torch.bfloat16)
-        joint_K = torch.zeros((b, nhk, joint_seq_len, d_k), dtype=torch.bfloat16)
-        joint_V = torch.zeros((b, nhv, joint_seq_len, d_v), dtype=torch.bfloat16)
 
         # Keep original tensors for reference comparison (before any reordering)
         Q_original, K_original, V_original = Q, K, V
@@ -602,14 +678,6 @@ def run_ring_joint_sdpa(
         if mesh_config.tp_size > 1 and nhk != 1:
             sdpa_k_shard_dims[tp_axis] = 1
 
-        sdpa_joint_shard_dims = [None, None]
-        if mesh_config.tp_size > 1:
-            sdpa_joint_shard_dims[tp_axis] = 1
-
-        sdpa_joint_k_shard_dims = [None, None]
-        if mesh_config.tp_size > 1 and nhk != 1:
-            sdpa_joint_k_shard_dims[tp_axis] = 1
-
         # Q tensor uses q_dtype
         tt_Q = ttnn.from_torch(
             Q,
@@ -639,33 +707,6 @@ def run_ring_joint_sdpa(
                 mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
             ),
         )
-        tt_joint_Q = ttnn.from_torch(
-            joint_Q,
-            dtype=q_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
-            ),
-        )
-        tt_joint_K = ttnn.from_torch(
-            joint_K,
-            dtype=kv_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_k_shard_dims
-            ),
-        )
-        tt_joint_V = ttnn.from_torch(
-            joint_V,
-            dtype=kv_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
-            ),
-        )
 
         # Set logical_n to the original full sequence length
         corrected_logical_n = sq
@@ -677,30 +718,24 @@ def run_ring_joint_sdpa(
         # Run ring joint attention
         reference_output = None
         for i in range(num_iterations):
-            tt_out, tt_joint_out, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+            tt_out = call_sdpa(
                 tt_Q,
                 tt_K,
                 tt_V,
-                tt_joint_Q,
-                tt_joint_K,
-                tt_joint_V,
-                persistent_output_buffer_k=persistent_output_buffer_k,
-                persistent_output_buffer_v=persistent_output_buffer_v,
-                joint_strategy="rear",
-                logical_n=corrected_logical_n,
+                corrected_logical_n,
                 is_causal=is_causal,
                 is_balanced=is_balanced,
+                p_buf_k=persistent_output_buffer_k,
+                p_buf_v=persistent_output_buffer_v,
                 program_config=program_config,
                 compute_kernel_config=compute_kernel_config,
-                dim=2,
-                multi_device_global_semaphore=ccl_semaphore_handles,
+                ccl_semaphore_handles=ccl_semaphore_handles,
                 num_links=num_links,
-                cluster_axis=sp_axis,
+                sp_axis=sp_axis,
                 mesh_device=mesh_device,
                 topology=topology,
-                subdevice_id=worker_sub_device_id,
-                ccl_core_grid_offset=(ccl_column, 0),  # Point to CCL column
-                use_column_major_ccl=True,
+                worker_sub_device_id=worker_sub_device_id,
+                ccl_column=ccl_column,
             )
 
             # Convert main output to torch and slice out tile-padding
@@ -736,35 +771,8 @@ def run_ring_joint_sdpa(
         if not do_check:
             return
 
-        # Convert and verify joint output (only if joint_seq_len > 0)
-        if joint_seq_len > 0:
-            if mesh_config.arch_type.startswith("galaxy"):
-                joint_row_dim = sdpa_joint_shard_dims[0] if sdpa_joint_shard_dims[0] is not None else -1
-                joint_col_dim = sdpa_joint_shard_dims[1] if sdpa_joint_shard_dims[1] is not None else -1
-                tt_joint_out_torch = ttnn.to_torch(
-                    tt_joint_out,
-                    mesh_composer=ttnn.create_mesh_composer(
-                        mesh_device, ttnn.MeshComposerConfig(joint_row_dim, joint_col_dim)
-                    ),
-                )
-            else:
-                tt_joint_out_torch = ttnn.to_torch(
-                    tt_joint_out,
-                    mesh_composer=ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(1, -1)),
-                )
-
-            if tt_joint_out_torch.shape[3] != d_v:
-                tt_joint_out_torch = tt_joint_out_torch[:, :, :, :d_v]
-            if tt_joint_out_torch.shape[0] > 1:
-                tt_joint_out_torch = tt_joint_out_torch[0:1, :, :, :]
-            tt_joint_out_torch = tt_joint_out_torch[:, :, :joint_seq_len, :]
-        else:
-            logger.info("Joint output - Dummy tensors (seq_len=0), skipping accuracy check (wan2.2 compatible)")
-
         # Compute PyTorch reference on ORIGINAL data (before balanced reordering)
-        gt_main, gt_joint = torch_joint_sdpa_reference(
-            Q_original, K_original, V_original, joint_Q, joint_K, joint_V, is_causal=is_causal
-        )
+        gt_main = torch_sdpa_reference(Q_original, K_original, V_original, is_causal=is_causal)
 
         # Verify accuracy for main output
         out_pass_main, out_pcc_main = comp_pcc(gt_main, tt_out_torch, pcc_threshold)
@@ -774,15 +782,6 @@ def run_ring_joint_sdpa(
         if rmse_threshold is not None:
             assert rmse_main < rmse_threshold, f"Main RMSE {rmse_main:.6f} exceeds threshold {rmse_threshold}"
         assert out_pass_main, f"Main PCC {out_pcc_main} below threshold {pcc_threshold}"
-
-        # Verify accuracy for joint output
-        if joint_seq_len > 0:
-            out_pass_joint, out_pcc_joint = comp_pcc(gt_joint, tt_joint_out_torch, pcc_threshold)
-            rmse_joint = torch.sqrt(((gt_joint - tt_joint_out_torch) ** 2).mean()).item()
-            logger.info(f"Joint output - PCC: {out_pcc_joint}, RMSE: {rmse_joint:.6f}")
-            if rmse_threshold is not None:
-                assert rmse_joint < rmse_threshold, f"Joint RMSE {rmse_joint:.6f} exceeds threshold {rmse_threshold}"
-            assert out_pass_joint, f"Joint PCC {out_pcc_joint} below threshold {pcc_threshold}"
 
     finally:
         # Clean up mesh device
@@ -814,9 +813,13 @@ def run_ring_joint_sdpa_chunked(
     chunk_size: int = CHUNKED_PREFILL_CHUNK_SIZE,
     total_seq: int = CHUNKED_PREFILL_TOTAL_SEQ,
     pcc_threshold: float = CHUNKED_PREFILL_PCC_THRESHOLD,
+    rmse_threshold: float = None,
     q_chunk_size: int = None,
     k_chunk_size: int = None,
     num_iterations: int = 1,
+    indexed_nd_sharded_kv_cache: bool = False,
+    cache_batch_idx: int = 1,
+    cache_batch: int = 2,
 ):
     """
     Validate ring joint SDPA chunked-prefill against a full-sequence torch oracle.
@@ -837,6 +840,9 @@ def run_ring_joint_sdpa_chunked(
     assert total_seq % sp_size == 0, f"total_seq {total_seq} must divide sp_size {sp_size}"
     assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} must divide sp_size {sp_size}"
     assert total_seq % chunk_size == 0, f"total_seq {total_seq} must be a multiple of chunk_size {chunk_size}"
+    if indexed_nd_sharded_kv_cache:
+        assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
+        assert 0 <= cache_batch_idx < cache_batch, f"cache_batch_idx {cache_batch_idx} must be in [0, {cache_batch})"
 
     n_chunks = total_seq // chunk_size
 
@@ -870,7 +876,6 @@ def run_ring_joint_sdpa_chunked(
 
     sp_axis = 1
     tp_axis = 0
-    joint_seq_len = 0
     num_links = 2
 
     mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
@@ -892,15 +897,11 @@ def run_ring_joint_sdpa_chunked(
 
         ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
 
-        joint_Q = torch.zeros((b, nhq, joint_seq_len, d_q), dtype=torch.bfloat16)
-        joint_K = torch.zeros((b, nhk, joint_seq_len, d_k), dtype=torch.bfloat16)
-        joint_V = torch.zeros((b, nhv, joint_seq_len, d_v), dtype=torch.bfloat16)
-
         torch.manual_seed(CHUNKED_PREFILL_SEED)
         Q_full = fa_rand(b, nhq, total_seq, d_q)
         K_full = fa_rand(b, nhk, total_seq, d_k)
         V_full = fa_rand(b, nhv, total_seq, d_v)
-        ref_full, _ = torch_joint_sdpa_reference(Q_full, K_full, V_full, joint_Q, joint_K, joint_V, is_causal=True)
+        ref_full = torch_sdpa_reference(Q_full, K_full, V_full, is_causal=True)
 
         sdpa_input_shard_dims = [None, None]
         sdpa_input_shard_dims[sp_axis] = 2
@@ -911,14 +912,6 @@ def run_ring_joint_sdpa_chunked(
         sdpa_k_shard_dims[sp_axis] = 2
         if mesh_config.tp_size > 1 and nhk != 1:
             sdpa_k_shard_dims[tp_axis] = 1
-
-        sdpa_joint_shard_dims = [None, None]
-        if mesh_config.tp_size > 1:
-            sdpa_joint_shard_dims[tp_axis] = 1
-
-        sdpa_joint_k_shard_dims = [None, None]
-        if mesh_config.tp_size > 1 and nhk != 1:
-            sdpa_joint_k_shard_dims[tp_axis] = 1
 
         persistent_k_shard_dims = [None, None]
         if mesh_config.tp_size > 1 and nhk != 1:
@@ -957,7 +950,10 @@ def run_ring_joint_sdpa_chunked(
                 ),
             )
 
-        def upload_k(k_host):
+        def upload_k(k_host, memory_config=None):
+            kwargs = {}
+            if memory_config is not None:
+                kwargs["memory_config"] = memory_config
             return ttnn.from_torch(
                 k_host,
                 dtype=kv_dtype,
@@ -966,9 +962,13 @@ def run_ring_joint_sdpa_chunked(
                 mesh_mapper=ttnn.ShardTensor2dMesh(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_k_shard_dims
                 ),
+                **kwargs,
             )
 
-        def upload_v(v_host):
+        def upload_v(v_host, memory_config=None):
+            kwargs = {}
+            if memory_config is not None:
+                kwargs["memory_config"] = memory_config
             return ttnn.from_torch(
                 v_host,
                 dtype=kv_dtype,
@@ -977,63 +977,8 @@ def run_ring_joint_sdpa_chunked(
                 mesh_mapper=ttnn.ShardTensor2dMesh(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
                 ),
+                **kwargs,
             )
-
-        tt_joint_Q = ttnn.from_torch(
-            joint_Q,
-            dtype=q_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
-            ),
-        )
-        tt_joint_K = ttnn.from_torch(
-            joint_K,
-            dtype=kv_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_k_shard_dims
-            ),
-        )
-        tt_joint_V = ttnn.from_torch(
-            joint_V,
-            dtype=kv_dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
-            ),
-        )
-
-        def call_sdpa(tt_Q, tt_K, tt_V, logical_n, is_causal, p_buf_k, p_buf_v):
-            tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
-                tt_Q,
-                tt_K,
-                tt_V,
-                tt_joint_Q,
-                tt_joint_K,
-                tt_joint_V,
-                persistent_output_buffer_k=p_buf_k,
-                persistent_output_buffer_v=p_buf_v,
-                joint_strategy="rear",
-                logical_n=logical_n,
-                is_causal=is_causal,
-                is_balanced=is_balanced,
-                program_config=program_config,
-                compute_kernel_config=compute_kernel_config,
-                dim=2,
-                multi_device_global_semaphore=ccl_semaphore_handles,
-                num_links=num_links,
-                cluster_axis=sp_axis,
-                mesh_device=mesh_device,
-                topology=topology,
-                subdevice_id=worker_sub_device_id,
-                ccl_core_grid_offset=(ccl_column, 0),
-                use_column_major_ccl=True,
-            )
-            return tt_out
 
         def to_host(tt_out, expected_q_len):
             out = ttnn.to_torch(
@@ -1047,33 +992,19 @@ def run_ring_joint_sdpa_chunked(
         logger.info(
             f"Chunked prefill: model={model.name}, total_seq={total_seq}, "
             f"sp_size={sp_size}, per-device Q seq_len={total_seq // sp_size}, "
-            f"q_chunk={q_chunk_size}, k_chunk={k_chunk_size}"
+            f"q_chunk={q_chunk_size}, k_chunk={k_chunk_size}, "
+            f"indexed_nd_sharded_kv_cache={indexed_nd_sharded_kv_cache}"
         )
 
-        # Balanced K/V layout: device d's local slab c holds global rows
-        # [c*chunk_size + d*slab_rows, c*chunk_size + (d+1)*slab_rows). Cache grows one
-        # chunk per call → program cache forks one entry per chunk.
+        # Chunked K/V cache layout: device d's local slab c holds global rows
+        # [c*chunk_size + d*slab_rows, c*chunk_size + (d+1)*slab_rows). This packing is
+        # independent of the is_balanced causal zigzag mode; the cache grows one chunk per call.
         slab_rows = chunk_size // sp_size
         assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} not divisible by sp_size {sp_size}"
         assert slab_rows % 32 == 0, f"slab_rows {slab_rows} not tile-aligned (TILE_HEIGHT=32)"
 
-        def to_balanced_growing(src_full, last_uploaded_chunk):
-            """Permute src_full into balanced per-device layout for the populated prefix
-            [0..last_uploaded_chunk]; returns length (last_uploaded_chunk + 1) * chunk_size.
-            """
-            n_populated = last_uploaded_chunk + 1
-            K_local_curr = n_populated * slab_rows
-            populated_len = n_populated * chunk_size
-            b_, nh_, _, d_ = src_full.shape
-            perm = torch.zeros(b_, nh_, populated_len, d_, dtype=src_full.dtype, device=src_full.device)
-            for dev in range(sp_size):
-                for c in range(n_populated):
-                    local_start = dev * K_local_curr + c * slab_rows
-                    global_start = c * chunk_size + dev * slab_rows
-                    perm[:, :, local_start : local_start + slab_rows, :] = src_full[
-                        :, :, global_start : global_start + slab_rows, :
-                    ]
-            return perm
+        k_memory_config = nd_sharded_dram_memory_config(mesh_device, d_k) if indexed_nd_sharded_kv_cache else None
+        v_memory_config = nd_sharded_dram_memory_config(mesh_device, d_v) if indexed_nd_sharded_kv_cache else None
 
         # SUT: per-chunk calls with growing K/V cache + growing logical_n.
         # In determinism mode (num_iterations > 1), the entire n_chunks sequence is
@@ -1085,17 +1016,30 @@ def run_ring_joint_sdpa_chunked(
             for i in range(n_chunks):
                 s, e = i * chunk_size, (i + 1) * chunk_size
 
-                K_balanced = to_balanced_growing(K_full, i)
-                V_balanced = to_balanced_growing(V_full, i)
+                K_balanced = to_balanced_growing_cache_layout(K_full, sp_size, chunk_size, i)
+                V_balanced = to_balanced_growing_cache_layout(V_full, sp_size, chunk_size, i)
                 Q_chunk = Q_full[:, :, s:e, :].contiguous()
+                kv_buffer_batch = b
+                cache_batch_idx_arg = None
+
+                if indexed_nd_sharded_kv_cache:
+                    kv_buffer_batch = cache_batch
+                    cache_batch_idx_arg = cache_batch_idx
+                    K_input = torch.randn(cache_batch, nhk, e, d_k, dtype=K_balanced.dtype) * 100
+                    V_input = torch.randn(cache_batch, nhv, e, d_v, dtype=V_balanced.dtype) * 100
+                    K_input[cache_batch_idx : cache_batch_idx + 1] = K_balanced
+                    V_input[cache_batch_idx : cache_batch_idx + 1] = V_balanced
+                else:
+                    K_input = K_balanced
+                    V_input = V_balanced
 
                 tt_Q = upload_q(Q_chunk)
-                tt_K = upload_k(K_balanced)
-                tt_V = upload_v(V_balanced)
+                tt_K = upload_k(K_input, memory_config=k_memory_config)
+                tt_V = upload_v(V_input, memory_config=v_memory_config)
 
                 # AllGather output buffer sized to post-gather K/V: N_global == (i+1) * chunk_size.
                 persistent_output_buffer_k = ttnn.from_torch(
-                    torch.zeros(b, nhk, e, d_k),
+                    torch.zeros(kv_buffer_batch, nhk, e, d_k),
                     dtype=kv_dtype,
                     layout=ttnn.TILE_LAYOUT,
                     device=mesh_device,
@@ -1104,7 +1048,7 @@ def run_ring_joint_sdpa_chunked(
                     ),
                 )
                 persistent_output_buffer_v = ttnn.from_torch(
-                    torch.zeros(b, nhv, e, d_v),
+                    torch.zeros(kv_buffer_batch, nhv, e, d_v),
                     dtype=kv_dtype,
                     layout=ttnn.TILE_LAYOUT,
                     device=mesh_device,
@@ -1120,8 +1064,19 @@ def run_ring_joint_sdpa_chunked(
                         tt_V,
                         e,
                         is_causal=True,
+                        is_balanced=is_balanced,
                         p_buf_k=persistent_output_buffer_k,
                         p_buf_v=persistent_output_buffer_v,
+                        program_config=program_config,
+                        compute_kernel_config=compute_kernel_config,
+                        ccl_semaphore_handles=ccl_semaphore_handles,
+                        num_links=num_links,
+                        sp_axis=sp_axis,
+                        mesh_device=mesh_device,
+                        topology=topology,
+                        worker_sub_device_id=worker_sub_device_id,
+                        ccl_column=ccl_column,
+                        cache_batch_idx=cache_batch_idx_arg,
                     )
                 except Exception as exc:
                     pytest.fail(
@@ -1138,11 +1093,12 @@ def run_ring_joint_sdpa_chunked(
                 expected_i = ref_full[:, :, s:e, :]
                 passed, pcc = comp_pcc(expected_i, out_i, pcc_threshold)
                 rmse = torch.sqrt(((expected_i - out_i) ** 2).mean()).item()
+                rmse_passed = rmse_threshold is None or rmse < rmse_threshold
                 logger.info(
                     f"Chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: PCC={pcc} RMSE={rmse:.6f} "
-                    f"-> {'PASS' if passed else 'FAIL'}"
+                    f"-> {'PASS' if passed and rmse_passed else 'FAIL'}"
                 )
-                per_chunk_results.append((i, e, passed, pcc, rmse))
+                per_chunk_results.append((i, e, passed, pcc, rmse_passed, rmse))
 
             if num_iterations > 1:
                 if reference_outputs is None:
@@ -1165,16 +1121,60 @@ def run_ring_joint_sdpa_chunked(
             )
             return
 
-        failures = [(i, e, pcc, rmse) for i, e, passed, pcc, rmse in per_chunk_results if not passed]
+        failures = [
+            (i, e, pcc, rmse)
+            for i, e, passed, pcc, rmse_passed, rmse in per_chunk_results
+            if not passed or not rmse_passed
+        ]
         if failures:
             details = "; ".join(
                 f"chunk {i} (logical_n={e}): PCC={pcc}, RMSE={rmse:.6f}" for i, e, pcc, rmse in failures
             )
-            pytest.fail(f"Chunked prefill PCC failures (threshold={pcc_threshold}): {details}")
+            pytest.fail(
+                f"Chunked prefill PCC/RMSE failures "
+                f"(pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}): {details}"
+            )
 
     finally:
         ttnn.close_mesh_device(mesh_device)
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
+@pytest.mark.timeout(600)
+def test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy():
+    """Validate chunked direct ND-sharded K/V cache inputs selected by cache_batch_idx."""
+    mesh_config = MESH_CONFIG
+    local_heads = 4
+    chunk_seq_len = 64
+    total_seq_len = 128
+    model = ModelConfig(
+        name="mla_indexed_nd_sharded_kv",
+        nhq=local_heads,
+        nhk=1,
+        nhv=local_heads,
+        d_q=64,
+        d_k=64,
+        d_v=32,
+        is_causal=True,
+        is_balanced=False,
+        q_dtype=ttnn.bfloat16,
+        kv_dtype=ttnn.bfloat16,
+        q_chunk_sizes=[32],
+        k_chunk_sizes=[32],
+        seq_len=total_seq_len,
+    )
+
+    run_ring_joint_sdpa_chunked(
+        mesh_config,
+        model,
+        chunk_size=chunk_seq_len * mesh_config.sp_size,
+        total_seq=total_seq_len * mesh_config.sp_size,
+        pcc_threshold=DEFAULT_PCC_THRESHOLD,
+        rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+        q_chunk_size=model.q_chunk_sizes[0],
+        k_chunk_size=model.k_chunk_sizes[0],
+        indexed_nd_sharded_kv_cache=True,
+    )
 
 
 # Generate test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -78,7 +78,9 @@ void kernel_main() {
     constexpr uint32_t total_mask_tiles =
         1 + (diag_tile_enabled ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
-    constexpr uint32_t q_start_idx_t = chunked_enabled ? (kv_local_padded_Nt - q_local_padded_Nt) * ring_size : 0;
+    // Chunked prefill masks against absolute Q/K coordinates. Use logical_nt as the populated
+    // cache boundary instead of deriving the Q start from the physical K cache extent.
+    constexpr uint32_t q_start_idx_t = chunked_enabled ? logical_nt - q_local_padded_Nt * ring_size : 0;
 
     uint32_t argidx = 0;
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -8,6 +8,117 @@
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
 
+template <bool has_joint_inputs, uint32_t joint_tensor_args_offset>
+constexpr uint32_t get_post_tensor_args_offset() {
+    if constexpr (has_joint_inputs) {
+        constexpr auto joint_q_args = TensorAccessorArgs<joint_tensor_args_offset>();
+        constexpr auto joint_k_args = TensorAccessorArgs<joint_q_args.next_compile_time_args_offset()>();
+        constexpr auto joint_v_args = TensorAccessorArgs<joint_k_args.next_compile_time_args_offset()>();
+        return joint_v_args.next_compile_time_args_offset();
+    } else {
+        return joint_tensor_args_offset;
+    }
+}
+
+template <
+    bool has_joint_k,
+    uint32_t joint_tensor_args_offset,
+    typename LocalKGenerator,
+    typename GatheredKGenerator,
+    typename JointInputTileLogical,
+    typename FetchK>
+inline void fetch_k_from_source(
+    bool kv_chunk_is_joint,
+    uint32_t ring_iter,
+    uint32_t joint_k_addr,
+    const LocalKGenerator& local_k_generator,
+    const GatheredKGenerator& gathered_k_generator,
+    const JointInputTileLogical& joint_input_tile_logical,
+    const FetchK& fetch_k) {
+    if constexpr (has_joint_k) {
+        if (kv_chunk_is_joint) {
+            constexpr auto joint_q_args = TensorAccessorArgs<joint_tensor_args_offset>();
+            constexpr auto joint_k_args = TensorAccessorArgs<joint_q_args.next_compile_time_args_offset()>();
+            const auto joint_k_reader = TensorAccessor(joint_k_args, joint_k_addr);
+            const auto joint_k_generator = PaddedAddrGenerator(joint_k_reader, joint_input_tile_logical);
+            fetch_k(joint_k_generator);
+        } else if (ring_iter == 0) {
+            fetch_k(local_k_generator);
+        } else {
+            fetch_k(gathered_k_generator);
+        }
+    } else {
+        if (ring_iter == 0) {
+            fetch_k(local_k_generator);
+        } else {
+            fetch_k(gathered_k_generator);
+        }
+    }
+}
+
+template <
+    bool has_joint_q,
+    uint32_t joint_tensor_args_offset,
+    typename QGenerator,
+    typename JointInputTileLogical,
+    typename ReadQ>
+inline void read_q_from_source(
+    bool is_joint_q,
+    uint32_t joint_q_addr,
+    const QGenerator& q_generator,
+    const JointInputTileLogical& joint_input_tile_logical,
+    const ReadQ& read_q) {
+    if constexpr (has_joint_q) {
+        if (is_joint_q) {
+            constexpr auto joint_q_args = TensorAccessorArgs<joint_tensor_args_offset>();
+            const auto joint_q_reader = TensorAccessor(joint_q_args, joint_q_addr);
+            const auto joint_q_generator = PaddedAddrGenerator(joint_q_reader, joint_input_tile_logical);
+            read_q(joint_q_generator);
+        } else {
+            read_q(q_generator);
+        }
+    } else {
+        read_q(q_generator);
+    }
+}
+
+template <
+    bool has_joint_k,
+    uint32_t joint_tensor_args_offset,
+    typename LocalVGenerator,
+    typename GatheredVGenerator,
+    typename JointInputTileLogical,
+    typename FetchV>
+inline void fetch_v_from_source(
+    bool kv_chunk_is_joint,
+    uint32_t ring_iter,
+    uint32_t joint_v_addr,
+    const LocalVGenerator& local_v_generator,
+    const GatheredVGenerator& gathered_v_generator,
+    const JointInputTileLogical& joint_input_tile_logical,
+    const FetchV& fetch_v) {
+    if constexpr (has_joint_k) {
+        if (kv_chunk_is_joint) {
+            constexpr auto joint_q_args = TensorAccessorArgs<joint_tensor_args_offset>();
+            constexpr auto joint_k_args = TensorAccessorArgs<joint_q_args.next_compile_time_args_offset()>();
+            constexpr auto joint_v_args = TensorAccessorArgs<joint_k_args.next_compile_time_args_offset()>();
+            const auto joint_v_reader = TensorAccessor(joint_v_args, joint_v_addr);
+            const auto joint_v_generator = PaddedAddrGenerator(joint_v_reader, joint_input_tile_logical);
+            fetch_v(joint_v_generator);
+        } else if (ring_iter == 0) {
+            fetch_v(local_v_generator);
+        } else {
+            fetch_v(gathered_v_generator);
+        }
+    } else {
+        if (ring_iter == 0) {
+            fetch_v(local_v_generator);
+        } else {
+            fetch_v(gathered_v_generator);
+        }
+    }
+}
+
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
@@ -41,20 +152,22 @@ void kernel_main() {
     constexpr bool chunked_enabled = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t num_q_readers = get_compile_time_arg_val(25);
     constexpr uint32_t chunk_size_t = get_compile_time_arg_val(26);
+    constexpr bool indexed_kv_cache = get_compile_time_arg_val(27) == 1;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and joint generator uses.
     constexpr bool has_joint_q = num_joint_q_chunks > 0;
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
+    constexpr bool has_joint_inputs = has_joint_q || has_joint_k;
 
-    constexpr auto q_args = TensorAccessorArgs<27>();
+    constexpr auto q_args = TensorAccessorArgs<28>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
     constexpr auto gathered_v_args = TensorAccessorArgs<gathered_k_args.next_compile_time_args_offset()>();
-    constexpr auto joint_q_args = TensorAccessorArgs<gathered_v_args.next_compile_time_args_offset()>();
-    constexpr auto joint_k_args = TensorAccessorArgs<joint_q_args.next_compile_time_args_offset()>();
-    constexpr auto joint_v_args = TensorAccessorArgs<joint_k_args.next_compile_time_args_offset()>();
+    constexpr uint32_t joint_tensor_args_offset = gathered_v_args.next_compile_time_args_offset();
+    constexpr uint32_t post_tensor_args_offset =
+        get_post_tensor_args_offset<has_joint_inputs, joint_tensor_args_offset>();
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -62,11 +175,17 @@ void kernel_main() {
     const uint32_t v_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t gathered_k_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t gathered_v_addr = get_arg_val<uint32_t>(argidx++);
-    const uint32_t joint_q_addr = get_arg_val<uint32_t>(argidx++);
-    const uint32_t joint_k_addr = get_arg_val<uint32_t>(argidx++);
-    const uint32_t joint_v_addr = get_arg_val<uint32_t>(argidx++);
+    uint32_t joint_q_addr = 0;
+    uint32_t joint_k_addr = 0;
+    uint32_t joint_v_addr = 0;
+    if constexpr (has_joint_inputs) {
+        joint_q_addr = get_arg_val<uint32_t>(argidx++);
+        joint_k_addr = get_arg_val<uint32_t>(argidx++);
+        joint_v_addr = get_arg_val<uint32_t>(argidx++);
+    }
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
+    const uint32_t cache_batch_idx = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     // Head chain runtime args (always present)
@@ -88,13 +207,10 @@ void kernel_main() {
 
     // Compile-time semaphore ids and chain flags are appended after all TensorAccessorArgs()
     // Head chain semaphores (head-level chain, always built)
-    uint32_t head_sender_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset()));
-    uint32_t head_receiver_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1));
-    uint32_t head_valid_semaphore_addr =
-        get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2));
-    constexpr bool head_mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
+    uint32_t head_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset));
+    uint32_t head_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 1));
+    uint32_t head_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 2));
+    constexpr bool head_mcast_enabled = get_compile_time_arg_val(post_tensor_args_offset + 3) == 1;
 
     // Batch chain semaphores (only present when k_uses_batch_chain / NHK == 1)
     // Initialize to 0; will be overwritten if k_uses_batch_chain
@@ -105,24 +221,20 @@ void kernel_main() {
     // batch_mcast_enabled: read from compile-time args if present, else false (for template instantiation)
     constexpr bool batch_mcast_enabled = []() {
         if constexpr (k_uses_batch_chain) {
-            return get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7) == 1;
+            return get_compile_time_arg_val(post_tensor_args_offset + 7) == 1;
         }
         return false;
     }();
 
     if constexpr (k_uses_batch_chain) {
-        batch_sender_semaphore_addr =
-            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 4));
-        batch_receiver_semaphore_addr =
-            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 5));
-        batch_valid_semaphore_addr =
-            get_semaphore(get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6));
+        batch_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 4));
+        batch_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 5));
+        batch_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(post_tensor_args_offset + 6));
     }
 
     constexpr uint32_t head_chain_arg_count = 4;
     constexpr uint32_t batch_chain_arg_count = k_uses_batch_chain ? 4 : 0;
-    constexpr uint32_t cb_arg_offset =
-        joint_v_args.next_compile_time_args_offset() + head_chain_arg_count + batch_chain_arg_count;
+    constexpr uint32_t cb_arg_offset = post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -206,15 +318,13 @@ void kernel_main() {
     const auto local_v_reader = TensorAccessor(v_args, v_addr);
     const auto gathered_k_reader = TensorAccessor(gathered_k_args, gathered_k_addr);
     const auto gathered_v_reader = TensorAccessor(gathered_v_args, gathered_v_addr);
-    const auto joint_q_reader = TensorAccessor(joint_q_args, joint_q_addr);
-    const auto joint_k_reader = TensorAccessor(joint_k_args, joint_k_addr);
-    const auto joint_v_reader = TensorAccessor(joint_v_args, joint_v_addr);
 
+    const uint32_t kv_batch_dim = indexed_kv_cache ? cache_batch_idx + 1 : B;
     const auto input_q_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, DHt);
-    const auto input_k_tile_logical = TensorTileShape(B, NHK, kv_local_padded_Nt, DHt);
-    const auto input_v_tile_logical = TensorTileShape(B, NH, kv_local_padded_Nt, vDHt);
-    const auto gathered_k_input_tile_logical = TensorTileShape(B, NHK, padded_Nt, DHt);
-    const auto gathered_v_input_tile_logical = TensorTileShape(B, NH, padded_Nt, vDHt);
+    const auto input_k_tile_logical = TensorTileShape(kv_batch_dim, NHK, kv_local_padded_Nt, DHt);
+    const auto input_v_tile_logical = TensorTileShape(kv_batch_dim, NH, kv_local_padded_Nt, vDHt);
+    const auto gathered_k_input_tile_logical = TensorTileShape(kv_batch_dim, NHK, padded_Nt, DHt);
+    const auto gathered_v_input_tile_logical = TensorTileShape(kv_batch_dim, NH, padded_Nt, vDHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
 
     const auto q_generator = PaddedAddrGenerator(q_reader, input_q_tile_logical);
@@ -222,9 +332,6 @@ void kernel_main() {
     const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
     const auto gathered_k_generator = PaddedAddrGenerator(gathered_k_reader, gathered_k_input_tile_logical);
     const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_v_input_tile_logical);
-    const auto joint_q_generator = PaddedAddrGenerator(joint_q_reader, joint_input_tile_logical);
-    const auto joint_k_generator = PaddedAddrGenerator(joint_k_reader, joint_input_tile_logical);
-    const auto joint_v_generator = PaddedAddrGenerator(joint_v_reader, joint_input_tile_logical);
 
     // Tracks whether Q has been pushed for q_per_core == 1 optimization.
     // When q_per_core == 1, Q is identical across ring iterations so we only push it once.
@@ -258,6 +365,15 @@ void kernel_main() {
         const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
         const bool ring_iter_processes_KV_chunks =
             chunked_enabled ? true : (ring_iter_kv_start_tile <= global_n_tile_id);
+        uint32_t ring_iter_valid_kv_tiles = kv_local_padded_Nt;
+        if constexpr (!chunked_enabled) {
+            ring_iter_valid_kv_tiles = 0;
+            if (ring_iter_kv_start_tile < logical_nt) {
+                const uint32_t remaining_kv_tiles = logical_nt - ring_iter_kv_start_tile;
+                ring_iter_valid_kv_tiles =
+                    remaining_kv_tiles < kv_local_padded_Nt ? remaining_kv_tiles : kv_local_padded_Nt;
+            }
+        }
 
         // In causal non balanced case when processing KV received from other devices:
         // - skip over KV received from subsequent devices
@@ -361,28 +477,31 @@ void kernel_main() {
                 // Default to local/gathered KV; override below for joint KV when applicable.
                 Slice k_slice;
                 Slice v_slice;
-                uint32_t end_seq_tile;
+                uint32_t k_end_seq_tile;
+                uint32_t v_end_seq_tile;
                 const uint32_t nk = nq / q_heads_per_k;
+                const uint32_t kv_batch = indexed_kv_cache ? cache_batch_idx : nb;
                 if (ring_iter == 0) {
-                    const uint32_t local_k_row_start_tile = k_chunk * Sk_chunk_t;
-                    k_slice = Slice(nb, nk, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, DHt);
-                    v_slice = Slice(nb, nq, local_k_row_start_tile, local_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                    // Chunked: gathered-K coord ≠ global-K coord, so skip the logical_nt clamp
-                    // (host pre-zeros padding slabs, so reading the full slice is safe).
-                    end_seq_tile = chunked_enabled ? kv_local_padded_Nt : std::min(logical_nt, kv_local_padded_Nt);
+                    const uint32_t local_k_start_tile = k_chunk * Sk_chunk_t;
+                    const uint32_t local_v_start_tile = k_chunk * Sk_chunk_t;
+                    k_slice = Slice(kv_batch, nk, local_k_start_tile, local_k_start_tile + Sk_chunk_t, 0, DHt);
+                    v_slice = Slice(kv_batch, nq, local_v_start_tile, local_v_start_tile + Sk_chunk_t, 0, vDHt);
+                    k_end_seq_tile = ring_iter_valid_kv_tiles;
+                    v_end_seq_tile = ring_iter_valid_kv_tiles;
                 } else {
-                    const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
-                    k_slice = Slice(nb, nk, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
-                    v_slice = Slice(nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, vDHt);
-                    end_seq_tile = chunked_enabled ? kv_local_padded_Nt * (ring_id + 1)
-                                                   : std::min(logical_nt, kv_local_padded_Nt * (ring_id + 1));
+                    const uint32_t gathered_start_tile = ring_id * kv_local_padded_Nt + k_chunk * Sk_chunk_t;
+                    k_slice = Slice(kv_batch, nk, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, DHt);
+                    v_slice = Slice(kv_batch, nq, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, vDHt);
+                    k_end_seq_tile = ring_id * kv_local_padded_Nt + ring_iter_valid_kv_tiles;
+                    v_end_seq_tile = k_end_seq_tile;
                 }
                 if constexpr (has_joint_k) {
                     if (kv_chunk_is_joint) {
                         const uint32_t joint_k_row_start_tile = (k_chunk - num_local_k_chunks) * Sk_chunk_t;
                         k_slice = Slice(nb, nk, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
                         v_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                        end_seq_tile = Lt;
+                        k_end_seq_tile = Lt;
+                        v_end_seq_tile = Lt;
                     }
                 }
 
@@ -399,17 +518,20 @@ void kernel_main() {
                 if (k_chain.should_receive(nb, nq)) {
                     k_chain.receive();
                 } else {
-                    // Injector or non-participant: read K from DRAM. Pick the generator once
-                    // (joint branch elided when has_joint_k is false), then issue one fetch.
-                    const auto& k_gen = [&]() -> const auto& {
-                        if constexpr (has_joint_k) {
-                            if (kv_chunk_is_joint) {
-                                return joint_k_generator;
-                            }
-                        }
-                        return ring_iter == 0 ? local_k_generator : gathered_k_generator;
-                    }();
-                    fetch_block(k_gen, k_slice, end_seq_tile, cb_k_start_address, k_tile_bytes, true /*transpose*/);
+                    // Injector or non-participant: read K from DRAM. Dispatch directly so
+                    // local and gathered tensors may use different accessor types.
+                    const auto fetch_k = [&](const auto& k_gen) {
+                        fetch_block(
+                            k_gen, k_slice, k_end_seq_tile, cb_k_start_address, k_tile_bytes, true /*transpose*/);
+                    };
+                    fetch_k_from_source<has_joint_k, joint_tensor_args_offset>(
+                        kv_chunk_is_joint,
+                        ring_iter,
+                        joint_k_addr,
+                        local_k_generator,
+                        gathered_k_generator,
+                        joint_input_tile_logical,
+                        fetch_k);
                 }
 
                 // Forward K chunk via chain (uses K's data size explicitly)
@@ -434,38 +556,34 @@ void kernel_main() {
                 // Placed after K forward so no outstanding NOC writes remain
                 // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
                 if (k_chunk == 0 && need_q_read) {
-                    const auto& q_gen = [&]() -> const auto& {
-                        if constexpr (has_joint_q) {
-                            if (is_joint_q) {
-                                return joint_q_generator;
+                    const auto read_q = [&](const auto& q_gen) {
+                        if constexpr (use_q_subblock_push) {
+                            for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
+                                const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;
+                                const uint32_t sb_row_end = sb_row_start + qk_subblock_h;
+                                Slice q_sub_slice(q_slice.d0, q_slice.d1, sb_row_start, sb_row_end, 0, DHt);
+                                read_block(
+                                    q_gen,
+                                    q_sub_slice,
+                                    q_end_seq_tile,
+                                    cb_q_in,
+                                    q_tile_bytes,
+                                    false /*transpose*/,
+                                    q_barrier_threshold);
                             }
-                        }
-                        return q_generator;
-                    }();
-                    if constexpr (use_q_subblock_push) {
-                        for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
-                            const uint32_t sb_row_start = q_slice.d2_start + q_sub * qk_subblock_h;
-                            const uint32_t sb_row_end = sb_row_start + qk_subblock_h;
-                            Slice q_sub_slice(q_slice.d0, q_slice.d1, sb_row_start, sb_row_end, 0, DHt);
+                        } else {
                             read_block(
                                 q_gen,
-                                q_sub_slice,
+                                q_slice,
                                 q_end_seq_tile,
                                 cb_q_in,
                                 q_tile_bytes,
                                 false /*transpose*/,
                                 q_barrier_threshold);
                         }
-                    } else {
-                        read_block(
-                            q_gen,
-                            q_slice,
-                            q_end_seq_tile,
-                            cb_q_in,
-                            q_tile_bytes,
-                            false /*transpose*/,
-                            q_barrier_threshold);
-                    }
+                    };
+                    read_q_from_source<has_joint_q, joint_tensor_args_offset>(
+                        is_joint_q, joint_q_addr, q_generator, joint_input_tile_logical, read_q);
                     q_pushed = true;
                 }
 
@@ -475,15 +593,18 @@ void kernel_main() {
                 if (v_chain.should_receive(nb, nq)) {
                     v_chain.receive();
                 } else {
-                    const auto& v_gen = [&]() -> const auto& {
-                        if constexpr (has_joint_k) {
-                            if (kv_chunk_is_joint) {
-                                return joint_v_generator;
-                            }
-                        }
-                        return ring_iter == 0 ? local_v_generator : gathered_v_generator;
-                    }();
-                    fetch_block(v_gen, v_slice, end_seq_tile, cb_v_start_address, v_tile_bytes, false /*transpose*/);
+                    const auto fetch_v = [&](const auto& v_gen) {
+                        fetch_block(
+                            v_gen, v_slice, v_end_seq_tile, cb_v_start_address, v_tile_bytes, false /*transpose*/);
+                    };
+                    fetch_v_from_source<has_joint_k, joint_tensor_args_offset>(
+                        kv_chunk_is_joint,
+                        ring_iter,
+                        joint_v_addr,
+                        local_v_generator,
+                        gathered_v_generator,
+                        joint_input_tile_logical,
+                        fetch_v);
                 }
 
                 // Forward V to next core(s) before push_back — prevents compute from

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -25,26 +25,125 @@ namespace ttnn::prim {
 
 using namespace experimental::ccl;
 
+namespace {
+
+void validate_ring_joint_all_gather_on_program_cache_miss(
+    const ttnn::experimental::prim::RingAttentionAllGatherAsyncParams& operation_attributes,
+    const ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs& tensor_args) {
+    const auto& input_tensors = tensor_args.input_tensor;
+    TT_FATAL(
+        !input_tensors.empty(), "Error, Input tensor size should be greater than 0 but has {}", input_tensors.size());
+    TT_FATAL(input_tensors[0].buffer() != nullptr, "Input tensor 0 must be allocated in buffers on device");
+
+    const auto dtype = input_tensors[0].dtype();
+    const auto page_size = input_tensors[0].buffer()->page_size();
+    for (size_t i = 0; i < input_tensors.size(); ++i) {
+        const auto& input_tensor = input_tensors[i];
+
+        TT_FATAL(input_tensor.layout() == Layout::TILE, "Input tensor {} must be tiled", i);
+        TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor {} must be on device", i);
+        TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor {} must be allocated in buffers on device", i);
+        TT_FATAL(
+            input_tensor.dtype() == dtype,
+            "All input tensors must have the same dtype. Input tensor {} has dtype {} but expected {}",
+            i,
+            input_tensor.dtype(),
+            dtype);
+        TT_FATAL(
+            input_tensor.buffer()->page_size() == page_size,
+            "All input tensors must have the same page size. Input tensor {} has page size {} but expected {}",
+            i,
+            input_tensor.buffer()->page_size(),
+            page_size);
+    }
+
+    TT_FATAL(
+        operation_attributes.num_links > 0,
+        "Error, num_links should be more than 0 but has {}",
+        operation_attributes.num_links);
+
+    const auto& output_tensors = tensor_args.persistent_output_buffer;
+    if (!output_tensors.empty()) {
+        TT_FATAL(
+            output_tensors.size() == input_tensors.size(),
+            "Number of output tensors ({}) must match number of input tensors ({})",
+            output_tensors.size(),
+            input_tensors.size());
+
+        for (size_t i = 0; i < output_tensors.size(); ++i) {
+            TT_FATAL(output_tensors[i].has_value(), "RingJointSDPA requires persistent all-gather output tensor {}", i);
+            const auto& output_tensor = output_tensors[i].value();
+
+            TT_FATAL(output_tensor.layout() == Layout::TILE, "Output tensor {} must be tiled", i);
+            TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor {} must be on device", i);
+            TT_FATAL(output_tensor.buffer() != nullptr, "Output tensor {} must be allocated in buffers on device", i);
+            TT_FATAL(
+                output_tensor.dtype() == dtype,
+                "Output tensor {} dtype should match input tensors but has {}",
+                i,
+                output_tensor.dtype());
+            TT_FATAL(
+                output_tensor.buffer()->page_size() == page_size,
+                "Output tensor {} page size should match input tensors but has {}",
+                i,
+                output_tensor.buffer()->page_size());
+            TT_FATAL(
+                output_tensor.memory_config() == operation_attributes.output_mem_config,
+                "Output tensor {} memory config should match output_mem_config",
+                i);
+
+            auto output_shape = output_tensor.logical_shape();
+            auto expected_output_shape = input_tensors[i].logical_shape();
+            expected_output_shape[operation_attributes.dim] *= operation_attributes.ring_size;
+            for (int d = 0; d < static_cast<int>(output_shape.rank()); ++d) {
+                if (d == operation_attributes.dim) {
+                    TT_FATAL(
+                        output_shape[d] >= expected_output_shape[d],
+                        "Output tensor {} gather dim {} too small: got {}, expected >= {} "
+                        "(= input_dim * ring_size {})",
+                        i,
+                        d,
+                        output_shape[d],
+                        expected_output_shape[d],
+                        operation_attributes.ring_size);
+                } else {
+                    TT_FATAL(
+                        output_shape[d] == expected_output_shape[d],
+                        "Output tensor {} non-gather dim {} mismatch: got {}, expected {}",
+                        i,
+                        d,
+                        output_shape[d],
+                        expected_output_shape[d]);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
 void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input_tensor_q = tensor_args.input_q;
 
-    const auto& joint_tensor_q = tensor_args.joint_q;
-    const auto& joint_tensor_k = tensor_args.joint_k;
-    const auto& joint_tensor_v = tensor_args.joint_v;
-
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
     const auto& gathered_input_tensor_v = tensor_args.gathered_v;
 
-    const std::vector<Tensor> sdpa_input_tensors = {
-        input_tensor_q,
-        gathered_input_tensor_k,
-        gathered_input_tensor_v,
-        joint_tensor_q,
-        joint_tensor_k,
-        joint_tensor_v};
+    const bool has_joint_tensors =
+        tensor_args.joint_q.has_value() || tensor_args.joint_k.has_value() || tensor_args.joint_v.has_value();
+    TT_FATAL(
+        tensor_args.joint_q.has_value() == has_joint_tensors && tensor_args.joint_k.has_value() == has_joint_tensors &&
+            tensor_args.joint_v.has_value() == has_joint_tensors,
+        "Joint tensors must be provided all together or omitted altogether");
 
-    ttnn::experimental::prim::RingAttentionAllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
+    std::vector<Tensor> sdpa_input_tensors = {input_tensor_q, gathered_input_tensor_k, gathered_input_tensor_v};
+    if (has_joint_tensors) {
+        sdpa_input_tensors.push_back(tensor_args.joint_q.value());
+        sdpa_input_tensors.push_back(tensor_args.joint_k.value());
+        sdpa_input_tensors.push_back(tensor_args.joint_v.value());
+    }
+
+    validate_ring_joint_all_gather_on_program_cache_miss(
         args.all_gather_operation_attributes, args.all_gather_tensor_args);
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
@@ -67,16 +166,19 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto& q_shape = input_tensor_q.logical_shape();
     const auto& k_shape = gathered_input_tensor_k.logical_shape();
     const auto& v_shape = gathered_input_tensor_v.logical_shape();
-    const auto& joint_q_shape = joint_tensor_q.logical_shape();
-    const auto& joint_k_shape = joint_tensor_k.logical_shape();
-    const auto& joint_v_shape = joint_tensor_v.logical_shape();
+    const auto joint_q_shape = has_joint_tensors ? tensor_args.joint_q.value().logical_shape() : q_shape;
+    const auto joint_k_shape = has_joint_tensors ? tensor_args.joint_k.value().logical_shape() : q_shape;
+    const auto joint_v_shape = has_joint_tensors ? tensor_args.joint_v.value().logical_shape() : q_shape;
+
+    const bool has_indexed_kv_cache = args.has_indexed_kv_cache();
 
     // Chunked-prefill (`tensor_args.is_chunked()`): Q is shorter than the per-device K shard
     // (latest slab against a growing K cache). Chunk 0 has equal shapes and uses the regular
     // is_causal=True path.
+    const bool is_chunked = tensor_args.is_chunked();
 
     const auto dtype = input_tensor_q.dtype();
-    if (!args.is_causal && !tensor_args.is_chunked()) {
+    if (!args.is_causal && !is_chunked) {
         for (const auto& tensor : sdpa_input_tensors) {
             TT_FATAL(
                 tensor.dtype() == dtype,
@@ -106,9 +208,9 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto NKH = k_shape[1];
     const auto NVH = v_shape[1];
     const auto N_local_q = q_shape[2];
-    const auto N_local_kv = tensor_args.input_k.logical_shape()[2];
+    const auto N_local_kv = tensor_args.local_kv_seq_len();
     const auto N_global = k_shape[2];
-    const auto L = joint_q_shape[2];
+    const auto L = has_joint_tensors ? joint_q_shape[2] : 0;
     const auto DH = q_shape[3];
 
     auto q_chunk_size = args.get_q_chunk_size();
@@ -128,7 +230,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_local_kv);
 
     TT_FATAL(
-        !tensor_args.is_chunked() || args.is_causal,
+        !is_chunked || args.is_causal,
         "Chunked-prefill (N_local_q < N_local_kv) is mathematically causal; callers must pass is_causal=True. "
         "Got N_local_q={}, N_local_kv={}, is_causal={}",
         N_local_q,
@@ -139,41 +241,75 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         !(args.is_balanced && (N_local_q / 2) % q_chunk_size != 0),
         "q_chunk_size must divide half of local q seq_len in balanced case");
 
-    TT_FATAL(
-        k_shape[0] == B && v_shape[0] == B && joint_q_shape[0] == B && joint_k_shape[0] == B && joint_v_shape[0] == B,
-        "Batch sizes must match. Got Q: {}, K: {}, V: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
-        B,
-        k_shape[0],
-        v_shape[0],
-        joint_q_shape[0],
-        joint_k_shape[0],
-        joint_v_shape[0]);
-
-    // Chunked-prefill targets MLA (K head dim == Q != V) — use is_causal's relaxed K-only check.
-    if (!args.is_causal && !tensor_args.is_chunked()) {
+    if (has_indexed_kv_cache) {
+        const auto K_cache_batch = tensor_args.input_k.logical_shape()[0];
+        const auto V_cache_batch = tensor_args.input_v.logical_shape()[0];
         TT_FATAL(
-            k_shape[3] == DH && v_shape[3] == DH && joint_q_shape[3] == DH && joint_k_shape[3] == DH &&
-                joint_v_shape[3] == DH,
-            "Head dimensions must match. Got Q: {}, K: {}, V: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
-            DH,
-            k_shape[3],
-            v_shape[3],
-            joint_q_shape[3],
-            joint_k_shape[3],
-            joint_v_shape[3]);
+            B == 1,
+            "cache_batch_idx currently selects one shared K/V cache slot for the whole query batch; indexed K/V cache "
+            "mode requires Q batch size 1. Got Q batch size {}",
+            B);
+        TT_FATAL(
+            args.cache_batch_idx.value() < K_cache_batch,
+            "cache_batch_idx={} is outside K cache batch={}",
+            args.cache_batch_idx.value(),
+            K_cache_batch);
+        TT_FATAL(
+            args.cache_batch_idx.value() < V_cache_batch,
+            "cache_batch_idx={} is outside V cache batch={}",
+            args.cache_batch_idx.value(),
+            V_cache_batch);
+        TT_FATAL(
+            k_shape[0] == K_cache_batch,
+            "Gathered K cache batch must match input K cache batch. Got gathered K: {}, input K: {}",
+            k_shape[0],
+            K_cache_batch);
+        TT_FATAL(
+            v_shape[0] == V_cache_batch,
+            "Gathered V cache batch must match input V cache batch. Got gathered V: {}, input V: {}",
+            v_shape[0],
+            V_cache_batch);
     } else {
+        TT_FATAL(k_shape[0] == B, "K batch size must match Q. Got Q: {}, K: {}", B, k_shape[0]);
+        TT_FATAL(v_shape[0] == B, "V batch size must match Q. Got Q: {}, V: {}", B, v_shape[0]);
+    }
+    if (has_joint_tensors) {
         TT_FATAL(
-            k_shape[3] == DH && joint_k_shape[3] == DH,
-            "Q/K head dimensions must match. Got Q: {}, K: {}",
-            DH,
-            k_shape[3]);
+            joint_q_shape[0] == B && joint_k_shape[0] == B && joint_v_shape[0] == B,
+            "Batch sizes must match. Got Q: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
+            B,
+            joint_q_shape[0],
+            joint_k_shape[0],
+            joint_v_shape[0]);
     }
 
-    TT_FATAL(
-        v_shape[2] == N_global,
-        "V sequence length must be equal to global sequence length. Got V: {}, global sequence length: {}",
-        v_shape[2],
-        N_global);
+    // Chunked-prefill targets MLA (K head dim == Q != V) — use is_causal's relaxed K-only check.
+    if (!args.is_causal && !is_chunked) {
+        TT_FATAL(
+            k_shape[3] == DH && v_shape[3] == DH,
+            "Head dimensions must match. Got Q: {}, K: {}, V: {}",
+            DH,
+            k_shape[3],
+            v_shape[3]);
+        if (has_joint_tensors) {
+            TT_FATAL(
+                joint_q_shape[3] == DH && joint_k_shape[3] == DH && joint_v_shape[3] == DH,
+                "Joint head dimensions must match Q. Got Q: {}, joint_Q: {}, joint_K: {}, joint_V: {}",
+                DH,
+                joint_q_shape[3],
+                joint_k_shape[3],
+                joint_v_shape[3]);
+        }
+    } else {
+        TT_FATAL(k_shape[3] == DH, "Q/K head dimensions must match. Got Q: {}, K: {}", DH, k_shape[3]);
+        if (has_joint_tensors) {
+            TT_FATAL(
+                joint_k_shape[3] == DH,
+                "Q/joint_K head dimensions must match. Got Q: {}, joint_K: {}",
+                DH,
+                joint_k_shape[3]);
+        }
+    }
 
     TT_FATAL(
         args.logical_n <= N_global,
@@ -182,11 +318,13 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         args.logical_n,
         N_global);
 
-    TT_FATAL(
-        joint_k_shape[2] == L && joint_v_shape[2] == L,
-        "Joint sequence length must match. Got joint_K: {}, joint_V: {}",
-        joint_k_shape[2],
-        joint_v_shape[2]);
+    if (has_joint_tensors) {
+        TT_FATAL(
+            joint_k_shape[2] == L && joint_v_shape[2] == L,
+            "Joint sequence length must match. Got joint_K: {}, joint_V: {}",
+            joint_k_shape[2],
+            joint_v_shape[2]);
+    }
 
     TT_FATAL(
         N_global == N_local_kv * args.ring_size,
@@ -227,6 +365,11 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         "Per-device K/V seq length must be divisible by TILE_HEIGHT. Got N_local_kv: {}, TILE_HEIGHT: {}",
         N_local_kv,
         tt::constants::TILE_HEIGHT);
+    TT_FATAL(
+        tensor_args.input_v.logical_shape()[2] == N_local_kv,
+        "V local seq length must match K local seq length. Got V: {}, K: {}",
+        tensor_args.input_v.logical_shape()[2],
+        N_local_kv);
 
     // Validate padding: Only the sequence dimension may be padded
     auto validate_padding = [](const Tensor& tensor) {
@@ -245,12 +388,21 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
 RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input = tensor_args.input_q;
-    const auto& joint_input = tensor_args.joint_q;
+    const bool has_joint_tensors = tensor_args.joint_q.has_value();
+    auto joint_output_shape = input.logical_shape();
+    joint_output_shape[2] = 0;
+    joint_output_shape[3] = tensor_args.input_v.logical_shape()[3];
+    uint32_t joint_padded_seq = 0;
+    if (has_joint_tensors) {
+        joint_output_shape = tensor_args.joint_q.value().logical_shape();
+        joint_padded_seq = tensor_args.joint_q.value().padded_shape()[2];
+    }
+
     auto stats_shape = input.logical_shape();
     stats_shape[3] = 1;
     // 2× the sequence length: first half stores running max, second half stores running sum.
     // Used as DRAM scratch for multi-Q-chunk deferred norm round-trips between ring iterations.
-    stats_shape[2] = (input.padded_shape()[2] + joint_input.padded_shape()[2]) * 2;
+    stats_shape[2] = (input.padded_shape()[2] + joint_padded_seq) * 2;
 
     auto out_shape = input.logical_shape();
     // head dim as v head dim
@@ -259,8 +411,7 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     return {
         TensorSpec(out_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
         TensorSpec(
-            joint_input.logical_shape(),
-            TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
+            joint_output_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
         TensorSpec(stats_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config))};
 }
 
@@ -269,23 +420,22 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     auto output_specs = compute_output_specs(args, tensor_args);
     return {
         create_device_tensor(output_specs[RING_JOINT_SDPA_OUTPUT_IDX], tensor_args.input_q.device()),
-        create_device_tensor(output_specs[RING_JOINT_SDPA_JOINT_OUTPUT_IDX], tensor_args.joint_q.device()),
+        create_device_tensor(output_specs[RING_JOINT_SDPA_JOINT_OUTPUT_IDX], tensor_args.input_q.device()),
         create_device_tensor(output_specs[RING_JOINT_SDPA_STATS_OUTPUT_IDX], tensor_args.input_q.device()),
     };
 }
 
 ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
-    const std::vector<Tensor> input_tensors = {
-        tensor_args.input_q,
-        tensor_args.input_k,
-        tensor_args.input_v,
-        tensor_args.joint_q,
-        tensor_args.joint_k,
-        tensor_args.joint_v,
-        tensor_args.gathered_k,
-        tensor_args.gathered_v,
-    };
+    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k, tensor_args.input_v};
+    if (tensor_args.joint_q.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_q.value());
+        input_tensors.emplace_back(tensor_args.joint_k.value());
+        input_tensors.emplace_back(tensor_args.joint_v.value());
+    }
+    input_tensors.emplace_back(tensor_args.gathered_k);
+    input_tensors.emplace_back(tensor_args.gathered_v);
+
     return tt::tt_metal::operation::hash_operation<RingJointSDPADeviceOperation>(
         input_tensors,
         args.joint_strategy,
@@ -297,6 +447,9 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         args.compute_kernel_config,
         args.program_config,
         args.ccl_core_grid_offset,
+        // cache_batch_idx is a reader runtime arg, but descriptor cache-hit patching only updates buffer rt args.
+        // Keep the value in the op hash so a cached Program never reuses stale scalar rt args for another slot.
+        args.cache_batch_idx,
         ttnn::experimental::prim::RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash(
             args.all_gather_operation_attributes, args.all_gather_tensor_args) /*all_gather input tensors*/
     );
@@ -304,15 +457,14 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
-    Tensors input_tensors = {
-        tensor_args.input_q,
-        tensor_args.input_k,
-        tensor_args.input_v,
-        tensor_args.joint_q,
-        tensor_args.joint_k,
-        tensor_args.joint_v,
-        tensor_args.gathered_k,
-        tensor_args.gathered_v};
+    Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k, tensor_args.input_v};
+    if (tensor_args.joint_q.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_q.value());
+        input_tensors.emplace_back(tensor_args.joint_k.value());
+        input_tensors.emplace_back(tensor_args.joint_v.value());
+    }
+    input_tensors.emplace_back(tensor_args.gathered_k);
+    input_tensors.emplace_back(tensor_args.gathered_v);
 
     auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
     auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
@@ -326,7 +478,6 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const auto& q_shape = tensor_args.input_q.logical_shape();
     const auto& gathered_k_shape = tensor_args.gathered_k.logical_shape();
     const auto& v_shape = tensor_args.gathered_v.logical_shape();
-    const auto& joint_q_shape = tensor_args.joint_q.logical_shape();
 
     CoreCoord grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
                                                      : output_tensor.device()->compute_with_storage_grid_size();
@@ -336,7 +487,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const uint32_t NQH = q_shape[1];
     const uint32_t N_local = q_shape[2];
     const uint32_t N_global = gathered_k_shape[2];
-    const uint32_t L = joint_q_shape[2];
+    const uint32_t L = tensor_args.joint_q.has_value() ? tensor_args.joint_q.value().logical_shape()[2] : 0;
     const uint32_t DH = q_shape[3];
     const uint32_t DV = v_shape[3];
 
@@ -360,9 +511,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
-    const ttnn::Tensor& joint_tensor_q,
-    const ttnn::Tensor& joint_tensor_k,
-    const ttnn::Tensor& joint_tensor_v,
+    const std::optional<ttnn::Tensor>& joint_tensor_q,
+    const std::optional<ttnn::Tensor>& joint_tensor_k,
+    const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
@@ -380,7 +531,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const bool is_balanced,
     const std::optional<float> scale,
     const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-    const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
+    const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    const std::optional<uint32_t> cache_batch_idx) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -415,7 +567,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         gather_dim,
         num_links,
         num_devices,
-        input_tensor_k.memory_config(),
+        persistent_output_buffer_k.memory_config(),
         topology,
         multi_device_global_semaphore,
         subdevice_id,
@@ -436,7 +588,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         kernel_config_val,
         std::move(all_gather_operation_attributes),
         std::move(all_gather_tensor_args),
-        ccl_core_grid_offset);
+        ccl_core_grid_offset,
+        cache_batch_idx);
 
     auto tensor_args = OperationType::tensor_args_t{
         .input_q = input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -35,9 +35,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
-    const ttnn::Tensor& joint_tensor_q,
-    const ttnn::Tensor& joint_tensor_k,
-    const ttnn::Tensor& joint_tensor_v,
+    const std::optional<ttnn::Tensor>& joint_tensor_q,
+    const std::optional<ttnn::Tensor>& joint_tensor_k,
+    const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
@@ -55,6 +55,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     bool is_balanced = false,
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -29,6 +29,7 @@ struct RingJointSDPAParams {
     experimental::prim::RingAttentionAllGatherAsyncParams all_gather_operation_attributes;
     experimental::prim::RingAttentionAllGatherAsyncInputs all_gather_tensor_args;
     CoreCoord ccl_core_grid_offset;
+    std::optional<std::uint32_t> cache_batch_idx = std::nullopt;
 
     // We need a constructor, because all_gather_struct is not default initializable.
     RingJointSDPAParams(
@@ -43,7 +44,8 @@ struct RingJointSDPAParams {
         DeviceComputeKernelConfig compute_kernel_config,
         experimental::prim::RingAttentionAllGatherAsyncParams all_gather_operation_attributes,
         experimental::prim::RingAttentionAllGatherAsyncInputs all_gather_tensor_args,
-        CoreCoord ccl_core_grid_offset) :
+        CoreCoord ccl_core_grid_offset,
+        std::optional<std::uint32_t> cache_batch_idx = std::nullopt) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
         is_causal(is_causal),
@@ -55,7 +57,8 @@ struct RingJointSDPAParams {
         compute_kernel_config(compute_kernel_config),
         all_gather_operation_attributes(std::move(all_gather_operation_attributes)),
         all_gather_tensor_args(std::move(all_gather_tensor_args)),
-        ccl_core_grid_offset(ccl_core_grid_offset) {}
+        ccl_core_grid_offset(ccl_core_grid_offset),
+        cache_batch_idx(cache_batch_idx) {}
 
     auto attributes() const {
         using ttsl::reflection::Attribute;
@@ -68,6 +71,9 @@ struct RingJointSDPAParams {
         attrs.emplace_back("output_memory_config", output_memory_config);
         attrs.emplace_back("compute_kernel_config", compute_kernel_config);
         attrs.emplace_back("ccl_core_grid_offset", ccl_core_grid_offset);
+        if (cache_batch_idx.has_value()) {
+            attrs.emplace_back("cache_batch_idx", cache_batch_idx.value());
+        }
         if (scale.has_value()) {
             attrs.emplace_back("scale", scale);
         }
@@ -80,21 +86,25 @@ struct RingJointSDPAParams {
     std::uint32_t get_q_chunk_size() const { return program_config.has_value() ? program_config->q_chunk_size : 32; }
 
     std::uint32_t get_k_chunk_size() const { return program_config.has_value() ? program_config->k_chunk_size : 32; }
+
+    bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
 };
 
 struct RingJointSDPAInputs {
     Tensor input_q;
     Tensor input_k;
     Tensor input_v;
-    Tensor joint_q;
-    Tensor joint_k;
-    Tensor joint_v;
+    std::optional<Tensor> joint_q;
+    std::optional<Tensor> joint_k;
+    std::optional<Tensor> joint_v;
     Tensor gathered_k;
     Tensor gathered_v;
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.
-    bool is_chunked() const { return input_q.logical_shape()[2] < input_k.logical_shape()[2]; }
+    uint32_t local_kv_seq_len() const { return static_cast<uint32_t>(input_k.logical_shape()[2]); }
+
+    bool is_chunked() const { return input_q.logical_shape()[2] < local_kv_seq_len(); }
 };
 
 // Index constants for RingJointSDPAResult vector

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -89,9 +89,10 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     const auto& input_tensor_k = tensor_args.input_k;
     const auto& input_tensor_v = tensor_args.input_v;
 
-    const auto& joint_tensor_q = tensor_args.joint_q;
-    const auto& joint_tensor_k = tensor_args.joint_k;
-    const auto& joint_tensor_v = tensor_args.joint_v;
+    const bool has_joint_tensors = tensor_args.joint_q.has_value();
+    const Tensor* joint_tensor_q = has_joint_tensors ? &tensor_args.joint_q.value() : nullptr;
+    const Tensor* joint_tensor_k = has_joint_tensors ? &tensor_args.joint_k.value() : nullptr;
+    const Tensor* joint_tensor_v = has_joint_tensors ? &tensor_args.joint_v.value() : nullptr;
 
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
     const auto& gathered_input_tensor_v = tensor_args.gathered_v;
@@ -160,7 +161,6 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     const auto& q_shape = input_tensor_q.logical_shape();
     const auto& k_shape = gathered_input_tensor_k.logical_shape();
-    const auto& joint_q_shape = joint_tensor_q.logical_shape();
     const auto& v_shape = gathered_input_tensor_v.logical_shape();
 
     log_debug(tt::LogOp, "q_shape: {}", q_shape);
@@ -168,14 +168,17 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "v_shape (gathered): {}", v_shape);
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
+    const bool indexed_kv_cache = args.has_indexed_kv_cache();
     const uint32_t B = q_shape[0];
     const uint32_t NH = q_shape[1];
     const uint32_t NHK = k_shape[1];
     const uint32_t DH = q_shape[3];
     const uint32_t q_local_padded_N = q_shape[2];
-    const uint32_t kv_local_padded_N = tensor_args.input_k.logical_shape()[2];
+    const uint32_t kv_local_padded_N = tensor_args.local_kv_seq_len();
+    const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
     const uint32_t padded_N = k_shape[2];
-    const uint32_t L = joint_q_shape[2];
+    const uint32_t cache_batch_idx = args.cache_batch_idx.value_or(0);
+    const uint32_t L = has_joint_tensors ? joint_tensor_q->logical_shape()[2] : 0;
     const uint32_t vDH = v_shape[3];
 
     const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
@@ -200,13 +203,13 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     // Chunked-prefill balanced layout: each device holds one per-chunk K region per chunk.
     // The region is q_local_padded_Nt tiles (Q is exactly one such region per call). The
     // diagonal-tile CB slot is shared with is_causal — needed whenever either is on.
-    const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
     const uint32_t chunk_size_t = q_local_padded_Nt * ring_size;
-    const bool diag_tile_enabled = args.is_causal || tensor_args.is_chunked();
+    const bool is_chunked = tensor_args.is_chunked();
+    const bool diag_tile_enabled = args.is_causal || is_chunked;
     // Kernel-level is_causal flag carries the legacy local-frame causal-stamp semantics. Chunked
     // prefill is mathematically causal (args.is_causal=True) but uses absolute-coords stamps every
     // ring iter, so the chunked path supersedes the legacy path — mask the flag off here.
-    const bool kernel_is_causal = args.is_causal && !tensor_args.is_chunked();
+    const bool kernel_is_causal = args.is_causal && !is_chunked;
 
     // Lightweight mask: needed when any K/joint dimension has padding, or when causal/chunked
     // masking is active.
@@ -337,7 +340,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
-    uint32_t k_tiles = Sk_chunk_t * DHt * 2;  // double buffer
+    uint32_t k_tiles = Sk_chunk_t * DHt * 2;   // double buffer
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;  // double buffer
     uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
@@ -492,9 +495,10 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         // Reader slot 24: chunked_enabled (writer/compute use slot 24/33 for use_streaming_compute).
-        static_cast<uint32_t>(tensor_args.is_chunked()),
+        static_cast<uint32_t>(is_chunked),
         num_active_cores,
         chunk_size_t,
+        static_cast<uint32_t>(indexed_kv_cache),
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -502,9 +506,11 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     TensorAccessorArgs(input_tensor_v.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(gathered_input_tensor_k.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(gathered_input_tensor_v.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(joint_tensor_q.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(joint_tensor_k.buffer()).append_to(reader_compile_time_args);
-    TensorAccessorArgs(joint_tensor_v.buffer()).append_to(reader_compile_time_args);
+    if (L != 0) {
+        TensorAccessorArgs(joint_tensor_q->buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(joint_tensor_k->buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(joint_tensor_v->buffer()).append_to(reader_compile_time_args);
+    }
 
     /**
      * Create semaphores used for L1-L1 store-and-forward of KV between cores.
@@ -601,7 +607,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
         static_cast<std::uint32_t>(out_out_subblock_h),
-        static_cast<uint32_t>(tensor_args.is_chunked()),
+        static_cast<uint32_t>(is_chunked),
         chunk_size_t,
     };
 
@@ -649,7 +655,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        static_cast<uint32_t>(tensor_args.is_chunked()),
+        static_cast<uint32_t>(is_chunked),
         chunk_size_t};
 
     std::map<std::string, std::string> defines;
@@ -779,9 +785,6 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     auto* const v_buf = input_tensor_v.buffer();
     auto* const gathered_k_buf = gathered_input_tensor_k.buffer();
     auto* const gathered_v_buf = gathered_input_tensor_v.buffer();
-    auto* const joint_q_buf = joint_tensor_q.buffer();
-    auto* const joint_k_buf = joint_tensor_k.buffer();
-    auto* const joint_v_buf = joint_tensor_v.buffer();
     auto* const out_buf = output_tensor.buffer();
     auto* const joint_out_buf = joint_output_tensor.buffer();
     auto* const stats_buf = stats_output_tensor.buffer();
@@ -1413,11 +1416,14 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         reader_args.push_back(v_buf);
         reader_args.push_back(gathered_k_buf);
         reader_args.push_back(gathered_v_buf);
-        reader_args.push_back(joint_q_buf);
-        reader_args.push_back(joint_k_buf);
-        reader_args.push_back(joint_v_buf);
+        if (L != 0) {
+            reader_args.push_back(joint_tensor_q->buffer());
+            reader_args.push_back(joint_tensor_k->buffer());
+            reader_args.push_back(joint_tensor_v->buffer());
+        }
         reader_args.push_back(global_q_start);
         reader_args.push_back(global_q_end);
+        reader_args.push_back(cache_batch_idx);
 
         // Append chain runtime args for store-and-forward
         const auto& head_chain = head_chain_configs.at(i);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -177,9 +177,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
-    const ttnn::Tensor& joint_tensor_q,
-    const ttnn::Tensor& joint_tensor_k,
-    const ttnn::Tensor& joint_tensor_v,
+    const std::optional<ttnn::Tensor>& joint_tensor_q,
+    const std::optional<ttnn::Tensor>& joint_tensor_k,
+    const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
@@ -197,7 +197,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     bool is_balanced,
     std::optional<float> scale,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
-    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    std::optional<uint32_t> cache_batch_idx) {
     auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_k,  // AllGather input
@@ -222,7 +223,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         is_balanced,
         scale,
         compute_kernel_config,
-        core_allocation_strategy);
+        core_allocation_strategy,
+        cache_batch_idx);
     return {
         output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
         output_tensors[prim::RING_JOINT_SDPA_JOINT_OUTPUT_IDX],

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -69,9 +69,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
-    const ttnn::Tensor& joint_tensor_q,
-    const ttnn::Tensor& joint_tensor_k,
-    const ttnn::Tensor& joint_tensor_v,
+    const std::optional<ttnn::Tensor>& joint_tensor_q,
+    const std::optional<ttnn::Tensor>& joint_tensor_k,
+    const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
@@ -89,7 +89,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     bool is_balanced = false,
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
 
 struct ExecuteExpRingJointAttention {
     static std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> invoke(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -27,9 +27,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
     const ttnn::Tensor& input_tensor_v,
-    const ttnn::Tensor& joint_tensor_q,
-    const ttnn::Tensor& joint_tensor_k,
-    const ttnn::Tensor& joint_tensor_v,
+    const std::optional<ttnn::Tensor>& joint_tensor_q,
+    const std::optional<ttnn::Tensor>& joint_tensor_k,
+    const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
     ttnn::Tensor& persistent_output_buffer_v,
     const std::string& joint_strategy,
@@ -47,9 +47,11 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     CoreCoord ccl_core_grid_offset,
     bool use_column_major_ccl,
     bool is_causal,
-    bool is_balanced) {
+    bool is_balanced,
+    std::optional<uint32_t> cache_batch_idx) {
     auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
                                          : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
+
     auto outputs = ttnn::transformer::ring_joint_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_k,
@@ -74,7 +76,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         is_balanced,
         scale,
         compute_kernel_config,
-        strategy);
+        strategy,
+        cache_batch_idx);
     return outputs;
 }
 
@@ -396,9 +399,9 @@ void bind_sdpa(nb::module_& mod) {
             input_tensor_k (ttnn.Tensor): Original keys     [b x nh x N/num_devices x dh].
             input_tensor_v (ttnn.Tensor): Original values   [b x nh x N/num_devices x dh].
 
-            joint_tensor_q (ttnn.Tensor): Joint queries     [b x nh x L x dh].
-            joint_tensor_k (ttnn.Tensor): Joint keys        [b x nh x L x dh].
-            joint_tensor_v (ttnn.Tensor): Joint values      [b x nh x L x dh].
+            joint_tensor_q (ttnn.Tensor, optional): Joint queries     [b x nh x L x dh]. Defaults to None.
+            joint_tensor_k (ttnn.Tensor, optional): Joint keys        [b x nh x L x dh]. Defaults to None.
+            joint_tensor_v (ttnn.Tensor, optional): Joint values      [b x nh x L x dh]. Defaults to None.
 
         Keyword args:
             persistent_output_buffer_k (ttnn.Tensor): Persistent buffer for gathered K tensor.
@@ -421,12 +424,16 @@ void bind_sdpa(nb::module_& mod) {
                 If False (default), uses row-major allocation. Defaults to False.
             is_causal (bool): Whether to use causal attention masking. Defaults to False.
             is_balanced (bool): Whether to use balanced attention computation. Defaults to False.
+            cache_batch_idx (int, optional): Selects the shared K/V cache batch slot when K and V are full caches.
 
         Chunked-prefill mode is entered implicitly when input_tensor_q's per-device seq
         length is less than input_tensor_k's (Q is the latest slab; K is the populated
         prefix from chunk 0 through the current chunk). The op derives chunk_size and
         the absolute Q-row offset from the shapes plus sp_size — no extra args needed.
         Chunked prefill is mathematically causal; callers must pass is_causal=True.
+        When cache_batch_idx is provided, input_tensor_k and input_tensor_v may be whole caches.
+        The same cache_batch_idx selects the K and V cache slot, and the full K/V sequence
+        dimension is treated as valid.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
@@ -442,9 +449,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("input_tensor_q").noconvert(),
         nb::arg("input_tensor_k").noconvert(),
         nb::arg("input_tensor_v").noconvert(),
-        nb::arg("joint_tensor_q").noconvert(),
-        nb::arg("joint_tensor_k").noconvert(),
-        nb::arg("joint_tensor_v").noconvert(),
+        nb::arg("joint_tensor_q") = nb::none(),
+        nb::arg("joint_tensor_k") = nb::none(),
+        nb::arg("joint_tensor_v") = nb::none(),
         nb::kw_only(),
         nb::arg("persistent_output_buffer_k").noconvert(),
         nb::arg("persistent_output_buffer_v").noconvert(),
@@ -463,7 +470,8 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("ccl_core_grid_offset"),
         nb::arg("use_column_major_ccl") = false,
         nb::arg("is_causal").noconvert() = false,
-        nb::arg("is_balanced").noconvert() = false);
+        nb::arg("is_balanced").noconvert() = false,
+        nb::arg("cache_batch_idx").noconvert() = nb::none());
 
     const auto* exp_ring_joint_doc = R"doc(
         ExpRingJointAttention operation that efficiently performs non-causal attention over two


### PR DESCRIPTION
## Summary
- Support ND-sharded K/V tensors in ring joint SDPA.
- Support selecting K/V cache batch slots with `cache_batch_idx`.
- Allow Python ring-joint SDPA calls to pass `None` for joint Q/K/V tensors.
- Add a chunked Blackhole SDPA correctness test covering indexed ND-sharded K/V with PCC and RMSE validation.
- Clean up `test_ring_joint_sdpa.py` so existing tests no longer construct or pass joint tensors.

## Testing
- `pytest -q tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy`
- `pytest -q tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_accuracy[mla_100k-q160-k160] tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_chunked_accuracy[mla_100k-q160-k160-chunk5120]`
- `pre-commit run --files tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp`
- `pre-commit run --files ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp`
- `git diff --check origin/main...HEAD`

## Triggered CI
- Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/26515759000
- Blackhole post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/26515761345
- Nightly tt-metal L2 tests (`additional_test_categories=sdpa`): https://github.com/tenstorrent/tt-metal/actions/runs/26515763222
- Blackhole e2e tests (`test-selection=sdpa`): https://github.com/tenstorrent/tt-metal/actions/runs/26515765585

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-nd-indexed-kv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-nd-indexed-kv)