### PR TITLE
ccl/all_to_all_combine: salt program hash to avoid stale-RTA cache hits

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <cstdint>
 #include <utility>
 
@@ -11,6 +12,7 @@
 #include "ttnn/device_operation.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::ccl {
 
@@ -112,6 +114,16 @@ void AllToAllCombineDeviceOperation::validate_on_program_cache_miss(
 
 void AllToAllCombineDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+
+ttsl::hash::hash_t AllToAllCombineDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    static std::atomic<uint64_t> counter{0};
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<AllToAllCombineDeviceOperation>,
+        attrs,
+        tensor_args,
+        counter.fetch_add(1, std::memory_order_relaxed));
+}
 
 AllToAllCombineDeviceOperation::spec_return_value_t AllToAllCombineDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_device_operation.hpp
@@ -86,6 +86,12 @@ struct AllToAllCombineDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Workaround for PR #44408 cache-hit-on-stale-RTA bug: salt per-call so
+    // every dispatch is a cache miss.  Restores legacy override_runtime_arguments
+    // behavior at the cost of cache-key proliferation.  Real fix is a
+    // ScalarBinding-style framework feature for non-Buffer RTAs (Metal 2.0 plan).
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::ccl
 


### PR DESCRIPTION
## Summary
Fixes the `test_all_to_all_combine_no_trace` failure introduced by PR #44408 (migration to `ProgramDescriptor`).

**Root cause:** the legacy `override_runtime_arguments` used to re-patch `cross_device_semaphore.address()` and `init_semaphore.address()` as non-Buffer `uint32_t` RTAs on every dispatch. The descriptor framework only re-patches `Buffer*` slots via `BufferBinding`, so those two semaphore RTAs are now baked at first cache miss and never refreshed. On iter 2 (cache hit) the kernel reads stale L1 addresses, the init barrier never completes, and the device writes all zeros to the output.

**Fix (tactical):** salt the program hash with a per-call atomic counter so every invocation gets a fresh cache entry. Same pattern previously used for `bernoulli`/`uniform`/`rand`/`dropout` in commit 84a456a95f8. Trades cache-key reuse for correctness.

**Real fix (deferred):** a `ScalarBinding`-style framework feature that re-patches non-Buffer RTAs on cache hit (Metal 2.0 plan).

## Validation
Validated locally on a 2-card Blackhole p300 (yyzo-bh-02). Failing parametrization was scaled `(4,1) → (2,1)` (cache-hit pattern is independent of mesh size).

- iter1 reproducer (`num_iters=1`, no fix) → **PASS** — confirms cache miss path is fine
- iter2 reproducer (`num_iters=2`, no fix) → **FAIL** — exact symptom: output all zeros vs ref tensor
- iter2 reproducer (`num_iters=2`, with fix) → **PASS** — cache-hit-on-stale theory confirmed and resolved

CI on the actual 4-card configuration (`(4, (4, 1))`) still pending.

## Test plan
- [ ] `tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_to_all_combine_bh.py::test_all_to_all_combine_no_trace` passes on 4-card box
- [ ] `tests/nightly/t3000/ccl/test_all_to_all_combine.py` regression run is clean
- [ ] No perf regression from the per-call cache miss (each dispatch now rebuilds the program — acceptable until the framework fix lands)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/local-debug-a2a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/local-debug-a2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/local-debug-a2a)