### PR TITLE
#45440: Skip docs deploy for pre-release tags

### DIFF
--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -87,7 +87,10 @@ jobs:
 
   deploy-docs:
     needs: build-docs
-    if: ${{ !inputs.dry-run && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
+    # Only deploy from main/stable or a final release tag (vX.Y.Z). Pre-release tags
+    # like v0.69.0-rc1 or v0.68.0-dev20260319 are excluded so they don't accumulate on
+    # gh-pages and inflate the Pages artifact past the 10 GB limit. See #45440.
+    if: ${{ !inputs.dry-run && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))) }}
     runs-on: ubuntu-latest
     concurrency:
       # Note that people may spam the post-commit pipeline on their branch, and

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -168,10 +168,13 @@ jobs:
             echo "docs-version=latest" >> "$GITHUB_OUTPUT"
           fi
 
-  # Only run docs release once per run on the main platform
+  # Only run docs release once per run on the main platform.
+  # Restricted to main/stable or final release tags (vX.Y.Z); pre-release tags
+  # like v0.69.0-rc1 or v0.68.0-dev20260319 are excluded so they don't accumulate
+  # on gh-pages and inflate the Pages artifact past the 10 GB limit. See #45440.
   release-docs:
     needs: [build-artifact-release, parse-platform, resolve-docs-version]
-    if: ${{ inputs.platform == inputs.main-platform && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run) }}
+    if: ${{ inputs.platform == inputs.main-platform && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')) || inputs.dry-run) }}
     uses: ./.github/workflows/docs-latest-public.yaml
     with:
       version: ${{ needs.resolve-docs-version.outputs.docs-version }}


### PR DESCRIPTION
## Summary

Closes #45440.

The Pages "build and deployment" workflow has been failing since the deploy artifact crossed 10 GB (last successful run was end of March), and the 1 GB warning had been firing for much longer. Root cause: the deploy gate matched **any** tag starting with `v`, so every pre-release tag (`v0.69.0-rc1`, `v0.68.0-dev20260319`, etc.) left a permanent versioned folder on `gh-pages` — the action uses `target-folder` + `force: false`, so nothing ever gets removed.

This PR tightens the gate in the two automatic deploy paths to require a final release tag (no `-` in the ref). `main`, `stable`, and `vX.Y.Z` tags still deploy as before.

| Ref | Before | After |
|---|---|---|
| `refs/heads/main` | deploy | deploy |
| `refs/heads/stable` | deploy | deploy |
| `refs/tags/v0.69.0` | deploy | deploy |
| `refs/tags/v0.69.0-rc1` | deploy | skip |
| `refs/tags/v0.68.0-dev20260319` | deploy | skip |

This stops new bloat from landing. Cleanup of the existing versioned folders on `gh-pages` is tracked separately in #45441.

## Test plan

- [ ] Verify on a pre-release tag push (`vX.Y.Z-rc*` / `vX.Y.Z-dev*`) that `release-docs` / `deploy-docs` are skipped
- [ ] Verify on a final release tag push (`vX.Y.Z`) that docs still deploy
- [ ] Verify the next `main` post-commit run still deploys to `gh-pages` under `latest/`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dimitri/45440-docs-skip-prerelease-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dimitri/45440-docs-skip-prerelease-tags)