### PR TITLE
[DEBUG / DO NOT MERGE] all_to_all_combine: isolated repro + runtime logging for PR-44408 regression

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -64,9 +64,10 @@ jobs:
             test-type: fast-viommu
           - name: ttnn ops fast unit tests (ccl, DRAM prefetcher)
             cmd: |
-              pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit
-              # Disabled due to issue https://github.com/tenstorrent/tt-metal/issues/41040
-              # pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+              # DEBUG-ONLY (branch dgomez/debug-a2a-combine-bug): isolate test_all_to_all_combine_no_trace
+              # with TT_METAL log level cranked up to capture host-side state. All other CCL tests
+              # in this job are skipped on this branch so the failing variant gets full CI bandwidth.
+              TT_METAL_LOGGER_TYPES=Op TT_METAL_LOGGER_LEVEL=DEBUG pytest -svv tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py
             timeout: 15
             test-type: fast
           # NOTE: All slow / loudbox / qb multi-card BH tests have been migrated

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -67,7 +67,11 @@ jobs:
               # DEBUG-ONLY (branch dgomez/debug-a2a-combine-bug): isolate test_all_to_all_combine_no_trace
               # with TT_METAL log level cranked up to capture host-side state. All other CCL tests
               # in this job are skipped on this branch so the failing variant gets full CI bandwidth.
-              TT_METAL_LOGGER_TYPES=Op TT_METAL_LOGGER_LEVEL=DEBUG pytest -svv tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py
+              # Enable device-side DPRINT on all worker cores for risc 0 (writer kernel),
+              # so the kernel's own log of the RTAs it reads at runtime ends up in CI output.
+              TT_METAL_DPRINT_CORES='(0,0)' TT_METAL_DPRINT_RISCVS='BR' \
+                TT_METAL_LOGGER_TYPES=Op TT_METAL_LOGGER_LEVEL=DEBUG \
+                pytest -svv tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py
             timeout: 15
             test-type: fast
           # NOTE: All slow / loudbox / qb multi-card BH tests have been migrated

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py
@@ -78,6 +78,9 @@ def test_all_to_all_combine_no_trace(
 
     bh_1d_mesh_device.disable_and_clear_program_cache()
     submesh_device = bh_1d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    # DEBUG: parent disable_and_clear_program_cache may not propagate to submesh.
+    # Force-disable on the submesh too to isolate cache-hit-vs-miss as a variable.
+    submesh_device.disable_and_clear_program_cache()
 
     run_all_to_all_combine_test(
         submesh_device,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -16,6 +16,16 @@ namespace ttnn::operations::ccl {
 
 void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    log_info(
+        tt::LogOp,
+        "[a2a_combine DBG] CACHE MISS — building fresh workload (input.buffer={:p} addr=0x{:x} | mapping.buffer={:p} "
+        "addr=0x{:x} | metadata.buffer={:p} addr=0x{:x})",
+        (void*)tensor_args.input_tensor.buffer(),
+        tensor_args.input_tensor.buffer()->address(),
+        (void*)tensor_args.mapping_tensor.buffer(),
+        tensor_args.mapping_tensor.buffer()->address(),
+        (void*)tensor_args.metadata_tensor.buffer(),
+        tensor_args.metadata_tensor.buffer()->address());
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& metadata_tensor = tensor_args.metadata_tensor;
     const auto& mapping_tensor = tensor_args.mapping_tensor;
@@ -111,7 +121,18 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
 }
 
 void AllToAllCombineDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    log_info(
+        tt::LogOp,
+        "[a2a_combine DBG] CACHE HIT — reusing cached workload (input.buffer={:p} addr=0x{:x} | mapping.buffer={:p} "
+        "addr=0x{:x} | metadata.buffer={:p} addr=0x{:x})",
+        (void*)tensor_args.input_tensor.buffer(),
+        tensor_args.input_tensor.buffer()->address(),
+        (void*)tensor_args.mapping_tensor.buffer(),
+        tensor_args.mapping_tensor.buffer()->address(),
+        (void*)tensor_args.metadata_tensor.buffer(),
+        tensor_args.metadata_tensor.buffer()->address());
+}
 
 AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -230,22 +230,12 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
         dest_mesh_id.push_back(*coord_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)coord_fabric_node_id.chip_id);
     }
-    {
-        std::vector<uint32_t> dbg_mesh_id_via_coords, dbg_chip_id_via_coords;
-        for (const auto& coord : tensor_coords.coords()) {
-            const auto fn = mesh_device->get_fabric_node_id(coord);
-            dbg_mesh_id_via_coords.push_back(*fn.mesh_id);
-            dbg_chip_id_via_coords.push_back((uint32_t)fn.chip_id);
-        }
-        log_info(
-            tt::LogOp,
-            "[a2a_combine DBG] coord={} src_chip_id={} | view_chip_id={} | coords_chip_id={} | match={}",
-            mesh_coordinate,
-            src_chip_id,
-            common::stringify(dest_chip_id),
-            common::stringify(dbg_chip_id_via_coords),
-            dbg_chip_id_via_coords == dest_chip_id);
-    }
+    log_info(
+        tt::LogOp,
+        "[a2a_combine DBG] coord={} src_chip_id={} dest_chip_id_via_view={}",
+        mesh_coordinate,
+        src_chip_id,
+        common::stringify(dest_chip_id));
     const auto [neighbors, directions] = common::get_neighbors(mesh_view, mesh_coordinate, topology, axis);
     log_info(
         tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -220,16 +220,48 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
     };
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
-    // fabric routing info — enumerated for every device in the mesh in row-major order to
-    // build the DEST_CHIP_ID / DEST_MESH_ID define arrays consumed by the writer kernel.
-    // Mirrors the legacy use of `all_mesh_coordinates` (passed as tensor_coords.coords()),
-    // which for these CCL ops covers the entire mesh.
+    // DEBUG-ONLY (branch dgomez/debug-a2a-combine-bug): build dest_chip_id/dest_mesh_id from
+    // tensor_coords.coords() (the legacy path) and ALSO from mesh_view.get_fabric_node_ids()
+    // (the current main path), compare them, log both. The 1D-topology kernel path doesn't
+    // actually consume dest_chip_ids[] for routing, but logging this lets us confirm at
+    // runtime whether the two iteration sources actually differ for this submesh.
     std::vector<uint32_t> dest_mesh_id, dest_chip_id;
     for (const auto& coord_fabric_node_id : mesh_view.get_fabric_node_ids()) {
         dest_mesh_id.push_back(*coord_fabric_node_id.mesh_id);
         dest_chip_id.push_back((uint32_t)coord_fabric_node_id.chip_id);
     }
+    {
+        std::vector<uint32_t> dbg_mesh_id_via_coords, dbg_chip_id_via_coords;
+        for (const auto& coord : tensor_coords.coords()) {
+            const auto fn = mesh_device->get_fabric_node_id(coord);
+            dbg_mesh_id_via_coords.push_back(*fn.mesh_id);
+            dbg_chip_id_via_coords.push_back((uint32_t)fn.chip_id);
+        }
+        log_info(
+            tt::LogOp,
+            "[a2a_combine DBG] coord={} src_chip_id={} | view_chip_id={} | coords_chip_id={} | match={}",
+            mesh_coordinate,
+            src_chip_id,
+            common::stringify(dest_chip_id),
+            common::stringify(dbg_chip_id_via_coords),
+            dbg_chip_id_via_coords == dest_chip_id);
+    }
     const auto [neighbors, directions] = common::get_neighbors(mesh_view, mesh_coordinate, topology, axis);
+    log_info(
+        tt::LogOp,
+        "[a2a_combine DBG] coord={} flat_mesh_idx={} num_devices={} mesh=({},{}) topology={} "
+        "axis={} locally_reduced={} #neighbors={} directions={}",
+        mesh_coordinate,
+        common::get_linearized_index(mesh_coordinate, mesh_view),
+        num_devices,
+        mesh_view.num_rows(),
+        mesh_view.num_cols(),
+        (uint32_t)topology,
+        axis.has_value() ? (int)axis.value() : -1,
+        (uint32_t)operation_attributes.locally_reduced,
+        neighbors.size(),
+        common::stringify(std::vector<uint32_t>{
+            (uint32_t)directions[0], (uint32_t)directions[1], (uint32_t)directions[2], (uint32_t)directions[3]}));
 
     std::map<std::string, std::string> writer_defines = {
         {"DEST_CHIP_ID", common::stringify(dest_chip_id)},
@@ -309,10 +341,48 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
             token_range_end,
             (uint32_t)cross_device_semaphore.address());
 
+        const size_t rt_args_before_fabric = writer_runtime_args.size();
         for (const auto& neighbor_coordinate : neighbors) {
             const auto neighbor_fabric_id = mesh_device->get_fabric_node_id(neighbor_coordinate);
+            const size_t before = writer_runtime_args.size();
+            const size_t sem_before = desc.semaphores.size();
             append_fabric_connection_rt_args<ProgramDescriptor>(
                 fabric_node_id, neighbor_fabric_id, link_id, desc, sender_core, writer_runtime_args);
+            log_info(
+                tt::LogOp,
+                "[a2a_combine DBG] coord={} core=({},{}) neighbor={} link_id={} | "
+                "rt_args grew {}->{} (+{}) | semaphores grew {}->{} (+{})",
+                mesh_coordinate,
+                sender_core.x,
+                sender_core.y,
+                neighbor_coordinate,
+                link_id,
+                before,
+                writer_runtime_args.size(),
+                writer_runtime_args.size() - before,
+                sem_before,
+                desc.semaphores.size(),
+                desc.semaphores.size() - sem_before);
+        }
+
+        // DEBUG-ONLY: dump full writer RT args after fabric append
+        {
+            std::vector<uint32_t> dbg_args(writer_runtime_args.begin(), writer_runtime_args.end());
+            log_info(
+                tt::LogOp,
+                "[a2a_combine DBG] coord={} core=({},{}) | output_addr=0x{:x} cross_dev_sem=0x{:x} "
+                "init_sem=0x{:x} tok_range=[{},{}) | writer_rt_args(total={}, base=5, fabric={}): {}",
+                mesh_coordinate,
+                sender_core.x,
+                sender_core.y,
+                output_tensor.buffer()->address(),
+                cross_device_semaphore.address(),
+                init_semaphore.address(),
+                token_range_start,
+                token_range_end,
+                writer_runtime_args.size(),
+                writer_runtime_args.size() - rt_args_before_fabric,
+                common::stringify(dbg_args));
         }
 
         KernelDescriptor::RTArgList writer_rt_args_builder;
@@ -323,6 +393,30 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
         }
         desc.kernels[unary_writer_kernel_id].emplace_runtime_args(sender_core, writer_rt_args_builder);
         link_id++;
+    }
+
+    // DEBUG-ONLY: final descriptor summary
+    {
+        std::vector<uint32_t> sem_ids;
+        for (const auto& s : desc.semaphores) {
+            sem_ids.push_back(s.id);
+        }
+        std::vector<uint32_t> cb_sizes;
+        for (const auto& cb : desc.cbs) {
+            cb_sizes.push_back(cb.total_size);
+        }
+        log_info(
+            tt::LogOp,
+            "[a2a_combine DBG] coord={} | final desc: #cbs={} cb_sizes={} #semaphores={} sem_ids={} "
+            "#kernels={} reader_rt_arg_lists={} writer_rt_arg_lists={}",
+            mesh_coordinate,
+            desc.cbs.size(),
+            common::stringify(cb_sizes),
+            desc.semaphores.size(),
+            common::stringify(sem_ids),
+            desc.kernels.size(),
+            desc.kernels[ternary_reader_kernel_id].runtime_args.size(),
+            desc.kernels[unary_writer_kernel_id].runtime_args.size());
     }
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
@@ -103,6 +104,13 @@ void kernel_main() {
     const auto init_semaphore_addr = get_arg_val<uint32_t>(rt_arg_count++);
     const uint32_t token_start_idx = get_arg_val<uint32_t>(rt_arg_count++);
     const uint32_t token_end_idx = get_arg_val<uint32_t>(rt_arg_count++);
+
+    // DEBUG: print the values the kernel ACTUALLY reads at runtime (DPRINT no-ops
+    // if device-side prints aren't enabled, so this is safe to leave compiled in).
+    DPRINT << "[a2a_combine KERNEL DBG] linearized_mesh_coord=" << (uint32_t)linearized_mesh_coord
+           << " src_chip_id=" << (uint32_t)src_chip_id << " output_base_addr=0x" << HEX() << output_base_addr
+           << " global_sema=0x" << HEX() << global_semaphore_addr << " init_sema=0x" << HEX() << init_semaphore_addr
+           << " tok_range=[" << DEC() << token_start_idx << "," << token_end_idx << ")" << ENDL();
 
     std::array<WorkerToFabricEdmSender, Num_Directions> fabric_connections;
     open_direction_connections_async(directions, fabric_connections, rt_arg_count);


### PR DESCRIPTION
## Purpose

**DEBUG-ONLY** branch. Investigates the `test_all_to_all_combine_no_trace[l1-l1, ring, local_reduce=True, axis=0, mesh_shape=(4,1)]` failure that PR #44408 (the descriptor migration of all_to_all_combine + all_to_all_dispatch) introduced.

This test has been red on every main BHPC LLMBox CCL run since 2026-05-23. My PR #45332's iteration-order fix doesn't address it (1D topology kernel path doesn't read `DEST_CHIP_ID[]`). Static analysis has been exhausted; need runtime data.

## What this branch does

1. **Restricts the BHPC LLMBox CCL job to ONLY the failing test** (and only that test file). Changes `blackhole-multi-card-unit-tests-impl.yaml` so the "ttnn ops fast unit tests (ccl, DRAM prefetcher)" matrix entry runs:
   ```
   TT_METAL_LOGGER_TYPES=Op TT_METAL_LOGGER_LEVEL=DEBUG pytest -svv tests/.../all_post_commit/test_all_to_all_combine_bh.py
   ```
   Other CCL fast-unit tests (all_gather, reduce_scatter, etc.) and the DRAM prefetcher are skipped on this branch only. Total job runtime drops from ~5min to ~30s, so we can iterate fast.

2. **Adds host-side `log_info()` calls** in `all_to_all_combine_program_factory.cpp` printing, per coord and per sender_core:
   - `src_chip_id`, linearized mesh index, num_devices, mesh shape, topology, axis, `locally_reduced`, neighbor count, `DIRECTIONS[]` bool array
   - Both `dest_chip_id` iteration paths (`mesh_view.get_fabric_node_ids()` vs `tensor_coords.coords()`) — confirms whether they actually differ for this submesh
   - Per-core: `output_tensor.buffer()->address()`, both `GlobalSemaphore.address()`s, token range
   - Full `writer_runtime_args` vector dump after `append_fabric_connection_rt_args<ProgramDescriptor>` per neighbor
   - Per-neighbor: how many uint32s and SemaphoreDescriptors the fabric helper added
   - Final descriptor summary: CB count + sizes, semaphore count + IDs, kernel rt-arg-list sizes

Once a run produces these logs from all 4 devices, I'll diff against the legacy behavior (commit `79925a3`, last green) and localize where the divergence begins.

## Not for merge

This is a throwaway investigation branch. Once we have a root-cause fix, that goes in a separate PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/debug-a2a-combine-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/debug-a2a-combine-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/debug-a2a-combine-bug)