### PR TITLE
[Fix] DP slot remap for device sampling

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1131,7 +1131,20 @@ class Generator(WarmupForwardMixin):
         # Apply slot remap from condense before advancing seeds.
         if slot_remap is not None:
             sm_bs = self.model.sampling.seed_manager.max_batch_size
-            rank_remap = slot_remap[0:sm_bs]
+            remap = torch.as_tensor(slot_remap, dtype=torch.int32)
+            # vLLM gathered-DP sends compact per-rank remaps concatenated as
+            # [rank0 B, rank1 B, ...], where values are local to each rank
+            # (0..B-1). Galaxy uses one physical sampling module for the global
+            # batch, so expand compact rank-local values back to global slot
+            # indices before remapping RNG state.
+            if remap.numel() == sm_bs and remap.numel() > 0:
+                local_slots = int(remap.max().item()) + 1
+                if 0 < local_slots < sm_bs and sm_bs % local_slots == 0:
+                    expanded = remap.clone()
+                    for start in range(0, sm_bs, local_slots):
+                        expanded[start : start + local_slots] += start
+                    remap = expanded
+            rank_remap = remap[:sm_bs]
             self.model.sampling.seed_manager.apply_slot_remap(rank_remap)
         self.model.sampling.seed_manager.get_new_values()
         if reset_inputs and sampling_params is not None:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1250,7 +1250,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # Apply slot remap from condense before advancing seeds.
                 if slot_remap is not None:
                     sm_bs = sampling_module.seed_manager.max_batch_size
-                    rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
+                    # vLLM gathered-DP sends compact per-rank remaps using the
+                    # scheduler batch size, which can be smaller than the
+                    # physical sampling slot count (for example B=8, sm_bs=32).
+                    # The seed manager owns physical local slots, so expand a
+                    # compact rank remap to identity-padded sm_bs before
+                    # applying it.
+                    local_slots = sum(
+                        len(chunk.temperature) if isinstance(chunk.temperature, list) else sm_bs
+                        for chunk in model_chunks
+                    )
+                    remap = torch.as_tensor(slot_remap, dtype=torch.int32)
+                    if remap.numel() == self.data_parallel * local_slots:
+                        rank_remap = torch.arange(sm_bs, dtype=torch.int32)
+                        start_slot = i * local_slots
+                        rank_remap[:local_slots] = remap[start_slot : start_slot + local_slots]
+                    else:
+                        rank_remap = remap[i * sm_bs : (i + 1) * sm_bs]
                     sampling_module.seed_manager.apply_slot_remap(rank_remap)
                 sampling_module.seed_manager.get_new_values()
 


### PR DESCRIPTION
### Summary

Handle compact per-rank slot remaps from vLLM before remapping device sampler RNG state, including the Galaxy global sampling path.

Maybe related: #37397

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-slot-remap)