### PR TITLE
[Model demo] Z-Image-Turbo - Remove trace_region_size, l1_small_size, and allow external device ownership

### DIFF
--- a/models/demos/z_image_turbo/tests/test_dit.py
+++ b/models/demos/z_image_turbo/tests/test_dit.py
@@ -52,7 +52,7 @@ def pcc(a, b):
 
 @pytest.fixture(scope="function")
 def device_params(request):
-    return {"l1_small_size": 1 << 15, "trace_region_size": 70_000_000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}
+    return {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)

--- a/models/demos/z_image_turbo/tests/test_pipeline.py
+++ b/models/demos/z_image_turbo/tests/test_pipeline.py
@@ -6,17 +6,22 @@ Full Z-Image-Turbo pipeline test — warmup + generate on (1,4) mesh.
 
 Verifies the complete end-to-end flow: text encoder → DIT denoising loop → VAE
 decode, including Metal Trace capture and replay for all three models.
-
-The pipeline opens its own mesh device internally, so no device fixture is needed.
 """
 
+import pytest
 from PIL import Image
 
+import ttnn
 from models.demos.z_image_turbo.tt.z_image_turbo import ZImageTurbo
 
 
-def test_z_image_turbo_pipeline(tmp_path):
-    pipeline = ZImageTurbo()
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [(ZImageTurbo.DEFAULT_MESH_SHAPE, {"fabric_config": ttnn.FabricConfig.FABRIC_1D})],
+    indirect=["mesh_device", "device_params"],
+)
+def test_z_image_turbo_pipeline(mesh_device, tmp_path):
+    pipeline = ZImageTurbo(mesh_device=mesh_device)
 
     warmup_image = pipeline.warmup(steps=9, seed=42)
     assert isinstance(warmup_image, Image.Image), "Warmup did not return a PIL Image"

--- a/models/demos/z_image_turbo/tests/test_text_encoder.py
+++ b/models/demos/z_image_turbo/tests/test_text_encoder.py
@@ -48,7 +48,7 @@ def pcc(a, b):
 
 @pytest.fixture(scope="function")
 def device_params(request):
-    return {"l1_small_size": 1 << 15, "trace_region_size": 70_000_000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}
+    return {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)

--- a/models/demos/z_image_turbo/tests/test_vae.py
+++ b/models/demos/z_image_turbo/tests/test_vae.py
@@ -25,7 +25,7 @@ def pcc(a, b):
 
 @pytest.fixture(scope="function")
 def device_params(request):
-    return {"l1_small_size": 1 << 15, "trace_region_size": 70_000_000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}
+    return {"fabric_config": ttnn.FabricConfig.FABRIC_1D}
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)

--- a/models/demos/z_image_turbo/tt/z_image_turbo.py
+++ b/models/demos/z_image_turbo/tt/z_image_turbo.py
@@ -135,7 +135,9 @@ def _make_scheduler(template, steps):
 class ZImageTurbo(LightweightModule):
     """Z-Image-Turbo pipeline with Metal Trace on TE, DIT, and VAE."""
 
-    def __init__(self):
+    DEFAULT_MESH_SHAPE = (1, 4)
+
+    def __init__(self, mesh_device=None):
         t0 = time.time()
 
         print("[1/5] Loading CPU components ...")
@@ -144,13 +146,15 @@ class ZImageTurbo(LightweightModule):
         self.scheduler_template = FlowMatchEulerDiscreteScheduler.from_pretrained(MODEL_ID, subfolder="scheduler")
         self.scheduler_template.sigma_min = 0.0
 
-        print("[2/5] Opening TTNN (1,4) mesh device ...")
-        ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
-        self.mesh_device = ttnn.open_mesh_device(
-            mesh_shape=ttnn.MeshShape((1, 4)),
-            l1_small_size=1 << 15,
-            trace_region_size=70_000_000,
-        )
+        if mesh_device is None:
+            print(f"[2/5] Opening TTNN {self.DEFAULT_MESH_SHAPE} mesh device ...")
+            ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
+            self.mesh_device = ttnn.open_mesh_device(
+                mesh_shape=ttnn.MeshShape(*self.DEFAULT_MESH_SHAPE),
+            )
+        else:
+            print("[2/5] Using caller-provided mesh device ...")
+            self.mesh_device = mesh_device
         self.mesh_device.enable_program_cache()
 
         print("[3/5] Building Text Encoder ...")


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Demo test passes in CI machines, but for some reason fails with `trace_region_size` error on the same machine type locally (QB2).

Fixed by unsetting the `trace_region_size` arg.

Additionally, allow user of model to own device.

Error:
```
E       RuntimeError: TT_FATAL @ /localdev/svuckovic/_workspace/repos/tt-metal/tt_metal/distributed/mesh_trace.cpp:78: mesh_cq.device()->get_trace_buffers_size() <= trace_region_size
E       info:
E       Creating trace buffers of size 77717504B on MeshDevice 0, but only 70000000B is allocated for trace region.
```

### Test
Re-running CI tests to confirm change:
https://github.com/tenstorrent/tt-metal/actions/runs/26517972143

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=svuckovic/z-image-turbo-fix-device-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:svuckovic/z-image-turbo-fix-device-args)