### PR TITLE
[Fix] GPT-OSS: Fix page table size by padding it

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -436,6 +436,26 @@ class Model:
             return ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.mesh_device.shape)
         return ttnn.ReplicateTensorToMesh(self.mesh_device)
 
+    def _pad_page_table_rows(self, pt: torch.Tensor) -> torch.Tensor:
+        """When ``users_row_sharded`` is active the page table must have
+        exactly ``max_batch_size`` rows so ``ShardTensor2dMesh`` can
+        split them evenly across the ``mesh_device.shape[0]`` mesh rows.
+
+        A prefill step may present fewer rows than ``max_batch_size``
+        (only the currently active sequences, no padding).  Padding with
+        zeros here is safe: the kernel only reads up to the per-user
+        block count, and the persistent device buffer was (or will be)
+        allocated at the full ``max_batch_size`` shape.
+        """
+        if not self.users_row_sharded:
+            return pt
+        num_rows = self.mesh_device.shape[0]
+        max_batch = self.max_local_batch_size * num_rows
+        if pt.shape[0] >= max_batch:
+            return pt
+        pad = torch.zeros(max_batch - pt.shape[0], pt.shape[1], dtype=pt.dtype)
+        return torch.cat([pt, pad], dim=0)
+
     def _page_tables_to_ttnn(self, page_tables_per_layer):
         """Resolve a per-layer torch list to *persistent* ttnn device
         tensors (allocate-only) — see
@@ -457,6 +477,7 @@ class Model:
                 if isinstance(pt, ttnn.Tensor):
                     persistent.append(pt)
                     continue
+                pt = self._pad_page_table_rows(pt)
                 persistent.append(
                     ttnn.from_torch(
                         pt,
@@ -482,6 +503,7 @@ class Model:
         for i, pt in enumerate(page_tables_per_layer):
             if pt is None or persistent[i] is None or isinstance(pt, ttnn.Tensor):
                 continue
+            pt = self._pad_page_table_rows(pt)
             host_pt = ttnn.from_torch(
                 pt,
                 device=None,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -278,6 +278,15 @@ class HybridAttentionForCausalLM(Generator):
                 for s in per_submesh:
                     s.append(pt)
                 continue
+            # torch.chunk returns fewer than dp chunks when pt has fewer
+            # rows than dp.  Pad to the nearest multiple of dp so the
+            # zip below always covers every submesh.
+            if pt.shape[0] % dp != 0:
+                pad_rows = dp - (pt.shape[0] % dp)
+                pt = torch.cat(
+                    [pt, torch.zeros(pad_rows, pt.shape[1], dtype=pt.dtype)],
+                    dim=0,
+                )
             chunks = torch.chunk(pt, dp, dim=0)
             for s, c in zip(per_submesh, chunks):
                 s.append(c)


### PR DESCRIPTION
### Summary

470d0a83bf2 (May 8) introduced _page_table_mesh_mapper, _page_tables_to_ttnn, and update_persistent_per_layer_page_tables on gpt_oss/tt/model.py, along with GptOssForCausalLM/HybridAttentionForCausalLM infrastructure. The mapper correctly uses ShardTensor2dMesh when users_row_sharded, but assumed the page table always arrives with max_batch_size rows. During that PR's CI run this wasn't hit because there were multiple KV cache groups, meaning _block_tables_per_layer padded the per-layer tables to max_batch_size before they reached the mapper.

60a9fbfaa00 (May 26) disabled SlidingWindowSpec — all layers collapse to a single FullAttentionSpec group. This set _layer_to_group_idx = None in the model runner, so _block_tables_per_layer now returns None. The model runner falls back to the legacy page_table = model_input.block_tables, which is the unpadded concatenation of only the active sequences in the current prefill step. With --data_parallel_size 4 and a small live batch (e.g. 3 active requests across all 4 ranks), that table has 3 rows. The mapper now sees 3 rows, tries to shard them across 4 mesh rows, and crashes.

In short: the disable-groups commit created the conditions by removing the padding step that the original groups implementation relied upon. The fix (_pad_page_table_rows) makes the padding unconditional within the model.py methods, so it no longer depends on upstream always providing a full-sized tensor.

### CI

Before: https://github.com/tenstorrent/tt-metal/actions/runs/26559685789/job/78240675158#step:17:12959

After: https://github.com/tenstorrent/tt-metal/actions/runs/26576560656

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-gptoss-ptable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-gptoss-ptable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-gptoss-ptable)