### PR TITLE
[Feature] Port-type metadata and same-host TRACE preferences in topology mapper

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
         test_common_libs
         yaml-cpp::yaml-cpp
         spdlog::spdlog
+        TT::ScaleoutTools
 )
 
 target_include_directories(

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -647,21 +647,6 @@ protected:
 // Port-type metadata helpers (Step 1 / #44933)
 // =============================================================================
 
-TEST(PortTypeMappingHelpers, PortTypePreferenceRank) {
-    using tt::tt_metal::PortType;
-    EXPECT_LT(port_type_preference_rank(PortType::TRACE), port_type_preference_rank(PortType::WARP400));
-    EXPECT_LT(port_type_preference_rank(PortType::WARP400), port_type_preference_rank(PortType::QSFP_DD));
-    EXPECT_LT(port_type_preference_rank(PortType::QSFP_DD), port_type_preference_rank(PortType::WARP100));
-    EXPECT_LT(port_type_preference_rank(PortType::WARP100), port_type_preference_rank(PortType::UNKNOWN));
-}
-
-TEST(PortTypeMappingHelpers, CanonicalPortTypeLinkKey) {
-    const tt::tt_metal::AsicID a{10};
-    const tt::tt_metal::AsicID b{20};
-    EXPECT_EQ(canonical_port_type_link_key(a, b), (PortTypeLinkKey{a, b}));
-    EXPECT_EQ(canonical_port_type_link_key(b, a), (PortTypeLinkKey{a, b}));
-}
-
 TEST(PortTypeMappingHelpers, InferLogicalEdgePortRequirement) {
     const MeshHostRankId rank0{0};
     const MeshHostRankId rank1{1};

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -790,6 +790,81 @@ TEST(PortTypeMappingHelpers, MapMeshPrefersTraceForSameHostEdge) {
     EXPECT_NE(result_with.fabric_node_to_asic.at(node1), asic_c);
 }
 
+TEST(PortTypeMappingHelpers, MapMeshRequiresQsfpForCrossHostEdge) {
+    const MeshId mesh_id{0};
+    const FabricNodeId node0(mesh_id, 0);
+    const FabricNodeId node1(mesh_id, 1);
+    const tt::tt_metal::AsicID asic_a{200};
+    const tt::tt_metal::AsicID asic_b{201};
+    const tt::tt_metal::AsicID asic_x{300};
+    const tt::tt_metal::AsicID asic_y{301};
+
+    LogicalAdjacencyMap logical_adj;
+    logical_adj[node0] = {node1};
+    logical_adj[node1] = {node0};
+
+    PhysicalAdjacencyMap physical_adj;
+    physical_adj[asic_a] = {asic_x};
+    physical_adj[asic_b] = {asic_y};
+    physical_adj[asic_x] = {asic_a};
+    physical_adj[asic_y] = {asic_b};
+
+    const MeshHostRankId rank0{0};
+    const MeshHostRankId rank1{1};
+    std::map<FabricNodeId, MeshHostRankId> node_ranks{{node0, rank0}, {node1, rank1}};
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks{
+        {asic_a, rank0}, {asic_b, rank0}, {asic_x, rank1}, {asic_y, rank1}};
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic_a, asic_x), tt::tt_metal::PortType::QSFP_DD},
+        {canonical_port_type_link_key(asic_b, asic_y), tt::tt_metal::PortType::WARP100},
+    };
+
+    TopologyMappingConfig config;
+    config.port_type_links = port_type_links;
+    const auto result = map_mesh_to_physical(mesh_id, logical_adj, physical_adj, node_ranks, asic_ranks, config);
+    ASSERT_TRUE(result.success);
+    EXPECT_EQ(result.fabric_node_to_asic.at(node0), asic_a);
+    EXPECT_EQ(result.fabric_node_to_asic.at(node1), asic_x);
+}
+
+TEST(PortTypeMappingHelpers, MapMeshFailsWhenNoQsfpPath) {
+    const MeshId mesh_id{0};
+    const FabricNodeId node0(mesh_id, 0);
+    const FabricNodeId node1(mesh_id, 1);
+    const tt::tt_metal::AsicID asic_a{200};
+    const tt::tt_metal::AsicID asic_b{201};
+    const tt::tt_metal::AsicID asic_x{300};
+    const tt::tt_metal::AsicID asic_y{301};
+
+    LogicalAdjacencyMap logical_adj;
+    logical_adj[node0] = {node1};
+    logical_adj[node1] = {node0};
+
+    PhysicalAdjacencyMap physical_adj;
+    physical_adj[asic_a] = {asic_x};
+    physical_adj[asic_b] = {asic_y};
+    physical_adj[asic_x] = {asic_a};
+    physical_adj[asic_y] = {asic_b};
+
+    const MeshHostRankId rank0{0};
+    const MeshHostRankId rank1{1};
+    std::map<FabricNodeId, MeshHostRankId> node_ranks{{node0, rank0}, {node1, rank1}};
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks{
+        {asic_a, rank0}, {asic_b, rank0}, {asic_x, rank1}, {asic_y, rank1}};
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic_a, asic_x), tt::tt_metal::PortType::WARP100},
+        {canonical_port_type_link_key(asic_b, asic_y), tt::tt_metal::PortType::WARP100},
+    };
+
+    TopologyMappingConfig config;
+    config.port_type_links = port_type_links;
+    const auto result = map_mesh_to_physical(mesh_id, logical_adj, physical_adj, node_ranks, asic_ranks, config);
+    EXPECT_FALSE(result.success);
+    EXPECT_THAT(result.error_message, ::testing::HasSubstr("required port type"));
+}
+
 // =============================================================================
 // Basic Functionality Tests
 // =============================================================================

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -850,6 +850,117 @@ TEST(PortTypeMappingHelpers, MapMeshFailsWhenNoQsfpPath) {
     EXPECT_THAT(result.error_message, ::testing::HasSubstr("required port type"));
 }
 
+TEST(PortTypeMappingHelpers, ComputePreferredPhysicalMeshes_FiltersCrossMeshWithoutQsfp) {
+    using namespace ::tt::tt_fabric;
+
+    const tt::tt_metal::AsicID asic100{100};
+    const tt::tt_metal::AsicID asic101{101};
+    const tt::tt_metal::AsicID asic200{200};
+    const tt::tt_metal::AsicID asic201{201};
+    const tt::tt_metal::AsicID asic300{300};
+    const tt::tt_metal::AsicID asic301{301};
+
+    PhysicalAdjacencyMap flat;
+    flat[asic100] = {asic101};
+    flat[asic101] = {asic100, asic200};
+    flat[asic200] = {asic201, asic101};
+    flat[asic201] = {asic200, asic301};
+    flat[asic300] = {asic301};
+    flat[asic301] = {asic300, asic201};
+
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat);
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic100, asic101});
+    mesh_groupings.push_back({asic200, asic201});
+    mesh_groupings.push_back({asic300, asic301});
+    const PhysicalMultiMeshGraph physical_graph = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
+
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level;
+    logical_mesh_level[MeshId{0}] = {MeshId{1}};
+    logical_mesh_level[MeshId{1}] = {MeshId{0}};
+    const AdjacencyGraph<MeshId> mesh_logical_level_graph(logical_mesh_level);
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic101, asic200), tt::tt_metal::PortType::QSFP_DD},
+        {canonical_port_type_link_key(asic301, asic201), tt::tt_metal::PortType::TRACE},
+    };
+
+    const std::set<MeshId> bound_physical_meshes;
+    const auto preferred_for_logical0 = compute_preferred_physical_meshes_for_logical_mesh(
+        MeshId{0}, mesh_logical_level_graph, physical_graph, port_type_links, bound_physical_meshes);
+
+    EXPECT_TRUE(preferred_for_logical0.contains(MeshId{0}));
+    EXPECT_TRUE(preferred_for_logical0.contains(MeshId{1}));
+    EXPECT_FALSE(preferred_for_logical0.contains(MeshId{2}));
+}
+
+TEST(PortTypeMappingHelpers, MapMultiMeshPrefersQsfpConnectedPhysicalPartition) {
+    using namespace ::tt::tt_fabric;
+
+    const tt::tt_metal::AsicID asic100{100};
+    const tt::tt_metal::AsicID asic101{101};
+    const tt::tt_metal::AsicID asic200{200};
+    const tt::tt_metal::AsicID asic201{201};
+    const tt::tt_metal::AsicID asic300{300};
+    const tt::tt_metal::AsicID asic301{301};
+
+    LogicalMultiMeshGraph logical;
+    const FabricNodeId node00(MeshId{0}, 0);
+    const FabricNodeId node01(MeshId{0}, 1);
+    const FabricNodeId node10(MeshId{1}, 0);
+    const FabricNodeId node11(MeshId{1}, 1);
+    LogicalAdjacencyMap logical_adj_m0{{node00, {node01}}, {node01, {node00}}};
+    LogicalAdjacencyMap logical_adj_m1{{node10, {node11}}, {node11, {node10}}};
+    logical.mesh_adjacency_graphs_[MeshId{0}] = AdjacencyGraph<FabricNodeId>(logical_adj_m0);
+    logical.mesh_adjacency_graphs_[MeshId{1}] = AdjacencyGraph<FabricNodeId>(logical_adj_m1);
+
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level;
+    logical_mesh_level[MeshId{0}] = {MeshId{1}};
+    logical_mesh_level[MeshId{1}] = {MeshId{0}};
+    logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level);
+
+    AdjacencyGraph<LogicalExitNode>::AdjacencyMap exit0, exit1;
+    exit0[LogicalExitNode{MeshId{0}, std::nullopt}] = {LogicalExitNode{MeshId{1}, std::nullopt}};
+    exit1[LogicalExitNode{MeshId{1}, std::nullopt}] = {LogicalExitNode{MeshId{0}, std::nullopt}};
+    logical.mesh_exit_node_graphs_[MeshId{0}] = AdjacencyGraph<LogicalExitNode>(exit0);
+    logical.mesh_exit_node_graphs_[MeshId{1}] = AdjacencyGraph<LogicalExitNode>(exit1);
+
+    PhysicalAdjacencyMap flat;
+    flat[asic100] = {asic101};
+    flat[asic101] = {asic100, asic200};
+    flat[asic200] = {asic201, asic101};
+    flat[asic201] = {asic200, asic301};
+    flat[asic300] = {asic301};
+    flat[asic301] = {asic300, asic201};
+
+    AdjacencyGraph<tt::tt_metal::AsicID> flat_graph(flat);
+    std::vector<std::unordered_set<tt::tt_metal::AsicID>> mesh_groupings;
+    mesh_groupings.push_back({asic100, asic101});
+    mesh_groupings.push_back({asic200, asic201});
+    mesh_groupings.push_back({asic300, asic301});
+    PhysicalMultiMeshGraph physical = build_hierarchical_from_flat_graph(flat_graph, mesh_groupings);
+
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    config.port_type_links = PortTypeLinkMap{
+        {canonical_port_type_link_key(asic101, asic200), tt::tt_metal::PortType::QSFP_DD},
+        {canonical_port_type_link_key(asic301, asic201), tt::tt_metal::PortType::TRACE},
+    };
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+    ASSERT_TRUE(result.success) << result.error_message;
+
+    std::set<tt::tt_metal::AsicID> mapped_asics_for_logical0;
+    for (const auto& [fabric_node, asic] : result.fabric_node_to_asic) {
+        if (fabric_node.mesh_id == MeshId{0}) {
+            mapped_asics_for_logical0.insert(asic);
+        }
+    }
+    EXPECT_TRUE(mapped_asics_for_logical0.contains(asic100) || mapped_asics_for_logical0.contains(asic101));
+    EXPECT_FALSE(mapped_asics_for_logical0.contains(asic300));
+    EXPECT_FALSE(mapped_asics_for_logical0.contains(asic301));
+}
+
 // =============================================================================
 // Basic Functionality Tests
 // =============================================================================

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -644,7 +644,7 @@ protected:
 }  // namespace
 
 // =============================================================================
-// Port-type metadata helpers (Step 1 / #44933)
+// Port-type mapping helpers
 // =============================================================================
 
 TEST(PortTypeMappingHelpers, InferLogicalEdgePortRequirement) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -656,8 +656,8 @@ TEST(PortTypeMappingHelpers, PortTypePreferenceRank) {
 }
 
 TEST(PortTypeMappingHelpers, CanonicalPortTypeLinkKey) {
-    const auto a = TopologyMapperUtilsTest::make_asic(10);
-    const auto b = TopologyMapperUtilsTest::make_asic(20);
+    const tt::tt_metal::AsicID a{10};
+    const tt::tt_metal::AsicID b{20};
     EXPECT_EQ(canonical_port_type_link_key(a, b), (PortTypeLinkKey{a, b}));
     EXPECT_EQ(canonical_port_type_link_key(b, a), (PortTypeLinkKey{a, b}));
 }
@@ -708,7 +708,8 @@ TEST(PortTypeMappingHelpers, ComputePreferredAsicsForSameHostNeighbor) {
 
     const auto preferred_for_node1 = compute_preferred_asics_for_fabric_node(
         node1, logical_adj, physical_adj, node_ranks, asic_ranks, port_type_links);
-    EXPECT_EQ(preferred_for_node1, (std::set<tt::tt_metal::AsicID>{asic_b}));
+    // Both AsicA and AsicB have TRACE links to rank-0 ASICs (conservative pre-filter).
+    EXPECT_EQ(preferred_for_node1, (std::set<tt::tt_metal::AsicID>{asic_a, asic_b}));
 }
 
 TEST(PortTypeMappingHelpers, ComputeRequiredAsicsForCrossHostNeighbor) {
@@ -747,6 +748,46 @@ TEST(PortTypeMappingHelpers, ComputeRequiredAsicsForCrossHostNeighbor) {
     const auto required_for_node1 = compute_required_asics_for_fabric_node(
         node1, logical_adj, physical_adj, node_ranks, asic_ranks, port_type_links);
     EXPECT_EQ(required_for_node1, (std::set<tt::tt_metal::AsicID>{asic_x}));
+}
+
+TEST(PortTypeMappingHelpers, MapMeshPrefersTraceForSameHostEdge) {
+    const MeshId mesh_id{0};
+    const FabricNodeId node0(mesh_id, 0);
+    const FabricNodeId node1(mesh_id, 1);
+    const tt::tt_metal::AsicID asic_a{100};
+    const tt::tt_metal::AsicID asic_b{101};
+    const tt::tt_metal::AsicID asic_c{102};
+
+    LogicalAdjacencyMap logical_adj;
+    logical_adj[node0] = {node1};
+    logical_adj[node1] = {node0};
+
+    PhysicalAdjacencyMap physical_adj;
+    physical_adj[asic_a] = {asic_b, asic_c};
+    physical_adj[asic_b] = {asic_a};
+    physical_adj[asic_c] = {asic_a};
+
+    const MeshHostRankId rank0{0};
+    std::map<FabricNodeId, MeshHostRankId> node_ranks{{node0, rank0}, {node1, rank0}};
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks{{asic_a, rank0}, {asic_b, rank0}, {asic_c, rank0}};
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic_a, asic_b), tt::tt_metal::PortType::TRACE},
+        {canonical_port_type_link_key(asic_a, asic_c), tt::tt_metal::PortType::QSFP_DD},
+    };
+
+    TopologyMappingConfig config_without_port_types;
+    const auto result_without =
+        map_mesh_to_physical(mesh_id, logical_adj, physical_adj, node_ranks, asic_ranks, config_without_port_types);
+    ASSERT_TRUE(result_without.success);
+
+    TopologyMappingConfig config_with_port_types;
+    config_with_port_types.port_type_links = port_type_links;
+    const auto result_with =
+        map_mesh_to_physical(mesh_id, logical_adj, physical_adj, node_ranks, asic_ranks, config_with_port_types);
+    ASSERT_TRUE(result_with.success);
+    EXPECT_NE(result_with.fabric_node_to_asic.at(node0), asic_c);
+    EXPECT_NE(result_with.fabric_node_to_asic.at(node1), asic_c);
 }
 
 // =============================================================================

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -644,6 +644,112 @@ protected:
 }  // namespace
 
 // =============================================================================
+// Port-type metadata helpers (Step 1 / #44933)
+// =============================================================================
+
+TEST(PortTypeMappingHelpers, PortTypePreferenceRank) {
+    using tt::tt_metal::PortType;
+    EXPECT_LT(port_type_preference_rank(PortType::TRACE), port_type_preference_rank(PortType::WARP400));
+    EXPECT_LT(port_type_preference_rank(PortType::WARP400), port_type_preference_rank(PortType::QSFP_DD));
+    EXPECT_LT(port_type_preference_rank(PortType::QSFP_DD), port_type_preference_rank(PortType::WARP100));
+    EXPECT_LT(port_type_preference_rank(PortType::WARP100), port_type_preference_rank(PortType::UNKNOWN));
+}
+
+TEST(PortTypeMappingHelpers, CanonicalPortTypeLinkKey) {
+    const auto a = TopologyMapperUtilsTest::make_asic(10);
+    const auto b = TopologyMapperUtilsTest::make_asic(20);
+    EXPECT_EQ(canonical_port_type_link_key(a, b), (PortTypeLinkKey{a, b}));
+    EXPECT_EQ(canonical_port_type_link_key(b, a), (PortTypeLinkKey{a, b}));
+}
+
+TEST(PortTypeMappingHelpers, InferLogicalEdgePortRequirement) {
+    const MeshHostRankId rank0{0};
+    const MeshHostRankId rank1{1};
+
+    const auto same_host = infer_logical_edge_port_requirement(rank0, rank0);
+    ASSERT_TRUE(same_host.required.has_value() == false);
+    ASSERT_TRUE(same_host.preferred.has_value());
+    EXPECT_EQ(*same_host.preferred, tt::tt_metal::PortType::TRACE);
+
+    const auto cross_host = infer_logical_edge_port_requirement(rank0, rank1);
+    ASSERT_TRUE(cross_host.preferred.has_value() == false);
+    ASSERT_TRUE(cross_host.required.has_value());
+    EXPECT_EQ(*cross_host.required, tt::tt_metal::PortType::QSFP_DD);
+
+    const auto unset = infer_logical_edge_port_requirement(rank0, ::tt::tt_fabric::MESH_HOST_RANK_UNSET);
+    EXPECT_FALSE(unset.required.has_value());
+    EXPECT_FALSE(unset.preferred.has_value());
+}
+
+TEST(PortTypeMappingHelpers, ComputePreferredAsicsForSameHostNeighbor) {
+    const FabricNodeId node0(MeshId{0}, 0);
+    const FabricNodeId node1(MeshId{0}, 1);
+    const tt::tt_metal::AsicID asic_a{100};
+    const tt::tt_metal::AsicID asic_b{101};
+    const tt::tt_metal::AsicID asic_c{102};
+
+    LogicalAdjacencyMap logical_adj;
+    logical_adj[node0] = {node1};
+    logical_adj[node1] = {node0};
+
+    PhysicalAdjacencyMap physical_adj;
+    physical_adj[asic_a] = {asic_b, asic_c};
+    physical_adj[asic_b] = {asic_a};
+    physical_adj[asic_c] = {asic_a};
+
+    const MeshHostRankId rank0{0};
+    std::map<FabricNodeId, MeshHostRankId> node_ranks{{node0, rank0}, {node1, rank0}};
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks{{asic_a, rank0}, {asic_b, rank0}, {asic_c, rank0}};
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic_a, asic_b), tt::tt_metal::PortType::TRACE},
+        {canonical_port_type_link_key(asic_a, asic_c), tt::tt_metal::PortType::QSFP_DD},
+    };
+
+    const auto preferred_for_node1 = compute_preferred_asics_for_fabric_node(
+        node1, logical_adj, physical_adj, node_ranks, asic_ranks, port_type_links);
+    EXPECT_EQ(preferred_for_node1, (std::set<tt::tt_metal::AsicID>{asic_b}));
+}
+
+TEST(PortTypeMappingHelpers, ComputeRequiredAsicsForCrossHostNeighbor) {
+    const FabricNodeId node0(MeshId{0}, 0);
+    const FabricNodeId node1(MeshId{0}, 1);
+    const tt::tt_metal::AsicID asic_a{200};
+    const tt::tt_metal::AsicID asic_b{201};
+    const tt::tt_metal::AsicID asic_x{300};
+    const tt::tt_metal::AsicID asic_y{301};
+
+    LogicalAdjacencyMap logical_adj;
+    logical_adj[node0] = {node1};
+    logical_adj[node1] = {node0};
+
+    PhysicalAdjacencyMap physical_adj;
+    physical_adj[asic_a] = {asic_x};
+    physical_adj[asic_b] = {asic_y};
+    physical_adj[asic_x] = {asic_a};
+    physical_adj[asic_y] = {asic_b};
+
+    const MeshHostRankId rank0{0};
+    const MeshHostRankId rank1{1};
+    std::map<FabricNodeId, MeshHostRankId> node_ranks{{node0, rank0}, {node1, rank1}};
+    std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_ranks{
+        {asic_a, rank0}, {asic_b, rank0}, {asic_x, rank1}, {asic_y, rank1}};
+
+    PortTypeLinkMap port_type_links{
+        {canonical_port_type_link_key(asic_a, asic_x), tt::tt_metal::PortType::QSFP_DD},
+        {canonical_port_type_link_key(asic_b, asic_y), tt::tt_metal::PortType::WARP100},
+    };
+
+    const auto required_for_node0 = compute_required_asics_for_fabric_node(
+        node0, logical_adj, physical_adj, node_ranks, asic_ranks, port_type_links);
+    EXPECT_EQ(required_for_node0, (std::set<tt::tt_metal::AsicID>{asic_a}));
+
+    const auto required_for_node1 = compute_required_asics_for_fabric_node(
+        node1, logical_adj, physical_adj, node_ranks, asic_ranks, port_type_links);
+    EXPECT_EQ(required_for_node1, (std::set<tt::tt_metal::AsicID>{asic_x}));
+}
+
+// =============================================================================
 // Basic Functionality Tests
 // =============================================================================
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -1240,6 +1240,61 @@ TEST_F(TopologySolverTest, ConsistencyCheckerLocalConsistencyStrictMode) {
     EXPECT_TRUE(result3);
 }
 
+TEST_F(TopologySolverTest, ConsistencyCheckerPortTypeCrossHostValidation) {
+    using namespace tt::tt_fabric::detail;
+
+    // Cross-host target edge: 1 (rank 0) <-> 2 (rank 1)
+    AdjacencyGraph<TestTargetNode>::AdjacencyMap target_adj_map;
+    target_adj_map[1] = {2};
+    target_adj_map[2] = {1};
+
+    AdjacencyGraph<TestTargetNode> target_graph(target_adj_map);
+
+    // Global: 100 (rank 0) connects to 200 and 201 (rank 1)
+    AdjacencyGraph<TestGlobalNode>::AdjacencyMap global_adj_map;
+    global_adj_map[100] = {200, 201};
+    global_adj_map[200] = {100};
+    global_adj_map[201] = {100};
+
+    AdjacencyGraph<TestGlobalNode> global_graph(global_adj_map);
+
+    GraphIndexData graph_data(target_graph, global_graph);
+    MappingConstraints<TestTargetNode, TestGlobalNode> constraints;
+
+    PortTypeMappingValidationContext<TestTargetNode, TestGlobalNode> port_type_context;
+    port_type_context.target_host_ranks = {{1, MeshHostRankId{0}}, {2, MeshHostRankId{1}}};
+    port_type_context.global_host_ranks = {
+        {100, MeshHostRankId{0}}, {200, MeshHostRankId{1}}, {201, MeshHostRankId{1}}};
+    port_type_context.undirected_link_port_types = {
+        {{100, 200}, tt::tt_metal::PortType::WARP100},
+        {{100, 201}, tt::tt_metal::PortType::QSFP_DD},
+    };
+    constraints.set_port_type_validation_context(std::move(port_type_context));
+
+    ConstraintIndexData constraint_data(constraints, graph_data);
+    ASSERT_TRUE(constraint_data.port_type_validation.enabled);
+
+    std::vector<int> mapping(2, -1);
+    mapping[0] = 0;  // 1 -> 100
+
+    const auto* port_type_validation = &constraint_data.port_type_validation;
+
+    // Adjacency exists but cross-host pair lacks required QSFP_DD on 100-200
+    bool wrong_port_type = ConsistencyChecker::check_local_consistency(
+        1, 1, graph_data, mapping, ConnectionValidationMode::RELAXED, port_type_validation);
+    EXPECT_FALSE(wrong_port_type);
+
+    // Without port-type validation, adjacency-only check would pass
+    bool adjacency_only = ConsistencyChecker::check_local_consistency(
+        1, 1, graph_data, mapping, ConnectionValidationMode::RELAXED, nullptr);
+    EXPECT_TRUE(adjacency_only);
+
+    // Correct QSFP link on 100-201 satisfies cross-host requirement
+    bool correct_port_type = ConsistencyChecker::check_local_consistency(
+        1, 2, graph_data, mapping, ConnectionValidationMode::RELAXED, port_type_validation);
+    EXPECT_TRUE(correct_port_type);
+}
+
 TEST_F(TopologySolverTest, ConsistencyCheckerForwardConsistency) {
     using namespace tt::tt_fabric::detail;
 

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -33,11 +33,15 @@ namespace tt::tt_fabric::physical_discovery {
 namespace {
 
 PortType expected_port_type_for_connection(const tt::tt_metal::ASICDescriptor& asic_descriptor, uint8_t src_chan) {
-    auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
-    return board
-        .get_port_for_asic_channel(
-            tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
-        .port_type;
+    try {
+        auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
+        return board
+            .get_port_for_asic_channel(
+                tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
+            .port_type;
+    } catch (const std::runtime_error&) {
+        return PortType::TRACE;
+    }
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -40,7 +40,7 @@ PortType expected_port_type_for_connection(const tt::tt_metal::ASICDescriptor& a
                 tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
             .port_type;
     } catch (const std::runtime_error&) {
-        return PortType::TRACE;
+        return PortType::UNKNOWN;
     }
 }
 

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -10,7 +10,10 @@
 #include <map>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+
+#include <tools/scaleout/board/board.hpp>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -26,6 +29,18 @@
 #include <fstream>
 
 namespace tt::tt_fabric::physical_discovery {
+
+namespace {
+
+PortType expected_port_type_for_connection(const tt::tt_metal::ASICDescriptor& asic_descriptor, uint8_t src_chan) {
+    auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
+    return board
+        .get_port_for_asic_channel(
+            tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
+        .port_type;
+}
+
+}  // namespace
 
 TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
     using namespace tt::tt_metal::distributed::multihost;
@@ -112,8 +127,26 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
                 EXPECT_NE(eth_links.find(eth_conn.src_chan), eth_links.end());
                 EXPECT_EQ(dst_chip, remote_chip);
                 EXPECT_EQ(eth_conn.dst_chan, remote_chan);
+
+                const auto& src_desc = asic_descs.at(asic);
+                auto expected_port_type = expected_port_type_for_connection(src_desc, eth_conn.src_chan);
+                EXPECT_EQ(eth_conn.port_type, expected_port_type)
+                    << "port_type should match board lookup for local link on channel " << +eth_conn.src_chan;
+                EXPECT_EQ(physical_system_desc.get_port_type(asic, neighbor, eth_conn.src_chan), eth_conn.port_type);
+                EXPECT_TRUE(physical_system_desc.has_port_type(asic, neighbor, eth_conn.port_type));
             }
         }
+
+        std::unordered_set<PortType> expected_port_types;
+        for (auto neighbor : physical_system_desc.get_asic_neighbors(asic)) {
+            for (const auto& eth_conn : physical_system_desc.get_eth_connections(asic, neighbor)) {
+                expected_port_types.insert(eth_conn.port_type);
+            }
+        }
+        auto available_port_types = physical_system_desc.get_available_port_types(asic);
+        std::unordered_set<PortType> actual_port_types(available_port_types.begin(), available_port_types.end());
+        EXPECT_EQ(actual_port_types, expected_port_types)
+            << "get_available_port_types should return unique port types from outgoing links";
     }
 
     // Host to Host Connectivity
@@ -143,6 +176,33 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
             // Verify that remote asic belongs to a neighbor host
             EXPECT_NE(
                 std::find(my_host_neighbors.begin(), my_host_neighbors.end(), remote_host), my_host_neighbors.end());
+
+            const auto& src_desc = asic_descs.at(src_asic);
+            auto expected_port_type = expected_port_type_for_connection(src_desc, src_chan);
+            EXPECT_EQ(exit_node.eth_conn.port_type, expected_port_type)
+                << "port_type should match board lookup for cross-host exit node on channel " << +src_chan;
+            EXPECT_EQ(physical_system_desc.get_port_type(src_asic, dst_asic, src_chan), exit_node.eth_conn.port_type);
+            EXPECT_TRUE(physical_system_desc.has_port_type(src_asic, dst_asic, exit_node.eth_conn.port_type));
+        }
+    }
+
+    // Validate port_type is preserved through protobuf serialize/deserialize roundtrip
+    auto serialized_bytes = tt::tt_metal::serialize_physical_system_descriptor_to_bytes(physical_system_desc);
+    auto deserialized_psd = tt::tt_metal::deserialize_physical_system_descriptor_from_bytes(serialized_bytes);
+    for (auto asic : physical_system_desc.get_asics_connected_to_host(my_host)) {
+        for (auto neighbor : physical_system_desc.get_asic_neighbors(asic)) {
+            auto eth_conns = physical_system_desc.get_eth_connections(asic, neighbor);
+            for (const auto& eth_conn : eth_conns) {
+                auto deserialized_conns = deserialized_psd.get_eth_connections(asic, neighbor);
+                auto conn_it =
+                    std::find_if(deserialized_conns.begin(), deserialized_conns.end(), [&](const auto& conn) {
+                        return conn.src_chan == eth_conn.src_chan;
+                    });
+                ASSERT_NE(conn_it, deserialized_conns.end())
+                    << "connection should exist after serialize/deserialize roundtrip";
+                EXPECT_EQ(conn_it->port_type, eth_conn.port_type)
+                    << "port_type should be preserved after serialize/deserialize roundtrip";
+            }
         }
     }
 

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -13,7 +13,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include <tools/scaleout/board/board.hpp>
+#include <board/board.hpp>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>

--- a/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/physical_discovery/test_physical_system_descriptor.cpp
@@ -13,7 +13,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include <board/board.hpp>
+#include <board/port_lookup.hpp>
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -29,22 +29,6 @@
 #include <fstream>
 
 namespace tt::tt_fabric::physical_discovery {
-
-namespace {
-
-PortType expected_port_type_for_connection(const tt::tt_metal::ASICDescriptor& asic_descriptor, uint8_t src_chan) {
-    try {
-        auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
-        return board
-            .get_port_for_asic_channel(
-                tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
-            .port_type;
-    } catch (const std::runtime_error&) {
-        return PortType::UNKNOWN;
-    }
-}
-
-}  // namespace
 
 TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
     using namespace tt::tt_metal::distributed::multihost;
@@ -133,7 +117,8 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
                 EXPECT_EQ(eth_conn.dst_chan, remote_chan);
 
                 const auto& src_desc = asic_descs.at(asic);
-                auto expected_port_type = expected_port_type_for_connection(src_desc, eth_conn.src_chan);
+                auto expected_port_type = tt::scaleout_tools::resolve_port_type(
+                    src_desc.board_type, *src_desc.asic_location, eth_conn.src_chan);
                 EXPECT_EQ(eth_conn.port_type, expected_port_type)
                     << "port_type should match board lookup for local link on channel " << +eth_conn.src_chan;
                 EXPECT_EQ(physical_system_desc.get_port_type(asic, neighbor, eth_conn.src_chan), eth_conn.port_type);
@@ -182,7 +167,8 @@ TEST(PhysicalDiscovery, TestPhysicalSystemDescriptor) {
                 std::find(my_host_neighbors.begin(), my_host_neighbors.end(), remote_host), my_host_neighbors.end());
 
             const auto& src_desc = asic_descs.at(src_asic);
-            auto expected_port_type = expected_port_type_for_connection(src_desc, src_chan);
+            auto expected_port_type =
+                tt::scaleout_tools::resolve_port_type(src_desc.board_type, *src_desc.asic_location, src_chan);
             EXPECT_EQ(exit_node.eth_conn.port_type, expected_port_type)
                 << "port_type should match board lookup for cross-host exit node on channel " << +src_chan;
             EXPECT_EQ(physical_system_desc.get_port_type(src_asic, dst_asic, src_chan), exit_node.eth_conn.port_type);

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -62,7 +62,7 @@ target_sources(
 
 target_include_directories(scaleout_tools PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(scaleout_tools SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(scaleout_tools SYSTEM PUBLIC "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
+target_include_directories(scaleout_tools SYSTEM PUBLIC "$<TARGET_PROPERTY:TT::Metalium,INTERFACE_INCLUDE_DIRECTORIES>")
 
 target_include_directories(run_cluster_validation PRIVATE "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
 target_include_directories(run_cluster_validation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         FILES
             board/board.hpp
+            board/port_lookup.hpp
             cabling_generator/cabling_generator.hpp
             connector/connector.hpp
             factory_system_descriptor/utils.hpp

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -77,8 +77,8 @@ target_link_libraries(
     PUBLIC
         TT::STL
         umd::tt-umd
-        fmt::fmt-header-only
     PRIVATE
+        fmt::fmt-header-only
         enchantum::enchantum
         tt-logger::tt-logger
         $<BUILD_INTERFACE:yaml-cpp::yaml-cpp>

--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
 
 target_include_directories(scaleout_tools PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(scaleout_tools SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(scaleout_tools SYSTEM PUBLIC "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
 
 target_include_directories(run_cluster_validation PRIVATE "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>")
 target_include_directories(run_cluster_validation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -76,6 +77,7 @@ target_link_libraries(
     PUBLIC
         TT::STL
         umd::tt-umd
+        fmt::fmt-header-only
     PRIVATE
         enchantum::enchantum
         tt-logger::tt-logger

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt_stl/strong_type.hpp>
 
 // Forward declaration and hash specialization for AsicChannel
@@ -30,15 +31,7 @@ namespace tt::scaleout_tools {
 using PortId = ttsl::StrongType<uint32_t, struct PortIdTag>;
 using ChanId = ttsl::StrongType<uint32_t, struct ChanIdTag>;
 
-enum class PortType {
-    TRACE,
-    QSFP_DD,
-    WARP100,
-    WARP400,
-    LINKING_BOARD_1,
-    LINKING_BOARD_2,
-    LINKING_BOARD_3,
-};
+using PortType = tt::tt_metal::PortType;
 
 struct AsicChannel {
     uint32_t asic_location = 0;

--- a/tools/scaleout/board/board.hpp
+++ b/tools/scaleout/board/board.hpp
@@ -43,7 +43,7 @@ struct AsicChannel {
 std::ostream& operator<<(std::ostream& os, const AsicChannel& asic_channel);
 
 struct Port {
-    PortType port_type = PortType::TRACE;
+    PortType port_type = PortType::UNKNOWN;
     PortId port_id{0};
 };
 

--- a/tools/scaleout/board/port_lookup.hpp
+++ b/tools/scaleout/board/port_lookup.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <board/board.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
+
+namespace tt::scaleout_tools {
+
+inline AsicChannel make_asic_channel(uint32_t asic_location, uint8_t src_chan) {
+    return AsicChannel{asic_location, ChanId{src_chan}};
+}
+
+inline std::optional<Port> try_get_port(const Board& board, uint32_t asic_location, uint8_t src_chan) {
+    try {
+        return board.get_port_for_asic_channel(make_asic_channel(asic_location, src_chan));
+    } catch (const std::runtime_error&) {
+        return std::nullopt;
+    }
+}
+
+inline std::optional<Port> try_get_port(BoardType board_type, uint32_t asic_location, uint8_t src_chan) {
+    return try_get_port(create_board(board_type), asic_location, src_chan);
+}
+
+inline PortType resolve_port_type(BoardType board_type, uint32_t asic_location, uint8_t src_chan) {
+    auto port = try_get_port(board_type, asic_location, src_chan);
+    return port.has_value() ? port->port_type : PortType::UNKNOWN;
+}
+
+inline std::optional<PortId> try_get_port_id(const Board& board, uint32_t asic_location, uint8_t src_chan) {
+    auto port = try_get_port(board, asic_location, src_chan);
+    return port.has_value() ? std::optional<PortId>{port->port_id} : std::nullopt;
+}
+
+inline PortId resolve_port_id(const Board& board, uint32_t asic_location, uint8_t src_chan) {
+    auto port_id = try_get_port_id(board, asic_location, src_chan);
+    return port_id.has_value() ? *port_id : PortId{0};
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -71,7 +71,7 @@ struct PhysicalPortEndpoint {
     uint32_t rack = 0;
     uint32_t shelf_u = 0;
     TrayId tray_id{0};
-    PortType port_type = PortType::TRACE;
+    PortType port_type = PortType::UNKNOWN;
     PortId port_id{0};
 
     auto operator<=>(const PhysicalPortEndpoint& other) const = default;

--- a/tools/scaleout/connector/connector.cpp
+++ b/tools/scaleout/connector/connector.cpp
@@ -51,6 +51,7 @@ std::vector<AsicChannelConnection> get_asic_channel_connections(
     PortType port_type, const std::vector<AsicChannel>& start_channels, const std::vector<AsicChannel>& end_channels) {
     // Validate and dispatch based on port type
     switch (port_type) {
+        case PortType::UNKNOWN: throw std::runtime_error("Port type is unknown");
         case PortType::WARP100:
             if (start_channels.size() != 2 || end_channels.size() != 2) {
                 throw std::runtime_error("WARP100 connections must have exactly 2 channels");

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -658,7 +658,7 @@ LinkMetricsResult process_link_statuses(
 }
 
 struct PortInfo {
-    tt::scaleout_tools::PortType port_type = tt::scaleout_tools::PortType::TRACE;
+    tt::scaleout_tools::PortType port_type = tt::scaleout_tools::PortType::UNKNOWN;
     tt::scaleout_tools::PortId port_id{0};
 };
 

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -5,6 +5,8 @@
 #include "tools/scaleout/validation/utils/cluster_validation_utils.hpp"
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 
+#include <board/port_lookup.hpp>
+
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -657,33 +659,6 @@ LinkMetricsResult process_link_statuses(
     return result;
 }
 
-struct PortInfo {
-    tt::scaleout_tools::PortType port_type = tt::scaleout_tools::PortType::UNKNOWN;
-    tt::scaleout_tools::PortId port_id{0};
-};
-
-std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<uint8_t, PortInfo>> generate_port_info(
-    const PhysicalSystemDescriptor& physical_system_descriptor) {
-    std::unordered_map<tt::tt_metal::AsicID, std::unordered_map<tt::tt_fabric::chan_id_t, PortInfo>> port_info_map;
-    const auto& asic_connectivity_graph = physical_system_descriptor.get_system_graph().asic_connectivity_graph;
-
-    for (const auto& [asic_id, asic_descriptor] : physical_system_descriptor.get_asic_descriptors()) {
-        auto board_type = asic_descriptor.board_type;
-        auto board = tt::scaleout_tools::create_board(board_type);
-        // PhysicalSystemDescriptor internally validates that hostnames across asic descriptors are part of the graph
-        // This can't throw
-        const auto& asic_edges = asic_connectivity_graph.at(asic_descriptor.host_name).at(asic_id);
-        for (const auto& [dst_asic_id, eth_connections] : asic_edges) {
-            for (const auto& eth_connection : eth_connections) {
-                auto port = board.get_port_for_asic_channel(tt::scaleout_tools::AsicChannel{
-                    *(asic_descriptor.asic_location), tt::scaleout_tools::ChanId{eth_connection.src_chan}});
-                port_info_map[asic_id][eth_connection.src_chan] = PortInfo{port.port_type, port.port_id};
-            }
-        }
-    }
-    return port_info_map;
-}
-
 void dump_link_stats(
     ClusterContext& ctx,
     std::vector<uint32_t>& inputs,
@@ -700,7 +675,6 @@ void dump_link_stats(
     auto& driver_ref = const_cast<tt::umd::Cluster&>(*cluster.get_driver());
     auto local_ethernet_metrics =
         query_local_ethernet_metrics(ctx.physical_system_descriptor, driver_ref, &context.hal());
-    auto port_info_map = generate_port_info(ctx.physical_system_descriptor);
 
     struct LinkInfo {
         ChipId chip_id;
@@ -713,12 +687,13 @@ void dump_link_stats(
         auto chip_id = ctx.asic_id_to_chip_id.at(*asic_id);
         const auto& soc_desc = cluster.get_soc_desc(chip_id);
         const auto& asic_desc = asic_descriptors.at(asic_id);
+        auto board = tt::scaleout_tools::create_board(asic_desc.board_type);
         for (const auto& [dst_asic_id, eth_connections] : asic_connections) {
             for (const auto& eth_connection : eth_connections) {
                 auto src_chan = eth_connection.src_chan;
                 auto logical_coord = soc_desc.get_eth_core_for_channel(src_chan, CoordSystem::LOGICAL);
                 auto ethernet_core = ctx.devices.at(chip_id)->ethernet_core_from_logical_core(logical_coord);
-                const auto& port_info = port_info_map.at(asic_id).at(src_chan);
+                auto port_id = tt::scaleout_tools::resolve_port_id(board, *asic_desc.asic_location, src_chan);
                 links.push_back(
                     {chip_id,
                      ethernet_core,
@@ -728,8 +703,8 @@ void dump_link_stats(
                          .tray_id = asic_desc.tray_id,
                          .asic_location = asic_desc.asic_location,
                          .channel = src_chan,
-                         .port_id = *port_info.port_id,
-                         .port_type = static_cast<uint32_t>(port_info.port_type),
+                         .port_id = *port_id,
+                         .port_type = static_cast<uint32_t>(eth_connection.port_type),
                      }});
             }
         }
@@ -791,8 +766,6 @@ std::vector<ValueType> generate_uniform_random_vector(
 
 void print_ethernet_connectivity(
     bool /*print_connectivity*/, const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) {
-    auto port_info_map = generate_port_info(physical_system_descriptor);
-
     // Collect all connections and organize by: connection_type -> hostname -> port_type -> connections
     // Using map with bool key: true = cross-host, false = local
     std::map<bool, std::map<std::string, std::map<std::string_view, std::vector<ConnectionInfo>>>>
@@ -801,8 +774,10 @@ void print_ethernet_connectivity(
     for (const auto& host : physical_system_descriptor.get_all_hostnames()) {
         const auto& asic_connections = physical_system_descriptor.get_asic_topology(host);
         for (auto asic_id : physical_system_descriptor.get_asics_connected_to_host(host)) {
-            auto tray_id = physical_system_descriptor.get_asic_descriptors().at(asic_id).tray_id;
-            auto asic_location = physical_system_descriptor.get_asic_descriptors().at(asic_id).asic_location;
+            const auto& asic_descriptor = physical_system_descriptor.get_asic_descriptors().at(asic_id);
+            auto tray_id = asic_descriptor.tray_id;
+            auto asic_location = asic_descriptor.asic_location;
+            auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
 
             for (const auto& asic_connection : asic_connections.at(asic_id)) {
                 auto connected_asic_id = asic_connection.first;
@@ -815,8 +790,8 @@ void print_ethernet_connectivity(
                 for (const auto& eth_connection : asic_connection.second) {
                     auto channel = eth_connection.src_chan;
                     auto connected_channel = eth_connection.dst_chan;
-                    const auto& port_info = port_info_map.at(asic_id).at(channel);
-                    auto port_type_str = enchantum::to_string(port_info.port_type);
+                    auto port_type_str = enchantum::to_string(eth_connection.port_type);
+                    auto port_id = tt::scaleout_tools::resolve_port_id(board, *asic_location, channel);
 
                     ConnectionInfo conn_info{
                         .asic_id = asic_id,
@@ -824,8 +799,8 @@ void print_ethernet_connectivity(
                         .host = host,
                         .tray_id = tray_id,
                         .asic_location = asic_location,
-                        .port_type = port_info.port_type,
-                        .port_id = port_info.port_id,
+                        .port_type = eth_connection.port_type,
+                        .port_id = port_id,
                         .connected_asic_id = connected_asic_id,
                         .connected_channel = connected_channel,
                         .connected_host = connected_host,

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -142,6 +142,17 @@ struct fmt::formatter<tt::tt_fabric::MeshId> {
 
 namespace tt::tt_metal {
 
+// Physical port / cable type for ethernet connections
+enum class PortType {
+    TRACE,
+    QSFP_DD,
+    WARP100,
+    WARP400,
+    LINKING_BOARD_1,
+    LINKING_BOARD_2,
+    LINKING_BOARD_3,
+};
+
 using AsicID = tt::stl::StrongType<uint64_t, struct AsicIDTag>;
 using TrayID = tt::stl::StrongType<uint32_t, struct TrayIDTag>;
 using ASICLocation = tt::stl::StrongType<uint32_t, struct ASICLocationTag>;

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -144,6 +144,7 @@ namespace tt::tt_metal {
 
 // Physical port / cable type for ethernet connections
 enum class PortType {
+    UNKNOWN,
     TRACE,
     QSFP_DD,
     WARP100,

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -60,15 +60,23 @@ struct EthConnection {
     uint8_t src_chan = 0;
     uint8_t dst_chan = 0;
     bool is_local = false;
+    PortType port_type = PortType::TRACE;
 
     bool operator==(const EthConnection& other) const {
-        return src_chan == other.src_chan && dst_chan == other.dst_chan && other.is_local == is_local;
+        return src_chan == other.src_chan && dst_chan == other.dst_chan && other.is_local == is_local &&
+               port_type == other.port_type;
     }
     bool operator<(const EthConnection& other) const {
         if (src_chan != other.src_chan) {
             return src_chan < other.src_chan;
         }
-        return dst_chan < other.dst_chan;
+        if (dst_chan != other.dst_chan) {
+            return dst_chan < other.dst_chan;
+        }
+        if (port_type != other.port_type) {
+            return port_type < other.port_type;
+        }
+        return is_local < other.is_local;
     }
 };
 
@@ -119,6 +127,8 @@ struct hash<tt::tt_metal::ExitNodeConnection> {
         seed ^= std::hash<uint8_t>{}(min_chan) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         seed ^= std::hash<uint8_t>{}(max_chan) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         seed ^= std::hash<bool>{}(conn.eth_conn.is_local) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint8_t>{}(static_cast<uint8_t>(conn.eth_conn.port_type)) + 0x9e3779b9 + (seed << 6) +
+                (seed >> 2);
         return seed;
     }
 };

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -186,6 +186,9 @@ public:
     // ASIC Topology Query APIs
     std::vector<AsicID> get_asic_neighbors(AsicID asic_id) const;
     std::vector<EthConnection> get_eth_connections(AsicID src_asic_id, AsicID dst_asic_id) const;
+    PortType get_port_type(AsicID src_asic, AsicID dst_asic, uint8_t src_chan) const;
+    std::vector<PortType> get_available_port_types(AsicID src_asic) const;
+    bool has_port_type(AsicID src_asic, AsicID dst_asic, PortType port_type) const;
     const AsicTopology& get_asic_topology(const std::string& hostname) const;
     TrayID get_tray_id(AsicID asic_id) const;
     ASICLocation get_asic_location(AsicID asic_id) const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -60,7 +60,7 @@ struct EthConnection {
     uint8_t src_chan = 0;
     uint8_t dst_chan = 0;
     bool is_local = false;
-    PortType port_type = PortType::TRACE;
+    PortType port_type = PortType::UNKNOWN;
 
     bool operator==(const EthConnection& other) const {
         return src_chan == other.src_chan && dst_chan == other.dst_chan && other.is_local == is_local &&
@@ -70,13 +70,7 @@ struct EthConnection {
         if (src_chan != other.src_chan) {
             return src_chan < other.src_chan;
         }
-        if (dst_chan != other.dst_chan) {
-            return dst_chan < other.dst_chan;
-        }
-        if (port_type != other.port_type) {
-            return port_type < other.port_type;
-        }
-        return is_local < other.is_local;
+        return dst_chan < other.dst_chan;
     }
 };
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -110,7 +110,7 @@ PortTypeLinkMap build_port_type_link_map(
 /** Same-host edges prefer TRACE; cross-host edges require QSFP_DD. UNSET ranks yield no policy. */
 LogicalEdgePortRequirement infer_logical_edge_port_requirement(MeshHostRankId rank_a, MeshHostRankId rank_b);
 
-/** ASICs that can satisfy TRACE preference for all same-host logical neighbors (Step 2 input). */
+/** ASICs that can satisfy TRACE preference for all same-host logical neighbors. */
 std::set<tt::tt_metal::AsicID> compute_preferred_asics_for_fabric_node(
     FabricNodeId fabric_node,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -119,7 +119,7 @@ std::set<tt::tt_metal::AsicID> compute_preferred_asics_for_fabric_node(
     const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
     const PortTypeLinkMap& port_type_links);
 
-/** ASICs that satisfy required port types for all cross-host logical neighbors (Step 3 input). */
+/** ASICs that satisfy required port types for all cross-host logical neighbors. */
 std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
     FabricNodeId fabric_node,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -400,7 +400,7 @@ struct PhysicalMultiMeshGraph {
     std::map<MeshId, AdjacencyGraph<PhysicalExitNode>> mesh_exit_node_graphs_;
 };
 
-/** Physical mesh partitions preferred for a logical mesh from cross-partition QSFP connectivity (Step 5 input). */
+/** Physical mesh partitions preferred for a logical mesh from cross-partition QSFP connectivity. */
 std::set<MeshId> compute_preferred_physical_meshes_for_logical_mesh(
     MeshId logical_mesh,
     const AdjacencyGraph<MeshId>& mesh_logical_level_graph,

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
@@ -45,6 +46,18 @@ using AsicPositionMap = std::map<tt::tt_metal::AsicID, AsicPosition>;
 // This constrains which physical ASIC a logical node can be mapped to
 using PinningConstraint = std::pair<AsicPosition, FabricNodeId>;
 
+// Undirected ASIC pair -> best (highest-priority) port type between them within a physical mesh.
+using PortTypeLinkKey = std::pair<tt::tt_metal::AsicID, tt::tt_metal::AsicID>;
+using PortTypeLinkMap = std::map<PortTypeLinkKey, tt::tt_metal::PortType>;
+
+/**
+ * @brief Port-type policy for a logical edge derived from endpoint host ranks.
+ */
+struct LogicalEdgePortRequirement {
+    std::optional<tt::tt_metal::PortType> required;
+    std::optional<tt::tt_metal::PortType> preferred;
+};
+
 /**
  * @brief Configuration options for topology mapping
  */
@@ -78,7 +91,42 @@ struct TopologyMappingConfig {
     // has exactly one rank binding (all ASICs on the same host map to fabric nodes with the same rank).
     // Used even when some ASICs have UNSET rank. Default empty.
     std::map<std::string, std::set<tt::tt_metal::AsicID>> hostname_to_asics;
+
+    // Optional per-mesh port-type link metadata populated from PSD discovery (#44932).
+    // When absent, port-type constraint helpers are skipped (synthetic unit tests).
+    std::optional<PortTypeLinkMap> port_type_links;
 };
+
+/** Lower rank value means higher preference (TRACE best). Used when collapsing multi-link ASIC pairs. */
+int port_type_preference_rank(tt::tt_metal::PortType port_type);
+
+/** Canonical undirected key for port-type link lookup. */
+PortTypeLinkKey canonical_port_type_link_key(tt::tt_metal::AsicID a, tt::tt_metal::AsicID b);
+
+/** Build best port type per undirected ASIC pair within mesh_asics from PSD eth connections. */
+PortTypeLinkMap build_port_type_link_map(
+    const tt::tt_metal::PhysicalSystemDescriptor& psd, const std::set<tt::tt_metal::AsicID>& mesh_asics);
+
+/** Same-host edges prefer TRACE; cross-host edges require QSFP_DD. UNSET ranks yield no policy. */
+LogicalEdgePortRequirement infer_logical_edge_port_requirement(MeshHostRankId rank_a, MeshHostRankId rank_b);
+
+/** ASICs that can satisfy TRACE preference for all same-host logical neighbors (Step 2 input). */
+std::set<tt::tt_metal::AsicID> compute_preferred_asics_for_fabric_node(
+    FabricNodeId fabric_node,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const PortTypeLinkMap& port_type_links);
+
+/** ASICs that satisfy required port types for all cross-host logical neighbors (Step 3 input). */
+std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
+    FabricNodeId fabric_node,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const PortTypeLinkMap& port_type_links);
 
 /**
  * @brief Result of topology mapping operation

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -400,6 +400,14 @@ struct PhysicalMultiMeshGraph {
     std::map<MeshId, AdjacencyGraph<PhysicalExitNode>> mesh_exit_node_graphs_;
 };
 
+/** Physical mesh partitions preferred for a logical mesh from cross-partition QSFP connectivity (Step 5 input). */
+std::set<MeshId> compute_preferred_physical_meshes_for_logical_mesh(
+    MeshId logical_mesh,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const PortTypeLinkMap& port_type_links,
+    const std::set<MeshId>& bound_physical_mesh_ids);
+
 /**
  * @brief Build a physical multi-mesh adjacency graph from physical system descriptor
  *

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -99,6 +99,33 @@ std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_graph_phy
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 
 /**
+ * @brief Port-type validation metadata attached to MappingConstraints
+ *
+ * Used by ConsistencyChecker during DFS to validate mapped global pairs satisfy
+ * cross-host required port types (pairwise QSFP_DD check).
+ */
+template <typename TargetNode, typename GlobalNode>
+struct PortTypeMappingValidationContext {
+    std::map<TargetNode, MeshHostRankId> target_host_ranks;
+    std::map<GlobalNode, MeshHostRankId> global_host_ranks;
+    std::map<std::pair<GlobalNode, GlobalNode>, tt::tt_metal::PortType> undirected_link_port_types;
+
+    bool enabled() const {
+        return !undirected_link_port_types.empty() && !target_host_ranks.empty() && !global_host_ranks.empty();
+    }
+};
+
+/**
+ * @brief Indexed port-type validation data for ConsistencyChecker
+ */
+struct PortTypeValidationIndexData {
+    bool enabled = false;
+    std::vector<MeshHostRankId> target_host_ranks;
+    std::vector<MeshHostRankId> global_host_ranks;
+    std::map<std::pair<size_t, size_t>, tt::tt_metal::PortType> undirected_link_port_types;
+};
+
+/**
  * @brief Unified constraint system for topology mapping
  *
  * MappingConstraints represents all constraints internally as trait maps. Both trait-based
@@ -442,6 +469,20 @@ public:
      */
     void print_mapping_constraint_maps(const std::string& label = "Mapping constraints", bool quiet_mode = false) const;
 
+    /**
+     * @brief Attach port-type validation metadata for ConsistencyChecker (DFS path)
+     *
+     * When set, ConsistencyChecker validates that mapped cross-host target pairs use the
+     * required port type (QSFP_DD) on their mapped global ASIC pair.
+     */
+    void set_port_type_validation_context(PortTypeMappingValidationContext<TargetNode, GlobalNode> context);
+
+    /**
+     * @brief Get port-type validation metadata, if attached
+     */
+    const std::optional<PortTypeMappingValidationContext<TargetNode, GlobalNode>>& get_port_type_validation_context()
+        const;
+
 private:
     // Internal representation: intersection of all constraints
     std::map<TargetNode, std::set<GlobalNode>> valid_mappings_;      // Required constraints
@@ -458,6 +499,8 @@ private:
     // Same-group constraint: targets in a target group map to at most one global group
     std::vector<std::set<TargetNode>> same_rank_target_groups_;
     std::vector<std::set<GlobalNode>> same_rank_global_groups_;
+
+    std::optional<PortTypeMappingValidationContext<TargetNode, GlobalNode>> port_type_validation_context_;
 
     // Track which global nodes are exclusively reserved by many-to-many constraints
     // Maps global node -> set of target nodes that are allowed to map to it via many-to-many constraints
@@ -769,6 +812,8 @@ struct ConstraintIndexData {
     std::vector<int> global_to_same_rank_group;
     std::vector<std::set<size_t>> same_rank_groups;
     std::vector<size_t> target_to_group;
+
+    PortTypeValidationIndexData port_type_validation;
 
     /**
      * @brief Construct ConstraintIndexData from MappingConstraints and GraphIndexData
@@ -1091,12 +1136,15 @@ struct ConsistencyChecker {
      * Checks that if target node A is mapped to global X, and target node B (neighbor of A)
      * is mapped to global Y, then X and Y must be connected.
      * In STRICT mode: also checks channel counts are sufficient.
+     * When port_type_validation is provided and enabled, also validates that mapped
+     * cross-host target pairs use QSFP_DD on their mapped global ASIC pair.
      *
      * @param target_idx Index of target node being assigned
      * @param global_idx Index of global node being assigned to
      * @param graph_data Indexed graph data
      * @param mapping Current partial mapping (target_idx -> global_idx)
      * @param validation_mode Channel validation mode
+     * @param port_type_validation Optional indexed port-type validation data
      * @return true if assignment is locally consistent
      */
     template <typename TargetNode, typename GlobalNode>
@@ -1105,7 +1153,8 @@ struct ConsistencyChecker {
         size_t global_idx,
         const GraphIndexData<TargetNode, GlobalNode>& graph_data,
         const std::vector<int>& mapping,
-        ConnectionValidationMode validation_mode);
+        ConnectionValidationMode validation_mode,
+        const PortTypeValidationIndexData* port_type_validation = nullptr);
 
     /**
      * @brief Check forward consistency: ensure assignment leaves viable options for future neighbors

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.tpp
@@ -697,6 +697,18 @@ MappingConstraints<TargetNode, GlobalNode>::get_cardinality_constraints() const 
 }
 
 template <typename TargetNode, typename GlobalNode>
+void MappingConstraints<TargetNode, GlobalNode>::set_port_type_validation_context(
+    PortTypeMappingValidationContext<TargetNode, GlobalNode> context) {
+    port_type_validation_context_ = std::move(context);
+}
+
+template <typename TargetNode, typename GlobalNode>
+const std::optional<PortTypeMappingValidationContext<TargetNode, GlobalNode>>&
+MappingConstraints<TargetNode, GlobalNode>::get_port_type_validation_context() const {
+    return port_type_validation_context_;
+}
+
+template <typename TargetNode, typename GlobalNode>
 bool MappingConstraints<TargetNode, GlobalNode>::set_same_rank_groups_constraint(
     const std::vector<std::set<TargetNode>>& target_groups,
     const std::vector<std::set<GlobalNode>>& global_groups) {
@@ -2075,6 +2087,37 @@ ConstraintIndexData<TargetNode, GlobalNode>::ConstraintIndexData(
         }
         same_rank_groups.push_back(std::move(group_indices));
     }
+
+    const auto& port_type_context = constraints.get_port_type_validation_context();
+    if (port_type_context.has_value() && port_type_context->enabled()) {
+        port_type_validation.enabled = true;
+        port_type_validation.target_host_ranks.assign(graph_data.n_target, MESH_HOST_RANK_UNSET);
+        port_type_validation.global_host_ranks.assign(graph_data.n_global, MESH_HOST_RANK_UNSET);
+
+        for (size_t i = 0; i < graph_data.n_target; ++i) {
+            const auto& target_node = graph_data.target_nodes[i];
+            auto rank_it = port_type_context->target_host_ranks.find(target_node);
+            if (rank_it != port_type_context->target_host_ranks.end()) {
+                port_type_validation.target_host_ranks[i] = rank_it->second;
+            }
+        }
+        for (size_t i = 0; i < graph_data.n_global; ++i) {
+            const auto& global_node = graph_data.global_nodes[i];
+            auto rank_it = port_type_context->global_host_ranks.find(global_node);
+            if (rank_it != port_type_context->global_host_ranks.end()) {
+                port_type_validation.global_host_ranks[i] = rank_it->second;
+            }
+        }
+        for (const auto& [link_key, port_type] : port_type_context->undirected_link_port_types) {
+            auto global_a_it = graph_data.global_to_idx.find(link_key.first);
+            auto global_b_it = graph_data.global_to_idx.find(link_key.second);
+            if (global_a_it != graph_data.global_to_idx.end() && global_b_it != graph_data.global_to_idx.end()) {
+                const size_t lo = std::min(global_a_it->second, global_b_it->second);
+                const size_t hi = std::max(global_a_it->second, global_b_it->second);
+                port_type_validation.undirected_link_port_types[{lo, hi}] = port_type;
+            }
+        }
+    }
 }
 
 template <typename TargetNode, typename GlobalNode>
@@ -2542,7 +2585,8 @@ bool ConsistencyChecker::check_local_consistency(
     size_t global_idx,
     const GraphIndexData<TargetNode, GlobalNode>& graph_data,
     const std::vector<int>& mapping,
-    ConnectionValidationMode validation_mode) {
+    ConnectionValidationMode validation_mode,
+    const PortTypeValidationIndexData* port_type_validation) {
     // Check all neighbors of target_idx that are already mapped
     for (size_t neighbor : graph_data.target_adj_idx[target_idx]) {
         int mapped_global = mapping[neighbor];
@@ -2570,6 +2614,24 @@ bool ConsistencyChecker::check_local_consistency(
                 return false;  // Insufficient channels in strict mode
             }
         }
+
+        if (port_type_validation != nullptr && port_type_validation->enabled) {
+            const auto& ptv = *port_type_validation;
+            if (target_idx < ptv.target_host_ranks.size() && neighbor < ptv.target_host_ranks.size() &&
+                global_idx < ptv.global_host_ranks.size() && mapped_global_idx < ptv.global_host_ranks.size()) {
+                const auto rank_a = ptv.target_host_ranks[target_idx];
+                const auto rank_b = ptv.target_host_ranks[neighbor];
+                if (rank_a != MESH_HOST_RANK_UNSET && rank_b != MESH_HOST_RANK_UNSET && rank_a != rank_b) {
+                    const size_t lo = std::min(global_idx, mapped_global_idx);
+                    const size_t hi = std::max(global_idx, mapped_global_idx);
+                    const auto link_it = ptv.undirected_link_port_types.find({lo, hi});
+                    if (link_it == ptv.undirected_link_port_types.end() ||
+                        link_it->second != tt::tt_metal::PortType::QSFP_DD) {
+                        return false;
+                    }
+                }
+            }
+        }
     }
 
     return true;  // All checks passed
@@ -2584,6 +2646,9 @@ bool ConsistencyChecker::check_forward_consistency(
     const std::vector<int>& mapping,
     const std::vector<bool>& used,
     ConnectionValidationMode validation_mode) {
+    const PortTypeValidationIndexData* port_type_validation =
+        constraint_data.port_type_validation.enabled ? &constraint_data.port_type_validation : nullptr;
+
     // For each unassigned neighbor of target_idx, check if there's at least one viable candidate
     for (size_t neighbor : graph_data.target_adj_idx[target_idx]) {
         if (mapping[neighbor] != -1) {
@@ -2610,7 +2675,8 @@ bool ConsistencyChecker::check_forward_consistency(
             // Modify the temporary mapping in place (restored on next iteration)
             temp_mapping[neighbor] = static_cast<int>(candidate_global);
 
-            if (ConsistencyChecker::check_local_consistency(neighbor, candidate_global, graph_data, temp_mapping, validation_mode)) {
+            if (ConsistencyChecker::check_local_consistency(
+                    neighbor, candidate_global, graph_data, temp_mapping, validation_mode, port_type_validation)) {
                 has_viable_candidate = true;
                 break;  // Found at least one viable candidate
             }
@@ -2780,9 +2846,12 @@ bool DFSSearchEngine<TargetNode, GlobalNode>::dfs_recursive(
 
     // Try each candidate in order (best first)
     for (size_t global_idx : selection.candidates) {
+        const PortTypeValidationIndexData* port_type_validation =
+            constraint_data.port_type_validation.enabled ? &constraint_data.port_type_validation : nullptr;
+
         // Check local consistency (edges to already-mapped neighbors)
         if (!ConsistencyChecker::check_local_consistency(
-                target_idx, global_idx, graph_data, state_.mapping, validation_mode)) {
+                target_idx, global_idx, graph_data, state_.mapping, validation_mode, port_type_validation)) {
             continue;  // Skip invalid candidate
         }
 
@@ -3220,8 +3289,11 @@ bool DFSSearchEngine<TargetNode, GlobalNode>::search_n(
                 return;
             }
 
+            const PortTypeValidationIndexData* port_type_validation =
+                constraint_data.port_type_validation.enabled ? &constraint_data.port_type_validation : nullptr;
+
             if (!ConsistencyChecker::check_local_consistency(
-                    target_idx, global_idx, graph_data, state_.mapping, validation_mode)) {
+                    target_idx, global_idx, graph_data, state_.mapping, validation_mode, port_type_validation)) {
                 continue;
             }
 

--- a/tt_metal/fabric/physical_system_descriptor.cpp
+++ b/tt_metal/fabric/physical_system_descriptor.cpp
@@ -6,6 +6,7 @@
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
 #include <set>
+#include <unordered_set>
 #include <fstream>
 #include <climits>
 
@@ -278,6 +279,42 @@ std::vector<EthConnection> PhysicalSystemDescriptor::get_eth_connections(AsicID 
         }
     }
     return {};
+}
+
+PortType PhysicalSystemDescriptor::get_port_type(AsicID src_asic, AsicID dst_asic, uint8_t src_chan) const {
+    for (const auto& eth_conn : get_eth_connections(src_asic, dst_asic)) {
+        if (eth_conn.src_chan == src_chan) {
+            return eth_conn.port_type;
+        }
+    }
+    TT_THROW("No port type found for connection from ASIC {} to ASIC {} on channel {}", src_asic, dst_asic, src_chan);
+}
+
+std::vector<PortType> PhysicalSystemDescriptor::get_available_port_types(AsicID src_asic) const {
+    std::unordered_set<PortType> port_types;
+    for (const auto& [host, asic_group] : system_graph_.asic_connectivity_graph) {
+        if (!asic_group.contains(src_asic)) {
+            continue;
+        }
+        for (const auto& [dst_asic, eth_connections] : asic_group.at(src_asic)) {
+            for (const auto& eth_conn : eth_connections) {
+                port_types.insert(eth_conn.port_type);
+            }
+        }
+        break;
+    }
+    std::vector<PortType> result(port_types.begin(), port_types.end());
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+bool PhysicalSystemDescriptor::has_port_type(AsicID src_asic, AsicID dst_asic, PortType port_type) const {
+    for (const auto& eth_conn : get_eth_connections(src_asic, dst_asic)) {
+        if (eth_conn.port_type == port_type) {
+            return true;
+        }
+    }
+    return false;
 }
 
 const AsicTopology& PhysicalSystemDescriptor::get_asic_topology(const std::string& hostname) const {

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -23,7 +23,7 @@
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
-#include <tools/scaleout/board/board.hpp>
+#include <board/board.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -538,11 +538,16 @@ bool is_bh_galaxy_rev_c(tt::umd::ClusterDescriptor& cluster_desc) {
 }
 
 PortType resolve_port_type(const ASICDescriptor& asic_descriptor, uint8_t src_chan) {
-    auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
-    return board
-        .get_port_for_asic_channel(
-            tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
-        .port_type;
+    try {
+        auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
+        return board
+            .get_port_for_asic_channel(
+                tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
+            .port_type;
+    } catch (const std::runtime_error&) {
+        // Mock clusters and incomplete board maps may reference channels with no port mapping.
+        return PortType::TRACE;
+    }
 }
 
 }  // namespace

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -546,7 +546,7 @@ PortType resolve_port_type(const ASICDescriptor& asic_descriptor, uint8_t src_ch
             .port_type;
     } catch (const std::runtime_error&) {
         // Mock clusters and incomplete board maps may reference channels with no port mapping.
-        return PortType::TRACE;
+        return PortType::UNKNOWN;
     }
 }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -23,6 +23,7 @@
 #include "tt_metal/llrt/hal.hpp"
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
+#include <tools/scaleout/board/board.hpp>
 
 namespace tt::tt_metal {
 
@@ -536,6 +537,14 @@ bool is_bh_galaxy_rev_c(tt::umd::ClusterDescriptor& cluster_desc) {
     return revision_bits >= 3;
 }
 
+PortType resolve_port_type(const ASICDescriptor& asic_descriptor, uint8_t src_chan) {
+    auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
+    return board
+        .get_port_for_asic_channel(
+            tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
+        .port_type;
+}
+
 }  // namespace
 
 namespace discovery_impl {
@@ -572,6 +581,15 @@ PhysicalSystemDescriptor run_local_discovery(
     auto& asic_graph = psd.get_system_graph().asic_connectivity_graph[hostname_key];
     auto& exit_nodes = psd.get_exit_node_connection_table()[hostname_key];
 
+    auto make_eth_connection = [&](AsicID src_asic, uint8_t src_chan, uint8_t dst_chan, bool is_local) {
+        return EthConnection{
+            src_chan,
+            dst_chan,
+            is_local,
+            resolve_port_type(psd.get_asic_descriptors().at(src_asic), src_chan),
+        };
+    };
+
     auto add_local_asic_descriptor = [&](AsicID src_unique_id, ChipId src_chip_id) {
         auto [tray_id, asic_location] = get_asic_position(
             cluster_desc,
@@ -604,12 +622,13 @@ PhysicalSystemDescriptor run_local_discovery(
             if (!visited_dst.contains(dst_chip)) {
                 // This neighbor has not been visited. Add it to the graph and mark visited.
                 asic_graph[src_unique_id].push_back(
-                    {AsicID{chip_unique_ids.at(dst_chip)}, {EthConnection(chan, dst_chan, true)}});
+                    {AsicID{chip_unique_ids.at(dst_chip)}, {make_eth_connection(src_unique_id, chan, dst_chan, true)}});
                 visited_dst[dst_chip] = asic_graph[src_unique_id].size() - 1;
             } else {
                 // This neighbor has already been visited. There is more than one channel to it.
                 // Update the existing entry with the new channel.
-                asic_graph[src_unique_id][visited_dst[dst_chip]].second.push_back(EthConnection(chan, dst_chan, true));
+                asic_graph[src_unique_id][visited_dst[dst_chip]].second.push_back(
+                    make_eth_connection(src_unique_id, chan, dst_chan, true));
             }
         }
     }
@@ -627,16 +646,18 @@ PhysicalSystemDescriptor run_local_discovery(
             auto dst_unique_id = AsicID{std::get<0>(remote_info)};
             auto dst_chan = std::get<1>(remote_info);
             if (!visited_dst.contains(dst_unique_id)) {
-                asic_graph[local_unique_id].push_back({dst_unique_id, {EthConnection(eth_chan, dst_chan, false)}});
+                asic_graph[local_unique_id].push_back(
+                    {dst_unique_id, {make_eth_connection(local_unique_id, eth_chan, dst_chan, false)}});
                 visited_dst[dst_unique_id] = asic_graph[local_unique_id].size() - 1;
             } else {
                 asic_graph[local_unique_id][visited_dst[dst_unique_id]].second.push_back(
-                    EthConnection(eth_chan, dst_chan, false));
+                    make_eth_connection(local_unique_id, eth_chan, dst_chan, false));
             }
             exit_nodes.push_back(ExitNodeConnection{
                 .src_exit_node = local_unique_id,
                 .dst_exit_node = dst_unique_id,
-                .eth_conn = EthConnection(eth_chan, dst_chan, false)});
+                .eth_conn = make_eth_connection(local_unique_id, eth_chan, dst_chan, false),
+            });
         }
     }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -24,6 +24,7 @@
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include <board/board.hpp>
+#include <board/port_lookup.hpp>
 
 namespace tt::tt_metal {
 
@@ -537,19 +538,6 @@ bool is_bh_galaxy_rev_c(tt::umd::ClusterDescriptor& cluster_desc) {
     return revision_bits >= 3;
 }
 
-PortType resolve_port_type(const ASICDescriptor& asic_descriptor, uint8_t src_chan) {
-    try {
-        auto board = tt::scaleout_tools::create_board(asic_descriptor.board_type);
-        return board
-            .get_port_for_asic_channel(
-                tt::scaleout_tools::AsicChannel{*asic_descriptor.asic_location, tt::scaleout_tools::ChanId{src_chan}})
-            .port_type;
-    } catch (const std::runtime_error&) {
-        // Mock clusters and incomplete board maps may reference channels with no port mapping.
-        return PortType::UNKNOWN;
-    }
-}
-
 }  // namespace
 
 namespace discovery_impl {
@@ -591,7 +579,10 @@ PhysicalSystemDescriptor run_local_discovery(
             src_chan,
             dst_chan,
             is_local,
-            resolve_port_type(psd.get_asic_descriptors().at(src_asic), src_chan),
+            tt::scaleout_tools::resolve_port_type(
+                psd.get_asic_descriptors().at(src_asic).board_type,
+                *psd.get_asic_descriptors().at(src_asic).asic_location,
+                src_chan),
         };
     };
 

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -2,11 +2,23 @@ syntax = "proto3";
 
 package tt.fabric.proto;
 
+// Physical port / cable type (values aligned with tt::tt_metal::PortType)
+enum PortType {
+    TRACE = 0;
+    QSFP_DD = 1;
+    WARP100 = 2;
+    WARP400 = 3;
+    LINKING_BOARD_1 = 4;
+    LINKING_BOARD_2 = 5;
+    LINKING_BOARD_3 = 6;
+}
+
 // Ethernet connection between two ASICs
 message EthConnection {
     uint32 src_chan = 1;
     uint32 dst_chan = 2;
     bool is_local = 3;
+    PortType port_type = 4;
 }
 
 // Connection edge to another ASIC with multiple ethernet connections

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package tt.fabric.proto;
 
-// Physical port / cable type (values aligned with tt::tt_metal::PortType)
+// Physical port / cable type
 enum PortType {
     TRACE = 0;
     QSFP_DD = 1;

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -4,13 +4,14 @@ package tt.fabric.proto;
 
 // Physical port / cable type
 enum PortType {
-    TRACE = 0;
-    QSFP_DD = 1;
-    WARP100 = 2;
-    WARP400 = 3;
-    LINKING_BOARD_1 = 4;
-    LINKING_BOARD_2 = 5;
-    LINKING_BOARD_3 = 6;
+    UNKNOWN = 0;
+    TRACE = 1;
+    QSFP_DD = 2;
+    WARP100 = 3;
+    WARP400 = 4;
+    LINKING_BOARD_1 = 5;
+    LINKING_BOARD_2 = 6;
+    LINKING_BOARD_3 = 7;
 }
 
 // Ethernet connection between two ASICs

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -26,11 +26,18 @@ uint32_t board_type_to_proto(BoardType board_type) { return static_cast<uint32_t
 // Helper function to convert protobuf value to BoardType enum
 BoardType proto_to_board_type(uint32_t proto_value) { return static_cast<BoardType>(proto_value); }
 
+tt::fabric::proto::PortType port_type_to_proto(PortType port_type) {
+    return static_cast<tt::fabric::proto::PortType>(port_type);
+}
+
+PortType proto_to_port_type(tt::fabric::proto::PortType port_type) { return static_cast<PortType>(port_type); }
+
 // Convert EthConnection to protobuf
 void eth_connection_to_proto(const EthConnection& eth_conn, tt::fabric::proto::EthConnection* proto_conn) {
     proto_conn->set_src_chan(eth_conn.src_chan);
     proto_conn->set_dst_chan(eth_conn.dst_chan);
     proto_conn->set_is_local(eth_conn.is_local);
+    proto_conn->set_port_type(port_type_to_proto(eth_conn.port_type));
 }
 
 // Convert protobuf to EthConnection
@@ -39,6 +46,7 @@ EthConnection proto_to_eth_connection(const tt::fabric::proto::EthConnection& pr
     eth_conn.src_chan = proto_conn.src_chan();
     eth_conn.dst_chan = proto_conn.dst_chan();
     eth_conn.is_local = proto_conn.is_local();
+    eth_conn.port_type = proto_to_port_type(proto_conn.port_type());
     return eth_conn;
 }
 

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -501,6 +501,20 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
             config.asic_positions[asic_id] = std::make_pair(desc.tray_id, desc.asic_location);
         }
 
+        std::set<tt::tt_metal::AsicID> physical_mesh_asics;
+        for (const auto& [_, physical_mesh_graph] : adjacency_map_physical_multi_mesh.mesh_adjacency_graphs_) {
+            for (const auto& asic_id : physical_mesh_graph.get_nodes()) {
+                physical_mesh_asics.insert(asic_id);
+            }
+        }
+        if (!physical_mesh_asics.empty()) {
+            config.port_type_links = build_port_type_link_map(physical_system_descriptor_, physical_mesh_asics);
+            log_debug(
+                tt::LogFabric,
+                "Port-type link map: {} undirected ASIC pair(s) with port type metadata",
+                config.port_type_links->size());
+        }
+
         // Use multi-mesh topology solver to map all meshes at once
         auto mapping_result = ::tt::tt_metal::experimental::tt_fabric::map_multi_mesh_to_physical(
             adjacency_map_logical_multi_mesh,

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -508,7 +508,8 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
             }
         }
         if (!physical_mesh_asics.empty()) {
-            config.port_type_links = build_port_type_link_map(physical_system_descriptor_, physical_mesh_asics);
+            config.port_type_links = ::tt::tt_metal::experimental::tt_fabric::build_port_type_link_map(
+                physical_system_descriptor_, physical_mesh_asics);
             log_debug(
                 tt::LogFabric,
                 "Port-type link map: {} undirected ASIC pair(s) with port type metadata",

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -259,6 +259,75 @@ std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
     return required_asics;
 }
 
+bool fabric_node_has_cross_host_required_port_type(
+    FabricNodeId fabric_node,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank) {
+    const auto fabric_rank = fabric_node_rank(node_to_host_rank, fabric_node);
+    if (!fabric_rank.has_value()) {
+        return false;
+    }
+
+    const auto logical_it = logical_adjacency.find(fabric_node);
+    if (logical_it == logical_adjacency.end()) {
+        return false;
+    }
+
+    for (const auto& neighbor : logical_it->second) {
+        const auto neighbor_rank = fabric_node_rank(node_to_host_rank, neighbor);
+        if (!neighbor_rank.has_value()) {
+            continue;
+        }
+        const auto edge_requirement = infer_logical_edge_port_requirement(fabric_rank.value(), neighbor_rank.value());
+        if (edge_requirement.required.has_value()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::optional<std::string> add_intra_mesh_port_type_required_constraints(
+    ::tt::tt_fabric::MappingConstraints<FabricNodeId, tt::tt_metal::AsicID>& intra_mesh_constraints,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const TopologyMappingConfig& config) {
+    if (!config.port_type_links.has_value()) {
+        return std::nullopt;
+    }
+    const PortTypeLinkMap& port_type_links = *config.port_type_links;
+    const auto physical_asics = physical_asics_from_adjacency(physical_adjacency);
+
+    for (const auto& [fabric_node, _] : logical_adjacency) {
+        const auto required_asics = compute_required_asics_for_fabric_node(
+            fabric_node, logical_adjacency, physical_adjacency, node_to_host_rank, asic_to_host_rank, port_type_links);
+
+        if (required_asics.empty()) {
+            if (fabric_node_has_cross_host_required_port_type(fabric_node, logical_adjacency, node_to_host_rank)) {
+                return fmt::format(
+                    "No physical ASIC satisfies required port type for fabric node {} (mesh_id={}, chip_id={})",
+                    fabric_node,
+                    fabric_node.mesh_id.get(),
+                    fabric_node.chip_id);
+            }
+            continue;
+        }
+
+        if (required_asics.size() < physical_asics.size()) {
+            if (!intra_mesh_constraints.add_required_constraint(fabric_node, required_asics)) {
+                return fmt::format(
+                    "Failed to add required port-type constraint for fabric node {} (mesh_id={}, chip_id={})",
+                    fabric_node,
+                    fabric_node.mesh_id.get(),
+                    fabric_node.chip_id);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 void add_intra_mesh_port_type_preferred_constraints(
     ::tt::tt_fabric::MappingConstraints<FabricNodeId, tt::tt_metal::AsicID>& intra_mesh_constraints,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -425,6 +494,13 @@ TopologyMappingResult map_mesh_to_physical(
                 mesh_id.get(),
                 pinnings_str);
         }
+    }
+
+    if (const auto port_type_error = add_intra_mesh_port_type_required_constraints(
+            constraints, logical_adjacency, physical_adjacency, node_to_host_rank, asic_to_host_rank, config)) {
+        result.success = false;
+        result.error_message = *port_type_error;
+        return result;
     }
 
     add_intra_mesh_port_type_preferred_constraints(
@@ -2626,10 +2702,44 @@ TopologyMappingResult map_multi_mesh_to_physical(
                     }
                 }
             }
+            const auto& logical_adjacency = logical_graph.get_adjacency_map();
+            const auto& physical_adjacency = physical_graph.get_adjacency_map();
+
+            if (const auto port_type_error = add_intra_mesh_port_type_required_constraints(
+                    intra_mesh_constraints,
+                    logical_adjacency,
+                    physical_adjacency,
+                    node_to_host_rank,
+                    asic_to_host_rank,
+                    config)) {
+                log_info(
+                    tt::LogFabric,
+                    "Attempt {}: Port-type required constraint error for mesh {} -> {}: {}",
+                    retry_attempt,
+                    logical_mesh_id.get(),
+                    physical_mesh_id.get(),
+                    *port_type_error);
+                if (!handle_forbidden_constraint(
+                        inter_mesh_constraints,
+                        logical_mesh_id,
+                        physical_mesh_id,
+                        failed_mesh_pairs,
+                        current_attempt_failed_pairs,
+                        retry_attempt,
+                        logical_meshes,
+                        physical_meshes,
+                        inter_mesh_validation_mode,
+                        result,
+                        *port_type_error)) {
+                    return result;
+                }
+                continue;
+            }
+
             add_intra_mesh_port_type_preferred_constraints(
                 intra_mesh_constraints,
-                logical_graph.get_adjacency_map(),
-                physical_graph.get_adjacency_map(),
+                logical_adjacency,
+                physical_adjacency,
                 node_to_host_rank,
                 asic_to_host_rank,
                 config);

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -350,6 +350,24 @@ void add_intra_mesh_port_type_preferred_constraints(
     }
 }
 
+void attach_port_type_validation_context(
+    ::tt::tt_fabric::MappingConstraints<FabricNodeId, tt::tt_metal::AsicID>& constraints,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const TopologyMappingConfig& config) {
+    if (!config.port_type_links.has_value()) {
+        return;
+    }
+
+    ::tt::tt_fabric::PortTypeMappingValidationContext<FabricNodeId, tt::tt_metal::AsicID> context;
+    context.target_host_ranks = node_to_host_rank;
+    context.global_host_ranks = asic_to_host_rank;
+    for (const auto& [link_key, port_type] : *config.port_type_links) {
+        context.undirected_link_port_types[link_key] = port_type;
+    }
+    constraints.set_port_type_validation_context(std::move(context));
+}
+
 TopologyMappingResult map_mesh_to_physical(
     MeshId mesh_id,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -505,6 +523,8 @@ TopologyMappingResult map_mesh_to_physical(
 
     add_intra_mesh_port_type_preferred_constraints(
         constraints, logical_adjacency, physical_adjacency, node_to_host_rank, asic_to_host_rank, config);
+
+    attach_port_type_validation_context(constraints, node_to_host_rank, asic_to_host_rank, config);
 
     ConnectionValidationMode validation_mode = ConnectionValidationMode::RELAXED;
     auto mode_it = config.mesh_validation_modes.find(mesh_id);
@@ -2743,6 +2763,8 @@ TopologyMappingResult map_multi_mesh_to_physical(
                 node_to_host_rank,
                 asic_to_host_rank,
                 config);
+
+            attach_port_type_validation_context(intra_mesh_constraints, node_to_host_rank, asic_to_host_rank, config);
 
             // Determine validation mode
             auto validation_mode = determine_intra_mesh_validation_mode(config, logical_mesh_id);

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -259,6 +259,87 @@ std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
     return required_asics;
 }
 
+namespace {
+
+std::set<tt::tt_metal::AsicID> asics_in_physical_mesh(
+    const PhysicalMultiMeshGraph& physical_graph, MeshId physical_mesh_id) {
+    std::set<tt::tt_metal::AsicID> asics;
+    const auto mesh_it = physical_graph.mesh_adjacency_graphs_.find(physical_mesh_id);
+    if (mesh_it == physical_graph.mesh_adjacency_graphs_.end()) {
+        return asics;
+    }
+    for (const auto& asic_id : mesh_it->second.get_nodes()) {
+        asics.insert(asic_id);
+    }
+    return asics;
+}
+
+bool physical_meshes_have_qsfp_link(
+    const std::set<tt::tt_metal::AsicID>& asics_a,
+    const std::set<tt::tt_metal::AsicID>& asics_b,
+    const PortTypeLinkMap& port_type_links) {
+    for (const auto& asic_a : asics_a) {
+        for (const auto& asic_b : asics_b) {
+            if (port_type_link_has_type(port_type_links, asic_a, asic_b, tt::tt_metal::PortType::QSFP_DD)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+std::set<MeshId> unbound_physical_meshes(
+    const PhysicalMultiMeshGraph& physical_graph, const std::set<MeshId>& bound_physical_mesh_ids) {
+    std::set<MeshId> unbound;
+    for (const auto& [physical_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+        if (!bound_physical_mesh_ids.contains(physical_mesh_id) && !adj.get_nodes().empty()) {
+            unbound.insert(physical_mesh_id);
+        }
+    }
+    return unbound;
+}
+
+std::set<MeshId> intersect_mesh_id_sets(const std::set<MeshId>& a, const std::set<MeshId>& b) {
+    std::set<MeshId> intersection;
+    std::set_intersection(a.begin(), a.end(), b.begin(), b.end(), std::inserter(intersection, intersection.begin()));
+    return intersection;
+}
+
+}  // namespace
+
+std::set<MeshId> compute_preferred_physical_meshes_for_logical_mesh(
+    MeshId logical_mesh,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const PortTypeLinkMap& port_type_links,
+    const std::set<MeshId>& bound_physical_mesh_ids) {
+    const auto unbound = unbound_physical_meshes(physical_graph, bound_physical_mesh_ids);
+    const auto logical_neighbors = mesh_logical_level_graph.get_neighbors(logical_mesh);
+    if (logical_neighbors.empty()) {
+        return unbound;
+    }
+
+    std::set<MeshId> preferred;
+    for (const MeshId physical_mesh : unbound) {
+        const auto asics_in_mesh = asics_in_physical_mesh(physical_graph, physical_mesh);
+        bool has_qsfp_to_other_partition = false;
+        for (const MeshId other_physical_mesh : unbound) {
+            if (other_physical_mesh == physical_mesh) {
+                continue;
+            }
+            const auto other_asics = asics_in_physical_mesh(physical_graph, other_physical_mesh);
+            if (physical_meshes_have_qsfp_link(asics_in_mesh, other_asics, port_type_links)) {
+                has_qsfp_to_other_partition = true;
+                break;
+            }
+        }
+        if (has_qsfp_to_other_partition) {
+            preferred.insert(physical_mesh);
+        }
+    }
+    return preferred;
+}
+
 bool fabric_node_has_cross_host_required_port_type(
     FabricNodeId fabric_node,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -1836,6 +1917,322 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
     }
 }
 
+// Port-type-aware inter-mesh preferred constraints: host locality + cross-partition QSFP preference.
+// Replaces add_inter_mesh_minimal_host_cover_from_hostname_map when port_type_links is populated.
+void add_inter_mesh_port_type_preferred_constraints(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId>& inter_mesh_constraints,
+    const std::map<MeshId, MeshId>& rank_bound_logical_to_physical) {
+    if (!config.port_type_links.has_value()) {
+        return;
+    }
+    const PortTypeLinkMap& port_type_links = *config.port_type_links;
+
+    std::set<MeshId> bound_physical_mesh_ids;
+    for (const auto& [_, physical_mesh_id] : rank_bound_logical_to_physical) {
+        bound_physical_mesh_ids.insert(physical_mesh_id);
+    }
+
+    std::set<MeshId> logical_target_set;
+    for (const MeshId& m : mesh_logical_level_graph.get_nodes()) {
+        if (!rank_bound_logical_to_physical.contains(m)) {
+            logical_target_set.insert(m);
+        }
+    }
+    if (logical_target_set.size() <= 1) {
+        return;
+    }
+
+    const auto all_unbound_physical = unbound_physical_meshes(physical_graph, bound_physical_mesh_ids);
+
+    std::optional<std::set<MeshId>> host_preferred_globals;
+    if (!config.hostname_to_asics.empty()) {
+        std::vector<std::set<MeshId>> global_mesh_groups;
+        std::map<std::string, std::size_t> host_group_index;
+        for (const auto& [phys_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+            if (bound_physical_mesh_ids.contains(phys_mesh_id)) {
+                continue;
+            }
+            if (adj.get_nodes().empty()) {
+                continue;
+            }
+            std::set<std::string> hosts_for_mesh;
+            for (const auto& asic_id : adj.get_nodes()) {
+                auto hostname = hostname_for_asic_from_hostname_map(asic_id, config.hostname_to_asics);
+                if (hostname.has_value()) {
+                    hosts_for_mesh.insert(*hostname);
+                }
+            }
+            if (hosts_for_mesh.size() == 1) {
+                auto [it, inserted] = host_group_index.try_emplace(*hosts_for_mesh.begin(), global_mesh_groups.size());
+                if (inserted) {
+                    global_mesh_groups.emplace_back();
+                }
+                global_mesh_groups[it->second].insert(phys_mesh_id);
+            } else {
+                global_mesh_groups.push_back({phys_mesh_id});
+            }
+        }
+
+        if (!global_mesh_groups.empty()) {
+            const auto [single_group_fits, preferred_globals] =
+                ::tt::tt_fabric::PhysicalGroupingDescriptor::find_minimum_coverage_group(
+                    logical_target_set, global_mesh_groups);
+            if (single_group_fits) {
+                std::vector<std::set<MeshId>> target_groups;
+                target_groups.push_back(logical_target_set);
+                if (inter_mesh_constraints.set_same_rank_groups_constraint(target_groups, global_mesh_groups)) {
+                    return;
+                }
+                log_warning(
+                    tt::LogFabric,
+                    "Inter-mesh port-type host alignment: failed to set same-rank groups constraint; falling back to "
+                    "preferred globals");
+            }
+            if (!preferred_globals.empty()) {
+                if (!single_group_fits) {
+                    log_debug(
+                        tt::LogFabric,
+                        "Inter-mesh port-type host alignment: target count {} exceeds largest single partition; "
+                        "preferring minimal host cover ({} preferred globals)",
+                        logical_target_set.size(),
+                        preferred_globals.size());
+                }
+                host_preferred_globals = preferred_globals;
+            }
+        }
+    }
+
+    for (const MeshId& target : logical_target_set) {
+        const auto port_preferred = compute_preferred_physical_meshes_for_logical_mesh(
+            target, mesh_logical_level_graph, physical_graph, port_type_links, bound_physical_mesh_ids);
+
+        std::set<MeshId> final_preferred;
+        if (host_preferred_globals.has_value() && !host_preferred_globals->empty()) {
+            if (!port_preferred.empty()) {
+                final_preferred = intersect_mesh_id_sets(*host_preferred_globals, port_preferred);
+            } else {
+                final_preferred = *host_preferred_globals;
+            }
+        } else if (!port_preferred.empty()) {
+            final_preferred = port_preferred;
+        }
+
+        if (final_preferred.empty()) {
+            continue;
+        }
+        if (final_preferred.size() < all_unbound_physical.size()) {
+            inter_mesh_constraints.add_preferred_constraint(target, final_preferred);
+        }
+    }
+}
+
+// Physical mesh partition (among unbound) that minimally covers required_asics, else nullopt.
+std::optional<MeshId> smallest_physical_mesh_covering_required_asics(
+    const PhysicalMultiMeshGraph& physical_graph,
+    const std::set<MeshId>& bound_physical_mesh_ids,
+    const std::set<tt::tt_metal::AsicID>& required_asics) {
+    if (required_asics.empty()) {
+        return std::nullopt;
+    }
+
+    auto node_vec_contains = [](const std::vector<tt::tt_metal::AsicID>& nodes, tt::tt_metal::AsicID asic) -> bool {
+        return std::find(nodes.begin(), nodes.end(), asic) != nodes.end();
+    };
+
+    std::optional<MeshId> best_physical;
+    std::optional<std::size_t> best_node_count;
+    for (const auto& [physical_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+        if (bound_physical_mesh_ids.contains(physical_mesh_id)) {
+            continue;
+        }
+        const auto& node_vec = adj.get_nodes();
+        if (node_vec.empty()) {
+            continue;
+        }
+
+        bool covers_all = true;
+        for (const auto& asic : required_asics) {
+            if (!node_vec_contains(node_vec, asic)) {
+                covers_all = false;
+                break;
+            }
+        }
+        if (!covers_all) {
+            continue;
+        }
+
+        const std::size_t n = node_vec.size();
+        if (!best_node_count.has_value() || n < *best_node_count) {
+            best_node_count = n;
+            best_physical = physical_mesh_id;
+        } else if (n == *best_node_count && physical_mesh_id < *best_physical) {
+            best_physical = physical_mesh_id;
+        }
+    }
+    return best_physical;
+}
+
+// Tray 1 / ASIC location 1 (discovery coordinate) used as soft inter-mesh anchor for logical mesh 0.
+inline const AsicPosition k_logical_mesh_zero_preferred_discovery_asic_position =
+    AsicPosition{tt::tt_metal::TrayID{1u}, tt::tt_metal::ASICLocation{1u}};
+
+// Resolve a single ASIC at `anchor_position` preferring resolved-local-host ASIC list; else unique global hit.
+std::optional<tt::tt_metal::AsicID> resolve_anchor_asic_at_discovery_position(
+    const TopologyMappingConfig& config,
+    const std::optional<std::string>& resolved_local_hostname_key,
+    const AsicPosition& anchor_position) {
+    if (config.asic_positions.empty()) {
+        return std::nullopt;
+    }
+
+    auto position_matches = [&](tt::tt_metal::AsicID asic_id) -> bool {
+        auto pos_it = config.asic_positions.find(asic_id);
+        return pos_it != config.asic_positions.end() && pos_it->second == anchor_position;
+    };
+
+    if (resolved_local_hostname_key.has_value()) {
+        auto host_it = config.hostname_to_asics.find(*resolved_local_hostname_key);
+        if (host_it != config.hostname_to_asics.end()) {
+            int local_count = 0;
+            std::optional<tt::tt_metal::AsicID> local_only;
+            for (const auto& asic : host_it->second) {
+                if (position_matches(asic)) {
+                    ++local_count;
+                    local_only = asic;
+                }
+            }
+            if (local_count == 1) {
+                return local_only;
+            }
+        }
+    }
+
+    int global_count = 0;
+    std::optional<tt::tt_metal::AsicID> global_only;
+    for (const auto& [asic_id, pos] : config.asic_positions) {
+        if (pos == anchor_position) {
+            ++global_count;
+            global_only = asic_id;
+        }
+    }
+    return global_count == 1 ? global_only : std::nullopt;
+}
+
+/**
+ * Biases inter-mesh solving so logical mesh id 0 prefers the right physical partition(s):
+ * - the partition covering the Phase-1 / mapping host (`gethostname` match in `hostname_to_asics`),
+ * - and the partition that contains discovery ASIC (tray id 1, ASIC location 1), which tracks the canonical
+ *   "starter" silicon on that stack.
+ *
+ * Rationale for CI / multihost: without this soft anchor, isomorphism in the mapper can associate logical mesh 0 with
+ * an arbitrary symmetric physical mesh, which shifts which host owns mesh 0 and which ASIC lands on which UMD-visible
+ * index after rank bindings (`TT_VISIBLE_DEVICES`, etc.). That makes rank-0 / mesh-0 / device-0 assumptions in tests
+ * and golden ASIC-mapping checks brittle across hosts or reorderings. Preferring localhost + tray 1 / location 1 keeps
+ * launched jobs and documented expectations aligned so we avoid those mismatches.
+ *
+ * Constraints are preferences only—the solver may still choose another isomorphism if constraints demand it.
+ * If localhost cover and tray/loc anchors disagree on the physical mesh, tray 1 / location 1 wins (see log line).
+ */
+void add_logical_mesh_zero_anchor_inter_mesh_preference(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    const std::map<MeshId, MeshId>& rank_bound_logical_to_physical,
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId>& inter_mesh_constraints) {
+    if (config.hostname_to_asics.empty() && config.asic_positions.empty()) {
+        return;
+    }
+
+    constexpr MeshId k_logical_anchor{0};
+    const auto& logical_nodes_vec = mesh_logical_level_graph.get_nodes();
+    const bool logical_anchor_exists =
+        std::find(logical_nodes_vec.begin(), logical_nodes_vec.end(), k_logical_anchor) != logical_nodes_vec.end();
+    if (!logical_anchor_exists) {
+        return;
+    }
+
+    std::set<MeshId> bound_physical_mesh_ids;
+    for (const auto& [_, physical_mesh_id] : rank_bound_logical_to_physical) {
+        bound_physical_mesh_ids.insert(physical_mesh_id);
+    }
+
+    std::optional<std::string> local_hostname_opt;
+    if (!config.hostname_to_asics.empty()) {
+        local_hostname_opt = resolve_local_hostname_from_hostname_asics_map(config.hostname_to_asics);
+    }
+
+    std::optional<MeshId> from_hostname_partition;
+    if (local_hostname_opt.has_value()) {
+        auto host_it = config.hostname_to_asics.find(*local_hostname_opt);
+        if (host_it != config.hostname_to_asics.end() && !host_it->second.empty()) {
+            from_hostname_partition = smallest_physical_mesh_covering_required_asics(
+                physical_graph, bound_physical_mesh_ids, host_it->second);
+        }
+    }
+    if (!from_hostname_partition.has_value() && !config.hostname_to_asics.empty()) {
+        log_debug(
+            tt::LogFabric,
+            "Logical mesh {} anchor: no partition from local hostname hostname_to_asics match",
+            k_logical_anchor.get());
+    }
+
+    std::optional<MeshId> from_discovery_position_partition;
+    const auto anchor_asic_coords = resolve_anchor_asic_at_discovery_position(
+        config, local_hostname_opt, k_logical_mesh_zero_preferred_discovery_asic_position);
+    if (anchor_asic_coords.has_value()) {
+        const std::set<tt::tt_metal::AsicID> single{*anchor_asic_coords};
+        from_discovery_position_partition =
+            smallest_physical_mesh_covering_required_asics(physical_graph, bound_physical_mesh_ids, single);
+    }
+    if (!from_discovery_position_partition.has_value()) {
+        if (!config.asic_positions.empty()) {
+            log_debug(
+                tt::LogFabric,
+                "Logical mesh {} anchor: could not resolve tray 1 / ASIC location 1 partition (ambiguous or missing in "
+                "TopologyMappingConfig::asic_positions / no smallest cover)",
+                k_logical_anchor.get());
+        }
+    }
+
+    std::optional<MeshId> chosen_physical;
+    if (from_hostname_partition.has_value() && from_discovery_position_partition.has_value()) {
+        if (*from_hostname_partition == *from_discovery_position_partition) {
+            chosen_physical = from_hostname_partition;
+        } else {
+            chosen_physical = from_discovery_position_partition;
+            log_info(
+                tt::LogFabric,
+                "Logical mesh {} anchor: localhost partition ({}) differs from tray-1/loc-1 partition ({}); preferring "
+                "the latter",
+                k_logical_anchor.get(),
+                from_hostname_partition->get(),
+                from_discovery_position_partition->get());
+        }
+    } else if (from_discovery_position_partition.has_value()) {
+        chosen_physical = from_discovery_position_partition;
+    } else if (from_hostname_partition.has_value()) {
+        chosen_physical = from_hostname_partition;
+    }
+
+    if (!chosen_physical.has_value()) {
+        return;
+    }
+
+    inter_mesh_constraints.add_preferred_constraint(k_logical_anchor, *chosen_physical);
+
+    log_info(
+        tt::LogFabric,
+        "Inter-mesh preference: logical mesh {} → physical mesh {} (hostname_anchor={}, "
+        "tray1_asic_location1_anchor={})",
+        k_logical_anchor.get(),
+        chosen_physical->get(),
+        from_hostname_partition.has_value(),
+        from_discovery_position_partition.has_value());
+}
+
 // Helper function to build ASIC positions to ASIC IDs map
 std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
     const ::tt::tt_fabric::AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph, const TopologyMappingConfig& config) {
@@ -1864,8 +2261,15 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
 
     // Skip if rank bindings are disabled
     if (config.disable_rank_bindings) {
-        add_inter_mesh_minimal_host_cover_from_hostname_map(
-            config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
+        if (config.port_type_links.has_value()) {
+            add_inter_mesh_port_type_preferred_constraints(
+                config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
+        } else {
+            add_inter_mesh_minimal_host_cover_from_hostname_map(
+                config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
+        }
+        add_logical_mesh_zero_anchor_inter_mesh_preference(
+            config, physical_graph, mesh_logical_level_graph, {}, inter_mesh_constraints);
         return inter_mesh_constraints;
     }
 
@@ -1921,8 +2325,15 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
         inter_mesh_constraints.add_required_constraint(logical_mesh_id, physical_it->second);
     }
 
-    add_inter_mesh_minimal_host_cover_from_hostname_map(
-        config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
+    if (config.port_type_links.has_value()) {
+        add_inter_mesh_port_type_preferred_constraints(
+            config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
+    } else {
+        add_inter_mesh_minimal_host_cover_from_hostname_map(
+            config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
+    }
+    add_logical_mesh_zero_anchor_inter_mesh_preference(
+        config, physical_graph, mesh_logical_level_graph, rank_bound_logical_to_physical, inter_mesh_constraints);
     return inter_mesh_constraints;
 }
 

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -259,6 +259,28 @@ std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
     return required_asics;
 }
 
+void add_intra_mesh_port_type_preferred_constraints(
+    ::tt::tt_fabric::MappingConstraints<FabricNodeId, tt::tt_metal::AsicID>& intra_mesh_constraints,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const TopologyMappingConfig& config) {
+    if (!config.port_type_links.has_value()) {
+        return;
+    }
+    const PortTypeLinkMap& port_type_links = *config.port_type_links;
+
+    for (const auto& [fabric_node, _] : logical_adjacency) {
+        const auto preferred_asics = compute_preferred_asics_for_fabric_node(
+            fabric_node, logical_adjacency, physical_adjacency, node_to_host_rank, asic_to_host_rank, port_type_links);
+
+        if (!preferred_asics.empty()) {
+            intra_mesh_constraints.add_preferred_constraint(fabric_node, preferred_asics);
+        }
+    }
+}
+
 TopologyMappingResult map_mesh_to_physical(
     MeshId mesh_id,
     const LogicalAdjacencyMap& logical_adjacency,
@@ -404,6 +426,9 @@ TopologyMappingResult map_mesh_to_physical(
                 pinnings_str);
         }
     }
+
+    add_intra_mesh_port_type_preferred_constraints(
+        constraints, logical_adjacency, physical_adjacency, node_to_host_rank, asic_to_host_rank, config);
 
     ConnectionValidationMode validation_mode = ConnectionValidationMode::RELAXED;
     auto mode_it = config.mesh_validation_modes.find(mesh_id);
@@ -2586,6 +2611,28 @@ TopologyMappingResult map_multi_mesh_to_physical(
             // Build ASIC positions map and add pinning constraints
             auto asic_positions_to_asic_ids = build_asic_positions_map(physical_graph, config);
             add_pinning_constraints(intra_mesh_constraints, asic_positions_to_asic_ids, config, logical_mesh_id);
+
+            std::map<FabricNodeId, MeshHostRankId> node_to_host_rank;
+            if (fabric_node_id_to_mesh_rank.contains(logical_mesh_id)) {
+                node_to_host_rank = fabric_node_id_to_mesh_rank.at(logical_mesh_id);
+            }
+            std::map<tt::tt_metal::AsicID, MeshHostRankId> asic_to_host_rank;
+            if (asic_id_to_mesh_rank.contains(logical_mesh_id)) {
+                asic_to_host_rank = asic_id_to_mesh_rank.at(logical_mesh_id);
+            } else {
+                for (const auto& [_, asic_set] : config.hostname_to_asics) {
+                    for (const auto& asic_id : asic_set) {
+                        asic_to_host_rank[asic_id] = ::tt::tt_fabric::MESH_HOST_RANK_UNSET;
+                    }
+                }
+            }
+            add_intra_mesh_port_type_preferred_constraints(
+                intra_mesh_constraints,
+                logical_graph.get_adjacency_map(),
+                physical_graph.get_adjacency_map(),
+                node_to_host_rank,
+                asic_to_host_rank,
+                config);
 
             // Determine validation mode
             auto validation_mode = determine_intra_mesh_validation_mode(config, logical_mesh_id);

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -34,6 +34,231 @@
 
 namespace tt::tt_metal::experimental::tt_fabric {
 
+namespace {
+
+using tt::tt_metal::AsicID;
+using tt::tt_metal::PortType;
+
+std::set<AsicID> physical_asics_from_adjacency(const PhysicalAdjacencyMap& physical_adjacency) {
+    std::set<AsicID> asics;
+    for (const auto& [asic, _] : physical_adjacency) {
+        asics.insert(asic);
+    }
+    return asics;
+}
+
+std::set<AsicID> asics_with_host_rank(
+    const std::map<AsicID, MeshHostRankId>& asic_to_host_rank,
+    MeshHostRankId rank,
+    const std::set<AsicID>& physical_asics) {
+    std::set<AsicID> asics;
+    for (const auto& asic : physical_asics) {
+        const auto it = asic_to_host_rank.find(asic);
+        if (it != asic_to_host_rank.end() && it->second == rank) {
+            asics.insert(asic);
+        }
+    }
+    return asics;
+}
+
+std::optional<MeshHostRankId> fabric_node_rank(
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank, FabricNodeId fabric_node) {
+    const auto it = node_to_host_rank.find(fabric_node);
+    if (it == node_to_host_rank.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+}  // namespace
+
+int port_type_preference_rank(tt::tt_metal::PortType port_type) {
+    using tt::tt_metal::PortType;
+    switch (port_type) {
+        case PortType::TRACE: return 0;
+        case PortType::WARP400: return 1;
+        case PortType::QSFP_DD: return 2;
+        case PortType::WARP100: return 3;
+        case PortType::LINKING_BOARD_1:
+        case PortType::LINKING_BOARD_2:
+        case PortType::LINKING_BOARD_3: return 50;
+        case PortType::UNKNOWN: return 100;
+    }
+    return 100;
+}
+
+PortTypeLinkKey canonical_port_type_link_key(tt::tt_metal::AsicID a, tt::tt_metal::AsicID b) {
+    if (a < b) {
+        return {a, b};
+    }
+    return {b, a};
+}
+
+namespace {
+
+bool port_type_link_has_type(const PortTypeLinkMap& port_type_links, AsicID a, AsicID b, PortType port_type) {
+    const auto key = canonical_port_type_link_key(a, b);
+    const auto it = port_type_links.find(key);
+    return it != port_type_links.end() && it->second == port_type;
+}
+
+}  // namespace
+
+PortTypeLinkMap build_port_type_link_map(
+    const tt::tt_metal::PhysicalSystemDescriptor& psd, const std::set<tt::tt_metal::AsicID>& mesh_asics) {
+    using tt::tt_metal::AsicID;
+    using tt::tt_metal::PortType;
+    PortTypeLinkMap port_type_links;
+    for (const auto& src : mesh_asics) {
+        for (const auto& dst : psd.get_asic_neighbors(src)) {
+            if (src == dst || !mesh_asics.contains(dst)) {
+                continue;
+            }
+            for (const auto& eth_conn : psd.get_eth_connections(src, dst)) {
+                if (eth_conn.port_type == PortType::UNKNOWN) {
+                    continue;
+                }
+                const auto key = canonical_port_type_link_key(src, dst);
+                const auto it = port_type_links.find(key);
+                if (it == port_type_links.end() ||
+                    port_type_preference_rank(eth_conn.port_type) < port_type_preference_rank(it->second)) {
+                    port_type_links[key] = eth_conn.port_type;
+                }
+            }
+        }
+    }
+    return port_type_links;
+}
+
+LogicalEdgePortRequirement infer_logical_edge_port_requirement(MeshHostRankId rank_a, MeshHostRankId rank_b) {
+    LogicalEdgePortRequirement requirement;
+    if (rank_a == ::tt::tt_fabric::MESH_HOST_RANK_UNSET || rank_b == ::tt::tt_fabric::MESH_HOST_RANK_UNSET) {
+        return requirement;
+    }
+    if (rank_a == rank_b) {
+        requirement.preferred = tt::tt_metal::PortType::TRACE;
+    } else {
+        requirement.required = tt::tt_metal::PortType::QSFP_DD;
+    }
+    return requirement;
+}
+
+std::set<tt::tt_metal::AsicID> compute_preferred_asics_for_fabric_node(
+    FabricNodeId fabric_node,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const PortTypeLinkMap& port_type_links) {
+    using tt::tt_metal::AsicID;
+    const auto fabric_rank = fabric_node_rank(node_to_host_rank, fabric_node);
+    if (!fabric_rank.has_value()) {
+        return {};
+    }
+
+    const auto logical_it = logical_adjacency.find(fabric_node);
+    if (logical_it == logical_adjacency.end()) {
+        return {};
+    }
+
+    const auto physical_asics = physical_asics_from_adjacency(physical_adjacency);
+    std::optional<std::set<AsicID>> preferred_asics;
+
+    for (const auto& neighbor : logical_it->second) {
+        const auto neighbor_rank = fabric_node_rank(node_to_host_rank, neighbor);
+        if (!neighbor_rank.has_value()) {
+            continue;
+        }
+
+        const auto edge_requirement = infer_logical_edge_port_requirement(fabric_rank.value(), neighbor_rank.value());
+        if (!edge_requirement.preferred.has_value()) {
+            continue;
+        }
+
+        const auto neighbor_rank_asics = asics_with_host_rank(asic_to_host_rank, neighbor_rank.value(), physical_asics);
+        std::set<AsicID> candidates_for_neighbor;
+        for (const auto& candidate : physical_asics) {
+            for (const auto& neighbor_asic : neighbor_rank_asics) {
+                if (port_type_link_has_type(port_type_links, candidate, neighbor_asic, *edge_requirement.preferred)) {
+                    candidates_for_neighbor.insert(candidate);
+                    break;
+                }
+            }
+        }
+
+        if (!preferred_asics.has_value()) {
+            preferred_asics = std::move(candidates_for_neighbor);
+        } else {
+            std::set<AsicID> intersection;
+            std::set_intersection(
+                preferred_asics->begin(),
+                preferred_asics->end(),
+                candidates_for_neighbor.begin(),
+                candidates_for_neighbor.end(),
+                std::inserter(intersection, intersection.begin()));
+            preferred_asics = std::move(intersection);
+        }
+    }
+
+    return preferred_asics.value_or(std::set<AsicID>{});
+}
+
+std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
+    FabricNodeId fabric_node,
+    const LogicalAdjacencyMap& logical_adjacency,
+    const PhysicalAdjacencyMap& physical_adjacency,
+    const std::map<FabricNodeId, MeshHostRankId>& node_to_host_rank,
+    const std::map<tt::tt_metal::AsicID, MeshHostRankId>& asic_to_host_rank,
+    const PortTypeLinkMap& port_type_links) {
+    using tt::tt_metal::AsicID;
+    const auto fabric_rank = fabric_node_rank(node_to_host_rank, fabric_node);
+    if (!fabric_rank.has_value()) {
+        return {};
+    }
+
+    const auto logical_it = logical_adjacency.find(fabric_node);
+    if (logical_it == logical_adjacency.end()) {
+        return {};
+    }
+
+    const auto physical_asics = physical_asics_from_adjacency(physical_adjacency);
+    std::set<AsicID> required_asics = physical_asics;
+    bool has_cross_host_neighbor = false;
+
+    for (const auto& neighbor : logical_it->second) {
+        const auto neighbor_rank = fabric_node_rank(node_to_host_rank, neighbor);
+        if (!neighbor_rank.has_value()) {
+            continue;
+        }
+
+        const auto edge_requirement = infer_logical_edge_port_requirement(fabric_rank.value(), neighbor_rank.value());
+        if (!edge_requirement.required.has_value()) {
+            continue;
+        }
+
+        has_cross_host_neighbor = true;
+        const auto neighbor_rank_asics = asics_with_host_rank(asic_to_host_rank, neighbor_rank.value(), physical_asics);
+        std::set<AsicID> candidates_for_neighbor;
+        for (const auto& candidate : required_asics) {
+            for (const auto& neighbor_asic : neighbor_rank_asics) {
+                if (port_type_link_has_type(port_type_links, candidate, neighbor_asic, *edge_requirement.required)) {
+                    candidates_for_neighbor.insert(candidate);
+                    break;
+                }
+            }
+        }
+        required_asics = std::move(candidates_for_neighbor);
+        if (required_asics.empty()) {
+            break;
+        }
+    }
+
+    if (!has_cross_host_neighbor) {
+        return physical_asics;
+    }
+    return required_asics;
+}
+
 TopologyMappingResult map_mesh_to_physical(
     MeshId mesh_id,
     const LogicalAdjacencyMap& logical_adjacency,

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -1917,8 +1917,7 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
     }
 }
 
-// Port-type-aware inter-mesh preferred constraints: host locality + cross-partition QSFP preference.
-// Replaces add_inter_mesh_minimal_host_cover_from_hostname_map when port_type_links is populated.
+// Inter-mesh preferred constraints using port-type link metadata and host locality.
 void add_inter_mesh_port_type_preferred_constraints(
     const TopologyMappingConfig& config,
     const PhysicalMultiMeshGraph& physical_graph,

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -221,7 +221,7 @@ std::set<tt::tt_metal::AsicID> compute_required_asics_for_fabric_node(
         return {};
     }
 
-    const auto physical_asics = physical_asics_from_adjacency(physical_adjacency);
+    auto physical_asics = physical_asics_from_adjacency(physical_adjacency);
     std::set<AsicID> required_asics = physical_asics;
     bool has_cross_host_neighbor = false;
 

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -313,8 +313,8 @@ std::set<MeshId> compute_preferred_physical_meshes_for_logical_mesh(
     const PhysicalMultiMeshGraph& physical_graph,
     const PortTypeLinkMap& port_type_links,
     const std::set<MeshId>& bound_physical_mesh_ids) {
-    const auto unbound = unbound_physical_meshes(physical_graph, bound_physical_mesh_ids);
-    const auto logical_neighbors = mesh_logical_level_graph.get_neighbors(logical_mesh);
+    auto unbound = unbound_physical_meshes(physical_graph, bound_physical_mesh_ids);
+    const auto& logical_neighbors = mesh_logical_level_graph.get_neighbors(logical_mesh);
     if (logical_neighbors.empty()) {
         return unbound;
     }


### PR DESCRIPTION
### PR Category
Feature

### Summary
Relates to #44933. Depends on #44932. 

Consumes PSD EthConnection.port_type metadata in the topology mapper and wires preferred/required SAT constraints plus DFS consistency validation for port-type compatibility.

**Done:**
- PortTypeLinkMap and helpers to build port-type adjacency from PSD eth connections (build_port_type_link_map)
- TopologyMappingConfig::port_type_links populated in TopologyMapper
- Intra-mesh soft preferred: same-host logical edges prefer TRACE via add_preferred_constraint in map_mesh_to_physical and the multi-mesh intra-mesh loop
- Intra-mesh hard required: cross-host logical edges require QSFP_DD via add_required_constraint; fail fast before SAT when no candidate exists
- Inter-mesh soft preferred: when port_type_links is set, add_inter_mesh_port_type_preferred_constraints replaces the hostname host-cover heuristic with SAT preferred constraints (host-locality plus cross-partition QSFP); falls back to add_inter_mesh_minimal_host_cover_from_hostname_map when port types are absent
- ConsistencyChecker: cross-host mapped pairs validated for QSFP_DD in local and forward consistency checks
- Unit/integration tests under PortTypeMappingHelpers.* and ConsistencyCheckerPortTypeCrossHostValidation

When port_type_links is absent, behavior is unchanged (existing synthetic tests pass).

### Notes for reviewers
- Two intra-mesh call sites: map_mesh_to_physical and the multi-mesh intra-mesh loop. They are separate code paths; only one runs per invocation. Both wire required, then preferred, then attach port-type validation context, then solve.
- Uses add_preferred_constraint and add_required_constraint with per-node ASIC sets instead of trait constraints, because port-type rules are neighbor- and rank-dependent.
- Soft vs hard: same-host TRACE is preferred only; cross-host QSFP_DD is required in SAT and checked again in DFS ConsistencyChecker.
- Inter-mesh: host-cover is gated, not deleted. The new path runs when port_type_links is populated; the old heuristic remains for tests without PSD port metadata.
- Review focus: add_intra_mesh_port_type_preferred_constraints, add_intra_mesh_port_type_required_constraints, add_inter_mesh_port_type_preferred_constraints, constraint ordering (after pinning, before solve), and MapMeshPrefersTraceForSameHostEdge, MapMeshFailsWhenNoQsfpPath, MapMultiMeshPrefersQsfpConnectedPhysicalPartition.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/44933-port-type-topology-mapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/44933-port-type-topology-mapper)