### PR TITLE
[Cleanup] Rename MeshTensor.device_mut() to mutable_device()

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -116,7 +116,7 @@ public:
      *
      * pre-condition: The device tensor must not be in a default constructed state.
      */
-    distributed::MeshDevice& device_mut() const;
+    distributed::MeshDevice& mutable_device() const;
 
     // Getters:
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -35,9 +35,9 @@ std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_break
     return impl().raw_mesh_buffer();
 }
 
-const distributed::MeshDevice& MeshTensor::device() const { return device_mut(); }
+const distributed::MeshDevice& MeshTensor::device() const { return mutable_device(); }
 
-distributed::MeshDevice& MeshTensor::device_mut() const { return *mesh_buffer().device(); }
+distributed::MeshDevice& MeshTensor::mutable_device() const { return *mesh_buffer().device(); }
 
 const TensorSpec& MeshTensor::tensor_spec() const { return impl().spec(); }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -218,7 +218,7 @@ distributed::MeshDevice* DeviceStorage::get_device_bypass_deallocate_check() con
     return std::visit(
         ttsl::overloaded{
             [](const MeshTensorHolder::Allocated& allocated) -> distributed::MeshDevice* {
-                return &allocated.mesh_tensor_.device_mut();
+                return &allocated.mesh_tensor_.mutable_device();
             },
             [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> distributed::MeshDevice* {
                 return tombstone.mesh_buffer_->device();


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

`MeshTensor.device_mut()` was introduced as a mutable version of the `device()` function to make the fact that users are taking a mutable reference to it's associated device explicit. See: #44344

However, `device_mut` is a horrible name, this PR renames it to `mutable_device`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rename-device-mut)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rename-device-mut)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rename-device-mut)