### PR TITLE
[DCAMP-649] Regenerate descriptors without unretrainable cables on recovery failure

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(
         FILES
             board/board.hpp
             cabling_generator/cabling_generator.hpp
+            cabling_generator/regen_descriptors.hpp
             connector/connector.hpp
             factory_system_descriptor/utils.hpp
             node/node_types.hpp
@@ -55,6 +56,7 @@ target_sources(
         node/node_types.cpp
         board/board.cpp
         cabling_generator/cabling_generator.cpp
+        cabling_generator/regen_descriptors.cpp
         connector/connector.cpp
         factory_system_descriptor/utils.cpp
         ${GENERATED_PROTO_SRCS}
@@ -151,6 +153,27 @@ target_include_directories(run_cabling_generator SYSTEM PRIVATE ${CMAKE_CURRENT_
 
 target_link_libraries(
     run_cabling_generator
+    PRIVATE
+        scaleout_tools
+        protobuf::libprotobuf
+        cxxopts::cxxopts
+)
+
+add_executable(run_regen_descriptors src/run_regen_descriptors.cpp)
+
+set_target_properties(
+    run_regen_descriptors
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${Metalium_BINARY_DIR}/tools/scaleout
+)
+
+add_dependencies(run_regen_descriptors scaleout_generated_protos)
+
+target_include_directories(run_regen_descriptors SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(
+    run_regen_descriptors
     PRIVATE
         scaleout_tools
         protobuf::libprotobuf

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -13,6 +13,7 @@
 #include <enchantum/enchantum.hpp>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <unordered_set>
 #include <fmt/base.h>
 #include <google/protobuf/text_format.h>
@@ -1751,6 +1752,130 @@ void CablingGenerator::emit_cabling_descriptor(const std::string& output_path) c
         throw std::runtime_error("Failed to write cabling descriptor to: " + output_path);
     }
     output_file.close();
+}
+
+std::set<PhysicalPortConnection> CablingGenerator::find_cables_containing_channels(
+    const std::set<PhysicalChannelEndpoint>& dead_channels) const {
+    std::set<PhysicalPortConnection> result;
+
+    if (!root_instance_ || dead_channels.empty()) {
+        return result;
+    }
+
+    // Index deployment_hosts_ by HostId value (relies on deployment_hosts_ being in DFS host_id order,
+    // same invariant relied on by build_factory_system_descriptor).
+    auto host_for = [&](HostId hid) -> const Host& { return deployment_hosts_.at(*hid); };
+
+    auto make_port_endpoint = [&](HostId host_id, TrayId tray, PortId port_id, PortType port_type) {
+        const Host& h = host_for(host_id);
+        return PhysicalPortEndpoint{
+            .hostname = h.hostname,
+            .aisle = h.aisle,
+            .rack = h.rack,
+            .shelf_u = h.shelf_u,
+            .tray_id = tray,
+            .port_type = port_type,
+            .port_id = port_id,
+        };
+    };
+
+    // Returns true if the cable's expanded channels intersect the dead set.
+    auto cable_intersects_dead = [&](PortType port_type,
+                                     const Board& start_board,
+                                     const Board& end_board,
+                                     HostId start_host_id,
+                                     TrayId start_tray,
+                                     PortId start_port,
+                                     HostId end_host_id,
+                                     TrayId end_tray,
+                                     PortId end_port) -> bool {
+        const auto& start_channels = start_board.get_port_channels(port_type, start_port);
+        const auto& end_channels = end_board.get_port_channels(port_type, end_port);
+        auto pairs = tt::scaleout_tools::get_asic_channel_connections(port_type, start_channels, end_channels);
+        const std::string& start_host = host_for(start_host_id).hostname;
+        const std::string& end_host = host_for(end_host_id).hostname;
+        for (const auto& [start_chan, end_chan] : pairs) {
+            if (dead_channels.contains(PhysicalChannelEndpoint{start_host, start_tray, start_chan}) ||
+                dead_channels.contains(PhysicalChannelEndpoint{end_host, end_tray, end_chan})) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    auto record = [&](PortType port_type, HostId ha, TrayId ta, PortId pa, HostId hb, TrayId tb, PortId pb) {
+        auto endpoint_a = make_port_endpoint(ha, ta, pa, port_type);
+        auto endpoint_b = make_port_endpoint(hb, tb, pb, port_type);
+        if (endpoint_a < endpoint_b) {
+            result.insert({endpoint_a, endpoint_b});
+        } else {
+            result.insert({endpoint_b, endpoint_a});
+        }
+    };
+
+    // Walk the resolved graph, mirroring generate_connections_from_resolved_graph(). Three layers:
+    // intra-board, inter-board (within a node), and graph-level (between nodes), plus subgraph recursion.
+    std::function<void(const std::unique_ptr<ResolvedGraphInstance>&)> walk =
+        [&](const std::unique_ptr<ResolvedGraphInstance>& graph) {
+            if (!graph) {
+                return;
+            }
+
+            for (const auto& [node_name, node] : graph->nodes) {
+                HostId host_id = node.host_id;
+
+                for (const auto& [tray_id, board] : node.boards) {
+                    for (const auto& [port_type, conns] : board.get_internal_connections()) {
+                        for (const auto& [port_a, port_b] : conns) {
+                            if (cable_intersects_dead(
+                                    port_type, board, board, host_id, tray_id, port_a, host_id, tray_id, port_b)) {
+                                record(port_type, host_id, tray_id, port_a, host_id, tray_id, port_b);
+                            }
+                        }
+                    }
+                }
+
+                for (const auto& [port_type, conns] : node.inter_board_connections) {
+                    for (const auto& [be_a, be_b] : conns) {
+                        TrayId tray_a = be_a.first;
+                        PortId port_a = be_a.second;
+                        TrayId tray_b = be_b.first;
+                        PortId port_b = be_b.second;
+                        const Board& board_a = node.boards.at(tray_a);
+                        const Board& board_b = node.boards.at(tray_b);
+                        if (cable_intersects_dead(
+                                port_type, board_a, board_b, host_id, tray_a, port_a, host_id, tray_b, port_b)) {
+                            record(port_type, host_id, tray_a, port_a, host_id, tray_b, port_b);
+                        }
+                    }
+                }
+            }
+
+            for (const auto& [port_type, conns] : graph->internal_connections) {
+                for (const auto& [pe_a, pe_b] : conns) {
+                    auto [host_a, tray_a, port_a] = pe_a;
+                    auto [host_b, tray_b, port_b] = pe_b;
+                    if (!host_id_to_node_.contains(host_a) || !host_id_to_node_.contains(host_b)) {
+                        continue;
+                    }
+                    const Node* node_a = host_id_to_node_.at(host_a);
+                    const Node* node_b = host_id_to_node_.at(host_b);
+                    const Board& board_a = node_a->boards.at(tray_a);
+                    const Board& board_b = node_b->boards.at(tray_b);
+                    if (cable_intersects_dead(
+                            port_type, board_a, board_b, host_a, tray_a, port_a, host_b, tray_b, port_b)) {
+                        record(port_type, host_a, tray_a, port_a, host_b, tray_b, port_b);
+                    }
+                }
+            }
+
+            for (const auto& [_, sub] : graph->subgraphs) {
+                walk(sub);
+            }
+        };
+
+    walk(root_instance_);
+    return result;
 }
 
 // Helper: Compare two nodes for equality (checks motherboard, boards, host_id, inter_board_connections)

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1903,10 +1903,11 @@ std::set<PhysicalPortConnection> CablingGenerator::prune_dead_channels(
 
     std::vector<LogicalChannelConnection> rebuilt;
 
-    // Single-pass walk that rebuilds chip_connections_ while detecting dead cables. For each
-    // cable: expand to channels, decide live-or-dead in one shot. Live -> append channels to
-    // rebuilt. Dead -> skip channels, record the cable into `pruned`.
-    auto process_cable = [&](PortType port_type,
+    // Inspect a single cable. Expands its channels via the connector mapping, records the
+    // cable into `pruned` if any channel is in the dead set; otherwise appends the channels
+    // to `rebuilt` (the new chip_connections_). Returns true if the cable was dead, so callers
+    // operating on mutable containers can erase it.
+    auto inspect_cable = [&](PortType port_type,
                              const Board& start_board,
                              const Board& end_board,
                              HostId start_host_id,
@@ -1914,7 +1915,7 @@ std::set<PhysicalPortConnection> CablingGenerator::prune_dead_channels(
                              PortId start_port,
                              HostId end_host_id,
                              TrayId end_tray,
-                             PortId end_port) {
+                             PortId end_port) -> bool {
         const auto& start_channels = start_board.get_port_channels(port_type, start_port);
         const auto& end_channels = end_board.get_port_channels(port_type, end_port);
         auto pairs = tt::scaleout_tools::get_asic_channel_connections(port_type, start_channels, end_channels);
@@ -1938,7 +1939,7 @@ std::set<PhysicalPortConnection> CablingGenerator::prune_dead_channels(
             } else {
                 pruned.insert({endpoint_b, endpoint_a});
             }
-            return;
+            return true;
         }
 
         for (const auto& [start_chan, end_chan] : pairs) {
@@ -1946,51 +1947,67 @@ std::set<PhysicalPortConnection> CablingGenerator::prune_dead_channels(
                 LogicalChannelEndpoint{.host_id = start_host_id, .tray_id = start_tray, .asic_channel = start_chan},
                 LogicalChannelEndpoint{.host_id = end_host_id, .tray_id = end_tray, .asic_channel = end_chan});
         }
+        return false;
     };
 
+    // Single-pass walk that:
+    //   1. Rebuilds chip_connections_ (drives FSD emission).
+    //   2. Mutates graph->internal_connections in place to drop dead graph-level cables
+    //      (drives emit_cabling_descriptor — only graph-level connections appear in the
+    //      cabling textproto, see resolved_graph_to_protobuf at line ~1336).
+    //   3. Mutates node.inter_board_connections in place for in-memory consistency, even
+    //      though they are not part of the emitted cabling textproto.
+    //   4. Board::internal_connections (intra-board traces) are board-type properties; we
+    //      filter their channels out of chip_connections_ but cannot mutate the Board.
     std::function<void(const std::unique_ptr<ResolvedGraphInstance>&)> walk =
         [&](const std::unique_ptr<ResolvedGraphInstance>& graph) {
             if (!graph) {
                 return;
             }
 
-            for (const auto& [node_name, node] : graph->nodes) {
+            for (auto& [node_name, node] : graph->nodes) {
                 HostId host_id = node.host_id;
 
+                // Intra-board: rebuild-only, no mutation of Board possible.
                 for (const auto& [tray_id, board] : node.boards) {
                     for (const auto& [port_type, conns] : board.get_internal_connections()) {
                         for (const auto& [port_a, port_b] : conns) {
-                            process_cable(port_type, board, board, host_id, tray_id, port_a, host_id, tray_id, port_b);
+                            inspect_cable(port_type, board, board, host_id, tray_id, port_a, host_id, tray_id, port_b);
                         }
                     }
                 }
 
-                for (const auto& [port_type, conns] : node.inter_board_connections) {
-                    for (const auto& [be_a, be_b] : conns) {
-                        TrayId tray_a = be_a.first;
-                        PortId port_a = be_a.second;
-                        TrayId tray_b = be_b.first;
-                        PortId port_b = be_b.second;
+                // Inter-board within node: erase dead cables from the node clone's container.
+                for (auto& [port_type, conns] : node.inter_board_connections) {
+                    auto new_end = std::remove_if(conns.begin(), conns.end(), [&](const auto& bc) {
+                        TrayId tray_a = bc.first.first;
+                        PortId port_a = bc.first.second;
+                        TrayId tray_b = bc.second.first;
+                        PortId port_b = bc.second.second;
                         const Board& board_a = node.boards.at(tray_a);
                         const Board& board_b = node.boards.at(tray_b);
-                        process_cable(port_type, board_a, board_b, host_id, tray_a, port_a, host_id, tray_b, port_b);
-                    }
+                        return inspect_cable(
+                            port_type, board_a, board_b, host_id, tray_a, port_a, host_id, tray_b, port_b);
+                    });
+                    conns.erase(new_end, conns.end());
                 }
             }
 
-            for (const auto& [port_type, conns] : graph->internal_connections) {
-                for (const auto& [pe_a, pe_b] : conns) {
-                    auto [host_a, tray_a, port_a] = pe_a;
-                    auto [host_b, tray_b, port_b] = pe_b;
+            // Graph-level (between nodes): erase dead cables so emit_cabling_descriptor reflects pruning.
+            for (auto& [port_type, conns] : graph->internal_connections) {
+                auto new_end = std::remove_if(conns.begin(), conns.end(), [&](const auto& pc) {
+                    auto [host_a, tray_a, port_a] = pc.first;
+                    auto [host_b, tray_b, port_b] = pc.second;
                     if (!host_id_to_node_.contains(host_a) || !host_id_to_node_.contains(host_b)) {
-                        continue;
+                        return false;
                     }
                     const Node* node_a = host_id_to_node_.at(host_a);
                     const Node* node_b = host_id_to_node_.at(host_b);
                     const Board& board_a = node_a->boards.at(tray_a);
                     const Board& board_b = node_b->boards.at(tray_b);
-                    process_cable(port_type, board_a, board_b, host_a, tray_a, port_a, host_b, tray_b, port_b);
-                }
+                    return inspect_cable(port_type, board_a, board_b, host_a, tray_a, port_a, host_b, tray_b, port_b);
+                });
+                conns.erase(new_end, conns.end());
             }
 
             for (const auto& [_, sub] : graph->subgraphs) {

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1878,6 +1878,134 @@ std::set<PhysicalPortConnection> CablingGenerator::find_cables_containing_channe
     return result;
 }
 
+std::set<PhysicalPortConnection> CablingGenerator::prune_dead_channels(
+    const std::set<PhysicalChannelEndpoint>& dead_channels) {
+    std::set<PhysicalPortConnection> pruned;
+
+    if (dead_channels.empty() || !root_instance_) {
+        return pruned;
+    }
+
+    auto host_for = [&](HostId hid) -> const Host& { return deployment_hosts_.at(*hid); };
+
+    auto make_port_endpoint = [&](HostId host_id, TrayId tray, PortId port_id, PortType port_type) {
+        const Host& h = host_for(host_id);
+        return PhysicalPortEndpoint{
+            .hostname = h.hostname,
+            .aisle = h.aisle,
+            .rack = h.rack,
+            .shelf_u = h.shelf_u,
+            .tray_id = tray,
+            .port_type = port_type,
+            .port_id = port_id,
+        };
+    };
+
+    std::vector<LogicalChannelConnection> rebuilt;
+
+    // Single-pass walk that rebuilds chip_connections_ while detecting dead cables. For each
+    // cable: expand to channels, decide live-or-dead in one shot. Live -> append channels to
+    // rebuilt. Dead -> skip channels, record the cable into `pruned`.
+    auto process_cable = [&](PortType port_type,
+                             const Board& start_board,
+                             const Board& end_board,
+                             HostId start_host_id,
+                             TrayId start_tray,
+                             PortId start_port,
+                             HostId end_host_id,
+                             TrayId end_tray,
+                             PortId end_port) {
+        const auto& start_channels = start_board.get_port_channels(port_type, start_port);
+        const auto& end_channels = end_board.get_port_channels(port_type, end_port);
+        auto pairs = tt::scaleout_tools::get_asic_channel_connections(port_type, start_channels, end_channels);
+        const std::string& start_host = host_for(start_host_id).hostname;
+        const std::string& end_host = host_for(end_host_id).hostname;
+
+        bool is_dead = false;
+        for (const auto& [start_chan, end_chan] : pairs) {
+            if (dead_channels.contains(PhysicalChannelEndpoint{start_host, start_tray, start_chan}) ||
+                dead_channels.contains(PhysicalChannelEndpoint{end_host, end_tray, end_chan})) {
+                is_dead = true;
+                break;
+            }
+        }
+
+        if (is_dead) {
+            auto endpoint_a = make_port_endpoint(start_host_id, start_tray, start_port, port_type);
+            auto endpoint_b = make_port_endpoint(end_host_id, end_tray, end_port, port_type);
+            if (endpoint_a < endpoint_b) {
+                pruned.insert({endpoint_a, endpoint_b});
+            } else {
+                pruned.insert({endpoint_b, endpoint_a});
+            }
+            return;
+        }
+
+        for (const auto& [start_chan, end_chan] : pairs) {
+            rebuilt.emplace_back(
+                LogicalChannelEndpoint{.host_id = start_host_id, .tray_id = start_tray, .asic_channel = start_chan},
+                LogicalChannelEndpoint{.host_id = end_host_id, .tray_id = end_tray, .asic_channel = end_chan});
+        }
+    };
+
+    std::function<void(const std::unique_ptr<ResolvedGraphInstance>&)> walk =
+        [&](const std::unique_ptr<ResolvedGraphInstance>& graph) {
+            if (!graph) {
+                return;
+            }
+
+            for (const auto& [node_name, node] : graph->nodes) {
+                HostId host_id = node.host_id;
+
+                for (const auto& [tray_id, board] : node.boards) {
+                    for (const auto& [port_type, conns] : board.get_internal_connections()) {
+                        for (const auto& [port_a, port_b] : conns) {
+                            process_cable(port_type, board, board, host_id, tray_id, port_a, host_id, tray_id, port_b);
+                        }
+                    }
+                }
+
+                for (const auto& [port_type, conns] : node.inter_board_connections) {
+                    for (const auto& [be_a, be_b] : conns) {
+                        TrayId tray_a = be_a.first;
+                        PortId port_a = be_a.second;
+                        TrayId tray_b = be_b.first;
+                        PortId port_b = be_b.second;
+                        const Board& board_a = node.boards.at(tray_a);
+                        const Board& board_b = node.boards.at(tray_b);
+                        process_cable(port_type, board_a, board_b, host_id, tray_a, port_a, host_id, tray_b, port_b);
+                    }
+                }
+            }
+
+            for (const auto& [port_type, conns] : graph->internal_connections) {
+                for (const auto& [pe_a, pe_b] : conns) {
+                    auto [host_a, tray_a, port_a] = pe_a;
+                    auto [host_b, tray_b, port_b] = pe_b;
+                    if (!host_id_to_node_.contains(host_a) || !host_id_to_node_.contains(host_b)) {
+                        continue;
+                    }
+                    const Node* node_a = host_id_to_node_.at(host_a);
+                    const Node* node_b = host_id_to_node_.at(host_b);
+                    const Board& board_a = node_a->boards.at(tray_a);
+                    const Board& board_b = node_b->boards.at(tray_b);
+                    process_cable(port_type, board_a, board_b, host_a, tray_a, port_a, host_b, tray_b, port_b);
+                }
+            }
+
+            for (const auto& [_, sub] : graph->subgraphs) {
+                walk(sub);
+            }
+        };
+
+    walk(root_instance_);
+
+    std::sort(rebuilt.begin(), rebuilt.end());
+    chip_connections_ = std::move(rebuilt);
+
+    return pruned;
+}
+
 // Helper: Compare two nodes for equality (checks motherboard, boards, host_id, inter_board_connections)
 static bool compare_nodes(const Node& lhs, const Node& rhs, bool check_host_id = true) {
     // Compare basic fields

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -83,6 +83,7 @@ std::ostream& operator<<(std::ostream& os, const PhysicalPortEndpoint& conn);
 
 using LogicalChannelConnection = std::pair<LogicalChannelEndpoint, LogicalChannelEndpoint>;
 using PhysicalChannelConnection = std::pair<PhysicalChannelEndpoint, PhysicalChannelEndpoint>;
+using PhysicalPortConnection = std::pair<PhysicalPortEndpoint, PhysicalPortEndpoint>;
 
 // Port connection types (graph-level connections between nodes)
 using PortEndpoint = std::tuple<HostId, TrayId, PortId>;  // host_id, tray_id, port_id
@@ -187,6 +188,13 @@ public:
 
     // Method to emit deployment descriptor (one host per node in host_id order; use for merged output)
     void emit_deployment_descriptor(const std::string& output_path) const;
+
+    // Given a set of dead physical channel endpoints (e.g. unretrainable channels reported by
+    // run_cluster_validation), return the set of cables (port-level connections) whose channel
+    // expansion contains at least one of those channels. Used to identify which cables to remove
+    // from a degraded cluster's cabling descriptor before regenerating its FSD.
+    std::set<PhysicalPortConnection> find_cables_containing_channels(
+        const std::set<PhysicalChannelEndpoint>& dead_channels) const;
 
 private:
     // Track which node_descriptors were explicitly present in source files (not inferred)

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -196,12 +196,20 @@ public:
     std::set<PhysicalPortConnection> find_cables_containing_channels(
         const std::set<PhysicalChannelEndpoint>& dead_channels) const;
 
-    // Mutating counterpart to find_cables_containing_channels: rebuilds chip_connections_ by
-    // walking the resolved graph and skipping every cable whose expansion intersects the dead
-    // set. After this call, emit_factory_system_descriptor() produces a regenerated FSD that
-    // omits all channels of the affected cables (dead-channel == dead-cable policy).
-    // The cabling descriptor itself is NOT mutated; emit_cabling_descriptor() still emits the
-    // canonical input. Returns the set of cables that were pruned, for diagnostics.
+    // Mutating counterpart to find_cables_containing_channels: walks the resolved graph and
+    // removes every cable whose expansion intersects the dead set, applying the
+    // dead-channel == dead-cable policy.
+    //
+    // Side effects on this CablingGenerator:
+    //   - chip_connections_ rebuilt with dead cables' channels excluded
+    //     (drives emit_factory_system_descriptor()).
+    //   - graph-level internal_connections in root_instance_ have dead cables erased
+    //     (drives emit_cabling_descriptor() -- only graph-level connections appear in the
+    //     emitted cabling textproto).
+    //   - per-node inter_board_connections also have dead cables erased, for in-memory
+    //     consistency. (These are not part of the emitted cabling textproto today.)
+    //
+    // Returns the set of cables that were pruned, for diagnostics.
     std::set<PhysicalPortConnection> prune_dead_channels(const std::set<PhysicalChannelEndpoint>& dead_channels);
 
 private:

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -196,6 +196,14 @@ public:
     std::set<PhysicalPortConnection> find_cables_containing_channels(
         const std::set<PhysicalChannelEndpoint>& dead_channels) const;
 
+    // Mutating counterpart to find_cables_containing_channels: rebuilds chip_connections_ by
+    // walking the resolved graph and skipping every cable whose expansion intersects the dead
+    // set. After this call, emit_factory_system_descriptor() produces a regenerated FSD that
+    // omits all channels of the affected cables (dead-channel == dead-cable policy).
+    // The cabling descriptor itself is NOT mutated; emit_cabling_descriptor() still emits the
+    // canonical input. Returns the set of cables that were pruned, for diagnostics.
+    std::set<PhysicalPortConnection> prune_dead_channels(const std::set<PhysicalChannelEndpoint>& dead_channels);
+
 private:
     // Track which node_descriptors were explicitly present in source files (not inferred)
     std::unordered_set<std::string> explicit_node_descriptors_;

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -199,17 +199,6 @@ public:
     // Mutating counterpart to find_cables_containing_channels: walks the resolved graph and
     // removes every cable whose expansion intersects the dead set, applying the
     // dead-channel == dead-cable policy.
-    //
-    // Side effects on this CablingGenerator:
-    //   - chip_connections_ rebuilt with dead cables' channels excluded
-    //     (drives emit_factory_system_descriptor()).
-    //   - graph-level internal_connections in root_instance_ have dead cables erased
-    //     (drives emit_cabling_descriptor() -- only graph-level connections appear in the
-    //     emitted cabling textproto).
-    //   - per-node inter_board_connections also have dead cables erased, for in-memory
-    //     consistency. (These are not part of the emitted cabling textproto today.)
-    //
-    // Returns the set of cables that were pruned, for diagnostics.
     std::set<PhysicalPortConnection> prune_dead_channels(const std::set<PhysicalChannelEndpoint>& dead_channels);
 
 private:

--- a/tools/scaleout/cabling_generator/regen_descriptors.cpp
+++ b/tools/scaleout/cabling_generator/regen_descriptors.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "regen_descriptors.hpp"
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+#include <board/board.hpp>
+#include <cabling_generator/cabling_generator.hpp>
+
+namespace tt::scaleout_tools {
+
+namespace {
+
+// Parse the YAML schema emitted by log_unretrainable_channels (cluster_validation_utils.cpp):
+//   unretrainable_channels:
+//     - host: <hostname>
+//       tray_id: <uint>
+//       asic_location: <uint>
+//       channel: <uint>
+//       asic_unique_id: <hex string>      # ignored here
+std::set<PhysicalChannelEndpoint> load_unretrainable_channels(const std::string& yaml_path) {
+    YAML::Node root;
+    try {
+        root = YAML::LoadFile(yaml_path);
+    } catch (const YAML::Exception& e) {
+        throw std::runtime_error("Failed to parse unretrainable channels YAML at '" + yaml_path + "': " + e.what());
+    }
+
+    std::set<PhysicalChannelEndpoint> dead_channels;
+
+    auto channels_node = root["unretrainable_channels"];
+    if (!channels_node || channels_node.IsNull()) {
+        return dead_channels;
+    }
+    if (!channels_node.IsSequence()) {
+        throw std::runtime_error("Expected 'unretrainable_channels' in '" + yaml_path + "' to be a YAML sequence");
+    }
+
+    for (const auto& entry : channels_node) {
+        try {
+            auto host = entry["host"].as<std::string>();
+            auto tray_id = entry["tray_id"].as<uint32_t>();
+            auto asic_location = entry["asic_location"].as<uint32_t>();
+            auto channel = entry["channel"].as<uint32_t>();
+
+            dead_channels.insert(PhysicalChannelEndpoint{
+                .hostname = std::move(host),
+                .tray_id = TrayId(tray_id),
+                .asic_channel =
+                    AsicChannel{
+                        .asic_location = asic_location,
+                        .channel_id = ChanId(channel),
+                    },
+            });
+        } catch (const YAML::Exception& e) {
+            throw std::runtime_error("Malformed entry in 'unretrainable_channels' (" + yaml_path + "): " + e.what());
+        }
+    }
+
+    return dead_channels;
+}
+
+}  // namespace
+
+RegenDescriptorsSummary regenerate_descriptors_excluding_dead_channels(
+    const std::string& cabling_descriptor_path,
+    const std::string& deployment_descriptor_path,
+    const std::string& unretrainable_channels_yaml_path,
+    const std::string& output_dir) {
+    auto dead_channels = load_unretrainable_channels(unretrainable_channels_yaml_path);
+
+    CablingGenerator gen(cabling_descriptor_path, deployment_descriptor_path);
+
+    auto pruned_cables = gen.prune_dead_channels(dead_channels);
+
+    std::filesystem::create_directories(output_dir);
+    std::filesystem::path out(output_dir);
+    auto fsd_path = (out / "factory_system_descriptor.textproto").string();
+    auto cabling_path = (out / "cabling_descriptor.textproto").string();
+    auto deployment_path = (out / "deployment_descriptor.textproto").string();
+
+    gen.emit_factory_system_descriptor(fsd_path);
+    gen.emit_cabling_descriptor(cabling_path);
+    gen.emit_deployment_descriptor(deployment_path);
+
+    return RegenDescriptorsSummary{
+        .pruned_cables = std::move(pruned_cables),
+        .channels_remaining = gen.get_chip_connections().size(),
+        .input_dead_channels = dead_channels.size(),
+        .output_fsd_path = std::move(fsd_path),
+        .output_cabling_descriptor_path = std::move(cabling_path),
+        .output_deployment_descriptor_path = std::move(deployment_path),
+    };
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/cabling_generator/regen_descriptors.hpp
+++ b/tools/scaleout/cabling_generator/regen_descriptors.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <set>
+#include <string>
+
+#include <cabling_generator/cabling_generator.hpp>
+
+namespace tt::scaleout_tools {
+
+struct RegenDescriptorsSummary {
+    // Cables (port-level connections) removed because at least one of their channels was
+    // reported as unretrainable. Treated as whole-cable failures per the
+    // dead-channel == dead-cable policy.
+    std::set<PhysicalPortConnection> pruned_cables;
+    // Number of channel-level connections in the regenerated FSD after pruning.
+    size_t channels_remaining = 0;
+    // Number of distinct channel endpoints read from the input YAML (informational).
+    size_t input_dead_channels = 0;
+    // Output paths written by the regen step.
+    std::string output_fsd_path;
+    std::string output_cabling_descriptor_path;
+    std::string output_deployment_descriptor_path;
+};
+
+// Read a list of unretrainable channel endpoints from `unretrainable_channels_yaml_path`
+// (the artifact emitted by run_cluster_validation on retrain exhaustion), construct a
+// CablingGenerator from `cabling_descriptor_path` + `deployment_descriptor_path`, prune any
+// cable whose channel expansion intersects the dead-channel set, and write the regenerated
+// descriptor set into `output_dir`:
+//   <output_dir>/factory_system_descriptor.textproto
+//   <output_dir>/cabling_descriptor.textproto
+//   <output_dir>/deployment_descriptor.textproto
+//
+// The deployment descriptor is emitted as-is (cable failures don't change hardware
+// placement); it's included so the output dir is a self-contained, regen_cabling-replayable
+// descriptor set. The original input descriptors are not modified.
+//
+// Returns a summary of what was pruned plus the emitted output paths. Throws
+// std::runtime_error on I/O failures, malformed YAML, or descriptor parse errors.
+RegenDescriptorsSummary regenerate_descriptors_excluding_dead_channels(
+    const std::string& cabling_descriptor_path,
+    const std::string& deployment_descriptor_path,
+    const std::string& unretrainable_channels_yaml_path,
+    const std::string& output_dir);
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -27,7 +27,9 @@ Optional:
                                             (Kubernetes CNI, flannel, docker) being selected by MPI
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
-    --output <directory>                     Output directory for log files (default: recover-logs)
+    --output <directory>                    Output directory for logs and validation artifacts (default: recover-logs).
+                                            Passed to run_cluster_validation as --output-path so the
+                                            unretrainable_channels.yaml artifact lands here too.
 
     --cabling-descriptor-path <path>        Path to cabling descriptor file (4x32 only, overrides --config default)
                                             (default: /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto)
@@ -43,6 +45,14 @@ Optional:
                                             e.g. --validation-args "--min-connections 2 --hard-fail"
                                             Use this for any run_cluster_validation flag (relaxed validation, strict
                                             failure, connectivity prints, metrics logging, etc.)
+    --no-regenerate-on-failure              Disable automatic descriptor regeneration after an unrecoverable
+                                            validation failure. By default, when run_cluster_validation
+                                            exhausts its retrain budget and emits unretrainable_channels.yaml,
+                                            recover.sh invokes run_regen_descriptors to write a degraded
+                                            descriptor set (FSD + cabling + deployment) to <output>/regenerated.
+                                            In --use-docker mode regen runs inside the image on the first host.
+                                            Regen is skipped automatically when only --factory-descriptor-path is
+                                            in use (cabling+deployment are required inputs).
     --help                                  Display this help message and exit
 
 ================================================================================
@@ -79,6 +89,7 @@ MPI_EXTRA_ARGS=()
 OUTPUT_DIR="recover-logs"
 RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
+REGENERATE_ON_FAILURE=true
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -226,6 +237,10 @@ while [[ $# -gt 0 ]]; do
             VALIDATION_EXTRA_ARGS+=("${_extra[@]}")
             shift 2
             ;;
+        --no-regenerate-on-failure)
+            REGENERATE_ON_FAILURE=false
+            shift
+            ;;
         --help)
             show_help
             exit 0
@@ -267,8 +282,12 @@ if [[ "$SKIP_RESET" == true && "$SKIP_VALIDATION" == true ]]; then
     exit 1
 fi
 
-# Set log file path inside output directory (captures actual start time)
+# Set log file path inside output directory (captures actual start time).
+# Resolve to an absolute path so it can be bind-mounted into Docker containers
+# (regen runs inside the image in --use-docker mode) and referenced identically
+# inside and outside the container.
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 LOG_FILE="$OUTPUT_DIR/recover_$(date +%Y%m%d_%H%M%S).log"
 
 # Redirect all output: terminal sees colors, log file gets ANSI/CR stripped
@@ -342,6 +361,7 @@ echo "Rerun on retrain: $RERUN_ON_RETRAIN"
 if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
     echo "Extra validation args: ${VALIDATION_EXTRA_ARGS[*]}"
 fi
+echo "Regenerate on failure: $REGENERATE_ON_FAILURE"
 echo "=========================================="
 echo ""
 
@@ -362,6 +382,7 @@ else
 fi
 
 # Step 2: Cluster validation
+VALIDATION_EXIT=0
 if [[ "$SKIP_VALIDATION" == false ]]; then
     VALIDATION_ARGS=("${DESCRIPTOR_ARGS[@]}")
     if [[ "$SEND_TRAFFIC" == true ]]; then
@@ -371,6 +392,7 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
     if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
         VALIDATION_ARGS+=("${VALIDATION_EXTRA_ARGS[@]}")
     fi
+    VALIDATION_ARGS+=(--output-path "$OUTPUT_DIR")
 
     run_cluster_validation() {
         if [[ -n "$DOCKER_IMAGE" ]]; then
@@ -395,19 +417,47 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
     echo ""
     echo "Running cluster validation..."
     VALIDATION_LOG=$(mktemp)
-    run_cluster_validation 2>&1 | tee "$VALIDATION_LOG"
+    # Capture the exit code without tripping `set -e` (the `if` context suspends it) so regen
+    # can run on failure. pipefail makes the pipeline reflect run_cluster_validation's status.
+    if run_cluster_validation 2>&1 | tee "$VALIDATION_LOG"; then VALIDATION_EXIT=0; else VALIDATION_EXIT=$?; fi
 
     if [[ "$RERUN_ON_RETRAIN" == true ]] && grep -q "Ethernet Links were Retrained" "$VALIDATION_LOG"; then
         echo ""
         echo "Ethernet links were retrained — rerunning validation to issue traffic..."
-        run_cluster_validation
+        if run_cluster_validation 2>&1 | tee "$VALIDATION_LOG"; then VALIDATION_EXIT=0; else VALIDATION_EXIT=$?; fi
     fi
     rm -f "$VALIDATION_LOG"
 else
     echo "Skipping validation (--skip-validation)"
 fi
 
+# Step 3: Regenerate descriptors if validation hit unrecoverable state
+if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
+    UNRETRAINABLE_YAML="$OUTPUT_DIR/unretrainable_channels.yaml"
+    if [[ -f "$UNRETRAINABLE_YAML" ]]; then
+        if [[ -z "$CABLING_DESCRIPTOR_PATH" || -z "$DEPLOYMENT_DESCRIPTOR_PATH" ]]; then
+            echo ""
+            echo "Skipping descriptor regeneration: requires --cabling-descriptor-path and"
+            echo "--deployment-descriptor-path (cannot regenerate from --factory-descriptor-path alone)."
+        else
+            REGEN_DIR="$OUTPUT_DIR/regenerated"
+            echo ""
+            echo "Validation exited unrecoverable; regenerating descriptors without unretrainable cables..."
+            ./build/tools/scaleout/run_regen_descriptors \
+                --cabling "$CABLING_DESCRIPTOR_PATH" \
+                --deployment "$DEPLOYMENT_DESCRIPTOR_PATH" \
+                --unretrainable-channels "$UNRETRAINABLE_YAML" \
+                --output-dir "$REGEN_DIR" || echo "Warning: descriptor regeneration failed (see error above)"
+        fi
+    fi
+fi
+
 echo ""
 echo "=========================================="
 echo "Recovery completed at $(date)"
 echo "=========================================="
+
+# Propagate validation's exit code so callers still see the failure
+if [[ $VALIDATION_EXIT -ne 0 ]]; then
+    exit "$VALIDATION_EXIT"
+fi

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -441,13 +441,43 @@ if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
             echo "--deployment-descriptor-path (cannot regenerate from --factory-descriptor-path alone)."
         else
             REGEN_DIR="$OUTPUT_DIR/regenerated"
+            REGEN_ARGS=(
+                --cabling "$CABLING_DESCRIPTOR_PATH"
+                --deployment "$DEPLOYMENT_DESCRIPTOR_PATH"
+                --unretrainable-channels "$UNRETRAINABLE_YAML"
+                --output-dir "$REGEN_DIR"
+            )
             echo ""
             echo "Validation exited unrecoverable; regenerating descriptors without unretrainable cables..."
-            ./build/tools/scaleout/run_regen_descriptors \
-                --cabling "$CABLING_DESCRIPTOR_PATH" \
-                --deployment "$DEPLOYMENT_DESCRIPTOR_PATH" \
-                --unretrainable-channels "$UNRETRAINABLE_YAML" \
-                --output-dir "$REGEN_DIR" || echo "Warning: descriptor regeneration failed (see error above)"
+            if [[ -n "$DOCKER_IMAGE" ]]; then
+                # run_regen_descriptors is a single-host offline tool. In docker mode the binary
+                # only exists inside the image, so run one rank on the first host, mounting the
+                # descriptor inputs and the output dir so paths resolve identically in-container.
+                # Relative input paths resolve against the container's working dir, which differs
+                # from the host cwd, so warn the operator to use absolute paths.
+                if [[ "$CABLING_DESCRIPTOR_PATH" != /* || "$DEPLOYMENT_DESCRIPTOR_PATH" != /* ]]; then
+                    echo "Warning: --cabling-descriptor-path / --deployment-descriptor-path are relative;"
+                    echo "         in --use-docker mode they may not resolve inside the container."
+                    echo "         Use absolute paths if regeneration fails to find the descriptors."
+                fi
+                FIRST_HOST="${HOSTS%%,*}"
+                REGEN_VOLUMES=(--volume /data/scaleout_configs --volume "$OUTPUT_DIR")
+                # Mount the directories holding the input descriptors too, in case they live
+                # outside /data/scaleout_configs (custom --cabling/--deployment paths).
+                CABLING_DIR="$(cd "$(dirname "$CABLING_DESCRIPTOR_PATH")" && pwd)"
+                DEPLOYMENT_DIR="$(cd "$(dirname "$DEPLOYMENT_DESCRIPTOR_PATH")" && pwd)"
+                REGEN_VOLUMES+=(--volume "$CABLING_DIR" --volume "$DEPLOYMENT_DIR")
+                ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+                    --empty-entrypoint \
+                    --mpi-interface "$MPI_IF" \
+                    "${REGEN_VOLUMES[@]}" \
+                    --host "$FIRST_HOST" -np 1 \
+                    ./build/tools/scaleout/run_regen_descriptors \
+                    "${REGEN_ARGS[@]}" || echo "Warning: descriptor regeneration failed (see error above)"
+            else
+                ./build/tools/scaleout/run_regen_descriptors \
+                    "${REGEN_ARGS[@]}" || echo "Warning: descriptor regeneration failed (see error above)"
+            fi
         fi
     fi
 fi

--- a/tools/scaleout/src/run_regen_descriptors.cpp
+++ b/tools/scaleout/src/run_regen_descriptors.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <cxxopts.hpp>
+
+#include <cabling_generator/regen_descriptors.hpp>
+
+using namespace tt::scaleout_tools;
+
+namespace {
+
+struct InputConfig {
+    std::string cabling_descriptor_path;
+    std::string deployment_descriptor_path;
+    std::string unretrainable_channels_path;
+    std::string output_dir;
+};
+
+bool file_exists(const std::string& path) {
+    return std::filesystem::exists(path) && std::filesystem::is_regular_file(path);
+}
+
+bool directory_exists(const std::string& path) {
+    return std::filesystem::exists(path) && std::filesystem::is_directory(path);
+}
+
+InputConfig parse_arguments(int argc, char** argv) {
+    cxxopts::Options options(
+        "run_regen_descriptors",
+        "Regenerate FSD, cabling and deployment descriptors with unretrainable cables removed.\n"
+        "\n"
+        "Reads the unretrainable_channels.yaml artifact emitted by run_cluster_validation when\n"
+        "it exhausts its retrain budget, then rebuilds a self-contained descriptor set that\n"
+        "omits every cable whose channel expansion intersects the unretrainable set\n"
+        "(dead-channel == dead-cable policy).\n"
+        "\n"
+        "Outputs three files under <output-dir>:\n"
+        "  - factory_system_descriptor.textproto\n"
+        "  - cabling_descriptor.textproto\n"
+        "  - deployment_descriptor.textproto  (unchanged; cable failures don't move hardware)\n"
+        "\n"
+        "The original input descriptors are not modified.");
+
+    options.add_options()(
+        "c,cabling",
+        "Path to original cabling descriptor file (.textproto) or directory of descriptors",
+        cxxopts::value<std::string>())(
+        "d,deployment", "Path to original deployment descriptor (.textproto)", cxxopts::value<std::string>())(
+        "u,unretrainable-channels",
+        "Path to unretrainable_channels.yaml emitted by run_cluster_validation",
+        cxxopts::value<std::string>())(
+        "o,output-dir", "Directory to write the regenerated descriptor set into", cxxopts::value<std::string>())(
+        "h,help", "Print usage information");
+
+    try {
+        auto result = options.parse(argc, argv);
+
+        if (result.contains("help") || argc == 1) {
+            std::cout << options.help() << std::endl;
+            std::cout << "\nExample:\n";
+            std::cout
+                << "  " << argv[0] << " --cabling /data/scaleout_configs/<cluster>/cabling_descriptor.textproto \\\n"
+                << "             --deployment /data/scaleout_configs/<cluster>/deployment_descriptor.textproto \\\n"
+                << "             --unretrainable-channels validation_output/unretrainable_channels.yaml \\\n"
+                << "             --output-dir validation_output/regenerated/\n";
+            std::exit(0);
+        }
+
+        for (const char* required : {"cabling", "deployment", "unretrainable-channels", "output-dir"}) {
+            if (!result.contains(required)) {
+                throw std::invalid_argument(std::string("--") + required + " is required");
+            }
+        }
+
+        InputConfig config{
+            .cabling_descriptor_path = result["cabling"].as<std::string>(),
+            .deployment_descriptor_path = result["deployment"].as<std::string>(),
+            .unretrainable_channels_path = result["unretrainable-channels"].as<std::string>(),
+            .output_dir = result["output-dir"].as<std::string>(),
+        };
+
+        if (!file_exists(config.cabling_descriptor_path) && !directory_exists(config.cabling_descriptor_path)) {
+            throw std::invalid_argument(
+                "Cabling descriptor not found (expected file or directory): '" + config.cabling_descriptor_path + "'");
+        }
+        if (!file_exists(config.deployment_descriptor_path)) {
+            throw std::invalid_argument("Deployment descriptor not found: '" + config.deployment_descriptor_path + "'");
+        }
+        if (!file_exists(config.unretrainable_channels_path)) {
+            throw std::invalid_argument(
+                "Unretrainable channels YAML not found: '" + config.unretrainable_channels_path + "'");
+        }
+
+        return config;
+    } catch (const cxxopts::exceptions::exception& e) {
+        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
+        std::cerr << options.help() << std::endl;
+        std::exit(1);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        auto config = parse_arguments(argc, argv);
+
+        std::cout << "Regenerating descriptors with unretrainable cables removed..." << std::endl;
+        std::cout << "  Cabling:                 " << config.cabling_descriptor_path << std::endl;
+        std::cout << "  Deployment:              " << config.deployment_descriptor_path << std::endl;
+        std::cout << "  Unretrainable channels:  " << config.unretrainable_channels_path << std::endl;
+        std::cout << "  Output dir:              " << config.output_dir << std::endl;
+
+        auto summary = regenerate_descriptors_excluding_dead_channels(
+            config.cabling_descriptor_path,
+            config.deployment_descriptor_path,
+            config.unretrainable_channels_path,
+            config.output_dir);
+
+        std::cout << "\nDone." << std::endl;
+        std::cout << "  Input dead channel endpoints: " << summary.input_dead_channels << std::endl;
+        std::cout << "  Cables pruned:                " << summary.pruned_cables.size() << std::endl;
+        std::cout << "  Channels in regenerated FSD:  " << summary.channels_remaining << std::endl;
+        std::cout << "\n  Wrote:" << std::endl;
+        std::cout << "    " << summary.output_fsd_path << std::endl;
+        std::cout << "    " << summary.output_cabling_descriptor_path << std::endl;
+        std::cout << "    " << summary.output_deployment_descriptor_path << std::endl;
+
+        if (!summary.pruned_cables.empty()) {
+            std::cout << "\nPruned cables:" << std::endl;
+            for (const auto& [endpoint_a, endpoint_b] : summary.pruned_cables) {
+                std::cout << "  - " << endpoint_a << " <-> " << endpoint_b << std::endl;
+            }
+        }
+
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tools/scaleout/src/run_regen_descriptors.cpp
+++ b/tools/scaleout/src/run_regen_descriptors.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
 
         std::cout << "\nDone." << std::endl;
         std::cout << "  Input dead channel endpoints: " << summary.input_dead_channels << std::endl;
-        std::cout << "  Cables pruned:                " << summary.pruned_cables.size() << std::endl;
+        std::cout << "  Cables pruned from FSD:       " << summary.pruned_cables.size() << std::endl;
         std::cout << "  Channels in regenerated FSD:  " << summary.channels_remaining << std::endl;
         std::cout << "\n  Wrote:" << std::endl;
         std::cout << "    " << summary.output_fsd_path << std::endl;
@@ -134,7 +134,8 @@ int main(int argc, char** argv) {
         std::cout << "    " << summary.output_deployment_descriptor_path << std::endl;
 
         if (!summary.pruned_cables.empty()) {
-            std::cout << "\nPruned cables:" << std::endl;
+            std::cout << "\nPruned cables (removed from FSD; inter-node ones also from cabling descriptor):"
+                      << std::endl;
             for (const auto& [endpoint_a, endpoint_b] : summary.pruned_cables) {
                 std::cout << "  - " << endpoint_a << " <-> " << endpoint_b << std::endl;
             }

--- a/tools/scaleout/validation/run_cluster_validation.cpp
+++ b/tools/scaleout/validation/run_cluster_validation.cpp
@@ -407,6 +407,8 @@ int main(int argc, char* argv[]) {
     distributed_context.barrier();
     if (num_retrains == MAX_RETRAINS_BEFORE_FAILURE && !missing_asic_topology.empty()) {
         log_link_retrain_summary(link_retrain_counts, num_retrains, input_args.output_path);
+        log_unretrainable_channels(
+            missing_asic_topology, physical_system_descriptor, num_retrains, input_args.output_path);
         TT_THROW("Encountered unrecoverable state. Please check the system and try again.");
         return -1;
     }

--- a/tools/scaleout/validation/utils/cluster_validation_utils.cpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.cpp
@@ -1412,6 +1412,68 @@ void log_link_retrain_summary(
     log_output_rank0("Link retrain report written to: " + csv_path.string());
 }
 
+void log_unretrainable_channels(
+    const tt::tt_metal::AsicTopology& missing_topology,
+    const PhysicalSystemDescriptor& physical_system_descriptor,
+    uint32_t total_retrain_iterations,
+    const std::filesystem::path& output_path) {
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().global_distributed_context();
+
+    if (*distributed_context.rank() != 0) {
+        return;
+    }
+
+    auto channels = collect_retrained_link_identifiers(missing_topology, physical_system_descriptor);
+    if (channels.empty()) {
+        return;
+    }
+
+    std::sort(channels.begin(), channels.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.host, *lhs.tray_id, *lhs.asic_location, lhs.channel) <
+               std::tie(rhs.host, *rhs.tray_id, *rhs.asic_location, rhs.channel);
+    });
+
+    auto format_unique_id = [](const auto& asic_id) {
+        std::stringstream ss;
+        ss << "0x" << std::hex << std::setfill('0') << std::setw(10) << *asic_id;
+        return ss.str();
+    };
+
+    // Best-effort filesystem; the caller is about to throw, so any failure here only loses
+    // diagnostic output, never propagates.
+    std::error_code ec;
+    std::filesystem::create_directories(output_path, ec);
+    if (ec) {
+        log_output_rank0(
+            "[WARN] Could not create output directory for unretrainable channels: " + output_path.string() + " (" +
+            ec.message() + ")");
+        return;
+    }
+
+    const std::filesystem::path yaml_path = output_path / "unretrainable_channels.yaml";
+    std::ofstream yaml_file(yaml_path);
+    if (!yaml_file.is_open()) {
+        log_output_rank0("[WARN] Could not open unretrainable channels file for writing: " + yaml_path.string());
+        return;
+    }
+
+    yaml_file << "# Channels that failed to retrain after " << total_retrain_iterations << " attempts.\n";
+    yaml_file << "# Each entry is one channel endpoint; both ends of an unretrainable cable\n";
+    yaml_file << "# typically appear as separate entries.\n";
+    yaml_file << "total_retrain_iterations: " << total_retrain_iterations << "\n";
+    yaml_file << "unretrainable_channels:\n";
+    for (const auto& channel_id : channels) {
+        yaml_file << "  - host: " << channel_id.host << "\n";
+        yaml_file << "    tray_id: " << *channel_id.tray_id << "\n";
+        yaml_file << "    asic_location: " << *channel_id.asic_location << "\n";
+        yaml_file << "    channel: " << static_cast<int>(channel_id.channel) << "\n";
+        yaml_file << "    asic_unique_id: " << format_unique_id(channel_id.asic_id) << "\n";
+    }
+    yaml_file.close();
+    log_output_rank0(
+        "Unretrainable channels (" + std::to_string(channels.size()) + " endpoints) written to: " + yaml_path.string());
+}
+
 void reset_local_ethernet_links(
     const PhysicalSystemDescriptor& physical_system_descriptor, const tt::tt_metal::AsicTopology& asic_topology) {
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();

--- a/tools/scaleout/validation/utils/cluster_validation_utils.hpp
+++ b/tools/scaleout/validation/utils/cluster_validation_utils.hpp
@@ -86,6 +86,12 @@ void log_link_retrain_summary(
     uint32_t total_retrain_iterations,
     const std::filesystem::path& output_path);
 
+void log_unretrainable_channels(
+    const tt_metal::AsicTopology& missing_topology,
+    const PhysicalSystemDescriptor& physical_system_descriptor,
+    uint32_t total_retrain_iterations,
+    const std::filesystem::path& output_path);
+
 tt_metal::AsicTopology build_reset_topology(
     const std::string& reset_host,
     uint32_t reset_tray_id,

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -410,4 +410,36 @@ TEST(Cluster, TestMinConnectionsStrictModeFailsWithMismatches) {
     std::filesystem::remove(fsd_file);
 }
 
+TEST(CablingGenerator, PruneDeadChannelsRemovesContainingCable) {
+    CablingGenerator gen(
+        "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto",
+        "tools/tests/scaleout/deployment_descriptors/16_lb_deployment.textproto");
+
+    const size_t before = gen.get_chip_connections().size();
+    ASSERT_GT(before, 0u);
+
+    // Take a real channel endpoint from the first connection (host_id -> hostname via deployment).
+    const auto& ep = gen.get_chip_connections().front().first;
+    PhysicalChannelEndpoint dead{gen.get_deployment_hosts().at(*ep.host_id).hostname, ep.tray_id, ep.asic_channel};
+
+    auto cables = gen.find_cables_containing_channels({dead});
+    EXPECT_EQ(cables.size(), 1u);  // dead channel maps to exactly one cable
+
+    auto pruned = gen.prune_dead_channels({dead});
+    EXPECT_EQ(pruned, cables);                             // prune reports the same cable
+    EXPECT_LT(gen.get_chip_connections().size(), before);  // its channels are gone from the FSD
+}
+
+TEST(CablingGenerator, PruneDeadChannelsIgnoresUnknownChannel) {
+    CablingGenerator gen(
+        "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto",
+        "tools/tests/scaleout/deployment_descriptors/16_lb_deployment.textproto");
+
+    const size_t before = gen.get_chip_connections().size();
+    PhysicalChannelEndpoint bogus{"nonexistent-host", TrayId(1), AsicChannel{0, ChanId(0)}};
+
+    EXPECT_TRUE(gen.prune_dead_channels({bogus}).empty());  // no cable matched
+    EXPECT_EQ(gen.get_chip_connections().size(), before);   // FSD unchanged
+}
+
 }  // namespace tt::scaleout_tools


### PR DESCRIPTION
### Ticket

https://tenstorrent.atlassian.net/browse/DCAMP-649

### PR Category
Feature

### Summary
When `run_cluster_validation` exhausts its retrain budget it throws "unrecoverable state" with no machine-readable record of which cables died. This adds a path to turn that failure into a usable degraded descriptor set.
- `run_cluster_validation` now emits `unretrainable_channels.yaml` at the throw point.
- `CablingGenerator::prune_dead_channels` removes every cable whose channel expansion intersects the dead set (dead-channel == dead-cable), rebuilding chip_connections_ and erasing the cables from the resolved graph.
- New `run_regen_descriptors` tool reads the YAML and emits a regenerated FSD + cabling + deployment descriptor set with the dead cables removed.
- `recover.sh` invokes it automatically on unrecoverable failure (opt out with `--no-regenerate-on-failure`; skipped when only `--factory-descriptor-path` is used). Works in both local-build and `--use-docker` mode (regen runs inside the image on the first host).

### Notes for reviewers
- `prune_dead_channels` mutates graph-level `internal_connections` (emitted in the cabling textproto) and per-node `inter_board_connections`; intra-board traces are board-type properties so they're filtered from the FSD but not the Board itself.
- **Cabling regen only reflects flat (single-level) cabling descriptors.** `emit_cabling_descriptor` doesn't serialize nested subgraphs, so for a nested cluster an intra-subgraph cable is pruned from the FSD but not from the emitted cabling textproto. This is a pre-existing `emit_cabling_descriptor` property, not introduced here. Every production descriptor (`/data/scaleout_configs/*`, and the `tt-cluster-config` aggregated output, which is generated via `run_cabling_generator` and therefore flat by construction) is flat — so this doesn't matter today and we're not addressing it in this PR.
- The FSD is the complete source of truth and is always faithful (all layers, all topologies); it's what validation/workloads consume.
- Deployment descriptor is emitted unchanged (cable failures don't move hardware); included so the output dir is a self-contained, replayable descriptor set.
- recover.sh propagates validation's original exit code after regen runs.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/backup_desc_gen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/backup_desc_gen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/backup_desc_gen)