### PR TITLE
ccl/all_to_all_dispatch: workaround stale semaphore RTAs on cache hit

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -502,7 +502,10 @@ def run_all_to_all_dispatch_test(
             tt_metadata_list = []
 
             for i in range(n_iters):
-                buffer_index = i
+                # PR #44408 workaround: trace mode reuses iter-0 buffers so the op's
+                # buffer-address-hashed program cache hits during capture (avoids
+                # writes/reads in capture). Revert to `i` once ScalarBinding lands.
+                buffer_index = 0 if trace_mode else i
                 if test_skew:
                     ttnn.apply_device_delay(mesh_device, delays)
                 output_tensor, metadata_tensor = ttnn.all_to_all_dispatch(
@@ -594,6 +597,11 @@ def run_all_to_all_dispatch_test(
     failed_metadata_indices = []
 
     for tensor_index in range(len(tt_out_tensor_list)):
+        # PR #44408 workaround: trace mode reuses iter-0 inputs (see run_op), so all outputs
+        # match iter-0's golden.
+        # Revert to `tensor_index` once ScalarBinding lands.
+        golden_index = 0 if trace_mode else tensor_index
+
         tt_torch_tensor = ttnn.to_torch(
             tt_out_tensor_list[tensor_index],
             mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=shard_dim),
@@ -605,22 +613,22 @@ def run_all_to_all_dispatch_test(
         )
 
         if is_unsigned_tensor(tt_metadata_tensor):
-            tt_metadata_tensor = tt_metadata_tensor.to(output_metadata_goldens_list[tensor_index].dtype)
+            tt_metadata_tensor = tt_metadata_tensor.to(output_metadata_goldens_list[golden_index].dtype)
 
         batch = tt_torch_tensor.shape[1]
         devices = tt_metadata_tensor.shape[0]
         selected_experts_k = tt_metadata_tensor.shape[3]
 
-        metadata_all_close = torch.allclose(tt_metadata_tensor, output_metadata_goldens_list[tensor_index])
-        metadata_all_equal = torch.equal(tt_metadata_tensor, output_metadata_goldens_list[tensor_index])
+        metadata_all_close = torch.allclose(tt_metadata_tensor, output_metadata_goldens_list[golden_index])
+        metadata_all_equal = torch.equal(tt_metadata_tensor, output_metadata_goldens_list[golden_index])
         if not metadata_all_close or not metadata_all_equal:
             metadata_passed = False
             first_failed_metadata_index = tensor_index
-            failed_metadata_indices = torch.where(tt_metadata_tensor != output_metadata_goldens_list[tensor_index])
+            failed_metadata_indices = torch.where(tt_metadata_tensor != output_metadata_goldens_list[golden_index])
             logger.info(f"All failed metadata devices: {failed_metadata_indices}")
             logger.info(f"Failing tt_metadata_tensor tensor {tt_metadata_tensor[failed_metadata_indices]}")
             logger.info(
-                f"Relevant output_metadata_goldens_list tensor {output_metadata_goldens_list[tensor_index][failed_metadata_indices]}"
+                f"Relevant output_metadata_goldens_list tensor {output_metadata_goldens_list[golden_index][failed_metadata_indices]}"
             )
             break
 
@@ -629,9 +637,9 @@ def run_all_to_all_dispatch_test(
                 for k in range(selected_experts_k):
                     expert_id = tt_metadata_tensor[0, b, s, k]
                     for d in range(devices):
-                        if torch_expert_mappings[tensor_index][0, 0, expert_id, d] == 1:
+                        if torch_expert_mappings[golden_index][0, 0, expert_id, d] == 1:
                             is_all_equal = torch.equal(
-                                tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[tensor_index][d, b, s, :]
+                                tt_torch_tensor[d, b, s, :], output_tensor_goldens_list[golden_index][d, b, s, :]
                             )
                             if not is_all_equal:
                                 logger.info(
@@ -643,7 +651,7 @@ def run_all_to_all_dispatch_test(
                                 first_failed_tensor_index = tensor_index
                                 first_failed_batch_index = b
                                 failed_indices = torch.where(
-                                    tt_torch_tensor[d, b, s, :] != output_tensor_goldens_list[tensor_index][d, b, s, :]
+                                    tt_torch_tensor[d, b, s, :] != output_tensor_goldens_list[golden_index][d, b, s, :]
                                 )
                                 first_10_fail_idx = failed_indices[0][:10]
                                 logger.info(f"First 10 failing indices: {first_10_fail_idx}")
@@ -651,7 +659,7 @@ def run_all_to_all_dispatch_test(
                                     f"Failing tt_torch_tensor tensor (first 10) {tt_torch_tensor[d, b, s, first_10_fail_idx]}"
                                 )
                                 logger.info(
-                                    f"Relevant output_tensor_goldens_list tensor (first 10) {output_tensor_goldens_list[tensor_index][d, b, s, first_10_fail_idx]}"
+                                    f"Relevant output_tensor_goldens_list tensor (first 10) {output_tensor_goldens_list[golden_index][d, b, s, first_10_fail_idx]}"
                                 )
                                 first_failed_expert_index = expert_id
                                 first_failed_device_index = d
@@ -880,7 +888,6 @@ def test_all_to_all_dispatch_trace(
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["dram"])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.skip(reason="Disabled by issue #45107")
 def test_decode_perf(
     mesh_device,
     trace_mode,

--- a/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_dispatch.py
@@ -669,9 +669,13 @@ def run_all_to_all_dispatch_test(
                     break
             if not passed:
                 break
-    num_program_cache_entries = 1
+    # PR #44408 workaround: non-trace iters use per-iter input buffers, so the op's
+    # buffer-address-hashed program cache misses once per iter. Trace mode reuses
+    # iter-0 buffers (see run_op) and still produces a single entry.
+    # Revert to a constant `1` (+1 for skew) once ScalarBinding lands.
+    num_program_cache_entries = 1 if trace_mode else num_iters
     if test_skew:
-        num_program_cache_entries = 2
+        num_program_cache_entries += 1
     logger.info(f"Device has {mesh_device.cache_entries_counter.total} program cache entries")
     assert (
         mesh_device.cache_entries_counter.total == num_program_cache_entries

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::ccl {
 
@@ -75,6 +76,24 @@ void AllToAllDispatchDeviceOperation::validate_on_program_cache_miss(
 
 void AllToAllDispatchDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+
+ttsl::hash::hash_t AllToAllDispatchDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    // Workaround for PR #44408: the cross_device_semaphore and init_semaphore
+    // L1 addresses are baked into the cached program at first miss and never
+    // refreshed on cache hit (the descriptor framework only re-patches Buffer*
+    // slots).  Hash the input tensor buffer addresses so any allocation churn
+    // -- e.g. the failing test reallocating input tensors per iter -- forces
+    // a fresh build with current semaphore addresses.  Stable across trace
+    // replays that reuse the same buffers, so trace tests still cache-hit.
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<AllToAllDispatchDeviceOperation>,
+        attrs,
+        tensor_args,
+        tensor_args.input_tensor.buffer()->address(),
+        tensor_args.expert_indices_tensor.buffer()->address(),
+        tensor_args.expert_mapping_tensor.buffer()->address());
+}
 
 AllToAllDispatchDeviceOperation::spec_return_value_t AllToAllDispatchDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_dispatch/device/all_to_all_dispatch_device_operation.hpp
@@ -97,6 +97,13 @@ struct AllToAllDispatchDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Workaround for PR #44408 cache-hit-on-stale-RTA bug: hash the input
+    // buffer addresses so reallocated tensors force a fresh build (and thus
+    // refresh the baked-in semaphore addresses).  Trace replays reuse the
+    // same buffers so cache hits still happen.  Real fix is a ScalarBinding-
+    // style framework feature for non-Buffer RTAs (Metal 2.0 plan).
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::ccl
 


### PR DESCRIPTION
### PR Category
Bug fix.

### Summary
`tests/nightly/t3000/ccl/test_all_to_all_dispatch.py::test_decode_perf` fails deterministically on iter 1: device-side metadata comes back as the preallocated zeros, every index mismatches the golden. Same root cause as #45332 (all_to_all_combine).

### Root cause
PR #44408 migrated the op to the `ProgramDescriptor` framework and dropped `override_runtime_arguments`. The framework only re-patches `Buffer*` slots via `BufferBinding`; plain `uint32_t` RTAs are baked at first cache miss and never refreshed. `init_semaphore` and `cross_device_semaphore` are passed as plain uint32 (program_factory.cpp:435, 450-451), and the factory allocates fresh `GlobalSemaphore`s on every cache miss — so cache hits replay stale L1 addresses, the init barrier never completes, and the kernel writes nothing.

### Workaround (this PR)
1. **op:** add `compute_program_hash` that mixes input buffer addresses into the hash. Per-call input reallocation now misses the cache → fresh semaphores baked into the new program. Mirrors #45332.
2. **pytest (`run_op`):** in trace mode, use the same input tensor for all iters. Stable addresses → cache hits during `begin_trace_capture` → no `TT_FATAL: writes/reads not supported during trace capture` (the failure mode of the earlier salt-with-counter approach the combine PR called out).

### Proper fix (not in this PR)
The "Metal 2.0 plan" referenced in the all_to_all_combine PR: extend the descriptor framework with a `ScalarBinding` analogous to `BufferBinding` — a late-bound slot the framework re-patches on every dispatch from a stored `GlobalSemaphore*` (or `uint32_t*`).

Once ScalarBinding lands, revert this PR's workarounds:
- Delete `compute_program_hash` override in `all_to_all_dispatch_device_operation.{hpp,cpp}` (and the include of `tt_stl/reflection.hpp`).
- `buffer_index = 0 if trace_mode else i` → `buffer_index = i` in `run_op`.
- `golden_index = 0 if trace_mode else tensor_index` → use `tensor_index` directly in the validator.
- `num_program_cache_entries = 1 if trace_mode else num_iters` → constant `1` (+1 for skew).

`git grep "PR #44408"` finds all these code blocks.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-a2a-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-a2a-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-a2a-dispatch)