### PR TITLE
point_to_point: fix cache-hit stale-buffer bug from optional-output aliasing (#45422)

### DIFF
--- a/tests/nightly/t3000/ccl/test_point_to_point.py
+++ b/tests/nightly/t3000/ccl/test_point_to_point.py
@@ -309,9 +309,7 @@ def test_point_to_point_cache_hit_with_output_tensor(mesh_device):
         tt_in = _to_device(input_torch)
         # Allocate a fresh output buffer for each iter so the buffer address differs.
         tt_out = _to_device(torch.zeros(multi_device_shape, dtype=torch.bfloat16))
-        out = ttnn.point_to_point(
-            tt_in, coord0, coord1, topology=ttnn.Topology.Linear, output_tensor=tt_out
-        )
+        out = ttnn.point_to_point(tt_in, coord0, coord1, topology=ttnn.Topology.Linear, output_tensor=tt_out)
         out_torch = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
         ttnn.deallocate(tt_in)
         ttnn.deallocate(tt_out)

--- a/tests/nightly/t3000/ccl/test_point_to_point.py
+++ b/tests/nightly/t3000/ccl/test_point_to_point.py
@@ -269,3 +269,56 @@ def test_point_to_point_optional_intermediate(mesh_device):
     )
     sent_tensor_torch = ttnn.to_torch(sent_tensor, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
     assert_equal(input_tensor_torch[idx_start0:idx_end0, :, :, :], sent_tensor_torch[idx_start1:idx_end1, :, :, :])
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [MESH_SHAPE], indirect=True)
+def test_point_to_point_cache_hit_with_output_tensor(mesh_device):
+    # Regression test for issue #45422. Two p2p invocations with the same coord pair
+    # (so the second is a program-cache hit) but distinct input/output buffers, both
+    # passing output_tensor=... so that tensor_return_value[1] aliases the optional.
+    # Pre-fix, the duplicate-Buffer* aliasing guard in resolve_bindings disabled the
+    # cache-hit fast path and the second invocation ran with stale buffer addresses
+    # from the first miss, producing garbage output.
+    shape, coords = ((1, 1, 1, 16), ((0, 0), (0, 1)))
+    coord0, coord1 = (ttnn.MeshCoordinate(c) for c in coords)
+
+    devices = prod(list(mesh_device.shape))
+    multi_device_shape = tuple(s * (devices if i == 0 else 1) for i, s in enumerate(shape))
+    lcoord0, lcoord1 = (_linear_coord(c, list(mesh_device.shape)) for c in coords)
+    idx_start0, idx_end0 = lcoord0 * shape[0], (lcoord0 + 1) * shape[0]
+    idx_start1, idx_end1 = lcoord1 * shape[0], (lcoord1 + 1) * shape[0]
+
+    def _make_inputs(seed):
+        torch.manual_seed(seed)
+        t = torch.zeros(multi_device_shape, dtype=torch.bfloat16)
+        t[idx_start0:idx_end0, :, :, :] = torch.rand(shape, dtype=torch.bfloat16)
+        return t
+
+    def _to_device(torch_tensor):
+        return ttnn.from_torch(
+            torch_tensor,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+        )
+
+    def _run_once(seed):
+        input_torch = _make_inputs(seed)
+        tt_in = _to_device(input_torch)
+        # Allocate a fresh output buffer for each iter so the buffer address differs.
+        tt_out = _to_device(torch.zeros(multi_device_shape, dtype=torch.bfloat16))
+        out = ttnn.point_to_point(
+            tt_in, coord0, coord1, topology=ttnn.Topology.Linear, output_tensor=tt_out
+        )
+        out_torch = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+        ttnn.deallocate(tt_in)
+        ttnn.deallocate(tt_out)
+        return input_torch, out_torch
+
+    in1_torch, out1_torch = _run_once(seed=0)
+    in2_torch, out2_torch = _run_once(seed=1)
+
+    assert_equal(in1_torch[idx_start0:idx_end0, :, :, :], out1_torch[idx_start1:idx_end1, :, :, :])
+    assert_equal(in2_torch[idx_start0:idx_end0, :, :, :], out2_torch[idx_start1:idx_end1, :, :, :])

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.hpp
@@ -128,4 +128,27 @@ ttnn::operations::point_to_point::PointToPointOp::tensor_return_value_t point_to
     const std::optional<ttnn::Tensor>& optional_output_tensor = std::nullopt,
     const std::optional<ttnn::Tensor>& optional_intermediate_tensor = std::nullopt);
 }  // namespace prim
+
+namespace device_operation {
+// `create_output_tensors` resolves `optional_output_tensor` -> `tensor_return_value[1]`
+// and `optional_intermediate_tensor` -> `tensor_return_value[0]` (same Tensor object,
+// same Buffer*).  Letting the default reflective walk enumerate the optionals AND the
+// return slots produces duplicate `Buffer*`s in the buffer list, which trips the
+// aliasing guard in `resolve_bindings` (program_descriptor_patching.cpp).  For
+// contract-2 ops that guard makes the cache-hit fast path a no-op — buffer addresses
+// are never re-patched and the program runs against stale L1/DRAM addresses from the
+// first cache miss (issue #45422).
+//
+// Skip the optionals here: when set they alias entries in `tensor_return_value` and
+// would only add duplicates; when unset they contribute nothing.  The return-value
+// walk still enumerates the canonical intermediate/final buffers.
+template <>
+struct extract_tensor_buffers_t<::ttnn::operations::point_to_point::PointToPointOp::tensor_args_t, void> {
+    template <typename Out>
+    static void call(
+        const ::ttnn::operations::point_to_point::PointToPointOp::tensor_args_t& args, Out& out) {
+        out.push_back(args.input_tensor.buffer());
+    }
+};
+}  // namespace device_operation
 }  // namespace ttnn


### PR DESCRIPTION
## Summary

Closes #45422 — P0 collective-permute PCC failure bisected to #44411 (point_to_point migration to ProgramDescriptor).

- **Root cause:** `create_output_tensors` aliases `tensor_args.optional_output_tensor` into `tensor_return_value[1]` (and `optional_intermediate_tensor` into `[0]`). The default reflective walk in `extract_tensor_buffers_into` enumerates BOTH the optional in `tensor_args` and its alias in `tensor_return_value`, producing duplicate `Buffer*`s. `resolve_bindings`' aliasing guard then returns empty `ResolvedBindings{}`, and `apply_descriptor` for contract-2 silently skips patching — kernels run with stale L1/DRAM addresses on cache hit.
- **Symptom:** when `output_tensor=...` is passed, the second invocation on the same `(sender_coord, receiver_coord)` hits the cache with addresses from the first miss → PCC ≈ 0. MeshDevice close/reopen masks the bug because it wipes the cache.
- **Fix:** specialize `extract_tensor_buffers_t<PointToPointOp::tensor_args_t>` to walk only `input_tensor`. The optionals, when set, are already enumerated via `tensor_return_value`; when unset, they contribute nothing. After this the buffer list has no duplicates, the aliasing guard does not fire, and the cache-hit fast path patches addresses on every dispatch.
- **Regression test:** the existing `test_point_to_point_with_device_delay` did two p2p calls on the same coords but never passed `output_tensor`, so it didn't exercise the aliasing path. Added `test_point_to_point_cache_hit_with_output_tensor` that runs two p2p calls with distinct input/output buffers, both passing `output_tensor=...`, and verifies both outputs are correct.

## Follow-up tech debt (not in this PR)

The underlying framework limitation — contract-2 having no fallback when `resolved_bindings` is empty due to aliasing — will bite again as more ops migrate (cf. `debug-a2a-force-cache-miss` branch evidence). Worth a separate framework PR to either make `resolve_bindings` position-aware or add a slow-path "rebuild programs only, keep workload-scoped resources" fallback for contract-2.

## Test plan

- [ ] `tests/nightly/t3000/ccl/test_point_to_point.py::test_point_to_point_cache_hit_with_output_tensor` passes on T3000
- [ ] Issue #45422 reproducer (`test.py --mode full_sweep` on 8-device mesh) reports TC0 & TC1 PASS
- [ ] Existing `test_point_to_point*` suite stays green
- [ ] Nightly tt-metal L2 tests stay green


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-p2p-cache-hit-binding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-p2p-cache-hit-binding)