### PR TITLE
fix: resolve DescriptorMergerTest host_id conflicts during merge

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -970,19 +970,19 @@ static void merge_resolved_graph_instances(
             const Node& source_node = it->second;
 
             if (target.nodes.contains(name)) {
-                // Same name at the same level -> same host. The host_id should have been
-                // collapsed in merge(), but even if there is a mismatch, reassign_host_ids_dfs()
-                // will renumber everything after the merge completes. Use the target's host_id
-                // to ensure consistency for the remainder of the merge operation.
+                // Same name at the same level -> same host. merge() calls remap_level() before
+                // this function, which synchronises source host_ids to match target host_ids for
+                // shared nodes. A mismatch here means remap_level() has a bug: throw so the
+                // caller gets a clear diagnostic rather than silently producing a merged graph
+                // with internal_connections referencing a host_id that has no corresponding node.
                 if (target.nodes[name].host_id != source_node.host_id) {
-                    log_warning(
-                        tt::LogDistributed,
-                        "Node '{}' has different host_id in source ({}) vs target ({}) from {} - "
-                        "using target's host_id (will be reassigned by DFS renumbering)",
+                    throw std::runtime_error(fmt::format(
+                        "Node '{}' has conflicting host_id: {} (source) vs {} (target) from {} - "
+                        "remap_level() should have equalised these before merge",
                         name,
                         source_node.host_id.get(),
                         target.nodes[name].host_id.get(),
-                        get_source_description(new_source_file));
+                        get_source_description(new_source_file)));
                 }
                 // Validate inter_board_connections match or are torus-compatible
                 // For torus-compatible nodes, we merge the connections

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -970,14 +970,19 @@ static void merge_resolved_graph_instances(
             const Node& source_node = it->second;
 
             if (target.nodes.contains(name)) {
-                // Same hostname -> same host; host_id was collapsed in merge() so they match
+                // Same name at the same level -> same host. The host_id should have been
+                // collapsed in merge(), but even if there is a mismatch, reassign_host_ids_dfs()
+                // will renumber everything after the merge completes. Use the target's host_id
+                // to ensure consistency for the remainder of the merge operation.
                 if (target.nodes[name].host_id != source_node.host_id) {
-                    throw std::runtime_error(fmt::format(
-                        "Node '{}' has conflicting host_id: {} vs {} from {} (same hostname must map to same host)",
+                    log_warning(
+                        tt::LogDistributed,
+                        "Node '{}' has different host_id in source ({}) vs target ({}) from {} - "
+                        "using target's host_id (will be reassigned by DFS renumbering)",
                         name,
-                        target.nodes[name].host_id.get(),
                         source_node.host_id.get(),
-                        get_source_description(new_source_file)));
+                        target.nodes[name].host_id.get(),
+                        get_source_description(new_source_file));
                 }
                 // Validate inter_board_connections match or are torus-compatible
                 // For torus-compatible nodes, we merge the connections
@@ -1126,27 +1131,20 @@ void CablingGenerator::merge(
     validate_and_merge_node_templates(node_templates_, other.node_templates_, existing_sources, new_file_path);
 
     // Assign temp host_ids to nodes in other, then remap their internal_connections to match.
-    // Shared nodes (same hostname in both) collapse to the existing host_id; new nodes get a fresh one.
+    // Shared nodes (same name at the same level) collapse to the existing host_id; new nodes get a fresh one.
+    // We walk target and source trees in parallel (level-by-level) to avoid name collisions across subgraphs
+    // (e.g., superpod1/node1 vs superpod2/node1 are different nodes but share the name "node1").
     std::unordered_map<HostId, HostId> temp_remap;
     {
-        std::unordered_map<std::string, HostId> target_name_to_id;
-        auto collect_target_ids = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
-            for (const auto& [name, node] : graph.nodes) {
-                target_name_to_id[name] = node.host_id;
-            }
-            for (const auto& [name, subgraph] : graph.subgraphs) {
-                self(self, *subgraph);
-            }
-        };
-        collect_target_ids(collect_target_ids, *root_instance_);
-
         HostId next_id = HostId(host_id_to_node_.size());
-        auto collect_temp_ids = [&](auto& self, ResolvedGraphInstance& graph) -> void {
-            for (auto& [name, node] : graph.nodes) {
+        auto remap_level = [&](auto& self, const ResolvedGraphInstance& target_graph,
+                               ResolvedGraphInstance& source_graph) -> void {
+            // At this level, build name->host_id map only for THIS level's target nodes
+            for (auto& [name, node] : source_graph.nodes) {
                 HostId mapped;
-                auto it = target_name_to_id.find(name);
-                if (it != target_name_to_id.end()) {
-                    mapped = it->second;  // shared node: collapse to existing host_id
+                auto it = target_graph.nodes.find(name);
+                if (it != target_graph.nodes.end()) {
+                    mapped = it->second.host_id;  // shared node: collapse to existing host_id
                 } else {
                     mapped = next_id;
                     next_id = HostId(*next_id + 1);
@@ -1154,11 +1152,28 @@ void CablingGenerator::merge(
                 temp_remap[node.host_id] = mapped;
                 node.host_id = mapped;
             }
-            for (auto& [name, subgraph] : graph.subgraphs) {
-                self(self, *subgraph);
+            // Recurse into matching subgraphs
+            for (auto& [name, source_subgraph] : source_graph.subgraphs) {
+                auto it = target_graph.subgraphs.find(name);
+                if (it != target_graph.subgraphs.end()) {
+                    self(self, *it->second, *source_subgraph);
+                } else {
+                    // Source subgraph has no corresponding target subgraph - assign fresh IDs
+                    auto assign_fresh = [&](auto& self2, ResolvedGraphInstance& graph) -> void {
+                        for (auto& [n, node] : graph.nodes) {
+                            temp_remap[node.host_id] = next_id;
+                            node.host_id = next_id;
+                            next_id = HostId(*next_id + 1);
+                        }
+                        for (auto& [n, sub] : graph.subgraphs) {
+                            self2(self2, *sub);
+                        }
+                    };
+                    assign_fresh(assign_fresh, *source_subgraph);
+                }
             }
         };
-        collect_temp_ids(collect_temp_ids, *other.root_instance_);
+        remap_level(remap_level, *root_instance_, *other.root_instance_);
     }
     if (!temp_remap.empty()) {
         auto remap_other_connections = [&](auto& self, ResolvedGraphInstance& graph) -> void {

--- a/tools/tests/scaleout/test_descriptor_merger.cpp
+++ b/tools/tests/scaleout/test_descriptor_merger.cpp
@@ -388,8 +388,7 @@ TEST_F(DescriptorMergerTest, RejectNonexistentFile) {
 // Torus Merge Tests: Torus-specific inter_board_connections merging
 // ============================================================================
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_MergeXTorusAndYTorusIntoXYTorus) {
+TEST_F(DescriptorMergerTest, MergeXTorusAndYTorusIntoXYTorus) {
     // Test that X_TORUS and Y_TORUS node types can merge into a combined XY_TORUS configuration
     // Both X and Y torus have the same Wormhole architecture and compatible topology
     // Their inter_board_connections should merge successfully to form an XY_TORUS
@@ -413,8 +412,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeXTorusAndYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "X torus + Y torus should equal XY torus";
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_MergeBHXTorusAndBHYTorusIntoXYTorus) {
+TEST_F(DescriptorMergerTest, MergeBHXTorusAndBHYTorusIntoXYTorus) {
     // Test that BH (Blackhole) X_TORUS and Y_TORUS can merge into XY_TORUS
     // Validates torus merging works for Blackhole architecture, not just Wormhole
     const std::string test_dir = create_test_dir("bh_xy_torus_merge");
@@ -437,8 +435,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeBHXTorusAndBHYTorusIntoXYTorus) {
     EXPECT_EQ(merged_gen, xy_gen) << "BH X torus + Y torus should equal BH XY torus";
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_MergeTwoIdenticalXTorusDescriptors) {
+TEST_F(DescriptorMergerTest, MergeTwoIdenticalXTorusDescriptors) {
     // Test merging two identical X_TORUS descriptors
     // Both have the same torus type and architecture - should merge successfully
     // (duplicate connections will be deduplicated during merge)
@@ -462,8 +459,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeTwoIdenticalXTorusDescriptors) {
     EXPECT_EQ(merged_gen, x_gen) << "Two identical X torus should merge into single X torus";
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_MergeXYTorusWithXTorusDescriptors) {
+TEST_F(DescriptorMergerTest, MergeXYTorusWithXTorusDescriptors) {
     // Test merging XY_TORUS with X_TORUS descriptors
     // XY_TORUS already contains X-direction connections, X_TORUS adds more
     // Both are torus types with the same architecture (Wormhole) - should merge to XY_TORUS
@@ -491,8 +487,7 @@ TEST_F(DescriptorMergerTest, DISABLED_MergeXYTorusWithXTorusDescriptors) {
 // Split/Merge Tests: End-to-end split and merge workflows for all topologies
 // ============================================================================
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
+TEST_F(DescriptorMergerTest, SplitAndMerge8x16WhGalaxyXyTorusSuperpod) {
     // Test splitting the 8x16 WH_GALAXY_XY_TORUS superpod descriptor and merging it back
     const std::string source_path =
         "tools/tests/scaleout/cabling_descriptors/8x16_wh_galaxy_xy_torus_superpod.textproto";
@@ -527,8 +522,7 @@ TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge8x16WhGalaxyXyTorusSuperpod) 
     }
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge5WhGalaxyYTorusSuperpod) {
+TEST_F(DescriptorMergerTest, SplitAndMerge5WhGalaxyYTorusSuperpod) {
     // Test splitting the 5 WH_GALAXY_Y_TORUS superpod descriptor and merging it back
     const std::string source_path = "tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto";
 
@@ -561,8 +555,7 @@ TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge5WhGalaxyYTorusSuperpod) {
     }
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_SplitAndMerge16N300Cluster) {
+TEST_F(DescriptorMergerTest, SplitAndMerge16N300Cluster) {
     // Test splitting and merging the 16 N300 cluster descriptor
     // This validates split/merge works for N300 architecture (not just WH/BH)
     const std::string source_path = "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto";
@@ -651,8 +644,7 @@ TEST_F(DescriptorMergerTest, RejectWHAndBHMesh) {
     }
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_RejectGraphTemplatesWithDifferentChildren_ForwardPass) {
+TEST_F(DescriptorMergerTest, RejectGraphTemplatesWithDifferentChildren_ForwardPass) {
     // Test forward pass: source has nodes that target doesn't have
     // File 1 has {node_a, node_b}, File 2 has {node_c, node_d} - completely different sets
     const std::string test_dir = create_test_dir("different_children_forward_test");
@@ -746,8 +738,7 @@ root_instance {
         << "Should reject graph_templates with different children (backward pass: target has extra nodes)";
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_AllowCrossDescriptorConnectionsOnDifferentPorts) {
+TEST_F(DescriptorMergerTest, AllowCrossDescriptorConnectionsOnDifferentPorts) {
     // Test that the same node can connect to different nodes across multiple descriptors
     // as long as different ports are used. This is valid because:
     // 1. Each port is only used once (no duplicate connections within a descriptor)
@@ -1109,8 +1100,7 @@ TEST_F(DescriptorMergerTest, LoadAllAvailableDescriptors) {
     }
 }
 
-// TODO: Disabled due to #36811
-TEST_F(DescriptorMergerTest, DISABLED_MergeExistingBHTorusDescriptors) {
+TEST_F(DescriptorMergerTest, MergeExistingBHTorusDescriptors) {
     // Test merging existing bh_galaxy_x_torus.textproto and bh_galaxy_y_torus.textproto
     // This demonstrates using actual existing descriptor files from the cabling_descriptors directory
     const std::string test_dir = create_test_dir("merge_existing_bh_torus");


### PR DESCRIPTION
## Summary

Closes #36811

The descriptor merger's \`merge()\` function used a flat \`name -> host_id\` mapping collected across **all** subgraph levels when remapping host_ids from the source descriptor. This caused name collisions when different subgraphs contained nodes with the same name (e.g., \`superpod1/node1\` vs \`superpod2/node1\` both map to key \`"node1"\`), leading to incorrect host_id assignments and "conflicting host_id" exceptions.

**Root cause**: \`collect_target_ids\` and \`collect_temp_ids\` recursively walked all levels of the graph hierarchy but stored results in a single flat \`unordered_map<string, HostId>\`. Nodes in different subgraphs sharing the same name would overwrite each other's mappings.

**Fix**:
- Replace the flat collection approach with a recursive \`remap_level\` function that walks target and source trees **in parallel** (level-by-level), comparing node names only within their respective subgraph level
- For subgraphs that exist in source but not target, assign fresh host_ids to all contained nodes
- Restore the host_id mismatch check in \`merge_resolved_graph_instances\` as a hard error — \`remap_level()\` guarantees they match before this point, so any mismatch is a bug that should fail loudly rather than silently corrupt connections (addresses Copilot review comment)

**Tests re-enabled**: All 10 tests that were disabled due to #36811.

## Test plan

- [x] All 10 previously-disabled \`DescriptorMergerTest\` tests pass (torus merge, split/merge, negative tests)
- [x] Existing enabled tests continue to pass
- [x] PR Gate passes (clang-tidy full + ASAN build)
- [x] BH post-commit clean ✅
- [x] Sanity tests — failures in ttsim BH segfault (`test_graph_report`) and Galaxy Fabric TLB allocation (`-12`) are pre-existing on main; unrelated to this PR
- [x] Galaxy unit tests — Galaxy Fabric TLB allocation failure is pre-existing hardware issue
- [x] T3K pipeline — `t3k_ttnn_tests` and `t3k_tt_metal_multiprocess_tests` failures are pre-existing and unrelated to cabling_generator.cpp
- [x] Galaxy pipeline — board reset failure is pre-existing hardware flakiness

## CI Status

| Workflow | Run | Status | Notes |
|---|---|---|---|
| PR Gate | [#26601839316](https://github.com/tenstorrent/tt-metal/actions/runs/26601839316) | ✅ passed | |
| BH Post-Commit | [#26613391495](https://github.com/tenstorrent/tt-metal/actions/runs/26613391495) | ✅ passed | |
| Sanity Tests | [#26613391475](https://github.com/tenstorrent/tt-metal/actions/runs/26613391475) | ❌ failed | ttsim BH segfault + Galaxy Fabric TLB alloc — pre-existing on main |
| Runtime Sanity | [#26613391462](https://github.com/tenstorrent/tt-metal/actions/runs/26613391462) | ❌ failed | Pre-existing hardware failures |
| Galaxy Unit Tests | [#26613391560](https://github.com/tenstorrent/tt-metal/actions/runs/26613391560) | ❌ failed | Galaxy Fabric `tt_tlb_alloc -12` — pre-existing |
| Pipeline Select T3K | [#26613392280](https://github.com/tenstorrent/tt-metal/actions/runs/26613392280) | ❌ failed | `t3k_ttnn_tests` failures — pre-existing, unrelated to this PR |
| Pipeline Select Galaxy | [#26613392282](https://github.com/tenstorrent/tt-metal/actions/runs/26613392282) | ❌ failed | Board reset failure — pre-existing hardware flakiness |

🤖 Generated with [Claude Code](https://claude.com/claude-code)