### PR TITLE
[ci] Disable consistently failing tests in Nightly tt-metal L2 tests (llk-sd-unit-tests)

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -374,6 +374,9 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       dispatch-mode: sd
+      # Disabled by issue #45320: MeshDeviceFixture.Top32RmDevPipelineCompletes fails deterministically
+      # in 3 consecutive scheduled runs (May 25-27 2026) across all platforms (WH N150/N300, BH P100/P150).
+      gtest-filter: "-MeshDeviceFixture.Top32RmDevPipelineCompletes"
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   # TTNN Tutorials
   test-ttnn-tutorials:


### PR DESCRIPTION
## Summary

Disables `MeshDeviceFixture.Top32RmDevPipelineCompletes` in the `llk-sd-unit-tests` job of the `Nightly tt-metal L2 tests` pipeline by adding a `gtest-filter` to `.github/workflows/tt-metal-l2-nightly.yaml`.

**Tracking issue:** #45320

## Evidence

The test `MeshDeviceFixture.Top32RmDevPipelineCompletes` (in `unit_tests_llk`) has failed in 3 consecutive scheduled main runs (May 25-27 2026) on all platforms:

| Date | Run | Failure |
|------|-----|---------|
| 2026-05-25 | [26388857253](https://github.com/tenstorrent/tt-metal/actions/runs/26388857253) | FAILED (457ms) |
| 2026-05-26 | [26437678698](https://github.com/tenstorrent/tt-metal/actions/runs/26437678698) | FAILED (472ms) |
| 2026-05-27 | [26496921030](https://github.com/tenstorrent/tt-metal/actions/runs/26496921030) | FAILED (465ms) |

Note: `workflow_dispatch` runs do not include `llk-sd-unit-tests` by default (`run_sd_unit_tests=false`), so these are scheduled-run-only failures.

## Disabled tests

```
MeshDeviceFixture.Top32RmDevPipelineCompletes  # unit_tests_llk (llk-sd-unit-tests job)
```

- WH N150, WH N300: TT_FATAL in JitBuildState::compile_one
- BH P100, BH P150: Test runs through row_elements but fails at end

## Changes

- `.github/workflows/tt-metal-l2-nightly.yaml`: Added `gtest-filter: "-MeshDeviceFixture.Top32RmDevPipelineCompletes"` to the `llk-sd-unit-tests` job

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/disable-failing-tests-l2-nightly-20260527)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/disable-failing-tests-l2-nightly-20260527)