### PR TITLE
ccl/all_to_all_combine: hash input buffer addresses to avoid stale-RTA cache hits (BHPC red since 2026-05-23)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::ccl {
 
@@ -112,6 +113,24 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
 
 void AllToAllCombineDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+
+ttsl::hash::hash_t AllToAllCombineDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // Workaround for PR #44408: the cross_device_semaphore and init_semaphore
+    // L1 addresses are baked into the cached program at first miss and never
+    // refreshed on cache hit (the descriptor framework only re-patches Buffer*
+    // slots).  Hash the input tensor buffer addresses so any allocation churn
+    // -- e.g. the failing test reallocating input tensors per iter -- forces
+    // a fresh build with current semaphore addresses.  Stable across trace
+    // replays that reuse the same buffers, so trace tests still cache-hit.
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<AllToAllCombineDeviceOperation>,
+        attrs,
+        tensor_args,
+        tensor_args.input_tensor.buffer()->address(),
+        tensor_args.mapping_tensor.buffer()->address(),
+        tensor_args.metadata_tensor.buffer()->address());
+}
 
 AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
@@ -86,6 +86,13 @@ struct AllToAllCombineDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Workaround for PR #44408 cache-hit-on-stale-RTA bug: hash the input
+    // buffer addresses so reallocated tensors force a fresh build (and thus
+    // refresh the baked-in semaphore addresses).  Trace replays reuse the
+    // same buffers so cache hits still happen.  Real fix is a ScalarBinding-
+    // style framework feature for non-Buffer RTAs (Metal 2.0 plan).
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::ccl
 


### PR DESCRIPTION
## Summary
Fixes `test_all_to_all_combine_no_trace` (red on BHPC since 2026-05-23) introduced by PR #44408 (migration to `ProgramDescriptor`).

**Root cause:** the legacy `override_runtime_arguments` re-patched `cross_device_semaphore.address()` and `init_semaphore.address()` as non-`Buffer` `uint32_t` RTAs on every dispatch. The descriptor framework only re-patches `Buffer*` slots via `BufferBinding`, so those two semaphore RTAs are now baked at first cache miss and never refreshed. On iter 2 of the failing test (cache hit) the kernel reads stale L1 addresses, the init barrier never completes, and the device writes all zeros.

**Fix (tactical):** mix the input tensor buffer addresses into the program hash. When a caller reallocates inputs between dispatches (the failing test re-creates them per iter) the addresses change → fresh cache entry → fresh semaphores. Trace replays that reuse the same buffers keep the same hash and still cache-hit, so the trace path is unaffected.

**Earlier attempt (force-pushed away):** salted the hash with a per-call atomic counter. Fixed the failing test but forced a cache miss inside trace capture → `TT_FATAL: Writes are not supported during trace capture`. The buffer-address mix is the minimum-discriminator variant that works for both paths.

**Real fix (deferred):** a `ScalarBinding`-style framework feature that re-patches non-`Buffer` RTAs on cache hit (Metal 2.0 plan).

## Note
This replaces the previous attempt on this branch (DEST_CHIP_ID iteration order fix) which did not address the root cause. Branch was reset; the prior commit `9724304a5fd` is preserved on `dgomez/debug-a2a-combine-bug`.

## Validation
Validated locally on a 2-card Blackhole p300 (yyzo-bh-02). Failing parametrization scaled `(4,1) → (2,1)` (cache-hit pattern is mesh-size-independent).

- BHPC `test_all_to_all_combine_no_trace[num_iters=1]`, no fix → PASS (cache-miss path is fine)
- BHPC `test_all_to_all_combine_no_trace[num_iters=2]`, no fix → FAIL — output all zeros (matches the prompt symptom)
- BHPC `test_all_to_all_combine_no_trace[num_iters=2]`, with fix → PASS
- Nightly `test_all_to_all_combine_trace` (num_iters=40+warmup, num_iters=10+warmup), with fix → 2 passed, 32 skipped (skips need >2 devices)

## Test plan
- [ ] BHPC `test_all_to_all_combine_no_trace` passes on a 4-card box
- [ ] `tests/nightly/t3000/ccl/test_all_to_all_combine.py` regression run is clean
- [ ] Perf check: cache hit rate in steady-state workloads (buffers should be reused → no per-call rebuild penalty)