### PR TITLE
Feature: Quasar SFPU binary gt_int (greater than int)  compute api and metal test

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -860,7 +860,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuBinaryParameterizedFixture, TensixSfpuBinar
 
     if (MetalContext::instance().get_cluster().arch() == ARCH::WORMHOLE_B0 ||
         MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
-        GTEST_SKIP() << "Binary SFPU op test (div_binary / add_int / mul_int) not fixed for WH/BH";
+        GTEST_SKIP() << "Binary SFPU op test (div_binary / add_int / mul_int / gt_int) not fixed for WH/BH";
     }
 
     // add_int/mul_int: Int8 L1 inputs promoted to sign-mag Int32 output. div_binary stays bfloat16.

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -93,9 +93,14 @@ const map<std::string, std::map<std::string, std::string>> sfpu_binary_op_to_op_
     {"mul_int",
      {{"SFPU_OP_INIT_0", "mul_int_tile_init<DataFormat::Int32>();"},
       {"SFPU_OP_CHAIN_0", "mul_int_tile<DataFormat::Int32>(0, 1, 0);"}}},
+    {"gt_int",
+     {{"SFPU_OP_INIT_0", "gt_int_tile_init<DataFormat::Int32>();"},
+      {"SFPU_OP_CHAIN_0", "gt_int_tile<DataFormat::Int32>(0, 1, 0);"}}},
 };
 
-bool is_int8_binary_sfpu_op(const std::string& op_name) { return (op_name == "add_int") or (op_name == "mul_int"); }
+bool is_int8_binary_sfpu_op(const std::string& op_name) {
+    return (op_name == "add_int") or (op_name == "mul_int") or (op_name == "gt_int");
+}
 
 bfloat16 sfpu_function(const std::string& op_name, const bfloat16& input) {
     if (op_name == "relu") {
@@ -159,6 +164,9 @@ int32_t get_binary_int_operation_result(const std::string& op_name, int lhs, int
     }
     if (op_name == "mul_int") {
         return static_cast<int32_t>(lhs * rhs);
+    }
+    if (op_name == "gt_int") {
+        return (lhs > rhs) ? 1 : 0;
     }
     TT_THROW("Unsupported int8 binary op_name in test");
 }
@@ -536,6 +544,8 @@ bool run_sfpu_binary_two_input_buffer(
             sfpu_defines["SFPU_OP_BINARY_ADD_INT_INCLUDE"] = "1";
         } else if (test_config.sfpu_op == "mul_int") {
             sfpu_defines["SFPU_OP_BINARY_MUL_INT_INCLUDE"] = "1";
+        } else if (test_config.sfpu_op == "gt_int") {
+            sfpu_defines["SFPU_OP_BINARY_GT_INT_INCLUDE"] = "1";
         }
     } else {
         sfpu_defines["SFPU_OP_BINARY_DIV_INCLUDE"] = "1";
@@ -880,8 +890,10 @@ INSTANTIATE_TEST_SUITE_P(
     SingleCoreSfpuBinaryCompute,
     SingleCoreSingleMeshDeviceSfpuBinaryParameterizedFixture,
     ::testing::Values(
-        std::make_tuple(1, "div_binary"), std::make_tuple(1, "add_int"), std::make_tuple(1, "mul_int")),
-    [](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
+        std::make_tuple(1, "div_binary"),
+        std::make_tuple(1, "add_int"),
+        std::make_tuple(1, "mul_int"),
+        std::make_tuple(1, "gt_int"))[](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
         return std::get<1>(info.param) + "_" + std::to_string(std::get<0>(info.param)) + "tiles";
     });
 

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -893,7 +893,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "div_binary"),
         std::make_tuple(1, "add_int"),
         std::make_tuple(1, "mul_int"),
-        std::make_tuple(1, "gt_int"))[](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
+        std::make_tuple(1, "gt_int")),
+    [](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
         return std::get<1>(info.param) + "_" + std::to_string(std::get<0>(info.param)) + "tiles";
     });
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_sfpu_api.h
@@ -7,3 +7,4 @@
 #include "llk_math_eltwise_binary_sfpu_binop.h"
 #include "llk_math_eltwise_binary_sfpu_add_int.h"
 #include "llk_math_eltwise_binary_sfpu_mul_int.h"
+#include "llk_math_eltwise_binary_sfpu_binary_comp.h"

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ARCH_QUASAR
+
+#include "llk_math_eltwise_binary_sfpu.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "llk_assert.h"
+#include "sfpu/ckernel_sfpu_binary_comp.h"
+
+namespace ckernel {
+
+/**
+ * @brief Initialize SFPU for elementwise integer greater-than compare
+ */
+template <DataFormat DATA_FORMAT>
+inline void llk_math_eltwise_binary_sfpu_gt_int_init() {
+    static_assert(DATA_FORMAT == DataFormat::Int32, "Quasar SFPU gt_int currently supports Int32 only");
+    _llk_math_eltwise_sfpu_init_();
+}
+
+/**
+ * @brief Performs elementwise integer greater-than: y = (x0 > x1) ? 1 : 0
+ *
+ * @tparam APPROXIMATE: Approximation mode (unused for integer compare)
+ * @tparam DATA_FORMAT: Data format of the integer operands
+ * @tparam ITERATIONS: Number of iterations for given face
+ * @tparam SIGN_MAGNITUDE_FORMAT: Sign-magnitude Int32 encoding for operands and result
+ *
+ * @param idst0: The index of the tile in DST register buffer to use as first operand
+ * @param idst1: The index of the tile in DST register buffer to use as second operand
+ * @param odst: The index of the tile in DST register buffer to use as output
+ * @param vector_mode: Vector mode (must be VectorMode::RC)
+ */
+template <bool APPROXIMATE, DataFormat DATA_FORMAT, int ITERATIONS = 8, bool SIGN_MAGNITUDE_FORMAT = false>
+inline void llk_math_eltwise_binary_sfpu_gt_int(
+    uint32_t idst0, uint32_t idst1, uint32_t odst, int vector_mode = (int)VectorMode::RC) {
+    LLK_ASSERT(vector_mode == (int)VectorMode::RC, "Quasar currently only supports vector mode RC");
+    static_assert(DATA_FORMAT == DataFormat::Int32, "Quasar SFPU gt_int currently supports Int32 only");
+
+    constexpr int tile_stride = NUM_FACES * FACE_R_DIM;
+    const int in0_offset = static_cast<int>(idst0) * tile_stride;
+    const int in1_offset = static_cast<int>(idst1) * tile_stride;
+    const int out_offset = static_cast<int>(odst) * tile_stride;
+
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_comp_int32<APPROXIMATE, ITERATIONS, SfpuType::gt, SIGN_MAGNITUDE_FORMAT>,
+        0,
+        ITERATIONS,
+        in0_offset,
+        in1_offset,
+        out_offset);
+}
+
+}  // namespace ckernel
+
+#endif  // ARCH_QUASAR

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_comp.h
@@ -15,8 +15,11 @@ namespace ckernel {
 
 /**
  * @brief Initialize SFPU for elementwise integer greater-than compare
+ *
+ * @tparam APPROXIMATE: Approximation mode (unused for integer compare)
+ * @tparam DATA_FORMAT: Data format of the integer operands
  */
-template <DataFormat DATA_FORMAT>
+template <bool APPROXIMATE, DataFormat DATA_FORMAT>
 inline void llk_math_eltwise_binary_sfpu_gt_int_init() {
     static_assert(DATA_FORMAT == DataFormat::Int32, "Quasar SFPU gt_int currently supports Int32 only");
     _llk_math_eltwise_sfpu_init_();

--- a/tt_metal/hw/inc/api/compute/binary_comp.h
+++ b/tt_metal/hw/inc/api/compute/binary_comp.h
@@ -80,7 +80,11 @@ ALWI void lt_int_tile_init() {
 
 template <DataFormat data_format>
 ALWI void gt_int_tile_init() {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_gt_int_init<APPROX, data_format>()));
+#else
     MATH((llk_math_eltwise_binary_sfpu_gt_int_init<data_format>()));
+#endif
 }
 
 #ifndef ARCH_QUASAR

--- a/tt_metal/hw/inc/api/compute/binary_comp.h
+++ b/tt_metal/hw/inc/api/compute/binary_comp.h
@@ -35,16 +35,26 @@ namespace ckernel {
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 template <DataFormat data_format>
 ALWI void lt_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_lt_int<APPROX, data_format>(idst0, idst1, odst)));
 }
+#endif
 
 template <DataFormat data_format>
 ALWI void gt_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+#if defined(ARCH_QUASAR)
+    // Int8 copy_tile + fp32_dest_acc FPU writes sign-magnitude Int32 into dest.
+    // Native Int32 tiles use 2's-comp dest and keep SIGN_MAGNITUDE_FORMAT=false.
+    MATH((llk_math_eltwise_binary_sfpu_gt_int<APPROX, data_format, 8 /*ITERATIONS*/, true /*SIGN_MAGNITUDE_FORMAT*/>(
+        idst0, idst1, odst)));
+#else
     MATH((llk_math_eltwise_binary_sfpu_gt_int<APPROX, data_format>(idst0, idst1, odst)));
+#endif
 }
 
+#ifndef ARCH_QUASAR
 template <DataFormat data_format>
 ALWI void le_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_le_int<APPROX, data_format>(idst0, idst1, odst)));
@@ -54,22 +64,26 @@ template <DataFormat data_format>
 ALWI void ge_int_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((llk_math_eltwise_binary_sfpu_ge_int<APPROX, data_format>(idst0, idst1, odst)));
 }
+#endif
 
 /**
  * The following functions initialize the relational operations. They should be invoked prior to calling the execution
  * API. Please refer to execution API documentation (lt_int_tile/gt_int_tile/le_int_tile/ge_int_tile) to find out more
  * about the relational operations.
  */
+#ifndef ARCH_QUASAR
 template <DataFormat data_format>
 ALWI void lt_int_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_lt_int_init<data_format>()));
 }
+#endif
 
 template <DataFormat data_format>
 ALWI void gt_int_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_gt_int_init<data_format>()));
 }
 
+#ifndef ARCH_QUASAR
 template <DataFormat data_format>
 ALWI void le_int_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_le_int_init<data_format>()));
@@ -79,5 +93,6 @@ template <DataFormat data_format>
 ALWI void ge_int_tile_init() {
     MATH((llk_math_eltwise_binary_sfpu_ge_int_init<data_format>()));
 }
+#endif
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
@@ -215,3 +215,7 @@
 #if SFPU_OP_BINARY_MUL_INT_INCLUDE
 #include "api/compute/mul_int_sfpu.h"
 #endif
+
+#if SFPU_OP_BINARY_GT_INT_INCLUDE
+#include "api/compute/binary_comp.h"
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_binary_comp.h
@@ -21,7 +21,7 @@ namespace sfpu
 // inversion:
 //   lt(A,B) = LT(A,B)           gt(A,B) = LT(B,A)
 //   ge(A,B) = NOT LT(A,B)       le(A,B) = NOT LT(B,A)
-template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
+template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, bool SIGN_MAGNITUDE_FORMAT = false>
 inline void calculate_binary_comp_int32(
     const int iterations, const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
 {
@@ -45,27 +45,45 @@ inline void calculate_binary_comp_int32(
         TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, idx_x + (d << 1));
         TT_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, idx_y + (d << 1));
 
-        TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG2, 0);
-        TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG3, 0);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
-
-        TTI_SFPXOR(p_sfpu::LREG2, p_sfpu::LREG3);
-
-        // Same-sign path: subtract and extract sign bit.
-        TTI_SFPSETCC(0, p_sfpu::LREG3, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-        // imod 6 = subtract (lreg_c - lreg_dest) with CC output disabled
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
-
-        // Different-sign path: result = sign bit of X.
-        TTI_SFPCOMPC;
-        TTI_SFPMOV(p_sfpu::LREG2, p_sfpu::LREG1, 0);
-        TTI_SFPENCC(0, 0);
-
-        if constexpr (invert_result)
+        if constexpr (SIGN_MAGNITUDE_FORMAT)
         {
-            TTI_SFPXOR(p_sfpu::LREG7, p_sfpu::LREG1);
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC);
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::SM32_TO_2SC);
+
+            // LT(X,Y): sign(X - Y); no overflow for Int8-promoted [-127,127] range.
+            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+
+            if constexpr (invert_result)
+            {
+                TTI_SFPXOR(p_sfpu::LREG7, p_sfpu::LREG1);
+            }
+
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::sfp_sfpcast_mod::TWO_SC_TO_SM);
+        }
+        else
+        {
+            TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG2, 0);
+            TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG3, 0);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG2, p_sfpu::LREG2, 1);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, 1);
+
+            TTI_SFPXOR(p_sfpu::LREG2, p_sfpu::LREG3);
+
+            // Same-sign path: subtract and extract sign bit.
+            TTI_SFPSETCC(0, p_sfpu::LREG3, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
+            TTI_SFPSHFT((-31) & 0xfff, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+
+            // Different-sign path: result = sign bit of X.
+            TTI_SFPCOMPC;
+            TTI_SFPMOV(p_sfpu::LREG2, p_sfpu::LREG1, 0);
+            TTI_SFPENCC(0, 0);
+
+            if constexpr (invert_result)
+            {
+                TTI_SFPXOR(p_sfpu::LREG7, p_sfpu::LREG1);
+            }
         }
 
         TT_SFPSTORE(p_sfpu::LREG1, p_sfpu::sfpmem::INT32, ADDR_MOD_7, 0, dst_index_out + (d << 1));


### PR DESCRIPTION
Adds Quasar `gt_int` compute API and metal test, following the same Int8 → DEST → SFPU pattern as `mul_int`.
### PR Category
Feature

### Summary
Relates to [#44751](https://github.com/tenstorrent/tt-metal/issues/44751)
Enables Quasar gt_int SFPU compute API, and adding on to mul_int.
Using Int8 inputs in L1, with fp32_dest_acc_en enabled so the FPU moves data into DEST via ELWADD (+0) (not MOVA2D). 
### Notes for reviewers
Because SFPU doesn't have semaphore bindings on Quasar right now, so ELWADD approach is used to get int8 into dest. 
ELWADD leaves sign-magnitude Int32 in DEST, but SFPU integer ops are 2’s-complement. Therefore separate path is needed for sign-magnitude with SFPCAST.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/sfpu-greater-than-int-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/sfpu-greater-than-int-compute-api)