### PR TITLE
[skip ci] Remove UF specific label for WH galaxies

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -51,14 +51,6 @@ skus:
       - topology-6u
       - in-service
 
-  # Temporary SKU separating UF machines
-  wh_galaxy_perf_uf:
-    runs_on:
-      - arch-wormhole_b0
-      - pipeline-perf-uf
-      - topology-6u
-      - in-service
-
   wh_galaxy_release:
     runs_on:
       - arch-wormhole_b0

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -196,8 +196,6 @@ models:
     wh_llmbox_perf: 685
     wh_galaxy: 280
     wh_galaxy_perf: 150
-    # UF Galaxy perf pool (see sku_config wh_galaxy_perf_uf)
-    wh_galaxy_perf_uf: 75
   device_perf:
     wh_n150: 10
     bh_p150: 10
@@ -208,7 +206,6 @@ models:
     wh_llmbox_perf_release: 1090
     wh_galaxy: 0
     wh_galaxy_perf: 150
-    wh_galaxy_perf_uf: 45
     wh_galaxy_release: 345
     bh_galaxy: 280
     wh_n150: 500
@@ -233,4 +230,4 @@ models:
 
 umd:
   unit:
-    wh_galaxy_perf_uf: 35
+    wh_galaxy_perf: 35

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -27,7 +27,7 @@
     pytest models/tt_dit/tests/models/sd35/test_pipeline_sd35.py -k "4x8cfg1sp0tp1" --timeout 1200
   model: sd35
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 10
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -38,7 +38,7 @@
     pytest models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "4x8sp0tp1-dev" --timeout 1200
   model: flux1
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -82,7 +82,7 @@
     pytest models/demos/deepseek_v3/demo/test_demo.py -k "tg_stress or tg_upr8" --timeout 900
   model: deepseek_v3
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08H32XUS9W # Yousef Al Rawwash
   team: models

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -16,7 +16,7 @@
   cmd: pytest models/tt_dit/tests/models/sd35/test_performance_sd35.py -k "4x8cfg1sp0tp1" --timeout=480
   model: sd35
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U03FJB5TM5Y # Colman Glagovich
   team: models
@@ -28,7 +28,7 @@
   cmd: HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "wh_4x8sp0tp1" --timeout=500
   model: flux1-dev
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 15
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models
@@ -69,7 +69,7 @@
     pytest models/tt_dit/tests/models/mochi/test_performance_mochi.py -k "4x8sp1tp0 " --timeout=1000
   model: mochi
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U09ELB03XRU # Stephen Osborne
   team: models
@@ -83,7 +83,7 @@
     pytest models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8" --timeout=1000
   model: qwenimage
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
   team: models

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -21,7 +21,7 @@
   auto_triage: true
   cmd: ./build/test/umd/galaxy/unit_tests_glx
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 10
 
 - id: galaxy-umd-api
@@ -31,7 +31,7 @@
   auto_triage: true
   cmd: ./build/test/umd/api/api_tests
   skus:
-    wh_galaxy_perf_uf:
+    wh_galaxy_perf:
       timeout: 20
 
 # Unusure why fabric test commands are duplicated, but keeping from original test matrix.


### PR DESCRIPTION
### PR Category
Infra

### Summary
WH galaxies in AUS and in UF DCs should now be equivalent and they should all have access to model weights as per @akirby-TT . Remove temporary sku denoting specifically UF machines.

### Notes for reviewers
Errors in tests below are not related to lack of weights or removal of UF tag.

### Testing
Galaxy unit https://github.com/tenstorrent/tt-metal/actions/runs/26537630337
Galaxy integration https://github.com/tenstorrent/tt-metal/actions/runs/26537666311
Galaxy e2e https://github.com/tenstorrent/tt-metal/actions/runs/26537675830
Galaxy perf https://github.com/tenstorrent/tt-metal/actions/runs/26537694654
Galaxy demo https://github.com/tenstorrent/tt-metal/actions/runs/26537711504

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=roseli/0-merge-wh-galaxy-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:roseli/0-merge-wh-galaxy-tags)