### PR TITLE
kernels: clean up remaining cb_read_ptr lint hits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,15 @@ repos:
       pass_filenames: false
 - repo: local
   hooks:
+    - id: check-kernel-cb-ptrs
+      name: Forbid get_read_ptr on cb_reserve_back'd CBs (issue #39432)
+      entry: python3 scripts/check_kernel_cb_ptrs.py
+      language: system
+      pass_filenames: true
+      types_or: [c++, c]
+      files: /kernels?/.*\.(cpp|cc|h|hpp)$
+- repo: local
+  hooks:
     - id: block-ttnn-pybind-changes
       name: Prevent edits to frozen pybind11 sources under ttnn
       entry: python3 scripts/block_ttnn_pybind_changes.py

--- a/scripts/check_kernel_cb_ptrs.py
+++ b/scripts/check_kernel_cb_ptrs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Forbid `get_read_ptr(cb)` when the most recent CB-state op on that cb id was
+`cb_reserve_back` (writer scratchpad) rather than `cb_wait_front` (read).
+
+See issue #39432. `get_read_ptr` returns the CB's read pointer, which does NOT
+advance with `cb_reserve_back` / `cb_push_back`. Using it as a write scratchpad
+silently aliases successive reservations to the same L1 address. Multi-iter
+loops that intend distinct scratch slots end up sharing one, mangling data.
+
+Heuristic, scoped per function via brace depth. Tracks the last cb_reserve_back
+or cb_wait_front per CB identifier; flags get_read_ptr(X) when the last op on X
+was cb_reserve_back. Only CB identifiers that look like a single C identifier
+are tracked (skips array indexing, expressions, etc.).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+RESERVE_RE = re.compile(r"\bcb_reserve_back\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]")
+PUSH_RE = re.compile(r"\bcb_push_back\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]")
+WAIT_RE = re.compile(r"\bcb_wait_front\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]")
+POP_RE = re.compile(r"\bcb_pop_front\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]")
+READ_PTR_RE = re.compile(r"\bget_read_ptr\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)")
+
+LINE_COMMENT_RE = re.compile(r"//.*$")
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+# Pre-existing violations not addressed in this PR. Each was audited to be safe
+# by construction (single-tile CB, sharded input CB, or single-shot reserve
+# where read_ptr == write_ptr at the call site). They're tracked separately so
+# the lint can still catch NEW violations. Remove an entry as each is fixed.
+KNOWN_VIOLATIONS: frozenset[str] = frozenset(
+    {
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz_sharded.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_height_width_sharded.cpp",
+        "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp",
+        "tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp",
+        "tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp",
+        "tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp",
+    }
+)
+
+
+def strip_comments(text: str) -> str:
+    # Preserve newlines inside block comments so line numbers stay accurate.
+    text = BLOCK_COMMENT_RE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+    return "\n".join(LINE_COMMENT_RE.sub("", line) for line in text.splitlines())
+
+
+def check_file(path: Path) -> list[tuple[Path, int, str, int]]:
+    try:
+        src = path.read_text()
+    except (UnicodeDecodeError, OSError):
+        return []
+    src = strip_comments(src)
+
+    # Per-CB state. "writing" iff cb_reserve_back was the most recent state-setting
+    # op AND no matching cb_push_back has happened yet. get_read_ptr while writing
+    # is the bug. cb_push_back exits writing; cb_wait_front enters reading;
+    # cb_pop_front exits reading.
+    state: dict[str, tuple[str, int]] = {}
+    depth = 0
+    errors: list[tuple[Path, int, str, int]] = []
+
+    for lineno, line in enumerate(src.splitlines(), start=1):
+        for cb in RESERVE_RE.findall(line):
+            state[cb] = ("writing", lineno)
+        for cb in PUSH_RE.findall(line):
+            if state.get(cb, ("", 0))[0] == "writing":
+                state[cb] = ("after_push", lineno)
+        for cb in WAIT_RE.findall(line):
+            state[cb] = ("reading", lineno)
+        for cb in POP_RE.findall(line):
+            if state.get(cb, ("", 0))[0] == "reading":
+                state[cb] = ("after_pop", lineno)
+        for cb in READ_PTR_RE.findall(line):
+            prev = state.get(cb)
+            if prev and prev[0] == "writing":
+                errors.append((path, lineno, cb, prev[1]))
+
+        depth += line.count("{") - line.count("}")
+        if depth <= 0:
+            depth = 0
+            state.clear()
+
+    return errors
+
+
+KERNEL_PATH_RE = re.compile(r"(^|/)kernels?/")
+KERNEL_SUFFIXES = {".cpp", ".cc", ".h", ".hpp"}
+
+
+def is_kernel_source(p: Path) -> bool:
+    return p.suffix in KERNEL_SUFFIXES and KERNEL_PATH_RE.search(str(p)) is not None
+
+
+def iter_default_paths() -> list[Path]:
+    roots = [Path("tt_metal"), Path("ttnn"), Path("tt-train")]
+    out: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if p.is_file() and is_kernel_source(p):
+                out.append(p)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    args = [Path(a) for a in argv[1:]]
+    if args:
+        paths = [p for p in args if p.is_file() and is_kernel_source(p)]
+    else:
+        paths = iter_default_paths()
+
+    all_errors: list[tuple[Path, int, str, int]] = []
+    for p in paths:
+        if str(p) in KNOWN_VIOLATIONS:
+            continue
+        all_errors.extend(check_file(p))
+
+    if not all_errors:
+        return 0
+
+    for path, lineno, cb, reserve_lineno in all_errors:
+        print(
+            f"{path}:{lineno}: error: get_read_ptr({cb}) follows "
+            f"cb_reserve_back({cb}) at line {reserve_lineno} — "
+            f"use get_write_ptr({cb}). See issue #39432.",
+            file=sys.stderr,
+        )
+    print(
+        "\nget_read_ptr() returns the CB's read pointer, which does not advance "
+        "with cb_reserve_back/cb_push_back.\nUsing it as a write scratchpad aliases "
+        "successive reservations to the same L1 address.\nUse get_write_ptr() when "
+        "the CB is reserved (about to be written).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_kernel_cb_ptrs.py
+++ b/scripts/check_kernel_cb_ptrs.py
@@ -31,23 +31,6 @@ READ_PTR_RE = re.compile(r"\bget_read_ptr\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)")
 LINE_COMMENT_RE = re.compile(r"//.*$")
 BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 
-# Pre-existing violations not addressed in this PR. Each was audited to be safe
-# by construction (single-tile CB, sharded input CB, or single-shot reserve
-# where read_ptr == write_ptr at the call site). They're tracked separately so
-# the lint can still catch NEW violations. Remove an entry as each is fixed.
-KNOWN_VIOLATIONS: frozenset[str] = frozenset(
-    {
-        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp",
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz_sharded.cpp",
-        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
-        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_height_width_sharded.cpp",
-        "ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp",
-        "tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp",
-        "tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp",
-        "tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp",
-    }
-)
-
 
 def strip_comments(text: str) -> str:
     # Preserve newlines inside block comments so line numbers stay accurate.
@@ -123,8 +106,6 @@ def main(argv: list[str]) -> int:
 
     all_errors: list[tuple[Path, int, str, int]] = []
     for p in paths:
-        if str(p) in KNOWN_VIOLATIONS:
-            continue
         all_errors.extend(check_file(p))
 
     if not all_errors:

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
@@ -102,7 +102,7 @@ void kernel_main() {
         cb_reserve_back(cb_target_logits, onetile);
         uint32_t l1_target_logits_write_addr = get_write_ptr(cb_target_logits);
 
-        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_target_idx));
+        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_target_indexes_write_addr);
         for (uint32_t h = 0; h < TILE_HEIGHT; ++h) {
             uint32_t target_value_idx = h;  // only first row of the tile is used
 

--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/kernels/dataflow/select_target_logit_reader.cpp
@@ -59,7 +59,7 @@ void kernel_main() {
         fill_zeros_async(l1_output_write_addr, get_tile_size(cb_output_idx));
         noc_async_read_barrier();
 
-        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(get_read_ptr(cb_target_idx));
+        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(l1_target_write_addr);
 
         for (uint32_t h = 0U; h < TILE_HEIGHT; ++h) {
             const uint32_t c = target_indexes_l1_ptr[h];

--- a/tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp
+++ b/tt-train/sources/ttml/metal/ops/subtract_at_target/device/kernels/dataflow/subtract_at_target_reader.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
         noc_async_read(get_noc_addr(page, target_addr_gen, offset), l1_target_write_addr, target_read_page_size);
         noc_async_read_barrier();
 
-        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(get_read_ptr(cb_target_idx));
+        auto target_indexes_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(l1_target_write_addr);
 
         // Process each tile column: read the input tile straight into the output CB,
         // patch any in-range target column in place, then publish to the writer.

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -112,7 +112,7 @@ void kernel_main() {
     volatile PACKET_HEADER_TYPE * packet_headers[2];
     for(uint8_t i =0;i<2;++i){
         cb_reserve_back(packet_header_cb_id,1);
-        const uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
+        const uint32_t packet_header_addr = get_write_ptr(packet_header_cb_id);
         packet_headers[i] = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
         cb_push_back(packet_header_cb_id,1);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
@@ -95,7 +95,7 @@ void kernel_main() {
 
     // set up packet header buffer
     cb_reserve_back(packet_header_cb_id, 1);
-    uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
+    uint32_t packet_header_addr = get_write_ptr(packet_header_cb_id);
     cb_push_back(packet_header_cb_id, 1);
 
     auto* packet_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_writer_kernel.cpp
@@ -95,7 +95,7 @@ void kernel_main() {
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle);
 
     cb_reserve_back(packet_header_cb_id, 1);
-    uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
+    uint32_t packet_header_addr = get_write_ptr(packet_header_cb_id);
     cb_push_back(packet_header_cb_id, 1);
 
     auto* packet_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
     const auto local_weights_addrgen = TensorAccessor(local_weights_args, local_weights_base_address);
 
     cb_reserve_back(local_weights_cb_id, 1);
-    const uint32_t local_weights_l1_addr = get_read_ptr(local_weights_cb_id);
+    const uint32_t local_weights_l1_addr = get_write_ptr(local_weights_cb_id);
     cb_push_back(local_weights_cb_id, 1);
 
     fill_with_val<weight_addr_t>(local_weights_l1_addr, num_cluster_experts, 0u);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_height_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_height_width_sharded.cpp
@@ -18,8 +18,6 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
     constexpr uint32_t pad_cb = get_compile_time_arg_val(2);
 
-    cb_reserve_back(cb_id_in0, num_input_rows);
-
     cb_reserve_back(cb_id_in1, num_padded_tiles_per_batch);
 
     cb_reserve_back(pad_cb, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -80,7 +80,7 @@ void kernel_main() {
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
         constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
         cb_reserve_back(packet_header_cb_id, buffering_factor * num_packet_headers_storable);
-        const auto packet_header_buffer_addr = get_read_ptr(packet_header_cb_id);
+        const auto packet_header_buffer_addr = get_write_ptr(packet_header_cb_id);
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
         auto* sem_inc_packet_header =
             reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr + packet_header_size);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp
@@ -23,7 +23,6 @@ void kernel_main() {
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
 
-    cb_reserve_back(cb_id_in0, block_size);  // Redundant
     cb_reserve_back(cb_id_out0, block_size);
 
     uint64_t noc_l1_read_addr = get_noc_addr(get_read_ptr(cb_id_in0)) + start_read_offset_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/device/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_boltz_sharded.cpp
@@ -22,7 +22,6 @@ void kernel_main() {
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
 
-    cb_reserve_back(cb_id_in0, block_size);  // Redundant
     cb_reserve_back(cb_id_out0, block_size);
 
     uint64_t noc_l1_read_addr = get_noc_addr(get_read_ptr(cb_id_in0)) + start_read_offset_bytes;

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
 
     // set up packet header buffer
     cb_reserve_back(packet_header_cb_id, 1);
-    uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
+    uint32_t packet_header_addr = get_write_ptr(packet_header_cb_id);
     cb_push_back(packet_header_cb_id, 1);
 
     auto* packet_header_ptr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -249,8 +249,8 @@ void generate_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, uint32_t cur_pos)
 
     cb_reserve_back(cb_mask_in, total_read_tiles);
 
-    uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_mask_in));
-    uint32_t q_write_ptr_base = get_read_ptr(cb_mask_in);
+    uint64_t noc_read_addr_base = get_noc_addr(get_write_ptr(cb_mask_in));
+    uint32_t q_write_ptr_base = get_write_ptr(cb_mask_in);
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
@@ -314,8 +314,8 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
 
     cb_reserve_back(cb_mask_in, total_read_tiles);
 
-    uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_mask_in));
-    uint32_t q_write_ptr_base = get_read_ptr(cb_mask_in);
+    uint64_t noc_read_addr_base = get_noc_addr(get_write_ptr(cb_mask_in));
+    uint32_t q_write_ptr_base = get_write_ptr(cb_mask_in);
     constexpr uint32_t tile_bytes = get_tile_size(cb_mask_in);
 
     for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
@@ -377,8 +377,8 @@ void generate_block_padding_mask(uint32_t Sk_chunk_t, uint32_t block_size) {
         fill_tile_partial<tile_bytes>(cb_block_pad_mask, i, block_size - 1, NEG_INF);
 
         // Copy to all heads
-        uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_block_pad_mask));
-        uint32_t write_ptr_base = get_read_ptr(cb_block_pad_mask);
+        uint64_t noc_read_addr_base = get_noc_addr(get_write_ptr(cb_block_pad_mask));
+        uint32_t write_ptr_base = get_write_ptr(cb_block_pad_mask);
         for (uint32_t j = 1; j < PNHt; ++j) {
             copy_tile<tile_bytes>(noc_read_addr_base, write_ptr_base, i, j * Sk_chunk_t + i);
             if (j == PNHt - 1) {


### PR DESCRIPTION
## Summary
Follow-up to #45454. Removes the `KNOWN_VIOLATIONS` exemption list by cleaning up the 8 pre-existing violations the lint added in #45454.

## Audit
Each was safe by construction but used the wrong API:
- `llama_reduce_scatter_create_heads` writer: single-shot reserve at function top, `read_ptr == write_ptr` at call site.
- `sdpa_decode/dataflow_common.hpp` (3 mask helpers): one-shot per-CB reserve+push, no prior state.
- tt-train (3 readers): single-tile CB (`num_tiles=1U`), only one possible address.
- `nlp_concat_heads*` and `tilize_with_val_padding` sharded readers: `cb_id_in0` IS the input shard (statically configured); `cb_reserve_back` on it is the original code's own `// Redundant` annotation.

## Changes
- `llama_reduce_scatter`, `sdpa_decode`, tt-train: `get_read_ptr` -> `get_write_ptr` (tt-train reuses the already-computed `l1_*_write_addr` variable since the kernel DMAs into `get_write_ptr` and reads back).
- Sharded readers (3 files): remove the redundant `cb_reserve_back(cb_id_in0, ...)` calls. `get_read_ptr` stays - these are reads of the input shard, not writes.

## Local validation (TT_METAL_HOME pointed at this branch)
- [x] `test_nlp_concat_heads.py` -> 1 passed
- [x] `test_nlp_concat_heads_decode.py` + `test_tilize_with_val_padding.py` -> 106 passed
- [x] `test_sdpa_decode.py` -> 11 passed (+1 grid-size skip)
- Build logs confirm the JIT picked up kernels from this branch (`-I/home/diego/tmp-metal/ttnn/cpp/...`).

## Test plan
- [ ] sdpa_decode nightly tests green
- [ ] nlp_concat_heads unit tests green
- [ ] tilize_with_val_padding unit tests green
- [ ] llama_reduce_scatter_create_heads tests green
- [ ] tt-train op tests green (cross_entropy_fw, subtract_at_target, select_target_logit)
- [ ] t3000-unit-tests.yaml green
- [ ] tt-train-build-and-test.yaml green

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-fast-tests.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-fast-tests.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-train-build-and-test.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-train-build-and-test.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-cb-read-ptr-39432-extras)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-cb-read-ptr-39432-extras)