### PR TITLE
[skip ci] Revert stale SDPA disable for blackhole 3-chunk 4x768 case

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_prefill_chunked_vs_not.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_prefill_chunked_vs_not.py
@@ -227,23 +227,6 @@ def test_chunked_flash_mla_prefill_vs_flash_mla_prefill(
     function_level_defaults,
     reset_seeds,
 ):
-    if (
-        ttnn.device.is_blackhole()
-        and batch == 4
-        and seq_len == 768
-        and nh == 16
-        and nkv == 1
-        and kv_lora_rank == 512
-        and d_rope == 64
-        and q_dtype == ttnn.bfloat16
-        and dtype == ttnn.bfloat8_b
-        and block_size == 64
-        and num_chunks == 3
-    ):
-        pytest.skip(
-            reason="Disabled by issue #44858: blackhole chunked_flash_mla_prefill vs flash_mla_prefill PCC mismatch for 3-chunk 4x768 case"
-        )
-
     run_flash_mla_prefill_chunked_vs_nonchunked(
         device,
         batch,


### PR DESCRIPTION
## Summary

PR #44860 disabled the `is_blackhole() and num_chunks==3 and batch==4 and seq_len==768 and nh==16` parametrization of `test_chunked_flash_mla_prefill_vs_flash_mla_prefill` on 2026-05-28 12:46 UTC, citing PCC mismatch tracked in #44858.

That disable is stale: Pavle's atol relaxation in #44856 (merged 2026-05-20 19:41 UTC) already fixed the underlying failure 8 days before the disable merged. L2 nightly run [26567256793](https://github.com/tenstorrent/tt-metal/actions/runs/26567256793) — `tt-metal-l2-tests (blackhole, P150b) / tt-sdpa-nightly tests blackhole P150b` job (id 78266990708) — explicitly logged `PASSED` for the exact disabled parametrization at 10:59 UTC, ~2 hours before PR #44860 landed.

This PR removes that single skip block. The other four files PR #44860 touched are not changed in this PR; they will be audited separately.

## Test plan

- [ ] L2 nightly post-merge BH P150b run shows `test_chunked_flash_mla_prefill_vs_flash_mla_prefill[3chunks-...batch=4-seq_len=768-nh=16-...]` passing on main.

## Related

- Disable that this PR reverts: #44860
- Original atol fix: #44856
- Tracking issue: #44858
- Pre-disable passing run: https://github.com/tenstorrent/tt-metal/actions/runs/26567256793

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert/sdpa-44860-stale-disable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert/sdpa-44860-stale-disable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert/sdpa-44860-stale-disable)