### PR TITLE
Fix MatmulMultiCoreReuseProgramConfig shard grid validation

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -290,6 +290,32 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
+void validate_matmul_sharded_operand_grids_within_program_compute_grid(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
+                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
+                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
+                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
+                // The only physical constraint is that the shard grid fits within the device grid.
+                // For non-sharded inputs the config grid drives split_work_to_cores, so the
+                // origin-anchored check is still correct there.
+                const auto& config_grid = program_config.compute_with_storage_grid_size;
+                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
+                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
+                check_tensor_in_grid(input_tensor_a, effective_grid_a);
+                check_tensor_in_grid(input_tensor_b, effective_grid_b);
+            }
+        },
+        chosen_program_config);
+}
+
 void validate_matmul_reuse_sharded_output_block_divisibility(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -302,6 +328,9 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // Mirror the shard_spec priority in MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor:
+                // when in0 is L1-sharded its shard grid becomes the kernel grid; in1's grid is only consulted when
+                // in0 is not sharded. num_output_blocks must divide evenly across that grid or the factory fatals.
                 const Tensor* sharded = nullptr;
                 if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
                     sharded = &input_tensor_a;
@@ -831,6 +860,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
     validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
+    validate_matmul_sharded_operand_grids_within_program_compute_grid(
+        input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_reuse_sharded_output_block_divisibility(
         input_tensor_a, input_tensor_b, a_shape_padded, b_shape_padded, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_work_distribution_and_gather_ring_topology(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -290,6 +290,45 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
+void validate_matmul_reuse_sharded_output_block_divisibility(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                const Tensor* sharded = nullptr;
+                if (input_tensor_a.is_sharded() && input_tensor_a.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_a;
+                } else if (
+                    input_tensor_b.is_sharded() && input_tensor_b.memory_config().buffer_type() != BufferType::DRAM) {
+                    sharded = &input_tensor_b;
+                }
+                if (sharded == nullptr) {
+                    return;
+                }
+                const uint32_t B = get_batch_size(a_shape_padded);
+                const uint32_t Mt = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, false);
+                const uint32_t Nt = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
+                const uint32_t num_output_blocks =
+                    (B * Mt / program_config.per_core_M) * (Nt / program_config.per_core_N);
+                const uint32_t num_cores = sharded->shard_spec().value().grid.num_cores();
+                TT_FATAL(
+                    num_output_blocks % num_cores == 0,
+                    "MatmulMultiCoreReuseProgramConfig: num_output_blocks ({}) must be evenly divisible by the "
+                    "number of cores in the input shard grid ({})",
+                    num_output_blocks,
+                    num_cores);
+            }
+        },
+        chosen_program_config);
+}
+
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -792,6 +831,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
     validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
+    validate_matmul_reuse_sharded_output_block_divisibility(
+        input_tensor_a, input_tensor_b, a_shape_padded, b_shape_padded, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_work_distribution_and_gather_ring_topology(
         input_tensor_a,
         input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -290,32 +290,6 @@ void validate_matmul_compute_grid_and_per_core_dims(
         chosen_program_config);
 }
 
-void validate_matmul_sharded_operand_grids_within_program_compute_grid(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    std::visit(
-        [&](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
-                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
-                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
-                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
-                // The only physical constraint is that the shard grid fits within the device grid.
-                // For non-sharded inputs the config grid drives split_work_to_cores, so the
-                // origin-anchored check is still correct there.
-                const auto& config_grid = program_config.compute_with_storage_grid_size;
-                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
-                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
-                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
-                check_tensor_in_grid(input_tensor_a, effective_grid_a);
-                check_tensor_in_grid(input_tensor_b, effective_grid_b);
-            }
-        },
-        chosen_program_config);
-}
-
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -818,8 +792,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
     validate_matmul_fused_operations(optional_bias, attributes.user_fused_activation, chosen_program_config);
-    validate_matmul_sharded_operand_grids_within_program_compute_grid(
-        input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_work_distribution_and_gather_ring_topology(
         input_tensor_a,
         input_tensor_b,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`validate_matmul_sharded_operand_grids_within_program_compute_grid` was introduced in d447542fb66 (#43987) under the assumption that `compute_with_storage_grid_size` bounds the kernel grid for all `MatmulMultiCoreReuse*` configs. This holds for the multicast variants, but not for `MatmulMultiCoreReuseProgramConfig`:

- `MatmulMultiCoreReuseOptimizedProgramFactory` reads inputs using tile-offset addressing and, when inputs are sharded, derives its kernel grid directly from the **tensor's shard spec**, not from `compute_with_storage_grid_size`. The containment check was therefore validating a property the factory never uses.
- `MatmulMultiCoreReuseProgramConfig` maps exclusively to `MatmulMultiCoreReuseOptimizedProgramFactory` — there is no ambiguity about which factory runs.

Models using `MatmulMultiCoreReuseProgramConfig` with input tensors sharded on a grid larger than `compute_with_storage_grid_size` (e.g. stable diffusion cross-attention) were incorrectly failing validation after #43987 landed.

### Notes for reviewers
Two commits:
1. Remove `validate_matmul_sharded_operand_grids_within_program_compute_grid` — the containment check is wrong for this config.
2. Add `validate_matmul_reuse_sharded_output_block_divisibility` — when inputs are L1-sharded, the factory uses the shard grid as the kernel grid and requires `num_output_blocks % num_cores == 0`. This mirrors what the factory actually asserts and gives a clear error before dispatch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/fix_matmul_reuse_shard_grid_validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/fix_matmul_reuse_shard_grid_validation)