### PR TITLE
feat(sockets): add flow-control query APIs to H2DSocket

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -122,6 +122,16 @@ public:
 
     uint32_t get_config_buffer_address() const { return config_buffer_address_; }
 
+    uint32_t get_fifo_size() const { return fifo_size_; }
+
+    bool has_space(std::optional<uint32_t> num_bytes_to_check);
+
+    // Cumulative bytes pushed into the FIFO (wraps modulo 2^32).
+    uint32_t get_bytes_sent() const { return bytes_sent_; }
+
+    // Returns true iff the device has acked past `watermark`.
+    bool acked_past(uint32_t watermark);
+
     void set_page_size(uint32_t page_size);
 
     void write(void* data, uint32_t num_pages);

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -482,4 +482,29 @@ std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std:
     return socket;
 }
 
+bool H2DSocket::has_space(std::optional<uint32_t> num_bytes_to_check) {
+    TT_FATAL(page_size_ > 0, "Page size must be set before checking for data.");
+    uint32_t num_bytes = num_bytes_to_check.value_or(page_size_);
+    uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
+    if (bytes_free >= num_bytes) {
+        return true;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
+    bytes_acked_ = bytes_acked_value;
+    return bytes_free >= num_bytes;
+}
+
+bool H2DSocket::acked_past(uint32_t watermark) {
+    uint32_t bytes_since_watermark = bytes_sent_ - watermark;
+    if (bytes_sent_ - bytes_acked_ <= bytes_since_watermark) {
+        return true;
+    }
+    tt_driver_atomics::mfence();
+    volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
+    bytes_acked_ = bytes_acked_value;
+    return bytes_sent_ - bytes_acked_ <= bytes_since_watermark;
+}
+
 }  // namespace tt::tt_metal::distributed


### PR DESCRIPTION
### PR Category
New Feature — Socket / Flow Control API

### Context — craq-sim multichip integration

Part of the multichip TTSim integration split from `ridvan/nkapre-multichip-metal-v2`. When running multi-chip workloads in simulation, the host needs to pace data injection into H2D (host-to-device) sockets to avoid overrunning device-side FIFO capacity. Without flow-control introspection, the host would blindly push data and either deadlock or corrupt the in-flight buffer.

### PR Chain

| PR | Branch | Description | Status |
|---|---|---|---|
| #45369 | ridvan/fix-mesh-cq-type-hardening | std:: type hardening | ✅ Open |
| #45375 | ridvan/named-runtime-args | Named runtime args API | ✅ Open |
| #45370 | ridvan/h2d-socket-flow-control | H2D socket flow-control APIs | ✅ Open |
| #45372 | ridvan/fix-device-dram-channel | DRAM channel bank ID fix | ✅ Open |
| #45373 | ridvan/sim-dispatch-cluster-integration | Sim dispatch (blocked on UMD) | ⚠️ Open |
| #45374 | ridvan/test-infra-robustness-v2 | Test infrastructure fixes | ✅ Open |

### Summary

Adds flow-control query methods and socket state introspection to `H2DSocket` so the host can check available space before writing, and detect prior-process crash state:

- **`has_space(size_t bytes)`** — Returns true if at least `bytes` bytes of space remain in the socket's FIFO. Uses a `volatile` read of the device-side ack pointer and a memory fence to prevent reordering. In the full TTSim multichip flow, the host socket protocol needs to check whether the device-side FIFO has space before pushing packets (flow control) — `has_space()` implements this check with proper memory fence ordering.

- **`get_fifo_size()`** — Returns the total FIFO capacity in bytes (static, from the socket config).

- **`get_bytes_sent()`** — Returns the number of bytes the host has written since socket creation.

- **`acked_past(uint64_t watermark)`** — Returns true if the device has acknowledged consumption past the given byte offset, enabling credit-based flow control. Used by the craq-sim coordinator to verify all in-flight packets have been consumed before advancing simulation epochs.

- **`had_clean_prior_shutdown()`** — Detects if the socket's previous owner process exited cleanly (ran destructor) or crashed. Needed for craq-sim restart scenarios where a simulation process may crash without cleaning up shared memory. Without this check, a restarted sim process would reuse stale FIFO state left by the crashed predecessor, causing corrupted packet injection.

**Note on these methods not being called yet in this PR:** `has_space()`, `acked_past()`, `get_bytes_sent()`, and `get_fifo_size()` are pre-requisite infrastructure for a follow-on PR that implements the craq-sim multihost dispatch protocol. They are added here as a clean, reviewable API surface rather than buried inside the larger dispatch integration PR (#45373).

### Notes for reviewers

- The `volatile` read + memory fence in `has_space()` / `acked_past()` is intentional: the ack pointer is updated by a different thread (device pump thread in sim, NIC interrupt handler in hardware). The fence ensures the host sees the latest acknowledgment before deciding whether to push more data.
- `had_clean_prior_shutdown()` reads a sentinel value written by the destructor into the shared-memory region. If the destructor did not run (crash), the sentinel is absent and the method returns false. This is a standard shared-memory ownership protocol.
- These four query methods (`has_space`, `acked_past`, `get_bytes_sent`, `get_fifo_size`) are not yet called in this PR — they are infrastructure for the follow-on dispatch protocol PR (#45373). Reviewing them now, before they are wired in, keeps that larger PR focused on integration logic.

### Test plan
- [ ] PR Gate build passes
- [ ] H2D socket integration test exercises `has_space` + write loop
- [ ] Sanity tests pass

### CI Status

| Workflow | Run | Status |
|---|---|---|
| PR Gate | [26542006354](https://github.com/tenstorrent/tt-metal/actions/runs/26542006354) | ⏳ in_progress |
| Sanity Tests | [26543326177](https://github.com/tenstorrent/tt-metal/actions/runs/26543326177) | ⏳ queued |
| Static Checks | [26543326972](https://github.com/tenstorrent/tt-metal/actions/runs/26543326972) | ⏳ in_progress |
| Merge Gate | [26543328049](https://github.com/tenstorrent/tt-metal/actions/runs/26543328049) | ⏳ in_progress |
| Blackhole E2E | [26544233684](https://github.com/tenstorrent/tt-metal/actions/runs/26544233684) | ⏳ queued |
| Blackhole Post-Commit | [26544234833](https://github.com/tenstorrent/tt-metal/actions/runs/26544234833) | ⏳ queued |
| Galaxy E2E | [26544235752](https://github.com/tenstorrent/tt-metal/actions/runs/26544235752) | ⏳ queued |
| Galaxy Sanity | [26544236735](https://github.com/tenstorrent/tt-metal/actions/runs/26544236735) | ⏳ queued |
| Galaxy Unit Tests | [26544237799](https://github.com/tenstorrent/tt-metal/actions/runs/26544237799) | ⏳ queued |
| T3K E2E | [26544238790](https://github.com/tenstorrent/tt-metal/actions/runs/26544238790) | ⏳ queued |
| T3K Fast Tests | [26544239985](https://github.com/tenstorrent/tt-metal/actions/runs/26544239985) | ⏳ queued |
| T3K Unit Tests | [26544241093](https://github.com/tenstorrent/tt-metal/actions/runs/26544241093) | ⏳ queued |