### PR TITLE
Adding initial tests for FP8

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -13,14 +13,18 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <type_traits>
+#include <vector>
 
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/float8.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 
@@ -292,6 +296,120 @@ TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
 
     EXPECT_TRUE(source.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
     EXPECT_FALSE(target.is_valueless_after_move());
+}
+
+// FP8_E4M3 host-side tensor operations.
+//
+// FP8 support in tt-metal tensor infra is intentionally limited (only what the DeepSeek V3
+// Prefill combine op needs today). These tests pin that contract on the host side:
+//   - to_layout: ROW_MAJOR is the only supported layout; any other target throws.
+//   - to_dtype: only FP8 <-> FLOAT32 is wired up; other cross-type conversions throw.
+//   - pad / unpad: not wired up, both throw.
+
+HostTensor make_fp8_host_tensor(const Shape& shape, std::vector<float8_e4m3> data) {
+    auto spec = create_simple_spec(shape, DataType::FP8_E4M3);
+    HostBuffer host_buffer(std::move(data));
+    return HostTensor(std::move(host_buffer), std::move(spec), TensorTopology());
+}
+
+TEST(HostTensorFp8Test, ToLayoutRowMajorIsNoOp) {
+    Shape shape{2, 32};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    auto out = to_layout(tensor, Layout::ROW_MAJOR);
+
+    EXPECT_EQ(out.dtype(), DataType::FP8_E4M3);
+    EXPECT_EQ(out.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(out.logical_shape(), shape);
+}
+
+TEST(HostTensorFp8Test, ToLayoutToTileThrows) {
+    Shape shape{2, 32};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    EXPECT_ANY_THROW(to_layout(tensor, Layout::TILE));
+}
+
+TEST(HostTensorFp8Test, ToDtypeFp8ToFp8IsNoOp) {
+    Shape shape{2, 32};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    auto out = to_dtype(tensor, DataType::FP8_E4M3);
+
+    EXPECT_EQ(out.dtype(), DataType::FP8_E4M3);
+    EXPECT_EQ(out.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(out.logical_shape(), shape);
+}
+
+TEST(HostTensorFp8Test, ToDtypeFp8ToFloat32Succeeds) {
+    Shape shape{1, 8};
+    // All values below are exactly representable in FP8 E4M3 so the FP8 round-trip is lossless.
+    std::vector<float> float_data{0.0f, 0.5f, 1.0f, 2.0f, -1.0f, -2.0f, 4.0f, -0.5f};
+    std::vector<float8_e4m3> fp8_data(float_data.size());
+    std::transform(float_data.begin(), float_data.end(), fp8_data.begin(), [](float v) { return float8_e4m3(v); });
+
+    auto tensor = make_fp8_host_tensor(shape, std::move(fp8_data));
+    auto out = to_dtype(tensor, DataType::FLOAT32);
+
+    EXPECT_EQ(out.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(out.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(out.logical_shape(), shape);
+
+    auto out_data = host_buffer::get_as<const float>(out);
+    ASSERT_EQ(out_data.size(), float_data.size());
+    for (size_t i = 0; i < float_data.size(); ++i) {
+        EXPECT_FLOAT_EQ(out_data[i], float_data[i]);
+    }
+}
+
+TEST(HostTensorFp8Test, ToDtypeFloat32ToFp8RoundTripsCleanly) {
+    Shape shape{1, 8};
+    std::vector<float> data{0.0f, 0.5f, 1.0f, 2.0f, -1.0f, -2.0f, 4.0f, -0.5f};
+    auto spec = create_simple_spec(shape, DataType::FLOAT32);
+    HostBuffer host_buffer(data);
+    HostTensor tensor(std::move(host_buffer), std::move(spec), TensorTopology());
+
+    auto fp8_tensor = to_dtype(tensor, DataType::FP8_E4M3);
+    EXPECT_EQ(fp8_tensor.dtype(), DataType::FP8_E4M3);
+    EXPECT_EQ(fp8_tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(fp8_tensor.logical_shape(), shape);
+
+    auto round_trip = to_dtype(fp8_tensor, DataType::FLOAT32);
+    auto round_trip_data = host_buffer::get_as<const float>(round_trip);
+    ASSERT_EQ(round_trip_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_FLOAT_EQ(round_trip_data[i], data[i]);
+    }
+}
+
+TEST(HostTensorFp8Test, ToDtypeFp8ToBfloat16Throws) {
+    Shape shape{1, 8};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    EXPECT_ANY_THROW(to_dtype(tensor, DataType::BFLOAT16));
+}
+
+TEST(HostTensorFp8Test, ToDtypeFp8ToUInt32Throws) {
+    Shape shape{1, 8};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    EXPECT_ANY_THROW(to_dtype(tensor, DataType::UINT32));
+}
+
+TEST(HostTensorFp8Test, ToDtypeBfloat16ToFp8Throws) {
+    Shape shape{1, 8};
+    auto spec = create_simple_spec(shape, DataType::BFLOAT16);
+    HostBuffer host_buffer(std::vector<bfloat16>(shape.volume(), bfloat16(0.5f)));
+    HostTensor tensor(std::move(host_buffer), std::move(spec), TensorTopology());
+
+    EXPECT_ANY_THROW(to_dtype(tensor, DataType::FP8_E4M3));
+}
+
+TEST(HostTensorFp8Test, PadThrows) {
+    Shape shape{1, 8};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    EXPECT_ANY_THROW(pad(tensor, Shape{1, 16}, Shape{0, 0}, /*pad_value=*/0.0f));
+}
+
+TEST(HostTensorFp8Test, UnpadThrows) {
+    Shape shape{1, 16};
+    auto tensor = make_fp8_host_tensor(shape, std::vector<float8_e4m3>(shape.volume(), float8_e4m3(0.5f)));
+    EXPECT_ANY_THROW(unpad(tensor, Shape{0, 0}, Shape{1, 8}));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -12,13 +12,22 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <algorithm>
+#include <functional>
+#include <stdexcept>
 #include <type_traits>
+#include <vector>
 
+#include <tt-metalium/distributed_host_buffer.hpp>
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/float8.hpp>
+#include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/math.hpp>
 
@@ -226,6 +235,102 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithTooSmallBufferFails) {
     auto topology = TensorTopology();
 
     EXPECT_ANY_THROW(MeshTensor(mesh_buffer, std::move(spec), std::move(topology)));
+}
+
+// FP8_E4M3 device-side support is intentionally narrow. The TensorSpec validator enforces
+// ROW_MAJOR layout for FP8_E4M3; MeshTensor::allocate_on_device adds the Blackhole-arch
+// requirement (FP8_E4M3's only producer today is the DeepSeek V3 Prefill combine op).
+// These tests pin both constraints and confirm a plain H2D->D2H round-trip works.
+
+TensorSpec make_fp8_row_major_spec(const Shape& shape) {
+    return TensorSpec(
+        shape,
+        TensorLayout(
+            DataType::FP8_E4M3,
+            PageConfig(Layout::ROW_MAJOR),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
+}
+
+TEST_F(MeshTensorDeviceTest, AllocateOnDeviceFp8RowMajorOnBlackholeSucceeds) {
+    if (mesh_device_->arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "FP8_E4M3 device allocation requires Blackhole.";
+    }
+    const Shape shape{2, 32};
+    auto spec = make_fp8_row_major_spec(shape);
+
+    testing::internal::CaptureStdout();
+    auto tensor = MeshTensor::allocate_on_device(*mesh_device_, spec, TensorTopology());
+    std::fflush(stdout);
+    const std::string captured = testing::internal::GetCapturedStdout();
+
+    EXPECT_EQ(tensor.dtype(), DataType::FP8_E4M3);
+    EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(tensor.logical_shape(), shape);
+    EXPECT_EQ(tensor.element_size(), sizeof(float8_e4m3));
+    // The unconditional FP8 warning fires even on Blackhole as a signpost of limited support.
+    EXPECT_THAT(captured, ::testing::HasSubstr("FP8_E4M3 has limited tensor infra support"));
+}
+
+TEST_F(MeshTensorDeviceTest, AllocateOnDeviceFp8OnNonBlackholeThrows) {
+    if (mesh_device_->arch() == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "Negative arch guard only fires off-Blackhole.";
+    }
+    auto spec = make_fp8_row_major_spec(Shape{2, 32});
+
+    testing::internal::CaptureStdout();
+    bool threw_with_message = false;
+    try {
+        (void)MeshTensor::allocate_on_device(*mesh_device_, spec, TensorTopology());
+    } catch (const std::runtime_error& e) {
+        threw_with_message =
+            std::string(e.what()).find("FP8_E4M3 is only supported on Blackhole hardware") != std::string::npos;
+    }
+    std::fflush(stdout);
+    const std::string captured = testing::internal::GetCapturedStdout();
+
+    EXPECT_TRUE(threw_with_message) << "Expected std::runtime_error with the Blackhole-only message; captured stdout: "
+                                    << captured;
+    EXPECT_THAT(captured, ::testing::HasSubstr("FP8_E4M3 has limited tensor infra support"));
+}
+
+TEST_F(MeshTensorDeviceTest, Fp8H2DToD2HRoundTripPreservesBytes) {
+    if (mesh_device_->arch() != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "H2D/D2H for FP8_E4M3 requires Blackhole.";
+    }
+
+    const Shape shape{2, 32};
+    auto spec = make_fp8_row_major_spec(shape);
+
+    const auto& mesh_shape = mesh_device_->shape();
+    auto dhb = DistributedHostBuffer::create(mesh_shape);
+    distributed::MeshCoordinateRange range(mesh_shape);
+    std::vector<distributed::MeshCoordinate> coords(range.begin(), range.end());
+    // Per-shard distinct fills make cross-shard corruption easy to spot; exact FP8 quantization
+    // doesn't matter since we compare raw bytes after the round-trip.
+    dhb.emplace_shards(coords, [&, idx = size_t{0}](const distributed::MeshCoordinate&) mutable {
+        const float v = 0.5f * static_cast<float>(idx++ + 1);
+        return HostBuffer(std::vector<float8_e4m3>(shape.volume(), float8_e4m3(v)));
+    });
+    auto topology = TensorTopology::create_sharded_tensor_topology(mesh_shape);
+    HostTensor host_tensor(std::move(dhb), spec, topology);
+
+    auto& cq = mesh_device_->mesh_command_queue();
+    MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_);
+    HostTensor result = enqueue_read_tensor(cq, device_tensor);
+
+    const auto& exp_coords = host_tensor.buffer().shard_coords();
+    const auto& act_coords = result.buffer().shard_coords();
+    ASSERT_EQ(exp_coords, act_coords);
+    for (const auto& coord : exp_coords) {
+        auto exp_shard = host_tensor.buffer().get_shard(coord);
+        auto act_shard = result.buffer().get_shard(coord);
+        ASSERT_TRUE(exp_shard.has_value());
+        ASSERT_TRUE(act_shard.has_value());
+        const auto exp_bytes = exp_shard->view_bytes();
+        const auto act_bytes = act_shard->view_bytes();
+        ASSERT_EQ(exp_bytes.size(), act_bytes.size());
+        EXPECT_TRUE(std::equal(exp_bytes.begin(), exp_bytes.end(), act_bytes.begin()));
+    }
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 #include <tt-metalium/mesh_device.hpp>
+#include <tt-logger/tt-logger.hpp>
 
 #include "mesh_tensor_impl.hpp"
 
@@ -90,6 +91,20 @@ void MeshTensor::update_tensor_topology(TensorTopology tensor_topology) {
 
 MeshTensor MeshTensor::allocate_on_device(
     distributed::MeshDevice& mesh_device, const TensorSpec& spec, const TensorTopology& topology) {
+    // FP8_E4M3 has narrow tensor infra support: ROW_MAJOR layout (enforced in TensorSpec)
+    // and Blackhole arch only. The warning fires on every FP8 allocation as a signpost of
+    // the limited support; the TT_FATAL guards the device-binding boundary against
+    // allocating on unsupported hardware where kernels would misbehave later.
+    if (spec.data_type() == DataType::FP8_E4M3) {
+        log_warning(
+            tt::LogAlways,
+            "FP8_E4M3 has limited tensor infra support: ROW_MAJOR layout and Blackhole arch only (got arch {}).",
+            mesh_device.arch());
+        TT_FATAL(
+            mesh_device.arch() == tt::ARCH::BLACKHOLE,
+            "FP8_E4M3 is only supported on Blackhole hardware (got arch {})",
+            mesh_device.arch());
+    }
     auto mesh_buffer = tensor_impl::allocate_device_buffer(&mesh_device, spec);
     return MeshTensor(std::move(mesh_buffer), spec, topology);
 }


### PR DESCRIPTION
### Problem description
Initial FP8 PR https://github.com/tenstorrent/tt-metal/pull/43775 introduced new DataType, but left some unresolved comments.

### What's changed
- Added arch guard for `MeshTensor::allocate_on_device` (since TILE_LAYOUT TensorSpec for FP8 can't be created)
- Initial tests for `pad`, `unpad`, `to_dtype`, `to_layout` for `HostTensor` (Claude generated, yet to be polished)
- Tests for **successful** and **unsuccessful** allocation of FP8 `MeshTensor` and `H2D<->D2H` allocation

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/fp8-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/fp8-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/fp8-tests)