### PR TITLE
bernoulli/uniform/rand/dropout: include per-call scalars in program hash

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
@@ -141,3 +141,36 @@ def test_bernoulli_with_compute_kernel_options(shape, in_dtype, out_dtype, devic
         npu_input, seed, dtype=get_lib_dtype(ttnn, out_dtype), compute_kernel_config=compute_kernel_config
     )
     assert list(npu_output.shape) == shape
+
+
+def test_bernoulli_seed_distinguishes_cache_entries(device):
+    """Regression: descriptor framework only re-patches Buffer* slots on cache hit.
+    `seed` is a non-Buffer RTA scalar; if it's omitted from compute_program_hash,
+    two same-shape calls with different seeds collide on the cached program and
+    the second uses the first call's seed. Asserts both the observable outcome
+    (different seed -> different output) and the underlying mechanism
+    (different seed -> distinct cache entry)."""
+    import torch
+
+    shape = [1, 32, 64]
+    cpu_input = torch.full(shape, 0.5, dtype=torch.float32)
+    npu_input = ttnn.from_torch(cpu_input, device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+    out_a = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=1234, dtype=ttnn.float32))
+    cache_after_a = device.num_program_cache_entries()
+
+    out_b = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=1234, dtype=ttnn.float32))
+    cache_after_b = device.num_program_cache_entries()
+
+    out_c = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=5678, dtype=ttnn.float32))
+    cache_after_c = device.num_program_cache_entries()
+
+    assert cache_after_b == cache_after_a, "same seed must reuse the cached program"
+    assert cache_after_c > cache_after_b, (
+        "different seed must produce a distinct cache entry — otherwise the second call "
+        "silently reuses the first call's seed (cache-collision bug)"
+    )
+    assert not torch.equal(out_a, out_c), "different seeds must produce different outputs"

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
@@ -97,7 +97,11 @@ def test_bernoulli_api_contract(shape, in_dtype, out_dtype, device, is_out_alloc
 @pytest.mark.parametrize("out_dtype", ["float32"])
 def test_bernoulli_callback(shape, seed, in_dtype, out_dtype, device):
     """
-    Tests program cache hits for the bernoulli operation.
+    Tests program cache hits for the bernoulli operation on identical (same-seed) calls.
+
+    NOTE: seed is now part of compute_program_hash (descriptor framework can't re-apply
+    non-Buffer RTAs on cache hit), so calls with different seeds each produce a new
+    cache entry. Same-seed calls still hit cache, which is what this test verifies.
     """
     num_program_cache_entries_list = []
     for i in range(2):
@@ -105,8 +109,8 @@ def test_bernoulli_callback(shape, seed, in_dtype, out_dtype, device):
         npu_input = ttnn.from_torch(
             cpu_input, device=device, dtype=get_lib_dtype(ttnn, in_dtype), layout=ttnn.TILE_LAYOUT
         )
-        # The operation itself is simple, the main point is to check the cache.
-        ttnn.bernoulli(npu_input, seed + i, dtype=get_lib_dtype(ttnn, out_dtype))
+        # Same seed each iteration → must cache-hit on the second call.
+        ttnn.bernoulli(npu_input, seed, dtype=get_lib_dtype(ttnn, out_dtype))
         # Add dummy tensor to make sure that created tensor in 2nd iteration doesn't share the same addr
         ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
@@ -162,7 +166,7 @@ def test_bernoulli_seed_distinguishes_cache_entries(device):
     out_a = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=1234, dtype=ttnn.float32))
     cache_after_a = device.num_program_cache_entries()
 
-    out_b = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=1234, dtype=ttnn.float32))
+    ttnn.bernoulli(npu_input, seed=1234, dtype=ttnn.float32)
     cache_after_b = device.num_program_cache_entries()
 
     out_c = ttnn.to_torch(ttnn.bernoulli(npu_input, seed=5678, dtype=ttnn.float32))

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -540,7 +540,7 @@ def test_rand_seed_range_distinguish_cache_entries(device):
     a = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=1234, **common))
     cache_a = device.num_program_cache_entries()
 
-    b_same = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=1234, **common))
+    ttnn.rand(shape=shape, low=0.0, high=1.0, seed=1234, **common)
     cache_b = device.num_program_cache_entries()
 
     c_seed = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=5678, **common))

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -524,3 +524,39 @@ def test_rand_mesh_2d_shard_and_replicate(mesh_device, shard_mesh_dim):
                     f"Device {coord} and device {tuple(shard_neighbor)} are on different "
                     f"shards but hold identical data"
                 )
+
+
+def test_rand_seed_range_distinguish_cache_entries(device):
+    """Regression: descriptor framework only re-patches Buffer* slots on cache hit.
+    `seed`, `from`, and `to` are non-Buffer RTA scalars on rand. If any are
+    omitted from compute_program_hash, calls that differ only in those values
+    collide on the cached program and silently reuse the first call's values."""
+    shape = (1, 32, 64)
+    common = dict(device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+    a = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=1234, **common))
+    cache_a = device.num_program_cache_entries()
+
+    b_same = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=1234, **common))
+    cache_b = device.num_program_cache_entries()
+
+    c_seed = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=1.0, seed=5678, **common))
+    cache_c = device.num_program_cache_entries()
+
+    d_high = ttnn.to_torch(ttnn.rand(shape=shape, low=0.0, high=10.0, seed=1234, **common))
+    cache_d = device.num_program_cache_entries()
+
+    e_low = ttnn.to_torch(ttnn.rand(shape=shape, low=-1.0, high=1.0, seed=1234, **common))
+    cache_e = device.num_program_cache_entries()
+
+    assert cache_b == cache_a, "same params must reuse the cached program"
+    assert cache_c > cache_b, "different seed must produce a distinct cache entry"
+    assert cache_d > cache_c, "different `high` must produce a distinct cache entry"
+    assert cache_e > cache_d, "different `low` must produce a distinct cache entry"
+
+    assert not torch.equal(a, c_seed), "different seeds must produce different outputs"
+    assert d_high.max() > 1.5, "different `high` must actually take effect — output range was capped to first call's"
+    assert e_low.min() < -0.1, "different `low` must actually take effect — output range was floored to first call's"

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
@@ -121,6 +121,14 @@ def test_uniform(shape, rand_range, dtype, seed, device):
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("seed", [0])
 def test_uniform_callback(shape, rand_range, dtype, seed, device):
+    """
+    NOTE: seed is now part of compute_program_hash (descriptor framework can't re-apply
+    non-Buffer RTAs on cache hit), so different-seed calls each produce a new cache
+    entry. This test was previously asserting that changing seed still cache-hit, which
+    relied on legacy override_runtime_arguments patching the seed RTA every dispatch.
+    Reframed to verify same-seed cache-hit, which is what the cache invariant actually
+    is now.
+    """
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):
@@ -128,9 +136,6 @@ def test_uniform_callback(shape, rand_range, dtype, seed, device):
         # Add dummy tensor to make sure that created tensor in 2 iteration don't share the same addr
         tt_dummy_tensor = ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
         num_program_cache_entries_list.append(device.num_program_cache_entries())
-
-        # Cache must hit when we change seed and seed runtime arg is overrode
-        seed = seed + 1
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
@@ -148,3 +148,34 @@ def test_uniform_callback(shape, rand_range, dtype, seed, device):
 def test_uniform_with_compute_kernel_options(shape, seed, rand_range, dtype, device, compute_kernel_options):
     torch.manual_seed(seed)
     run_uniform(shape, rand_range, dtype, device, seed=seed, compute_kernel_options=compute_kernel_options)
+
+
+def test_uniform_seed_distinguishes_cache_entries(device):
+    """Regression: descriptor framework only re-patches Buffer* slots on cache hit.
+    `seed` is a non-Buffer RTA scalar; if it's omitted from compute_program_hash,
+    two same-shape calls with different seeds collide on the cached program and
+    the second uses the first call's seed."""
+    shape = [1, 32, 64]
+    cpu_input = torch.zeros(shape, dtype=torch.float32)
+    npu_input = ttnn.from_torch(cpu_input, device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+    ttnn.uniform(npu_input, 0.0, 1.0, seed=1234)
+    out_a = ttnn.to_torch(npu_input).clone()
+    cache_after_a = device.num_program_cache_entries()
+
+    ttnn.uniform(npu_input, 0.0, 1.0, seed=1234)
+    cache_after_b = device.num_program_cache_entries()
+
+    ttnn.uniform(npu_input, 0.0, 1.0, seed=5678)
+    out_c = ttnn.to_torch(npu_input).clone()
+    cache_after_c = device.num_program_cache_entries()
+
+    assert cache_after_b == cache_after_a, "same seed must reuse the cached program"
+    assert cache_after_c > cache_after_b, (
+        "different seed must produce a distinct cache entry — otherwise the second call "
+        "silently reuses the first call's seed (cache-collision bug)"
+    )
+    assert not torch.equal(out_a, out_c), "different seeds must produce different outputs"

--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -57,3 +57,31 @@ def test_dropout_output_tensor(device):
     assert torch.allclose(
         tensor_torch, output_torch
     ), "output_tensor parameter not working: input tensor was not modified in place"
+
+
+def test_dropout_seed_distinguishes_cache_entries(device):
+    """Regression: descriptor framework only re-patches Buffer* slots on cache hit.
+    `seed` is a non-Buffer RTA scalar; if it's omitted from compute_program_hash,
+    two same-shape calls with different seeds collide on the cached program and
+    the second uses the first call's seed (identical dropout mask)."""
+    t = torch.ones((1, 1, 32, 64))
+    tensor = ttnn.from_torch(t, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+
+    out_a = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=1234))
+    cache_after_a = device.num_program_cache_entries()
+
+    out_b = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=1234))
+    cache_after_b = device.num_program_cache_entries()
+
+    out_c = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=5678))
+    cache_after_c = device.num_program_cache_entries()
+
+    assert cache_after_b == cache_after_a, "same seed must reuse the cached program"
+    assert cache_after_c > cache_after_b, (
+        "different seed must produce a distinct cache entry — otherwise the second call "
+        "silently reuses the first call's seed (identical dropout mask bug)"
+    )
+    assert not torch.equal(out_a, out_c), "different seeds must produce different dropout masks"

--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -73,7 +73,7 @@ def test_dropout_seed_distinguishes_cache_entries(device):
     out_a = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=1234))
     cache_after_a = device.num_program_cache_entries()
 
-    out_b = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=1234))
+    ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=1234)
     cache_after_b = device.num_program_cache_entries()
 
     out_c = ttnn.to_torch(ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=5678))

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -66,6 +66,7 @@ ttsl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     return ttsl::hash::hash_objects_with_default_seed(
         ttsl::hash::type_hash<BernoulliDeviceOperation>,
+        attrs.seed,
         attrs.dtype,
         attrs.memory_config,
         attrs.compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -110,15 +110,9 @@ ttsl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     const auto& input_shape = input_tensor.padded_shape();
-    auto args_without_seed = args;
-    args_without_seed.seed = 0;
     auto program_factory = select_program_factory(args, tensor_args);
     operation::Hash hash = operation::hash_operation<DropoutDeviceOperation>(
-        args_without_seed,
-        program_factory.index(),
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_shape.volume());
+        args, program_factory.index(), input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -50,7 +50,8 @@ ttsl::hash::hash_t RandDeviceOperation::compute_program_hash(
         operation_attributes.memory_config,
         operation_attributes.seed,
         operation_attributes.from,
-        operation_attributes.to);
+        operation_attributes.to,
+        operation_attributes.mesh_dim_is_sharded);
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -47,7 +47,10 @@ ttsl::hash::hash_t RandDeviceOperation::compute_program_hash(
         operation_attributes.shape,
         operation_attributes.dtype,
         operation_attributes.layout,
-        operation_attributes.memory_config);
+        operation_attributes.memory_config,
+        operation_attributes.seed,
+        operation_attributes.from,
+        operation_attributes.to);
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -35,9 +35,7 @@ UniformDeviceOperation::tensor_return_value_t UniformDeviceOperation::create_out
 }
 
 ttsl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
-    return ttsl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
+    return ttsl::hash::hash_objects_with_default_seed(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::operations::uniform


### PR DESCRIPTION
## Summary

Four ops on `main` (`bernoulli`, `uniform`, `rand`, `experimental/dropout`) were migrated to the descriptor framework but kept their pre-migration custom `compute_program_hash`, which **excludes `seed`** (and for `rand`, also `from`/`to`).

Under the legacy contract this exclusion was correct: `override_runtime_arguments` patched the scalar into RTAs on every dispatch, so the hash didn't need to differentiate. The descriptor framework only re-patches `Buffer*` slots on cache hit — **non-Buffer RTAs are baked at first cache miss and never updated**.

Result on `main` today: two same-shape calls with different seeds collide on the cached program and the second uses the first call's seed.

Surfaced during the audit triggered by @AudreyKertesz's review of #45332, which generalized the cache-hit-correctness rule beyond CB sizing to **every** previously-mutable slot (non-Buffer RTAs, CRTAs, CB total_size / page_size, compile-time args/defines).

## Repro (LLM token sampling on main)

```python
out1 = ttnn.bernoulli(x, seed=1)
out2 = ttnn.bernoulli(x, seed=2)   # cache hit on the seed=1 program
assert torch.equal(ttnn.to_torch(out1), ttnn.to_torch(out2))  # passes — bug
```

Same pattern for `uniform`, `rand`, `experimental/dropout`.

## Fix

Minimal: include the missing fields in each op's `compute_program_hash`.
- `bernoulli`: add `attrs.seed`
- `uniform`: stop zeroing `seed` before hashing
- `rand`: add `seed`, `from`, `to`
- `dropout`: stop zeroing `seed` before hashing

Each unique seed now gets its own cache entry. Trades cache-hit reuse on varying-seed loops for correctness.

## Perf measurement (microbench, shape 1×1×32×32, warm ELF cache)

| Op | Cache MISS | Cache HIT | Per-call delta | Slowdown |
|---|---|---|---|---|
| bernoulli (f32) | 0.39 ms | 0.07 ms | +0.32 ms | 5.6× |
| uniform (f32) | 0.22 ms | 0.01 ms | +0.20 ms | 17.7× |
| rand (f32) | 0.22 ms | 0.02 ms | +0.20 ms | 10.0× |
| dropout (bf16) | 0.31 ms | 0.02 ms | +0.28 ms | 14.5× |

Aggregate impact in realistic loops:
- BERT training dropout (~15 dropout calls/step, fresh seed): **+4.2 ms/step**
- LLM token sampling (100 RNGs/sequence): **+30 ms/sequence**
- Constant-seed fixtures (test code): **0 ms** (still cache-reuses)

The regression is bounded — RNG/dropout call counts per step are small. For most production workloads, the per-step overhead is sub-10ms.

## Side effects worth knowing

1. **Program cache memory.** Each unique seed becomes a permanent cache entry. Long-running jobs (100k steps × 15 dropout calls) accumulate ~1.5M entries unless the framework evicts. Worth confirming the program cache has bounded size / LRU.
2. **"Regression" is also correctness restoration.** Today's fast hits produce the same seed every call. Models that have been silently using identical dropout masks across steps will see different (correct) behavior — may surface as model-test PCC drift unrelated to the per-call timing.

## Long-term

This is the minimal correctness fix. The structural fix — declarative per-slot patching of non-Buffer RTAs in the descriptor framework (a `ScalarBinding` analog to `BufferBinding`) — is deferred to Metal 2.0's semantic tensor bindings. Until then, the migration playbook rule is: **before migrating an op to descriptors, if its legacy `override_runtime_arguments` mutates anything besides `Buffer*` addresses, defer.**

## Test plan

- [ ] PR Gate green
- [ ] Sanity + runtime sanity on branch
- [ ] Spot-check `tests/ttnn/unit_tests/operations/test_bernoulli.py`, `test_uniform.py`, `test_rand.py`, and the dropout tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-rng-dropout-hash-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-rng-dropout-hash-coverage)