### PR TITLE
Disable failing conv1d replicate pad case

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -643,9 +643,22 @@ def run_conv1d_replicate_pad(
         (1, 64, 32, 512, 3, 1, 2, 2, 1),
         # depthwise (groups == in_channels == out_channels) with replicate pad.
         (1, 32, 32, 512, 3, 1, 1, 1, 32),
-        # depthwise with kernel_size > 1 (Mamba-style d_conv = 4): exercises the 1d-depthwise
-        # path that was previously gated on kernel_size == 1. See PR #44490 (issue #42163)
-        (1, 512, 512, 512, 4, 1, (1, 2), 1, 512),
+        pytest.param(
+            # depthwise with kernel_size > 1 (Mamba-style d_conv = 4): exercises the 1d-depthwise
+            # path that was previously gated on kernel_size == 1. See PR #44490 (issue #42163)
+            1,
+            512,
+            512,
+            512,
+            4,
+            1,
+            (1, 2),
+            1,
+            512,
+            marks=pytest.mark.skip(
+                reason="Issue #45392: L1 CB allocation overflow for 512-channel depthwise conv1d with bias"
+            ),
+        ),
     ),
 )
 def test_conv1d_replicate_pad(


### PR DESCRIPTION
### Summary
Disable only the failing `test_conv1d_replicate_pad` parameter that deterministically overflows L1 during program creation:

```python
(1, 512, 512, 512, 4, 1, (1, 2), 1, 512)
```

The skip points to #45392 so the temporary mitigation remains tied to the follow-up owner investigation.

### Context
Regression analysis report: https://github.com/tenstorrent/tt-metal/actions/runs/26555900652

Filed owner issue: #45392

Failure signature:

```shell
RuntimeError: TT_THROW @ /project/tt_metal/impl/program/program.cpp:1450: tt::exception
info:
Statically allocated circular buffers on core range [0-0 - 7-1] grow to 2495904 B which is beyond max L1 size of 1499136 B
```

### Testing
- `python -m pytest tests/ttnn/unit_tests/operations/conv/test_conv1d.py -k 'test_conv1d_replicate_pad' --collect-only -q`
- `python -m pytest -q "tests/ttnn/unit_tests/operations/conv/test_conv1d.py::test_conv1d_replicate_pad[batch_size=1-output_channels=512-input_channels=512-input_length=512-kernel_size=4-stride=1-padding=(1, 2)-dilation=1-groups=512-device_params={'l1_small_size': 16384}]"`
- `git diff --check`
- commit hooks passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/disable-conv1d-replicate-pad-l1-overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/disable-conv1d-replicate-pad-l1-overflow)