### PR TITLE
[skip ci] Disable MeshDeviceFixture.Top32RmDevPipelineCompletes in tt-metal-l2-nightly llk-sd-unit-tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -375,6 +375,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       dispatch-mode: sd
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+      gtest-filter: "-MeshDeviceFixture.Top32RmDevPipelineCompletes"  # disabled — deterministic compile failure, tracking issue #45483
   # TTNN Tutorials
   test-ttnn-tutorials:
     needs: [build-artifact, generate-arch-matrix]


### PR DESCRIPTION
Disable consistently failing gtest `MeshDeviceFixture.Top32RmDevPipelineCompletes` in the `tt-metal-l2-nightly` `llk-sd-unit-tests` job across all hardware variants (N150, N300, P100, P150). The test fails deterministically with a `trisc1 compile failure` in the `top32_rm_dev_compute_v2` kernel. This test is already excluded in `runtime-unit-tests` via `disabled_llk_filter` (PR #44767); this PR applies the same exclusion to the nightly L2 pipeline.

Tracking issue: #45483

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `MeshDeviceFixture.Top32RmDevPipelineCompletes` [wh_n150] | https://github.com/tenstorrent/tt-metal/actions/runs/26628149873/job/78471369457 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:18 UTC |
| `MeshDeviceFixture.Top32RmDevPipelineCompletes` [wh_n300] | https://github.com/tenstorrent/tt-metal/actions/runs/26628149873/job/78471369454 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:18 UTC |
| `MeshDeviceFixture.Top32RmDevPipelineCompletes` [bh_p100] | https://github.com/tenstorrent/tt-metal/actions/runs/26628149873/job/78471369413 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:26 UTC |
| `MeshDeviceFixture.Top32RmDevPipelineCompletes` [bh_p150] | https://github.com/tenstorrent/tt-metal/actions/runs/26628149873/job/78471369416 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:21 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/tt-metal-l2-nightly-mesh-device-top32-20260528)