### PR TITLE
Add BH p300a trace entries + sweep routing

### DIFF
--- a/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
@@ -518,7 +518,7 @@ jobs:
             local is_galaxy=0
             [[ "$tg" == *galaxy* ]] && is_galaxy=1
             local hw_series_filter=""
-            for series in n150 n300 p150b p100a galaxy; do
+            for series in n150 n300 p150b p100a p300a galaxy; do
               if [[ "$tg" == *"$series"* ]]; then hw_series_filter="$series"; break; fi
             done
             # Filter MODULE_SELECTOR to modules with vector files matching our

--- a/model_tracer/trace_selection_registry.yaml
+++ b/model_tracer/trace_selection_registry.yaml
@@ -135,6 +135,13 @@ targets:
         - resnet50_3
       trace: [96, 97, 98, 99]
 
+    # BH p300a models (traces 100-102, blackhole p300a 2-card)
+    - model:
+        - llama-3.1-8b-instruct
+        - llama-3.3-70b-instruct
+        - tt_dit
+      trace: [100, 101, 102]
+
 registry:
   - trace_id: 1
     status: draft
@@ -1226,6 +1233,48 @@ registry:
     tt_metal_sha: f19f708f6442c3f3a35cc2c88dcb0f7616ea9e42
     config_count: 136
     loaded_at: '2026-05-27'
+    notes: ''
+    pytest_args: null
+    tt_kmd: "TT-KMD 2.4.1"
+    tt_smi: "5.2.0"
+    tt_firmware: "18.12.1.0"
+
+  - trace_id: 100
+    status: draft
+    models: [llama-3.1-8b-instruct]
+    hardware: {board_type: Blackhole, device_series: p300a, card_count: 2}
+    trace_uid: bf71f5ab-fa1b-48bc-93ec-8802de406834
+    tt_metal_sha: f5339e9aa03623c3610ca6192bbf0ede608ef734
+    config_count: 352
+    loaded_at: '2026-05-28'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.4.1"
+    tt_smi: "5.2.0"
+    tt_firmware: "18.12.1.0"
+
+  - trace_id: 101
+    status: draft
+    models: [llama-3.3-70b-instruct]
+    hardware: {board_type: Blackhole, device_series: p300a, card_count: 2}
+    trace_uid: bacc7703-faea-4380-bbc8-be427c6347cb
+    tt_metal_sha: f5339e9aa03623c3610ca6192bbf0ede608ef734
+    config_count: 233
+    loaded_at: '2026-05-28'
+    notes: ''
+    pytest_args: '-k batch-1 or batch-32 or long-context-16k or reasoning-1'
+    tt_kmd: "TT-KMD 2.4.1"
+    tt_smi: "5.2.0"
+    tt_firmware: "18.12.1.0"
+
+  - trace_id: 102
+    status: draft
+    models: [tt_dit]
+    hardware: {board_type: Blackhole, device_series: p300a, card_count: 2}
+    trace_uid: 7fc01bd5-1c87-4b0a-933c-a59dd8682da1
+    tt_metal_sha: f5339e9aa03623c3610ca6192bbf0ede608ef734
+    config_count: 206
+    loaded_at: '2026-05-28'
     notes: ''
     pytest_args: null
     tt_kmd: "TT-KMD 2.4.1"

--- a/tests/sweep_framework/framework/matrix_runner_config.py
+++ b/tests/sweep_framework/framework/matrix_runner_config.py
@@ -102,6 +102,13 @@ RUNNER_PROFILES = {
         "tt_smi_cmd": "tt-smi -r",
         "matrix_output_key": "p150b",
     },
+    "p300a": {
+        "arch": "blackhole",
+        "runs_on": "P300-viommu",
+        "runner_label": "P300",
+        "tt_smi_cmd": "tt-smi -r",
+        "matrix_output_key": "p150b",
+    },
     "t3k": {
         "arch": "wormhole_b0",
         "runs_on": ["config-t3000", "arch-wormhole_b0", "in-service", "pipeline-functional"],
@@ -136,6 +143,7 @@ TEST_GROUPS = {
     "n300-llmbox-ccl": {"runner_profile": "n300-llmbox"},
     "blackhole-p150b-sweeps": {"runner_profile": "p150b"},
     "blackhole-p100a-sweeps": {"runner_profile": "p100a"},
+    "blackhole-p300a-sweeps": {"runner_profile": "p300a"},
     "wormhole-t3k-sweeps": {"runner_profile": "t3k"},
     "wormhole-galaxy-sweeps": {"runner_profile": "galaxy-topology-6u"},
     "lead-models-single-chip": {"runner_profile": "n150"},
@@ -214,6 +222,7 @@ TEST_GROUP_HARDWARE_CAPABILITY_RULES = {
     "wormhole-n300-sweeps": ({"board_type": "wormhole", "device_series": "n300", "card_count": 1},),
     "blackhole-p150b-sweeps": ({"board_type": "blackhole", "device_series": "p150b", "card_count": 1},),
     "blackhole-p100a-sweeps": ({"board_type": "blackhole", "device_series": "p100a", "card_count": 1},),
+    "blackhole-p300a-sweeps": ({"board_type": "blackhole", "device_series": "p300a", "card_count": 2},),
     "wormhole-t3k-sweeps": ({"device_series": "n300", "card_count": 4},),
     "wormhole-galaxy-sweeps": ({"device_series": "tt_galaxy_wh"},),
     "lead-models-single-chip": ({"max_card_count": 1, "excluded_device_series": ("tt_galaxy_wh",)},),
@@ -256,6 +265,10 @@ LOCAL_HARDWARE_MESH_CAPABILITY_RULES = (
         "match": {"board_type": "blackhole", "device_series": "p100a", "card_count": 1},
         "allowed_mesh_shapes": ("1x1",),
     },
+    {
+        "match": {"board_type": "blackhole", "device_series": "p300a", "card_count": 2},
+        "allowed_mesh_shapes": ("1x1", "1x2"),
+    },
 )
 
 
@@ -291,6 +304,8 @@ def get_test_group_name_for_hardware_group(hardware_group):
 
     board_type, device_series, card_count = hardware_group
 
+    if device_series == "p300a":
+        return "blackhole-p300a-sweeps"
     if device_series == "p100a":
         return "blackhole-p100a-sweeps"
     if board_type == "blackhole" or device_series == "p150b":


### PR DESCRIPTION
## Summary
- Add traces 100-102 (llama-3.1-8b-instruct, llama-3.3-70b-instruct, tt_dit) to trace_selection_registry.yaml with p300a target group
- Add p300a runner profile (P300-viommu), test group (blackhole-p300a-sweeps), hardware routing, and capability rules in matrix_runner_config.py
- Add p300a to hw_series_filter in validation workflow impl

## Test plan
- [ ] Trigger validation pipeline on this branch
- [ ] Verify p300a jobs route to P300-viommu runner
- [ ] Verify traces 100-102 reconstruct correctly

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/sweep-validation-p300a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/sweep-validation-p300a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/sweep-validation-p300a)