### PR TITLE
ring SDPA: switch per-coord factories to WorkloadDescriptor (fix #45391)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -31,20 +31,19 @@
 
 namespace ttnn::experimental::prim {
 
-tt::tt_metal::ProgramDescriptor RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_descriptor(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+namespace {
+
+// Per-coord ProgramDescriptor build. Pulled into an anonymous-namespace helper so
+// create_workload_descriptor() can loop coords and reuse this body verbatim. The
+// op-specific name suffix avoids Unity-build collisions across sibling factories.
+tt::tt_metal::ProgramDescriptor build_ring_attention_all_gather_program_descriptor(
+    const RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::operation_attributes_t& operation_attributes,
+    const RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::tensor_args_t& tensor_args,
+    RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinate& mesh_coordinate) {
     tt::tt_metal::ProgramDescriptor desc;
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> empty_fused_op_signaler;
-    log_debug(tt::LogOp, "DEBUG: create_descriptor is called");
-
-    TT_FATAL(
-        mesh_dispatch_coordinate.has_value(),
-        "RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_descriptor requires "
-        "mesh_dispatch_coordinate to be provided");
-    const auto& mesh_coordinate = mesh_dispatch_coordinate.value();
+    log_debug(tt::LogOp, "DEBUG: build_ring_attention_all_gather_program_descriptor is called");
 
     uint32_t device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
         tensor_args.input_tensor[0], mesh_coordinate, operation_attributes.cluster_axis);
@@ -80,6 +79,28 @@ tt::tt_metal::ProgramDescriptor RingAttentionAllGatherAsyncMultiCoreWithWorkersP
         empty_fused_op_signaler);
 
     return desc;
+}
+
+}  // namespace
+
+// Returns a WorkloadDescriptor with one ProgramDescriptor per coord: device_index /
+// forward_coord / backward_coord all depend on the mesh coordinate, so descriptors
+// cannot be shared across coords.
+tt::tt_metal::WorkloadDescriptor
+RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_workload_descriptor(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor wd;
+    const auto coords = tensor_coords.coords();
+    wd.programs.reserve(coords.size());
+    for (const auto& coord : coords) {
+        auto desc = build_ring_attention_all_gather_program_descriptor(
+            operation_attributes, tensor_args, tensor_return_value, coord);
+        wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+    return wd;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <cstdint>
+#include <tt-metalium/workload_descriptor.hpp>
 #include <optional>
 #include <vector>
 
@@ -21,11 +22,11 @@ struct RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory {
 
     using tensor_return_value_t = std::vector<Tensor>;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 }  // namespace ttnn::experimental::prim
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -102,9 +102,10 @@ void fabric_mux_connection_rt_args(
     worker_rt_args.push_back(termination_master_virtual_core.y);
 }
 
-}  // namespace
-
-tt::tt_metal::ProgramDescriptor ExpRingJointSDPAProgramFactory::create_descriptor(
+// Per-coord ProgramDescriptor build. Kept inside the anonymous namespace so
+// create_workload_descriptor() below can loop coords and reuse this body verbatim.
+// Op-specific name suffix avoids Unity-build collisions with sibling ring sdpa factories.
+tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     const ExpRingJointSDPAParams& operation_attributes,
     const ExpRingJointSDPAInputs& tensor_args,
     ExpRingJointSDPAResult& tensor_return_value,
@@ -113,7 +114,7 @@ tt::tt_metal::ProgramDescriptor ExpRingJointSDPAProgramFactory::create_descripto
     auto& output_tensors = tensor_return_value;
     TT_FATAL(
         mesh_dispatch_coordinate.has_value(),
-        "ExpRingJointSDPAProgramFactory::create_descriptor requires mesh_dispatch_coordinate");
+        "build_exp_ring_joint_sdpa_program_descriptor requires mesh_dispatch_coordinate");
     const auto& coord = mesh_dispatch_coordinate.value();
     /*
     The QKV inputs are fractured on the sequence dimension across ring_size.
@@ -1722,6 +1723,27 @@ tt::tt_metal::ProgramDescriptor ExpRingJointSDPAProgramFactory::create_descripto
     }
 
     return desc;
+}
+
+}  // namespace
+
+// Exp ring-joint SDPA returns a WorkloadDescriptor with one ProgramDescriptor per coord:
+// device_index / forward_coord / backward_coord / DEST_CHIP_ID-style fabric routing all
+// depend on the mesh coordinate, so descriptors cannot be shared across coords.
+tt::tt_metal::WorkloadDescriptor ExpRingJointSDPAProgramFactory::create_workload_descriptor(
+    const ExpRingJointSDPAParams& operation_attributes,
+    const ExpRingJointSDPAInputs& tensor_args,
+    ExpRingJointSDPAResult& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor wd;
+    const auto coords = tensor_coords.coords();
+    wd.programs.reserve(coords.size());
+    for (const auto& coord : coords) {
+        auto desc =
+            build_exp_ring_joint_sdpa_program_descriptor(operation_attributes, tensor_args, tensor_return_value, coord);
+        wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+    return wd;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operation.hpp"
@@ -20,11 +21,11 @@
 namespace ttnn::prim {
 
 struct ExpRingJointSDPAProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const ExpRingJointSDPAParams& operation_attributes,
         const ExpRingJointSDPAInputs& tensor_args,
         ExpRingJointSDPAResult& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_device_operation.hpp
@@ -8,6 +8,7 @@
 #include <variant>
 
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
@@ -25,11 +26,11 @@ struct RingDistributedSdpaDeviceOperation {
     using tensor_return_value_t = Tensor;
 
     struct RingDistributedSdpaProgramFactory {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value,
-            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+            const ttnn::MeshCoordinateRangeSet& tensor_coords);
     };
 
     using program_factory_t = std::variant<RingDistributedSdpaProgramFactory>;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -69,10 +69,9 @@ uint32_t resolve_ring_id(
     return 0;  // unreachable; satisfies non-void return.
 }
 
-}  // namespace
-
-// Ring-distributed SDPA program factory
-ProgramDescriptor RingDistributedSdpaDeviceOperation::RingDistributedSdpaProgramFactory::create_descriptor(
+// Ring-distributed SDPA per-coord program build. Pulled into an anonymous-namespace helper
+// so create_workload_descriptor() can loop coords and reuse this body verbatim.
+ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
     const RingDistributedSDPAParams& operation_attributes,
     const RingDistributedSDPAInputs& tensor_args,
     Tensor& tensor_return_value,
@@ -558,6 +557,26 @@ ProgramDescriptor RingDistributedSdpaDeviceOperation::RingDistributedSdpaProgram
     desc.kernels.push_back(std::move(compute_desc));
 
     return desc;
+}
+
+}  // namespace
+
+// Ring-distributed SDPA returns a WorkloadDescriptor with one ProgramDescriptor per coord:
+// ring_id is inferred from the coord, so each coord builds a distinct descriptor.
+WorkloadDescriptor RingDistributedSdpaDeviceOperation::RingDistributedSdpaProgramFactory::create_workload_descriptor(
+    const RingDistributedSDPAParams& operation_attributes,
+    const RingDistributedSDPAInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    WorkloadDescriptor wd;
+    const auto coords = tensor_coords.coords();
+    wd.programs.reserve(coords.size());
+    for (const auto& coord : coords) {
+        auto desc = build_ring_distributed_sdpa_program_descriptor(
+            operation_attributes, tensor_args, tensor_return_value, coord);
+        wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+    return wd;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -571,14 +571,20 @@ void apply_ring_joint_scalar_runtime_args(
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
+namespace {
+
+// Per-coord ProgramDescriptor build. Pulled into an anonymous-namespace helper so
+// create_workload_descriptor() can loop coords and reuse this body verbatim. The
+// op-specific name suffix avoids Unity-build collisions with the sibling ring
+// sdpa factories that share the same helper signature.
+tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const RingJointSDPAParams& args,
     const RingJointSDPAInputs& tensor_args,
     RingJointSDPAResult& output_tensors,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     TT_FATAL(
         mesh_dispatch_coordinate.has_value(),
-        "RingJointSDPAProgramFactory::create_descriptor requires mesh_dispatch_coordinate");
+        "build_ring_joint_sdpa_program_descriptor requires mesh_dispatch_coordinate");
     const auto& coord = mesh_dispatch_coordinate.value();
     /*
     The QKV inputs are fractured on the sequence dimension across ring_size.
@@ -2178,6 +2184,29 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         args.kv_cache_batch_idx);
 
     return desc;
+}
+
+}  // namespace
+
+// Ring-joint SDPA returns a WorkloadDescriptor with one ProgramDescriptor per coord:
+// device_index / forward_coord / backward_coord (used by the all-gather portion) all
+// depend on the mesh coordinate, so descriptors cannot be shared across coords. Returning
+// a WorkloadDescriptor (rather than a per-coord ProgramDescriptor) keeps the framework on
+// its no-rebuild cache-hit fast path; the dynamic scalar runtime args (indexed kv-cache /
+// kv-pad rotation) are still re-applied every dispatch by override_runtime_arguments below.
+tt::tt_metal::WorkloadDescriptor RingJointSDPAProgramFactory::create_workload_descriptor(
+    const RingJointSDPAParams& args,
+    const RingJointSDPAInputs& tensor_args,
+    RingJointSDPAResult& output_tensors,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+    tt::tt_metal::WorkloadDescriptor wd;
+    const auto coords = tensor_coords.coords();
+    wd.programs.reserve(coords.size());
+    for (const auto& coord : coords) {
+        auto desc = build_ring_joint_sdpa_program_descriptor(args, tensor_args, output_tensors, coord);
+        wd.programs.push_back({ttnn::MeshCoordinateRange(coord), std::move(desc)});
+    }
+    return wd;
 }
 
 RingJointSDPAMeshWorkloadFactory::cached_mesh_workload_t RingJointSDPAMeshWorkloadFactory::create_mesh_workload(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/mesh_device_operation_adapter.hpp"
@@ -33,11 +34,11 @@ struct RingJointSDPADescriptorAdapterOperation {
 }  // namespace detail
 
 struct RingJointSDPAProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
         const RingJointSDPAParams& args,
         const RingJointSDPAInputs& tensor_args,
         RingJointSDPAResult& output_tensors,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+        const ttnn::MeshCoordinateRangeSet& tensor_coords);
 };
 
 struct RingJointSDPAMeshWorkloadFactory {


### PR DESCRIPTION
Fix for issue #45391 — `ring_joint_scaled_dot_product_attention` host-dispatch regression on multi-device meshes.

## Summary

After PR #44755 migrated the transformer/sdpa family to the descriptor framework, `ring_joint_sdpa` op-to-op gap on Blackhole / Wormhole Galaxy regressed from ~13µs → ~42,400µs / call (~3260×). Kernel exec time was unchanged — pure host-side dispatch overhead.

## Root cause

The migrated factories returned per-coord `ProgramDescriptor`. The framework's cache-hit fast path at `ttnn/api/ttnn/mesh_device_operation_adapter.hpp:545` checks `resolved_bindings.rt_args.empty()` — when empty, it falls into a **slow-path rebuild** that calls `create_descriptor` PER COORD on every cache hit. On 32-chip Galaxy that's 32× full descriptor rebuilds per dispatch.

## Fix

Switch the 4 ring sdpa factories to return `WorkloadDescriptor` instead. The framework's `WorkloadDescriptor` cache-hit path has no rebuild fallback — only the resolved bindings get patched.

Files converted:
- `ring_joint_sdpa_program_factory.{cpp,hpp}`
- `ring_distributed_sdpa_program_factory.cpp` + `ring_distributed_sdpa_device_operation.hpp`
- `exp_ring_joint_sdpa_program_factory.{cpp,hpp}`
- `ring_attention_all_gather_async_multi_core_with_workers_program_factory.{cpp,hpp}`

Each factory's old per-coord body is preserved verbatim as an anon-namespace helper (op-prefixed to avoid Unity-build collisions). New `create_workload_descriptor` iterates `tensor_coords.coords()`, building one `ProgramDescriptor` per coord into `wd.programs`. No tensors parked on `wd.buffers` — persistent buffers come from the caller via `tensor_args`.

## Galaxy measurement (WH Galaxy 32-chip, SD3.5 shape, n_iters=10 no-trace cache-on)

| Iteration | Host dispatch time |
|---:|---:|
| iter[0] (cache miss / first build of 32 program descriptors) | 2916 ms (expected) |
| iter[1] | 1.014 ms (cold cache tail) |
| iter[2-9] | 0.494 – 0.542 ms each |
| **Steady-state mean (iters 1-9)** | **0.570 ms** |
| **Steady-state max** | **1.014 ms** |

Compared to the regression:

| State | Op-to-op gap / call |
|---|---|
| Healthy baseline (pre-#44755) | ~13 µs |
| Regression at HEAD (post-#44755) | ~42,400 µs |
| **With this fix** | **~570 µs total (≈ kernel exec; host gap negligible)** |

**~74× improvement.** Back to the healthy regime. Validated on Wormhole Galaxy in workflow run [26606280627](https://github.com/tenstorrent/tt-metal/actions/runs/26606280627).

## Scope

The non-ring sdpa family members (`sdpa`, `sdpa_decode`, `joint_sdpa`) are not touched here. They have lower aliasing surface and fewer mesh coords in their typical use cases; revisit if a similar regression surfaces.

## Residual risk

The `WorkloadDescriptor` fast path still depends on `resolve_bindings` returning non-empty bindings. If a caller passes the same Tensor twice through one of these op APIs, `resolve_bindings` bails (duplicate `Buffer*` in `tensor_buffers`) and runtime args stay pointing at the first call's addresses — silent miscompute on cache hit. The normal ring SDPA call shape passes 11 distinct buffers so this isn't reachable in practice; a framework-level fix to disambiguate bindings by parameter slot would close the residual risk for every descriptor op at once.

Closes #45391.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-sdpa-host-dispatch-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-sdpa-host-dispatch-regression)