### PR TITLE
Migrate plusone + nlp_concat_heads family + pad's remaining factories to descriptors

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_multi_core_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
@@ -154,14 +157,34 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
         nbatch_per_core_h,
         ncores_per_batch_h);
 }
-}  // namespace
 
-PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMultiCoreProgramFactory::create(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+// Allocate the on-device pad-value const tensor.  Pulled out so
+// create_workload_descriptor() can build it once on cache miss and park it on
+// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
+// device memory) until the cached workload is evicted (see #44565).
+Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_value) {
+    MeshDevice* device = tensor_args.input.device();
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    auto pad_value_const_buffer =
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+    // NOTE: The const buffer is always in L1
+    // TODO: make a local buffer for each core?
+    return Tensor(
+               std::move(pad_value_const_buffer),
+               ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
+               DataType::BFLOAT16,
+               Layout::ROW_MAJOR)
+        .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+}
+
+ProgramDescriptor build_program_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    Buffer* pad_value_const_buffer) {
     const auto& a = tensor_args.input;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
-    Program program{};
 
     auto output_shape = output_padded_shape;
 
@@ -172,21 +195,8 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
 
     distributed::MeshDevice* device = a.device();
 
-    // construct const buffer with the pad_value
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * a.element_size();
-    auto pad_value_const_buffer =
-        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
-    // NOTE: The const buffer is always in L1
-    // TODO: make a local buffer for each core?
-    const Tensor pad_value_const_tensor =
-        Tensor(
-            std::move(pad_value_const_buffer),
-            ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
-            DataType::BFLOAT16,
-            Layout::ROW_MAJOR)
-            .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
-    auto pad_value_const_tensor_addr = pad_value_const_tensor.buffer()->address();
 
     // uint32_t ntiles_h = output_tensor_shape[0] * output_tensor_shape[1] * output_tensor_shape[2] / TILE_HEIGHT;
     uint32_t ntiles_h = output_padded_shape[2] / TILE_HEIGHT;
@@ -213,6 +223,8 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
     Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
+    ProgramDescriptor desc;
+
     uint32_t cb_id = tt::CBIndex::c_0;
     uint32_t cb_npages = 16;  // multibuffering for perf
     // uint32_t cb_npages = 1; // multibuffering for perf
@@ -220,14 +232,20 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
     uint32_t cb_pagesize =
         static_cast<uint32_t>(std::ceil((float)dst_nbytes_per_core_w / cb_page_alignment)) * cb_page_alignment;
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_npages * cb_pagesize, {{cb_id, in_df}}).set_page_size(cb_id, cb_pagesize);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_npages * cb_pagesize,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = in_df,
+            .page_size = cb_pagesize,
+        }}},
+    });
 
     std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
     TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_tensor.buffer()).append_to(reader_ct_args);
+    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
     std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
     uint32_t packed_pad_value;
@@ -239,18 +257,23 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
     // int32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
-    log_rt_args(CoreCoord{0, 0}, reader_ct_args);
+    log_rt_args(CoreCoord{0, 0}, reader_desc.compile_time_args);
 
 #if 1
     {
@@ -272,7 +295,7 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
         log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
         log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
         // log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_tensor_addr: {}", pad_value_const_tensor_addr);
+        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
         log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
         log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
         log_debug(tt::LogOp, "src_nbytes_per_core_w: {}", src_nbytes_per_core_w);
@@ -315,34 +338,40 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
                     curr_stick_diff_nbytes = dst_nbytes_per_core_w - curr_stick_size_nbytes;
                     rem_src_stick_size_nbytes = 0;
                 }
-                const std::array reader_rt_args = {
-                    src0_buffer->address(),
-                    dst_buffer->address(),
-                    a.padded_shape()[0],
-                    output_shape[0],
-                    a.padded_shape()[1],
-                    output_shape[1],
-                    a.padded_shape()[2],
-                    output_shape[2],
-                    a.padded_shape()[3],
-                    output_shape[3],
-                    curr_stick_size_nbytes,
-                    (uint32_t)dst_nbytes_per_core_w,
-                    (uint32_t)curr_stick_diff_nbytes,
-                    pad_value_const_tensor_addr,
-                    pad_value_const_buffer_nbytes,
-                    packed_pad_value,
-                    start_src_stick_id,
-                    start_dst_stick_id,
-                    start_src_stick_wi,
-                    start_dst_stick_wi,
-                    start_src_stick_wi * a.element_size(),
-                    (uint32_t)local_nsticks,
-                    num_local_unpadded_nsticks,
-                    unpadded_row_size_nbytes,
-                    padded_row_size_nbytes,
-                    start_dst_stick_wi * output.element_size(),
-                    nbatch_per_core_h};
+                // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
+                // bind them as Buffer* so the framework patches the addresses on cache hits
+                // without rebuilding the descriptor.  The const tensor is owned by
+                // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
+                // remains valid across cache hits.
+                KernelDescriptor::RTArgList reader_rt_args;
+                reader_rt_args.reserve(27);
+                reader_rt_args.push_back(src0_buffer);
+                reader_rt_args.push_back(dst_buffer);
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
+                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
+                reader_rt_args.push_back(curr_stick_size_nbytes);
+                reader_rt_args.push_back(static_cast<uint32_t>(dst_nbytes_per_core_w));
+                reader_rt_args.push_back(static_cast<uint32_t>(curr_stick_diff_nbytes));
+                reader_rt_args.push_back(pad_value_const_buffer);
+                reader_rt_args.push_back(pad_value_const_buffer_nbytes);
+                reader_rt_args.push_back(packed_pad_value);
+                reader_rt_args.push_back(start_src_stick_id);
+                reader_rt_args.push_back(start_dst_stick_id);
+                reader_rt_args.push_back(start_src_stick_wi);
+                reader_rt_args.push_back(start_dst_stick_wi);
+                reader_rt_args.push_back(start_src_stick_wi * a.element_size());
+                reader_rt_args.push_back(static_cast<uint32_t>(local_nsticks));
+                reader_rt_args.push_back(num_local_unpadded_nsticks);
+                reader_rt_args.push_back(unpadded_row_size_nbytes);
+                reader_rt_args.push_back(padded_row_size_nbytes);
+                reader_rt_args.push_back(start_dst_stick_wi * output.element_size());
+                reader_rt_args.push_back(nbatch_per_core_h);
                 // if (core.x == 0) log_rt_args(core, reader_rt_args);
                 // if (core.x == 0) {
                 //     log_debug(tt::LogOp, "{} :: start_src_stick_id: {}", core.y, start_src_stick_id);
@@ -352,9 +381,10 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
                 //     log_debug(tt::LogOp, "{} :: nbatch_per_core_h: {}", core.y, nbatch_per_core_h);
                 //     log_debug(tt::LogOp, "{} :: ncores_per_batch_h: {}", core.y, ncores_per_batch_h);
                 // }
-                const auto& writer_rt_args = reader_rt_args;
-                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
-                tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_rt_args);
+                // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
+                KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+                reader_desc.emplace_runtime_args(core, reader_rt_args);
+                writer_desc.emplace_runtime_args(core, writer_rt_args);
                 start_src_stick_wi += ntiles_per_core_w * TILE_WIDTH;
                 start_dst_stick_wi += ntiles_per_core_w * TILE_WIDTH;
             }  // for ncores_w
@@ -363,42 +393,41 @@ PadRmReaderWriterMultiCoreProgramFactory::cached_program_t PadRmReaderWriterMult
         }  // for ncores_h
     }
 
-    return cached_program_t{
-        std::move(program),
-        {ncores_h, ncores_w, reader_kernel_id, writer_kernel_id, /*pad_value_const_tensor=*/pad_value_const_tensor}};
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void PadRmReaderWriterMultiCoreProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& output) {
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = output.buffer();
-    // See create() / shared_variables: pad_value_const_tensor is owned to survive cache hits.
-    // Forward its current address so the kernel never reads from a freed/reused DRAM slot.
-    const uint32_t pad_value_const_tensor_addr =
-        cached_program.shared_variables.pad_value_const_tensor.buffer()->address();
+}  // namespace
 
-    for (uint32_t j = 0; j < cached_program.shared_variables.ncores_h; ++j) {
-        for (uint32_t i = 0; i < cached_program.shared_variables.ncores_w; ++i) {
-            CoreCoord core = {i, j};
-            {
-                auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-                    cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-                runtime_args[1] = dst_buffer->address();
-                runtime_args[13] = pad_value_const_tensor_addr;
-            }
-            {
-                auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-                    cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-                runtime_args[1] = dst_buffer->address();
-                runtime_args[13] = pad_value_const_tensor_addr;
-            }
-        }
+WorkloadDescriptor PadRmReaderWriterMultiCoreProgramFactory::create_workload_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    WorkloadDescriptor wd;
+
+    // Build the pad-value const tensor once on cache miss and park it on the
+    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
+    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
+    // device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor(tensor_args, operation_attributes.pad_value);
+    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
+    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
+    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
+
+    auto desc = build_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        wd.programs.push_back({ranges[i], desc});
     }
+    if (!ranges.empty()) {
+        wd.programs.push_back({ranges.back(), std::move(desc)});
+    }
+    return wd;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -162,7 +162,7 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
 // create_workload_descriptor() can build it once on cache miss and park it on
 // WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
 // device memory) until the cached workload is evicted (see #44565).
-Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_value) {
+Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     auto pad_value_const_buffer =
@@ -177,7 +177,7 @@ Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_valu
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_program_descriptor(
+ProgramDescriptor build_pad_rm_mc_program_descriptor(
     const PadParams& operation_attributes,
     const PadInputs& tensor_args,
     Tensor& output,
@@ -413,12 +413,12 @@ WorkloadDescriptor PadRmReaderWriterMultiCoreProgramFactory::create_workload_des
     // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
     // device memory through DeviceStorage::deallocate regardless of external
     // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor(tensor_args, operation_attributes.pad_value);
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_mc(tensor_args, operation_attributes.pad_value);
     auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
     Buffer* pad_value_const_buffer = pad_value_owner->buffer();
     wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
 
-    auto desc = build_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
+    auto desc = build_pad_rm_mc_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
 
     auto ranges = tensor_coords.ranges();
     for (size_t i = 0; i + 1 < ranges.size(); ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
@@ -5,33 +5,28 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadRmReaderWriterMultiCoreSharedVariables {
-    int ncores_h{};
-    int ncores_w{};
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    // Owns the on-device pad-value constant. Without this the local Tensor in create()
-    // drops its DRAM buffer at the end of the function and a subsequent cache hit reads
-    // the pad value from a slot the allocator may have re-handed out (see #44565).
-    Tensor pad_value_const_tensor;
-};
-
 struct PadRmReaderWriterMultiCoreProgramFactory {
-    using shared_variables_t = PadRmReaderWriterMultiCoreSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
+    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
+    // so it outlives the cached workload via the program cache.  Holding the SOURCE
+    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
+    // the device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
+    // lets the framework patch the const tensor's address on cache hits without rerunning
+    // this factory.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const PadParams& operation_attributes,
         const PadInputs& tensor_args,
-        Tensor& output);
+        Tensor& output,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_program_factory.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
@@ -13,11 +16,32 @@ namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactory::create(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+namespace {
+
+// Allocate the on-device pad-value const tensor.  Pulled out so
+// create_workload_descriptor() can build it once on cache miss and park it on
+// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
+// device memory) until the cached workload is evicted (see #44565).
+Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_value) {
+    MeshDevice* device = tensor_args.input.device();
+    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
+    auto pad_value_const_buffer =
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+    return Tensor(
+               std::move(pad_value_const_buffer),
+               ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
+               DataType::BFLOAT16,
+               Layout::ROW_MAJOR)
+        .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+}
+
+ProgramDescriptor build_program_descriptor(
+    const PadParams& operation_attributes,
+    const PadInputs& tensor_args,
+    Tensor& output,
+    Buffer* pad_value_const_buffer) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
-    Program program{};
 
     auto output_shape = operation_attributes.output_padded_shape;
 
@@ -28,39 +52,37 @@ PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactor
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
 
     // construct const buffer with the pad_value
-    MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * tensor_args.input.element_size();
-    auto pad_value_const_buffer =
-        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
-    const Tensor pad_value_const_tensor =
-        Tensor(
-            std::move(pad_value_const_buffer),
-            ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
-            DataType::BFLOAT16,
-            Layout::ROW_MAJOR)
-            .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
-    auto pad_value_const_tensor_addr = pad_value_const_tensor.buffer()->address();
 
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     CoreRange cores({0, 0}, {0, 0});
+
+    ProgramDescriptor desc;
+
     uint32_t cb_id = tt::CBIndex::c_0;
     uint32_t cb_npages = 16;  // multibuffering
     uint32_t cb_pagesize =
         tt::round_up(padded_row_size_nbytes, std::max(src0_buffer->alignment(), tt::constants::TILE_WIDTH));
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::tt_metal::CircularBufferConfig cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_npages * cb_pagesize, {{cb_id, in_df}}).set_page_size(cb_id, cb_pagesize);
-    tt::tt_metal::CreateCircularBuffer(program, cores, cb_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_npages * cb_pagesize,
+        .core_ranges = cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_id),
+            .data_format = in_df,
+            .page_size = cb_pagesize,
+        }}},
+    });
 
     std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
     TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_tensor.buffer()).append_to(reader_ct_args);
-    const std::vector<uint32_t>& writer_ct_args = reader_ct_args;
+    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
+    std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -71,16 +93,21 @@ PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactor
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp",
-        cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp",
-        cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = cores;
+    writer_desc.compile_time_args = std::move(writer_ct_args);
+    writer_desc.config = WriterConfigDescriptor{};
     uint32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
 
 #if 0
@@ -98,7 +125,7 @@ PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactor
         log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
         log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
         log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_tensor_addr: {}", pad_value_const_tensor_addr);
+        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
         log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
         log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
     }
@@ -106,74 +133,83 @@ PadRmReaderWriterProgramFactory::cached_program_t PadRmReaderWriterProgramFactor
 
     uint32_t start_src_stick_id = 0;
     uint32_t start_dst_stick_id = 0;
-    const std::array reader_rt_args = {
-        src0_buffer->address(),
-        dst_buffer->address(),
-        a.padded_shape()[0],
-        output_shape[0],
-        a.padded_shape()[1],
-        output_shape[1],
-        a.padded_shape()[2],
-        output_shape[2],
-        a.padded_shape()[3],
-        output_shape[3],
-        unpadded_row_size_nbytes,
-        padded_row_size_nbytes,
-        padded_row_diff_size_nbytes,
-        pad_value_const_tensor_addr,
-        pad_value_const_buffer_nbytes,
-        packed_pad_value,
-        start_src_stick_id,
-        start_dst_stick_id,
-        std::uint32_t{0},
-        std::uint32_t{0},
-        std::uint32_t{0},
-        output_shape[2],
-        a.padded_shape()[2],
-        unpadded_row_size_nbytes,
-        padded_row_size_nbytes,
-        std::uint32_t{0},
-        output.padded_shape()[0]};
-    const auto& writer_rt_args = reader_rt_args;
-    tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, cores, reader_rt_args);
-    tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, cores, writer_rt_args);
+    // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
+    // bind them as Buffer* so the framework patches the addresses on cache hits
+    // without rebuilding the descriptor.  The const tensor is owned by
+    // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
+    // remains valid across cache hits.
+    KernelDescriptor::RTArgList reader_rt_args;
+    reader_rt_args.reserve(27);
+    reader_rt_args.push_back(src0_buffer);
+    reader_rt_args.push_back(dst_buffer);
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
+    reader_rt_args.push_back(unpadded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_diff_size_nbytes);
+    reader_rt_args.push_back(pad_value_const_buffer);
+    reader_rt_args.push_back(pad_value_const_buffer_nbytes);
+    reader_rt_args.push_back(packed_pad_value);
+    reader_rt_args.push_back(start_src_stick_id);
+    reader_rt_args.push_back(start_dst_stick_id);
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
+    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
+    reader_rt_args.push_back(unpadded_row_size_nbytes);
+    reader_rt_args.push_back(padded_row_size_nbytes);
+    reader_rt_args.push_back(std::uint32_t{0});
+    reader_rt_args.push_back(static_cast<uint32_t>(output.padded_shape()[0]));
 
-    return cached_program_t{
-        std::move(program),
-        {/*ncores_h=*/0,
-         /*ncores_w=*/0,
-         reader_kernel_id,
-         writer_kernel_id,
-         /*pad_value_const_tensor=*/pad_value_const_tensor}};
+    // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
+    KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, reader_rt_args);
+    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, writer_rt_args);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
 }
 
-void PadRmReaderWriterProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const PadParams& /*operation_attributes*/,
+}  // namespace
+
+WorkloadDescriptor PadRmReaderWriterProgramFactory::create_workload_descriptor(
+    const PadParams& operation_attributes,
     const PadInputs& tensor_args,
-    Tensor& tensor_return_value) {
-    auto* src_buffer = tensor_args.input.buffer();
-    auto* dst_buffer = tensor_return_value.buffer();
-    // pad_value_const_tensor is owned by shared_variables so its DRAM buffer survives
-    // the cache hit. Forward its current address into the kernel's runtime args; the
-    // allocator may have placed it at a different DRAM offset than the previous run.
-    const uint32_t pad_value_const_tensor_addr =
-        cached_program.shared_variables.pad_value_const_tensor.buffer()->address();
-    CoreCoord core = {0, 0};
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        runtime_args[1] = dst_buffer->address();
-        runtime_args[13] = pad_value_const_tensor_addr;
+    Tensor& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    WorkloadDescriptor wd;
+
+    // Build the pad-value const tensor once on cache miss and park it on the
+    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
+    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
+    // device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor(tensor_args, operation_attributes.pad_value);
+    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
+    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
+    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
+
+    auto desc =
+        build_program_descriptor(operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
+
+    auto ranges = tensor_coords.ranges();
+    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
+        wd.programs.push_back({ranges[i], desc});
     }
-    {
-        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(
-            cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-        runtime_args[1] = dst_buffer->address();
-        runtime_args[13] = pad_value_const_tensor_addr;
+    if (!ranges.empty()) {
+        wd.programs.push_back({ranges.back(), std::move(desc)});
     }
+    return wd;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -22,7 +22,7 @@ namespace {
 // create_workload_descriptor() can build it once on cache miss and park it on
 // WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
 // device memory) until the cached workload is evicted (see #44565).
-Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_value) {
+Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     auto pad_value_const_buffer =
@@ -35,7 +35,7 @@ Tensor build_pad_value_const_tensor(const PadInputs& tensor_args, float pad_valu
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_program_descriptor(
+ProgramDescriptor build_pad_rm_sc_program_descriptor(
     const PadParams& operation_attributes,
     const PadInputs& tensor_args,
     Tensor& output,
@@ -194,13 +194,13 @@ WorkloadDescriptor PadRmReaderWriterProgramFactory::create_workload_descriptor(
     // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
     // device memory through DeviceStorage::deallocate regardless of external
     // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor(tensor_args, operation_attributes.pad_value);
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_sc(tensor_args, operation_attributes.pad_value);
     auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
     Buffer* pad_value_const_buffer = pad_value_owner->buffer();
     wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
 
-    auto desc =
-        build_program_descriptor(operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
+    auto desc = build_pad_rm_sc_program_descriptor(
+        operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
 
     auto ranges = tensor_coords.ranges();
     for (size_t i = 0; i + 1 < ranges.size(); ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
@@ -5,34 +5,28 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
-struct PadRmReaderWriterSharedVariables {
-    int ncores_h{};
-    int ncores_w{};
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    // Owns the on-device pad-value constant. Without this, the local Tensor in create() drops
-    // its DRAM buffer at the end of the function; on a cache hit override_runtime_arguments
-    // does not refresh runtime_args[13], so the kernel reads the pad value from a freed slot
-    // that the allocator may have handed out for other data (see #44565).
-    Tensor pad_value_const_tensor;
-};
-
 struct PadRmReaderWriterProgramFactory {
-    using shared_variables_t = PadRmReaderWriterSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
+    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
+    // so it outlives the cached workload via the program cache.  Holding the SOURCE
+    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
+    // the device memory through DeviceStorage::deallocate regardless of external
+    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
+    // lets the framework patch the const tensor's address on cache hits without rerunning
+    // this factory.
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const PadParams& operation_attributes,
         const PadInputs& tensor_args,
-        Tensor& tensor_return_value);
+        Tensor& tensor_return_value,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -10,15 +10,18 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::experimental::prim {
 
-PlusOneProgramFactory::cached_program_t PlusOneProgramFactory::create(
+using namespace tt::tt_metal;
+
+tt::tt_metal::ProgramDescriptor PlusOneProgramFactory::create_descriptor(
     const PlusoneParams& operation_attributes, const Tensor& input, Tensor& /*tensor_return_value*/) {
-    tt::tt_metal::Program program{};
+    ProgramDescriptor desc;
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     uint32_t input_unit_size = input.element_size();
 
@@ -47,48 +50,44 @@ PlusOneProgramFactory::cached_program_t PlusOneProgramFactory::create(
         src_is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
     uint32_t aligned_input_page_size = tt::align(num_input_units * input_unit_size, page_alignment);
 
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(aligned_input_page_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_page_size);
-    if (input.is_sharded()) {
-        cb_src0_config.set_globally_allocated_address(*src_buffer);
-    }
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    // When the input is sharded, bind the CB to the input buffer so the framework
+    // can re-apply the globally-allocated address on a program-cache hit. For the
+    // interleaved path the CB is plain L1 scratch and the buffer address is passed
+    // through the reader runtime arg instead.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = aligned_input_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = aligned_input_page_size,
+        }}},
+        .buffer = input.is_sharded() ? src_buffer : nullptr,
+    });
 
     std::vector<uint32_t> reader_compile_time_args = {
         src0_cb_index, src_is_dram, aligned_input_page_size, W, H, operation_attributes.skip_negative_entries};
-    tt::tt_metal::TensorAccessorArgs(src_buffer).append_to(reader_compile_time_args);
-    std::map<std::string, std::string> kernel_defines;
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp",
-        all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+    tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
 
     auto cores = corerange_to_cores(all_cores, num_cores, true);
 
+    // Pass Buffer* (not address) so the framework's cache-hit path can re-patch
+    // the runtime arg without rebuilding the descriptor.
     for (const auto& core : cores) {
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {src_buffer->address()});
+        reader_desc.emplace_runtime_args(core, {src_buffer});
     }
 
-    return cached_program_t{
-        std::move(program),
-        {/* reader_kernel_id = */ reader_kernel_id,
-         /* cores            = */ cores}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
 
-void PlusOneProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program, const PlusoneParams&, const Tensor& input, Tensor&) {
-    auto* src_buffer = input.buffer();
-
-    auto& program = cached_program.program;
-    const auto& cores = cached_program.shared_variables.cores;
-    const auto& reader_kernel_id = cached_program.shared_variables.reader_kernel_id;
-
-    for (const auto& core : cores) {
-        auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-        runtime_args[0] = src_buffer->address();
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.hpp
@@ -6,26 +6,13 @@
 
 #include "plusone_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::experimental::prim {
 
-struct PlusOneSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    std::vector<CoreCoord> cores;
-};
-
 struct PlusOneProgramFactory {
-    using shared_variables_t = PlusOneSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const PlusoneParams& operation_attributes, const Tensor& input, Tensor& tensor_return_value);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const PlusoneParams& operation_attributes,
-        const Tensor& input,
-        Tensor& tensor_return_value);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_program_factory.hpp"
 #include "nlp_concat_heads_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
@@ -13,8 +14,9 @@ namespace ttnn::experimental::prim {
 
 using namespace tt::constants;
 using namespace tt;
+using namespace tt::tt_metal;
 
-NLPConcatHeadsProgramFactory::cached_program_t NLPConcatHeadsProgramFactory::create(
+ProgramDescriptor NLPConcatHeadsProgramFactory::create_descriptor(
     const NlpConcatHeadsParams& /*operation_attributes*/, const Tensor& input, Tensor& output) {
     const auto& a = input;
     const auto& ashape = a.padded_shape();
@@ -76,10 +78,11 @@ NLPConcatHeadsProgramFactory::cached_program_t NLPConcatHeadsProgramFactory::cre
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
     uint32_t src0_cb_index = 0, out_cb_index = 16;
 
-    tt::tt_metal::KernelHandle reader_kernel_id = 0, writer_kernel_id = 0;
+    KernelDescriptor reader_desc;
+    KernelDescriptor writer_desc;
     if (in_sharded) {
         std::vector<uint32_t> compile_time_args = {
             (std::uint32_t)src0_cb_index,
@@ -89,18 +92,21 @@ NLPConcatHeadsProgramFactory::cached_program_t NLPConcatHeadsProgramFactory::cre
             (std::uint32_t)num_blocks_per_core_group_1 * in0_w_tiles * single_tile_size,
             (std::uint32_t)num_blocks_per_core_group_1 * in0_HtWt,
         };
-        reader_kernel_id = tt_metal::CreateKernel(
-            program,
+        reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
-            all_cores,
-            tt_metal::ReaderDataMovementConfig(compile_time_args));
-        writer_kernel_id = tt_metal::CreateKernel(
-            program,
+            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = all_cores;
+        reader_desc.compile_time_args = compile_time_args;
+        reader_desc.config = ReaderConfigDescriptor{};
+
+        writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
-            all_cores,
-            tt_metal::WriterDataMovementConfig(compile_time_args));
+            "reader_tm_tile_layout_nlp_concat_heads_sharded.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = std::move(compile_time_args);
+        writer_desc.config = WriterConfigDescriptor{};
     } else {
         std::vector<uint32_t> reader_compile_time_args = {
             (std::uint32_t)in0_h_tiles,
@@ -111,59 +117,75 @@ NLPConcatHeadsProgramFactory::cached_program_t NLPConcatHeadsProgramFactory::cre
         tt_metal::TensorAccessorArgs(*in0_buffer).append_to(reader_compile_time_args);
         std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)src0_cb_index};
         tt_metal::TensorAccessorArgs(*out_buffer).append_to(writer_compile_time_args);
-        reader_kernel_id = tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
-            "reader_tm_tile_layout_nlp_concat_heads.cpp",
-            all_cores,
-            tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-        writer_kernel_id = tt_metal::CreateKernel(
-            program,
-            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-            all_cores,
-            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/"
+            "reader_tm_tile_layout_nlp_concat_heads.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = all_cores;
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.config = ReaderConfigDescriptor{};
+
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = all_cores;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        writer_desc.config = WriterConfigDescriptor{};
     }
 
     // Create circular buffers
-    tt::tt_metal::CBHandle cb_src0 = 0, cb_out = 0;
     uint32_t cb_src0_num_tiles = per_tensor_tiles;
     if (!in_sharded) {
         cb_src0_num_tiles *= 2;  // double buffer
     }
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(cb_src0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    if (in_sharded) {
-        cb_src0_config = cb_src0_config.set_globally_allocated_address(*in0_buffer);
-    }
-    cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_src0_num_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(src0_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = in_sharded ? in0_buffer : nullptr,
+    });
 
     if (out_sharded) {
         uint32_t cb_out_num_tiles = per_tensor_tiles;
-        tt_metal::CircularBufferConfig cb_out_config =
-            tt_metal::CircularBufferConfig(cb_out_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
-                .set_page_size(out_cb_index, single_tile_size);
-        cb_out_config = cb_out_config.set_globally_allocated_address(*out_buffer);
-        cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb_out_num_tiles * single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(out_cb_index),
+                .data_format = cb_data_format,
+                .page_size = single_tile_size,
+            }}},
+            .buffer = out_buffer,
+        });
     }
 
     const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
     if (in_sharded) {
         uint32_t nheads_first_risc = div_up(num_blocks_per_core_group_1, 2);
         uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
-        std::vector<uint32_t> reader_runtime_args = {
-            (std::uint32_t)nheads_first_risc,
-            0,
-            0,
-        };
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores, reader_runtime_args);
-        std::vector<uint32_t> writer_runtime_args = {
-            (std::uint32_t)nheads_second_risc,
-            (std::uint32_t)nheads_first_risc * in0_HtWt * single_tile_size,
-            (std::uint32_t)nheads_first_risc * in0_w_tiles * single_tile_size,
-        };
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, all_cores, writer_runtime_args);
+        // Mirror SetRuntimeArgs(program, kernel, all_cores, args) by emplacing the same
+        // per-core args on every logical core in the sharded range set.
+        for (const auto& core : corerange_to_cores(all_cores, num_cores, /*row_major=*/true)) {
+            reader_desc.emplace_runtime_args(
+                core,
+                {
+                    (std::uint32_t)nheads_first_risc,
+                    uint32_t{0},
+                    uint32_t{0},
+                });
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    (std::uint32_t)nheads_second_risc,
+                    (std::uint32_t)nheads_first_risc * in0_HtWt * single_tile_size,
+                    (std::uint32_t)nheads_first_risc * in0_w_tiles * single_tile_size,
+                });
+        }
 
     } else {
         for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i) {
@@ -173,64 +195,30 @@ NLPConcatHeadsProgramFactory::cached_program_t NLPConcatHeadsProgramFactory::cre
             uint32_t in0_h_dim = num_blocks_written % in0_h_tiles;
             uint32_t in0_tensor_tile_id = (num_blocks_written / in0_h_tiles * in0_CHtWt) + (in0_h_dim * in0_w_tiles);
 
-            std::vector<uint32_t> reader_runtime_args = {
-                (std::uint32_t)in0_buffer->address(),
-                num_blocks_per_core,  // num_blocks
-                in0_h_dim,            // in0_h_dim
-                in0_tensor_tile_id,   // in0_tensor_tile_id
-            };
+            reader_desc.emplace_runtime_args(
+                core,
+                {
+                    in0_buffer,
+                    num_blocks_per_core,  // num_blocks
+                    in0_h_dim,            // in0_h_dim
+                    in0_tensor_tile_id,   // in0_tensor_tile_id
+                });
 
-            std::vector<uint32_t> writer_runtime_args = {
-                (std::uint32_t)out_buffer->address(),  // out_tensor_addr
-                num_blocks_per_core * per_tensor_tiles,
-                num_blocks_written * per_tensor_tiles,
-            };
-
-            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+            writer_desc.emplace_runtime_args(
+                core,
+                {
+                    out_buffer,  // out_tensor_addr
+                    num_blocks_per_core * per_tensor_tiles,
+                    num_blocks_written * per_tensor_tiles,
+                });
             num_blocks_written += num_blocks_per_core;
         }
     }
 
-    return cached_program_t{
-        std::move(program),
-        {/* reader_kernel_id = */ reader_kernel_id,
-         /* writer_kernel_id = */ writer_kernel_id,
-         /* cb_src0 = */ cb_src0,
-         /* cb_out = */ cb_out,
-         /* cores = */ cores,
-         /* in_sharded = */ in_sharded,
-         /* out_sharded = */ out_sharded}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void NLPConcatHeadsProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const NlpConcatHeadsParams& /*operation_attributes*/,
-    const Tensor& input,
-    Tensor& output) {
-    auto& shared_vars = cached_program.shared_variables;
-    auto& program = cached_program.program;
-
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-
-    if (shared_vars.in_sharded) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_src0, *src_buffer);
-    } else {
-        for (const auto& core : shared_vars.cores) {
-            auto& runtime_args = GetRuntimeArgs(program, shared_vars.reader_kernel_id, core);
-            runtime_args[0] = src_buffer->address();
-        }
-    }
-
-    if (shared_vars.out_sharded) {
-        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_out, *dst_buffer);
-    } else {
-        for (const auto& core : shared_vars.cores) {
-            auto& runtime_args = GetRuntimeArgs(program, shared_vars.writer_kernel_id, core);
-            runtime_args[0] = dst_buffer->address();
-        }
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.cpp
@@ -170,7 +170,7 @@ ProgramDescriptor NLPConcatHeadsProgramFactory::create_descriptor(
         uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
         // Mirror SetRuntimeArgs(program, kernel, all_cores, args) by emplacing the same
         // per-core args on every logical core in the sharded range set.
-        for (const auto& core : corerange_to_cores(all_cores, num_cores, /*row_major=*/true)) {
+        for (const auto& core : corerange_to_cores(all_cores, num_cores, /*row_wise=*/true)) {
             reader_desc.emplace_runtime_args(
                 core,
                 {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_program_factory.hpp
@@ -4,33 +4,16 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "nlp_concat_heads_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct NLPConcatHeadsSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id = 0;
-    tt::tt_metal::KernelHandle writer_kernel_id = 0;
-    tt::tt_metal::CBHandle cb_src0 = 0;
-    tt::tt_metal::CBHandle cb_out = 0;
-    std::vector<CoreCoord> cores;
-    bool in_sharded = false;
-    bool out_sharded = false;
-};
-
 struct NLPConcatHeadsProgramFactory {
-    using shared_variables_t = NLPConcatHeadsSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const NlpConcatHeadsParams& operation_attributes, const Tensor& input, Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const NlpConcatHeadsParams& operation_attributes,
-        const Tensor& input,
-        Tensor& output);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_decode_program_factory.hpp"
 #include <tt-metalium/work_split.hpp>
 
@@ -11,13 +12,14 @@ namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
-NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgramFactory::create(
+ProgramDescriptor NLPConcatHeadsDecodeProgramFactory::create_descriptor(
     const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
     const NlpConcatHeadsDecodeInputs& tensor_args,
     Tensor& output) {
     const auto& input_tensor = tensor_args.input;
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t head_dim = input_shape[-1];
@@ -41,13 +43,18 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
     auto in_cores = in_shard_spec.grid;
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_q_output_config =
-        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output.buffer(),
+    });
 
-    uint32_t q_base_addr = input_tensor.buffer()->address();
+    Buffer* in_buffer = input_tensor.buffer();
 
     // cores to read and write to output
     uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
@@ -82,21 +89,27 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
         1,  // read the first phase
         in_num_cores_x,
         in_num_cores_y};
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp",
-        q_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    reader_compile_time_args[6] = 2;  // read the second phase
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp",
-        q_cores,
-        tt_metal::WriterDataMovementConfig(reader_compile_time_args));
 
-    uint32_t q_start_addr = q_base_addr;
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = q_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
+    writer_compile_time_args[6] = 2;  // read the second phase
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
+        "reader_tm_tile_layout_nlp_concat_heads_decode.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = q_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         // Each output core i corresponds to head index i. Within the input shard, that head lives in
@@ -111,64 +124,21 @@ NLPConcatHeadsDecodeProgramFactory::cached_program_t NLPConcatHeadsDecodeProgram
             head_tile_idx * head_size;
 
         const auto& core = cores[i];
-        std::vector<uint32_t> reader_runtime_args;
-        reader_runtime_args.reserve(2 + in_num_cores_x + in_num_cores_y);
-        reader_runtime_args = {
-            in_tile_offset_by_batch,
-            q_start_addr,
-        };
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+        KernelDescriptor::RTArgList rt_args;
+        rt_args.reserve(2 + in_num_cores_x + in_num_cores_y);
+        rt_args.push_back(in_tile_offset_by_batch);
+        rt_args.push_back(in_buffer);
+        rt_args.append(noc_x_coords);
+        rt_args.append(noc_y_coords);
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(core, rt_args);
+        writer_desc.emplace_runtime_args(core, rt_args);
     }
 
-    return cached_program_t{
-        std::move(program),
-        shared_variables_t{
-            .reader_kernel_id = reader_kernel_id,
-            .writer_kernel_id = writer_kernel_id,
-            .cores = cores,
-            .element_size = element_size,
-            .sub_tile_line_bytes = sub_tile_line_bytes,
-            .num_cores = num_cores,
-            .cb_q_output = cb_q_output,
-            .head_size = head_size}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void NLPConcatHeadsDecodeProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
-    const NlpConcatHeadsDecodeInputs& tensor_args,
-    Tensor& output) {
-    const auto& input_tensor = tensor_args.input;
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto *dst_buffer_query = output.buffer();
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_q_output, *dst_buffer_query);
-
-    uint32_t q_base_addr = input_tensor.buffer()->address();
-    uint32_t q_start_addr = q_base_addr;
-
-    for (uint32_t i = 0; i < shared_variables.num_cores; ++i) {
-        uint32_t head_tile_idx = i / 32;
-        uint32_t head_in_tile = i % 32;
-        uint32_t in_tile_offset_by_batch =
-            (head_in_tile < 16
-                 ? head_in_tile * shared_variables.sub_tile_line_bytes
-                 : (head_in_tile - 16) * shared_variables.sub_tile_line_bytes + 512 * shared_variables.element_size) +
-            head_tile_idx * shared_variables.head_size;
-        const auto& core = shared_variables.cores[i];
-        auto& runtime_args = GetRuntimeArgs(program, shared_variables.reader_kernel_id, core);
-        runtime_args[0] = in_tile_offset_by_batch;
-        runtime_args[1] = q_start_addr;
-
-        auto& runtime_args_writer = GetRuntimeArgs(program, shared_variables.writer_kernel_id, core);
-        runtime_args_writer[0] = in_tile_offset_by_batch;
-        runtime_args_writer[1] = q_start_addr;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_program_factory.hpp
@@ -4,33 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "nlp_concat_heads_decode_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct NLPConcatHeadsDecodeSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    std::vector<CoreCoord> cores;
-    uint32_t element_size{};
-    uint32_t sub_tile_line_bytes{};
-    uint32_t num_cores{};
-    tt::tt_metal::CBHandle cb_q_output{};
-    uint32_t head_size{};
-};
-
 struct NLPConcatHeadsDecodeProgramFactory {
-    using shared_variables_t = NLPConcatHeadsDecodeSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const NlpConcatHeadsDecodeParams& operation_attributes,
-        const NlpConcatHeadsDecodeInputs& tensor_args,
-        Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const NlpConcatHeadsDecodeParams& operation_attributes,
         const NlpConcatHeadsDecodeInputs& tensor_args,
         Tensor& output);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include "nlp_concat_heads_decode_subcoregrids_program_factory.hpp"
 #include "nlp_concat_heads_decode_device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
@@ -12,13 +13,14 @@ namespace ttnn::experimental::prim {
 
 using namespace tt;
 using namespace tt::constants;
+using namespace tt::tt_metal;
 
-NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsDecodeSubcoregridsProgramFactory::create(
+ProgramDescriptor NLPConcatHeadsDecodeSubcoregridsProgramFactory::create_descriptor(
     const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
     const NlpConcatHeadsDecodeInputs& tensor_args,
     Tensor& output) {
     const auto& input_tensor = tensor_args.input;
-    tt_metal::Program program = tt_metal::CreateProgram();
+    ProgramDescriptor desc;
 
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t head_dim = input_shape[-1];
@@ -51,13 +53,18 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
     const auto in_cores = in_shard_spec.grid;
 
     uint32_t q_output_cb_index = CBIndex::c_16;
-    tt_metal::CircularBufferConfig cb_q_output_config =
-        tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
-            .set_page_size(q_output_cb_index, single_tile_size)
-            .set_globally_allocated_address(*output.buffer());
-    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = q_num_tiles * single_tile_size,
+        .core_ranges = q_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(q_output_cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+        .buffer = output.buffer(),
+    });
 
-    uint32_t q_start_addr = input_tensor.buffer()->address();
+    Buffer* in_buffer = input_tensor.buffer();
 
     // cores to read and write to output
     const uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
@@ -89,19 +96,27 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
         in_num_cores,
         face_h,
         face_hw};
-    auto reader_kernel_id = tt_metal::CreateKernel(
-        program,
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp",
-        q_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-    reader_compile_time_args[6] = 2;  // read the second phase
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
+        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = q_cores;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = reader_compile_time_args;
+    writer_compile_time_args[6] = 2;  // read the second phase
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/kernels/dataflow/"
-        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp",
-        q_cores,
-        tt_metal::WriterDataMovementConfig(reader_compile_time_args));
+        "reader_tm_tile_layout_nlp_concat_heads_decode_subcoregrid.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = q_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         // in_tile_offset_by_batch is the byte offset of head row i within the input shard. Within
@@ -116,67 +131,21 @@ NLPConcatHeadsDecodeSubcoregridsProgramFactory::cached_program_t NLPConcatHeadsD
                                            head_tile_idx * head_size;
 
         const auto& core = cores[i];
-        std::vector<uint32_t> reader_runtime_args;
-        reader_runtime_args.reserve(2 + (2 * in_num_cores));
-        reader_runtime_args = {
-            in_tile_offset_by_batch,
-            q_start_addr,
-        };
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
-        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+        KernelDescriptor::RTArgList rt_args;
+        rt_args.reserve(2 + (2 * in_num_cores));
+        rt_args.push_back(in_tile_offset_by_batch);
+        rt_args.push_back(in_buffer);
+        rt_args.append(noc_x_coords);
+        rt_args.append(noc_y_coords);
 
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        reader_desc.emplace_runtime_args(core, rt_args);
+        writer_desc.emplace_runtime_args(core, rt_args);
     }
 
-    return cached_program_t{
-        std::move(program),
-        {/* reader_kernel_id     = */ reader_kernel_id,
-         /* writer_kernel_id     = */ writer_kernel_id,
-         /* cores                = */ cores,
-         /* element_size         = */ element_size,
-         /* sub_tile_line_bytes  = */ sub_tile_line_bytes,
-         /* num_cores            = */ num_cores,
-         /* cb_q_output          = */ cb_q_output,
-         /* face_h               = */ face_h,
-         /* tile_w               = */ tile_w,
-         /* head_size            = */ head_size}};
-}
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
 
-void NLPConcatHeadsDecodeSubcoregridsProgramFactory::override_runtime_arguments(
-    cached_program_t& cached_program,
-    const NlpConcatHeadsDecodeParams& /*operation_attributes*/,
-    const NlpConcatHeadsDecodeInputs& tensor_args,
-    Tensor& output) {
-    const auto& input_tensor = tensor_args.input;
-    auto& program = cached_program.program;
-    auto& shared_variables = cached_program.shared_variables;
-
-    auto *dst_buffer_query = output.buffer();
-    UpdateDynamicCircularBufferAddress(program, shared_variables.cb_q_output, *dst_buffer_query);
-
-    uint32_t q_start_addr = input_tensor.buffer()->address();
-
-    auto& reader_args_by_core = GetRuntimeArgs(program, shared_variables.reader_kernel_id);
-    auto& writer_args_by_core = GetRuntimeArgs(program, shared_variables.writer_kernel_id);
-
-    for (uint32_t i = 0; i < shared_variables.num_cores; ++i) {
-        uint32_t head_tile_idx = i / (2 * shared_variables.face_h);
-        uint32_t head_in_tile = i % (2 * shared_variables.face_h);
-        uint32_t in_tile_offset_by_batch =
-            (head_in_tile < shared_variables.face_h
-                 ? head_in_tile * shared_variables.sub_tile_line_bytes
-                 : (head_in_tile + shared_variables.face_h) * shared_variables.sub_tile_line_bytes) +
-            head_tile_idx * shared_variables.head_size;
-        const auto& core = shared_variables.cores[i];
-        auto& runtime_args_reader = reader_args_by_core[core.x][core.y];
-        runtime_args_reader[0] = in_tile_offset_by_batch;
-        runtime_args_reader[1] = q_start_addr;
-
-        auto& runtime_args_writer = writer_args_by_core[core.x][core.y];
-        runtime_args_writer[0] = in_tile_offset_by_batch;
-        runtime_args_writer[1] = q_start_addr;
-    }
+    return desc;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_subcoregrids_program_factory.hpp
@@ -4,35 +4,15 @@
 
 #pragma once
 
+#include <tt-metalium/program_descriptors.hpp>
+
 #include "nlp_concat_heads_decode_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::experimental::prim {
 
-struct NLPConcatHeadsDecodeSubcoregridsSharedVariables {
-    tt::tt_metal::KernelHandle reader_kernel_id{};
-    tt::tt_metal::KernelHandle writer_kernel_id{};
-    std::vector<CoreCoord> cores;
-    uint32_t element_size{};
-    uint32_t sub_tile_line_bytes{};
-    uint32_t num_cores{};
-    tt::tt_metal::CBHandle cb_q_output{};
-    uint32_t face_h{};
-    uint32_t tile_w{};
-    uint32_t head_size{};
-};
-
 struct NLPConcatHeadsDecodeSubcoregridsProgramFactory {
-    using shared_variables_t = NLPConcatHeadsDecodeSubcoregridsSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-    static cached_program_t create(
-        const NlpConcatHeadsDecodeParams& operation_attributes,
-        const NlpConcatHeadsDecodeInputs& tensor_args,
-        Tensor& output);
-
-    static void override_runtime_arguments(
-        cached_program_t& cached_program,
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const NlpConcatHeadsDecodeParams& operation_attributes,
         const NlpConcatHeadsDecodeInputs& tensor_args,
         Tensor& output);


### PR DESCRIPTION
Closes the last unstarted ops from the metal 2.0 prerequisite list.

## Migrations

| Op | Factory(ies) | Return type |
|---|---|---|
| experimental/plusone (#42383) | `PlusOneProgramFactory` | `ProgramDescriptor` |
| experimental/transformer/nlp_concat_heads (#42305) | `NLPConcatHeadsProgramFactory` | `ProgramDescriptor` |
| experimental/transformer/nlp_concat_heads_decode (#42307) | `NLPConcatHeadsDecodeProgramFactory`, `NLPConcatHeadsDecodeSubcoregridsProgramFactory` | `ProgramDescriptor` |
| data_movement/pad (#42224 — remaining 2 of 7) | `PadRmReaderWriterProgramFactory`, `PadRmReaderWriterMultiCoreProgramFactory` | `WorkloadDescriptor` |

## Why `WorkloadDescriptor` for pad?

Both remaining pad factories allocate a `pad_value_const` Tensor on device whose `Buffer*` is referenced by the descriptor (the kernel reads pad values via the slot-13 NOC address). A plain `ProgramDescriptor` factory would let the local Tensor go out of scope at function exit, force-deallocating the DRAM buffer; the cached descriptor would then dangle on cache hits.

`WorkloadDescriptor.buffers` parks the source Tensor so its lifetime ties to the cached workload — same approach as conv2d's `conv_reader_indices` (PR-45075) and sort's helper tensor.

## Cache-hit address patching

All per-core runtime args that reference buffers (`src`, `dst`, input/output for the transformer factories, slot-13 pad-value-const for pad) are passed as `Buffer*` rather than `buffer->address()`, so the framework's cache-hit path patches addresses without rebuilding the descriptor.

## compute_program_hash audit

Every non-`Buffer*` scalar runtime arg in the migrated factories is a function of fields already present in each op's default `compute_program_hash` on its `operation_attributes_t` / `tensor_args_t`. No new hash fields needed.

## Scope

No `device_operation.hpp` / `.cpp` edits — the `program_factory_t` variants already list the same class names; only each class's static method changed.

## Test plan

- [ ] Local build verification on the bundle (only the nlp_concat_heads sub-bundle was verified locally by one of the agents that helped on this PR; plusone and pad bundles are pending)
- [ ] `runtime-sanity-tests.yaml` dispatch
- [ ] `blackhole-post-commit.yaml` dispatch
- [ ] Per-op Python tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/desc-pad-plusone-nlp-concat-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/desc-pad-plusone-nlp-concat-heads)