### PR TITLE
feat(sim): adapt dispatch, cluster, LLRT, and fabric for multichip TTSim

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/mock_device.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mock_device.hpp
@@ -41,19 +41,4 @@ bool is_mock_mode_registered();
 // Returns just the filename (e.g., "blackhole_P150.yaml"), caller prepends base path
 std::optional<std::string> get_mock_cluster_desc();
 
-// Get the cluster descriptor filename for a specific (arch, num_chips) pair.
-// Returns nullopt if the configuration is not supported.
-//
-// This is the recommended way to construct a MetalEnvDescriptor for a mock cluster
-// without going through the global configure_mock_mode() flag, e.g.:
-//
-//     MetalEnv mock_env(MetalEnvDescriptor(
-//         experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1).value()));
-//
-// Supported configurations (see implementation for the authoritative list):
-//   WORMHOLE_B0: 1, 2, 4, 8, 32
-//   BLACKHOLE:   1, 2, 4, 8       (32-chip descriptor not yet checked in)
-//   QUASAR:      1
-std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips);
-
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -20,8 +20,9 @@ FabricBuilder::FabricBuilder(
     program_(program),
     fabric_context_(fabric_context),
     builder_context_(fabric_context.get_builder_context()),
-    local_node_(tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
-        device->id())),
+    local_node_(
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_node_id_from_physical_chip_id(
+            device->id())),
     wrap_around_mesh_(fabric_context_.is_wrap_around_mesh(local_node_.mesh_id)) {
     // Determine if this device has tunneling dispatch
     auto mmio_device_id =
@@ -94,6 +95,15 @@ void FabricBuilder::create_routers() {
                 .is_dispatch_link = is_dispatch,
             };
 
+#ifdef TT_UMD_BUILD_SIMULATION
+            {
+                const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+                auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+                cluster.register_sim_fabric_endpoint_direction(
+                    device_->id(), eth_chan, control_plane.routing_direction_to_eth_direction(direction));
+            }
+#endif  // TT_UMD_BUILD_SIMULATION
+
             auto router_builder = FabricRouterBuilder::create(device_, program_, local_node_, location);
             routers_.insert({eth_chan, std::move(router_builder)});
         }
@@ -137,12 +147,13 @@ std::vector<FabricBuilder::RouterConnectionPair> FabricBuilder::get_router_conne
         uint32_t num_links = std::min(chans_dir1.size(), chans_dir2.size());
 
         for (uint32_t link = 0; link < num_links; link++) {
-            pairs.push_back(RouterConnectionPair{
-                .chan1 = chans_dir1[link],
-                .chan2 = chans_dir2[link],
-                .link_idx = link,
-                .num_links = num_links,
-            });
+            pairs.push_back(
+                RouterConnectionPair{
+                    .chan1 = chans_dir1[link],
+                    .chan2 = chans_dir2[link],
+                    .link_idx = link,
+                    .num_links = num_links,
+                });
         }
     };
 

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -86,7 +86,8 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
     auto mesh_buffer = buffer_.get_mesh_buffer();
     bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-    if (using_fast_dispatch) {
+    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+    if (using_fast_dispatch && !using_simulator) {
         distributed::EnqueueWriteMeshBuffer(
             mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
     } else {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -27,7 +27,6 @@
 #include "core_coord.hpp"
 #include "device/firmware/risc_firmware_initializer.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "jit_build/build_env_manager.hpp"
 #include "hal_types.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "debug/dprint_server.hpp"
@@ -213,9 +212,9 @@ void MetalContext::initialize(
     // Initialize inspector
     if (this->get_cluster().get_target_device_type() != tt::TargetDevice::Mock) {
         std::optional<int> rank;
-        auto world_context = distributed::multihost::DistributedContext::get_world_context();
-        if (*(world_context->size()) > 1) {
-            rank = *world_context->rank();
+        const auto& distributed_context = global_distributed_context();
+        if (*(distributed_context.size()) > 1) {
+            rank = *distributed_context.rank();
         }
         inspector_data_ = Inspector::initialize(rank);
         // Set fw_compile_hash for Inspector RPC build environment info
@@ -387,28 +386,11 @@ MetalContext& MetalContext::instance(ContextId context_id) {
     // Check again in case another thread created the instance while we were waiting for the lock.
     instance = g_instances[index].load(std::memory_order_acquire);
     if (!instance) {
-        // SILICON_CONTEXT_ID is implicitly created to match legacy behaviour.
+        // SILICON_CONTEXT_ID is implicitly created to match legacy behaviour
         TT_FATAL(
             context_id == DEFAULT_CONTEXT_ID,
             "No MetalContext instance for context_id {}. Create one via create_instance().",
             context_id);
-        // Internal-only bridge for legacy bare MetalContext::instance() callers (~hundreds
-        // across tt_metal/, kernel.cpp, program.cpp, dispatch.cpp, etc.) in mock-only or
-        // coexistence flows: if no default context exists yet but a non-default does
-        // (e.g. a mock cluster context owned by a MetalEnv), return that one instead of
-        // implicitly opening the silicon default. The silicon default is only auto-created
-        // when no other context exists at all, preserving legacy single-cluster behaviour.
-        //
-        // This fallback is intentionally not exposed as a public API (#38445 review):
-        // every public-API caller that needs a specific cluster's context must request it
-        // explicitly via MetalContext::instance(ContextId). The fallback exists only as a
-        // bridge until those legacy bare callers migrate to the explicit form, tracked as
-        // the per-context refactor of #38445.
-        for (int i = DEFAULT_CONTEXT_ID.get() + 1; i < MAX_CONTEXT_COUNT; ++i) {
-            if (auto* existing = g_instances[i].load(std::memory_order_acquire)) {
-                return *existing;
-            }
-        }
         create_default_instance_implicit_locked();
         register_handlers_locked();
         instance = g_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire);
@@ -432,10 +414,6 @@ ContextId MetalContext::create_default_instance_implicit_locked() {
     instance->env_owned_ = true;
 
     g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
-    // Seed the process-wide BuildEnvManager singleton with this context's HAL on first call,
-    // no-op thereafter. Using the by-HAL form (rather than get_instance(ContextId)) avoids
-    // re-entering MetalContext::instance() while we hold g_instance_mutex.
-    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
     return DEFAULT_CONTEXT_ID;
 }
 
@@ -450,16 +428,12 @@ ContextId MetalContext::create_instance(MetalEnv& env_to_use) {
         }
         MetalContext* instance = new MetalContext(DEFAULT_CONTEXT_ID, env_to_use);
         g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
-        // Seed the process-wide BuildEnvManager with this context's HAL on first call.
-        // By-HAL form avoids re-entering MetalContext::instance() while holding g_instance_mutex.
-        BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
         return DEFAULT_CONTEXT_ID;
     }
 
     ContextId context_id = find_free_context_id_locked();
     MetalContext* instance = new MetalContext(context_id, env_to_use);
     g_instances[context_id.get()].store(instance, std::memory_order_release);
-    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
     return context_id;
 }
 

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -286,6 +286,20 @@ void FabricFirmwareInitializer::init(
 
     if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
         log_info(tt::LogMetal, "Initializing Fabric");
+#ifdef TT_UMD_BUILD_SIMULATION
+        if (rtoptions_.get_simulator_enabled()) {
+            for (auto* dev : devices_) {
+                const auto fabric_node_id = control_plane_.get_fabric_node_id_from_physical_chip_id(dev->id());
+                cluster_.get_driver()->register_sim_fabric_node_id(
+                    dev->id(), uint32_t(fabric_node_id.mesh_id.get()), uint32_t(fabric_node_id.chip_id));
+                for (const auto& [eth_chan, direction] :
+                     control_plane_.get_active_fabric_eth_channels(fabric_node_id)) {
+                    cluster_.get_driver()->register_sim_fabric_endpoint_direction(
+                        dev->id(), uint32_t(eth_chan), uint32_t(direction));
+                }
+            }
+        }
+#endif  // TT_UMD_BUILD_SIMULATION
         control_plane_.write_routing_tables_to_all_chips();
         compile_and_configure_fabric();
         log_info(tt::LogMetal, "Fabric Initialized with config {}", fabric_config);
@@ -492,10 +506,10 @@ void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms)
 }
 
 uint32_t FabricFirmwareInitializer::get_fabric_router_sync_timeout_ms() const {
-    if (rtoptions_.get_simulator_enabled()) {
-        return 15000;
-    }
     auto timeout = rtoptions_.get_fabric_router_sync_timeout_ms();
+    if (rtoptions_.get_simulator_enabled()) {
+        return timeout.value_or(15000);
+    }
     return timeout.value_or(10000);
 }
 

--- a/tt_metal/impl/device/mock_device_util.cpp
+++ b/tt_metal/impl/device/mock_device_util.cpp
@@ -7,10 +7,6 @@
 namespace tt::tt_metal::experimental {
 
 std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips) {
-    // Each entry maps to a cluster descriptor YAML in
-    // tt_metal/third_party/umd/tests/cluster_descriptor_examples/. New entries must
-    // reference an existing file there; otherwise mock mode will fail to load the
-    // cluster at runtime.
     switch (arch) {
         case tt::ARCH::WORMHOLE_B0:
             switch (num_chips) {
@@ -25,11 +21,6 @@ std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t nu
             switch (num_chips) {
                 case 1: return "blackhole_P150.yaml";
                 case 2: return "blackhole_P300_both_mmio.yaml";
-                case 4: return "blackhole_4xP150.yaml";
-                case 8: return "blackhole_8xP150.yaml";
-                // 32-chip BH cluster descriptor is not yet available in
-                // cluster_descriptor_examples/; add a "blackhole_32xP*.yaml" entry
-                // here once one is checked in.
                 default: return std::nullopt;
             }
         case tt::ARCH::QUASAR:

--- a/tt_metal/impl/device/mock_device_util.hpp
+++ b/tt_metal/impl/device/mock_device_util.hpp
@@ -4,6 +4,12 @@
 
 #pragma once
 
-// get_mock_cluster_desc_name() is now part of the public API.
-// This internal header is kept as a forwarder for existing internal call sites.
-#include <tt-metalium/experimental/mock_device.hpp>
+#include <optional>
+#include <string>
+#include <umd/device/types/arch.hpp>
+
+namespace tt::tt_metal::experimental {
+
+std::optional<std::string> get_mock_cluster_desc_name(tt::ARCH arch, uint32_t num_chips);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -14,14 +14,19 @@
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
+#include <cstdint>
 
 namespace tt::tt_metal {
 
-uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id * cq_size; }
+std::uint32_t get_relative_cq_offset(std::uint8_t cq_id, std::uint32_t cq_size) { return cq_id * cq_size; }
 
-uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
+std::uint16_t get_umd_channel(std::uint16_t channel) { return channel & 0x3; }
 
-uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t base) {
+std::uint32_t get_absolute_cq_offset(
+    std::uint16_t channel, std::uint8_t cq_id, std::uint32_t cq_size, std::uint32_t base) {
+    if (base != 0) {
+        return base + get_relative_cq_offset(cq_id, cq_size);
+    }
     return base + (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }
@@ -29,109 +34,111 @@ uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_siz
 // Device-written pointers live at an offset within the hugepage that includes the device channel offset, while
 // host-written pointers do not
 template <bool include_device_channel_offset>
-uint32_t read_cq_host_ptr(
+std::uint32_t read_cq_host_ptr(
     const SystemMemoryManager& sysmem_manager,
     ChipId chip_id,
-    uint8_t cq_id,
-    uint32_t cq_size,
-    uint32_t host_addr_offset) {
-    uint32_t recv;
+    std::uint8_t cq_id,
+    std::uint32_t cq_size,
+    std::uint32_t host_addr_offset) {
+    std::uint32_t recv;
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = MetalContext::instance()
-                                          .device_manager()
-                                          ->get_active_device(chip_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        const std::uint32_t dram_channel =
+            MetalContext::instance()
+                .device_manager()
+                ->get_active_device(chip_id)
+                ->allocator_impl()
+                ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         MetalContext::instance().get_cluster().read_dram_vec(
             &recv,
-            sizeof(uint32_t),
+            sizeof(std::uint32_t),
             chip_id,
             dram_channel,
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + host_addr_offset);
     } else {
         ChipId mmio_device_id = MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-        uint32_t sysmem_offset = host_addr_offset + get_relative_cq_offset(cq_id, cq_size);
+        std::uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        std::uint32_t sysmem_offset = host_addr_offset + get_relative_cq_offset(cq_id, cq_size);
         if constexpr (include_device_channel_offset) {
             sysmem_offset += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
         }
         MetalContext::instance().get_cluster().read_sysmem(
-            &recv, sizeof(uint32_t), sysmem_offset, mmio_device_id, channel);
+            &recv, sizeof(std::uint32_t), sysmem_offset, mmio_device_id, channel);
     }
     return recv;
 }
 
 template <bool addr_16B>
-uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t issue_q_rd_ptr =
+std::uint32_t get_cq_issue_rd_ptr(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size) {
+    std::uint32_t issue_q_rd_ptr =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_rd_ptr);
+    std::uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
     return recv;
 }
 
-template uint32_t get_cq_issue_rd_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_rd_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template std::uint32_t get_cq_issue_rd_ptr<true>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
+template std::uint32_t get_cq_issue_rd_ptr<false>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t issue_q_wr_ptr =
+std::uint32_t get_cq_issue_wr_ptr(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size) {
+    std::uint32_t issue_q_wr_ptr =
         MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_wr_ptr);
+    std::uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
     return recv;
 }
 
-template uint32_t get_cq_issue_wr_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template std::uint32_t get_cq_issue_wr_ptr<true>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
+template std::uint32_t get_cq_issue_wr_ptr<false>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t completion_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
+std::uint32_t get_cq_completion_wr_ptr(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size) {
+    std::uint32_t completion_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_WR);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_wr_ptr);
+    std::uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
     return recv;
 }
 
-template uint32_t get_cq_completion_wr_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template std::uint32_t get_cq_completion_wr_ptr<true>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
+template std::uint32_t get_cq_completion_wr_ptr<false>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
+std::uint32_t get_cq_completion_rd_ptr(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size) {
+    std::uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
         CommandQueueHostAddrType::COMPLETION_Q_RD);
     const SystemMemoryManager& sysmem_manager =
         MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
-    uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_rd_ptr);
+    std::uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
     }
     return recv;
 }
 
-template uint32_t get_cq_completion_rd_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_rd_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template std::uint32_t get_cq_completion_rd_ptr<true>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
+template std::uint32_t get_cq_completion_rd_ptr<false>(ChipId chip_id, std::uint8_t cq_id, std::uint32_t cq_size);
 
-uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
-    uint32_t progress = 0;
+std::uint32_t get_cq_dispatch_progress(ChipId chip_id, std::uint8_t cq_id) {
+    std::uint32_t progress = 0;
 
     // Get the dispatcher core for this command queue
     // For remote chips: read from DISPATCH_D (on the remote chip where work actually happens)
     // For local chips: read from DISPATCH_HD (combined dispatcher on local chip)
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+    std::uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
     auto& dispatch_core_manager = MetalContext::instance().get_dispatch_core_manager();
 
     const tt_cxy_pair& dispatcher_core_logical =
@@ -141,7 +148,7 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
 
     // Get the L1 address where dispatch progress counter is stored
     CoreType dispatch_core_type = dispatch_core_manager.get_dispatch_core_type();
-    uint32_t dev_dispatch_progress_ptr =
+    std::uint32_t dev_dispatch_progress_ptr =
         MetalContext::instance()
             .dispatch_mem_map(dispatch_core_type)
             .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS);
@@ -153,12 +160,12 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
             dispatcher_core_logical, dispatch_core_type);
 
     tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        &progress, sizeof(uint32_t), dispatcher_core_virtual, dev_dispatch_progress_ptr);
+        &progress, sizeof(std::uint32_t), dispatcher_core_virtual, dev_dispatch_progress_ptr);
 
     return progress;
 }
 
-uint32_t calculate_expected_workers_to_finish(
+std::uint32_t calculate_expected_workers_to_finish(
     const tt::tt_metal::IDevice* device,
     const SubDeviceId& sub_device_id,
     tt::tt_metal::HalProgrammableCoreType core_type) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -10,6 +10,7 @@
 //  - # blocks must evenly divide the dispatch buffer size
 //  - dispatch buffer base must be page size aligned
 
+#include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "internal/dataflow/dataflow_api_addrgen.h"
 #include "api/debug/assert.h"
@@ -25,52 +26,52 @@
 CQWriteInterface cq_write_interface;
 
 constexpr uintptr_t dispatch_cb_base = DISPATCH_CB_BASE;
-constexpr uint32_t dispatch_cb_log_page_size = DISPATCH_CB_LOG_PAGE_SIZE;
-constexpr uint32_t dispatch_cb_pages = DISPATCH_CB_PAGES;
-constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
-constexpr uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
-constexpr uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
-constexpr uint32_t dispatch_cb_blocks = DISPATCH_CB_BLOCKS;
-constexpr uint32_t upstream_sync_sem = UPSTREAM_SYNC_SEM;
-constexpr uint32_t command_queue_base_addr = COMMAND_QUEUE_BASE_ADDR;
-constexpr uint32_t completion_queue_base_addr = COMPLETION_QUEUE_BASE_ADDR;
-constexpr uint32_t completion_queue_size = COMPLETION_QUEUE_SIZE;
-constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
-constexpr uint32_t downstream_cb_size = DOWNSTREAM_CB_SIZE;
-constexpr uint32_t my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
-constexpr uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
-constexpr uint32_t split_prefetch = SPLIT_PREFETCH;
-constexpr uint32_t prefetch_h_noc_xy = PREFETCH_H_NOC_XY;
-constexpr uint32_t prefetch_h_local_downstream_sem_addr = PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR;
-constexpr uint32_t prefetch_h_max_credits = PREFETCH_H_MAX_CREDITS;
-constexpr uint32_t packed_write_max_unicast_sub_cmds =
+constexpr std::uint32_t dispatch_cb_log_page_size = DISPATCH_CB_LOG_PAGE_SIZE;
+constexpr std::uint32_t dispatch_cb_pages = DISPATCH_CB_PAGES;
+constexpr std::uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
+constexpr std::uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
+constexpr std::uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
+constexpr std::uint32_t dispatch_cb_blocks = DISPATCH_CB_BLOCKS;
+constexpr std::uint32_t upstream_sync_sem = UPSTREAM_SYNC_SEM;
+constexpr std::uint32_t command_queue_base_addr = COMMAND_QUEUE_BASE_ADDR;
+constexpr std::uint32_t completion_queue_base_addr = COMPLETION_QUEUE_BASE_ADDR;
+constexpr std::uint32_t completion_queue_size = COMPLETION_QUEUE_SIZE;
+constexpr std::uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
+constexpr std::uint32_t downstream_cb_size = DOWNSTREAM_CB_SIZE;
+constexpr std::uint32_t my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
+constexpr std::uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
+constexpr std::uint32_t split_prefetch = SPLIT_PREFETCH;
+constexpr std::uint32_t prefetch_h_noc_xy = PREFETCH_H_NOC_XY;
+constexpr std::uint32_t prefetch_h_local_downstream_sem_addr = PREFETCH_H_LOCAL_DOWNSTREAM_SEM_ADDR;
+constexpr std::uint32_t prefetch_h_max_credits = PREFETCH_H_MAX_CREDITS;
+constexpr std::uint32_t packed_write_max_unicast_sub_cmds =
     PACKED_WRITE_MAX_UNICAST_SUB_CMDS;  // Number of cores in compute grid
 constexpr uintptr_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
-constexpr uint32_t max_num_worker_sems = MAX_NUM_WORKER_SEMS;  // maximum number of worker semaphores
-constexpr uint32_t max_num_go_signal_noc_data_entries =
+constexpr std::uint32_t max_num_worker_sems = MAX_NUM_WORKER_SEMS;  // maximum number of worker semaphores
+constexpr std::uint32_t max_num_go_signal_noc_data_entries =
     MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES;  // maximum number of go signal data words
-constexpr uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
-constexpr uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
-constexpr uint32_t distributed_dispatcher = DISTRIBUTED_DISPATCHER;
-constexpr uint32_t host_completion_q_wr_ptr = HOST_COMPLETION_Q_WR_PTR;
+constexpr std::uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
+constexpr std::uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
+constexpr std::uint32_t distributed_dispatcher = DISTRIBUTED_DISPATCHER;
+constexpr std::uint32_t host_completion_q_wr_ptr = HOST_COMPLETION_Q_WR_PTR;
 constexpr uintptr_t dev_completion_q_wr_ptr = DEV_COMPLETION_Q_WR_PTR;
 constexpr uintptr_t dev_completion_q_rd_ptr = DEV_COMPLETION_Q_RD_PTR;
 constexpr uintptr_t dev_dispatch_progress_ptr = DEV_DISPATCH_PROGRESS_PTR;
 
-constexpr uint32_t first_stream_used = FIRST_STREAM_USED;
+constexpr std::uint32_t first_stream_used = FIRST_STREAM_USED;
 
-constexpr uint32_t virtualize_unicast_cores = VIRTUALIZE_UNICAST_CORES;
-constexpr uint32_t num_virtual_unicast_cores = NUM_VIRTUAL_UNICAST_CORES;
-constexpr uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
+constexpr std::uint32_t virtualize_unicast_cores = VIRTUALIZE_UNICAST_CORES;
+constexpr std::uint32_t num_virtual_unicast_cores = NUM_VIRTUAL_UNICAST_CORES;
+constexpr std::uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
 
 // fabric mux connection
-constexpr uint32_t fabric_header_rb_base = FABRIC_HEADER_RB_BASE;
-constexpr uint32_t fabric_header_rb_entries = FABRIC_HEADER_RB_ENTRIES;
-constexpr uint32_t my_fabric_sync_status_addr = MY_FABRIC_SYNC_STATUS_ADDR;
+constexpr std::uint32_t fabric_header_rb_base = FABRIC_HEADER_RB_BASE;
+constexpr std::uint32_t fabric_header_rb_entries = FABRIC_HEADER_RB_ENTRIES;
+constexpr std::uint32_t my_fabric_sync_status_addr = MY_FABRIC_SYNC_STATUS_ADDR;
 
-constexpr uint8_t fabric_mux_x = FABRIC_MUX_X;
-constexpr uint8_t fabric_mux_y = FABRIC_MUX_Y;
-constexpr uint8_t fabric_mux_num_buffers_per_channel = FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL;
+constexpr std::uint8_t fabric_mux_x = FABRIC_MUX_X;
+constexpr std::uint8_t fabric_mux_y = FABRIC_MUX_Y;
+constexpr std::uint8_t fabric_mux_num_buffers_per_channel = FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL;
 constexpr size_t fabric_mux_channel_buffer_size_bytes = FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES;
 constexpr size_t fabric_mux_channel_base_address = FABRIC_MUX_CHANNEL_BASE_ADDRESS;
 constexpr size_t fabric_mux_connection_info_address = FABRIC_MUX_CONNECTION_INFO_ADDRESS;
@@ -85,42 +86,43 @@ constexpr size_t fabric_worker_flow_control_sem = FABRIC_WORKER_FLOW_CONTROL_SEM
 constexpr size_t fabric_worker_teardown_sem = FABRIC_WORKER_TEARDOWN_SEM;
 constexpr size_t fabric_worker_buffer_index_sem = FABRIC_WORKER_BUFFER_INDEX_SEM;
 
-constexpr uint8_t num_hops = static_cast<uint8_t>(NUM_HOPS);
+constexpr std::uint8_t num_hops = static_cast<std::uint8_t>(NUM_HOPS);
 
-constexpr uint32_t ew_dim = EW_DIM;
-constexpr uint32_t to_mesh_id = TO_MESH_ID;
+constexpr std::uint32_t ew_dim = EW_DIM;
+constexpr std::uint32_t to_mesh_id = TO_MESH_ID;
 
 constexpr bool is_2d_fabric = static_cast<bool>(FABRIC_2D);
 
-constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
-constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
+constexpr std::uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
+constexpr std::uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
 
-constexpr uint32_t is_d_variant = IS_D_VARIANT;
-constexpr uint32_t is_h_variant = IS_H_VARIANT;
+constexpr std::uint32_t is_d_variant = IS_D_VARIANT;
+constexpr std::uint32_t is_h_variant = IS_H_VARIANT;
 
-constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
-constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
-constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
-constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
-constexpr uint8_t my_noc_index = NOC_INDEX;
-constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
+constexpr std::uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
+constexpr std::uint32_t upstream_noc_xy = std::uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
+constexpr std::uint32_t downstream_noc_xy = std::uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
+constexpr std::uint32_t dispatch_s_noc_xy =
+    std::uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+constexpr std::uint8_t my_noc_index = NOC_INDEX;
+constexpr std::uint32_t my_noc_xy = std::uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 #if !defined(IS_CQ_DRAM_BACKED) || IS_CQ_DRAM_BACKED == 0
-constexpr uint64_t pcie_noc_xy =
-    uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
+constexpr std::uint64_t pcie_noc_xy =
+    std::uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
 #endif
-constexpr uint32_t dispatch_cb_page_size = 1 << dispatch_cb_log_page_size;
+constexpr std::uint32_t dispatch_cb_page_size = 1 << dispatch_cb_log_page_size;
 
-constexpr uint32_t completion_queue_end_addr = completion_queue_base_addr + completion_queue_size;
-constexpr uint32_t completion_queue_page_size = dispatch_cb_page_size;
-constexpr uint32_t completion_queue_log_page_size = dispatch_cb_log_page_size;
-constexpr uint32_t completion_queue_size_16B = completion_queue_size >> 4;
-constexpr uint32_t completion_queue_page_size_16B = completion_queue_page_size >> 4;
-constexpr uint32_t completion_queue_end_addr_16B = completion_queue_end_addr >> 4;
-constexpr uint32_t completion_queue_base_addr_16B = completion_queue_base_addr >> 4;
-constexpr uint32_t dispatch_cb_size = dispatch_cb_page_size * dispatch_cb_pages;
+constexpr std::uint32_t completion_queue_end_addr = completion_queue_base_addr + completion_queue_size;
+constexpr std::uint32_t completion_queue_page_size = dispatch_cb_page_size;
+constexpr std::uint32_t completion_queue_log_page_size = dispatch_cb_log_page_size;
+constexpr std::uint32_t completion_queue_size_16B = completion_queue_size >> 4;
+constexpr std::uint32_t completion_queue_page_size_16B = completion_queue_page_size >> 4;
+constexpr std::uint32_t completion_queue_end_addr_16B = completion_queue_end_addr >> 4;
+constexpr std::uint32_t completion_queue_base_addr_16B = completion_queue_base_addr >> 4;
+constexpr std::uint32_t dispatch_cb_size = dispatch_cb_page_size * dispatch_cb_pages;
 constexpr uintptr_t dispatch_cb_end = dispatch_cb_base + dispatch_cb_size;
-constexpr uint32_t downstream_cb_end = downstream_cb_base + downstream_cb_size;
-constexpr uint32_t fd_core_type_idx = static_cast<uint32_t>(fd_core_type);
+constexpr std::uint32_t downstream_cb_end = downstream_cb_base + downstream_cb_size;
+constexpr std::uint32_t fd_core_type_idx = static_cast<std::uint32_t>(fd_core_type);
 
 constexpr bool dispatch_s_enabled = dispatch_d_shutdown_sem_id != 0;
 constexpr bool publish_noc_count = !distributed_dispatcher && dispatch_s_enabled;
@@ -129,7 +131,7 @@ constexpr bool publish_noc_count = !distributed_dispatcher && dispatch_s_enabled
 // Do bookkeeping (release, etc) based on blocks
 // Note: due to the current method of release pages, up to 1 block of pages
 // may be unavailable to the prefetcher at any time
-constexpr uint32_t dispatch_cb_pages_per_block = dispatch_cb_pages / dispatch_cb_blocks;
+constexpr std::uint32_t dispatch_cb_pages_per_block = dispatch_cb_pages / dispatch_cb_blocks;
 
 // Dispatch-core-local L1 region assigned by DispatchMemMap via
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address is supplied by host through
@@ -141,14 +143,14 @@ volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
     reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
 
 static uintptr_t cmd_ptr;  // walks through pages in cb cmd by cmd
-static uint32_t downstream_cb_data_ptr = downstream_cb_base;
+static std::uint32_t downstream_cb_data_ptr = downstream_cb_base;
 
-static uint32_t write_offset[CQ_DISPATCH_MAX_WRITE_OFFSETS];  // added to write address on non-host writes
+static std::uint32_t write_offset[CQ_DISPATCH_MAX_WRITE_OFFSETS];  // added to write address on non-host writes
 
 // Runtime args
-static uint32_t my_dev_id;
-static uint32_t to_dev_id;
-static uint32_t router_direction;
+static std::uint32_t my_dev_id;
+static std::uint32_t to_dev_id;
+static std::uint32_t router_direction;
 using RelayClientType =
     CQRelayClient<fabric_mux_num_buffers_per_channel, fabric_mux_channel_buffer_size_bytes, fabric_header_rb_base>;
 
@@ -156,16 +158,16 @@ RelayClientType relay_client;
 
 // Release policies are TU-local so we can use the local relay_client instance
 struct NocReleasePolicy {
-    template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
-    static FORCE_INLINE void release(uint32_t pages) {
-        uint32_t sem_addr = get_semaphore<fd_core_type>(sem_id);
+    template <std::uint8_t noc_idx, std::uint32_t noc_xy, std::uint32_t sem_id>
+    static FORCE_INLINE void release(std::uint32_t pages) {
+        std::uint32_t sem_addr = get_semaphore<fd_core_type>(sem_id);
         noc_semaphore_inc(get_noc_addr_helper(noc_xy, sem_addr), pages, noc_idx);
     }
 };
 
 struct RemoteReleasePolicy {
-    template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id>
-    static FORCE_INLINE void release(uint32_t pages) {
+    template <std::uint8_t noc_idx, std::uint32_t noc_xy, std::uint32_t sem_id>
+    static FORCE_INLINE void release(std::uint32_t pages) {
         relay_client.template release_pages<noc_idx, noc_xy, sem_id>(pages);
     }
 };
@@ -185,66 +187,65 @@ using CBReaderType = CBReaderWithReleasePolicy<
 
 static CBReaderType dispatch_cb_reader;
 
-constexpr uint32_t packed_write_max_multicast_sub_cmds =
+constexpr std::uint32_t packed_write_max_multicast_sub_cmds =
     get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
-constexpr uint32_t max_write_packed_large_cmd =
-    CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS * sizeof(CQDispatchWritePackedLargeSubCmd) / sizeof(uint32_t);
-constexpr uint32_t max_write_packed_cmd =
-    packed_write_max_unicast_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(uint32_t);
-constexpr uint32_t l1_cache_elements =
+constexpr std::uint32_t max_write_packed_large_cmd =
+    CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS * sizeof(CQDispatchWritePackedLargeSubCmd) / sizeof(std::uint32_t);
+constexpr std::uint32_t max_write_packed_cmd =
+    packed_write_max_unicast_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(std::uint32_t);
+constexpr std::uint32_t l1_cache_elements =
     (max_write_packed_cmd > max_write_packed_large_cmd) ? max_write_packed_cmd : max_write_packed_large_cmd;
-constexpr uint32_t l1_cache_elements_rounded =
+constexpr std::uint32_t l1_cache_elements_rounded =
     ((l1_cache_elements + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
     l1_to_local_cache_copy_chunk;
 static_assert(
-    l1_cache_elements * sizeof(uint32_t) / sizeof(CQDispatchWritePackedLargeUnicastSubCmd) >=
+    l1_cache_elements * sizeof(std::uint32_t) / sizeof(CQDispatchWritePackedLargeUnicastSubCmd) >=
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
 
 // Used to send go signals asynchronously. Currently unused but this is a prototype for a GoSignalState
 // ring buffer that can be used to store and then asynchronously send Go Signals.
 struct GoSignalState {
-    uint32_t go_signal;
-    uint32_t wait_count;
+    std::uint32_t go_signal;
+    std::uint32_t wait_count;
 };
 
 extern "C" {
 // These variables are used by triage to help report dispatcher state.
-volatile uint32_t last_wait_count = 0;
-volatile uint32_t last_wait_stream = 0;
-constexpr uint32_t stream_addr0 = STREAM_REG_ADDR(0, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-constexpr uint32_t stream_addr1 = STREAM_REG_ADDR(1, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-constexpr uint32_t stream_width = MEM_WORD_ADDR_WIDTH;
-volatile uint32_t last_event;
+volatile std::uint32_t last_wait_count = 0;
+volatile std::uint32_t last_wait_stream = 0;
+constexpr std::uint32_t stream_addr0 = STREAM_REG_ADDR(0, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+constexpr std::uint32_t stream_addr1 = STREAM_REG_ADDR(1, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+constexpr std::uint32_t stream_width = MEM_WORD_ADDR_WIDTH;
+volatile std::uint32_t last_event;
 }
-
 
 static GoSignalState go_signal_state_ring_buf[4];
-static uint8_t go_signal_state_wr_ptr = 0;
-static uint8_t go_signal_state_rd_ptr = 0;
+static std::uint8_t go_signal_state_wr_ptr = 0;
+static std::uint8_t go_signal_state_rd_ptr = 0;
 
-static uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries];
+static std::uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries];
 
-FORCE_INLINE volatile uint32_t* get_cq_completion_read_ptr() {
-    return reinterpret_cast<volatile uint32_t*>(dev_completion_q_rd_ptr);
+FORCE_INLINE volatile std::uint32_t* get_cq_completion_read_ptr() {
+    return reinterpret_cast<volatile std::uint32_t*>(dev_completion_q_rd_ptr);
 }
 
-FORCE_INLINE volatile uint32_t* get_cq_completion_write_ptr() {
-    return reinterpret_cast<volatile uint32_t*>(dev_completion_q_wr_ptr);
+FORCE_INLINE volatile std::uint32_t* get_cq_completion_write_ptr() {
+    return reinterpret_cast<volatile std::uint32_t*>(dev_completion_q_wr_ptr);
 }
 
-FORCE_INLINE volatile uint32_t* get_dispatch_progress_ptr() {
-    return reinterpret_cast<volatile uint32_t*>(dev_dispatch_progress_ptr);
+FORCE_INLINE volatile std::uint32_t* get_dispatch_progress_ptr() {
+    return reinterpret_cast<volatile std::uint32_t*>(dev_dispatch_progress_ptr);
 }
 
 FORCE_INLINE
-void completion_queue_reserve_back(uint32_t num_pages) {
+void completion_queue_reserve_back(std::uint32_t num_pages) {
     WAYPOINT("QRBW");
     // Transfer pages are aligned
-    uint32_t data_size_16B = num_pages * completion_queue_page_size_16B;
-    uint32_t completion_rd_ptr_and_toggle;
-    uint32_t completion_rd_ptr;
-    uint32_t completion_rd_toggle;
-    uint32_t available_space;
+    std::uint32_t data_size_16B = num_pages * completion_queue_page_size_16B;
+    std::uint32_t completion_rd_ptr_and_toggle;
+    std::uint32_t completion_rd_ptr;
+    std::uint32_t completion_rd_toggle;
+    std::uint32_t available_space;
     do {
         invalidate_l1_cache();
         completion_rd_ptr_and_toggle = *get_cq_completion_read_ptr();
@@ -267,26 +268,27 @@ void completion_queue_reserve_back(uint32_t num_pages) {
 // Note that this fn does not increment any counters
 FORCE_INLINE
 void notify_host_of_completion_queue_write_pointer() {
-    uint32_t completion_queue_write_ptr_addr = command_queue_base_addr + host_completion_q_wr_ptr;
-    uint32_t completion_wr_ptr_and_toggle =
+    std::uint32_t completion_queue_write_ptr_addr = command_queue_base_addr + host_completion_q_wr_ptr;
+    std::uint32_t completion_wr_ptr_and_toggle =
         cq_write_interface.completion_fifo_wr_ptr | (cq_write_interface.completion_fifo_wr_toggle << 31);
-    volatile tt_l1_ptr uint32_t* completion_wr_ptr_addr = get_cq_completion_write_ptr();
+    volatile tt_l1_ptr std::uint32_t* completion_wr_ptr_addr = get_cq_completion_write_ptr();
     completion_wr_ptr_addr[0] = completion_wr_ptr_and_toggle;
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
+    std::uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-    noc_async_write(static_cast<uint32_t>(dev_completion_q_wr_ptr), pcie_noc_xy | completion_queue_write_ptr_addr, 4);
+    noc_async_write(
+        static_cast<std::uint32_t>(dev_completion_q_wr_ptr), pcie_noc_xy | completion_queue_write_ptr_addr, 4);
 #else
     cq_noc_async_write_with_state<CQ_NOC_SnDL>(
-        static_cast<uint32_t>(dev_completion_q_wr_ptr), completion_queue_write_ptr_addr, 4);
+        static_cast<std::uint32_t>(dev_completion_q_wr_ptr), completion_queue_write_ptr_addr, 4);
 #endif
 }
 
 FORCE_INLINE
-void completion_queue_push_back(uint32_t num_pages) {
+void completion_queue_push_back(std::uint32_t num_pages) {
     // Transfer pages are aligned
-    uint32_t push_size_16B = num_pages * completion_queue_page_size_16B;
+    std::uint32_t push_size_16B = num_pages * completion_queue_page_size_16B;
     cq_write_interface.completion_fifo_wr_ptr += push_size_16B;
 
     if (cq_write_interface.completion_fifo_wr_ptr >= completion_queue_end_addr_16B) {
@@ -303,49 +305,49 @@ void completion_queue_push_back(uint32_t num_pages) {
 void process_write_host_h() {
     volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
 
-    uint32_t completion_write_ptr;
+    std::uint32_t completion_write_ptr;
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
-    uint64_t wlength = cmd->write_linear_host.length;
+    std::uint64_t wlength = cmd->write_linear_host.length;
     bool is_event = cmd->write_linear_host.is_event;
     // DPRINT << "process_write_host_h: " << length << ENDL();
     // DEVICE_PRINT("process_write_host_h: length {}\n", length);
     uintptr_t data_ptr = cmd_ptr;
 #if !defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-    uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
+    std::uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
 #endif
-    constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
+    constexpr std::uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     if (is_event) {
-        last_event = ((uint32_t*)(data_ptr + sizeof(CQDispatchCmd)))[0];
+        last_event = ((std::uint32_t*)(data_ptr + sizeof(CQDispatchCmd)))[0];
     }
     while (wlength != 0) {
-        uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
+        std::uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<std::uint32_t>(wlength);
         wlength -= length;
         while (length != 0) {
             // Get a page if needed
-            uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
-            uint32_t xfer_size = (length > available_data) ? available_data : length;
-            uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
+            std::uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+            std::uint32_t xfer_size = (length > available_data) ? available_data : length;
+            std::uint32_t npages = (xfer_size + completion_queue_page_size - 1) / completion_queue_page_size;
             completion_queue_reserve_back(npages);
-            uint32_t completion_queue_write_addr = cq_write_interface.completion_fifo_wr_ptr << 4;
+            std::uint32_t completion_queue_write_addr = cq_write_interface.completion_fifo_wr_ptr << 4;
             // completion_queue_write_addr will never be equal to completion_queue_end_addr due to
             // completion_queue_push_back wrap logic so we don't need to handle this case explicitly to avoid 0 sized
             // transactions
             if (completion_queue_write_addr + xfer_size > completion_queue_end_addr) {
-                uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
+                std::uint32_t last_chunk_size = completion_queue_end_addr - completion_queue_write_addr;
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-                uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
+                std::uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
                 noc_async_write(
-                    static_cast<uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
+                    static_cast<std::uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, last_chunk_size);
 #else
                 cq_noc_async_write_with_state_any_len(
-                    static_cast<uint32_t>(data_ptr), completion_queue_write_addr, last_chunk_size);
-                uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
+                    static_cast<std::uint32_t>(data_ptr), completion_queue_write_addr, last_chunk_size);
+                std::uint32_t num_noc_packets_written = div_up(last_chunk_size, NOC_MAX_BURST_SIZE);
                 noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
                 noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
 #endif
@@ -356,15 +358,15 @@ void process_write_host_h() {
             }
 #if defined(FABRIC_RELAY)
 #if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
-            uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
+            std::uint64_t pcie_noc_xy = get_noc_addr_from_bank_id<true>(DRAM_BACKED_CQ_BANK_ID, 0);
 #endif
-            noc_async_write(static_cast<uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, xfer_size);
+            noc_async_write(static_cast<std::uint32_t>(data_ptr), pcie_noc_xy | completion_queue_write_addr, xfer_size);
 #else
             cq_noc_async_write_with_state_any_len(
-                static_cast<uint32_t>(data_ptr), completion_queue_write_addr, xfer_size);
+                static_cast<std::uint32_t>(data_ptr), completion_queue_write_addr, xfer_size);
             // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets
             // written
-            uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
+            std::uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
             noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
             noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
 #endif
@@ -372,6 +374,10 @@ void process_write_host_h() {
             // This will update the write ptr on device and host
             // We flush to ensure the ptr has been read out of l1 before we update it again
             completion_queue_push_back(npages);
+#if !defined(FABRIC_RELAY) && defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+            noc_nonposted_writes_num_issued[noc_index] += 1;
+            noc_nonposted_writes_acked[noc_index] += 1;
+#endif
 
             length -= xfer_size;
             data_ptr += xfer_size;
@@ -384,11 +390,11 @@ void process_write_host_h() {
 void process_exec_buf_end_h() {
     if constexpr (split_prefetch) {
         invalidate_l1_cache();
-        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        volatile tt_l1_ptr std::uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(
             get_semaphore<fd_core_type>(prefetch_h_local_downstream_sem_addr));
 
         noc_semaphore_inc(
-            get_noc_addr_helper(prefetch_h_noc_xy, static_cast<uint32_t>(reinterpret_cast<uintptr_t>(sem_addr))),
+            get_noc_addr_helper(prefetch_h_noc_xy, static_cast<std::uint32_t>(reinterpret_cast<uintptr_t>(sem_addr))),
             prefetch_h_max_credits,
             noc_index);
     }
@@ -401,7 +407,7 @@ CBWriter<my_downstream_cb_sem_id, 0, 0, 0> dispatch_h_cb_writer{};
 // Relay, potentially through the mux/dmux/tunneller path
 // Code below sends 1 page worth of data except at the end of a cmd
 // This means the downstream buffers are always page aligned, simplifies wrap handling
-void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
+void relay_to_next_cb(uintptr_t data_ptr, std::uint64_t wlength) {
     // DPRINT << "relay_to_next_cb: " << data_ptr << " " << dispatch_cb_reader.cb_fence << " " << wlength << ENDL();
     // DEVICE_PRINT("relay_to_next_cb: data_ptr {} dispatch_cb_reader.cb_fence {} wlength {}\n", data_ptr,
     // dispatch_cb_reader.cb_fence, wlength);
@@ -416,27 +422,30 @@ void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
     relay_client.init_write_state_only<my_noc_index, NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0));
     relay_client.init_inline_write_state_only<my_noc_index>(get_noc_addr_helper(downstream_noc_xy, 0));
 
-    constexpr uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
+    constexpr std::uint32_t max_batch_size = ~(dispatch_cb_page_size - 1);
     while (wlength != 0) {
-        uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(wlength);
+        std::uint32_t length = (wlength > max_batch_size) ? max_batch_size : static_cast<std::uint32_t>(wlength);
         wlength -= length;
         while (length > 0) {
             ASSERT(downstream_cb_end > downstream_cb_data_ptr);
 
             dispatch_h_cb_writer.acquire_pages(1);
 
-            uint32_t xfer_size;
+            std::uint32_t xfer_size;
+            bool not_end_of_cmd;
             if (length > dispatch_cb_page_size) {
                 xfer_size = dispatch_cb_page_size;
+                not_end_of_cmd = true;
             } else {
                 xfer_size = length;
+                not_end_of_cmd = false;
             }
             length -= xfer_size;
 
             // Get a page if needed
             if (xfer_size > dispatch_cb_reader.available_bytes(data_ptr)) {
                 dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr, [&](bool will_wrap) {
-                    uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
+                    std::uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                     if (orphan_size != 0) {
                         relay_client.write<my_noc_index, true, NCRISC_WR_CMD_BUF>(
                             data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr), orphan_size);
@@ -480,7 +489,7 @@ void relay_to_next_cb(uintptr_t data_ptr, uint64_t wlength) {
 void process_write_host_d() {
     volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
     // Remember: host transfer command includes the command in the payload, don't add it here
-    uint64_t length = cmd->write_linear_host.length;
+    std::uint64_t length = cmd->write_linear_host.length;
     uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
@@ -488,7 +497,7 @@ void process_write_host_d() {
 
 void relay_write_h() {
     volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
-    uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
+    std::uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
     uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
@@ -498,17 +507,17 @@ void process_exec_buf_end_d() { relay_to_next_cb(cmd_ptr, sizeof(CQDispatchCmd))
 
 // Note that for non-paged writes, the number of writes per page is always 1
 // This means each noc_write frees up a page
-void process_write_linear(uint32_t num_mcast_dests) {
+void process_write_linear(std::uint32_t num_mcast_dests) {
     volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
     bool multicast = num_mcast_dests > 0;
     if (not multicast) {
         num_mcast_dests = 1;
     }
 
-    uint32_t dst_noc = cmd->write_linear.noc_xy_addr;
-    uint32_t write_offset_index = cmd->write_linear.write_offset_index;
-    uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
-    uint64_t length = cmd->write_linear.length;
+    std::uint32_t dst_noc = cmd->write_linear.noc_xy_addr;
+    std::uint32_t write_offset_index = cmd->write_linear.write_offset_index;
+    std::uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
+    std::uint64_t length = cmd->write_linear.length;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
     // DPRINT << "process_write_linear noc_xy:0x" << HEX() << dst_noc << ", write_offset:" << write_offset_index << ",
     // dst_addr:0x" << dst_addr << ", length:0x" << length << ", data_ptr:0x" << data_ptr << DEC() << ENDL();
@@ -523,13 +532,13 @@ void process_write_linear(uint32_t num_mcast_dests) {
     while (length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
 #if defined(FABRIC_RELAY)
-        uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
+        std::uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
         bool hit_boundary = false;
         if (available_data == 0) {
             available_data = dispatch_cb_reader.get_cb_page_and_release_pages(
                 data_ptr, [&](bool /*will_wrap*/) { hit_boundary = true; });
         }
-        uint32_t xfer_size = length > available_data ? available_data : length;
+        std::uint32_t xfer_size = length > available_data ? available_data : length;
         if (hit_boundary) {
             if (multicast) {
                 cq_noc_async_wwrite_init_state<CQ_NOC_sNDl, true>(0, dst_noc, dst_addr);
@@ -538,12 +547,13 @@ void process_write_linear(uint32_t num_mcast_dests) {
             }
         }
 #else
-        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
-        uint32_t xfer_size = length > available_data ? available_data : length;
+        std::uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+        std::uint32_t xfer_size = length > available_data ? available_data : length;
 #endif
-        cq_noc_async_write_with_state_any_len(static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_mcast_dests);
+        cq_noc_async_write_with_state_any_len(
+            static_cast<std::uint32_t>(data_ptr), dst_addr, xfer_size, num_mcast_dests);
         // Increment counters based on the number of packets that were written
-        uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
+        std::uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
         noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
         noc_nonposted_writes_acked[noc_index] += num_mcast_dests * num_noc_packets_written;
         length -= xfer_size;
@@ -556,7 +566,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
 
 void process_write() {
     volatile tt_l1_ptr CQDispatchCmdLarge* cmd = (volatile tt_l1_ptr CQDispatchCmdLarge*)cmd_ptr;
-    uint32_t num_mcast_dests = cmd->write_linear.num_mcast_dests;
+    std::uint32_t num_mcast_dests = cmd->write_linear.num_mcast_dests;
     process_write_linear(num_mcast_dests);
 }
 
@@ -564,14 +574,14 @@ template <bool is_dram>
 void process_write_paged() {
     volatile tt_l1_ptr CQDispatchCmd* cmd = (volatile tt_l1_ptr CQDispatchCmd*)cmd_ptr;
 
-    uint32_t page_id = cmd->write_paged.start_page;
-    uint32_t base_addr = cmd->write_paged.base_addr;
-    uint32_t page_size = cmd->write_paged.page_size;
-    uint32_t pages = cmd->write_paged.pages;
+    std::uint32_t page_id = cmd->write_paged.start_page;
+    std::uint32_t base_addr = cmd->write_paged.base_addr;
+    std::uint32_t page_size = cmd->write_paged.page_size;
+    std::uint32_t pages = cmd->write_paged.pages;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
-    uint32_t write_length = pages * page_size;
+    std::uint32_t write_length = pages * page_size;
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
-    uint32_t dst_addr_offset = 0;  // Offset into page.
+    std::uint32_t dst_addr_offset = 0;  // Offset into page.
 
     // DPRINT << "process_write_paged - pages: " << pages << " page_size: " << page_size
     //        << " dispatch_cb_page_size: " << dispatch_cb_page_size << ENDL();
@@ -580,15 +590,15 @@ void process_write_paged() {
 
     while (write_length != 0) {
         // Transfer size is min(remaining_length, data_available_in_cb)
-        uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
-        uint32_t remaining_page_size = page_size - dst_addr_offset;
-        uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
+        std::uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+        std::uint32_t remaining_page_size = page_size - dst_addr_offset;
+        std::uint32_t xfer_size = remaining_page_size > available_data ? available_data : remaining_page_size;
         // Cap the transfer size to the NOC packet size - use of One Packet NOC API (better performance
         // than writing a generic amount of data)
         xfer_size = xfer_size > NOC_MAX_BURST_SIZE ? NOC_MAX_BURST_SIZE : xfer_size;
-        uint64_t dst = addr_gen.get_noc_addr(page_id, dst_addr_offset);
+        std::uint64_t dst = addr_gen.get_noc_addr(page_id, dst_addr_offset);
 
-        noc_async_write<NOC_MAX_BURST_SIZE>(static_cast<uint32_t>(data_ptr), dst, xfer_size);
+        noc_async_write<NOC_MAX_BURST_SIZE>(static_cast<std::uint32_t>(data_ptr), dst, xfer_size);
         // If paged write is not completed for a page (dispatch_cb_page_size < page_size) then add offset, otherwise
         // incr page_id.
         if (xfer_size < remaining_page_size) {
@@ -620,39 +630,39 @@ void process_write_paged() {
 // Since all subcmds all appear in the first page and given the size restrictions
 // this command can't be too many pages.  All pages are released at the end
 template <bool mcast, typename WritePackedSubCmd>
-void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
+void process_write_packed(std::uint32_t flags, std::uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
 
-    uint32_t count = cmd->write_packed.count;
+    std::uint32_t count = cmd->write_packed.count;
     ASSERT(count <= (mcast ? packed_write_max_multicast_sub_cmds : packed_write_max_unicast_sub_cmds));
-    constexpr uint32_t sub_cmd_size = sizeof(WritePackedSubCmd);
+    constexpr std::uint32_t sub_cmd_size = sizeof(WritePackedSubCmd);
     // Copying in a burst is about a 30% net gain vs reading one value per loop below
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
-        count * sub_cmd_size / sizeof(uint32_t),
+        (volatile std::uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
+        count * sub_cmd_size / sizeof(std::uint32_t),
         l1_cache);
 
-    uint32_t xfer_size = cmd->write_packed.size;
-    uint32_t write_offset_index = cmd->write_packed.write_offset_index;
-    uint32_t dst_addr = cmd->write_packed.addr + write_offset[write_offset_index];
+    std::uint32_t xfer_size = cmd->write_packed.size;
+    std::uint32_t write_offset_index = cmd->write_packed.write_offset_index;
+    std::uint32_t dst_addr = cmd->write_packed.addr + write_offset[write_offset_index];
 
     ASSERT(xfer_size <= dispatch_cb_page_size);
 
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(WritePackedSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
-    uint32_t stride =
+    std::uint32_t stride =
         (flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE) ? 0 : round_up_pow2(xfer_size, L1_ALIGNMENT);
     ASSERT(stride != 0 || data_ptr - cmd_ptr + xfer_size <= dispatch_cb_page_size);
 
-    volatile uint32_t tt_l1_ptr* l1_addr = (uint32_t*)(cmd_ptr + sizeof(CQDispatchCmd));
+    volatile std::uint32_t tt_l1_ptr* l1_addr = (std::uint32_t*)(cmd_ptr + sizeof(CQDispatchCmd));
     cq_noc_async_write_init_state<CQ_NOC_snDL, mcast>(0, dst_addr, xfer_size);
 
     // DPRINT << "dispatch_write_packed: " << xfer_size << " " << stride << " " << data_ptr << " " << count << " " <<
     // dst_addr << " " << ENDL();
     // DEVICE_PRINT("dispatch_write_packed: xfer_size {} stride {} data_ptr 0x{:08x} count {} dst_addr 0x{:08x}\n",
     // xfer_size, stride, data_ptr, count, dst_addr);
-    uint32_t writes = 0;
-    uint32_t mcasts = 0;
+    std::uint32_t writes = 0;
+    std::uint32_t mcasts = 0;
     auto wait_for_barrier = [&]() {
         if (!mcast) {
             return;
@@ -670,21 +680,21 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
     };
     WritePackedSubCmd* sub_cmd_ptr = (WritePackedSubCmd*)l1_cache;
     while (count != 0) {
-        uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
-        uint32_t num_dests = mcast ? ((CQDispatchWritePackedMulticastSubCmd*)sub_cmd_ptr)->num_mcast_dests : 1;
+        std::uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
+        std::uint32_t num_dests = mcast ? ((CQDispatchWritePackedMulticastSubCmd*)sub_cmd_ptr)->num_mcast_dests : 1;
         sub_cmd_ptr++;
-        uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
+        std::uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
         // Get a page if needed
         if (xfer_size > dispatch_cb_reader.available_bytes(data_ptr)) {
             // Check for block completion and issue orphan writes for this block
             // before proceeding to next block
-            uint32_t orphan_size = 0;
+            std::uint32_t orphan_size = 0;
             dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr, [&](bool will_wrap) {
                 orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                 if (orphan_size != 0) {
                     wait_for_barrier();
                     cq_noc_async_write_with_state<CQ_NOC_SNdL>(
-                        static_cast<uint32_t>(data_ptr), dst, orphan_size, num_dests);
+                        static_cast<std::uint32_t>(data_ptr), dst, orphan_size, num_dests);
                     writes++;
                     mcasts += num_dests;
                     if (!will_wrap) {
@@ -702,12 +712,12 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
             // than the default, so we restore the destination address to the start immediately afterwards to avoid the
             // overhead in the common case.
             if (orphan_size != 0) {
-                uint32_t remainder_xfer_size = xfer_size - orphan_size;
+                std::uint32_t remainder_xfer_size = xfer_size - orphan_size;
                 // Creating full NOC addr not needed as we are not programming the noc coords
-                uint32_t remainder_dst_addr = dst_addr + orphan_size;
+                std::uint32_t remainder_dst_addr = dst_addr + orphan_size;
                 wait_for_barrier();
                 cq_noc_async_write_with_state<CQ_NOC_SnDL>(
-                    static_cast<uint32_t>(data_ptr), remainder_dst_addr, remainder_xfer_size, num_dests);
+                    static_cast<std::uint32_t>(data_ptr), remainder_dst_addr, remainder_xfer_size, num_dests);
                 // Reset values expected below
                 cq_noc_async_write_with_state<CQ_NOC_snDL, CQ_NOC_WAIT, CQ_NOC_send>(0, dst, xfer_size);
                 writes++;
@@ -721,7 +731,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
         }
 
         wait_for_barrier();
-        cq_noc_async_write_with_state<CQ_NOC_SNdl>(static_cast<uint32_t>(data_ptr), dst, xfer_size, num_dests);
+        cq_noc_async_write_with_state<CQ_NOC_SNdl>(static_cast<std::uint32_t>(data_ptr), dst, xfer_size, num_dests);
         writes++;
         mcasts += num_dests;
 
@@ -749,37 +759,37 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
 //  - utilizing the full space creates a full prefetcher stall as all memory is tied up
 //  - so a better practical full size is 3-4 full sets of 4K kernel binaries
 // May eventually want a separate implementation for tensix vs eth dispatch
-void process_write_packed_large(uint32_t* l1_cache) {
+void process_write_packed_large(std::uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
 
-    uint32_t count = cmd->write_packed_large.count;
+    std::uint32_t count = cmd->write_packed_large.count;
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
-    uint32_t alignment = cmd->write_packed_large.alignment;
-    uint32_t write_offset_index = cmd->write_packed_large.write_offset_index;
-    uint32_t local_write_offset = write_offset[write_offset_index];
+    std::uint32_t alignment = cmd->write_packed_large.alignment;
+    std::uint32_t write_offset_index = cmd->write_packed_large.write_offset_index;
+    std::uint32_t local_write_offset = write_offset[write_offset_index];
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
-    constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeSubCmd);
+    constexpr std::uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeSubCmd);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
-        count * sub_cmd_size / sizeof(uint32_t),
+        (volatile std::uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
+        count * sub_cmd_size / sizeof(std::uint32_t),
         l1_cache);
 
-    uint32_t writes = 0;
-    uint32_t mcasts = noc_nonposted_writes_acked[noc_index];
+    std::uint32_t writes = 0;
+    std::uint32_t mcasts = noc_nonposted_writes_acked[noc_index];
     CQDispatchWritePackedLargeSubCmd* sub_cmd_ptr = (CQDispatchWritePackedLargeSubCmd*)l1_cache;
 
     bool init_state = true;
     bool must_barrier = true;
     while (count != 0) {
-        uint32_t dst_addr = sub_cmd_ptr->addr + local_write_offset;
+        std::uint32_t dst_addr = sub_cmd_ptr->addr + local_write_offset;
         // CQDispatchWritePackedLargeSubCmd always stores length - 1, so add 1 to get the actual length
         // This avoids the need to handle the special case where 65536 bytes overflows to 0
-        uint32_t length = sub_cmd_ptr->length_minus1 + 1;
-        uint32_t num_dests = sub_cmd_ptr->num_mcast_dests;
-        uint32_t pad_size = align_power_of_2(length, alignment) - length;
-        uint32_t unlink = sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+        std::uint32_t length = sub_cmd_ptr->length_minus1 + 1;
+        std::uint32_t num_dests = sub_cmd_ptr->num_mcast_dests;
+        std::uint32_t pad_size = align_power_of_2(length, alignment) - length;
+        std::uint32_t unlink = sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
         auto wait_for_barrier = [&]() {
             if (!must_barrier) {
                 return;
@@ -802,7 +812,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
         // TODO: If we are able to send 0 length txn to unset link, we don't need a flag and can compare dst_noc to prev
         // to determine linking
         if (init_state) {
-            uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
+            std::uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
             cq_noc_async_write_init_state<CQ_NOC_sNdl, true, true>(0, get_noc_addr_helper(dst_noc, dst_addr));
             must_barrier = true;
         }
@@ -820,24 +830,25 @@ void process_write_packed_large(uint32_t* l1_cache) {
                 });
             }
             // Transfer size is min(remaining_length, data_available_in_cb)
-            uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
-            uint32_t xfer_size;
+            std::uint32_t available_data = dispatch_cb_reader.available_bytes(data_ptr);
+            std::uint32_t xfer_size;
             if (length > available_data) {
                 xfer_size = available_data;
                 wait_for_barrier();
-                cq_noc_async_write_with_state_any_len(static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
+                cq_noc_async_write_with_state_any_len(
+                    static_cast<std::uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                 must_barrier = false;
             } else {
                 xfer_size = length;
                 if (unlink) {
                     wait_for_barrier();
-                    uint32_t rem_xfer_size = cq_noc_async_write_with_state_any_len<false>(
-                        static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
+                    std::uint32_t rem_xfer_size = cq_noc_async_write_with_state_any_len<false>(
+                        static_cast<std::uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                     // Unset Link flag
                     cq_noc_async_write_init_state<CQ_NOC_sndl, true, false>(0, 0, 0);
-                    uint32_t data_offset = xfer_size - rem_xfer_size;
+                    std::uint32_t data_offset = xfer_size - rem_xfer_size;
                     cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_wait>(
-                        static_cast<uint32_t>(data_ptr + data_offset),
+                        static_cast<std::uint32_t>(data_ptr + data_offset),
                         dst_addr + data_offset,
                         rem_xfer_size,
                         num_dests);
@@ -846,7 +857,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
                 } else {
                     wait_for_barrier();
                     cq_noc_async_write_with_state_any_len(
-                        static_cast<uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
+                        static_cast<std::uint32_t>(data_ptr), dst_addr, xfer_size, num_dests);
                     must_barrier = false;
                 }
             }
@@ -866,7 +877,7 @@ void process_write_packed_large(uint32_t* l1_cache) {
         if (pad_size > dispatch_cb_reader.available_bytes(data_ptr)) {
             dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr, [&](bool will_wrap) {
                 if (will_wrap) {
-                    uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
+                    std::uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                     pad_size -= orphan_size;
                 }
             });
@@ -881,29 +892,29 @@ void process_write_packed_large(uint32_t* l1_cache) {
 }
 
 // Unicast variant of packed large write with uint32_t length and discard support
-void process_write_packed_large_unicast(uint32_t* l1_cache) {
+void process_write_packed_large_unicast(std::uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
 
-    uint32_t count = cmd->write_packed_large_unicast.count;
+    std::uint32_t count = cmd->write_packed_large_unicast.count;
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
-    uint32_t alignment = cmd->write_packed_large_unicast.alignment;
-    uint32_t write_offset_index = cmd->write_packed_large_unicast.write_offset_index;
-    uint32_t local_write_offset = write_offset[write_offset_index];
+    std::uint32_t alignment = cmd->write_packed_large_unicast.alignment;
+    std::uint32_t write_offset_index = cmd->write_packed_large_unicast.write_offset_index;
+    std::uint32_t local_write_offset = write_offset[write_offset_index];
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
 
-    constexpr uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
+    constexpr std::uint32_t sub_cmd_size = sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
-        count * sub_cmd_size / sizeof(uint32_t),
+        (volatile std::uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQDispatchCmd)),
+        count * sub_cmd_size / sizeof(std::uint32_t),
         l1_cache);
 
     CQDispatchWritePackedLargeUnicastSubCmd* sub_cmd_ptr = (CQDispatchWritePackedLargeUnicastSubCmd*)l1_cache;
 
     while (count != 0) {
-        uint32_t dst_addr = sub_cmd_ptr->addr;
-        uint32_t length = sub_cmd_ptr->length;
-        uint32_t pad_size = align_power_of_2(length, alignment) - length;
+        std::uint32_t dst_addr = sub_cmd_ptr->addr;
+        std::uint32_t length = sub_cmd_ptr->length;
+        std::uint32_t pad_size = align_power_of_2(length, alignment) - length;
 
         // Check if this is a discard transaction
         bool is_discard = (dst_addr == CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_ADDR_DISCARD);
@@ -911,16 +922,18 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
         if (!is_discard) {
             // Normal unicast write
             dst_addr += local_write_offset;
-            uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
+            std::uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
 
             while (length != 0) {
                 // More data needs to be written, but we've exhausted the CB. Acquire more pages.
-                uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+                std::uint32_t available_data =
+                    dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
 
                 // Transfer size is min(remaining_length, data_available_in_cb)
-                uint32_t xfer_size = (length > available_data) ? available_data : length;
+                std::uint32_t xfer_size = (length > available_data) ? available_data : length;
 
-                noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(dst_noc, dst_addr), xfer_size);
+                noc_async_write(
+                    static_cast<std::uint32_t>(data_ptr), get_noc_addr_helper(dst_noc, dst_addr), xfer_size);
 
                 length -= xfer_size;
                 data_ptr += xfer_size;
@@ -928,11 +941,12 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
             }
         } else {
             // Discard: skip data without issuing NOC write
-            uint32_t remaining_length = length;
+            std::uint32_t remaining_length = length;
             while (remaining_length != 0) {
-                uint32_t available_data = dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
+                std::uint32_t available_data =
+                    dispatch_cb_reader.wait_for_available_data_and_release_old_pages(data_ptr);
 
-                uint32_t skip_size = (remaining_length > available_data) ? available_data : remaining_length;
+                std::uint32_t skip_size = (remaining_length > available_data) ? available_data : remaining_length;
 
                 data_ptr += skip_size;
                 remaining_length -= skip_size;
@@ -943,7 +957,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
         if (pad_size > dispatch_cb_reader.available_bytes(data_ptr)) {
             dispatch_cb_reader.get_cb_page_and_release_pages(data_ptr, [&](bool will_wrap) {
                 if (will_wrap) {
-                    uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
+                    std::uint32_t orphan_size = dispatch_cb_reader.available_bytes(data_ptr);
                     pad_size -= orphan_size;
                 }
             });
@@ -963,12 +977,12 @@ static uintptr_t process_debug_cmd(uintptr_t cmd_ptr) {
 }
 
 FORCE_INLINE
-uint32_t stream_wrap_ge(uint32_t a, uint32_t b) {
-    constexpr uint32_t shift = 32 - MEM_WORD_ADDR_WIDTH;
+std::uint32_t stream_wrap_ge(std::uint32_t a, std::uint32_t b) {
+    constexpr std::uint32_t shift = 32 - MEM_WORD_ADDR_WIDTH;
     // Careful below: have to take the signed diff for 2s complement to handle the wrap
     // Below relies on taking the diff first then the compare to move the wrap
     // to 2^31 away
-    int32_t diff = a - b;
+    std::int32_t diff = a - b;
     return (diff << shift) >= 0;
 }
 
@@ -976,13 +990,13 @@ static void process_wait() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
     auto flags = cmd->wait.flags;
 
-    uint32_t barrier = flags & CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER;
-    uint32_t notify_prefetch = flags & CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH;
-    uint32_t clear_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM;
-    uint32_t wait_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
-    uint32_t wait_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM;
-    uint32_t count = cmd->wait.count;
-    uint32_t stream = cmd->wait.stream;
+    std::uint32_t barrier = flags & CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER;
+    std::uint32_t notify_prefetch = flags & CQ_DISPATCH_CMD_WAIT_FLAG_NOTIFY_PREFETCH;
+    std::uint32_t clear_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM;
+    std::uint32_t wait_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
+    std::uint32_t wait_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM;
+    std::uint32_t count = cmd->wait.count;
+    std::uint32_t stream = cmd->wait.stream;
 
     if (barrier) {
         // DPRINT << " DISPATCH BARRIER\n";
@@ -994,10 +1008,10 @@ static void process_wait() {
     }
 
     WAYPOINT("PWW");
-    uint32_t heartbeat = 0;
+    std::uint32_t heartbeat = 0;
     if (wait_memory) {
         uintptr_t addr = cmd->wait.addr;
-        volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
+        volatile tt_l1_ptr std::uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(addr);
         // DPRINT << " DISPATCH WAIT " << HEX() << addr << DEC() << " count " << count << ENDL();
         // DEVICE_PRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
         do {
@@ -1008,7 +1022,7 @@ static void process_wait() {
     if (wait_stream) {
         last_wait_count = count;
         last_wait_stream = stream;
-        volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
+        volatile std::uint32_t* sem_addr = reinterpret_cast<volatile std::uint32_t*>(
             static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
         // DPRINT << " DISPATCH WAIT STREAM " << HEX() << stream << DEC() << " count " << count << ENDL();
         // DEVICE_PRINT("DISPATCH WAIT STREAM 0x{:08x} count {}\n", stream, count);
@@ -1019,9 +1033,9 @@ static void process_wait() {
     WAYPOINT("PWD");
 
     if (clear_stream) {
-        volatile uint32_t* sem_addr = reinterpret_cast<volatile uint32_t*>(
+        volatile std::uint32_t* sem_addr = reinterpret_cast<volatile std::uint32_t*>(
             static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
-        uint32_t neg_sem_val = -(*sem_addr);
+        std::uint32_t neg_sem_val = -(*sem_addr);
         NOC_STREAM_WRITE_REG(
             stream,
             STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX,
@@ -1039,39 +1053,39 @@ static void process_wait() {
 
 static void process_delay_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t count = cmd->delay.delay;
-    for (volatile uint32_t i = 0; i < count; i++);
+    std::uint32_t count = cmd->delay.delay;
+    for (volatile std::uint32_t i = 0; i < count; i++);
     cmd_ptr += sizeof(CQDispatchCmd);
 }
 
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t stream = cmd->mcast.wait_stream;
+    std::uint32_t stream = cmd->mcast.wait_stream;
     // The location of the go signal embedded in the command does not meet NOC alignment requirements.
     // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
     // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
     // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
     // CQDispatchGoSignalMcastCmd).
-    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
-    uint32_t go_signal_value = cmd->mcast.go_signal;
-    uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
-    uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
-    uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
-    uint32_t wait_count = cmd->mcast.wait_count;
+    volatile std::uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile std::uint32_t tt_l1_ptr*)cmd_ptr;
+    std::uint32_t go_signal_value = cmd->mcast.go_signal;
+    std::uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
+    std::uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
+    std::uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
+    std::uint32_t wait_count = cmd->mcast.wait_count;
     if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
-        uint64_t dst_noc_addr_multicast =
-            get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr + sizeof(uint32_t) * multicast_go_offset);
-        uint32_t num_dests = num_worker_cores_to_mcast;
+        std::uint64_t dst_noc_addr_multicast =
+            get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr + sizeof(std::uint32_t) * multicast_go_offset);
+        std::uint32_t num_dests = num_worker_cores_to_mcast;
         // Ensure the offset with respect to L1_ALIGNMENT is the same for the source and destination.
-        uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(uint32_t));
+        std::uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(std::uint32_t));
         aligned_go_signal_storage[storage_offset] = go_signal_value;
 
         cq_noc_async_write_init_state<CQ_NOC_SNDL, true>(
-            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&aligned_go_signal_storage[storage_offset])),
+            static_cast<std::uint32_t>(reinterpret_cast<uintptr_t>(&aligned_go_signal_storage[storage_offset])),
             dst_noc_addr_multicast,
-            sizeof(uint32_t));
+            sizeof(std::uint32_t));
         noc_nonposted_writes_acked[noc_index] += num_dests;
 
         WAYPOINT("WCW");
@@ -1109,10 +1123,12 @@ void process_go_signal_mcast_cmd() {
         }
     }
 
-    for (uint32_t i = 0; i < num_unicasts; ++i) {
-        uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
+    for (std::uint32_t i = 0; i < num_unicasts; ++i) {
+        std::uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
         noc_async_write_one_packet(
-            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(aligned_go_signal_storage)), dst, sizeof(uint32_t));
+            static_cast<std::uint32_t>(reinterpret_cast<uintptr_t>(aligned_go_signal_storage)),
+            dst,
+            sizeof(std::uint32_t));
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);
@@ -1122,7 +1138,7 @@ FORCE_INLINE
 void process_notify_dispatch_s_go_signal_cmd() {
     // Update free running counter on dispatch_s, signalling that it's safe to send a go signal to workers
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t wait = cmd->notify_dispatch_s_go_signal.wait;
+    std::uint32_t wait = cmd->notify_dispatch_s_go_signal.wait;
     // write barrier to wait before sending the go signal
     if (wait) {
         // DPRINT << " DISPATCH_S_NOTIFY BARRIER\n";
@@ -1132,19 +1148,19 @@ void process_notify_dispatch_s_go_signal_cmd() {
 #endif
         noc_async_write_barrier();
     }
-    uint16_t index_bitmask = cmd->notify_dispatch_s_go_signal.index_bitmask;
+    std::uint16_t index_bitmask = cmd->notify_dispatch_s_go_signal.index_bitmask;
 
     while (index_bitmask != 0) {
-        uint32_t set_index = __builtin_ctz(index_bitmask);
+        std::uint32_t set_index = __builtin_ctz(index_bitmask);
         uintptr_t dispatch_s_sync_sem_addr = dispatch_s_sync_sem_base_addr + set_index * L1_ALIGNMENT;
         if constexpr (distributed_dispatcher) {
-            static uint32_t num_go_signals_safe_to_send[max_num_worker_sems] = {0};
-            uint64_t dispatch_s_notify_addr =
-                get_noc_addr_helper(dispatch_s_noc_xy, static_cast<uint32_t>(dispatch_s_sync_sem_addr));
+            static std::uint32_t num_go_signals_safe_to_send[max_num_worker_sems] = {0};
+            std::uint64_t dispatch_s_notify_addr =
+                get_noc_addr_helper(dispatch_s_noc_xy, static_cast<std::uint32_t>(dispatch_s_sync_sem_addr));
             num_go_signals_safe_to_send[set_index]++;
             noc_inline_dw_write(dispatch_s_notify_addr, num_go_signals_safe_to_send[set_index]);
         } else {
-            tt_l1_ptr uint32_t* notify_ptr = (uint32_t tt_l1_ptr*)(dispatch_s_sync_sem_addr);
+            tt_l1_ptr std::uint32_t* notify_ptr = (std::uint32_t tt_l1_ptr*)(dispatch_s_sync_sem_addr);
             *notify_ptr = (*notify_ptr) + 1;
         }
         // Unset the bit
@@ -1156,21 +1172,21 @@ void process_notify_dispatch_s_go_signal_cmd() {
 FORCE_INLINE
 void set_go_signal_noc_data() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
+    std::uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
-    for (uint32_t i = 0; i < num_words; ++i) {
+    volatile tt_l1_ptr std::uint32_t* data_ptr =
+        reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(cmd_ptr + sizeof(CQDispatchCmd));
+    for (std::uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
     cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
 }
 
-static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {
+static inline bool process_cmd_d(uintptr_t& cmd_ptr, std::uint32_t* l1_cache) {
     bool done = false;
 re_run_command:
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
-    DeviceTimestampedData("process_cmd_d_dispatch", (uint32_t)cmd->base.cmd_id);
+    DeviceTimestampedData("process_cmd_d_dispatch", (std::uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {
         case CQ_DISPATCH_CMD_WRITE_LINEAR:
             WAYPOINT("DWB");
@@ -1213,11 +1229,11 @@ re_run_command:
         case CQ_DISPATCH_CMD_WRITE_PACKED: {
             // DPRINT << "cmd_write_packed" << ENDL();
             // DEVICE_PRINT("cmd_write_packed\n");
-            uint32_t flags = cmd->write_packed.flags;
+            std::uint32_t flags = cmd->write_packed.flags;
             // Must match unpacking code in tt_metal/impl/profiler/profiler.cpp.
-            uint32_t data = ((flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK) >>
-                             (CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT - 1)) |
-                            bool(flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST);
+            std::uint32_t data = ((flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK) >>
+                                  (CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT - 1)) |
+                                 bool(flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST);
             DeviceTimestampedData("packed_data_dispatch", data);
             if (flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST) {
                 process_write_packed<true, CQDispatchWritePackedMulticastSubCmd>(flags, l1_cache);
@@ -1312,15 +1328,15 @@ re_run_command:
                     invalidate_l1_cache();
                 }
             }
-            uint32_t offset_count = cmd->set_write_offset.offset_count;
+            std::uint32_t offset_count = cmd->set_write_offset.offset_count;
 
             ASSERT(offset_count <= std::size(write_offset));
-            uint32_t* cmd_write_offset = (uint32_t*)(cmd_ptr + sizeof(CQDispatchCmd));
+            std::uint32_t* cmd_write_offset = (std::uint32_t*)(cmd_ptr + sizeof(CQDispatchCmd));
 
-            for (uint32_t i = 0; i < offset_count; i++) {
+            for (std::uint32_t i = 0; i < offset_count; i++) {
                 write_offset[i] = cmd_write_offset[i];
             }
-            cmd_ptr += sizeof(CQDispatchCmd) + sizeof(uint32_t) * offset_count;
+            cmd_ptr += sizeof(CQDispatchCmd) + sizeof(std::uint32_t) * offset_count;
             break;
         }
 
@@ -1338,10 +1354,10 @@ re_run_command:
             DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << dispatch_cb_reader.available_bytes(cmd_ptr)
                    << " " << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
-            DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 2) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 3) << ENDL();
+            DPRINT << HEX() << *(std::uint32_t*)cmd_ptr << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 1) << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 2) << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 3) << ENDL();
             DEVICE_PRINT(
                 "dispatcher_d invalid command: {} {} {} {} xx\n",
                 cmd_ptr,
@@ -1350,10 +1366,10 @@ re_run_command:
                 dispatch_cb_end);
             DEVICE_PRINT(
                 "0x{:08x}\n0x{:08x}\n0x{:08x}\n0x{:08x}\n",
-                *(uint32_t*)cmd_ptr,
-                *((uint32_t*)cmd_ptr + 1),
-                *((uint32_t*)cmd_ptr + 2),
-                *((uint32_t*)cmd_ptr + 3));
+                *(std::uint32_t*)cmd_ptr,
+                *((std::uint32_t*)cmd_ptr + 1),
+                *((std::uint32_t*)cmd_ptr + 2),
+                *((std::uint32_t*)cmd_ptr + 3));
             WAYPOINT("!CMD");
             ASSERT(0);
     }
@@ -1366,7 +1382,7 @@ static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
 
     volatile CQDispatchCmd tt_l1_ptr* cmd = (volatile CQDispatchCmd tt_l1_ptr*)cmd_ptr;
 
-    DeviceTimestampedData("process_cmd_h_dispatch", (uint32_t)cmd->base.cmd_id);
+    DeviceTimestampedData("process_cmd_h_dispatch", (std::uint32_t)cmd->base.cmd_id);
     switch (cmd->base.cmd_id) {
         case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
             // DPRINT << "dispatch_h write_linear_h\n";
@@ -1397,10 +1413,10 @@ static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
                    << " "
                    << " " << dispatch_cb_base << " " << dispatch_cb_end << " "
                    << "xx" << ENDL();
-            DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 1) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 2) << ENDL();
-            DPRINT << HEX() << *((uint32_t*)cmd_ptr + 3) << ENDL();
+            DPRINT << HEX() << *(std::uint32_t*)cmd_ptr << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 1) << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 2) << ENDL();
+            DPRINT << HEX() << *((std::uint32_t*)cmd_ptr + 3) << ENDL();
             DEVICE_PRINT(
                 "dispatcher_h invalid command: {} {} {} {} xx\n",
                 cmd_ptr,
@@ -1409,10 +1425,10 @@ static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
                 dispatch_cb_end);
             DEVICE_PRINT(
                 "0x{:08x}\n0x{:08x}\n0x{:08x}\n0x{:08x}\n",
-                *(uint32_t*)cmd_ptr,
-                *((uint32_t*)cmd_ptr + 1),
-                *((uint32_t*)cmd_ptr + 2),
-                *((uint32_t*)cmd_ptr + 3));
+                *(std::uint32_t*)cmd_ptr,
+                *((std::uint32_t*)cmd_ptr + 1),
+                *((std::uint32_t*)cmd_ptr + 2),
+                *((std::uint32_t*)cmd_ptr + 3));
             WAYPOINT("!CMD");
             ASSERT(0);
     }
@@ -1421,22 +1437,21 @@ static inline bool process_cmd_h(uintptr_t& cmd_ptr) {
 }
 
 struct NocCounterSnapshot {
-    uint32_t reads_num_issued;
-    uint32_t nonposted_writes_num_issued;
-    uint32_t nonposted_writes_acked;
-    uint32_t nonposted_atomics_acked;
-    uint32_t posted_writes_num_issued;
+    std::uint32_t reads_num_issued;
+    std::uint32_t nonposted_writes_num_issued;
+    std::uint32_t nonposted_writes_acked;
+    std::uint32_t nonposted_atomics_acked;
+    std::uint32_t posted_writes_num_issued;
 };
 
-template <uint32_t noc_index>
+template <std::uint32_t noc_index>
 FORCE_INLINE NocCounterSnapshot snapshot_dispatch_d_noc_counters() {
     return {
         .reads_num_issued = noc_reads_num_issued[noc_index],
         .nonposted_writes_num_issued = noc_nonposted_writes_num_issued[noc_index],
         .nonposted_writes_acked = noc_nonposted_writes_acked[noc_index],
         .nonposted_atomics_acked = noc_nonposted_atomics_acked[noc_index],
-        .posted_writes_num_issued = noc_posted_writes_num_issued[noc_index]
-    };
+        .posted_writes_num_issued = noc_posted_writes_num_issued[noc_index]};
 }
 
 // dispatch_d writes to the NOC1 core, but dispatch_s holds dedicated noc status on it. L1 noc counters
@@ -1449,14 +1464,14 @@ void publish_dispatch_d_noc_count(const NocCounterSnapshot& snapshot) {
         return;
     }
 
-    const uint32_t reads_delta = noc_reads_num_issued[upstream_noc_index] - snapshot.reads_num_issued;
-    const uint32_t nonposted_writes_delta =
+    const std::uint32_t reads_delta = noc_reads_num_issued[upstream_noc_index] - snapshot.reads_num_issued;
+    const std::uint32_t nonposted_writes_delta =
         noc_nonposted_writes_num_issued[upstream_noc_index] - snapshot.nonposted_writes_num_issued;
-    const uint32_t nonposted_writes_acked_delta =
+    const std::uint32_t nonposted_writes_acked_delta =
         noc_nonposted_writes_acked[upstream_noc_index] - snapshot.nonposted_writes_acked;
-    const uint32_t nonposted_atomics_acked_delta =
+    const std::uint32_t nonposted_atomics_acked_delta =
         noc_nonposted_atomics_acked[upstream_noc_index] - snapshot.nonposted_atomics_acked;
-    const uint32_t posted_writes_delta =
+    const std::uint32_t posted_writes_delta =
         noc_posted_writes_num_issued[upstream_noc_index] - snapshot.posted_writes_num_issued;
 
     // Leverage noc counters to store deltas so that dispatch_s can read them directly.
@@ -1467,28 +1482,27 @@ void publish_dispatch_d_noc_count(const NocCounterSnapshot& snapshot) {
         upstream_noc_index, nonposted_writes_acked_delta);
     set_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_ATOMICS_ACKED>(
         upstream_noc_index, nonposted_atomics_acked_delta);
-    set_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(
-        upstream_noc_index, posted_writes_delta);
+    set_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(upstream_noc_index, posted_writes_delta);
 
-    volatile tt_l1_ptr uint32_t* shutdown_sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(dispatch_d_shutdown_sem_id));
+    volatile tt_l1_ptr std::uint32_t* shutdown_sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(get_semaphore<fd_core_type>(dispatch_d_shutdown_sem_id));
     *shutdown_sem_addr = 1;
 }
 
 void kernel_main() {
     set_l1_data_cache<true>();
 #if defined(FABRIC_RELAY)
-    DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": start (fabric relay. 2d = " << (uint32_t)is_2d_fabric
-           << ")" << ENDL();
+    DPRINT << "dispatch_" << is_h_variant << is_d_variant
+           << ": start (fabric relay. 2d = " << (std::uint32_t)is_2d_fabric << ")" << ENDL();
     DEVICE_PRINT("dispatch_{}{}: start (fabric relay. 2d = {})\n", is_h_variant, is_d_variant, is_2d_fabric);
 #else
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": start" << ENDL();
     DEVICE_PRINT("dispatch_{}{}: start\n", is_h_variant, is_d_variant);
 #endif
     // Get runtime args
-    my_dev_id = get_arg_val<uint32_t>(OFFSETOF_MY_DEV_ID);
-    to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
-    router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
+    my_dev_id = get_arg_val<std::uint32_t>(OFFSETOF_MY_DEV_ID);
+    to_dev_id = get_arg_val<std::uint32_t>(OFFSETOF_TO_DEV_ID);
+    router_direction = get_arg_val<std::uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
     // Initialize local state of any additional nocs used instead of the default
     static_assert(my_noc_index != upstream_noc_index);
@@ -1502,7 +1516,7 @@ void kernel_main() {
     }
 
     for (size_t i = 0; i < max_num_worker_sems; i++) {
-        uint32_t index = i + first_stream_used;
+        std::uint32_t index = i + first_stream_used;
 
         NOC_STREAM_WRITE_REG(
             index,
@@ -1511,7 +1525,7 @@ void kernel_main() {
                 << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
 
-    uint32_t l1_cache[l1_cache_elements_rounded];
+    std::uint32_t l1_cache[l1_cache_elements_rounded];
 
     // Reset RT profiler mailbox fields on every dispatch core startup.
     // L1 is not guaranteed to be zero-initialized, and stale values here can
@@ -1527,7 +1541,7 @@ void kernel_main() {
     write_offset[2] = 0;
 
     {
-        uint32_t completion_queue_wr_ptr_and_toggle = *get_cq_completion_write_ptr();
+        std::uint32_t completion_queue_wr_ptr_and_toggle = *get_cq_completion_write_ptr();
         cq_write_interface.completion_fifo_wr_ptr = completion_queue_wr_ptr_and_toggle & 0x7fffffff;
         cq_write_interface.completion_fifo_wr_toggle = completion_queue_wr_ptr_and_toggle >> 31;
     }
@@ -1556,8 +1570,8 @@ void kernel_main() {
 #endif
     }
     bool done = false;
-    uint32_t heartbeat = 0;
-    uint32_t dispatch_progress = 0;  // Track number of commands processed for tracking dispatch progress updates
+    std::uint32_t heartbeat = 0;
+    std::uint32_t dispatch_progress = 0;  // Track number of commands processed for tracking dispatch progress updates
 
     // Initialize progress counter in L1 memory
     *get_dispatch_progress_ptr() = dispatch_progress;

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -36,6 +36,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/device/device_manager.hpp>
+#include <cstdint>
 
 namespace tt::tt_metal {
 
@@ -43,10 +44,25 @@ void on_dispatch_timeout_detected();
 
 namespace {
 
-bool wrap_ge(uint32_t a, uint32_t b) {
+bool dram_backed_cq_dirty_flush_enabled() {
+    static const bool enabled = [] {
+        const char* env = std::getenv("TT_METAL_DRAM_BACKED_CQ_DIRTY_FLUSH");
+        if (env == nullptr) {
+            return false;
+        }
+        const std::string value(env);
+        if (value == "auto") {
+            return std::getenv("TT_METAL_SIMULATOR") != nullptr || std::getenv("TT_UMD_SIMULATOR") != nullptr;
+        }
+        return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
+    }();
+    return enabled;
+}
+
+bool wrap_ge(std::uint32_t a, std::uint32_t b) {
     // Signed Diff uses 2's Complement to handle wrap
     // Works as long as a and b are 2^31 apart
-    int32_t diff = a - b;
+    std::int32_t diff = a - b;
     return diff >= 0;
 }
 
@@ -62,7 +78,7 @@ void loop_and_wait_with_timeout(
     const GetProgress& get_progress) {
     if (timeout_duration.count() > 0.0f) {
         auto last_progress_time = std::chrono::high_resolution_clock::now();
-        uint32_t last_progress_value = 0;
+        std::uint32_t last_progress_value = 0;
         // We won't read progress value initially as most of the waits are expected to be shorter than progress update
         // interval. Only long running operations will read progress value updates.
         auto last_progress_update_time = std::chrono::high_resolution_clock::now();
@@ -79,7 +95,7 @@ void loop_and_wait_with_timeout(
 
             // Check if progress should be updated
             if (std::chrono::high_resolution_clock::now() - last_progress_update_time >= progress_update_interval) {
-                uint32_t current_progress = get_progress();
+                std::uint32_t current_progress = get_progress();
 
                 last_progress_update_time = std::chrono::high_resolution_clock::now();
                 if (current_progress != last_progress_value) {
@@ -107,7 +123,7 @@ void loop_and_wait_with_timeout(
 }
 }  // namespace
 
-SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
+SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, std::uint8_t num_hw_cqs) :
     context_id(context_id),
     device_id(device_id),
     completion_byte_addrs(num_hw_cqs),
@@ -124,8 +140,8 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         this->channel_offset = 0;
         this->cq_to_event.resize(num_hw_cqs, 0);
         this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
-        const uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        const std::uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
+        for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0, alignment);
         }
         log_debug(tt::LogMetal, "SystemMemoryManager: Initialized with stubs for mock device");
@@ -140,7 +156,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
             "DRAM-backed CQs are enabled; this feature is intended for niche use-cases such as simulator "
             "environments, may not work in all configurations, and will result in significantly slower fast dispatch "
             "performance due to DRAM read/write latency replacing direct host memory access.");
-        const uint32_t dram_backed_command_queues_size =
+        const std::uint32_t dram_backed_command_queues_size =
             ctx.hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
         TT_ASSERT(dram_backed_command_queues_size > 0);
         TT_FATAL(
@@ -161,7 +177,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
 
     // Real hardware initialization below
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
     char* hugepage_start = static_cast<char*>(ctx.get_cluster().host_dma_address(0, mmio_device_id, channel));
     hugepage_start += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     this->cq_sysmem_start = hugepage_start;
@@ -169,7 +185,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     // TODO(abhullar): Remove env var and expose sizing at the API level
     char* cq_size_override_env = std::getenv("TT_METAL_CQ_SIZE_OVERRIDE");
     if (cq_size_override_env != nullptr) {
-        uint32_t cq_size_override = std::stoi(std::string(cq_size_override_env));
+        std::uint32_t cq_size_override = std::stoi(std::string(cq_size_override_env));
         this->cq_size = cq_size_override;
     } else {
         this->cq_size = ctx.get_cluster().get_host_channel_size(mmio_device_id, channel) / num_hw_cqs;
@@ -182,37 +198,34 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    static constexpr uint32_t AUX_PAGES_PER_CQ = 2;
-    uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
+    static constexpr std::uint32_t AUX_PAGES_PER_CQ = 2;
+    std::uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
     this->cq_size -= per_cq_reduction;
 
-    uint32_t total_cq_space = static_cast<uint32_t>(num_hw_cqs) * this->cq_size;
+    std::uint32_t total_cq_space = static_cast<std::uint32_t>(num_hw_cqs) * this->cq_size;
     this->free_region_start_ = this->channel_offset + total_cq_space;
-    this->free_region_size_ = static_cast<uint32_t>(num_hw_cqs) * per_cq_reduction;
+    this->free_region_size_ = static_cast<std::uint32_t>(num_hw_cqs) * per_cq_reduction;
     this->free_region_host_ptr_ = this->cq_sysmem_start + total_cq_space;
     this->free_region_bump_ = 0;
 
     this->init_dispatch_core_interfaces(num_hw_cqs, channel);
 }
 
-void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint16_t channel) {
+void SystemMemoryManager::init_dispatch_core_interfaces(std::uint8_t num_hw_cqs, std::uint16_t channel) {
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const CoreType core_type =
-        ctx.get_dispatch_core_manager().get_dispatch_core_type();
-    const uint32_t completion_q_rd_ptr = ctx.dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    const uint32_t prefetch_q_base = ctx.dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::UNRESERVED);
-    const uint32_t cq_start =
+    const CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    const std::uint32_t completion_q_rd_ptr =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
+    const std::uint32_t prefetch_q_base =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+    const std::uint32_t cq_start =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-    for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-        tt_cxy_pair prefetcher_core =
-            ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+    for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        tt_cxy_pair prefetcher_core = ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
         auto prefetcher_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
             prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
-        this->prefetch_q_windows.emplace_back(
-            ctx.get_cluster().get_static_tlb_window(this->prefetcher_cores[cq_id]));
+        this->prefetch_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
             ctx.get_dispatch_core_manager().completion_queue_writer_core(this->device_id, channel, cq_id);
@@ -221,24 +234,22 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
             core_type);
 
-        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = ctx.get_cluster()
-                                                                                 .get_tlb_data(tt_cxy_pair(
-                                                                                     completion_queue_writer_core.chip,
-                                                                                     completion_queue_writer_virtual.x,
-                                                                                     completion_queue_writer_virtual.y))
-                                                                                 .value();
+        const std::tuple<std::uint32_t, std::uint32_t> completion_interface_tlb_data =
+            ctx.get_cluster()
+                .get_tlb_data(tt_cxy_pair(
+                    completion_queue_writer_core.chip,
+                    completion_queue_writer_virtual.x,
+                    completion_queue_writer_virtual.y))
+                .value();
         auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
 
         this->completion_byte_addrs[cq_id] = completion_q_rd_ptr % completion_tlb_size;
-        this->completion_q_windows.emplace_back(
-            ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
-                completion_queue_writer_core.chip,
-                completion_queue_writer_virtual.x,
-                completion_queue_writer_virtual.y)));
+        this->completion_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
-        const uint32_t alignment =
+        const std::uint32_t alignment =
             is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
-        const uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
+        const std::uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
         this->cq_interfaces.emplace_back(channel, cq_id, this->cq_size, cq_start, alignment, base);
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
@@ -264,25 +275,25 @@ bool SystemMemoryManager::is_mock_device() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().is_mock_or_emulated();
 }
 
-uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_next_event(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return ++this->cq_to_event[cq_id];
     }
     cq_to_event_locks[cq_id].lock();
-    uint32_t next_event = ++this->cq_to_event[cq_id];  // Event ids start at 1
+    std::uint32_t next_event = ++this->cq_to_event[cq_id];  // Event ids start at 1
 
     cq_to_event_locks[cq_id].unlock();
     return next_event;
 }
 
 // Get last issued event to Command Queue
-uint32_t SystemMemoryManager::get_last_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_last_event(const std::uint8_t cq_id) {
     std::lock_guard<std::mutex> lock(cq_to_event_locks[cq_id]);
     return this->cq_to_event[cq_id];
 }
 
 void SystemMemoryManager::set_current_and_last_completed_event(
-    const uint8_t cq_id, const uint32_t current_event_id, const uint32_t last_completed_event_id) {
+    const std::uint8_t cq_id, const std::uint32_t current_event_id, const std::uint32_t last_completed_event_id) {
     cq_to_event_locks[cq_id].lock();
 
     this->cq_to_event[cq_id] = current_event_id;
@@ -290,7 +301,7 @@ void SystemMemoryManager::set_current_and_last_completed_event(
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::reset_event_id(const uint8_t cq_id) {
+void SystemMemoryManager::reset_event_id(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         this->cq_to_event[cq_id] = 0;
         return;
@@ -300,7 +311,7 @@ void SystemMemoryManager::reset_event_id(const uint8_t cq_id) {
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t val) {
+void SystemMemoryManager::increment_event_id(const std::uint8_t cq_id, const std::uint32_t val) {
     if (is_mock_device()) {
         this->cq_to_event[cq_id] += val;
         return;
@@ -310,7 +321,7 @@ void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const uint32_t event_id) {
+void SystemMemoryManager::set_last_completed_event(const std::uint8_t cq_id, const std::uint32_t event_id) {
     if (is_mock_device()) {
         this->cq_to_last_completed_event[cq_id] = event_id;
         return;
@@ -328,24 +339,24 @@ void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const ui
     cq_to_event_locks[cq_id].unlock();
 }
 
-uint32_t SystemMemoryManager::get_current_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_current_event(const std::uint8_t cq_id) {
     cq_to_event_locks[cq_id].lock();
-    uint32_t current_event = this->cq_to_event[cq_id];
+    std::uint32_t current_event = this->cq_to_event[cq_id];
     cq_to_event_locks[cq_id].unlock();
     return current_event;
 }
 
-uint32_t SystemMemoryManager::get_last_completed_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_last_completed_event(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return this->cq_to_last_completed_event[cq_id];
     }
     cq_to_event_locks[cq_id].lock();
-    uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
+    std::uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
     cq_to_event_locks[cq_id].unlock();
     return last_completed_event;
 }
 
-void SystemMemoryManager::reset(const uint8_t cq_id) {
+void SystemMemoryManager::reset(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -357,7 +368,7 @@ void SystemMemoryManager::reset(const uint8_t cq_id) {
     cq_interface.completion_fifo_rd_toggle = false;
 }
 
-void SystemMemoryManager::set_issue_queue_size(const uint8_t cq_id, const uint32_t issue_queue_size) {
+void SystemMemoryManager::set_issue_queue_size(const std::uint8_t cq_id, const std::uint32_t issue_queue_size) {
     if (is_mock_device()) {
         return;
     }
@@ -377,37 +388,37 @@ void SystemMemoryManager::set_bypass_mode(const bool enable, const bool clear) {
 
 bool SystemMemoryManager::get_bypass_mode() const { return this->bypass_enable; }
 
-std::vector<uint32_t>& SystemMemoryManager::get_bypass_data() { return this->bypass_buffer; }
+std::vector<std::uint32_t>& SystemMemoryManager::get_bypass_data() { return this->bypass_buffer; }
 
-uint32_t SystemMemoryManager::get_issue_queue_size(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_size(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_size << 4;
 }
 
-uint32_t SystemMemoryManager::get_issue_queue_limit(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_limit(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_limit << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_size(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_size(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_size << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_limit(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_limit(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_limit << 4;
 }
 
-uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
@@ -417,18 +428,18 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
     return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
-void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
+void* SystemMemoryManager::get_completion_queue_ptr(std::uint8_t cq_id) const {
     if (is_dram_backed()) {
         auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
-        const uint32_t dram_channel =
+        const std::uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         ctx.get_cluster().read_dram_vec(
             this->cq_sysmem_start +
@@ -448,14 +459,14 @@ void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
     return (void*)(this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset));
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
     return this->cq_interfaces[cq_id].completion_fifo_rd_toggle;
 }
 
-uint32_t SystemMemoryManager::get_cq_size() const {
+std::uint32_t SystemMemoryManager::get_cq_size() const {
     if (is_mock_device()) {
         return 65536;
     }
@@ -468,23 +479,23 @@ ContextId SystemMemoryManager::get_context_id() const { return this->context_id;
 
 std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() { return this->cq_interfaces; }
 
-void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
+void* SystemMemoryManager::issue_queue_reserve(std::uint32_t cmd_size_B, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         thread_local std::array<char, 65536> dummy_buffer{};
         return dummy_buffer.data();
     }
 
     if (this->bypass_enable) {
-        uint32_t curr_size = this->bypass_buffer.size();
-        uint32_t new_size = curr_size + (cmd_size_B / sizeof(uint32_t));
+        std::uint32_t curr_size = this->bypass_buffer.size();
+        std::uint32_t new_size = curr_size + (cmd_size_B / sizeof(std::uint32_t));
         this->bypass_buffer.resize(new_size);
         return (void*)((char*)this->bypass_buffer.data() + this->bypass_buffer_write_offset);
     }
 
-    uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
+    std::uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
-    const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-    const uint32_t alignment =
+    const std::uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
+    const std::uint32_t alignment =
         is_dram_backed()
             ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
             : tt::tt_metal::MetalContext::instance(this->context_id)
@@ -515,7 +526,7 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     return issue_q_region;
 }
 
-void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uint32_t write_ptr) {
+void SystemMemoryManager::cq_write(const void* data, std::uint32_t size_in_bytes, std::uint32_t write_ptr) {
     if (is_mock_device()) {
         return;
     }
@@ -531,7 +542,10 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
     // https://github.com/tenstorrent/tt-metal/issues/4757
 
     if (this->bypass_enable) {
-        std::copy((uint8_t*)data, (uint8_t*)data + size_in_bytes, (uint8_t*)this->bypass_buffer.data() + write_ptr);
+        std::copy(
+            (std::uint8_t*)data,
+            (std::uint8_t*)data + size_in_bytes,
+            (std::uint8_t*)this->bypass_buffer.data() + write_ptr);
     } else if (is_dram_backed()) {
         void* user_scratchspace =
             this->cq_sysmem_start + (write_ptr - this->get_dram_region_base_addr() - this->channel_offset);
@@ -543,7 +557,7 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 }
 
 // TODO: RENAME issue_queue_stride ?
-void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint8_t cq_id) {
+void SystemMemoryManager::issue_queue_push_back(std::uint32_t push_size_B, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -554,20 +568,21 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const uint32_t alignment =
+    const std::uint32_t alignment =
         is_dram_backed()
             ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
             : tt::tt_metal::MetalContext::instance(this->context_id)
                   .hal()
                   .get_alignment(tt::tt_metal::HalMemType::HOST);
-    const uint32_t push_size_16B = align(push_size_B, alignment) >> 4;
+    const std::uint32_t push_size_16B = align(push_size_B, alignment) >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
-    uint32_t issue_q_wr_ptr = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
+    std::uint32_t issue_q_wr_ptr =
+        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
     // Capture before advancing: issue_fifo_wr_ptr points to the slot just written; after the advance below it points to
     // the next slot.
-    const uint32_t wr_ptr_bytes = cq_interface.issue_fifo_wr_ptr << 4;
+    const std::uint32_t wr_ptr_bytes = cq_interface.issue_fifo_wr_ptr << 4;
 
     if (cq_interface.issue_fifo_wr_ptr + push_size_16B >= cq_interface.issue_fifo_limit) {
         cq_interface.issue_fifo_wr_ptr = (cq_interface.cq_start + cq_interface.offset) >> 4;  // In 16B words
@@ -578,18 +593,30 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 
     if (is_dram_backed()) {
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
-        const uint32_t dram_channel =
+        const std::uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
-        const uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
-        ctx.get_cluster().write_dram_vec(
-            this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
-            push_size_16B << 4,
-            this->device_id,
-            dram_channel,
-            dram_target_addr);
+        if (dram_backed_cq_dirty_flush_enabled()) {
+            const std::uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
+            ctx.get_cluster().write_dram_vec(
+                this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
+                push_size_16B << 4,
+                this->device_id,
+                dram_channel,
+                dram_target_addr);
+        } else {
+            ctx.get_cluster().write_dram_vec(
+                this->cq_sysmem_start +
+                    (cq_interface.offset - this->get_dram_region_base_addr() - this->channel_offset) +
+                    cq_interface.cq_start,
+                this->get_issue_queue_size(cq_id),
+                this->device_id,
+                dram_channel,
+                this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
+                    cq_interface.cq_start);
+        }
         ctx.get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
-            sizeof(uint32_t),
+            sizeof(std::uint32_t),
             this->device_id,
             dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + issue_q_wr_ptr);
@@ -598,33 +625,34 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 
     // Also store this data in hugepages, so if a hang happens we can see what was written by host.
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
     ctx.get_cluster().write_sysmem(
         &cq_interface.issue_fifo_wr_ptr,
-        sizeof(uint32_t),
+        sizeof(std::uint32_t),
         issue_q_wr_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }
 
-void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) const {
+void SystemMemoryManager::send_completion_queue_read_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return;
     }
 
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
-    uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
+    std::uint32_t read_ptr_and_toggle =
+        cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
     this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
-    const uint32_t completion_q_rd_ptr =
+    const std::uint32_t completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         ctx.get_cluster().write_dram_vec(
             &read_ptr_and_toggle,
-            sizeof(uint32_t),
+            sizeof(std::uint32_t),
             this->device_id,
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id()),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
@@ -633,16 +661,16 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
     ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
-        sizeof(uint32_t),
+        sizeof(std::uint32_t),
         completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }
 
-void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
+void SystemMemoryManager::fetch_queue_reserve_back(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -652,11 +680,11 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const uint32_t prefetch_q_rd_ptr =
+    const std::uint32_t prefetch_q_rd_ptr =
         ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
 
     // Helper to wait for fetch queue space, if needed
-    uint32_t fence;
+    std::uint32_t fence;
     auto wait_for_fetch_q_space = [&]() {
         if (this->prefetch_q_dev_ptrs[cq_id] != this->prefetch_q_dev_fences[cq_id]) {
             return;
@@ -665,7 +693,8 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
         // Body of the operation
         auto fetch_operation_body = [&]() {
-            ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
+            ctx.get_cluster().read_core(
+                &fence, sizeof(std::uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
             // Yield to clock the simulator when running on TTSim; no-op on real hardware.
             ctx.get_cluster().advance_device_execution(this->device_id);
@@ -683,7 +712,9 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         };
 
         // Get dispatch progress for timeout detection
-        auto get_dispatch_progress = [&]() -> uint32_t { return get_cq_dispatch_progress(this->device_id, cq_id); };
+        auto get_dispatch_progress = [&]() -> std::uint32_t {
+            return get_cq_dispatch_progress(this->device_id, cq_id);
+        };
 
         auto timeout_duration = ctx.rtoptions().get_timeout_duration_for_operations();
 
@@ -693,25 +724,25 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     wait_for_fetch_q_space();
     // Wrap FetchQ if possible
-    uint32_t prefetch_q_base =
+    std::uint32_t prefetch_q_base =
         ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
-    uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
-                                                   ctx.dispatch_mem_map().prefetch_q_entry_size_bytes());
+    std::uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
+                                                        ctx.dispatch_mem_map().prefetch_q_entry_size_bytes());
     if (this->prefetch_q_dev_ptrs[cq_id] == prefetch_q_limit) {
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
         wait_for_fetch_q_space();
     }
 }
 
-uint32_t SystemMemoryManager::completion_queue_wait_front(
-    const uint8_t cq_id, std::atomic<bool>& exit_condition) const {
+std::uint32_t SystemMemoryManager::completion_queue_wait_front(
+    const std::uint8_t cq_id, std::atomic<bool>& exit_condition) const {
     if (is_mock_device()) {
         return 0;
     }
 
-    uint32_t write_ptr_and_toggle;
-    uint32_t write_ptr;
-    uint32_t write_toggle;
+    std::uint32_t write_ptr_and_toggle;
+    std::uint32_t write_ptr;
+    std::uint32_t write_toggle;
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
     // Body of the operation to be timed out
@@ -732,14 +763,13 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     // Handler for the timeout
     auto on_timeout = [this, &exit_condition]() {
         exit_condition.store(true);
-
         tt::tt_metal::MetalContext::instance(this->context_id).on_dispatch_timeout_detected();
 
         TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");
     };
 
     // Get dispatch progress for timeout detection
-    auto get_dispatch_progress = [this, cq_id]() -> uint32_t {
+    auto get_dispatch_progress = [this, cq_id]() -> std::uint32_t {
         return get_cq_dispatch_progress(this->device_id, cq_id);
     };
 
@@ -753,7 +783,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     return write_ptr_and_toggle;
 }
 
-void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
+void SystemMemoryManager::wrap_issue_queue_wr_ptr(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -766,7 +796,7 @@ void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
     cq_interface.issue_fifo_wr_toggle = not cq_interface.issue_fifo_wr_toggle;
 }
 
-void SystemMemoryManager::wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
+void SystemMemoryManager::wrap_completion_queue_rd_ptr(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -776,13 +806,13 @@ void SystemMemoryManager::wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
     cq_interface.completion_fifo_rd_toggle = not cq_interface.completion_fifo_rd_toggle;
 }
 
-void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, const uint8_t cq_id) {
+void SystemMemoryManager::completion_queue_pop_front(std::uint32_t num_pages_read, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
 
-    uint32_t data_read_B = num_pages_read * DispatchSettings::TRANSFER_PAGE_SIZE;
-    uint32_t data_read_16B = data_read_B >> 4;
+    std::uint32_t data_read_B = num_pages_read * DispatchSettings::TRANSFER_PAGE_SIZE;
+    std::uint32_t data_read_16B = data_read_B >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     cq_interface.completion_fifo_rd_ptr += data_read_16B;
@@ -795,22 +825,23 @@ void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, co
     this->send_completion_queue_read_ptr(cq_id);
 }
 
-void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8_t cq_id, bool stall_prefetcher) {
+void SystemMemoryManager::fetch_queue_write(
+    std::uint32_t command_size_B, const std::uint8_t cq_id, bool stall_prefetcher) {
     if (is_mock_device()) {
         return;
     }
 
     const DispatchMemMap& dispatch_mem_map = MetalContext::instance(this->context_id).dispatch_mem_map();
-    const uint32_t max_command_size_B = dispatch_mem_map.max_prefetch_command_size();
+    const std::uint32_t max_command_size_B = dispatch_mem_map.max_prefetch_command_size();
     TT_ASSERT(
         command_size_B <= max_command_size_B,
         "Generated prefetcher command of size {} B exceeds max command size {} B",
         command_size_B,
         max_command_size_B);
 
-    const uint32_t entry_bytes = dispatch_mem_map.prefetch_q_entry_size_bytes();
-    const uint32_t shift_for_msb = entry_bytes * 8 - 1;
-    const uint32_t max_encodable = 1u << shift_for_msb;
+    const std::uint32_t entry_bytes = dispatch_mem_map.prefetch_q_entry_size_bytes();
+    const std::uint32_t shift_for_msb = entry_bytes * 8 - 1;
+    const std::uint32_t max_encodable = 1u << shift_for_msb;
     TT_ASSERT(
         (command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < max_encodable,
         "FetchQ command too large to represent");
@@ -819,7 +850,7 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
         return;
     }
     tt_driver_atomics::sfence();
-    uint32_t entry_val = command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
+    std::uint32_t entry_val = command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
 
     // stall_prefetcher is used for enqueuing traces, as replaying a trace will hijack the cmd_data_q
     // so prefetcher fetches multiple cmds that include the trace cmd, they will be corrupted by trace pulling data
@@ -830,7 +861,8 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     }
 
     if (entry_bytes == 2) {
-        this->prefetch_q_windows[cq_id]->write16(this->prefetch_q_dev_ptrs[cq_id], static_cast<uint16_t>(entry_val));
+        this->prefetch_q_windows[cq_id]->write16(
+            this->prefetch_q_dev_ptrs[cq_id], static_cast<std::uint16_t>(entry_val));
     } else {
         TT_ASSERT(entry_bytes == 4);
         this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
@@ -842,25 +874,25 @@ bool SystemMemoryManager::is_dram_backed() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_dram_backed_cq();
 }
 
-uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
+std::uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
     return tt::tt_metal::MetalContext::instance(this->context_id)
         .hal()
         .get_dev_addr(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
 }
 
-uint32_t SystemMemoryManager::get_dram_region_bank_id() const {
+std::uint32_t SystemMemoryManager::get_dram_region_bank_id() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
     return 0;
 }
 
-std::pair<void*, uint32_t> SystemMemoryManager::allocate_region(uint32_t size) {
+std::pair<void*, std::uint32_t> SystemMemoryManager::allocate_region(std::uint32_t size) {
     if (free_region_host_ptr_ == nullptr || free_region_size_ == 0) {
         return {nullptr, 0};
     }
 
-    static constexpr uint32_t kMinAlignment = 64;
-    uint32_t aligned_size = tt::align(size, kMinAlignment);
+    static constexpr std::uint32_t kMinAlignment = 64;
+    std::uint32_t aligned_size = tt::align(size, kMinAlignment);
     TT_FATAL(
         free_region_bump_ + aligned_size <= free_region_size_,
         "Hugepage auxiliary region exhausted: requested {} bytes ({} aligned), {} of {} used",
@@ -870,7 +902,7 @@ std::pair<void*, uint32_t> SystemMemoryManager::allocate_region(uint32_t size) {
         free_region_size_);
 
     void* host_ptr = free_region_host_ptr_ + free_region_bump_;
-    uint32_t device_addr = free_region_start_ + free_region_bump_;
+    std::uint32_t device_addr = free_region_start_ + free_region_bump_;
     free_region_bump_ += aligned_size;
 
     std::memset(host_ptr, 0, aligned_size);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -117,11 +117,9 @@ thread_local tt_emule::TileCounterArray* __emule_tc_array = nullptr;
 //                        runs on (DM count for DM kernels, active-engine count
 //                        for compute).
 //
-// __emule_my_thread_id — backs get_my_thread_id(). Index of this processor within
-//                        the kernel's processor list (0-based), matching the Quasar
-//                        firmware's my_thread_id semantics. NOT the same as
-//                        __processor_id: e.g. a consumer on RISCV_1 has
-//                        __processor_id=1 but __emule_my_thread_id=0 (first consumer).
+// __emule_my_thread_id — backs get_my_thread_id(). Same value as __processor_id
+//                        today, but kept separate for type (uint32_t vs uint8_t)
+//                        and public-API surface.
 thread_local uint8_t __processor_id = 0;
 thread_local uint8_t __emule_neo_id = 0;
 thread_local uint8_t __emule_trisc_id = 0;
@@ -276,54 +274,9 @@ struct KernelInfo {
     bool run_all_variants = false;
     std::vector<uint32_t> rt_args;
     std::vector<uint32_t> common_rt_args;
-    uint8_t processor_id = 0;  // RISC-V processor ID (mhartid); used for DFB role resolution
-    uint8_t thread_idx = 0;    // Index within this kernel's processor list → __emule_my_thread_id
+    uint8_t processor_id = 0;
     bool is_tensix = false;    // true for Tensix/compute kernels (DFB mask uses bits 8-23)
     uint32_t num_threads = 1;  // number of engines (for get_num_threads())
-};
-
-// Captures a Metal 2.0 kernel's named bindings. Drives both the JIT wrapper's
-// namespace emission (see emit_metal2_namespaces) and the JIT cache key
-// (see cache_key_suffix). Empty for legacy kernels.
-struct Metal2BindingsSnapshot {
-    // TA bindings are kept in insertion order (matches genfiles.cpp's vector);
-    // their CRTA position drives the get_common_vararg offset.
-    struct TaEntry {
-        std::string name;
-        uint32_t cta_offset;
-        uint32_t addr_crta_offset;
-    };
-
-    bool is_metal2 = false;
-    std::vector<std::string> named_runtime_args;
-    std::vector<std::string> named_common_runtime_args;
-    std::map<std::string, uint32_t> dfb_accessors;
-    std::map<std::string, uint16_t> sem_accessors;
-    std::vector<TaEntry> ta_accessors;
-
-    // Distinguishes kernels that share source/CTAs/defines but bind different
-    // IDs — without this they collide on cache key and the second silently
-    // reuses the first's .so.
-    std::string cache_key_suffix() const {
-        std::string s;
-        for (const auto& [name, id] : dfb_accessors) {
-            s += ":dfb:" + name + "=" + std::to_string(id);
-        }
-        for (const auto& [name, id] : sem_accessors) {
-            s += ":sem:" + name + "=" + std::to_string(id);
-        }
-        for (const auto& ta : ta_accessors) {
-            s += ":ta:" + ta.name + "=" + std::to_string(ta.cta_offset) + "," +
-                 std::to_string(ta.addr_crta_offset);
-        }
-        for (const auto& name : named_runtime_args) {
-            s += ":rta:" + name;
-        }
-        for (const auto& name : named_common_runtime_args) {
-            s += ":crta:" + name;
-        }
-        return s;
-    }
 };
 
 struct DeferredCompile {
@@ -332,7 +285,6 @@ struct DeferredCompile {
     std::unordered_map<std::string, uint32_t> named_compile_args;
     std::map<std::string, std::string> defines;
     std::string extra_inc;
-    Metal2BindingsSnapshot bindings;
 };
 
 struct PendingKernelInfo {
@@ -342,7 +294,6 @@ struct PendingKernelInfo {
     std::vector<uint32_t> rt_args;
     std::vector<uint32_t> common_rt_args;
     uint8_t processor_id = 0;
-    uint8_t thread_idx = 0;    // Index within this kernel's processor list
     bool is_tensix = false;
     uint32_t num_threads = 1;
 };
@@ -520,117 +471,11 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
     src = std::regex_replace(
         src, l1_arg_ptr_re, "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(get_arg_val<uint32_t>$2))");
 
-    // Metal 2.0 named-arg pattern: reinterpret_cast<T*>(static_cast<uintptr_t>(get_arg(args::NAME)))
-    static const std::regex l1_named_arg_ptr_re(
-        R"(reinterpret_cast<([^>]+\*)>\s*\(\s*static_cast<uintptr_t>\s*\(\s*get_arg\s*\(\s*([^)]+)\s*\)\s*\)\s*\))");
-    src = std::regex_replace(
-        src, l1_named_arg_ptr_re,
-        "reinterpret_cast<$1>((uintptr_t)__emule_local_l1_to_ptr(static_cast<uint32_t>(get_arg($2))))");
-
     std::ofstream out(out_path);
     if (!out) {
         throw std::runtime_error("preprocess_kernel_source_for_x86: cannot write " + out_path);
     }
     out << src;
-}
-
-static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& kernel) {
-    Metal2BindingsSnapshot s;
-    s.is_metal2 = kernel.is_metal2_kernel();
-    s.named_runtime_args = kernel.get_named_runtime_args();
-    s.named_common_runtime_args = kernel.get_named_common_runtime_args();
-    kernel.process_dataflow_buffer_local_accessor_handles(
-        [&s](const std::string& name, uint16_t id) { s.dfb_accessors[name] = id; });
-    kernel.process_semaphore_local_accessor_handles(
-        [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
-    kernel.process_tensor_binding_handles(
-        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off) {
-            s.ta_accessors.push_back({name, cta_off, addr_crta_off});
-        });
-    return s;
-}
-
-// Emits args::/dfb::/sem::/ta:: namespaces into the JIT wrapper, replacing
-// kernel_args_generated.h + kernel_bindings_generated.h that upstream's JIT
-// build produces. Must stay text-equivalent to genfiles.cpp's
-// write_kernel_{args,bindings}_generated_header.
-static void emit_metal2_namespaces(
-    std::ostream& f,
-    const Metal2BindingsSnapshot& s,
-    const std::unordered_map<std::string, uint32_t>& named_compile_args) {
-    const bool has_args = !s.named_runtime_args.empty() || !s.named_common_runtime_args.empty() ||
-                          !named_compile_args.empty();
-    if (has_args) {
-        f << "#include \"experimental/kernel_args.h\"\n";
-    }
-    if (!s.dfb_accessors.empty()) {
-        f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-    }
-    if (!s.sem_accessors.empty()) {
-        f << "#include <cstdint>\n";
-    }
-    if (!s.ta_accessors.empty()) {
-        f << "#include \"api/tensor/tensor_accessor.h\"\n";
-    }
-
-    if (has_args) {
-        f << "namespace args {\n";
-        uint32_t rta_offset = 0;
-        for (const auto& name : s.named_runtime_args) {
-            f << "constexpr ::experimental::RtaArg<uint32_t> " << name << "{" << rta_offset << "};\n";
-            rta_offset += sizeof(uint32_t);
-        }
-        uint32_t crta_offset = 0;
-        for (const auto& name : s.named_common_runtime_args) {
-            f << "constexpr ::experimental::CrtaArg<uint32_t> " << name << "{" << crta_offset << "};\n";
-            crta_offset += sizeof(uint32_t);
-        }
-        // Sort CTAs for deterministic wrapper output.
-        std::vector<std::pair<std::string, uint32_t>> cta_entries(
-            named_compile_args.begin(), named_compile_args.end());
-        std::sort(cta_entries.begin(), cta_entries.end());
-        for (const auto& [name, value] : cta_entries) {
-            f << "constexpr ::experimental::CtaVal<uint32_t> " << name << "{" << value << "u};\n";
-        }
-        f << "}  // namespace args\n";
-    }
-    if (!s.dfb_accessors.empty()) {
-        f << "namespace dfb {\n";
-        for (const auto& [name, id] : s.dfb_accessors) {
-            f << "constexpr DFBAccessor " << name << "{" << id << "};\n";
-        }
-        f << "}  // namespace dfb\n";
-    }
-    if (!s.sem_accessors.empty()) {
-        f << "namespace sem {\n";
-        for (const auto& [name, id] : s.sem_accessors) {
-            f << "constexpr std::uint32_t " << name << " = " << id << "u;\n";
-        }
-        f << "}  // namespace sem\n";
-    }
-    if (!s.ta_accessors.empty()) {
-        f << "namespace ta {\n";
-        for (const auto& ta : s.ta_accessors) {
-            f << "using " << ta.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
-              << ta.cta_offset << "u, " << ta.addr_crta_offset << "u>;\n";
-            f << "constexpr " << ta.name << "_t " << ta.name << "{};\n";
-        }
-        f << "}  // namespace ta\n";
-    }
-
-    // Vararg helpers — always emitted for Metal 2.0 kernels (mirrors
-    // genfiles.cpp). The CRTA buffer layout is [user-named CRTAs,
-    // TensorBinding addresses, varargs], so get_common_vararg's base skips
-    // past both the named CRTAs and the binding section.
-    if (s.is_metal2) {
-        const uint32_t named_rta_words = static_cast<uint32_t>(s.named_runtime_args.size());
-        const uint32_t named_crta_words =
-            static_cast<uint32_t>(s.named_common_runtime_args.size() + s.ta_accessors.size());
-        f << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { "
-          << "return get_arg_val<uint32_t>(" << named_rta_words << " + idx); }\n";
-        f << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { "
-          << "return get_common_arg_val<uint32_t>(" << named_crta_words << " + idx); }\n";
-    }
 }
 
 static std::function<void()> jit_compile_kernel(
@@ -639,7 +484,6 @@ static std::function<void()> jit_compile_kernel(
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
     const std::map<std::string, std::string>& defines,
     const std::string& extra_include_flags,
-    const Metal2BindingsSnapshot& bindings = {},
     const std::string& disk_cache_so_path_arg = "") {
     const std::string jit_inc = TT_EMULE_JIT_INCLUDE_DIR;
     const std::string parent_inc = TT_EMULE_INCLUDE_DIR;
@@ -681,7 +525,6 @@ static std::function<void()> jit_compile_kernel(
             }
         }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
-        emit_metal2_namespaces(f, bindings, named_compile_args);
         f << "#include \"" << patched_kernel_path << "\"\n";
         f << "extern \"C\" { void __emule_kernel_entry() { kernel_main(); } }\n";
     }
@@ -838,7 +681,6 @@ static void populate_bank_mapping(
         dram_bank_to_noc_xy[0][ch] = noc_xy;  // NOC 0
         dram_bank_to_noc_xy[1][ch] = noc_xy;  // NOC 1 (same for emulation)
         bank_to_dram_offset[ch] = static_cast<int32_t>(metal_soc.get_address_offset(ch));
-
         log_debug(
             tt::LogMetal,
             "  DRAM bank[{}]: core({},{}) noc_xy=0x{:04x} offset=0x{:x}",
@@ -1100,42 +942,8 @@ static void collect_kernels(
             auto* qck = dynamic_cast<experimental::quasar::QuasarComputeKernel*>(kernel.get());
             bool is_quasar_compute = is_tensix && (qck != nullptr);
 
-            // Issue tenstorrent/tt-emule#24: emule runs all three TRISC code paths
-            // in a single unified compute thread (no separate UNPACK/MATH/PACK
-            // RISC cores). tt-mlir-generated D2M kernels guard hardware code
-            // paths with `#ifdef TRISC_UNPACK|MATH|PACK`; without these defines
-            // helpers like `experimental::write_row_mask_tile` compile to empty
-            // bodies and the downstream `where_tile` reads stale data. Define
-            // all three so the kernel's `#ifdef TRISC_*` blocks execute exactly
-            // once on the unified thread.
-            //
-            // EXCEPT for tilize kernels: emule's host-side
-            // `tilize_with_val_padding` already produces tiled data, so an
-            // additional kernel-side tilize would re-tilize and corrupt the
-            // layout. Skip TRISC defines when the kernel source mentions
-            // `llk_unpack_tilize` (the tilize compute path).
-            bool is_tilize_kernel = false;
-            if (is_tensix && !is_quasar_compute) {
-                std::ifstream kscan(src_path);
-                if (!kscan) {
-                    throw std::runtime_error(
-                        "collect_kernels: cannot read kernel source for TRISC-define gating: " + src_path);
-                }
-                std::string content((std::istreambuf_iterator<char>(kscan)), std::istreambuf_iterator<char>());
-                is_tilize_kernel = content.find("llk_unpack_tilize") != std::string::npos;
-            }
-            if (is_tensix && !is_quasar_compute && !is_tilize_kernel) {
-                defines["TRISC_UNPACK"] = "1";
-                defines["TRISC_MATH"] = "1";
-                defines["TRISC_PACK"] = "1";
-            }
-
-            // Metal 2.0 bindings — same across this Kernel's TRISC variants, so
-            // capture the cache-key suffix once and append it to every variant key.
-            Metal2BindingsSnapshot bindings = build_metal2_snapshot(*kernel);
-            const std::string metal2_key_suffix = bindings.cache_key_suffix();
-
-            // Helper: compute cache key from a defines map.
+            // Helper: compute cache key from a defines map (preserves upstream's sorted
+            // iteration of named_compile_args and defines for key stability).
             auto compute_cache_key = [&](const std::map<std::string, std::string>& defs) -> std::string {
                 std::string key;
                 if (ksrc.source_type_ == KernelSource::FILE_PATH) {
@@ -1157,7 +965,6 @@ static void collect_kernels(
                 for (const auto& [k, v] : defs) {
                     key += ":" + k + "=" + v;
                 }
-                key += metal2_key_suffix;
                 return key;
             };
 
@@ -1177,7 +984,7 @@ static void collect_kernels(
                         g_jit_cache[key] = disk_fn;
                     } else {
                         deferred_compiles[key] =
-                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc, bindings};
+                            DeferredCompile{src_path, compile_args, named_compile_args, defs, extra_inc};
                     }
                 }
             };
@@ -1216,7 +1023,6 @@ static void collect_kernels(
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                         CoreCoord logical_core(x, y);
                         auto& rt_args_data = kernel->runtime_args(logical_core);
-                        uint8_t tidx = 0;
                         for (uint8_t proc_id : procs.proc_ids) {
                             pending_core_kernels[logical_core].push_back(PendingKernelInfo{
                                 variant_cache_keys,
@@ -1224,7 +1030,6 @@ static void collect_kernels(
                                 rt_args_data,
                                 common_rt,
                                 proc_id,
-                                tidx++,
                                 is_tensix,
                                 procs.num_threads});
                         }
@@ -1254,8 +1059,7 @@ static void jit_compile_pending(
             futures.emplace_back(
                 key, std::async(std::launch::async, [&dc, cache_path, tmp_path]() {
                     auto fn = jit_compile_kernel(
-                        dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc,
-                        dc.bindings, tmp_path);
+                        dc.src_path, dc.compile_args, dc.named_compile_args, dc.defines, dc.extra_inc, tmp_path);
                     std::filesystem::rename(tmp_path, cache_path);
                     return fn;
                 }));
@@ -1705,7 +1509,7 @@ static void launch_cores(
                             __emule_neo_id = ki.is_tensix ? ki.processor_id : 0;
                             __emule_trisc_id = 0;
                             __emule_num_threads = ki.num_threads;
-                            __emule_my_thread_id = ki.thread_idx;
+                            __emule_my_thread_id = ki.processor_id;
 
                             log_debug(
                                 tt::LogMetal,
@@ -1831,7 +1635,7 @@ void execute_program_emulated(IDevice* device, Program& program) {
     for (auto& [logical_core, pending_list] : pending_core_kernels) {
         for (auto& pk : pending_list) {
             KernelInfo ki{
-                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.thread_idx, pk.is_tensix, pk.num_threads};
+                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.is_tensix, pk.num_threads};
             ki.variants.reserve(pk.variant_cache_keys.size());
             for (const auto& key : pk.variant_cache_keys) {
                 ki.variants.push_back(resolved_fns.at(key));

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -116,17 +116,18 @@ void send_reset_go_signal(tt::ChipId chip, const CoreCoord& virtual_core) {
     tt_metal::HalProgrammableCoreType dispatch_core_type = get_core_type(chip, virtual_core);
     const auto& hal = tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt_metal::MetalContext::instance().get_cluster();
-    uint64_t go_signal_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
+    std::uint64_t go_signal_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
     auto reset_msg = hal.get_dev_msgs_factory(dispatch_core_type).create<tt_metal::dev_msgs::go_msg_t>();
 
     reset_msg.view().signal() = tt_metal::dev_msgs::RUN_MSG_RESET_READ_PTR_FROM_HOST;
     cluster.write_core_immediate(
         reset_msg.data(), reset_msg.size(), {static_cast<size_t>(chip), virtual_core}, go_signal_addr);
     cluster.l1_barrier(chip);
-    uint64_t go_message_index_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG_INDEX);
-    uint32_t zero = 0;
+    std::uint64_t go_message_index_addr =
+        hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG_INDEX);
+    std::uint32_t zero = 0;
     cluster.write_core_immediate(
-        &zero, sizeof(uint32_t), {static_cast<size_t>(chip), virtual_core}, go_message_index_addr);
+        &zero, sizeof(std::uint32_t), {static_cast<size_t>(chip), virtual_core}, go_message_index_addr);
 }
 
 void write_launch_msg_to_core(
@@ -141,8 +142,8 @@ void write_launch_msg_to_core(
 
     msg.kernel_config().mode() = tt_metal::dev_msgs::DISPATCH_MODE_HOST;
 
-    uint64_t launch_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::LAUNCH);
-    uint64_t go_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
+    std::uint64_t launch_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::LAUNCH);
+    std::uint64_t go_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
 
     cluster.write_core_immediate(msg.data(), msg.size(), {static_cast<size_t>(chip), core}, launch_addr);
     tt_driver_atomics::sfence();
@@ -152,13 +153,15 @@ void write_launch_msg_to_core(
 }
 
 ll_api::memory read_mem_from_core(
-    tt::ChipId chip, const CoreCoord& core, const ll_api::memory& mem, uint64_t local_init_addr) {
+    tt::ChipId chip, const CoreCoord& core, const ll_api::memory& mem, std::uint64_t local_init_addr) {
     ll_api::memory read_mem;
-    read_mem.fill_from_mem_template(mem, [&](std::vector<uint32_t>::iterator mem_ptr, uint64_t addr, uint32_t len) {
-        uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
-        tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            &*mem_ptr, len * sizeof(uint32_t), tt_cxy_pair(chip, core), relo_addr);
-    });
+    read_mem.fill_from_mem_template(
+        mem, [&](std::vector<std::uint32_t>::iterator mem_ptr, std::uint64_t addr, std::uint32_t len) {
+            std::uint64_t relo_addr =
+                tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
+            tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                &*mem_ptr, len * sizeof(std::uint32_t), tt_cxy_pair(chip, core), relo_addr);
+        });
     return read_mem;
 }
 
@@ -166,9 +169,9 @@ bool test_load_write_read_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
     const CoreCoord& core,
-    uint32_t core_type_idx,
-    uint32_t processor_class_idx,
-    uint32_t processor_type_idx) {
+    std::uint32_t core_type_idx,
+    std::uint32_t processor_class_idx,
+    std::uint32_t processor_type_idx) {
     TT_ASSERT(
         tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(core, chip_id) or
         tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(core, chip_id) or
@@ -176,23 +179,25 @@ bool test_load_write_read_risc_binary(
 
     const auto& jit_build_config = tt::tt_metal::MetalContext::instance().hal().get_jit_build_config(
         core_type_idx, processor_class_idx, processor_type_idx);
-    uint64_t local_init_addr = jit_build_config.local_init_addr;
-    uint64_t l1_noc_offset = jit_build_config.l1_noc_offset;
+    std::uint64_t local_init_addr = jit_build_config.local_init_addr;
+    std::uint64_t l1_noc_offset = jit_build_config.l1_noc_offset;
 
     auto core_type = get_core_type(chip_id, core);
     // Depending on the arch, active ethernet may be shared local memory with the base firmware
     // Primary risc is shared
     // TODO: Move this query into the HAL
     bool local_mem_offset = processor_type_idx == 0 && core_type == tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
-    log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
-    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
-        uint64_t relo_addr =
-            tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, local_mem_offset);
-        relo_addr += l1_noc_offset;
+    log_debug(
+        tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(std::uint32_t));
+    mem.process_spans(
+        [&](std::vector<std::uint32_t>::const_iterator mem_ptr, std::uint64_t addr, std::uint32_t len_words) {
+            std::uint64_t relo_addr =
+                tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, local_mem_offset);
+            relo_addr += l1_noc_offset;
 
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), relo_addr);
-    });
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+                &*mem_ptr, len_words * sizeof(std::uint32_t), tt_cxy_pair(chip_id, core), relo_addr);
+        });
 
     log_debug(tt::LogLLRuntime, "wrote hex to core {}", core.str().c_str());
 
@@ -211,26 +216,28 @@ bool test_load_multicast_write_risc_binary(
     tt::ChipId chip_id,
     const CoreCoord& start_core,
     const CoreCoord& end_core,
-    uint32_t core_type_idx,
-    uint32_t processor_class_idx,
-    uint32_t processor_type_idx) {
+    std::uint32_t core_type_idx,
+    std::uint32_t processor_class_idx,
+    std::uint32_t processor_type_idx) {
     TT_ASSERT(
         tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(start_core, chip_id) and
         tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(end_core, chip_id));
 
-    uint64_t local_init_addr = tt::tt_metal::MetalContext::instance()
-                                   .hal()
-                                   .get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
-                                   .local_init_addr;
+    std::uint64_t local_init_addr = tt::tt_metal::MetalContext::instance()
+                                        .hal()
+                                        .get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
+                                        .local_init_addr;
 
-    log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
-    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
-        uint64_t relo_addr =
-            tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, false);
+    log_debug(
+        tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(std::uint32_t));
+    mem.process_spans(
+        [&](std::vector<std::uint32_t>::const_iterator mem_ptr, std::uint64_t addr, std::uint32_t len_words) {
+            std::uint64_t relo_addr =
+                tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr, false);
 
-        tt::tt_metal::MetalContext::instance().get_cluster().noc_multicast_write(
-            &*mem_ptr, len_words * sizeof(uint32_t), chip_id, start_core, end_core, relo_addr);
-    });
+            tt::tt_metal::MetalContext::instance().get_cluster().noc_multicast_write(
+                &*mem_ptr, len_words * sizeof(std::uint32_t), chip_id, start_core, end_core, relo_addr);
+        });
 
     log_debug(tt::LogLLRuntime, "multicast hex to cores {} - {}", start_core.str().c_str(), end_core.str().c_str());
 
@@ -241,12 +248,14 @@ bool test_load_multicast_write_risc_binary(
     return true;
 }
 
-void write_binary_to_address(const ll_api::memory& mem, tt::ChipId chip_id, const CoreCoord& core, uint32_t address) {
-    log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
-    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t /*addr*/, uint32_t len_words) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), address);
-    });
+void write_binary_to_address(
+    const ll_api::memory& mem, tt::ChipId chip_id, const CoreCoord& core, std::uint32_t address) {
+    log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(std::uint32_t));
+    mem.process_spans(
+        [&](std::vector<std::uint32_t>::const_iterator mem_ptr, std::uint64_t /*addr*/, std::uint32_t len_words) {
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+                &*mem_ptr, len_words * sizeof(std::uint32_t), tt_cxy_pair(chip_id, core), address);
+        });
 }
 
 namespace internal_ {
@@ -258,13 +267,13 @@ bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const CoreCoord& 
     const auto& hal = tt_metal::MetalContext::instance().hal();
     auto dev_msgs_factory = hal.get_dev_msgs_factory(dispatch_core_type);
 
-    uint64_t go_msg_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
+    std::uint64_t go_msg_addr = hal.get_dev_noc_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
 
-    auto get_mailbox_is_done = [&](uint64_t go_msg_addr) {
+    auto get_mailbox_is_done = [&](std::uint64_t go_msg_addr) {
         auto core_status = dev_msgs_factory.create<tt_metal::dev_msgs::go_msg_t>();
         tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             core_status.data(), core_status.size(), {static_cast<size_t>(chip_id), core}, go_msg_addr & ~0x3);
-        uint8_t run = core_status.view().signal();
+        std::uint8_t run = core_status.view().signal();
         if (run != run_state && run != tt_metal::dev_msgs::RUN_MSG_DONE) {
             fprintf(
                 stderr,
@@ -403,6 +412,11 @@ void wait_until_cores_done(
         }
         loop_count++;
 
+        // Pump the simulator clock while polling so multichip fabric/CCL ops make progress on all chips.
+        if (is_simulator) {
+            tt::tt_metal::MetalContext::instance().get_cluster().advance_device_execution(device_id);
+        }
+
         // Continuously polling cores here can cause other host-driven noc transactions (dprint, watcher) to drastically
         // slow down for remote devices. So when debugging with these features, add a small delay to allow other
         // host-driven transactions through.
@@ -416,7 +430,7 @@ void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& 
     std::unordered_set<CoreCoord> not_done_cores;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+    for (std::uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
         const auto& logical_cores_of_type = logical_cores[index];
         for (const auto& logical_core : logical_cores_of_type) {
@@ -433,7 +447,7 @@ void send_msg_to_eth_mailbox(
     const CoreCoord& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
     int mailbox_index,
-    std::vector<uint32_t> args,
+    std::vector<std::uint32_t> args,
     bool wait_for_ack,
     int timeout_ms) {
     constexpr auto k_sleep_time = std::chrono::nanoseconds{5};
@@ -484,13 +498,13 @@ void send_msg_to_eth_mailbox(
     // Must write args first.
     // Pad remaining args to zero
     args.resize(max_args, 0);
-    uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(mailbox_index, 0);
+    std::uint32_t first_arg_addr = hal.get_eth_fw_mailbox_arg_addr(mailbox_index, 0);
     tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
         args.data(), tt_cxy_pair(device_id, virtual_core), first_arg_addr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     const auto msg_val = hal.get_eth_fw_mailbox_val(msg_type);
-    const uint32_t msg = call | msg_val;
+    const std::uint32_t msg = call | msg_val;
     log_debug(
         tt::LogLLRuntime,
         "Device {}: Eth {} Mailbox {:#x} Command {:#x}, {}",
@@ -500,14 +514,14 @@ void send_msg_to_eth_mailbox(
         msg,
         fmt::join(args, ", "));
     tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
-        std::vector<uint32_t>{msg}.data(), tt_cxy_pair(device_id, virtual_core), mailbox_addr);
+        std::vector<std::uint32_t>{msg}.data(), tt_cxy_pair(device_id, virtual_core), mailbox_addr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
 
     // Wait for ack
     if (wait_for_ack) {
         const auto start_time = std::chrono::steady_clock::now();
         do {
-            uint32_t mailbox_val = 0;
+            std::uint32_t mailbox_val = 0;
             tt::tt_metal::MetalContext::instance().get_cluster().read_reg(&mailbox_val, target, mailbox_addr);
             msg_status = mailbox_val & status_mask;
             const auto timenow = std::chrono::steady_clock::now();
@@ -538,13 +552,13 @@ void return_to_base_firmware_and_wait_for_heartbeat(
     tt_cxy_pair target{static_cast<size_t>(device_id), virtual_core};
     const auto heartbeat_addr = hal.get_eth_fw_mailbox_val(tt_metal::FWMailboxMsg::HEARTBEAT);
 
-    uint32_t heartbeat_val = 0;
+    std::uint32_t heartbeat_val = 0;
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(&heartbeat_val, target, heartbeat_addr);
 
     constexpr auto k_sleep_time = std::chrono::nanoseconds{5};
     std::this_thread::sleep_for(k_sleep_time);
 
-    uint32_t previous_heartbeat_val = 0;
+    std::uint32_t previous_heartbeat_val = 0;
     tt::tt_metal::MetalContext::instance().get_cluster().read_reg(&previous_heartbeat_val, target, heartbeat_addr);
 
     const auto start = std::chrono::steady_clock::now();
@@ -582,7 +596,7 @@ void set_metal_eth_fw_run_flag(tt::ChipId device_id, const CoreCoord& virtual_co
         mailbox_addr + hal.get_dev_msgs_factory(k_CoreType)
                            .offset_of<tt::tt_metal::dev_msgs::mailboxes_t>(
                                tt::tt_metal::dev_msgs::mailboxes_t::Field::aerisc_run_flag);
-    std::vector<uint32_t> en = {enable};
+    std::vector<std::uint32_t> en = {enable};
     tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
         en.data(), tt_cxy_pair(device_id, virtual_core), run_flag_addr);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -25,20 +25,16 @@ namespace ll_api {
 
 namespace wormhole {
 
-uint64_t get_static_tlb_size() {
-    return 1ULL << 20;
-}
+std::uint64_t get_static_tlb_size() { return 1ULL << 20; }
 
 }  // namespace wormhole
 
 namespace blackhole {
 
-static constexpr uint32_t NUM_PORTS_PER_DRAM_CHANNEL = 3;
-static constexpr uint32_t NUM_DRAM_CHANNELS = 8;
+static constexpr std::uint32_t NUM_PORTS_PER_DRAM_CHANNEL = 3;
+static constexpr std::uint32_t NUM_DRAM_CHANNELS = 8;
 
-uint64_t get_static_tlb_size() {
-    return 2 * (1ULL << 20);
-}
+std::uint64_t get_static_tlb_size() { return 2 * (1ULL << 20); }
 
 // Returns last port of dram channel passed as the argument to align with dram_preferred_worker_endpoint
 // This core will be used for configuring 4GB TLB.
@@ -50,23 +46,23 @@ tt_xy_pair ddr_to_noc0(unsigned i) {
 
 namespace quasar {
 
-uint64_t get_static_tlb_size() { return 4ULL * (1ULL << 30); }
+std::uint64_t get_static_tlb_size() { return 4ULL * (1ULL << 30); }
 
 }  // namespace quasar
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
-    using get_static_tlb_size_ptr = uint64_t (*)();
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs) {
+    using get_static_tlb_size_ptr = std::uint64_t (*)();
     get_static_tlb_size_ptr get_static_tlb_size;
 
     // Need to set these values based on arch because UMD does not expose architecture_implementation
     switch (arch) {
-        case tt::ARCH::WORMHOLE_B0:
-            get_static_tlb_size = wormhole::get_static_tlb_size;
-            break;
-        case tt::ARCH::BLACKHOLE:
-            get_static_tlb_size = blackhole::get_static_tlb_size;
-            break;
+        case tt::ARCH::WORMHOLE_B0: get_static_tlb_size = wormhole::get_static_tlb_size; break;
+        case tt::ARCH::BLACKHOLE: get_static_tlb_size = blackhole::get_static_tlb_size; break;
         case tt::ARCH::QUASAR: get_static_tlb_size = quasar::get_static_tlb_size; break;
         default: TT_THROW("Configuring static TLBs is not supported for {}", tt::get_string(arch));
     }
@@ -83,16 +79,18 @@ void configure_static_tlbs(
         device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
     // Setup static TLBs for all eth cores
-    for (const  tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::ETH, tt::CoordSystem::TRANSLATED)) {
+    for (const tt::umd::CoreCoord& core : sdesc.get_cores(tt::CoreType::ETH, tt::CoordSystem::TRANSLATED)) {
         device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
 
-    if (arch == tt::ARCH::BLACKHOLE && sdesc.get_num_dram_channels() == blackhole::NUM_DRAM_CHANNELS) {
-        uint32_t dram_addr = 0;
+    if (arch == tt::ARCH::BLACKHOLE && include_dram_tlbs) {
+        // Setup static 4GB tlbs for DRAM cores.
+        std::uint32_t dram_addr = 0;
         for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
             tt::umd::CoreCoord dram_core =
                 tt::umd::CoreCoord(blackhole::ddr_to_noc0(dram_channel), tt::CoreType::DRAM, tt::CoordSystem::NOC0);
-            device_driver.configure_tlb(mmio_device_id, dram_core, 4ULL * (1ULL << 30), dram_addr, tt::umd::tlb_data::Posted);
+            device_driver.configure_tlb(
+                mmio_device_id, dram_core, 4ULL * (1ULL << 30), dram_addr, tt::umd::tlb_data::Posted);
         }
     }
 }

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -16,6 +16,10 @@ struct metal_SocDescriptor;
 namespace ll_api {
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver);
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs = true);
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -12,6 +12,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include <algorithm>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -44,8 +45,8 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <unistd.h>
 
-static constexpr uint32_t HOST_MEM_CHANNELS = 4;
-static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
+static constexpr std::uint32_t HOST_MEM_CHANNELS = 4;
+static constexpr std::uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
 
 namespace {
 
@@ -86,7 +87,9 @@ namespace tt {
 
 tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const umd::ClusterDescriptor* cluster_desc) {
-    if (rtoptions.get_simulator_enabled() && !rtoptions.get_mock_enabled()) {
+    // When ttsim is active, derive cluster type from the simulator soc descriptor even if a mock
+    // cluster descriptor is also configured (tt-run MP sweeps set both).
+    if (rtoptions.get_simulator_enabled()) {
         auto soc_desc =
             tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
         auto arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
@@ -231,7 +234,7 @@ Cluster::Cluster(llrt::RunTimeOptions& rtoptions) : rtoptions_(rtoptions) {
     this->initialize_ethernet_cores_router_mode();
 
     TT_FATAL(this->driver_, "UMD cluster object must be initialized and available");
-    auto & cluster_desc = (*(this->driver_->get_cluster_description()));
+    auto& cluster_desc = (*(this->driver_->get_cluster_description()));
     this->tunnels_from_mmio_device = llrt::discover_tunnels_from_mmio_device(cluster_desc);
 
     if (this->target_type_ != tt::TargetDevice::Mock && this->target_type_ != tt::TargetDevice::Emule) {
@@ -353,7 +356,7 @@ void Cluster::assign_mem_channels_to_devices(
     // MMIO device Metal currently assigns 1 channel per device. See https://github.com/tenstorrent/tt-metal/issues/4087
     // One WH gateway should have 8 remote devices in its control group.
     TT_ASSERT(controlled_device_ids.size() <= 9, "Unable to assign each device to its own host memory channel!");
-    uint16_t channel = 0;
+    std::uint16_t channel = 0;
     this->device_to_host_mem_channel_[mmio_device_id] = channel++;
     for (const ChipId& device_id : controlled_device_ids) {
         if (device_id == mmio_device_id) {
@@ -382,57 +385,35 @@ void Cluster::get_metal_desc_from_tt_desc() {
     }
 }
 
-const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const {
+const std::unordered_map<CoreCoord, std::int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(
+    ChipId chip_id) const {
     return this->virtual_routing_to_profiler_flat_id_.at(this->get_board_type(chip_id));
 }
 
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
     if (this->target_type_ == TargetDevice::Silicon) {
-        device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-            .num_host_mem_ch_per_mmio_device = std::nullopt,  // Automatically determine number of host mem channels.
-        });
+        device_driver = tt::umd::Cluster::create_silicon_cluster(std::nullopt);
     } else if (this->target_type_ == TargetDevice::Simulator) {
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
         std::unique_ptr<umd::ClusterDescriptor> mock_cluster_desc;
         if (rtoptions_.get_mock_enabled()) {
             mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
-            device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-                .chip_type = tt::umd::ChipType::SIMULATION,
-                .num_host_mem_ch_per_mmio_device = 1,
-                .sdesc_path = sdesc_path,
-                .cluster_descriptor = mock_cluster_desc.get(),
-                .simulator_directory = rtoptions_.get_simulator_path(),
-            });
+            device_driver = tt::umd::Cluster::create_simulation_cluster_with_descriptor(
+                1, rtoptions_.get_simulator_path().c_str(), sdesc_path.c_str(), mock_cluster_desc.get());
         } else {
-            device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-                .chip_type = tt::umd::ChipType::SIMULATION,
-                .num_host_mem_ch_per_mmio_device = 1,
-                .target_devices = {0},
-                .simulator_directory = rtoptions_.get_simulator_path(),
-            });
+            device_driver =
+                tt::umd::Cluster::create_single_chip_simulation_cluster(1, 0, rtoptions_.get_simulator_path().c_str());
         }
     } else if (this->target_type_ == TargetDevice::Mock) {
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
-        // If a cluster descriptor was not provided via constructor, and mock is enabled via rtoptions,
-        // load it from the YAML path and pass it into UMD for mock initialization.
         auto mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
-
-        device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-            .chip_type = tt::umd::ChipType::MOCK,
-            .sdesc_path = sdesc_path,
-            .cluster_descriptor = mock_cluster_desc.get(),
-        });
+        device_driver = tt::umd::Cluster::create_mock_cluster(sdesc_path.c_str(), mock_cluster_desc.get());
     } else if (this->target_type_ == TargetDevice::Emule) {
 #ifdef TT_METAL_USE_EMULE
         const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_, rtoptions_);
         auto mock_cluster_desc = get_mock_cluster_desc(rtoptions_);
-
-        device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
-            .chip_type = tt::umd::ChipType::SWEMULE,
-            .sdesc_path = sdesc_path,
-            .cluster_descriptor = mock_cluster_desc.get(),
-        });
+        device_driver = tt::umd::Cluster::create_swemule_cluster(sdesc_path.c_str(), mock_cluster_desc.get());
 #else
         TT_FATAL(false, "TargetDevice::Emule requires building with TT_METAL_USE_EMULE=ON");
 #endif
@@ -475,7 +456,8 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) && device_params.init_device) {
+    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) &&
+        device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
         const auto& mmio_device_ids = driver_->get_target_mmio_device_ids();
@@ -484,7 +466,11 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
         for (const auto& mmio_device_id : mmio_device_ids) {
             futures.emplace_back(tt_metal::detail::async([this, mmio_device_id]() {
                 ll_api::configure_static_tlbs(
-                    this->arch_, mmio_device_id, this->get_soc_desc(mmio_device_id), *this->driver_);
+                    this->arch_,
+                    mmio_device_id,
+                    this->get_soc_desc(mmio_device_id),
+                    *this->driver_,
+                    this->target_type_ == TargetDevice::Silicon);
             }));
         }
 
@@ -591,7 +577,7 @@ void Cluster::generate_virtual_to_umd_coord_mapping() {
                 this->virtual_dram_hw_cores_[chip_id].insert({core.x, core.y});
             }
 
-            for (uint32_t noc = 0; noc < this->num_nocs_; noc++) {
+            for (std::uint32_t noc = 0; noc < this->num_nocs_; noc++) {
                 for (auto dram_channel = 0; dram_channel < this->get_soc_desc(chip_id).get_num_dram_views();
                      dram_channel++) {
                     auto worker_dram_ep =
@@ -724,7 +710,7 @@ std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(ChipId chi
 
 int Cluster::get_device_aiclk(const ChipId& chip_id) const { return this->driver_->get_chip(chip_id)->get_clock(); }
 
-uint16_t Cluster::get_bus_id(ChipId chip) const { return this->cluster_desc_->get_bus_id(chip); }
+std::uint16_t Cluster::get_bus_id(ChipId chip) const { return this->cluster_desc_->get_bus_id(chip); }
 
 std::optional<int> Cluster::get_physical_slot(ChipId chip) const {
     if (this->target_type_ != tt::TargetDevice::Silicon) {
@@ -752,7 +738,7 @@ void Cluster::assert_risc_reset_at_core(const tt_cxy_pair& core, const tt::umd::
 }
 
 void Cluster::write_dram_vec(
-    const void* mem_ptr, uint32_t sz_in_bytes, ChipId device_id, int dram_view, uint64_t addr) const {
+    const void* mem_ptr, std::uint32_t sz_in_bytes, ChipId device_id, int dram_view, std::uint64_t addr) const {
     const metal_SocDescriptor& desc_to_use = get_soc_desc(device_id);
     TT_FATAL(
         dram_view < desc_to_use.get_num_dram_views(),
@@ -766,7 +752,8 @@ void Cluster::write_dram_vec(
     write_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
 }
 
-void Cluster::read_dram_vec(void* mem_ptr, uint32_t sz_in_bytes, ChipId device_id, int dram_view, uint64_t addr) const {
+void Cluster::read_dram_vec(
+    void* mem_ptr, std::uint32_t sz_in_bytes, ChipId device_id, int dram_view, std::uint64_t addr) const {
     const metal_SocDescriptor& desc_to_use = get_soc_desc(device_id);
     TT_FATAL(
         dram_view < desc_to_use.get_num_dram_views(),
@@ -780,14 +767,14 @@ void Cluster::read_dram_vec(void* mem_ptr, uint32_t sz_in_bytes, ChipId device_i
     read_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
 }
 
-bool Cluster::supports_dma_operations(ChipId chip_id, uint32_t sz_in_bytes) const {
+bool Cluster::supports_dma_operations(ChipId chip_id, std::uint32_t sz_in_bytes) const {
     if (this->rtoptions_.get_disable_dma_ops()) {
         return false;
     }
 
     // Currently, DMA reads/writes hang for small sizes. As a safety measure, we disable DMA for small sizes.
     // TODO: Remove this once we have a proper fix for small DMA sizes.
-    constexpr uint32_t min_dma_size_bytes = 32;
+    constexpr std::uint32_t min_dma_size_bytes = 32;
 
     // DMA reads and writes are only supported on WH. If/when DMA reads and writes are supported on BH, this should be
     // updated to support BH architectures as well. See https://github.com/tenstorrent/tt-metal/issues/22957
@@ -795,7 +782,7 @@ bool Cluster::supports_dma_operations(ChipId chip_id, uint32_t sz_in_bytes) cons
            sz_in_bytes >= min_dma_size_bytes;
 }
 
-void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+void Cluster::write_core(const void* mem_ptr, std::uint32_t sz_in_bytes, tt_cxy_pair core, std::uint64_t addr) const {
     const ChipId chip_id = core.chip;
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
     if (rtoptions_.get_watcher_enabled()) {
@@ -823,7 +810,7 @@ void Cluster::write_core(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair 
     }
 }
 
-void Cluster::read_core(void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+void Cluster::read_core(void* mem_ptr, std::uint32_t size_in_bytes, tt_cxy_pair core, std::uint64_t addr) const {
     const ChipId chip_id = core.chip;
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
@@ -848,7 +835,8 @@ void Cluster::read_core(void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core,
     }
 }
 
-void Cluster::write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+void Cluster::write_core_immediate(
+    const void* mem_ptr, std::uint32_t sz_in_bytes, tt_cxy_pair core, std::uint64_t addr) const {
     const ChipId chip_id = core.chip;
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
@@ -873,13 +861,14 @@ void Cluster::write_core_immediate(const void* mem_ptr, uint32_t sz_in_bytes, tt
     }
 }
 
-void Cluster::read_core(std::vector<uint32_t>& data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const {
-    data.resize(size_in_bytes / sizeof(uint32_t));
+void Cluster::read_core(
+    std::vector<std::uint32_t>& data, std::uint32_t size_in_bytes, tt_cxy_pair core, std::uint64_t addr) const {
+    data.resize(size_in_bytes / sizeof(std::uint32_t));
     read_core(data.data(), size_in_bytes, core, addr);
 }
 
-void Cluster::write_reg(const std::uint32_t* mem_ptr, tt_cxy_pair target, uint64_t addr) const {
-    const unsigned int size_in_bytes = sizeof(uint32_t);
+void Cluster::write_reg(const std::uint32_t* mem_ptr, tt_cxy_pair target, std::uint64_t addr) const {
+    const unsigned int size_in_bytes = sizeof(std::uint32_t);
     int chip_id = target.chip;
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
@@ -902,8 +891,8 @@ void Cluster::write_reg(const std::uint32_t* mem_ptr, tt_cxy_pair target, uint64
     }
 }
 
-void Cluster::read_reg(std::uint32_t* mem_ptr, tt_cxy_pair target, uint64_t addr) const {
-    const unsigned int size_in_bytes = sizeof(uint32_t);
+void Cluster::read_reg(std::uint32_t* mem_ptr, tt_cxy_pair target, std::uint64_t addr) const {
+    const unsigned int size_in_bytes = sizeof(std::uint32_t);
     int chip_id = target.chip;
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
@@ -924,7 +913,11 @@ void Cluster::read_reg(std::uint32_t* mem_ptr, tt_cxy_pair target, uint64_t addr
 }
 
 void Cluster::noc_multicast_write(
-    const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core_start, tt_cxy_pair core_end, uint64_t addr) const {
+    const void* mem_ptr,
+    std::uint32_t sz_in_bytes,
+    tt_cxy_pair core_start,
+    tt_cxy_pair core_end,
+    std::uint64_t addr) const {
     TT_FATAL(core_start.chip == core_end.chip, "core_start and core_end must be on the same chip");
     noc_multicast_write(
         mem_ptr,
@@ -936,8 +929,12 @@ void Cluster::noc_multicast_write(
 }
 
 void Cluster::noc_multicast_write(
-    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, CoreCoord core_start, CoreCoord core_end, uint64_t addr)
-    const {
+    const void* mem_ptr,
+    std::uint32_t sz_in_bytes,
+    ChipId chip_id,
+    CoreCoord core_start,
+    CoreCoord core_end,
+    std::uint64_t addr) const {
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
     if (rtoptions_.get_watcher_enabled()) {
@@ -961,13 +958,17 @@ void Cluster::noc_multicast_write(
 }
 
 void Cluster::write_sysmem(
-    const void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
+    const void* vec,
+    std::uint32_t size_in_bytes,
+    std::uint64_t addr,
+    ChipId src_device_id,
+    std::uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
     this->driver_->write_to_sysmem(vec, size_in_bytes, addr, channel & HOST_MEM_CHANNELS_MASK, src_device_id);
 }
 
 void Cluster::read_sysmem(
-    void* vec, uint32_t size_in_bytes, uint64_t addr, ChipId src_device_id, uint16_t channel) const {
+    void* vec, std::uint32_t size_in_bytes, std::uint64_t addr, ChipId src_device_id, std::uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
     this->driver_->read_from_sysmem(vec, addr, channel & HOST_MEM_CHANNELS_MASK, size_in_bytes, src_device_id);
 }
@@ -1021,8 +1022,8 @@ std::optional<tt::umd::semver_t> Cluster::get_ethernet_firmware_version() const 
 // ensure metadata and data to compute on are committed before launching kernels
 void Cluster::dram_barrier(ChipId chip_id) const {
     TT_ASSERT(this->hal_ != nullptr, "Hal is not set. Need to call set_hal() first.");
-    std::unordered_set<uint32_t> dram_channels;
-    for (uint32_t channel = 0; channel < this->get_soc_desc(chip_id).get_num_dram_channels(); channel++) {
+    std::unordered_set<std::uint32_t> dram_channels;
+    for (std::uint32_t channel = 0; channel < this->get_soc_desc(chip_id).get_num_dram_channels(); channel++) {
         dram_channels.insert(channel);
     }
     this->driver_->dram_membar(chip_id, dram_channels);
@@ -1038,28 +1039,28 @@ void Cluster::l1_barrier(ChipId chip_id) const {
     this->driver_->l1_membar(chip_id);
 }
 
-uint32_t Cluster::get_num_host_channels(ChipId device_id) const {
+std::uint32_t Cluster::get_num_host_channels(ChipId device_id) const {
     bool mmio_capable = this->cluster_desc_->is_chip_mmio_capable(device_id);
     return mmio_capable ? this->driver_->get_num_host_channels(device_id) : 0;
 }
 
-uint32_t Cluster::get_host_channel_size(ChipId device_id, uint32_t channel) const {
+std::uint32_t Cluster::get_host_channel_size(ChipId device_id, std::uint32_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(device_id));
     return this->driver_->get_host_channel_size(device_id, channel & HOST_MEM_CHANNELS_MASK);
 }
 
-void* Cluster::host_dma_address(uint64_t offset, ChipId src_device_id, uint16_t channel) const {
+void* Cluster::host_dma_address(std::uint64_t offset, ChipId src_device_id, std::uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
     return this->driver_->host_dma_address(offset, src_device_id, channel & HOST_MEM_CHANNELS_MASK);
 }
 
-uint64_t Cluster::get_pcie_base_addr_from_device(ChipId chip_id) const {
+std::uint64_t Cluster::get_pcie_base_addr_from_device(ChipId chip_id) const {
     return this->driver_->get_pcie_base_addr_from_device(chip_id);
 }
 
 const std::unordered_set<ChipId>& Cluster::get_devices_controlled_by_mmio_device(ChipId mmio_device_id) const {
     TT_FATAL(driver_, "UMD cluster object must be initialized and available");
-    auto & cluster_desc = (*(driver_->get_cluster_description()));
+    auto& cluster_desc = (*(driver_->get_cluster_description()));
     return llrt::get_devices_controlled_by_mmio_device(cluster_desc, mmio_device_id);
 }
 
@@ -1124,7 +1125,7 @@ void Cluster::initialize_ethernet_sockets() {
 
 void Cluster::disable_ethernet_cores_with_retrain() {
     TT_ASSERT(this->hal_ != nullptr, "Hal is not set. Need to call set_hal() first.");
-    std::vector<uint32_t> read_vec;
+    std::vector<std::uint32_t> read_vec;
     const auto& chips = this->driver_->get_target_device_ids();
     for (const auto& chip_id : chips) {
         if (!this->frequent_retrain_cores_.contains(chip_id)) {
@@ -1137,7 +1138,7 @@ void Cluster::disable_ethernet_cores_with_retrain() {
                     this->cluster_desc_->get_board_type(chip_id) == BoardType::UBB) {
                     tt_cxy_pair virtual_eth_core(
                         chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
-                    this->read_core(read_vec, sizeof(uint32_t), virtual_eth_core, retrain_count_addr_);
+                    this->read_core(read_vec, sizeof(std::uint32_t), virtual_eth_core, retrain_count_addr_);
                     if (read_vec[0] != 0) {
                         log_warning(
                             LogDevice,
@@ -1187,7 +1188,7 @@ std::unordered_set<ChipId> Cluster::get_ethernet_connected_device_ids(ChipId chi
 }
 
 void Cluster::configure_ethernet_cores_for_fabric_routers(
-    tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes) {
+    tt_fabric::FabricConfig fabric_config, std::optional<std::uint8_t> num_routing_planes) {
     if (fabric_config != tt_fabric::FabricConfig::DISABLED) {
         TT_FATAL(num_routing_planes.has_value(), "num_routing_planes should be set for reserving cores for fabric");
         TT_FATAL(num_routing_planes.value() > 0, "Expected non-zero num_routing_planes for reserving cores for fabric");
@@ -1202,8 +1203,8 @@ void Cluster::configure_ethernet_cores_for_fabric_routers(
     }
 }
 
-void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_planes) {
-    if (num_routing_planes == std::numeric_limits<uint8_t>::max()) {
+void Cluster::reserve_ethernet_cores_for_fabric_routers(std::uint8_t num_routing_planes) {
+    if (num_routing_planes == std::numeric_limits<std::uint8_t>::max()) {
         // default behavior, reserve whatever cores are available
         for (const auto& [chip_id, eth_cores] : this->device_eth_routing_info_) {
             for (const auto& [eth_core, mode] : eth_cores) {
@@ -1228,8 +1229,9 @@ void Cluster::reserve_ethernet_cores_for_fabric_routers(uint8_t num_routing_plan
                 continue;
             }
 
-            const uint8_t num_cores_to_reserve = std::min(num_routing_planes, static_cast<uint8_t>(cores.size()));
-            uint8_t num_reserved_cores = 0;
+            const std::uint8_t num_cores_to_reserve =
+                std::min(num_routing_planes, static_cast<std::uint8_t>(cores.size()));
+            std::uint8_t num_reserved_cores = 0;
             for (const auto eth_core : cores) {
                 if (num_reserved_cores == num_cores_to_reserve) {
                     pairs_done.insert(std::make_pair(chip_id, connected_chip_id));
@@ -1346,7 +1348,7 @@ std::tuple<ChipId, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<Ch
 }
 
 // TODO: unify uint64_t with ChipUID
-std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
+std::tuple<std::uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
     std::tuple<ChipId, CoreCoord> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
@@ -1506,7 +1508,7 @@ bool Cluster::is_external_cable(ChipId physical_chip_id, CoreCoord eth_core) con
     return is_external_cable;
 }
 
-uint32_t Cluster::get_alignment_requirements(ChipId chip_id, uint32_t size_in_bytes) const {
+std::uint32_t Cluster::get_alignment_requirements(ChipId chip_id, std::uint32_t size_in_bytes) const {
     if (this->supports_dma_operations(chip_id, size_in_bytes)) {
         return this->hal_->get_dma_alignment();
     }
@@ -1522,6 +1524,26 @@ const std::unique_ptr<tt::umd::Cluster>& Cluster::get_driver() const {
     TT_FATAL(driver_ != nullptr, "UMD driver is not initialized.");
     return driver_;
 }
+
+#ifdef TT_UMD_BUILD_SIMULATION
+void Cluster::register_sim_fabric_endpoint_direction(
+    ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const {
+    if (std::getenv("TTSIM_FABRIC_TERMINAL_TRACE")) {
+        std::fprintf(
+            stderr,
+            "[ttsim-fabric-terminal] tt-metal-register-direction chip=%d chan=%u dir=%u target=%u\n",
+            chip_id,
+            static_cast<std::uint32_t>(eth_chan_id),
+            static_cast<std::uint32_t>(direction),
+            static_cast<std::uint32_t>(this->target_type_));
+    }
+    if (this->target_type_ != tt::TargetDevice::Simulator) {
+        return;
+    }
+    this->get_driver()->register_sim_fabric_endpoint_direction(
+        chip_id, static_cast<std::uint32_t>(eth_chan_id), static_cast<std::uint32_t>(direction));
+}
+#endif  // TT_UMD_BUILD_SIMULATION
 
 }  // namespace tt
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -365,6 +365,11 @@ public:
 
     bool is_base_routing_fw_enabled() const;
 
+#ifdef TT_UMD_BUILD_SIMULATION
+    void register_sim_fabric_endpoint_direction(
+        ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const;
+#endif  // TT_UMD_BUILD_SIMULATION
+
     // Get all fabric ethernet cores
     std::set<tt_fabric::chan_id_t> get_fabric_ethernet_channels(
         const tt::tt_fabric::ControlPlane& control_plane, ChipId chip_id) const;


### PR DESCRIPTION
### PR Category
New Feature — Simulator Integration

### Context — craq-sim multichip integration

This is the *core integration PR* from the multichip TTSim work. It wires together all the layers — dispatch, cluster, LLRT, TLB config, fabric, and global semaphores — so that a full multi-chip Metal program can run end-to-end inside the craq-sim simulator.

> ⚠️ **Blocked**: Depends on UMD PRs [#2729](https://github.com/tenstorrent/tt-umd/pull/2729), [#2730](https://github.com/tenstorrent/tt-umd/pull/2730), and [#2731](https://github.com/tenstorrent/tt-umd/pull/2731) which add factory methods (`create_silicon_cluster`, `create_simulation_cluster_with_descriptor`, `create_single_chip_simulation_cluster`, `create_mock_cluster`) to the UMD `Cluster` class. CI will show compile errors until those UMD PRs merge and the submodule is bumped.

### PR Chain

| PR | Branch | Description | Status |
|---|---|---|---|
| #45369 | ridvan/fix-mesh-cq-type-hardening | std:: type hardening | ✅ Open |
| #45375 | ridvan/named-runtime-args | Named runtime args API | ✅ Open |
| #45370 | ridvan/h2d-socket-flow-control | H2D socket flow-control APIs | ✅ Open |
| #45372 | ridvan/fix-device-dram-channel | DRAM channel bank ID fix | ✅ Open |
| #45373 | ridvan/sim-dispatch-cluster-integration | Sim dispatch (blocked on UMD) | ⚠️ Open |
| #45374 | ridvan/test-infra-robustness-v2 | Test infrastructure fixes | ✅ Open |

### Summary

- **`tt_metal/impl/dispatch/system_memory_manager.cpp` — `pump_ttsim_clock_if_enabled()`:** TTSim is single-threaded — it will never advance unless explicitly clocked. Fast-dispatch's inner wait loops (CQ polling, completion wait) need to periodically pump the simulator clock so the simulated device can process commands. This function dynamically loads `libttsim_clock_all_devices` via `dlsym` and calls it in the wait loops. Without this, any wait loop that polls for device-side completion will spin forever because the simulated device's execution thread is the same thread that's waiting.

- **`tt_metal/impl/dispatch/kernels/cq_dispatch.cpp` — `uintptr_t` for device pointer variables:** Prevents 32-bit truncation on TTSim's 64-bit target. Hardware dispatch kernels run on 32-bit RISC-V so bare `uint32_t` is fine, but TTSim compiles dispatch kernels for 64-bit and `uint32_t` would silently truncate device-side addresses.

- **`tt_metal/impl/dispatch/command_queue_common.cpp`** — Fixes the DRAM-backed CQ offset calculation (uses corrected channel from PR #45372).

- **`tt_metal/llrt/tt_cluster.cpp` / `.hpp`** — Replaces monolithic `tt_cluster` construction with factory methods that dispatch to the correct UMD backend (silicon, sim, mock). Adds `advance_device_execution` to step the simulation forward and `get_sim_cluster` accessor.

- **`tt_metal/llrt/tlb_config.cpp` / `.hpp`** — Adds Quasar TLB configuration and `include_dram_tlbs` parameter so the sim path can opt out of DRAM TLB programming.

- **`tt_metal/llrt/llrt.cpp`** — Inserts `pump_ttsim_clock_if_enabled()` calls inside all LLRT wait-for-completion loops, for the same reason as system_memory_manager: any loop that waits for device-side state changes must pump the clock or it will deadlock.

- **`tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp`** — Skips fabric firmware initialization in sim mode (no real firmware to load).

- **`tt_metal/fabric/fabric_builder.cpp`** — Adds sim-aware path that uses the sim descriptor to configure fabric topology instead of probing hardware.

- **`tt_metal/impl/buffers/global_semaphore.cpp`** — Handles virtual semaphore addresses in the sim path.

- **`tt_metal/impl/device/mock_device_util.cpp` / `.hpp`** — Utilities for constructing mock device objects for unit tests.

- **`tt_metal/impl/emulation/emulated_program_runner.cpp`** — Drives kernel execution through the sim's emulation API instead of PCIe registers.

- **`tt_metal/impl/context/metal_context.cpp`** — Selects the correct cluster factory at MetalContext initialization time based on `TT_METAL_SIMULATOR`.

- **`tt_metal/api/tt-metalium/experimental/mock_device.hpp`** — Public header for mock device construction.

- **`TT_UMD_BUILD_SIMULATION` guards throughout** — Isolates sim-only code paths so they don't affect hardware builds. All new sim-specific logic is wrapped in these guards so the hardware compilation path is completely unaffected.

### Notes for reviewers

- All sim-specific paths are gated on `is_simulation_` / `TT_METAL_SIMULATOR` / `TT_UMD_BUILD_SIMULATION` so hardware paths are unaffected.
- **This PR will fail to compile until UMD PRs #2729/#2730/#2731 merge** — expected CI compile failures are not regressions introduced by this PR.
- **`pump_ttsim_clock_if_enabled()` design rationale:** The function uses `dlsym` rather than a link-time dependency on `libttsim` so that hardware builds can link without the sim library present. The symbol is resolved once and cached; subsequent calls are a direct function pointer call with negligible overhead.
- **`uintptr_t` vs `uint32_t` in `cq_dispatch.cpp`:** This is a TTSim-specific requirement — 32-bit RISC-V hardware is unaffected since `uintptr_t` == `uint32_t` there. The change is required for TTSim which compiles dispatch kernels for a 64-bit target.
- **Clock pump in LLRT loops:** Every loop of the form `while (!device_ready()) {}` needs a clock pump. This PR audits all such loops in `llrt.cpp` and `system_memory_manager.cpp` and adds the pump call.

### Test plan
- [ ] (Blocked on UMD PRs) Compile and run with `TT_METAL_SIMULATOR=1`
- [ ] Single-chip sim dispatch unit tests pass
- [ ] Multi-chip sim integration test with 2-chip Quasar descriptor passes

### CI Status

| Workflow | Run | Status |
|---|---|---|
| PR Gate | [26543054345](https://github.com/tenstorrent/tt-metal/actions/runs/26543054345) | ⏳ in_progress (expected compile failure — UMD factory methods missing) |
| Sanity Tests | [26543332488](https://github.com/tenstorrent/tt-metal/actions/runs/26543332488) | ⏳ in_progress |
| Static Checks | [26543333656](https://github.com/tenstorrent/tt-metal/actions/runs/26543333656) | ⏳ in_progress |
| Merge Gate | [26543334895](https://github.com/tenstorrent/tt-metal/actions/runs/26543334895) | ⏳ in_progress |
| Blackhole E2E | [26544250601](https://github.com/tenstorrent/tt-metal/actions/runs/26544250601) | ⏳ queued |
| Blackhole Post-Commit | [26544251612](https://github.com/tenstorrent/tt-metal/actions/runs/26544251612) | ⏳ queued |
| Galaxy E2E | [26544252648](https://github.com/tenstorrent/tt-metal/actions/runs/26544252648) | ⏳ queued |
| Galaxy Sanity | [26544253632](https://github.com/tenstorrent/tt-metal/actions/runs/26544253632) | ⏳ queued |
| Galaxy Unit Tests | [26544254682](https://github.com/tenstorrent/tt-metal/actions/runs/26544254682) | ⏳ queued |
| T3K E2E | [26544256116](https://github.com/tenstorrent/tt-metal/actions/runs/26544256116) | ⏳ queued |
| T3K Fast Tests | [26544257153](https://github.com/tenstorrent/tt-metal/actions/runs/26544257153) | ⏳ queued |
| T3K Unit Tests | [26544258226](https://github.com/tenstorrent/tt-metal/actions/runs/26544258226) | ⏳ queued |