### PR TITLE
Replace deprecated API calls in kernels and docs

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -118,8 +118,8 @@ void kernel_main() {
 
         const uint32_t cb_in0_addr = get_write_ptr(cb_in0);
         const uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-        noc_async_read_tile(i, a, cb_in0_addr);
-        noc_async_read_tile(i, b, cb_in1_addr);
+        noc_async_read_page(i, a, cb_in0_addr);
+        noc_async_read_page(i, b, cb_in1_addr);
 
         noc_async_read_barrier();  // Wait until tile reads are done
 
@@ -194,7 +194,7 @@ void kernel_main() {
         cb_wait_front(cb_out, 1);
 
         const uint32_t cb_out_addr = get_read_ptr(cb_out);
-        noc_async_write_tile(i, c, cb_out_addr);
+        noc_async_write_page(i, c, cb_out_addr);
 
         noc_async_write_barrier();
 

--- a/docs/source/tt-metalium/tt_metal/advanced_topics/memory_for_kernel_developers.rst
+++ b/docs/source/tt-metalium/tt_metal/advanced_topics/memory_for_kernel_developers.rst
@@ -229,7 +229,7 @@ As interleaved memory is the most common allocation scheme. Instead of manually 
     for (uint32_t i = 0; i < n_tiles; i++) {
         cb_reserve_back(cb_in0, 1);
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-        noc_async_read_tile(i, in0, cb_in0_addr); // read the i-th tile from the interleaved buffer
+        noc_async_read_page(i, in0, cb_in0_addr); // read the i-th tile from the interleaved buffer
 
         noc_async_read_barrier();
         cb_push_back(cb_in0, 1);
@@ -271,7 +271,7 @@ As allocation type and scheme is known at compile time. The same ``TensorAccesso
     for (uint32_t i = 0; i < n_tiles; i++) {
         cb_reserve_back(cb_in0, 1);
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-        noc_async_read_tile(i, in0, cb_in0_addr);
+        noc_async_read_page(i, in0, cb_in0_addr);
 
         noc_async_read_barrier();
         cb_push_back(cb_in0, 1);

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_add.rst
@@ -72,8 +72,8 @@ The reader kernel reads tiles from two source DRAM buffers and pushes them into 
             cb_reserve_back(cb_in1, 1);
             uint32_t cb_in0_addr = get_write_ptr(cb_in0);
             uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-            noc_async_read_tile(i, in0, cb_in0_addr);
-            noc_async_read_tile(i, in1, cb_in1_addr);
+            noc_async_read_page(i, in0, cb_in0_addr);
+            noc_async_read_page(i, in1, cb_in1_addr);
 
             noc_async_read_barrier();
             cb_push_back(cb_in0, 1);
@@ -91,7 +91,7 @@ The writer kernel is straightforward: it reads result tiles from the output circ
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_wait_front(cb_out0, 1);
             uint32_t cb_out0_addr = get_read_ptr(cb_out0);
-            noc_async_write_tile(i, out0, cb_out0_addr);
+            noc_async_write_page(i, out0, cb_out0_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_out0, 1);
         }

--- a/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/custom_sfpi_smoothstep.rst
@@ -103,7 +103,7 @@ The reader kernel reads tiles from a single source DRAM buffer and pushes them i
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_reserve_back(cb_in0, 1);
             uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-            noc_async_read_tile(i, in0, cb_in0_addr);
+            noc_async_read_page(i, in0, cb_in0_addr);
             noc_async_read_barrier();
             cb_push_back(cb_in0, 1);
         }
@@ -121,7 +121,7 @@ The writer kernel is straightforward: it reads result tiles from the output circ
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_wait_front(cb_out0, 1);
             uint32_t cb_out0_addr = get_read_ptr(cb_out0);
-            noc_async_write_tile(i, out0, cb_out0_addr);
+            noc_async_write_page(i, out0, cb_out0_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_out0, 1);
         }

--- a/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/dram_loopback.rst
@@ -161,10 +161,10 @@ The ``TensorAccessor`` object handles bank addressing and page size automaticall
         const auto out0 = TensorAccessor(out0_args, dram_buffer_dst_addr, tile_size_bytes);
 
         for(uint32_t i=0;i<num_tiles;i++) {
-            noc_async_read_tile(i, in0, l1_buffer_addr);
+            noc_async_read_page(i, in0, l1_buffer_addr);
             noc_async_read_barrier();
 
-            noc_async_write_tile(i, out0, l1_buffer_addr);
+            noc_async_write_page(i, out0, l1_buffer_addr);
             noc_async_write_barrier();
         }
     }

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_binary.rst
@@ -178,8 +178,8 @@ To do so, the reader creates 2 interleaved address generators. Unlike on most pr
             cb_reserve_back(cb_in0, 1);
             cb_reserve_back(cb_in1, 1);
 
-            noc_async_read_tile(i, in0, get_write_ptr(cb_in0));
-            noc_async_read_tile(i, in1, get_write_ptr(cb_in1));
+            noc_async_read_page(i, in0, get_write_ptr(cb_in0));
+            noc_async_read_page(i, in1, get_write_ptr(cb_in1));
 
             // Wait until tile reads are done
             noc_async_read_barrier();
@@ -247,7 +247,7 @@ The writer kernel looks similar to the reader kernel. Instead of reading, it wri
 
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_wait_front(cb_out0, 1);
-            noc_async_write_tile(i, out, get_read_ptr(cb_out0));
+            noc_async_write_page(i, out, get_read_ptr(cb_out0));
             noc_async_write_barrier();
             cb_pop_front(cb_out0, 1);
         }

--- a/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/eltwise_sfpu.rst
@@ -125,7 +125,7 @@ The reader kernel takes in the address of the source buffer and the number of ti
         for (uint32_t i = 0; i < n_tiles; i++) {
             cb_reserve_back(cb_in0, 1);
             uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-            noc_async_read_tile(i, in0, cb_in0_addr);
+            noc_async_read_page(i, in0, cb_in0_addr);
 
             noc_async_read_barrier();
             cb_push_back(cb_in0, 1);
@@ -157,7 +157,7 @@ The writer kernel is the exact same as the previous example.
             cb_wait_front(cb_out0, 1);
             uint32_t cb_out0_addr = get_read_ptr(cb_out0);
             // write the tile to DRAM
-            noc_async_write_tile(i, out0, cb_out0_addr);
+            noc_async_write_page(i, out0, cb_out0_addr);
             noc_async_write_barrier();
             // Mark the tile as consumed
             cb_pop_front(cb_out0, 1);

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_multi_core.rst
@@ -239,7 +239,7 @@ To support work distribution, the kernel is updated so that each core processes 
             cb_wait_front(cb_id_out, 1);
             uint32_t l1_read_addr = get_read_ptr(cb_id_out);
             // Write to the correct offset based on start_id
-            noc_async_write_tile(i + start_id, c, l1_read_addr);
+            noc_async_write_page(i + start_id, c, l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_id_out, 1);
         }
@@ -325,7 +325,7 @@ The reader kernel is responsible for reading the input data from the DRAM buffer
                 {
                     cb_reserve_back(cb_id_in0, 1);
                     uint32_t l1_write_addr_in0     = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(tile_A, a, l1_write_addr_in0);
+                    noc_async_read_page(tile_A, a, l1_write_addr_in0);
                     noc_async_read_barrier();
                     cb_push_back(cb_id_in0, 1);
                 }
@@ -334,7 +334,7 @@ The reader kernel is responsible for reading the input data from the DRAM buffer
                 {
                     cb_reserve_back(cb_id_in1, 1);
                     uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                    noc_async_read_tile(tile_B, b, l1_write_addr_in1);
+                    noc_async_read_page(tile_B, b, l1_write_addr_in1);
                     noc_async_read_barrier();
                     cb_push_back(cb_id_in1, 1);
                 }

--- a/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
+++ b/docs/source/tt-metalium/tt_metal/examples/matmul_single_core.rst
@@ -220,7 +220,7 @@ maps tiles in the row-major order of the matrices in DRAM to read into the circu
                         uint32_t a_tile_index = mt * Kt + kt;  // A is MK, so we stride by Kt
                         cb_reserve_back(cb_id_in0, 1);
                         uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                        noc_async_read_tile(a_tile_index, s0, l1_write_addr_in0);
+                        noc_async_read_page(a_tile_index, s0, l1_write_addr_in0);
                         noc_async_read_barrier();
                         cb_push_back(cb_id_in0, 1);
                     }
@@ -229,7 +229,7 @@ maps tiles in the row-major order of the matrices in DRAM to read into the circu
                         uint32_t b_tile_index = kt * Nt + nt;  // B is KN, so we stride by Nt
                         cb_reserve_back(cb_id_in1, 1);
                         uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                        noc_async_read_tile(b_tile_index, s1, l1_write_addr_in1);
+                        noc_async_read_page(b_tile_index, s1, l1_write_addr_in1);
                         noc_async_read_barrier();
                         cb_push_back(cb_id_in1, 1);
                     }
@@ -323,7 +323,7 @@ The writer kernel consumes tiles from the output circular buffer ``cb_id_out0`` 
                 cb_wait_front(cb_id_out0, 1);
                 // Write the output tile to DRAM.
                 uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-                noc_async_write_tile(mt * Nt + nt, s, l1_read_addr);
+                noc_async_write_page(mt * Nt + nt, s, l1_read_addr);
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_out0, 1);
             }

--- a/docs/source/tt-metalium/tt_metal/labs/matmul/lab1/lab1.rst
+++ b/docs/source/tt-metalium/tt_metal/labs/matmul/lab1/lab1.rst
@@ -556,11 +556,11 @@ The main processing loop iterates over all tiles, implementing a producer-consum
 For each tile, the kernel first reserves space in both circular buffers using blocking calls to ``cb_reserve_back``
 to ensure that space is available before attempting to write.
 Once space is reserved, the kernel obtains write pointers to the circular buffers and initiates two non-blocking asynchronous
-read operations using ``noc_async_read_tile``. Observe that this call takes in the index of the tile being read and an address generator,
+read operations using ``noc_async_read_page``. Observe that this call takes in the index of the tile being read and an address generator,
 along with the circular buffer address to write the tile to. The address generator automatically maps the logical tile index to the correct physical
 DRAM address based on the specific memory layout.
 
-Because ``noc_async_read_tile`` is non-blocking, the two reads can proceed in parallel if sufficient bandwidth is available, transferring data from DRAM to
+Because ``noc_async_read_page`` is non-blocking, the two reads can proceed in parallel if sufficient bandwidth is available, transferring data from DRAM to
 the circular buffers simultaneously. After both reads are initiated, the kernel calls ``noc_async_read_barrier`` to wait
 for both transfers to complete. This is important because the kernel should not signal that the tiles are ready for consumption
 until data is actually available.
@@ -1153,11 +1153,11 @@ Then, adjust the code to perform matrix multiplication, by making the following 
 
 #. Update the reader kernel to read the tiles of ``A`` and ``B`` in the correct order.
    The order of reading tiles from ``A`` and ``B`` should match the pattern of visiting one row of tiles of ``A``
-   with all columns of tiles of ``B``, as discussed above. Keep in mind that ``noc_async_read_tile`` function only requires the index of the tile to read,
+   with all columns of tiles of ``B``, as discussed above. Keep in mind that ``noc_async_read_page`` function only requires the index of the tile to read,
    not the actual memory address, so your code only needs to generate indices in the right order.
 
 #. Update the writer kernel to write the tiles of ``C`` in the correct order. The order should match the pattern of visiting tiles of ``C`` in row-major order.
-   Keep in mind that ``noc_async_write_tile`` function only requires the index of the tile to write, not the actual memory address,
+   Keep in mind that ``noc_async_write_page`` function only requires the index of the tile to write, not the actual memory address,
    so your code only needs to generate indices in the right order.
 
 #. Update the compute kernel to perform matrix multiplication rather than elementwise addition.

--- a/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
+++ b/tech_reports/prog_examples/NoC_tile_transfer/NoC_tile_transfer.md
@@ -189,7 +189,7 @@ mesh_device->close();
 ```cpp
 cb_reserve_back(src0_cb_index, one_tile);
 const uint32_t l1_write_addr = get_write_ptr(src0_cb_index);
-noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+noc_async_read_page(0, interleaved_accessor, l1_write_addr);
 noc_async_read_barrier();
 cb_push_back(src0_cb_index, one_tile);
 ```
@@ -235,7 +235,7 @@ noc_semaphore_set(sem_ptr, 0);
 
 ```cpp
 cb_wait_front(src1_cb_index, one_tile);
-noc_async_write_tile(0, output_tensor_dram, l1_write_addr_output);
+noc_async_write_page(0, output_tensor_dram, l1_write_addr_output);
 noc_async_write_barrier();
 cb_pop_front(src1_cb_index, one_tile);
 ```

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -263,7 +263,7 @@ In the reader kernel, we specify the DRAM buffer address generators for the inpu
         for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
             bool read_stick = (curr_h >= front_pad_h and curr_h < H) and (curr_c >= front_pad_c and curr_c < C) and
                               (curr_n >= front_pad_n and curr_n < N);
-            uint64_t read_noc_addr = get_noc_addr(i_stick, s);
+            uint64_t read_noc_addr = s.get_noc_addr(i_stick);
             // Seed pad value in first word to guarantee padding when writer writes only stick_size_bytes
             *((volatile tt_l1_ptr uint32_t*)l1_write_addr) = packed_pad_value;
             if (read_stick) {
@@ -309,7 +309,7 @@ Using the start and end index, the kernel reads the pad value into the circular 
         cb_wait_front(cb_out0, num_sticks_per_barrier);
         uint32_t l1_read_addr = get_read_ptr(cb_out0);
         for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
-            uint64_t write_noc_addr = get_noc_addr(i_stick, s);
+            uint64_t write_noc_addr = s.get_noc_addr(i_stick);
             noc_async_write(l1_read_addr, write_noc_addr, stick_size_bytes);
             l1_read_addr += stick_size_padded_aligned;
             i_stick += 1;

--- a/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
+++ b/tech_reports/prog_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.md
@@ -196,7 +196,7 @@ The reader kernel performs two main tasks:
 // Read input data
 cb_reserve_back(src_cb_index, one_tile);
 const uint32_t l1_write_addr = get_write_ptr(src_cb_index);
-noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+noc_async_read_page(0, interleaved_accessor, l1_write_addr);
 noc_async_read_barrier();
 cb_push_back(src_cb_index, one_tile);
 
@@ -221,7 +221,7 @@ The writer kernel reads computed values from the circular buffer and writes thes
 ```cpp
 cb_wait_front(result_cb_index, one_tile);
 const uint32_t l1_read_addr = get_read_ptr(result_cb_index);
-noc_async_write_tile(0, interleaved_accessor, l1_read_addr);
+noc_async_write_page(0, interleaved_accessor, l1_read_addr);
 noc_async_write_barrier();
 cb_pop_front(result_cb_index, one_tile);
 ```

--- a/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
+++ b/tech_reports/prog_examples/shard_data_rm/shard_data_rm.md
@@ -157,7 +157,7 @@ cb_reserve_back(cb_id_in0, shard_height);
 uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
 DPRINT_DATA0("Core (0,{}): ", current_core);
 for (uint32_t h = 0; h < shard_height; ++h) {
-    uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
+    uint64_t src_noc_addr = s0.get_noc_addr(stick_id);
     noc_async_read(src_noc_addr, l1_write_addr, stick_size);
     uint32_t* read_ptr = (uint32_t*)l1_write_addr;
     DPRINT_DATA0("{} {} ", (uint16_t)*read_ptr, (uint16_t)(*read_ptr >> 16));

--- a/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/kernels/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/kernels/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
         for (uint32_t h = 0; h < block_height_tiles; h++) {
             uint32_t tile_id = curr_tile_id;
             for (uint32_t w = 0; w < block_width_tiles; w++) {
-                noc_async_read_tile(tile_id, s, l1_write_addr);
+                noc_async_read_page(tile_id, s, l1_write_addr);
                 tile_id++;
                 l1_write_addr += tile_bytes;
                 if (++barrier_count == barrier_threshold) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/kernels/reader_dram.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
         uint32_t cb_addr = get_write_ptr(cb_id);
         for (uint32_t i = 0; i < block_size; ++i) {
-            noc_async_read_tile(input_start_tile_id, s, cb_addr);
+            noc_async_read_page(input_start_tile_id, s, cb_addr);
             cb_addr += single_tile_size_bytes;
             input_start_tile_id++;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/kernels/writer_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/kernels/writer_dram.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
         uint32_t cb_addr = get_write_ptr(cb_id);
         for (uint32_t i = 0; i < block_size; ++i) {
-            noc_async_write_tile(input_start_tile_id, s, cb_addr);
+            noc_async_write_page(input_start_tile_id, s, cb_addr);
             cb_addr += single_tile_size_bytes;
             input_start_tile_id++;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -74,7 +74,7 @@ void kernel_main() {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; w++) {
                     if (h < last_block_h) {
-                        noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                        noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr_in0);
                     }
                     l1_write_addr_in0 += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -158,7 +158,7 @@ void kernel_main() {
                 for (uint32_t h = 0; h < out_subblock_h_; h++) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w_; w++) {
-                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                        noc_async_write_page(out_tensor_tile_id, s, l1_read_addr);
 
                         l1_read_addr += output_single_tile_size_bytes;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -149,7 +149,7 @@ void kernel_main() {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; w++) {
                     if (w < last_block_w) {
-                        noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                        noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr_in1);
                     }
                     l1_write_addr_in1 += in1_single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
@@ -220,7 +220,7 @@ void kernel_main() {
             uint32_t in3_tensor_tile_id = in3_tensor_start_tile_id;
             for (uint32_t w = 0; w < in1_block_w; w++) {
                 if (w < last_block_w) {
-                    noc_async_read_tile(in3_tensor_tile_id, s3, l1_write_addr_in3);
+                    noc_async_read_page(in3_tensor_tile_id, s3, l1_write_addr_in3);
                 }
                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                 in3_tensor_tile_id += in3_tensor_stride_w;
@@ -300,7 +300,7 @@ void kernel_main() {
                 for (uint32_t h = 0; h < out_subblock_h_; h++) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w_; w++) {
-                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                        noc_async_write_page(out_tensor_tile_id, s, l1_read_addr);
 
                         l1_read_addr += output_single_tile_size_bytes;
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -69,7 +69,7 @@ void kernel_main() {
         noc_async_read_one_packet(noc_addr, l1_read_addr, page_size, noc);
         noc_async_read(noc_addr, l1_read_addr, page_size, noc);
         // interleaved read
-        noc_async_read_tile(i % 1024, s0, l1_read_addr, 0, noc);
+        noc_async_read_page(i % 1024, s0, l1_read_addr, 0, noc);
 
         // Test semaphore
         noc_semaphore_inc(noc_addr, 1, noc);
@@ -79,7 +79,7 @@ void kernel_main() {
         noc_async_write(l1_read_addr, noc_addr, page_size, noc);
         noc_async_write_one_packet(l1_read_addr, noc_addr, page_size, noc);
         // interleaved write
-        noc_async_write_tile(i % 1024, s0, l1_read_addr, noc);
+        noc_async_write_page(i % 1024, s0, l1_read_addr, 0, 0, noc);
 
         // Test mcast
         if (mcast) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_arbiter_hang.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_arbiter_hang.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
 
     for (uint32_t iter_idx = 0; iter_idx < num_iterations; iter_idx++) {
         for (uint32_t page_id = 0; page_id < num_pages_to_read; page_id++) {
-            noc_async_read_tile(page_id, s, dst_l1_addr);
+            noc_async_read_page(page_id, s, dst_l1_addr);
         }
     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -89,7 +89,7 @@ void kernel_main() {
         noc_async_read_one_packet(noc_addr, l1_read_addr, page_size, noc);
         noc_async_read(noc_addr, l1_read_addr, page_size, noc);
         // interleaved read
-        noc_async_read_tile(i % 1024, s0, l1_read_addr, 0, noc);
+        noc_async_read_page(i % 1024, s0, l1_read_addr, 0, noc);
 
         // Test semaphore
         noc_semaphore_inc(noc_addr, 1, noc);
@@ -99,7 +99,7 @@ void kernel_main() {
         noc_async_write(l1_read_addr, noc_addr, page_size, noc);
         noc_async_write_one_packet(l1_read_addr, noc_addr, page_size, noc);
         // interleaved write
-        noc_async_write_tile(i % 1024, s0, l1_read_addr, noc);
+        noc_async_write_page(i % 1024, s0, l1_read_addr, 0, 0, noc);
 
         // Test mcast
         if (mcast) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_multiple_tiles.cpp
@@ -24,13 +24,13 @@ void kernel_main() {
     for (uint32_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
         cb_reserve_back(cb_id_in0, 1);
         uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(tile_idx, s0, l1_write_addr_in0);
+        noc_async_read_page(tile_idx, s0, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, 1);
 
         cb_reserve_back(cb_id_in1, 1);
         uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-        noc_async_read_tile(tile_idx, s1, l1_write_addr_in1);
+        noc_async_read_page(tile_idx, s1, l1_write_addr_in1);
         noc_async_read_barrier();
         cb_push_back(cb_id_in1, 1);
     }

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -88,7 +88,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_reserve_back(cb_id, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id);
-        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_page(i, s, l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(cb_id, 1);
     }
@@ -134,7 +134,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
-        noc_async_write_tile(i, d, l1_read_addr);
+        noc_async_write_page(i, d, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id, 1);
     }
@@ -2053,7 +2053,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
-        noc_async_write_tile(i, d, l1_read_addr);
+        noc_async_write_page(i, d, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id, 1);
     }

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_global_cb.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential_global_cb.py
@@ -41,7 +41,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_reserve_back(cb_id, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id);
-        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_page(i, s, l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(cb_id, 1);
     }
@@ -89,7 +89,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
-        noc_async_write_tile(i, d, l1_read_addr);
+        noc_async_write_page(i, d, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id, 1);
     }
@@ -162,7 +162,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
-        noc_async_write_tile(i, d, l1_read_addr);
+        noc_async_write_page(i, d, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id, 1);
     }

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/reader_binary_1_tile.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/reader_binary_1_tile.cpp
@@ -32,14 +32,14 @@ void kernel_main() {
     // read the tiles from DRAM into the circular buffers
     cb_reserve_back(cb_in0, 1);
     uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-    noc_async_read_tile(0, in0, cb_in0_addr);  // read
+    noc_async_read_page(0, in0, cb_in0_addr);  // read
     noc_async_read_barrier();                  // wait until the read is done
     cb_push_back(cb_in0, 1);                   // mark the tile as ready.
 
     // same process for the second input (different circular buffer and input buffer)
     cb_reserve_back(cb_in1, 1);
     uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-    noc_async_read_tile(0, in1, cb_in1_addr);
+    noc_async_read_page(0, in1, cb_in1_addr);
     noc_async_read_barrier();
     cb_push_back(cb_in1, 1);
 }

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/writer_1_tile.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/kernels/dataflow/writer_1_tile.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     cb_wait_front(cb_out0, 1);
     uint32_t cb_out0_addr = get_read_ptr(cb_out0);
     // write the tile to DRAM
-    noc_async_write_tile(0, dst, cb_out0_addr);
+    noc_async_write_page(0, dst, cb_out0_addr);
     noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                 // noc_async_write_flushed() can be faster because it waits
                                 // until the write request is sent. In that case, you have to

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/reader_cross_entropy_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/reader_cross_entropy_bw_interleaved_start_id.cpp
@@ -71,7 +71,7 @@ void kernel_main() {
 
         auto [page, offset] = get_page_and_offset(start_row + i, tiled_H);
 
-        auto noc_async_target_indexes_page_addr = get_noc_addr(page, target_indexes_address_generator, offset);
+        auto noc_async_target_indexes_page_addr = target_indexes_address_generator.get_noc_addr(page, offset);
         noc_async_read(
             noc_async_target_indexes_page_addr,
             l1_target_indexes_write_addr,

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
@@ -92,7 +92,7 @@ void kernel_main() {
 
         auto [page, offset] = get_page_and_offset(start_row + i, tiled_H);
 
-        auto noc_async_target_indexes_page_addr = get_noc_addr(page, target_indexes_address_generator, offset);
+        auto noc_async_target_indexes_page_addr = target_indexes_address_generator.get_noc_addr(page, offset);
         noc_async_read(
             noc_async_target_indexes_page_addr,
             l1_target_indexes_write_addr,

--- a/tt-train/sources/ttml/metal/ops/moe_group/device/kernels/dataflow/moe_group_combined_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/moe_group/device/kernels/dataflow/moe_group_combined_kernel.cpp
@@ -219,7 +219,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* fill = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fill_addr);
 
     // ---- Load leids (uint16) into leids_buf ----
-    noc_async_read(get_noc_addr(0, leids_addrgen), (uint32_t)leids_buf, leids_aligned_page);
+    noc_async_read(leids_addrgen.get_noc_addr(0), (uint32_t)leids_buf, leids_aligned_page);
     noc_async_read_barrier();
     volatile tt_l1_ptr uint16_t* leids_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(leids_buf);
 
@@ -236,7 +236,7 @@ void kernel_main() {
             for (uint32_t row = block_start; row < block_end; ++row) {
                 uint32_t local_row = row - block_start;
                 noc_async_read(
-                    get_noc_addr(row, md_addrgen), md_block_addr + local_row * md_aligned_page, md_aligned_page);
+                    md_addrgen.get_noc_addr(row), md_block_addr + local_row * md_aligned_page, md_aligned_page);
             }
             noc_async_read_barrier();
             // Count
@@ -343,9 +343,9 @@ void kernel_main() {
             stamp_entries += copy_entries;
         }
 
-        uint64_t plan_base_noc = get_noc_addr(0, plan_addrgen);
-        uint64_t gs_base_noc = get_noc_addr(0, gs_addrgen);
-        uint64_t ks_base_noc = get_noc_addr(0, ks_addrgen);
+        uint64_t plan_base_noc = plan_addrgen.get_noc_addr(0);
+        uint64_t gs_base_noc = gs_addrgen.get_noc_addr(0);
+        uint64_t ks_base_noc = ks_addrgen.get_noc_addr(0);
         constexpr uint32_t gs_entries_per_burst = MEM_ZEROS_SIZE / sizeof(uint16_t);
         for (uint32_t base = 0; base < t_cap; base += prefill_stamp_entries) {
             uint32_t n = (base + prefill_stamp_entries <= t_cap) ? prefill_stamp_entries : (t_cap - base);
@@ -359,9 +359,9 @@ void kernel_main() {
 
         // Write counts and offsets to DRAM (use stage as staging)
         for (uint32_t e = 0; e < e_local; ++e) stage[e] = counts[e];
-        noc_async_write((uint32_t)stage, get_noc_addr(0, cnt_addrgen), cnt_page_bytes);
+        noc_async_write((uint32_t)stage, cnt_addrgen.get_noc_addr(0), cnt_page_bytes);
         for (uint32_t e = 0; e <= e_local; ++e) stage[e] = offsets[e];
-        noc_async_write((uint32_t)stage, get_noc_addr(0, off_addrgen), off_page_bytes);
+        noc_async_write((uint32_t)stage, off_addrgen.get_noc_addr(0), off_page_bytes);
         noc_async_write_barrier();
 
         // Signal phase 2 done on every core (incl. lead) via ONE NOC multicast
@@ -399,9 +399,9 @@ void kernel_main() {
 
     for (uint32_t e = 0; e < e_local; ++e) fill[e] = 0;
 
-    uint64_t plan_base_noc = get_noc_addr(0, plan_addrgen);
-    uint64_t gs_base_noc = get_noc_addr(0, gs_addrgen);
-    uint64_t ks_base_noc = get_noc_addr(0, ks_addrgen);
+    uint64_t plan_base_noc = plan_addrgen.get_noc_addr(0);
+    uint64_t gs_base_noc = gs_addrgen.get_noc_addr(0);
+    uint64_t ks_base_noc = ks_addrgen.get_noc_addr(0);
     if (my_slice_size > 0U) {
         for (uint32_t block_start = my_slice_start; block_start < my_slice_end; block_start += block_rows) {
             uint32_t block_end = block_start + block_rows;
@@ -411,9 +411,9 @@ void kernel_main() {
             for (uint32_t row = block_start; row < block_end; ++row) {
                 uint32_t local_row = row - block_start;
                 noc_async_read(
-                    get_noc_addr(row, md_addrgen), md_block_addr + local_row * md_aligned_page, md_aligned_page);
+                    md_addrgen.get_noc_addr(row), md_block_addr + local_row * md_aligned_page, md_aligned_page);
                 noc_async_read(
-                    get_noc_addr(row, scores_addrgen), sc_block_addr + local_row * sc_aligned_page, sc_aligned_page);
+                    scores_addrgen.get_noc_addr(row), sc_block_addr + local_row * sc_aligned_page, sc_aligned_page);
             }
             noc_async_read_barrier();
             // Scatter: on match, write plan[i]=row, gs[i]=scores[row,ki], ks[i]=ki.
@@ -524,7 +524,7 @@ void kernel_main() {
 
     // Pull offsets[e_local] from DRAM so we can short-circuit reads for
     // tile-rows past the last active expert slice.
-    noc_async_read(get_noc_addr(0, off_addrgen), (uint32_t)stage, (e_local + 1U) * sizeof(uint32_t));
+    noc_async_read(off_addrgen.get_noc_addr(0), (uint32_t)stage, (e_local + 1U) * sizeof(uint32_t));
     noc_async_read_barrier();
     const uint32_t max_active_tiles = stage[e_local] / TILE_H;
 
@@ -555,7 +555,7 @@ void kernel_main() {
     const uint64_t zeros_noc = get_noc_addr(MEM_ZEROS_BASE);
     constexpr uint32_t zero_chunk_bytes = MEM_ZEROS_SIZE;
     for (uint32_t step = 0; step < my_active_count; ++step, tile_row += worker_stride) {
-        uint64_t plan_noc = get_noc_addr(0, plan_addrgen) + tile_row * TILE_H * sizeof(uint32_t);
+        uint64_t plan_noc = plan_addrgen.get_noc_addr(0, tile_row * TILE_H * sizeof(uint32_t));
         noc_async_read(plan_noc, plan_l1_addr, TILE_H * sizeof(uint32_t));
         noc_async_read_barrier();
 
@@ -580,7 +580,7 @@ void kernel_main() {
                         remaining -= n;
                     }
                 } else {
-                    uint64_t row_noc = get_noc_addr(src, dispatched_addrgen) + chunk_off_bytes;
+                    uint64_t row_noc = dispatched_addrgen.get_noc_addr(src, chunk_off_bytes);
                     noc_async_read(row_noc, row_dst, read_bytes);
                     if (pad_bytes > 0U) {
                         uint32_t remaining = pad_bytes;

--- a/tt-train/sources/ttml/metal/ops/moe_group/device/kernels/dataflow/moe_group_worker_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/moe_group/device/kernels/dataflow/moe_group_worker_writer.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
     cb_reserve_back(cb_offset, 1U);
     uint32_t scratch_addr = get_write_ptr(cb_offset);
     volatile tt_l1_ptr uint32_t* scratch_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_addr);
-    noc_async_read(get_noc_addr(0, offsets_addrgen), scratch_addr, (e_local + 1U) * sizeof(uint32_t));
+    noc_async_read(offsets_addrgen.get_noc_addr(0, 0), scratch_addr, (e_local + 1U) * sizeof(uint32_t));
     noc_async_read_barrier();
     uint32_t max_active_tiles = scratch_buf[e_local] / TILE_H;
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/dataflow/sdpa_fw_writer_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/dataflow/sdpa_fw_writer_kernel.cpp
@@ -74,7 +74,7 @@ void kernel_main() {
 
         cb_wait_front(cb_intermediates, kIntermediateTilesPerRow);
         const uint32_t l1_intermediates_read_addr = get_read_ptr(cb_intermediates);
-        noc_async_write_tile(intermediate_base_idx, intermediates_addr_generator, l1_intermediates_read_addr);
+        noc_async_write_page(intermediate_base_idx, intermediates_addr_generator, l1_intermediates_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_intermediates, kIntermediateTilesPerRow);
 #endif
@@ -119,7 +119,7 @@ void kernel_main() {
 
         cb_wait_front(cb_intermediates, kIntermediateTilesPerRow);
         const uint32_t l1_intermediates_read_addr = get_read_ptr(cb_intermediates);
-        noc_async_write_tile(intermediate_base_idx, intermediates_addr_generator, l1_intermediates_read_addr);
+        noc_async_write_page(intermediate_base_idx, intermediates_addr_generator, l1_intermediates_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_intermediates, kIntermediateTilesPerRow);
 #endif

--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
         uint32_t l1_target_write_addr = get_write_ptr(cb_target_idx);
 
         auto [page, offset] = get_page_and_offset(row, tiled_H);
-        noc_async_read(get_noc_addr(page, target_addr_gen, offset), l1_target_write_addr, target_read_page_size);
+        noc_async_read(target_addr_gen.get_noc_addr(page, offset), l1_target_write_addr, target_read_page_size);
 
         // Zero-initialize so out-of-shard targets produce 0.0.
         cb_reserve_back(cb_output_idx, onetile);

--- a/tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
         uint32_t l1_target_write_addr = get_write_ptr(cb_target_idx);
 
         auto [page, offset] = get_page_and_offset(row, tiled_H);
-        noc_async_read(get_noc_addr(page, target_addr_gen, offset), l1_target_write_addr, target_read_page_size);
+        noc_async_read(target_addr_gen.get_noc_addr(page, offset), l1_target_write_addr, target_read_page_size);
         noc_async_read_barrier();
 
         auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(get_read_ptr(cb_target_idx));

--- a/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/reader0.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/reader0.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     DPRINT("1. READER 0: Reading input data to L1 src0 CB\n");
     cb_reserve_back(src0_cb_index, one_tile);
     const uint32_t l1_write_addr = get_write_ptr(src0_cb_index);
-    noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+    noc_async_read_page(0, interleaved_accessor, l1_write_addr);
     noc_async_read_barrier();
 
     // Print data in buffer

--- a/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/writer1.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/kernels/dataflow/writer1.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     DPRINT(" > Received data from src1: {}\n", ptr[0]);
 
     // Save output data
-    noc_async_write_tile(0, output_tensor_dram, l1_write_addr_output);
+    noc_async_write_page(0, output_tensor_dram, l1_write_addr_output);
     noc_async_write_barrier();
 
     cb_pop_front(src1_cb_index, one_tile);

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp
@@ -37,14 +37,14 @@ void kernel_main() {
     // read the tiles from DRAM into the circular buffers
     cb_reserve_back(cb_in0, 1);
     uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-    noc_async_read_tile(0, in0, cb_in0_addr);  // read
+    noc_async_read_page(0, in0, cb_in0_addr);  // read
     noc_async_read_barrier();                  // wait until the read is done
     cb_push_back(cb_in0, 1);                   // mark the tile as ready.
 
     // same process for the second input (different circular buffer and input buffer)
     cb_reserve_back(cb_in1, 1);
     uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-    noc_async_read_tile(0, in1, cb_in1_addr);
+    noc_async_read_page(0, in1, cb_in1_addr);
     noc_async_read_barrier();
     cb_push_back(cb_in1, 1);
 }

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     cb_wait_front(cb_out0, 1);
     uint32_t cb_out0_addr = get_read_ptr(cb_out0);
     // write the tile to DRAM
-    noc_async_write_tile(0, dst, cb_out0_addr);
+    noc_async_write_page(0, dst, cb_out0_addr);
     noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                 // noc_async_write_flushed() can be faster because it waits
                                 // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
@@ -25,8 +25,8 @@ void kernel_main() {
     // The first argument is the page index, which is 0 in this case as we are reading the first page of the buffer.
     // The second argument is the address generator for the buffer.
     // "Page" simply means a unit of data.
-    uint64_t src0_dram_noc_addr = get_noc_addr(0, src0);
-    uint64_t src1_dram_noc_addr = get_noc_addr(0, src1);
+    uint64_t src0_dram_noc_addr = src0.get_noc_addr(0);
+    uint64_t src1_dram_noc_addr = src1.get_noc_addr(0);
     noc_async_read(src0_dram_noc_addr, src0_l1, sizeof(uint32_t));
     noc_async_read(src1_dram_noc_addr, src1_l1, sizeof(uint32_t));
     noc_async_read_barrier();
@@ -43,7 +43,7 @@ void kernel_main() {
     // Write data from L1 -> DRAM. Again this is a non-blocking operation.
     // Thus we need to use noc_async_write_barrier() to wait until the data is
     // is written to DRAM before we can continue.
-    uint64_t dst_dram_noc_addr = get_noc_addr(0, dst);
+    uint64_t dst_dram_noc_addr = dst.get_noc_addr(0);
     noc_async_write(dst_l1, dst_dram_noc_addr, sizeof(uint32_t));
     noc_async_write_barrier();
 }

--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp
@@ -20,7 +20,7 @@ void kernel_main() {
 
     ////////// CALCULATE OFFSET AND WRITE TO DRAM //////////
     uint32_t dram_tile_id = tile_offset;
-    noc_async_write_tile(dram_tile_id, dram_writer, l1_read_addr);
+    noc_async_write_page(dram_tile_id, dram_writer, l1_read_addr);
     noc_async_write_barrier();
 
     cb_pop_front(cb_id_out0, 1);

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/interleaved_tile_read.cpp
@@ -38,8 +38,8 @@ void kernel_main() {
                                      // Deciding how large the buffer should be is a tradeoff.
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
         uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-        noc_async_read_tile(i, a, cb_in0_addr);  // read the tile into the circular buffer
-        noc_async_read_tile(i, b, cb_in1_addr);  // We can overlap async reads and writes
+        noc_async_read_page(i, a, cb_in0_addr);  // read the tile into the circular buffer
+        noc_async_read_page(i, b, cb_in1_addr);  // We can overlap async reads and writes
                                                  // to reduce the data movement overhead.
 
         // NOTE: Since circular buffers are backed by SRAM, we can actually access them by

--- a/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
@@ -21,7 +21,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
-        noc_async_write_tile(i, c, cb_out0_addr);
+        noc_async_write_page(i, c, cb_out0_addr);
         noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                     // noc_async_write_flushed() can be faster because it waits
                                     // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/custom_sfpi_add/kernels/dataflow/read_tiles.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/kernels/dataflow/read_tiles.cpp
@@ -38,8 +38,8 @@ void kernel_main() {
                                      // Deciding how large the buffer should be is a tradeoff.
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
         uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-        noc_async_read_tile(i, in0, cb_in0_addr);  // read the tile into the circular buffer
-        noc_async_read_tile(i, in1, cb_in1_addr);  // We can overlap async reads and writes
+        noc_async_read_page(i, in0, cb_in0_addr);  // read the tile into the circular buffer
+        noc_async_read_page(i, in1, cb_in1_addr);  // We can overlap async reads and writes
                                                    // to reduce the data movement overhead.
 
         noc_async_read_barrier();  // Wait until tile reads are done

--- a/tt_metal/programming_examples/custom_sfpi_add/kernels/dataflow/write_tile.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/kernels/dataflow/write_tile.cpp
@@ -21,7 +21,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
-        noc_async_write_tile(i, out0, cb_out0_addr);
+        noc_async_write_page(i, out0, cb_out0_addr);
         noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                     // noc_async_write_flushed() can be faster because it waits
                                     // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/dataflow/read_tiles.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/dataflow/read_tiles.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
                                      // other kernels cannot consume the tiles fast enough.
                                      // Deciding how large the buffer should be is a tradeoff.
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-        noc_async_read_tile(i, in0, cb_in0_addr);  // read the tile into the circular buffer
+        noc_async_read_page(i, in0, cb_in0_addr);  // read the tile into the circular buffer
                                                    // We can overlap async reads and writes
                                                    // to reduce the data movement overhead.
 

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/dataflow/write_tile.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/kernels/dataflow/write_tile.cpp
@@ -21,7 +21,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
-        noc_async_write_tile(i, out0, cb_out0_addr);
+        noc_async_write_page(i, out0, cb_out0_addr);
         noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                     // noc_async_write_flushed() can be faster because it waits
                                     // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
+++ b/tt_metal/programming_examples/loopback/kernels/loopback_dram_copy.cpp
@@ -30,12 +30,12 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i++) {
         // Issue a read to the NoC and write to the L1 buffer. This operation is asynchronous.
         // thus a barrier is needed to ensure that the read is complete before the write.
-        noc_async_read_tile(i, in0, l1_buffer_addr);
+        noc_async_read_page(i, in0, l1_buffer_addr);
         noc_async_read_barrier();
         // Write back the tile to the destination DRAM buffer.
         // Again, this is an asynchronous operation, so we need a barrier to ensure the write
         // is complete before the next iteration.
-        noc_async_write_tile(i, out0, l1_buffer_addr);
+        noc_async_write_page(i, out0, l1_buffer_addr);
         noc_async_write_barrier();
     }
 }

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
             {  // Read A's tile at (mt, kt)
                 cb_reserve_back(cb_id_in0, onetile);
                 uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(itileA, s0, l1_write_addr_in0);
+                noc_async_read_page(itileA, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
             }
@@ -59,7 +59,7 @@ void kernel_main() {
             {  // Read B's tile at (kt, nt)
                 cb_reserve_back(cb_id_in1, onetile);
                 uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(itileB, s1, l1_write_addr_in1);
+                noc_async_read_page(itileB, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
             }

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -67,7 +67,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in0_block_h; h++) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; w++) {
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                    noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr_in0);
                     l1_write_addr_in0 += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
                 }
@@ -79,7 +79,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in1_block_h; h++) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; w++) {
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                    noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr_in1);
                     l1_write_addr_in1 += in1_single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                 }

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
@@ -116,7 +116,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in1_block_h; h++) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; w++) {
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                    noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr_in1);
                     l1_write_addr_in1 += single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                     in1_block_size_bytes += single_tile_size_bytes;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
@@ -98,7 +98,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in0_block_h; h++) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; w++) {
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                    noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr_in0);
                     l1_write_addr_in0 += single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
                     in0_block_size_bytes += single_tile_size_bytes;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
@@ -112,7 +112,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in0_block_h; h++) {
                 uint32_t in0_tensor_tile_id = in0_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in0_block_w; w++) {
-                    noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr_in0);
+                    noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr_in0);
                     l1_write_addr_in0 += single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
                     in0_block_size_bytes += single_tile_size_bytes;
@@ -174,7 +174,7 @@ void kernel_main() {
             for (uint32_t h = 0; h < in1_block_h; h++) {
                 uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
                 for (uint32_t w = 0; w < in1_block_w; w++) {
-                    noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr_in1);
+                    noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr_in1);
                     l1_write_addr_in1 += single_tile_size_bytes;
                     in1_tensor_tile_id += in1_tensor_stride_w;
                     in1_block_size_bytes += single_tile_size_bytes;

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
                 for (uint32_t h = 0; h < out_subblock_h; h++) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w; w++) {
-                        noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+                        noc_async_write_page(out_tensor_tile_id, s, l1_read_addr);
                         l1_read_addr += single_tile_size_bytes;
 
                         out_tensor_tile_id += out_tensor_stride_w;

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
             {
                 cb_reserve_back(cb_id_in0, 1);
                 uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(tile_A, a, l1_write_addr_in0);
+                noc_async_read_page(tile_A, a, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, 1);
             }
@@ -55,7 +55,7 @@ void kernel_main() {
             {
                 cb_reserve_back(cb_id_in1, 1);
                 uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(tile_B, b, l1_write_addr_in1);
+                noc_async_read_page(tile_B, b, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, 1);
             }

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
         cb_wait_front(cb_id_out, onetile);
         // Write the output tile to DRAM.
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_tile(i, c, l1_read_addr);
+        noc_async_write_page(i, c, l1_read_addr);
         noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                     // noc_async_write_flushed() can be faster because it waits
                                     // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
                     uint32_t a_tile_index = mt * Kt + kt;  // A is MK, so we stride by Kt
                     cb_reserve_back(cb_id_in0, 1);
                     uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(a_tile_index, s0, l1_write_addr_in0);
+                    noc_async_read_page(a_tile_index, s0, l1_write_addr_in0);
                     noc_async_read_barrier();
                     cb_push_back(cb_id_in0, 1);
                 }
@@ -44,7 +44,7 @@ void kernel_main() {
                     uint32_t b_tile_index = kt * Nt + nt;  // B is KN, so we stride by Nt
                     cb_reserve_back(cb_id_in1, 1);
                     uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                    noc_async_read_tile(b_tile_index, s1, l1_write_addr_in1);
+                    noc_async_read_page(b_tile_index, s1, l1_write_addr_in1);
                     noc_async_read_barrier();
                     cb_push_back(cb_id_in1, 1);
                 }

--- a/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
             cb_wait_front(cb_id_out0, 1);
             // Write the output tile to DRAM.
             uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-            noc_async_write_tile(m * Nt + n, s, l1_read_addr);
+            noc_async_write_page(m * Nt + n, s, l1_read_addr);
             noc_async_write_barrier();  // This will wait until the write is done. As an alternative,
                                         // noc_async_write_flushed() can be faster because it waits
                                         // until the write request is sent. In that case, you have to

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -77,7 +77,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
             bool read_stick = (curr_h >= front_pad_h and curr_h < H) and (curr_c >= front_pad_c and curr_c < C) and
                               (curr_n >= front_pad_n and curr_n < N);
-            uint64_t read_noc_addr = get_noc_addr(i_stick, s);
+            uint64_t read_noc_addr = s.get_noc_addr(i_stick);
             // Seed pad value in first word to guarantee padding when writer writes only stick_size_bytes
             *((volatile tt_l1_ptr uint32_t*)l1_write_addr) = packed_pad_value;
             if (read_stick) {

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, num_sticks_per_barrier);
         uint32_t l1_read_addr = get_read_ptr(cb_out0);
         for (uint32_t i = 0; i < num_sticks_per_barrier && iter < num_sticks_per_core; ++i, ++iter) {
-            uint64_t write_noc_addr = get_noc_addr(i_stick, s);
+            uint64_t write_noc_addr = s.get_noc_addr(i_stick);
             noc_async_write(l1_read_addr, write_noc_addr, stick_size_bytes);
             l1_read_addr += stick_size_padded_aligned;
             i_stick += 1;

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
     // Read input value data
     cb_reserve_back(src_cb_index, one_tile);
     const uint32_t l1_write_addr = get_write_ptr(src_cb_index);
-    noc_async_read_tile(0, interleaved_accessor, l1_write_addr);
+    noc_async_read_page(0, interleaved_accessor, l1_write_addr);
     noc_async_read_barrier();
     cb_push_back(src_cb_index, one_tile);
 

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/writer.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/writer.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     // Save output data
     cb_wait_front(result_cb_index, one_tile);
     const uint32_t l1_read_addr = get_read_ptr(result_cb_index);
-    noc_async_write_tile(0, interleaved_accessor, l1_read_addr);
+    noc_async_write_page(0, interleaved_accessor, l1_read_addr);
     noc_async_write_barrier();
     cb_pop_front(result_cb_index, one_tile);
 }

--- a/tt_metal/programming_examples/shard_data_rm/kernels/reader_sharded_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/kernels/reader_sharded_rm.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
     constexpr uint32_t element_per_stick = 2;  // Each stick contains two bfloat16 values
     const uint32_t n_sticks = stick_size / element_per_stick;
     for (uint32_t i = 0; i < n_sticks; i++) {
-        uint64_t src_noc_addr = get_noc_addr(stick_id, s0);
+        uint64_t src_noc_addr = s0.get_noc_addr(stick_id);
         // Read a tick at a time from the source address and write it to the L1 write address.
         noc_async_read(src_noc_addr, l1_write_addr, stick_size);
         noc_async_read_barrier();  // wait for the read to finish

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp
@@ -49,8 +49,8 @@ void kernel_main() {
                  // Deciding how large the buffer should be is a tradeoff.
         uint32_t cb_in0_addr = get_write_ptr(cb_in0);
         uint32_t cb_in1_addr = get_write_ptr(cb_in1);
-        noc_async_read_tile(i, a, cb_in0_addr);  // read the tile into the circular buffer
-        noc_async_read_tile(i, b, cb_in1_addr);  // We can overlap async reads and writes
+        noc_async_read_page(i, a, cb_in0_addr);  // read the tile into the circular buffer
+        noc_async_read_page(i, b, cb_in1_addr);  // We can overlap async reads and writes
                                                  // to reduce the data movement overhead.
 
         // NOTE: Since circular buffers are backed by SRAM, we can actually

--- a/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
-        noc_async_write_tile(i, c, cb_out0_addr);
+        noc_async_write_page(i, c, cb_out0_addr);
         // This will wait until the write is done. As an alternative, noc_async_writes_flushed()
         // can be faster because it waits until the write request is sent. In that case, you
         // have to use noc_async_write_barrier() at least once at the end of data movement

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -68,7 +68,7 @@ template <typename AddrGen>
 FORCE_INLINE void noc_async_read_tile_helper(tt::CBIndex cb, uint32_t num_tiles, uint32_t tile_idx, AddrGen addr_gen) {
     cb_reserve_back(cb, num_tiles);
     uint32_t addr = get_write_ptr(cb);
-    noc_async_read_tile(tile_idx, addr_gen, addr);
+    noc_async_read_page(tile_idx, addr_gen, addr);
     noc_async_read_barrier();
     cb_push_back(cb, num_tiles);
 }
@@ -77,7 +77,7 @@ template <typename AddrGen>
 FORCE_INLINE void noc_async_write_tile_helper(tt::CBIndex cb, uint32_t num_tiles, uint32_t tile_idx, AddrGen addr_gen) {
     cb_wait_front(cb, num_tiles);
     uint32_t l1_read_addr = get_read_ptr(cb);
-    noc_async_write_tile(tile_idx, addr_gen, l1_read_addr);
+    noc_async_write_page(tile_idx, addr_gen, l1_read_addr);
     noc_async_write_barrier();
     cb_pop_front(cb, num_tiles);
 }
@@ -727,7 +727,7 @@ void read_tile(
     }
 
     auto l1_write_addr = get_write_ptr(cb_id);
-    auto noc_addr = get_noc_addr(noc_id, addrgen, offset);
+    auto noc_addr = addrgen.get_noc_addr(noc_id, offset);
     noc_async_read(noc_addr, l1_write_addr, size);
 
     noc_async_read_barrier();
@@ -754,7 +754,7 @@ void read_value(
     uint32_t size = get_tile_size(cb_id) / 1024;
 
     auto l1_write_addr = get_write_ptr(cb_id);
-    auto noc_addr = get_noc_addr(noc_id, addrgen);
+    auto noc_addr = addrgen.get_noc_addr(noc_id);
     noc_async_read(noc_addr + tilized_idx * size, l1_write_addr + tilized_idx * size, size);
     noc_async_read_barrier();
 
@@ -808,7 +808,7 @@ void read_line(
         if (noc_id * 2 != i) {
             noc_offset += (FACE_HEIGHT * FACE_WIDTH) * element_bytes;
         }
-        auto src_noc_addr = get_noc_addr(noc_id, addrgen, noc_offset);
+        auto src_noc_addr = addrgen.get_noc_addr(noc_id, noc_offset);
 
         if (noc_read_size_bytes == valid_elements_bytes) {
             // DRAM and L1 read sizes are aligned, so we can read directly into the destination CB.

--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
@@ -27,7 +27,7 @@ inline void write_tiles_in_block(
             if (block_row_id >= num_rows_unpadded) {
                 break;
             }
-            uint64_t dst_noc_addr = get_noc_addr(block_row_id, s, block_row_offset);
+            uint64_t dst_noc_addr = s.get_noc_addr(block_row_id, block_row_offset);
             noc_async_write(l1_read_addr, dst_noc_addr, block_row_size_unpadded);
             l1_read_addr += block_row_size;
             block_row_id++;

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/reader_bernoulli.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     for (uint32_t i = start_id; i < end_id; ++i) {
         cb_reserve_back(in_cb_id, 1);
         uint32_t in_cb_write_ptr = get_write_ptr(in_cb_id);
-        noc_async_read_tile(i, input_addrg, in_cb_write_ptr);
+        noc_async_read_page(i, input_addrg, in_cb_write_ptr);
         noc_async_read_barrier();
         cb_push_back(in_cb_id, 1);
     }

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/kernels/writer_bernoulli.cpp
@@ -69,7 +69,7 @@ void kernel_main() {
         cb_pop_front(in_cb_id, 1);
         cb_pop_front(intermed_cb_id, 1);
 
-        noc_async_write_tile(i, output_addrg, intermed1_cb_write_ptr);
+        noc_async_write_page(i, output_addrg, intermed1_cb_write_ptr);
         noc_async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_tile_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/kernels/broadcast_tile_reader.cpp
@@ -65,7 +65,7 @@ void kernel_main() {
 #ifdef SHARDED
                 noc_async_read_page(tile_id, tensor0_addrgen, l1_write_addr);
 #else
-                noc_async_read_tile(tile_id, tensor0_addrgen, l1_write_addr);
+                noc_async_read_page(tile_id, tensor0_addrgen, l1_write_addr);
 #endif
                 l1_write_addr += tensor0_page_size;
                 tile_id++;

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send.cpp
@@ -143,14 +143,14 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor_to_address(
         contig_pages = 1;
 #ifdef ROW_MAJOR_LAYOUT
 #ifdef INTERLEAVED_MEM_LAYOUT
-        uint64_t src_noc_addr = get_noc_addr(curr_page_idx, s);
+        uint64_t src_noc_addr = s.get_noc_addr(curr_page_idx);
         noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
 #elif defined SHARDED_MEM_LAYOUT
         ASSERT(false);  // unimplemented
 #endif
 #elif defined TILED_LAYOUT
 #ifdef INTERLEAVED_MEM_LAYOUT
-        noc_async_read_tile(curr_page_idx, s, local_l1_read_addr);
+        noc_async_read_page(curr_page_idx, s, local_l1_read_addr);
         // common with `write_chunk_v2`
 #elif defined SHARDED_MEM_LAYOUT
         auto const& [noc_yx, page_offset, contig_pages_] =

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; wt++) {
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i, s0, l1_write_addr_in0);
+                noc_async_read_page(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
 
@@ -47,7 +47,7 @@ void kernel_main() {
                 // but we loop the second list around
                 cb_reserve_back(cb_id_in1, onetile);
                 l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(i1, s1, l1_write_addr_in1);
+                noc_async_read_page(i1, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
                 i1++;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_interleaved_input_rows_partitioned.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; wt++) {
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i, s0, l1_write_addr_in0);
+                noc_async_read_page(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
 
@@ -51,7 +51,7 @@ void kernel_main() {
                 // but we loop the second list around
                 cb_reserve_back(cb_id_in1, onetile);
                 l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(i1, s1, l1_write_addr_in1);
+                noc_async_read_page(i1, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
                 i1++;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
             // but we loop the second list around
             cb_reserve_back(cb_id_in1, onetile);
             l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-            noc_async_read_tile(offset, s1, l1_write_addr_in1);
+            noc_async_read_page(offset, s1, l1_write_addr_in1);
             noc_async_read_barrier();
             cb_push_back(cb_id_in1, onetile);
             offset++;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
             cb_reserve_back(cb_id_in1, w_blk);
             l1_write_addr_in1 = get_write_ptr(cb_id_in1);
             for (uint32_t r = 0; r < w_blk; r++) {
-                noc_async_read_tile(offset + wt + r, s1, l1_write_addr_in1);
+                noc_async_read_page(offset + wt + r, s1, l1_write_addr_in1);
                 l1_write_addr_in1 += tile_bytes;
             }
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
 #ifdef BCAST_SCALAR
     cb_reserve_back(cb_id_in1, onetile);
     l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-    noc_async_read_tile(i1, s1, l1_write_addr_in1);
+    noc_async_read_page(i1, s1, l1_write_addr_in1);
     noc_async_read_barrier();
     cb_push_back(cb_id_in1, onetile);
 #endif
@@ -59,7 +59,7 @@ void kernel_main() {
 #ifndef IN0_SHARDED
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i, s0, l1_write_addr_in0);
+                noc_async_read_page(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
                 i++;  // input tile iterates over NC Ht Wt
@@ -70,7 +70,7 @@ void kernel_main() {
                 // but we don't advance the second tile index for H,W
                 cb_reserve_back(cb_id_in1, onetile);
                 l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(i1, s1, l1_write_addr_in1);
+                noc_async_read_page(i1, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_hw_interleaved_partitioned.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
 #ifdef BCAST_SCALAR
     cb_reserve_back(cb_id_in1, onetile);
     l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-    noc_async_read_tile(bcast_id, s1, l1_write_addr_in1);
+    noc_async_read_page(bcast_id, s1, l1_write_addr_in1);
     noc_async_read_barrier();
     cb_push_back(cb_id_in1, onetile);
 #endif
@@ -53,7 +53,7 @@ void kernel_main() {
 #ifndef IN0_SHARDED
         cb_reserve_back(cb_id_in0, onetile);
         l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(curr_id, s0, l1_write_addr_in0);
+        noc_async_read_page(curr_id, s0, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
 #endif
@@ -63,7 +63,7 @@ void kernel_main() {
 #ifndef BCAST_SCALAR
         cb_reserve_back(cb_id_in1, onetile);
         l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-        noc_async_read_tile(bcast_id, s1, l1_write_addr_in1);
+        noc_async_read_page(bcast_id, s1, l1_write_addr_in1);
         noc_async_read_barrier();
         cb_push_back(cb_id_in1, onetile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
 #ifndef IN0_SHARDED
         cb_reserve_back(cb_id_in0, onetile);
         l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(curr_id, s0, l1_write_addr_in0);
+        noc_async_read_page(curr_id, s0, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
                 // So we push a total of NC*H tiles from src1
                 cb_reserve_back(cb_id_in1, onetile);
                 l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(i_bcast, s1, l1_write_addr_in1);
+                noc_async_read_page(i_bcast, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
                 i_bcast++;
@@ -51,7 +51,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; wt++) {
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i, s0, l1_write_addr_in0);
+                noc_async_read_page(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
                 i++;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_w_interleaved_input_cols_partitioned.cpp
@@ -47,7 +47,7 @@ void kernel_main() {
                 // So we push a total of NC*H tiles from src1
                 cb_reserve_back(cb_id_in1, onetile);
                 l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-                noc_async_read_tile(i_bcast, s1, l1_write_addr_in1);
+                noc_async_read_page(i_bcast, s1, l1_write_addr_in1);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in1, onetile);
                 i_bcast++;
@@ -56,7 +56,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; wt++) {
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(i, s0, l1_write_addr_in0);
+                noc_async_read_page(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
                 i++;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/writer_unary_interleaved_input_cols_batched.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
                 cb_wait_front(cb_id_out0, onetile);
                 uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
 
-                noc_async_write_tile(tile_id, s, l1_read_addr);
+                noc_async_write_page(tile_id, s, l1_read_addr);
 
                 noc_async_write_barrier();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/docs/Gather.md
@@ -350,12 +350,12 @@ for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
 ```cpp
 // Single Row Single Core: Batch memory access
 for (uint32_t w = 0; w < Wt_input; w++) {
-    noc_async_read_tile(h * Wt_input + w, input_tensor_dram, l1_addr);  // Sequential reads
+    noc_async_read_page(h * Wt_input + w, input_tensor_dram, l1_addr);  // Sequential reads
 }
 
 // Single Row Multi Core: Interleaved memory access
 for (uint32_t wi = 0; wi < Wt_input; wi++) {
-    noc_async_read_tile(h * Wt_input + wi, input_tensor_dram, l1_addr);  // Per-tile reads
+    noc_async_read_page(h * Wt_input + wi, input_tensor_dram, l1_addr);  // Per-tile reads
 }
 ```
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
     cb.reserve_back(num_tiles);
     uint32_t l1_write_addr = cb.get_write_ptr();
     for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
-        noc_async_read_tile(i, src_addrgen, l1_write_addr);
+        noc_async_read_page(i, src_addrgen, l1_write_addr);
         noc_async_read_barrier();
         l1_write_addr += tile_bytes;
     }
@@ -87,7 +87,7 @@ void kernel_main() {
     cb.wait_front(num_tiles);
     uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t i = start_id; i < start_id + num_tiles; i += ublock_size_tiles) {
-        noc_async_write_tile(i, dst_addrgen, l1_read_addr);
+        noc_async_write_page(i, dst_addrgen, l1_read_addr);
         noc_async_write_barrier();
         l1_read_addr += tile_bytes;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -88,7 +88,7 @@ void kernel_main() {
                         pad_value);
                 } else {
                     // this is a data row possibly with padding at end
-                    uint64_t src_noc_addr = get_noc_addr(src_stick_id, s0, start_src_stick_offset);
+                    uint64_t src_noc_addr = s0.get_noc_addr(src_stick_id, start_src_stick_offset);
                     noc_async_read(src_noc_addr, l1_addr, unpadded_X_nbytes);
                     l1_addr_partial = l1_addr + unpadded_X_nbytes;
                     fill_with_val_async(

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
                 // DPRINT("WR: w={} z={} y={}\n", w, z, y);
                 cb.wait_front(1);
                 uint32_t l1_addr = cb.get_read_ptr();
-                uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, s1, dst_stick_offset);
+                uint64_t dst_noc_addr = s1.get_noc_addr(dst_stick_id, dst_stick_offset);
                 noc_async_write(l1_addr, dst_noc_addr, padded_X_nbytes);
                 noc_async_write_barrier();
                 ++dst_stick_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
 
     auto pad_tiles = [&](uint32_t num_tiles) {
         for (uint32_t pad_tile = 0; pad_tile < num_tiles; pad_tile++) {
-            noc_async_write_tile(dst_tile_id, s1, pad_buffer_l1_addr);
+            noc_async_write_page(dst_tile_id, s1, pad_buffer_l1_addr);
             dst_tile_id++;
         }
         noc_async_write_barrier();
@@ -56,7 +56,7 @@ void kernel_main() {
                 for (uint32_t xt = 0; xt < num_unpadded_Xt; xt++) {
                     cb_out0.wait_front(1);
                     uint32_t src_buffer_l1_addr = cb_out0.get_read_ptr();
-                    noc_async_write_tile(dst_tile_id, s1, src_buffer_l1_addr);
+                    noc_async_write_page(dst_tile_id, s1, src_buffer_l1_addr);
                     noc_async_write_barrier();
                     cb_out0.pop_front(1);
                     dst_tile_id++;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
@@ -192,7 +192,7 @@ void kernel_main() {
 
             for (uint32_t x = x_start; x < x_end; ++x) {
                 uint32_t l1_col_base = src_buffer_l1_addr + page_offset;
-                uint64_t src_noc_addr = get_noc_addr(tile, s, base_face_line_offset_bytes);
+                uint64_t src_noc_addr = s.get_noc_addr(tile, base_face_line_offset_bytes);
 
                 // Read each face in [0..real_faces_w)
                 uint16_t w_offset = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_tiled_generic.cpp
@@ -232,7 +232,7 @@ void kernel_main() {
                     tile = base_tile_offset;
                 }
 
-                uint64_t dest_noc_addr = get_noc_addr(tile, s, local_face_offset_bytes);
+                uint64_t dest_noc_addr = s.get_noc_addr(tile, local_face_offset_bytes);
                 uint32_t l1_row_base = transposed_buffer_read_addr + page_offset;
 
                 // Write each face
@@ -297,7 +297,7 @@ void kernel_main() {
                     for (uint8_t sub_tile_line = sub_tile_line_start; sub_tile_line < FACE_HEIGHT; ++sub_tile_line) {
                         uint16_t offset =
                             static_cast<uint16_t>((face_offset + (sub_tile_line * FACE_WIDTH)) * element_size);
-                        uint64_t write_noc_base_addr = get_noc_addr(linear_idx, s, offset);
+                        uint64_t write_noc_base_addr = s.get_noc_addr(linear_idx, offset);
 
                         noc_async_write(l1_read_ptr, write_noc_base_addr, SUBTILE_LINE_BYTES);
                     }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
@@ -126,7 +126,7 @@ FORCE_INLINE void load_to_cb(
     const uint32_t& stick_id) {
     CircularBuffer cb_exp(cb);
     cb_exp.reserve_back(ONE_PAGE);
-    const uint64_t source_noc_address = get_noc_addr(stick_id, addr_gtor);
+    const uint64_t source_noc_address = addr_gtor.get_noc_addr(stick_id);
     const uint32_t l1_write_address = cb_exp.get_write_ptr();
 
     // Use legacy NOC API for raw address reads
@@ -146,7 +146,7 @@ FORCE_INLINE void write_to_output(
     const uint32_t& stick_id) {
     CircularBuffer cb_exp(cb);
     cb_exp.wait_front(ONE_PAGE);
-    const uint64_t destination_noc_address = get_noc_addr(stick_id, addr_gtor);
+    const uint64_t destination_noc_address = addr_gtor.get_noc_addr(stick_id);
     const uint32_t l1_read_address = cb_exp.get_read_ptr();
 
     // Use legacy NOC API for raw address writes

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = row_start_tile_id;
         for (uint32_t w = 0; w < block_width_tiles; w++) {
-            uint64_t dst_noc_addr = get_noc_addr(tile_id, s);
+            uint64_t dst_noc_addr = s.get_noc_addr(tile_id);
             noc_async_write(l1_read_addr, dst_noc_addr, tile_bytes);
             tile_id++;
             l1_read_addr += tile_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     cb_out.wait_front(block_height);
     uint32_t l1_read_addr = cb_out.get_read_ptr();
     for (uint32_t h = 0; h < block_height; ++h) {
-        uint64_t dst_noc_addr = get_noc_addr(stick_id, s);
+        uint64_t dst_noc_addr = s.get_noc_addr(stick_id);
         noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
         stick_id += output_width_in_pages;
         l1_read_addr += padded_block_width_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -71,21 +71,21 @@ void kernel_main() {
             // Save index tile to output index tensor
             cb_wait_front(index_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr_index_tensor_cb = get_read_ptr(index_tensor_cb_index);
-            noc_async_write_tile(h * Wt + w, output_index_tensor_addr_gen, l1_write_addr_index_tensor_cb);
+            noc_async_write_page(h * Wt + w, output_index_tensor_addr_gen, l1_write_addr_index_tensor_cb);
             noc_async_write_barrier();
             cb_pop_front(index_tensor_cb_index, one_tile);
 
             // Read input value data
             cb_reserve_back(input_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr_input_tensor_cb = get_write_ptr(input_tensor_cb_index);
-            noc_async_read_tile(h * Wt + w, input_tensor_addr_ger, l1_write_addr_input_tensor_cb);
+            noc_async_read_page(h * Wt + w, input_tensor_addr_ger, l1_write_addr_input_tensor_cb);
             noc_async_read_barrier();
             cb_push_back(input_tensor_cb_index, one_tile);
 
             // Write output value data
             cb_wait_front(input_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr_output_tensor_cb = get_read_ptr(input_tensor_cb_index);
-            noc_async_write_tile(h * Wt + w, output_tensor_addr_gen, l1_write_addr_output_tensor_cb);
+            noc_async_write_page(h * Wt + w, output_tensor_addr_gen, l1_write_addr_output_tensor_cb);
             noc_async_write_barrier();
             cb_pop_front(input_tensor_cb_index, one_tile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_cross_core_data_exchange.cpp
@@ -77,7 +77,7 @@ void kernel_main() {
             cb_reserve_back(input_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr = get_write_ptr(input_tensor_cb_index);
             const uint32_t tile_offset = h * Wt + core_id * number_of_tiles_per_core + w;
-            noc_async_read_tile(tile_offset, input_tensor_accessor, l1_write_addr);
+            noc_async_read_page(tile_offset, input_tensor_accessor, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(input_tensor_cb_index, one_tile);
         }  // w loop
@@ -137,7 +137,7 @@ void kernel_main() {
             cb_wait_front(index_tensor_output_cb_index, one_tile);
             const uint32_t l1_write_addr_index = get_read_ptr(index_tensor_output_cb_index);
             const uint32_t tile_offset = h * Wt + core_id * number_of_tiles_per_core + w;
-            noc_async_write_tile(tile_offset, index_tensor_output_accessor, l1_write_addr_index);
+            noc_async_write_page(tile_offset, index_tensor_output_accessor, l1_write_addr_index);
             noc_async_write_barrier();
             cb_pop_front(index_tensor_output_cb_index, one_tile);
         }  // Wt loop

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
@@ -82,26 +82,26 @@ void kernel_main() {
                             // Read input value data
                             cb_reserve_back(input_tensor_cb_index, one_tile);
                             const uint32_t l1_input_left_tile = get_write_ptr(input_tensor_cb_index);
-                            noc_async_read_tile(h * Wt + left_tile_id, input_tensor_addr_gen, l1_input_left_tile);
+                            noc_async_read_page(h * Wt + left_tile_id, input_tensor_addr_gen, l1_input_left_tile);
                             noc_async_read_barrier();
                             cb_push_back(input_tensor_cb_index, one_tile);
 
                             cb_reserve_back(input_tensor_cb_index, one_tile);
                             const uint32_t l1_input_right_tile = get_write_ptr(input_tensor_cb_index);
-                            noc_async_read_tile(h * Wt + right_tile_id, input_tensor_addr_gen, l1_input_right_tile);
+                            noc_async_read_page(h * Wt + right_tile_id, input_tensor_addr_gen, l1_input_right_tile);
                             noc_async_read_barrier();
                             cb_push_back(input_tensor_cb_index, one_tile);
 
                             // Read index data
                             cb_reserve_back(index_tensor_cb_index, one_tile);
                             const uint32_t l1_index_left_tile = get_write_ptr(index_tensor_cb_index);
-                            noc_async_read_tile(h * Wt + left_tile_id, index_tensor_addr_gen, l1_index_left_tile);
+                            noc_async_read_page(h * Wt + left_tile_id, index_tensor_addr_gen, l1_index_left_tile);
                             noc_async_read_barrier();
                             cb_push_back(index_tensor_cb_index, one_tile);
 
                             cb_reserve_back(index_tensor_cb_index, one_tile);
                             const uint32_t l1_index_right_tile = get_write_ptr(index_tensor_cb_index);
-                            noc_async_read_tile(h * Wt + right_tile_id, index_tensor_addr_gen, l1_index_right_tile);
+                            noc_async_read_page(h * Wt + right_tile_id, index_tensor_addr_gen, l1_index_right_tile);
                             noc_async_read_barrier();
                             cb_push_back(index_tensor_cb_index, one_tile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_single_core.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; w++) {
             cb_reserve_back(input_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr = get_write_ptr(input_tensor_cb_index);
-            noc_async_read_tile(h * Wt + w, interleaved_accessor0, l1_write_addr);
+            noc_async_read_page(h * Wt + w, interleaved_accessor0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(input_tensor_cb_index, one_tile);
         }  // Wt loop
@@ -60,7 +60,7 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; w++) {
             cb_wait_front(index_tensor_output_cb_index, one_tile);
             const uint32_t l1_write_addr_index = get_read_ptr(index_tensor_output_cb_index);
-            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_write_addr_index);
+            noc_async_write_page(h * Wt + w, interleaved_accessor1, l1_write_addr_index);
             noc_async_write_barrier();
             cb_pop_front(index_tensor_output_cb_index, one_tile);
         }  // Wt loop

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_cross_core_data_exchange.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
             const uint32_t l1_write_addr_val = get_read_ptr(value_tensor_cb_index);
             const uint32_t tile_offset = h * Wt + core_id * number_of_tiles_per_core + w;
 
-            noc_async_write_tile(tile_offset, output_tensor_accessor, l1_write_addr_val);
+            noc_async_write_page(tile_offset, output_tensor_accessor, l1_write_addr_val);
             noc_async_write_barrier();
 
             cb_pop_front(value_tensor_cb_index, one_tile);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
@@ -67,7 +67,7 @@ void kernel_main() {
                             cb_wait_front(index_tensor_output_cb_index, one_tile);
                             const uint32_t l1_write_addr_index_output_tensor_cb_i =
                                 get_read_ptr(index_tensor_output_cb_index);
-                            noc_async_write_tile(
+                            noc_async_write_page(
                                 h * Wt + left_tile_id, index_tensor_addr_gen, l1_write_addr_index_output_tensor_cb_i);
                             noc_async_write_barrier();
                             cb_pop_front(index_tensor_output_cb_index, one_tile);
@@ -75,7 +75,7 @@ void kernel_main() {
                             cb_wait_front(index_tensor_output_cb_index, one_tile);
                             const uint32_t l1_write_addr_index_output_tensor_cb_j =
                                 get_read_ptr(index_tensor_output_cb_index);
-                            noc_async_write_tile(
+                            noc_async_write_page(
                                 h * Wt + right_tile_id, index_tensor_addr_gen, l1_write_addr_index_output_tensor_cb_j);
                             noc_async_write_barrier();
                             cb_pop_front(index_tensor_output_cb_index, one_tile);
@@ -84,7 +84,7 @@ void kernel_main() {
                             cb_wait_front(input_tensor_output_cb_index, one_tile);
                             const uint32_t l1_write_addr_output_tensor_cb_i =
                                 get_read_ptr(input_tensor_output_cb_index);
-                            noc_async_write_tile(
+                            noc_async_write_page(
                                 h * Wt + left_tile_id, input_tensor_addr_gen, l1_write_addr_output_tensor_cb_i);
                             noc_async_write_barrier();
                             cb_pop_front(input_tensor_output_cb_index, one_tile);
@@ -92,7 +92,7 @@ void kernel_main() {
                             cb_wait_front(input_tensor_output_cb_index, one_tile);
                             const uint32_t l1_write_addr_output_tensor_cb_j =
                                 get_read_ptr(input_tensor_output_cb_index);
-                            noc_async_write_tile(
+                            noc_async_write_page(
                                 h * Wt + right_tile_id, input_tensor_addr_gen, l1_write_addr_output_tensor_cb_j);
                             noc_async_write_barrier();
                             cb_pop_front(input_tensor_output_cb_index, one_tile);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_single_core.cpp
@@ -57,7 +57,7 @@ void kernel_main() {
         for (uint32_t w = 0; w < Wt; w++) {
             cb_wait_front(value_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr_val = get_read_ptr(value_tensor_cb_index);
-            noc_async_write_tile(h * Wt + w, interleaved_accessor0, l1_write_addr_val);
+            noc_async_write_page(h * Wt + w, interleaved_accessor0, l1_write_addr_val);
             noc_async_write_barrier();
             cb_pop_front(value_tensor_cb_index, one_tile);
         }  // Wt loop

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_sticks / tile_height; i++) {
         for (uint32_t tile_id = 0; tile_id < num_tiles_per_core; tile_id++) {
             for (uint32_t j = stick_id; j < (tile_height + stick_id); j++) {
-                base_dst_noc_addr[j] = get_noc_addr(j, s, curr_offset);
+                base_dst_noc_addr[j] = s.get_noc_addr(j, curr_offset);
             }
             write_tiles(1, tile_width_size, stick_size - curr_offset - tile_width_size);
             curr_offset += tile_width_size;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -166,7 +166,7 @@ void kernel_main() {
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a);
                                 const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
                                 const uint32_t row_l1_addr =
@@ -182,7 +182,7 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
@@ -193,7 +193,7 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
@@ -201,7 +201,7 @@ void kernel_main() {
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b);
                                 const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
                                 const uint32_t row_l1_addr =

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -135,7 +135,7 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
@@ -144,7 +144,7 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -140,13 +140,13 @@ void kernel_main() {
                             const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST
-                            const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
+                            const uint64_t addr_a = src.get_noc_addr(row_block_a) + current_chunk_offset;
                             noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
@@ -156,12 +156,12 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
 
-                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
+                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b) + current_chunk_offset;
                             noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
 
                             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -166,7 +166,7 @@ void kernel_main() {
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_a = row_block_a + static_cast<uint32_t>(k) * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src);
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a);
                                 const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
                                 const uint32_t row_l1_addr =
@@ -179,7 +179,7 @@ void kernel_main() {
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b) + current_chunk_offset;
+                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b) + current_chunk_offset;
                             noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
@@ -188,7 +188,7 @@ void kernel_main() {
 
                             for (int32_t k = static_cast<int32_t>(limit) - 1; k >= 0; --k) {
                                 const uint32_t row_idx_b = row_block_b + static_cast<uint32_t>(k) * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b);
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b);
                                 const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                                 const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
                                 const uint32_t row_l1_addr =
@@ -201,7 +201,7 @@ void kernel_main() {
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            const uint64_t addr_a = get_noc_addr(row_block_a, src) + current_chunk_offset;
+                            const uint64_t addr_a = src.get_noc_addr(row_block_a) + current_chunk_offset;
                             noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -163,7 +163,7 @@ void kernel_main() {
 
 #if SRC_BCAST
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
-                            const uint64_t addr_a = get_noc_addr(row_block_a, src);
+                            const uint64_t addr_a = src.get_noc_addr(row_block_a);
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
@@ -176,7 +176,7 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = get_noc_addr(row_idx_b, src_b) + current_chunk_offset;
+                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
                                 noc_async_read(addr_b, curr_l1_b, current_read_len_b);
                                 curr_l1_b += current_chunk_bytes;
                             }
@@ -188,13 +188,13 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
                                 noc_async_read(addr_a, curr_l1_a, current_read_len_a);
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
 
-                            const uint64_t addr_b = get_noc_addr(row_block_b, src_b);
+                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b);
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -123,7 +123,7 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = get_noc_addr(row_idx_a, src) + current_chunk_offset;
+                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
                                 noc_async_read(addr_a, curr_l1_a, current_read_len);
                                 curr_l1_a += current_chunk_bytes;
                             }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -80,7 +80,7 @@ void kernel_main() {
                             uint32_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
-                                const uint64_t dst_noc_addr = get_noc_addr(row_abs_idx, dst) + current_chunk_offset;
+                                const uint64_t dst_noc_addr = dst.get_noc_addr(row_abs_idx) + current_chunk_offset;
                                 noc_async_write(l1_read_addr, dst_noc_addr, current_write_len);
                                 l1_read_addr += current_chunk_bytes;
                             }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
         if (token == pad_token) {
             src_noc_addr = pad_noc_addr;
         } else {
-            src_noc_addr = get_noc_addr(token, weights);
+            src_noc_addr = weights.get_noc_addr(token);
         }
 #elif defined BINARY
         if (token == 0) {
@@ -66,9 +66,9 @@ void kernel_main() {
         } u;
         u.u = (uint32_t)input_l1_ptr[token_idx] << 16;
         uint32_t token_casted = static_cast<uint32_t>(u.f);
-        src_noc_addr = get_noc_addr(token_casted, weights);
+        src_noc_addr = weights.get_noc_addr(token_casted);
 #else
-        src_noc_addr = get_noc_addr(token, weights);
+        src_noc_addr = weights.get_noc_addr(token);
 #endif
 #endif
         noc_async_read(src_noc_addr, weight_l1_addr, width_size);
@@ -86,8 +86,8 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_rows; ++i) {
         if (read_indices) {
-            uint64_t noc_input_src_addr = get_noc_addr(curr_tile, input) + (offset * sizeof(uint32_t));
-            noc_async_read_tile(curr_tile, s, input_l1_addr);
+            uint64_t noc_input_src_addr = input.get_noc_addr(curr_tile) + (offset * sizeof(uint32_t));
+            noc_async_read_page(curr_tile, s, input_l1_addr);
             noc_async_read_barrier();
             read_indices = false;
         }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     uint32_t curr_row = input_start_id;
     uint32_t offset = input_start_offset;
     for (uint32_t i = 0; i < num_blocks; ++i) {
-        uint64_t noc_input_src_addr = get_noc_addr(curr_row, input) + offset;
+        uint64_t noc_input_src_addr = input.get_noc_addr(curr_row) + offset;
         noc_async_read<input_block_size_bytes>(noc_input_src_addr, input_l1_addr, input_block_size_bytes);
         noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
@@ -128,7 +128,7 @@ void kernel_main() {
     uint32_t out_tile_idx = hidden_offset;
     for (uint32_t i = 0; i < num_embeddings; ++i) {
         for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-            noc_async_write_tile(out_tile_idx + hidden_dim, out_s, out_read_ptr);
+            noc_async_write_page(out_tile_idx + hidden_dim, out_s, out_read_ptr);
         }
         out_tile_idx += tiles_per_hidden;
     }
@@ -139,7 +139,7 @@ void kernel_main() {
 
     uint32_t grad_tile_idx = hidden_offset;
     for (uint32_t b = 0; b < batch_size; ++b) {
-        uint64_t index_seq_noc_addr = get_noc_addr(b, index_s);
+        uint64_t index_seq_noc_addr = index_s.get_noc_addr(b);
         for (uint32_t s = 0; s < seq_len_tiles; ++s) {
             noc_async_read(index_seq_noc_addr, index_l1_addr, index_block_size);
             noc_async_read_barrier();
@@ -155,7 +155,7 @@ void kernel_main() {
             cb_reserve_back(cb_grad, max_tiles_per_core);
             uint32_t grad_write_ptr = get_write_ptr(cb_grad);
             for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                noc_async_read_tile(grad_tile_idx + hidden_dim, grad_s, grad_write_ptr);
+                noc_async_read_page(grad_tile_idx + hidden_dim, grad_s, grad_write_ptr);
                 grad_write_ptr += grad_page_size;
             }
             noc_async_read_barrier();
@@ -183,7 +183,7 @@ void kernel_main() {
                 uint32_t out_write_ptr = get_write_ptr(cb_out_intermed);
                 out_tile_idx = chunk_idx * tiles_per_hidden + hidden_offset;
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                    noc_async_read_tile(out_tile_idx + hidden_dim, out_s, out_write_ptr);
+                    noc_async_read_page(out_tile_idx + hidden_dim, out_s, out_write_ptr);
                     out_write_ptr += out_page_size;
                 }
                 noc_async_read_barrier();
@@ -192,7 +192,7 @@ void kernel_main() {
                 cb_wait_front(cb_id_out0, max_tiles_per_core);
                 uint32_t out_read_ptr = get_read_ptr(cb_id_out0);
                 for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
-                    noc_async_write_tile(out_tile_idx + hidden_dim, out_s, out_read_ptr);
+                    noc_async_write_page(out_tile_idx + hidden_dim, out_s, out_read_ptr);
                     out_read_ptr += out_page_size;
                 }
                 noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
@@ -26,12 +26,12 @@ void kernel_main() {
 
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
         if (dst_addr1 != 0) {
-            noc_async_write_tile(i, s1, l1_read_addr);
+            noc_async_write_page(i, s1, l1_read_addr);
             noc_async_write_barrier();
         }
 
         if (dst_addr2 != 0) {
-            noc_async_write_tile(i, s2, l1_read_addr);
+            noc_async_write_page(i, s2, l1_read_addr);
             noc_async_write_barrier();
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_col_bcast_to.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
             for (uint32_t th = start_th; th < Ht && num_tiles_read < num_tiles; ++th, start_tw = 0) {
                 cb_reserve_back(cb_id_src, onetile);
                 uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset + th, src, l1_write_addr);
+                noc_async_read_page(tile_offset + th, src, l1_write_addr);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_src, onetile);
                 num_tiles_read += Wt - start_tw;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_no_bcast_to.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t) {
                 cb_reserve_back(cb_id_src, onetile);
                 uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                noc_async_read_tile(tile_offset++, src, l1_write_addr_src);
+                noc_async_read_page(tile_offset++, src, l1_write_addr_src);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_src, onetile);
                 ++num_tiles_read;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_row_bcast_to.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
                     // DeviceZoneScopedN("reader_row_tw");
                     cb_reserve_back(cb_id_src, onetile);
                     uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-                    noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+                    noc_async_read_page(tile_offset + tw, src, l1_write_addr_src);
                     noc_async_read_barrier();
                     cb_push_back(cb_id_src, onetile);
                     ++num_tiles_read;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/reader_interleaved_scalar_bcast_to.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
             cb_reserve_back(cb_id_src, onetile);
             uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
-            noc_async_read_tile(tile_offset, src, l1_write_addr_src);
+            noc_async_read_page(tile_offset, src, l1_write_addr_src);
             noc_async_read_barrier();
             cb_push_back(cb_id_src, onetile);
             num_tiles_read += HtWt - start_t;

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_col_bcast_to.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
                 uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
                 for (uint32_t tw = start_tw; tw < Wt && num_tiles_written < num_tiles; ++tw, ++num_tiles_written) {
                     // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                    noc_async_write_page(start_tile_id + num_tiles_written, dst, l1_read_addr);
                 }
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_dst, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_no_bcast_to.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
                 // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
                 cb_wait_front(cb_id_dst, onetile);
                 uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_page(start_tile_id + num_tiles_written, dst, l1_read_addr);
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_dst, onetile);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_row_bcast_to.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
                     // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
                     cb_wait_front(cb_id_dst, onetile);
                     uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
-                    noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                    noc_async_write_page(start_tile_id + num_tiles_written, dst, l1_read_addr);
                     noc_async_write_barrier();
                     cb_pop_front(cb_id_dst, onetile);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/device/kernels/dataflow/writer_interleaved_scalar_bcast_to.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
             uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                noc_async_write_tile(start_tile_id + num_tiles_written, dst, l1_read_addr);
+                noc_async_write_page(start_tile_id + num_tiles_written, dst, l1_read_addr);
             }
             noc_async_write_barrier();
             cb_pop_front(cb_id_dst, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -120,7 +120,7 @@ void kernel_main() {
             size_t l1_write_addr = get_write_ptr(cb_output_id);
             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                 uint32_t tile_id = output_tile_id_start + tiles_read;
-                uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                 noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
                 l1_write_addr += page_size;
@@ -310,7 +310,7 @@ void kernel_main() {
 
                             for (uint32_t j = 0; j < num_tiles_to_read; ++j) {
                                 uint32_t tile_id = output_tile_id_start + cb_row_offset + cb_pages_read_in_row;
-                                uint64_t noc_read_addr = get_noc_addr(tile_id, output_tensor_addrgen);
+                                uint64_t noc_read_addr = output_tensor_addrgen.get_noc_addr(tile_id);
                                 noc_async_read(noc_read_addr, l1_write_addr, page_size);
 
                                 l1_write_addr += page_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -358,7 +358,7 @@ void kernel_main() {
                 }
 
                 noc_addrs[i] = tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, tile_id, 0);
-                local_noc_addrs[i] = get_noc_addr(tile_id, output_addrgen);
+                local_noc_addrs[i] = output_addrgen.get_noc_addr(tile_id);
             }
 
             if (direction == 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -450,7 +450,7 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -249,7 +249,7 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/matmul_dataflow_common.hpp
@@ -320,11 +320,11 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_tile(tile_id, in3_accessor, write_ptr);
+                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -341,11 +341,11 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_tile(tile_id, in3_accessor, write_ptr);
+                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -388,7 +388,7 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
             } else {
                 fill_zeros_async(write_ptr, tile_size_bytes);
             }
@@ -405,7 +405,7 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
             } else {
                 fill_zeros_async(write_ptr, tile_size_bytes);
             }
@@ -444,7 +444,7 @@ void write_block_sync(
                 continue;
             }
             uint32_t tile_id = i * shape.logical_d1 + j;
-            noc_async_write_tile(tile_id, tensor_accessor, read_ptr);
+            noc_async_write_page(tile_id, tensor_accessor, read_ptr);
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
@@ -491,7 +491,7 @@ void read_ternary_blocks_sync(
             if (n_tile_id >= shape.logical_d1) {
                 break;
             }
-            noc_async_read_tile(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
+            noc_async_read_page(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
             ternary_b_write_ptr += b_tile_size_bytes;
         }
         noc_async_read_barrier();
@@ -509,7 +509,7 @@ void read_ternary_blocks_sync(
                 }
                 if (b_i < shape.logical_d0) {
                     uint32_t tile_id = b_i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, ternary_b_accessor, ternary_b_write_ptr);
+                    noc_async_read_page(tile_id, ternary_b_accessor, ternary_b_write_ptr);
                 }
                 ternary_b_write_ptr += b_tile_size_bytes;
             }
@@ -538,7 +538,7 @@ void read_ternary_blocks_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, ternary_a_accessor, ternary_a_write_ptr);
+                noc_async_read_page(tile_id, ternary_a_accessor, ternary_a_write_ptr);
             }
             ternary_a_write_ptr += a_tile_size_bytes;
         }
@@ -576,7 +576,7 @@ void write_block_sync_granular(
                     break;
                 }
                 uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
-                noc_async_write_tile(tile_id, tensor_accessor, out_read_ptr);
+                noc_async_write_page(tile_id, tensor_accessor, out_read_ptr);
                 out_read_ptr += tile_size_bytes;
             }
         }
@@ -587,14 +587,14 @@ void write_block_sync_granular(
 
 /**
  * Helper: dispatch to correct tuple element using fold expression.
- * Each branch calls noc_async_write_tile with the concrete TensorAccessor type.
+ * Each branch calls noc_async_write_page with the concrete TensorAccessor type.
  */
 template <typename Tuple, size_t... Is>
 FORCE_INLINE void write_tile_to_chunk(
     const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
     // Fold expression: expands to if/else chain at compile time
-    // Each branch calls noc_async_write_tile with the concrete type
-    ((chunk_idx == Is ? (noc_async_write_tile(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
+    // Each branch calls noc_async_write_page with the concrete type
+    ((chunk_idx == Is ? (noc_async_write_page(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_reader.cpp
@@ -75,7 +75,7 @@ void kernel_main() {
 
                 uint32_t num_pages_to_read = std::min(shard_col_end_id - col_tile_id, packet_size_in_pages);
                 for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                    noc_async_read_tile(tile_id, tensor0_addrgen, l1_write_addr);
+                    noc_async_read_page(tile_id, tensor0_addrgen, l1_write_addr);
                     l1_write_addr += tensor0_page_size;
                     tile_id++;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_reader.cpp
@@ -67,7 +67,7 @@ void kernel_main() {
 
                 uint32_t num_pages_to_read = std::min(shard_col_end_id - col_tile_id, num_pages_per_packet);
                 for (uint32_t j = 0; j < num_pages_to_read; j++) {
-                    noc_async_read_tile(tile_id, input_tensor_addrgen, l1_write_addr);
+                    noc_async_read_page(tile_id, input_tensor_addrgen, l1_write_addr);
                     l1_write_addr += page_size;
                     tile_id++;
                 }
@@ -106,7 +106,7 @@ void kernel_main() {
                     uint32_t global_id = sender_relative_ring_id + packet_id * NUM_SENDERS;
                     uint32_t first_id = (global_id % N_DRAM_BANKS) + 2 * N_DRAM_BANKS * (global_id / N_DRAM_BANKS);
                     uint64_t packet_addr =
-                        get_noc_addr(first_id, intermediate_tensor_addrgen, 0 /*offset*/, 0 /*noc_id*/);
+                        intermediate_tensor_addrgen.get_noc_addr(first_id, 0 /*offset*/, 0 /*noc_id*/);
 
                     noc_async_read(packet_addr, l1_write_addr, payload_size_bytes);
                     l1_write_addr += payload_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/kernels/interleaved_all_to_all_receiver_writer.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t col_tile = out_col_id + j;
                     uint32_t tile_id = out_row_id * out_col_tiles + col_tile;
-                    noc_async_write_tile(tile_id, output_tensor_addrgen, l1_read_addr);
+                    noc_async_write_page(tile_id, output_tensor_addrgen, l1_read_addr);
 
                     l1_read_addr += payload_size_bytes;
                 }
@@ -79,7 +79,7 @@ void kernel_main() {
                 for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
                     uint32_t col_tile = out_col_id + j;
                     uint32_t tile_id = out_row_id * out_col_tiles + col_tile;
-                    noc_async_write_tile(tile_id, output_tensor_addrgen, l1_read_addr);
+                    noc_async_write_page(tile_id, output_tensor_addrgen, l1_read_addr);
                     l1_read_addr += page_size;
                 }
                 noc_async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -143,7 +143,7 @@ void kernel_main() {
         // Read input token (or portion of it in payload split mode)
         // In non-split mode: payload_offset=0, payload_size=input_page_size (reads full page)
         // In split mode: reads only this worker's portion
-        uint64_t input_page_noc_addr = get_noc_addr(i, input_addr_gen);
+        uint64_t input_page_noc_addr = input_addr_gen.get_noc_addr(i);
         l1_write_addr = get_write_ptr(input_tensor_cb_id);
         noc_async_read(input_page_noc_addr + payload_offset, l1_write_addr, payload_size);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -1108,7 +1108,7 @@ void kernel_main() {
         // we need the global token index to write to the output buffer – each global token that could potentially be
         // sent has a unique output buffer address to ensure that it is not overwritten by another token
         uint32_t global_token = (local_token + (tokens_per_device * dispatch_index));
-        uint64_t output_token_write_addr = get_noc_addr(global_token, output_addr_gen);
+        uint64_t output_token_write_addr = output_addr_gen.get_noc_addr(global_token);
         // All workers read indices (needed for routing decisions)
         // Only primary worker reads scores (only primary sends metadata)
         cb_wait_front(indices_tensor_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -29,7 +29,7 @@ void read_block_from_dram(
     for (uint32_t h = 0; h < block_h_t; ++h) {
         uint32_t tile_id = block_tile_id + h * tensor_width_in_tiles;
         for (uint32_t w = 0; w < block_w_t; ++w) {
-            noc_async_read_tile(tile_id + w, s1, l1_write_addr);
+            noc_async_read_page(tile_id + w, s1, l1_write_addr);
             l1_write_addr += tile_size_bytes;
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/reader.cpp
@@ -132,7 +132,7 @@ void kernel_main() {
     // read activations
     cb_reserve_back(token_activations_cb_id, 1);
     const uint32_t token_activations_l1_addr = get_write_ptr(token_activations_cb_id);
-    const uint64_t token_activations_noc_addr = get_noc_addr(0, token_activations_addrgen, /*offset=*/0, /*noc=*/1);
+    const uint64_t token_activations_noc_addr = token_activations_addrgen.get_noc_addr(0, /*offset=*/0, /*noc=*/1);
     noc_async_read(
         token_activations_noc_addr, token_activations_l1_addr, aligned_token_activations_page_size_bytes, /*noc=*/1);
 
@@ -148,7 +148,7 @@ void kernel_main() {
     const uint32_t dense_token_maps_l1_addr = get_write_ptr(dense_token_maps_cb_id);
     for (uint32_t e = 0, l1_offset = 0, maps_page = 0; e < num_local_experts; ++e) {
         const uint64_t dense_token_maps_noc_addr =
-            get_noc_addr(maps_page++, dense_token_maps_addrgen, /*offset=*/0, /*noc=*/1);
+            dense_token_maps_addrgen.get_noc_addr(maps_page++, /*offset=*/0, /*noc=*/1);
         noc_async_read(
             dense_token_maps_noc_addr,
             dense_token_maps_l1_addr + l1_offset,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
@@ -289,7 +289,7 @@ void kernel_main() {
 
             if (dest_device_idx == linearized_mesh_coord) {
                 const uint64_t output_noc_addr =
-                    get_noc_addr(output_page_idx, output_addrgen, dest_token_segment_offset_bytes, /*noc=*/1);
+                    output_addrgen.get_noc_addr(output_page_idx, dest_token_segment_offset_bytes, /*noc=*/1);
                 noc_async_write(src_data_l1_addr, output_noc_addr, source_token_segment_size_bytes, /*noc=*/1);
                 noc_async_writes_flushed(/*noc=*/1);
             } else {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -754,7 +754,7 @@ void kernel_main() {
         // ========== Write expert_activation buffer to DRAM ==========
         // Write to DRAM: activated rows (num_activated_tokens) rows
         uint32_t expert_activation_write_size = num_activated_tokens * aligned_activation_row_bytes;
-        uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
+        uint64_t expert_activation_dram_addr = expert_activation_output_tensor_addr_gen.get_noc_addr(0);
         if (num_activated_tokens > 0) {
             noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
         }
@@ -952,7 +952,7 @@ void kernel_main() {
                 uint32_t token_id = *reinterpret_cast<uint32_t*>(e_t_expert_addr + (chunk_start + i) * e_t_entry_size);
                 // read the token from the input tensor at the tilize subtoken offset and size
                 noc_async_read(
-                    get_noc_addr(token_id, input_tensor_addr_gen) + global_subtoken_offset,
+                    input_tensor_addr_gen.get_noc_addr(token_id) + global_subtoken_offset,
                     get_write_ptr(tilize_input_cb_id) + i * subtoken_size,
                     subtoken_size);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -646,7 +646,7 @@ void kernel_main() {
         // Skip if address is 0 (fused mode: no output tensors allocated)
         if (expert_activation_output_address != 0) {
             uint32_t expert_activation_write_size = (num_activated_tokens + 1) * aligned_activation_row_bytes;
-            uint64_t expert_activation_dram_addr = get_noc_addr(0, expert_activation_output_tensor_addr_gen);
+            uint64_t expert_activation_dram_addr = expert_activation_output_tensor_addr_gen.get_noc_addr(0);
             noc_async_write(expert_activation_base, expert_activation_dram_addr, expert_activation_write_size);
         }
 
@@ -836,7 +836,7 @@ void kernel_main() {
                 uint32_t token_id = *reinterpret_cast<uint32_t*>(e_t_expert_addr + (chunk_start + i) * e_t_entry_size);
                 // read the token from the input tensor at the tilize subtoken offset and size
                 noc_async_read(
-                    get_noc_addr(token_id, input_tensor_addr_gen) + global_subtoken_offset,
+                    input_tensor_addr_gen.get_noc_addr(token_id) + global_subtoken_offset,
                     get_write_ptr(tilize_input_cb_id) + i * subtoken_size,
                     subtoken_size);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -176,7 +176,7 @@ void kernel_main() {
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                        uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
                     }
@@ -203,7 +203,7 @@ void kernel_main() {
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = input_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                        uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
                     }
@@ -219,7 +219,7 @@ void kernel_main() {
                     l1_write_addr = get_write_ptr(cb_intermediate_id);
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = intermediate_tile_id_start + tiles_read + j;
-                        uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
+                        uint64_t noc_read_addr = intermediate_tensor_addrgen.get_noc_addr(tile_id);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
                     }
@@ -277,8 +277,8 @@ void kernel_main() {
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t tile_id = tile_id_start + tiles_read + j;
                     uint64_t noc_read_addr = detail::do_accumulate_output(is_forward)
-                                                 ? get_noc_addr(tile_id, output_tensor_addrgen)
-                                                 : get_noc_addr(tile_id, input_tensor_addrgen);
+                                                 ? output_tensor_addrgen.get_noc_addr(tile_id)
+                                                 : input_tensor_addrgen.get_noc_addr(tile_id);
                     noc_async_read(noc_read_addr, l1_write_addr, page_size);
                     l1_write_addr += page_size;
                 }
@@ -293,7 +293,7 @@ void kernel_main() {
                 l1_write_addr = get_write_ptr(cb_intermediate_id);
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t intermediate_tile_id = intermediate_tile_id_start + tiles_read + j;
-                    uint64_t noc_read_addr = get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
+                    uint64_t noc_read_addr = intermediate_tensor_addrgen.get_noc_addr(intermediate_tile_id);
                     noc_async_read(noc_read_addr, l1_write_addr, page_size);
                     l1_write_addr += page_size;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -365,7 +365,7 @@ void kernel_main() {
                 size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
                 for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                     uint32_t output_tile_id = output_tile_id_start + tiles_read;
-                    uint64_t local_noc_addr = get_noc_addr(output_tile_id, output_addrgen);
+                    uint64_t local_noc_addr = output_addrgen.get_noc_addr(output_tile_id);
                     noc_async_write(l1_read_addr, local_noc_addr, page_size);
                     l1_read_addr += page_size;
                     tiles_read++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -198,7 +198,7 @@ void kernel_main() {
                         uint32_t l1_write_addr = get_write_ptr(cb_in0);
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                            uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                             noc_async_read(noc_read_addr, l1_write_addr, page_size);
                             l1_write_addr += page_size;
 
@@ -236,7 +236,7 @@ void kernel_main() {
                         uint32_t l1_write_addr = get_write_ptr(cb_in0);
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id = input_tile_id_start + input_row_offset + input_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, input_tensor_addrgen);
+                            uint64_t noc_read_addr = input_tensor_addrgen.get_noc_addr(tile_id);
                             noc_async_read(noc_read_addr, l1_write_addr, page_size);
                             l1_write_addr += page_size;
 
@@ -260,7 +260,7 @@ void kernel_main() {
                         for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                             uint32_t tile_id =
                                 intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                            uint64_t noc_read_addr = get_noc_addr(tile_id, intermediate_tensor_addrgen);
+                            uint64_t noc_read_addr = intermediate_tensor_addrgen.get_noc_addr(tile_id);
                             noc_async_read(noc_read_addr, l1_write_addr, page_size);
                             l1_write_addr += page_size;
 
@@ -367,8 +367,8 @@ void kernel_main() {
                     uint32_t l1_write_addr = get_write_ptr(cb_in0);
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t tile_id = tile_id_start + row_offset + pages_read_in_row;
-                        uint64_t noc_read_addr = accumulate_output ? get_noc_addr(tile_id, output_tensor_addrgen)
-                                                                   : get_noc_addr(tile_id, input_tensor_addrgen);
+                        uint64_t noc_read_addr = accumulate_output ? output_tensor_addrgen.get_noc_addr(tile_id)
+                                                                   : input_tensor_addrgen.get_noc_addr(tile_id);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
 
@@ -392,7 +392,7 @@ void kernel_main() {
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t intermediate_tile_id =
                             intermediate_tile_id_start + intermediate_row_offset + intermediate_pages_read_in_row;
-                        uint64_t noc_read_addr = get_noc_addr(intermediate_tile_id, intermediate_tensor_addrgen);
+                        uint64_t noc_read_addr = intermediate_tensor_addrgen.get_noc_addr(intermediate_tile_id);
                         noc_async_read(noc_read_addr, l1_write_addr, page_size);
                         l1_write_addr += page_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -398,7 +398,7 @@ void kernel_main() {
                     size_t l1_read_addr = get_read_ptr(cb_compute_output_id);
                     for (uint32_t j = 0; j < num_pages_to_read; ++j) {
                         uint32_t output_tile_id = output_tile_id_start + tiles_read;
-                        uint64_t local_noc_addr = get_noc_addr(output_tile_id, output_addrgen);
+                        uint64_t local_noc_addr = output_addrgen.get_noc_addr(output_tile_id);
                         noc_async_write(l1_read_addr, local_noc_addr, page_size);
                         l1_read_addr += page_size;
                         tiles_read++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/strided_all_gather_common.hpp
@@ -294,8 +294,8 @@ FORCE_INLINE uint32_t write_chunk(
                         NocUnicastScatterCommandHeader({noc_address0, noc_address1}, {0}));
                 }
                 if (direction == 1 && write_local) {
-                    uint64_t local_noc0_dest_noc_addr_tile_one = get_noc_addr(tile_one_id, output_addrgen);
-                    uint64_t local_noc0_dest_noc_addr_tile_two = get_noc_addr(tile_two_id, output_addrgen);
+                    uint64_t local_noc0_dest_noc_addr_tile_one = output_addrgen.get_noc_addr(tile_one_id);
+                    uint64_t local_noc0_dest_noc_addr_tile_two = output_addrgen.get_noc_addr(tile_two_id);
 
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr_tile_one, output_page_size);
                     noc_async_write(
@@ -313,7 +313,7 @@ FORCE_INLINE uint32_t write_chunk(
                         &mux_connection, pkt_unicast_hdr, l1_read_addr, NocUnicastCommandHeader{noc_address0});
                 }
                 if (direction == 1 && write_local) {
-                    uint64_t local_noc0_dest_noc_addr = get_noc_addr(tile_one_id, output_addrgen);
+                    uint64_t local_noc0_dest_noc_addr = output_addrgen.get_noc_addr(tile_one_id);
                     noc_async_write(l1_read_addr, local_noc0_dest_noc_addr, output_page_size);
                     noc_async_write_barrier();
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -283,10 +283,10 @@ void kernel_main() {
                                         slice_row, col_in_slice, actual_slice_idx, slice_Wt, input_tensor_Wt);
                                     const uint32_t input_tile_id = global_tile_idx + batch_offset;
                                     noc_async_read(
-                                        get_noc_addr(input_tile_id, input_tensor_addrgen), l1_write_addr, page_size);
+                                        input_tensor_addrgen.get_noc_addr(input_tile_id), l1_write_addr, page_size);
                                     if (do_reduce) {
                                         noc_async_read(
-                                            get_noc_addr(global_tile_idx, intermediate_tensor_addrgen),
+                                            intermediate_tensor_addrgen.get_noc_addr(global_tile_idx),
                                             intermediate_l1_write_addr,
                                             page_size);
                                     }
@@ -301,11 +301,11 @@ void kernel_main() {
                                             b * addcmul_a_batch_pages + slice_row * slice_Wt + col_in_slice;
 #endif
                                         noc_async_read(
-                                            get_noc_addr(a_tile_idx, addcmul_a_addrgen),
+                                            addcmul_a_addrgen.get_noc_addr(a_tile_idx),
                                             addcmul_a_l1_write_addr,
                                             page_size);
                                         noc_async_read(
-                                            get_noc_addr(b_gate_idx, addcmul_b_addrgen),
+                                            addcmul_b_addrgen.get_noc_addr(b_gate_idx),
                                             addcmul_b_l1_write_addr,
                                             page_size);
                                     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -424,8 +424,7 @@ void kernel_main() {
                                         // Write the tile to the output buffer on this device.
                                         if (num_in_bounds_tiles > 0) {
                                             const uint32_t output_tile_id = output_tile_id_start + slice_tile_idx_first;
-                                            const uint64_t local_noc_addr =
-                                                get_noc_addr(output_tile_id, output_addrgen);
+                                            const uint64_t local_noc_addr = output_addrgen.get_noc_addr(output_tile_id);
                                             noc_async_write(valid_l1_addrs[0], local_noc_addr, page_size);
                                         }
                                     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/kernels/deepseek_moe_post_combine_tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_moe_post_combine_tilize/device/kernels/deepseek_moe_post_combine_tilize_reader.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
 
     uint32_t page_id = row_page_offset;
     for (uint32_t row = 0; row < tile_height; ++row) {
-        uint64_t noc_addr = get_noc_addr(page_id, input_tensor_accessor, intra_row_byte_offset);
+        uint64_t noc_addr = input_tensor_accessor.get_noc_addr(page_id, intra_row_byte_offset);
         noc_async_read(noc_addr, l1_write_addr, bytes_to_read_per_row);
 
         l1_write_addr += bytes_to_read_per_row;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_common.hpp
@@ -27,7 +27,7 @@ template <typename AddrGen>
 FORCE_INLINE void zero_pages(
     uint32_t zero_buf, uint32_t page_start, uint32_t page_end, uint32_t page_size, const AddrGen& addr_gen) {
     for (uint32_t page = page_start; page < page_end; page++) {
-        uint64_t page_noc_addr = get_noc_addr(page, addr_gen);
+        uint64_t page_noc_addr = addr_gen.get_noc_addr(page);
         uint32_t remaining = page_size;
         while (remaining > 0) {
             uint32_t chunk = (remaining > (uint32_t)NOC_MAX_BURST_SIZE) ? (uint32_t)NOC_MAX_BURST_SIZE : remaining;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
@@ -121,7 +121,7 @@ void kernel_main() {
         cb_reserve_back(cb_tile, batch);
         uint32_t l1_write_addr = get_write_ptr(cb_tile);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_read_tile(tile_idx + i, global_accessor, l1_write_addr);
+            noc_async_read_page(tile_idx + i, global_accessor, l1_write_addr);
             l1_write_addr += tile_bytes;
         }
         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
@@ -103,7 +103,7 @@ void kernel_main() {
         cb_wait_front(cb_tile, batch);
         uint32_t l1_read_addr = get_read_ptr(cb_tile);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_write_tile(tile_idx + i, output_accessor, l1_read_addr);
+            noc_async_write_page(tile_idx + i, output_accessor, l1_read_addr);
             l1_read_addr += tile_bytes;
         }
         noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
@@ -98,7 +98,7 @@ void kernel_main() {
         cb_reserve_back(cb_tile, batch);
         uint32_t l1_write_addr = get_write_ptr(cb_tile);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_read_tile(tile_idx + i, local_accessor, l1_write_addr);
+            noc_async_read_page(tile_idx + i, local_accessor, l1_write_addr);
             l1_write_addr += tile_bytes;
         }
         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
         cb_wait_front(cb_tile, batch);
         uint32_t l1_read_addr = get_read_ptr(cb_tile);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_write_tile(my_dst_start + offset + i, global_accessor, l1_read_addr);
+            noc_async_write_page(my_dst_start + offset + i, global_accessor, l1_read_addr);
             l1_read_addr += tile_bytes;
         }
         noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/reader_dropout_interleaved_start_id.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
 #endif
         cb_reserve_back(cb_id_in0, onetile);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_page(i, s, l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/kernels/dataflow/writer_dropout_interleaved_start_id.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
 #endif
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_page(i, s, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_out, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/kernels/dataflow/isin_common.hpp
@@ -99,7 +99,7 @@ FORCE_INLINE void load_to_cb(
     const uint32_t& datum_size) {
     cb_reserve_back(cb, ONE_PAGE);
 
-    const uint64_t source_noc_address = get_noc_addr(FIRST_STICK, addr_gtor);
+    const uint64_t source_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
     const uint32_t l1_write_address = get_write_ptr(cb);
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;
@@ -119,7 +119,7 @@ FORCE_INLINE void write_to_dram(
     const uint32_t& datum_size) {
     cb_wait_front(cb, ONE_PAGE);
 
-    const uint64_t destination_noc_address = get_noc_addr(FIRST_STICK, addr_gtor);
+    const uint64_t destination_noc_address = addr_gtor.get_noc_addr(FIRST_STICK);
     const uint32_t l1_read_address = get_read_ptr(cb);
     const uint32_t subchunk_size_bytes = subchunk_size * datum_size;
     const uint32_t offset_bytes = offset * datum_size;

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -328,7 +328,7 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -286,7 +286,7 @@ void kernel_main() {
 
                 uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
                 for (uint32_t n_tile_id = n_tile; n_tile_id < n_tile_end; n_tile_id++) {
-                    noc_async_read_tile(n_tile_id, in2_reader, l1_write_addr_in2);
+                    noc_async_read_page(n_tile_id, in2_reader, l1_write_addr_in2);
                     l1_write_addr_in2 += in2_tile_size;
                 }
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -107,11 +107,11 @@ void read_in0_block_sync(
                 if (local_k_start <= j && j <= local_k_end) {
                     // read from self_tensor_accessor
                     uint32_t tile_id = i * input_tensor_Wt + (j - local_k_start);
-                    noc_async_read_tile(tile_id, in3_accessor, write_ptr);
+                    noc_async_read_page(tile_id, in3_accessor, write_ptr);
                 } else {
 #endif
                     uint32_t tile_id = i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                    noc_async_read_page(tile_id, tensor_accessor, write_ptr);
 #ifdef READ_FROM_LOCAL_INPUT
                 }
 #endif
@@ -151,7 +151,7 @@ void read_in1_block_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, tensor_accessor, write_ptr);
+                noc_async_read_page(tile_id, tensor_accessor, write_ptr);
             } else {
                 fill_zeros_async(write_ptr, tile_size_bytes);
             }
@@ -190,7 +190,7 @@ void write_block_sync(
                 continue;
             }
             uint32_t tile_id = i * shape.logical_d1 + j;
-            noc_async_write_tile(tile_id, tensor_accessor, read_ptr);
+            noc_async_write_page(tile_id, tensor_accessor, read_ptr);
             read_ptr += tile_size_bytes;
         }
         // finish up incrementing read_ptr if (d1_end - d1_start) < N_block_tiles
@@ -236,7 +236,7 @@ void read_ternary_blocks_sync(
             if (n_tile_id >= shape.logical_d1) {
                 break;
             }
-            noc_async_read_tile(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
+            noc_async_read_page(n_tile_id, ternary_b_accessor, ternary_b_write_ptr);
             ternary_b_write_ptr += b_tile_size_bytes;
         }
         noc_async_read_barrier();
@@ -254,7 +254,7 @@ void read_ternary_blocks_sync(
                 }
                 if (b_i < shape.logical_d0) {
                     uint32_t tile_id = b_i * shape.logical_d1 + j;
-                    noc_async_read_tile(tile_id, ternary_b_accessor, ternary_b_write_ptr);
+                    noc_async_read_page(tile_id, ternary_b_accessor, ternary_b_write_ptr);
                 }
                 ternary_b_write_ptr += b_tile_size_bytes;
             }
@@ -283,7 +283,7 @@ void read_ternary_blocks_sync(
             }
             if (i < shape.logical_d0) {
                 uint32_t tile_id = i * shape.logical_d1 + j;
-                noc_async_read_tile(tile_id, ternary_a_accessor, ternary_a_write_ptr);
+                noc_async_read_page(tile_id, ternary_a_accessor, ternary_a_write_ptr);
             }
             ternary_a_write_ptr += a_tile_size_bytes;
         }
@@ -321,7 +321,7 @@ void write_block_sync_granular(
                     break;
                 }
                 uint32_t tile_id = m_tile * shape.logical_d1 + n_tile_id;
-                noc_async_write_tile(tile_id, tensor_accessor, out_read_ptr);
+                noc_async_write_page(tile_id, tensor_accessor, out_read_ptr);
                 out_read_ptr += tile_size_bytes;
             }
         }
@@ -332,14 +332,14 @@ void write_block_sync_granular(
 
 /**
  * Helper: dispatch to correct tuple element using fold expression.
- * Each branch calls noc_async_write_tile with the concrete TensorAccessor type.
+ * Each branch calls noc_async_write_page with the concrete TensorAccessor type.
  */
 template <typename Tuple, size_t... Is>
 FORCE_INLINE void write_tile_to_chunk(
     const Tuple& accessors, uint32_t chunk_idx, uint32_t tile_id, uint32_t read_ptr, std::index_sequence<Is...>) {
     // Fold expression: expands to if/else chain at compile time
-    // Each branch calls noc_async_write_tile with the concrete type
-    ((chunk_idx == Is ? (noc_async_write_tile(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
+    // Each branch calls noc_async_write_page with the concrete type
+    ((chunk_idx == Is ? (noc_async_write_page(tile_id, std::get<Is>(accessors), read_ptr), void()) : void()), ...);
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
         cb_reserve_back(cb_id_in, Wt);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in);
         for (uint32_t w = 0; w < Wt; ++w) {
-            noc_async_read_tile(tile_id, s, l1_write_addr);
+            noc_async_read_page(tile_id, s, l1_write_addr);
             l1_write_addr += tile_bytes;
             tile_id++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -146,7 +146,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
                 cache_l1_write_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -148,7 +148,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
                 cache_l1_write_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -120,7 +120,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
                 cache_l1_write_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -172,7 +172,7 @@ void kernel_main() {
             cb_wait_front(cb_id_in, Wt);
             uint32_t l1_read_addr = get_read_ptr(cb_id_in);
             for (uint32_t w = 0; w < Wt; ++w) {
-                noc_async_write_tile(physical_tile_id, out_gen, l1_read_addr);
+                noc_async_write_page(physical_tile_id, out_gen, l1_read_addr);
                 l1_read_addr += tile_bytes;
                 physical_tile_id += 1;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -121,7 +121,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
                 out_l1_read_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -129,7 +129,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
                 out_l1_read_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
         if (!skip_update) {
             uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
                 out_l1_read_addr += cache_tile_bytes;
             }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common_dataflow.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/kernels/common_dataflow.hpp
@@ -12,7 +12,7 @@ FORCE_INLINE void write_to_dram(
     ReadCBGuard read_guard{cb, num_tiles};
 
     uint32_t l1_read_addr{get_read_ptr(cb)};
-    noc_async_write_tile(write_tile_id, addr_gtor, l1_read_addr);
+    noc_async_write_page(write_tile_id, addr_gtor, l1_read_addr);
     noc_async_write_barrier();
 }
 
@@ -22,7 +22,7 @@ FORCE_INLINE void load_from_dram(
     WriteCBGuard write_guard{cb, num_tiles};
 
     uint32_t l1_write_addr{get_write_ptr(cb)};
-    noc_async_read_tile(read_tile_id, addr_gtor, l1_write_addr);
+    noc_async_read_page(read_tile_id, addr_gtor, l1_write_addr);
     noc_async_read_barrier();
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/reader_ssm_1d_sum_reduce.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
         for (uint32_t i = start_id; i < end_id; i++) {
             cb_reserve_back(cb_id_in0, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-            noc_async_read_tile((block_h_id * input_total_blocks_w) + i, s, l1_write_addr);
+            noc_async_read_page((block_h_id * input_total_blocks_w) + i, s, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/kernels/writer_ssm_1d_sum_reduce.cpp
@@ -64,7 +64,7 @@ void kernel_main() {
 
             cb_wait_front(output_cb_id, onetile);
             uint32_t l1_read_addr = get_read_ptr(output_cb_id);
-            noc_async_write_tile((block_h_id * out_num_blocks_w) + i, s, l1_read_addr);
+            noc_async_write_page((block_h_id * out_num_blocks_w) + i, s, l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(output_cb_id, onetile);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/reader_ssm_eltwise_mul.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
         // in0 only has one tile and read in only once
         cb_reserve_back(cb_id_in0, onetile);
         l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(block_h_id, s0, l1_write_addr_in0);
+        noc_async_read_page(block_h_id, s0, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
 #endif
@@ -46,7 +46,7 @@ void kernel_main() {
         for (uint32_t i = in1_start_id; i < in1_start_id + in1_num_blocks; i++) {
             cb_reserve_back(cb_id_in1, onetile);
             l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-            noc_async_read_tile(block_h_id * in1_num_blocks_w + i, s1, l1_write_addr_in1);
+            noc_async_read_page(block_h_id * in1_num_blocks_w + i, s1, l1_write_addr_in1);
 
             noc_async_read_barrier();
             cb_push_back(cb_id_in1, onetile);
@@ -64,7 +64,7 @@ void kernel_main() {
 #ifndef REPEAT_IN0
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(
+                noc_async_read_page(
                     block_h_id * in0_num_blocks_w + (i * in0_blocks_per_in1_block + tile_row_id),
                     s0,
                     l1_write_addr_in0);
@@ -93,7 +93,7 @@ void kernel_main() {
 #ifndef REPEAT_IN0
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                noc_async_read_tile(
+                noc_async_read_page(
                     block_h_id * 5120 + (i * in0_blocks_per_in1_block + tile_row_id), s0, l1_write_addr_in0);
 #endif
                 noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/writer_ssm_eltwise_mul.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
         for (uint32_t i = start_id; i < end_id; ++i) {
             cb_wait_front(cb_id_out, onetile);
             uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-            noc_async_write_tile((block_h_id * out_total_blocks_w) + i, s, l1_read_addr);
+            noc_async_write_page((block_h_id * out_total_blocks_w) + i, s, l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_id_out, onetile);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm0.cpp
@@ -68,8 +68,8 @@ void kernel_main() {
 
         for (uint32_t k = 0; k < block; k++) {
             uint32_t kg = k_tile_offset + tiles_done + k;
-            noc_async_read_tile(kg, input_addrgen, inp_wr + k * tile_size);
-            noc_async_read_tile(kg * n_tiles_total + n_tile_id, weight_addrgen, wt_wr + k * tile_size);
+            noc_async_read_page(kg, input_addrgen, inp_wr + k * tile_size);
+            noc_async_read_page(kg * n_tiles_total + n_tile_id, weight_addrgen, wt_wr + k * tile_size);
         }
         noc_async_read_barrier();
         cb_push_back(cb_input, block);
@@ -84,7 +84,7 @@ void kernel_main() {
 
         cb_reserve_back(cb_bias, 1);
         uint32_t bias_write_ptr = get_write_ptr(cb_bias);
-        noc_async_read_tile(n_tile_id, bias_addrgen, bias_write_ptr);
+        noc_async_read_page(n_tile_id, bias_addrgen, bias_write_ptr);
         noc_async_read_barrier();
         cb_push_back(cb_bias, 1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
@@ -65,7 +65,7 @@ void kernel_main() {
         cb_reserve_back(cb_batch_offset_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_batch_offset_id);
         // Read the batch offset 1 page to read
-        uint64_t batch_offset_index_noc_addr = get_noc_addr(0, addrg);
+        uint64_t batch_offset_index_noc_addr = addrg.get_noc_addr(0);
         noc_async_read(batch_offset_index_noc_addr, index_cb_wr_ptr, index_stick_size);
         noc_async_read_barrier();
         cb_push_back(cb_batch_offset_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/reader_tm_tile_layout_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/reader_tm_tile_layout_concat_heads.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
 
         in0_tensor_current_tile_id = in0_tensor_tile_id;
         for (uint32_t w_dim = 0; w_dim < in0_w_tiles; w_dim++) {
-            noc_async_read_tile(in0_tensor_current_tile_id, s0, l1_write_addr_in0);
+            noc_async_read_page(in0_tensor_current_tile_id, s0, l1_write_addr_in0);
             l1_write_addr_in0 += single_tile_size_bytes;
             in0_tensor_current_tile_id++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/writer_tm_tile_layout_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/kernels/dataflow/writer_tm_tile_layout_concat_heads.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
         cb_wait_front(cb_id_out0, out_num_tiles_read);
 
         for (uint32_t w_dim = 0; w_dim < in0_w_tiles; w_dim++) {
-            noc_async_write_tile(out_tensor_tile_id, s, l1_read_addr);
+            noc_async_write_page(out_tensor_tile_id, s, l1_read_addr);
             l1_read_addr += single_tile_size_bytes;
             out_tensor_tile_id++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/reader_layernorm_postallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/reader_layernorm_postallgather_dit.cpp
@@ -82,7 +82,7 @@ void kernel_main() {
         DPRINT("reserve_back stats on tile_row: {}\n", tile_row);
         uint32_t stats_wr_ptr = get_write_ptr(cb_stats);
         for (uint32_t st = 0; st < stats_tiles_cols; ++st) {
-            noc_async_read_tile(stats_tile_idx, src_stats, stats_wr_ptr);
+            noc_async_read_page(stats_tile_idx, src_stats, stats_wr_ptr);
             stats_wr_ptr += stats_tile_bytes;
             stats_tile_idx++;
         }
@@ -125,7 +125,7 @@ void kernel_main() {
             DPRINT("reserve_back input on tile_row: {} col_tile: {}\n", tile_row, col_tile);
             uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
             for (uint32_t i = 0; i < block_size && col_tile + i < Wt; i++) {
-                noc_async_read_tile(input_tile_idx, src_a, inp_wr_ptr);
+                noc_async_read_page(input_tile_idx, src_a, inp_wr_ptr);
                 inp_wr_ptr += src0_tile_bytes;
                 input_tile_idx++;
             }
@@ -141,7 +141,7 @@ void kernel_main() {
                 // Calculate tile offset for this batch
                 uint32_t gamma_batch_offset = gamma_is_batched ? (batch_idx * gamma_batch_stride_tiles) : 0;
                 for (uint32_t i = 0; i < block_size && col_tile + i < Wt; i++) {
-                    uint64_t gamma_noc_addr = get_noc_addr(gamma_batch_offset + col_tile + i, addrg);
+                    uint64_t gamma_noc_addr = addrg.get_noc_addr(gamma_batch_offset + col_tile + i);
                     async_read_row_to_tile<gamma_is_row_major, gamma_element_size>(gamma_noc_addr, l1_write_addr_g);
                     l1_write_addr_g += gamma_tile_bytes;
                 }
@@ -158,7 +158,7 @@ void kernel_main() {
                 // Calculate tile offset for this batch
                 uint32_t beta_batch_offset = beta_is_batched ? (batch_idx * beta_batch_stride_tiles) : 0;
                 for (uint32_t i = 0; i < block_size && col_tile + i < Wt; i++) {
-                    uint64_t beta_noc_addr = get_noc_addr(beta_batch_offset + col_tile + i, addrb);
+                    uint64_t beta_noc_addr = addrb.get_noc_addr(beta_batch_offset + col_tile + i);
                     async_read_row_to_tile<beta_is_row_major, beta_element_size>(beta_noc_addr, l1_write_addr_b);
                     l1_write_addr_b += beta_tile_bytes;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/writer_layernorm_postallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/writer_layernorm_postallgather_dit.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
             cb_wait_front(cb_out, block_size);
             uint32_t l1_read_addr = get_read_ptr(cb_out);
             for (uint32_t i = 0; i < block_size && col_tile + i < Wt; i++) {
-                noc_async_write_tile(output_tile_idx, s, l1_read_addr);
+                noc_async_write_page(output_tile_idx, s, l1_read_addr);
                 output_tile_idx++;
                 l1_read_addr += tile_bytes;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
             cb_reserve_back(cb_inp, input_block_size);
             uint32_t inp_wr_ptr = get_write_ptr(cb_inp);
             for (uint32_t r = 0; r < input_block_size && wt + r < Wt; r++) {
-                noc_async_read_tile(inp_tile_idx, src_a, inp_wr_ptr);
+                noc_async_read_page(inp_tile_idx, src_a, inp_wr_ptr);
                 inp_wr_ptr += src0_tile_bytes;
                 inp_tile_idx++;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/writer_layernorm_preallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/writer_layernorm_preallgather_dit.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
         cb_wait_front(cb_out, output_block_size);
         uint32_t l1_read_addr = get_read_ptr(cb_out);
         for (uint32_t j = 0; j < output_block_size; j++) {
-            noc_async_write_tile(tile_id, s, l1_read_addr);
+            noc_async_write_page(tile_id, s, l1_read_addr);
             tile_id++;
             l1_read_addr += tile_bytes;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
@@ -81,7 +81,7 @@ void kernel_main() {
         // Read the single-tile transformation matrix for ROPE.
         cb_reserve_back(transformation_mat_cb, 1);
         uint32_t transformation_mat_wr_ptr = get_write_ptr(transformation_mat_cb);
-        noc_async_read_tile(0, transformation_mat_accessor, transformation_mat_wr_ptr);
+        noc_async_read_page(0, transformation_mat_accessor, transformation_mat_wr_ptr);
         noc_async_read_barrier();
         cb_push_back(transformation_mat_cb, 1);
     }
@@ -92,7 +92,7 @@ void kernel_main() {
         cb_reserve_back(stats_cb, stats_tiles_cols);
         uint32_t stats_wr_ptr = get_write_ptr(stats_cb);
         for (uint32_t col_tile = 0; col_tile < stats_tiles_cols; col_tile++) {
-            noc_async_read_tile(stats_tile_idx, stats_accessor, stats_wr_ptr);
+            noc_async_read_page(stats_tile_idx, stats_accessor, stats_wr_ptr);
             stats_wr_ptr += stats_tile_bytes;
             stats_tile_idx++;
         }
@@ -106,7 +106,7 @@ void kernel_main() {
             uint32_t input_wr_ptr = get_write_ptr(input_cb);
 
             for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
-                noc_async_read_tile(input_tile_idx, input_accessor, input_wr_ptr);
+                noc_async_read_page(input_tile_idx, input_accessor, input_wr_ptr);
                 input_wr_ptr += input_tile_bytes;
                 input_tile_idx++;
             }
@@ -118,7 +118,7 @@ void kernel_main() {
                     cb_reserve_back(weight_cb, block_size);
                     uint32_t weight_wr_ptr = get_write_ptr(weight_cb);
                     for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
-                        uint64_t weight_noc_addr = get_noc_addr(col_tile + i, weight_accessor);
+                        uint64_t weight_noc_addr = weight_accessor.get_noc_addr(col_tile + i);
 
                         // Rather than read a full tile containing sparse data,
                         // just read the first row of the tile from the faces.
@@ -140,7 +140,7 @@ void kernel_main() {
                     cb_reserve_back(rope_cos_cb, head_dim_tiles);
                     uint32_t rope_cos_wr_ptr = get_write_ptr(rope_cos_cb);
                     for (uint32_t i = 0; i < head_dim_tiles; i++) {
-                        noc_async_read_tile(rope_tile_start_idx + i, rope_cos_accessor, rope_cos_wr_ptr);
+                        noc_async_read_page(rope_tile_start_idx + i, rope_cos_accessor, rope_cos_wr_ptr);
                         rope_cos_wr_ptr += rope_cos_tile_bytes;
                     }
                     noc_async_read_barrier();
@@ -149,7 +149,7 @@ void kernel_main() {
                     cb_reserve_back(rope_sin_cb, head_dim_tiles);
                     uint32_t rope_sin_wr_ptr = get_write_ptr(rope_sin_cb);
                     for (uint32_t i = 0; i < head_dim_tiles; i++) {
-                        noc_async_read_tile(rope_tile_start_idx + i, rope_sin_accessor, rope_sin_wr_ptr);
+                        noc_async_read_page(rope_tile_start_idx + i, rope_sin_accessor, rope_sin_wr_ptr);
                         rope_sin_wr_ptr += rope_sin_tile_bytes;
                     }
                     noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_writer.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
             cb_wait_front(output_cb, block_size);
             uint32_t output_read_ptr = get_read_ptr(output_cb);
             for (uint32_t i = 0; i < block_size && col_tile + i < num_tile_cols; i++) {
-                noc_async_write_tile(tile_id, output_accessor, output_read_ptr);
+                noc_async_write_page(tile_id, output_accessor, output_read_ptr);
                 output_read_ptr += tile_bytes;
                 tile_id++;
                 tile_idx_in_head++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_reader.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
             cb_reserve_back(input_cb, block_size);
             uint32_t input_wr_ptr = get_write_ptr(input_cb);
             for (uint32_t r = 0; r < block_size && col_tile + r < num_tile_cols; r++) {
-                noc_async_read_tile(input_tile_idx, input_accessor, input_wr_ptr);
+                noc_async_read_page(input_tile_idx, input_accessor, input_wr_ptr);
                 input_wr_ptr += input_tile_bytes;
                 input_tile_idx++;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_writer.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
         cb_wait_front(output_cb, output_tiles_per_row);
         uint32_t l1_read_addr = get_read_ptr(output_cb);
         for (uint32_t tile_col = 0; tile_col < output_tiles_per_row; tile_col++) {
-            noc_async_write_tile(tile_id, output_accessor, l1_read_addr);
+            noc_async_write_page(tile_id, output_accessor, l1_read_addr);
             tile_id++;
             l1_read_addr += tile_bytes;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
         cb_wait_front(cb_out, blk);
         uint32_t l1_read_addr = get_read_ptr(cb_out);
         for (uint32_t j = 0; j < blk; j++) {
-            noc_async_write_tile(tile_id, s, l1_read_addr);
+            noc_async_write_page(tile_id, s, l1_read_addr);
             tile_id++;
             l1_read_addr += tile_bytes;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < in0_w_tiles; w_dim++) {
                 cb_reserve_back(cb_id_in0, block_size);
 
-                noc_async_read_tile(in0_tensor_current_tile_id, s0, l1_write_addr);
+                noc_async_read_page(in0_tensor_current_tile_id, s0, l1_write_addr);
                 l1_write_addr += single_tile_size_bytes;
                 in0_tensor_current_tile_id++;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < in0_w_tiles; w_dim++) {
                 cb_reserve_back(cb_id_in0, block_size);
 
-                noc_async_read_tile(in0_tensor_current_tile_id, s0, l1_write_addr);
+                noc_async_read_page(in0_tensor_current_tile_id, s0, l1_write_addr);
                 l1_write_addr += single_tile_size_bytes;
                 in0_tensor_current_tile_id++;
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < q_num_tiles; i++) {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_qv, onetile);
             in0_tensor_tile_id++;
@@ -50,10 +50,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_k, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_k);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();
@@ -65,10 +65,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                noc_async_write_page(q_out_tensor_current_tile_id, sq, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);
@@ -77,7 +77,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_k, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_k);
-                noc_async_write_tile(k_out_tensor_current_tile_id, sk, l1_read_addr);
+                noc_async_write_page(k_out_tensor_current_tile_id, sk, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_k, out_num_tiles_read);
@@ -100,7 +100,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(v_out_tensor_current_tile_id, sv, l1_read_addr);
+                noc_async_write_page(v_out_tensor_current_tile_id, sv, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < q_num_tiles; i++) {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_qv, onetile);
             in0_tensor_tile_id++;
@@ -50,10 +50,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_k, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_k);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();
@@ -65,10 +65,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_boltz.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                noc_async_write_page(q_out_tensor_current_tile_id, sq, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);
@@ -77,7 +77,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_k, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_k);
-                noc_async_write_tile(k_out_tensor_current_tile_id, sk, l1_read_addr);
+                noc_async_write_page(k_out_tensor_current_tile_id, sk, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_k, out_num_tiles_read);
@@ -100,7 +100,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(v_out_tensor_current_tile_id, sv, l1_read_addr);
+                noc_async_write_page(v_out_tensor_current_tile_id, sv, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -75,7 +75,7 @@ void kernel_main() {
             uint32_t scratch_offset = scratch_base;
             uint32_t local_tile_id = starting_tile_id;
             for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-                uint64_t aligned_src = get_noc_addr(local_tile_id, qkv_reader) + aligned_offset;
+                uint64_t aligned_src = qkv_reader.get_noc_addr(local_tile_id) + aligned_offset;
                 noc_async_read(aligned_src, scratch_offset, DRAM_ALIGN_BYTES);
                 scratch_offset += DRAM_ALIGN_BYTES;
                 local_tile_id++;
@@ -182,7 +182,7 @@ void kernel_main() {
         uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+            uint64_t qkv_in_noc_addr = qkv_reader.get_noc_addr(qkv_tile_id) + in_tile_offset_by_batch;
 
             // Read first phase
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
@@ -213,7 +213,7 @@ void kernel_main() {
         uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+            uint64_t qkv_in_noc_addr = qkv_reader.get_noc_addr(qkv_tile_id) + in_tile_offset_by_batch;
 
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
                 noc_async_read(qkv_in_noc_addr, k_write_addr, SUBTILE_LINE_BYTES);
@@ -242,7 +242,7 @@ void kernel_main() {
         uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
 
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+            uint64_t qkv_in_noc_addr = qkv_reader.get_noc_addr(qkv_tile_id) + in_tile_offset_by_batch;
 
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
                 noc_async_read(qkv_in_noc_addr, v_write_addr, SUBTILE_LINE_BYTES);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
         cb_reserve_back(cb_batch_offset_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_batch_offset_id);
         // Read the batch offset 1 page to read
-        uint64_t batch_offset_index_noc_addr = get_noc_addr(0, addrg);
+        uint64_t batch_offset_index_noc_addr = addrg.get_noc_addr(0);
         noc_async_read(batch_offset_index_noc_addr, index_cb_wr_ptr, index_stick_size);
         noc_async_read_barrier();
         cb_push_back(cb_batch_offset_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_tm_tile_layout_nlp_create_qkv_heads_decode_on_subcoregrids.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
         cb_reserve_back(cb_batch_offset_id, 1);
         uint32_t index_cb_wr_ptr = get_write_ptr(cb_batch_offset_id);
         // Read the batch offset 1 page to read
-        uint64_t batch_offset_index_noc_addr = get_noc_addr(0, addrg);
+        uint64_t batch_offset_index_noc_addr = addrg.get_noc_addr(0);
         noc_async_read(batch_offset_index_noc_addr, index_cb_wr_ptr, index_stick_size);
         noc_async_read_barrier();
         cb_push_back(cb_batch_offset_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_falcon7b.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_falcon7b.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
                 out_num_tiles_read += block_size;
                 cb_wait_front(cb_id_out0, out_num_tiles_read);
 
-                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                noc_async_write_page(q_out_tensor_current_tile_id, sq, l1_read_addr);
                 l1_read_addr += single_tile_size_bytes;
                 q_out_tensor_current_tile_id++;
             }
@@ -66,7 +66,7 @@ void kernel_main() {
             out_num_tiles_read += block_size;
             cb_wait_front(cb_id_out0, out_num_tiles_read);
 
-            noc_async_write_tile(out_tensor_current_tile_id, sk, l1_read_addr);
+            noc_async_write_page(out_tensor_current_tile_id, sk, l1_read_addr);
             l1_read_addr += single_tile_size_bytes;
             out_tensor_current_tile_id++;
         }
@@ -77,7 +77,7 @@ void kernel_main() {
             out_num_tiles_read += block_size;
             cb_wait_front(cb_id_out0, out_num_tiles_read);
 
-            noc_async_write_tile(out_tensor_current_tile_id, sv, l1_read_addr);
+            noc_async_write_page(out_tensor_current_tile_id, sv, l1_read_addr);
             l1_read_addr += single_tile_size_bytes;
             out_tensor_current_tile_id++;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < q_num_tiles; i++) {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_qv, onetile);
             in0_tensor_tile_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                noc_async_write_page(q_out_tensor_current_tile_id, sq, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < q_num_tiles; i++) {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_qv, onetile);
             in0_tensor_tile_id++;
@@ -51,10 +51,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_k, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_k);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();
@@ -66,10 +66,10 @@ void kernel_main() {
             cb_reserve_back(cb_id_qv, onetile);
             uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
 #ifdef READ_FROM_INPUT_TENSOR_KV
-            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            noc_async_read_page(in1_tensor_tile_id, s1, l1_write_addr);
             in1_tensor_tile_id++;
 #else
-            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
             in0_tensor_tile_id++;
 #endif
             noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/device/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                noc_async_write_page(q_out_tensor_current_tile_id, sq, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);
@@ -78,7 +78,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_k, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_k);
-                noc_async_write_tile(k_out_tensor_current_tile_id, sk, l1_read_addr);
+                noc_async_write_page(k_out_tensor_current_tile_id, sk, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_k, out_num_tiles_read);
@@ -101,7 +101,7 @@ void kernel_main() {
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
                 cb_wait_front(cb_id_qv, out_num_tiles_read);
                 l1_read_addr = get_read_ptr(cb_id_qv);
-                noc_async_write_tile(v_out_tensor_current_tile_id, sv, l1_read_addr);
+                noc_async_write_page(v_out_tensor_current_tile_id, sv, l1_read_addr);
 
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_qv, out_num_tiles_read);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_shard_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_shard_optimized.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_iterations; i++) {
         // Copy Input
         for (uint32_t j = 0; j < num_unpadded_tiles_head_dim; j++) {
-            noc_async_read_tile(src_tile_id, s0, src_buffer_l1_addr);
+            noc_async_read_page(src_tile_id, s0, src_buffer_l1_addr);
             src_buffer_l1_addr += tile_size;
             src_tile_id++;
             if (++barrier_count == barrier_threshold) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id.cpp
@@ -57,8 +57,8 @@ void kernel_main() {
     uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
     uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
     for (uint32_t i = 0; i < Wt; i++) {
-        noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
         cos_sin_curr_id++;
         sin_l1_write_addr += sin_tile_bytes;
         cos_l1_write_addr += cos_tile_bytes;
@@ -73,7 +73,7 @@ void kernel_main() {
         for (uint32_t j = 0; j < Wt; ++j) {
             cb_reserve_back(rotated_input_cb_id, onetile);
             uint32_t rotated_input_l1_write_addr = get_write_ptr(rotated_input_cb_id);
-            noc_async_read_tile(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
+            noc_async_read_page(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(rotated_input_cb_id, onetile);
             rotated_input_curr_id++;
@@ -81,14 +81,14 @@ void kernel_main() {
 #ifndef DECODE_MODE
             cb_reserve_back(sin_cb_id, onetile);
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(sin_cb_id, onetile);
 #endif
 
             cb_reserve_back(input_cb_id, onetile);
             uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-            noc_async_read_tile(input_curr_id, s0, input_l1_write_addr);
+            noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(input_cb_id, onetile);
             input_curr_id++;
@@ -96,7 +96,7 @@ void kernel_main() {
 #ifndef DECODE_MODE
             cb_reserve_back(cos_cb_id, onetile);
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cos_cb_id, onetile);
             cos_sin_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_interleaved_start_id_sharded.cpp
@@ -54,8 +54,8 @@ void kernel_main() {
     uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
     uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
     for (uint32_t i = 0; i < Wt; i++) {
-        noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
         cos_sin_curr_id++;
         sin_l1_write_addr += sin_tile_bytes;
         cos_l1_write_addr += cos_tile_bytes;
@@ -82,13 +82,13 @@ void kernel_main() {
         for (uint32_t j = 0; j < Wt; ++j) {
             cb_reserve_back(sin_cb_id, onetile);
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(sin_cb_id, onetile);
 
             cb_reserve_back(cos_cb_id, onetile);
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cos_cb_id, onetile);
             cos_sin_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id.cpp
@@ -116,8 +116,8 @@ void kernel_main() {
     {
         uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
         uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-        noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
         noc_async_read_barrier();
     }
     cb_push_back(sin_cb_id, onetile);
@@ -127,7 +127,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_rows; ++i) {
         cb_reserve_back(input_cb_id, onetile);
         uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-        noc_async_read_tile(input_curr_id, s0, input_l1_write_addr);
+        noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(input_cb_id, onetile);
         input_curr_id++;
@@ -136,7 +136,7 @@ void kernel_main() {
         cb_reserve_back(sin_cb_id, onetile);
         {
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(sin_cb_id, onetile);
@@ -144,7 +144,7 @@ void kernel_main() {
         cb_reserve_back(cos_cb_id, onetile);
         {
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(cos_cb_id, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/reader_rotary_embedding_single_tile_interleaved_start_id_sharded.cpp
@@ -99,8 +99,8 @@ void kernel_main() {
     {
         uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
         uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-        noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
-        noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
+        noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
         noc_async_read_barrier();
     }
     cb_push_back(sin_cb_id, onetile);
@@ -111,7 +111,7 @@ void kernel_main() {
         cb_reserve_back(sin_cb_id, onetile);
         {
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(sin_cb_id, onetile);
@@ -119,7 +119,7 @@ void kernel_main() {
         cb_reserve_back(cos_cb_id, onetile);
         {
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(cos_cb_id, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/kernels/dataflow/writer_rotary_embedding_interleaved_start_id.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_page(i, s, l1_read_addr);
 
         noc_async_write_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_interleaved.cpp
@@ -57,27 +57,27 @@ void kernel_main() {
         for (uint32_t j = 0; j < Wt; ++j) {
             cb_reserve_back(rotated_input_cb_id, onetile);
             uint32_t rotated_input_l1_write_addr = get_write_ptr(rotated_input_cb_id);
-            noc_async_read_tile(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
+            noc_async_read_page(rotated_input_curr_id, s0, rotated_input_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(rotated_input_cb_id, onetile);
             rotated_input_curr_id++;
 
             cb_reserve_back(sin_cb_id, onetile);
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(sin_cb_id, onetile);
 
             cb_reserve_back(input_cb_id, onetile);
             uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-            noc_async_read_tile(input_curr_id, s0, input_l1_write_addr);
+            noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(input_cb_id, onetile);
             input_curr_id++;
 
             cb_reserve_back(cos_cb_id, onetile);
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cos_cb_id, onetile);
             cos_sin_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id.cpp
@@ -108,7 +108,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_rows; ++i) {
         cb_reserve_back(input_cb_id, onetile);
         uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
-        noc_async_read_tile(input_curr_id, s0, input_l1_write_addr);
+        noc_async_read_page(input_curr_id, s0, input_l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(input_cb_id, onetile);
         input_curr_id++;
@@ -116,7 +116,7 @@ void kernel_main() {
         cb_reserve_back(sin_cb_id, onetile);
         {
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(sin_cb_id, onetile);
@@ -124,7 +124,7 @@ void kernel_main() {
         cb_reserve_back(cos_cb_id, onetile);
         {
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(cos_cb_id, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/reader_rotary_embedding_hf_single_tile_interleaved_start_id_sharded.cpp
@@ -105,7 +105,7 @@ void kernel_main() {
         cb_reserve_back(sin_cb_id, onetile);
         {
             uint32_t sin_l1_write_addr = get_write_ptr(sin_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s2, sin_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s2, sin_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(sin_cb_id, onetile);
@@ -113,7 +113,7 @@ void kernel_main() {
         cb_reserve_back(cos_cb_id, onetile);
         {
             uint32_t cos_l1_write_addr = get_write_ptr(cos_cb_id);
-            noc_async_read_tile(cos_sin_curr_id, s1, cos_l1_write_addr);
+            noc_async_read_page(cos_sin_curr_id, s1, cos_l1_write_addr);
             noc_async_read_barrier();
         }
         cb_push_back(cos_cb_id, onetile);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/writer_rotary_embedding_hf_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/dataflow/writer_rotary_embedding_hf_interleaved.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; ++i) {
         cb_wait_front(output_cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(output_cb_id);
-        noc_async_write_tile(output_curr_id, s, l1_read_addr);
+        noc_async_write_page(output_curr_id, s, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(output_cb_id, 1);
         output_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_interleaved_start_id.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
     // Read transformation matrix in CB (only once, because it will be reused)
     cb_reserve_back(trans_mat_cb_id, onetile);
     uint32_t trans_mat_l1_write_addr = get_write_ptr(trans_mat_cb_id);
-    noc_async_read_tile(trans_mat_curr_idx, s3, trans_mat_l1_write_addr);
+    noc_async_read_page(trans_mat_curr_idx, s3, trans_mat_l1_write_addr);
     noc_async_read_barrier();
     cb_push_back(trans_mat_cb_id, onetile);
 
@@ -105,13 +105,13 @@ void kernel_main() {
                 }
                 for (uint32_t j = 0; j < Wt; ++j) {
                     // Read input into CB
-                    noc_async_read_tile(input_curr_idx, s0, input_l1_write_addr);
+                    noc_async_read_page(input_curr_idx, s0, input_l1_write_addr);
                     input_curr_idx++;
                     input_l1_write_addr += input_tile_bytes;
 
                     if (!done_sin_cos) {
-                        noc_async_read_tile(sin_curr_idx, s2, sin_l1_write_addr);
-                        noc_async_read_tile(cos_curr_idx, s1, cos_l1_write_addr);
+                        noc_async_read_page(sin_curr_idx, s2, sin_l1_write_addr);
+                        noc_async_read_page(cos_curr_idx, s1, cos_l1_write_addr);
                         sin_curr_idx++;
                         cos_curr_idx++;
                         sin_l1_write_addr += sin_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_prefill_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/reader_rotary_embedding_llama_prefill_sharded.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
 
         cb_reserve_back(trans_mat_cb_id, onetile);
         uint32_t trans_mat_l1_write_addr = get_write_ptr(trans_mat_cb_id);
-        noc_async_read_tile(0, s3, trans_mat_l1_write_addr);
+        noc_async_read_page(0, s3, trans_mat_l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(trans_mat_cb_id, onetile);
     }
@@ -88,8 +88,8 @@ void kernel_main() {
                     uint32_t cos_curr_idx = freq_per_head ? (head_num * cos_Ht * Wt + seq_tile * Wt) : (seq_tile * Wt);
                     uint32_t sin_curr_idx = freq_per_head ? (head_num * sin_Ht * Wt + seq_tile * Wt) : (seq_tile * Wt);
                     for (uint32_t j = 0; j < Wt; ++j) {
-                        noc_async_read_tile(cos_curr_idx, s1, cos_l1_write_addr);
-                        noc_async_read_tile(sin_curr_idx, s2, sin_l1_write_addr);
+                        noc_async_read_page(cos_curr_idx, s1, cos_l1_write_addr);
+                        noc_async_read_page(sin_curr_idx, s2, sin_l1_write_addr);
                         cos_curr_idx++;
                         sin_curr_idx++;
                         cos_l1_write_addr += cos_tile_bytes;
@@ -99,7 +99,7 @@ void kernel_main() {
                     uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
                     uint32_t input_curr_idx = batch_id * n_heads * Ht * Wt + head_num * Ht * Wt + seq_tile * Wt;
                     for (uint32_t j = 0; j < Wt; ++j) {
-                        noc_async_read_tile(input_curr_idx, s0, input_l1_write_addr);
+                        noc_async_read_page(input_curr_idx, s0, input_l1_write_addr);
                         input_curr_idx++;
                         input_l1_write_addr += input_tile_bytes;
                     }
@@ -157,13 +157,13 @@ void kernel_main() {
                     }
                     for (uint32_t j = 0; j < Wt; ++j) {
                         // Read input into CB
-                        noc_async_read_tile(input_curr_idx, s0, input_l1_write_addr);
+                        noc_async_read_page(input_curr_idx, s0, input_l1_write_addr);
                         input_curr_idx++;
                         input_l1_write_addr += input_tile_bytes;
 
                         if (!done_sin_cos) {
-                            noc_async_read_tile(sin_curr_idx, s2, sin_l1_write_addr);
-                            noc_async_read_tile(cos_curr_idx, s1, cos_l1_write_addr);
+                            noc_async_read_page(sin_curr_idx, s2, sin_l1_write_addr);
+                            noc_async_read_page(cos_curr_idx, s1, cos_l1_write_addr);
                             sin_curr_idx++;
                             cos_curr_idx++;
                             sin_l1_write_addr += sin_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/writer_rotary_embedding_llama_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/dataflow/writer_rotary_embedding_llama_interleaved_start_id.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
                 uint32_t l1_read_addr = write_rotary_output ? get_read_ptr(cb_id_out) : get_read_ptr(cb_id_zero);
                 const uint32_t l1_read_stride = write_rotary_output ? tile_bytes : zero_tile_bytes;
                 for (uint32_t j = 0; j < Wt; j++) {
-                    noc_async_write_tile(output_curr_idx, s, l1_read_addr);
+                    noc_async_write_page(output_curr_idx, s, l1_read_addr);
                     l1_read_addr += l1_read_stride;
                     output_curr_idx++;
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/reader_rotate_half_interleaved_start_id.cpp
@@ -38,14 +38,14 @@ void kernel_main() {
         for (uint32_t j = 0; j < half_row_size; j++) {
             cb_reserve_back(cb_id_in_no_mul, onetile);
             uint32_t in_no_mul_l1_write_addr = get_write_ptr(cb_id_in_no_mul);
-            noc_async_read_tile(in_no_mul_curr_id, s, in_no_mul_l1_write_addr);
+            noc_async_read_page(in_no_mul_curr_id, s, in_no_mul_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in_no_mul, onetile);
             in_no_mul_curr_id++;
 
             cb_reserve_back(cb_id_in_mul, onetile);
             uint32_t in1_l1_write_addr = get_write_ptr(cb_id_in_mul);
-            noc_async_read_tile(in_mul_curr_id, s, in1_l1_write_addr);
+            noc_async_read_page(in_mul_curr_id, s, in1_l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in_mul, onetile);
             in_mul_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/kernels/dataflow/writer_rotate_half_interleaved_start_id.cpp
@@ -28,14 +28,14 @@ void kernel_main() {
         for (uint32_t j = 0; j < half_row_width; j++) {
             cb_wait_front(cb_id_out_no_mul, onetile);
             uint32_t out_no_mul_l1_read_addr = get_read_ptr(cb_id_out_no_mul);
-            noc_async_write_tile(out_no_mul_curr_id, s, out_no_mul_l1_read_addr);
+            noc_async_write_page(out_no_mul_curr_id, s, out_no_mul_l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_id_out_no_mul, onetile);
             out_no_mul_curr_id++;
 
             cb_wait_front(cb_id_out_mul, onetile);
             uint32_t out_mul_l1_read_addr = get_read_ptr(cb_id_out_mul);
-            noc_async_write_tile(out_mul_curr_id, s, out_mul_l1_read_addr);
+            noc_async_write_page(out_mul_curr_id, s, out_mul_l1_read_addr);
             noc_async_write_barrier();
             cb_pop_front(cb_id_out_mul, onetile);
             out_mul_curr_id++;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/dataflow/reader_tm_tile_layout_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/dataflow/reader_tm_tile_layout_create_qkv_heads.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
         for (uint32_t block_idx = 0; block_idx < out_num_blocks_per_tensor; block_idx++) {
             cb_reserve_back(cb_id, block_size);
             for (uint32_t i = 0; i < block_size; i++) {
-                noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+                noc_async_read_page(in0_tensor_tile_id, s0, l1_write_addr);
                 l1_write_addr += single_tile_size_bytes;
                 in0_tensor_tile_id++;
             }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/dataflow/writer_tm_tile_layout_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/kernels/dataflow/writer_tm_tile_layout_create_qkv_heads.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
                     out_num_tiles_read_out1++;
                 }
 
-                noc_async_write_tile(out_tensor_current_tile_id, sq, l1_read_addr_out1);
+                noc_async_write_page(out_tensor_current_tile_id, sq, l1_read_addr_out1);
                 l1_read_addr_out1 += single_tile_size_bytes;
                 out_tensor_current_tile_id++;
             }
@@ -81,7 +81,7 @@ void kernel_main() {
                     out_num_tiles_read_out0++;
                 }
 
-                noc_async_write_tile(out_tensor_current_tile_id, sk, l1_read_addr_out0);
+                noc_async_write_page(out_tensor_current_tile_id, sk, l1_read_addr_out0);
                 l1_read_addr_out0 += single_tile_size_bytes;
                 out_tensor_current_tile_id += out_h_tiles;
             }
@@ -104,7 +104,7 @@ void kernel_main() {
                     out_num_tiles_read_out1++;
                 }
 
-                noc_async_write_tile(out_tensor_current_tile_id, sv, l1_read_addr_out1);
+                noc_async_write_page(out_tensor_current_tile_id, sv, l1_read_addr_out1);
                 l1_read_addr_out1 += single_tile_size_bytes;
                 out_tensor_current_tile_id++;
             }

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
 #endif
         cb_reserve_back(cb_id_in0, onetile);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_page(i, s, l1_write_addr);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
     }

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
         cb_reserve_back(input_cb_id, Wt);
         uint32_t input_l1_write_addr = get_write_ptr(input_cb_id);
         for (uint32_t i = 0; i < Wt; ++i) {
-            noc_async_read_tile(input_id, s1, input_l1_write_addr);
+            noc_async_read_page(input_id, s1, input_l1_write_addr);
             input_l1_write_addr += input_tile_bytes;
             input_id++;
         }
@@ -57,7 +57,7 @@ void kernel_main() {
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t g = 0; g < granularity; ++g) {
                 for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                    noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+                    noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
                     cache_l1_write_addr += cache_tile_bytes;
                 }
                 cache_id += cache_batch_num_tiles;  // Input is read in by batch, then heads so skip to next batch

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
                 cb_wait_front(cache_cb_id, Wt);
                 uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
                 for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                    noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+                    noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
                     out_l1_read_addr += cache_tile_bytes;
                 }
                 cache_id += cache_batch_num_tiles;  // Input is read in by batch, then heads so skip to next batch

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp
@@ -76,7 +76,7 @@ void kernel_main() {
 
         for (uint32_t page_segment_idx = 0; page_segment_idx < page_segments; ++page_segment_idx) {
             if (page_idx == page_idx_start || packet_page_idx == curr_pages_per_packet) {
-                const uint64_t packet_noc_addr = get_noc_addr(packet_idx, packet_buffer, 0, 0);
+                const uint64_t packet_noc_addr = packet_buffer.get_noc_addr(packet_idx, 0, 0);
                 noc_async_read(packet_noc_addr, packet_l1_addr, packet_size_bytes);
                 noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_unary_interleaved_start_id_gen.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
         cb_reserve_back(cb_id_in0, onetile);
         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
 
-        const uint64_t src_noc_addr = get_noc_addr(i, s);
+        const uint64_t src_noc_addr = s.get_noc_addr(i);
         noc_async_read(src_noc_addr, l1_write_addr, s.get_aligned_page_size());
         noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -85,7 +85,7 @@ void kernel_main() {
             tt_memmove<false, false, false, 0>(packet_addr, src_addr, transfer_size_bytes);
             ++packet_page_idx;
             if (packet_page_idx >= curr_pages_per_packet) {
-                const uint64_t dst_noc_addr = get_noc_addr(packet_idx, dst_buffer, 0, 0);
+                const uint64_t dst_noc_addr = dst_buffer.get_noc_addr(packet_idx, 0, 0);
                 tt::tt_fabric::linear::to_noc_unicast_write(
                     align(payload_size_bytes, alignment), packet_header_ptr, packet_idx, dst_buffer);
                 perform_payload_send(connection_direction, packet_base_addr, payload_size_bytes, packet_header_ptr);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -85,7 +85,6 @@ void kernel_main() {
             tt_memmove<false, false, false, 0>(packet_addr, src_addr, transfer_size_bytes);
             ++packet_page_idx;
             if (packet_page_idx >= curr_pages_per_packet) {
-                const uint64_t dst_noc_addr = dst_buffer.get_noc_addr(packet_idx, 0, 0);
                 tt::tt_fabric::linear::to_noc_unicast_write(
                     align(payload_size_bytes, alignment), packet_header_ptr, packet_idx, dst_buffer);
                 perform_payload_send(connection_direction, packet_base_addr, payload_size_bytes, packet_header_ptr);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_unary_interleaved_start_id_gen.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
 
-        const uint64_t dst_noc_addr = get_noc_addr(i, s);
+        const uint64_t dst_noc_addr = s.get_noc_addr(i);
         noc_async_write(l1_read_addr, dst_noc_addr, s.get_aligned_page_size());
 
         noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
         auto intermed_cb_addr = reinterpret_cast<float*>(intermed_cb_read_ptr);
 
 #ifdef OUTPUT_DTYPE_FLOAT32
-        noc_async_write_tile(i, output_addrg, intermed_cb_read_ptr);
+        noc_async_write_page(i, output_addrg, intermed_cb_read_ptr);
         noc_async_write_barrier();
         cb_pop_front(intermed_cb_id, 1);
 #endif
@@ -48,7 +48,7 @@ void kernel_main() {
         }
         cb_pop_front(intermed_cb_id, 1);
 
-        noc_async_write_tile(i, output_addrg, dst_cb_write_ptr);
+        noc_async_write_page(i, output_addrg, dst_cb_write_ptr);
         noc_async_write_barrier();
 #endif
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -185,7 +185,7 @@ uint32_t read_mask_chunk(
     for (uint32_t row = 0; row < PNHt; ++row) {
         uint32_t mask_tile_id = mask_start_tile_id + row * PSt;
         for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
-            noc_async_read_tile(mask_tile_id, mask_reader, mask_write_ptr);
+            noc_async_read_page(mask_tile_id, mask_reader, mask_write_ptr);
             mask_tile_id++;
             mask_write_ptr += mask_tile_bytes;
 
@@ -398,7 +398,7 @@ uint32_t write_tiles_to_memory(uint32_t& out_tile_id, const WriterType& out_writ
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
     uint32_t l1_read_addr = get_read_ptr(cb_out);
     for (uint32_t tile = 0; tile < out_chunk_tiles; ++tile) {
-        noc_async_write_tile(out_tile_id, out_writer, l1_read_addr);
+        noc_async_write_page(out_tile_id, out_writer, l1_read_addr);
         ++out_tile_id;
         l1_read_addr += tile_bytes;
         if (++barrier_count == barrier_threshold) {
@@ -442,7 +442,7 @@ uint32_t write_partial_tiles_to_memory(
             uint32_t l1_read_addr_head = l1_base_addr + tile_index * tile_bytes + in_tile_offset;
 
             // DRAM tile: global index = out_tile_id + tile_index
-            uint64_t out_writer_tile_addr = get_noc_addr(out_tile_id + tile_index, out_writer);
+            uint64_t out_writer_tile_addr = out_writer.get_noc_addr(out_tile_id + tile_index);
             uint64_t out_writer_noc_addr_head = out_writer_tile_addr + in_tile_offset;
 
             // Write first phase
@@ -615,7 +615,7 @@ uint64_t read_k(
                                                   DHt,
                                                   capacity_t>(virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
                 for (uint32_t col = 0; col < DHt; ++col) {
-                    noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                    noc_async_read_page(physical_k_tile_id, k_reader, k_write_ptr_col);
                     physical_k_tile_id += 1;
                     k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;
                     if (++barrier_count == barrier_threshold) {
@@ -671,7 +671,7 @@ uint64_t read_k(
                     : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, DHt, capacity_t>(
                           virtual_k_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < DHt; ++col) {
-                noc_async_read_tile(physical_k_tile_id, k_reader, k_write_ptr_col);
+                noc_async_read_page(physical_k_tile_id, k_reader, k_write_ptr_col);
                 physical_k_tile_id += 1;                               // Go to next tile in row
                 k_write_ptr_col += Sk_chunk_t_dynamic * k_tile_bytes;  // Go to next column in CB
 
@@ -737,7 +737,7 @@ void read_v(
                     : virtual_seq_tile_id_to_physical_tile_id<uint32_t, num_kv_heads, block_size_t, vDHt, capacity_t>(
                           virtual_v_tile_row_num, cur_head, page_table_ptr_u32);
             for (uint32_t col = 0; col < vDHt; ++col) {
-                noc_async_read_tile(physical_v_tile_id, v_reader, v_write_ptr);
+                noc_async_read_page(physical_v_tile_id, v_reader, v_write_ptr);
                 physical_v_tile_id += 1;
                 v_write_ptr += v_tile_bytes;
 
@@ -793,7 +793,7 @@ void read_kv_mask_chunks(
         for (uint32_t col = 0; col < DHt; ++col) {
             uint32_t k_tile_id = k_start_tile_id + col;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
-                noc_async_read_tile(k_tile_id, k_reader, k_write_ptr);
+                noc_async_read_page(k_tile_id, k_reader, k_write_ptr);
                 if (++barrier_count == barrier_threshold) {
                     noc_async_read_barrier();
                     barrier_count = 0;
@@ -833,7 +833,7 @@ void read_kv_mask_chunks(
             uint32_t v_tile_id = v_start_tile_id;
             for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
                 for (uint32_t col = 0; col < vDHt; ++col) {
-                    noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
+                    noc_async_read_page(v_tile_id, v_reader, v_write_ptr);
                     if (++barrier_count == barrier_threshold) {
                         noc_async_read_barrier();
                         barrier_count = 0;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -220,9 +220,9 @@ void kernel_main() {
 
         for (uint32_t tile = 0; tile < PNHt; ++tile) {
             uint64_t sink_noc_addr = attention_sink_reader.get_noc_addr(tile);
-            // Use noc_async_read with explicit size instead of noc_async_read_tile because
+            // Use noc_async_read with explicit size instead of noc_async_read_page because
             // the CB may use half tiles (16x32) while the DRAM buffer stores full tiles (32x32).
-            // noc_async_read_tile would read buffer->aligned_page_size() bytes, overflowing the CB.
+            // noc_async_read_page would read buffer->aligned_page_size() bytes, overflowing the CB.
             noc_async_read(sink_noc_addr, attention_sink_write_ptr, attention_sink_tile_bytes);
             attention_sink_write_ptr += attention_sink_tile_bytes;
         }

--- a/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
         auto intermed_cb_addr = reinterpret_cast<float*>(intermed_cb_read_ptr);
 
 #ifdef OUTPUT_DTYPE_FLOAT32
-        noc_async_write_tile(i, output_addrg, intermed_cb_read_ptr);
+        noc_async_write_page(i, output_addrg, intermed_cb_read_ptr);
         noc_async_write_barrier();
         cb_pop_front(intermed_cb_id, 1);
 #endif
@@ -48,7 +48,7 @@ void kernel_main() {
         }
         cb_pop_front(intermed_cb_id, 1);
 
-        noc_async_write_tile(i, output_addrg, dst_cb_write_ptr);
+        noc_async_write_page(i, output_addrg, dst_cb_write_ptr);
         noc_async_write_barrier();
 #endif
     }

--- a/ttnn/examples/lab_eltwise_binary/kernels/dataflow/read_tiles.cpp
+++ b/ttnn/examples/lab_eltwise_binary/kernels/dataflow/read_tiles.cpp
@@ -53,8 +53,8 @@ void kernel_main() {
         // They are used to determine the address to read the tiles from. i is the index of the tile to read.
         // cb_in0_addr and cb_in1_addr are the circular buffer addresses to write the tiles to.
         // These are non-blocking calls, so they both proceed in parallel.
-        noc_async_read_tile(i, in0_addr_gen, cb_in0_addr);
-        noc_async_read_tile(i, in1_addr_gen, cb_in1_addr);
+        noc_async_read_page(i, in0_addr_gen, cb_in0_addr);
+        noc_async_read_page(i, in1_addr_gen, cb_in1_addr);
 
         // Wait until both reads are done before signaling the circular buffers that the tiles are ready.
         noc_async_read_barrier();

--- a/ttnn/examples/lab_eltwise_binary/kernels/dataflow/write_tiles.cpp
+++ b/ttnn/examples/lab_eltwise_binary/kernels/dataflow/write_tiles.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
         cb_wait_front(cb_out0, 1);
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // Write the tile to device memory. This is a non-blocking call.
-        noc_async_write_tile(i, out0_addr_gen, cb_out0_addr);
+        noc_async_write_page(i, out0_addr_gen, cb_out0_addr);
 
         // Wait until the write is done. This is a blocking call.
         noc_async_write_barrier();

--- a/ttnn/examples/lab_multicast/kernels/dataflow/mcast_sender.cpp
+++ b/ttnn/examples/lab_multicast/kernels/dataflow/mcast_sender.cpp
@@ -46,7 +46,7 @@ void kernel_main() {
         uint32_t cb_write_addr = get_write_ptr(cb_id_in0);
 
         // Read tile from DRAM into L1 circular buffer
-        noc_async_read_tile(tile_idx, src_addr_gen, cb_write_addr);
+        noc_async_read_page(tile_idx, src_addr_gen, cb_write_addr);
         noc_async_read_barrier();
 
         // Mark tile as ready in CB (for tracking, though we're the only consumer)

--- a/ttnn/examples/lab_multicast/kernels/dataflow/write_tiles.cpp
+++ b/ttnn/examples/lab_multicast/kernels/dataflow/write_tiles.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
 
         // Write tile to DRAM at the appropriate offset
         uint32_t dram_tile_id = tile_offset + tile_idx;
-        noc_async_write_tile(dram_tile_id, dst_addr_gen, l1_read_addr);
+        noc_async_write_page(dram_tile_id, dst_addr_gen, l1_read_addr);
         noc_async_write_barrier();
 
         // Free the CB slot for next tile


### PR DESCRIPTION
### PR Category
Cleanup, bugfix

### Summary
noc_async_read_tile → noc_async_read_page (deprecated in https://github.com/tenstorrent/tt-metal/pull/25976/changes#diff-2a2e24d6d8b29baeb30787c3a29b4492580823a3538bb233a8baed1084416f54R982)
noc_async_write_tile → noc_async_write_page (deprecated in https://github.com/tenstorrent/tt-metal/pull/24879/changes#diff-2a2e24d6d8b29baeb30787c3a29b4492580823a3538bb233a8baed1084416f54R961)
get_noc_addr(id, accessor) → accessor.get_noc_addr(id)

### Manually added CI jobs

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:vlad/deprecated-api)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/deprecated-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/deprecated-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/deprecated-api)