### PR TITLE
[MeshTensor Integration] Integrate critical data movement ops with MeshTensor

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -33,7 +33,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     uint32_t num_output_pages;
     uint32_t single_page_size;
-    const uint32_t common_align_len = std::max(input_tensors[0].buffer()->alignment(), output.buffer()->alignment());
+    const uint32_t common_align_len = std::max(
+        input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment(),
+        output.mesh_tensor().mesh_buffer().get_reference_buffer()->alignment());
     if (rm_layout) {
         num_output_pages = output.physical_volume() / output.padded_shape()[-1];
         single_page_size = tt::align(output.element_size() * output.padded_shape()[-1], common_align_len);
@@ -104,8 +106,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     }
 
     const uint32_t num_input_tensors = input_tensors.size();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     const uint32_t src0_cb_index = 0;
     // Depth=2 is a prefetch optimization; fall back to depth=1 when it would overflow L1.
@@ -171,9 +172,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
-            page_size_per_tensor[i] = buffer->page_size();
+            const auto& input_tensor = input_tensors[i].mesh_tensor();
+            src_addr[i] = input_tensor.address();
+            page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
             } else {
@@ -187,9 +188,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
         }
     } else {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
-            page_size_per_tensor[i] = buffer->page_size();
+            const auto& input_tensor = input_tensors[i].mesh_tensor();
+            src_addr[i] = input_tensor.address();
+            page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             uint32_t dim_pages = input_tensors[i].padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
@@ -206,7 +207,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), page_size_per_tensor.cbegin(), page_size_per_tensor.cend());
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
-        TensorAccessorArgs(*input_tensors[i].buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(input_tensors[i].mesh_tensor()).append_to(reader_compile_time_args);
     }
 
     KernelDescriptor::Defines concat_defines;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -42,13 +42,13 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
     }
 
     KernelDescriptor::CompileTimeArgs reader_compile_time_args = {num_input_tensors};
     KernelDescriptor::CompileTimeArgs writer_compile_time_args = {num_input_tensors, input_unit_size};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -79,7 +79,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
         std::vector<uint32_t> reader_runtime_args;
         reader_runtime_args.reserve(num_input_tensors * 2);
         std::vector<uint32_t> writer_runtime_args = {
-            output.buffer()->address(),
+            output.mesh_tensor().address(),
             core_id,
             curr_num_output_rows,
             num_input_tensors * input_shard_spec.shape[0],

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -46,7 +46,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
 
     // Assume inputs and output have the same element size and alignment.
     const uint32_t element_size = input_tensors[0].element_size();
-    const uint32_t alignment = input_tensors[0].buffer()->alignment();
+    const uint32_t alignment = input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment();
 
     uint32_t page_size;
     uint32_t elements_per_page_width;
@@ -95,7 +95,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
 
         curr_input_write_offset +=
@@ -114,7 +114,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = page_size,
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     const uint32_t output_stride = page_size * output_num_pages_per_stick;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
@@ -66,7 +66,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
         cb_ids[input_id] = input_id;
     }
@@ -83,7 +83,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = output_page_size,
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     const ShardSpec output_shard_spec = output.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -99,7 +99,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
                 .data_format = datatype_to_dataformat_converter(input_tensor.dtype()),
                 .page_size = tt::tile_size(datatype_to_dataformat_converter(input_tensor.dtype())),
             }}},
-            .buffer = input_tensor.buffer(),
+            .tensor = &input_tensor.mesh_tensor(),
         });
     }
 
@@ -113,7 +113,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
             .data_format = datatype_to_dataformat_converter(output.dtype()),
             .page_size = tt::tile_size(datatype_to_dataformat_converter(output.dtype())),
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     tt::DataFormat cb_data_format = data_format;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -54,8 +54,8 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
 
     // Input page-based addressing
     uint32_t num_input_pages_in_row = 1;
-    uint32_t input_page_size = a.buffer()->page_size();
-    uint32_t size_of_valid_data_in_last_input_page_in_row = a.buffer()->page_size();
+    uint32_t input_page_size = a.mesh_tensor().mesh_buffer().page_size();
+    uint32_t size_of_valid_data_in_last_input_page_in_row = a.mesh_tensor().mesh_buffer().page_size();
     if (a.is_sharded()) {
         uint32_t shard_width =
             a.shard_spec().has_value() ? a.shard_spec().value().shape[1] : a.nd_shard_spec().value().shard_shape[-1];
@@ -65,8 +65,8 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
 
     // Output page-based addressing
     uint32_t num_output_pages_in_row = 1;
-    uint32_t output_page_size = output.buffer()->page_size();
-    uint32_t size_of_valid_data_in_last_output_page_in_row = output.buffer()->page_size();
+    uint32_t output_page_size = output.mesh_tensor().mesh_buffer().page_size();
+    uint32_t size_of_valid_data_in_last_output_page_in_row = output.mesh_tensor().mesh_buffer().page_size();
     if (output.is_sharded()) {
         uint32_t output_shard_width = output.shard_spec().has_value() ? output.shard_spec().value().shape[1]
                                                                       : output.nd_shard_spec().value().shard_shape[-1];
@@ -99,9 +99,8 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -197,7 +197,8 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     const auto& pad_value = operation_attributes.pad_value;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
 
-    const auto& a_shape = a.logical_shape();
+    const auto& src_tensor = a.mesh_tensor();
+    const auto& a_shape = src_tensor.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
     [[maybe_unused]] uint32_t num_unpadded_sticks = H * C * N;
     uint32_t W_padded = output_padded_shape[3], H_padded = output_padded_shape[2], C_padded = output_padded_shape[1],
@@ -209,8 +210,8 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "front_pad: {}", front_pad);
 
     // stick sizes
-    auto stick_size_unpadded = W * a.element_size();
-    auto stick_size_padded = W_padded * a.element_size();
+    auto stick_size_unpadded = W * src_tensor.element_size();
+    auto stick_size_padded = W_padded * src_tensor.element_size();
     uint32_t row_major_min_bytes = 16;
 
     uint32_t zero_pad_stick_size = tt::tt_metal::find_max_divisor(stick_size_padded, 512);
@@ -224,13 +225,14 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         stick_size_unpadded == stick_size_padded,
         "sharded pad does not support pad on last dim currently as that will cause perf degradation");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(src_tensor.dtype());
+    const auto& dst_tensor = output.mesh_tensor();
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_tensor.dtype());
 
-    IDevice* device = a.device();
+    IDevice* device = &src_tensor.mutable_device();
 
     // input shard spec
-    auto shard_spec_unpadded = a.shard_spec().value();
+    auto shard_spec_unpadded = src_tensor.shard_spec().value();
     uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
     bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
 
@@ -247,7 +249,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
 
     // output shard spec
-    auto shard_spec_padded = output.shard_spec().value();
+    auto shard_spec_padded = dst_tensor.shard_spec().value();
     uint32_t shard_height_padded = shard_spec_padded.shape[0];
 
     auto& all_cores_padded = shard_spec_padded.grid;
@@ -267,9 +269,6 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    Buffer* src_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-
     ProgramDescriptor desc;
 
     // Sharded input CB — globally allocated to the input buffer; framework patches
@@ -284,7 +283,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = stick_size_unpadded,
         });
-        cb_src0.buffer = src_buffer;
+        cb_src0.tensor = &src_tensor;
         desc.cbs.push_back(std::move(cb_src0));
     }
 
@@ -299,7 +298,7 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
             .data_format = dst_cb_data_format,
             .page_size = stick_size_padded,
         });
-        cb_output.buffer = dst_buffer;
+        cb_output.tensor = &dst_tensor;
         desc.cbs.push_back(std::move(cb_output));
     }
 
@@ -317,9 +316,9 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     });
 
     uint32_t packed_pad_value;
-    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
+    if (src_tensor.dtype() == DataType::INT32 || src_tensor.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
-    } else if (a.dtype() == DataType::UINT16) {
+    } else if (src_tensor.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -19,7 +19,7 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
-    const auto& input_tensor = tensor_args.input;
+    const auto& input_tensor = tensor_args.input.mesh_tensor();
     Tensor& output = tensor_return_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
@@ -36,7 +36,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     auto unpadded_stick_bytes = W * input_tensor.element_size();
     auto padded_stick_bytes = W_padded * input_tensor.element_size();
 
-    IDevice* device = input_tensor.device();
+    IDevice* device = &input_tensor.mutable_device();
 
     // input shard spec
     auto input_shard_spec = input_tensor.shard_spec().value();
@@ -54,8 +54,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    Buffer* input_buffer = input_tensor.buffer();
-    Buffer* output_buffer = output.buffer();
+    const auto& output_tensor = output.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -72,7 +71,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
             .data_format = input_cb_data_format,
             .page_size = unpadded_stick_bytes,
         });
-        cb_input.buffer = input_buffer;
+        cb_input.tensor = &input_tensor;
         desc.cbs.push_back(std::move(cb_input));
     }
 
@@ -88,7 +87,7 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
             .data_format = output_cb_data_format,
             .page_size = padded_stick_bytes,
         });
-        cb_output.buffer = output_buffer;
+        cb_output.tensor = &output_tensor;
         desc.cbs.push_back(std::move(cb_output));
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -49,7 +49,7 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
     auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    uint32_t page_size = output.buffer()->page_size();
+    uint32_t page_size = output.mesh_tensor().mesh_buffer().page_size();
     uint32_t multi_buffering_size = 2;
     uint32_t input_cb_index = tt::CBIndex::c_0;
     uint32_t output_cb_index = tt::CBIndex::c_1;
@@ -87,9 +87,8 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         }}},
     });
 
-    Buffer* input_buffer = a.buffer();
-    Buffer* output_buffer = output.buffer();
-    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
+    const auto& input_tensor = a.mesh_tensor();
+    const auto& output_tensor = output.mesh_tensor();
 
     uint32_t packed_pad_value;
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
@@ -118,7 +117,7 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         (std::uint32_t)page_size,
         (std::uint32_t)output_padded_shape.rank(),
     };
-    TensorAccessorArgs(*input_buffer).append_to(reader_ct_args);
+    TensorAccessorArgs(input_tensor).append_to(reader_ct_args);
 
     std::vector<uint32_t> writer_ct_args = {
         (std::uint32_t)input_cb_index,
@@ -129,7 +128,7 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         (std::uint32_t)packed_pad_value,
         (std::uint32_t)output.element_size(),
     };
-    TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
+    TensorAccessorArgs(output_tensor).append_to(writer_ct_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -219,8 +218,8 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         KernelDescriptor::RTArgList writer_runtime_args;
 
         if (num_pages_per_core != 0) {
-            reader_runtime_args.push_back(input_buffer);
-            writer_runtime_args.push_back(output_buffer);
+            reader_runtime_args.push_back(input_tensor);
+            writer_runtime_args.push_back(output_tensor);
         } else {
             reader_runtime_args.push_back(0u);
             writer_runtime_args.push_back(0u);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -28,9 +28,8 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
 
     const auto& output_shape = output_padded_shape;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -34,7 +34,7 @@ void push_i2s_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor* bound_buffer) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -43,7 +43,7 @@ void push_i2s_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.tensor = bound_buffer;
     desc.cbs.push_back(std::move(cb));
 }
 
@@ -75,11 +75,13 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     uint32_t num_units_per_shard_width_last = 0;
     uint32_t padded_offset_bytes = 0;
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& src_tensor = input.mesh_tensor();
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(src_tensor.dtype());
+    const auto& dst_tensor = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_tensor.dtype());
 
-    auto shard_spec = output.shard_spec().value();
-    auto shard_strategy = output.memory_config().memory_layout();
+    auto shard_spec = dst_tensor.shard_spec().value();
+    auto shard_strategy = dst_tensor.memory_config().memory_layout();
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
@@ -88,13 +90,11 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     CoreCoord end_core = cores.back();
 
     bool convert_df = input_cb_data_format != output_cb_data_format;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    bool src_is_dram = src_tensor.mesh_buffer().device_local_config().buffer_type == tt::tt_metal::BufferType::DRAM;
+    bool dst_is_dram = dst_tensor.mesh_buffer().device_local_config().buffer_type == tt::tt_metal::BufferType::DRAM;
+    bool is_blackhole = (src_tensor.device().arch() == tt::ARCH::BLACKHOLE);
 
-    if (input.layout() == Layout::TILE) {
+    if (src_tensor.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
         output_unit_size = tt::tile_size(output_cb_data_format);
         TT_FATAL(
@@ -106,9 +106,9 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
         num_units_per_shard_width = shard_spec.shape[1] / TILE_WIDTH;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+        num_units_per_row = src_tensor.padded_shape()[-1] / TILE_WIDTH;
         num_units_offset = num_units_per_row;
-        uint32_t num_units_height = (input.physical_volume() / input.padded_shape()[-1]) / TILE_HEIGHT;
+        uint32_t num_units_height = (src_tensor.physical_volume() / src_tensor.padded_shape()[-1]) / TILE_HEIGHT;
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -117,14 +117,14 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
             (tt::round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
         padded_offset_bytes = (num_units_per_shard_width - num_units_per_shard_width_last) * input_unit_size;
     } else {
-        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
-        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
+        input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * src_tensor.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * dst_tensor.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
-        num_units_per_row = static_cast<uint32_t>(input.logical_shape()[-1] * input.element_size());
+        num_units_per_row = static_cast<uint32_t>(src_tensor.logical_shape()[-1] * src_tensor.element_size());
         num_units_offset = 1;
-        uint32_t num_units_height = static_cast<uint32_t>(input.logical_volume() / input.logical_shape()[-1]);
+        uint32_t num_units_height = static_cast<uint32_t>(src_tensor.logical_volume() / src_tensor.logical_shape()[-1]);
         num_units_per_shard_height_last =
             num_units_per_shard_height -
             (tt::round_up(num_units_height, num_units_per_shard_height) - num_units_height);
@@ -135,7 +135,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         if (keep_l1_aligned) {
             padded_offset_bytes = tt::align(input_unit_size, hal::get_l1_alignment());
         } else {
-            padded_offset_bytes = tt::align(input_unit_size, input.buffer()->alignment());
+            padded_offset_bytes = tt::align(input_unit_size, src_tensor.mesh_buffer().get_reference_buffer()->alignment());
         }
     }
 
@@ -143,13 +143,13 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     uint32_t scratch_cb_index = tt::CBIndex::c_1;
     uint32_t out_cb_index = input_cb_index;
     uint32_t num_input_units = num_units_per_shard;
-    uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+    uint32_t output_page_size = tt::align(output_unit_size, dst_tensor.mesh_buffer().get_reference_buffer()->alignment());
 
     ProgramDescriptor desc;
 
     if (convert_df) {
         out_cb_index = tt::CBIndex::c_16;
-        uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
+        uint32_t input_page_size = tt::align(input_unit_size, src_tensor.mesh_buffer().get_reference_buffer()->alignment());
         // Non-globally-allocated input CB (interleaved input streamed via reader).
         push_i2s_cb_pair(
             desc,
@@ -170,7 +170,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         num_input_units * output_page_size,
         output_page_size,
         all_cores,
-        /*bound_buffer=*/dst_is_dram ? nullptr : dst_buffer);
+        /*bound_buffer=*/dst_is_dram ? nullptr : &dst_tensor);
 
     uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t l1_alignment = hal::get_l1_alignment();
@@ -195,16 +195,16 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.config = ReaderConfigDescriptor{};
-    if (input.layout() == Layout::TILE) {
+    if (src_tensor.layout() == Layout::TILE) {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, all_cores.num_cores()};
-        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(src_tensor).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
             "reader_unary_sharded_blocks_interleaved_start_id.cpp";
         reader_desc.compile_time_args = std::move(reader_compile_time_args);
     } else {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
-        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(src_tensor).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
             "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
@@ -218,7 +218,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
     if (dst_is_dram) {
-        if (input.layout() == Layout::TILE) {
+        if (src_tensor.layout() == Layout::TILE) {
             writer_desc.kernel_source =
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
                 "writer_unary_sharded_blocks_start_id.cpp";
@@ -251,7 +251,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
 
     for (const auto& core : cores) {
         uint32_t curr_num_units_per_shard = num_units_per_shard;
-        if (input.layout() == Layout::TILE) {
+        if (src_tensor.layout() == Layout::TILE) {
             uint32_t shard_height = num_units_per_shard_height;
             uint32_t shard_width = num_units_per_shard_width;
             uint32_t padded_offset = 0;
@@ -287,7 +287,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
 
             // Reader run-time args: arg 0 is the source-buffer base address (binding).
             KernelDescriptor::RTArgList reader_rt;
-            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(src_tensor.mesh_buffer().get_reference_buffer());
             reader_rt.push_back(shard_height);
             reader_rt.push_back(shard_width);
             reader_rt.push_back(padded_offset);
@@ -301,7 +301,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
             uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
             if (dst_is_dram) {
                 KernelDescriptor::RTArgList writer_rt;
-                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(dst_tensor.mesh_buffer().get_reference_buffer());
                 writer_rt.push_back(shard_height);
                 writer_rt.push_back(shard_width);
                 writer_rt.push_back(pad_offset);
@@ -387,7 +387,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
 
             // Reader run-time args: arg 0 is the source-buffer base address (binding).
             KernelDescriptor::RTArgList reader_rt;
-            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(src_tensor.mesh_buffer().get_reference_buffer());
             reader_rt.push_back(num_units_per_row);
             reader_rt.push_back(shard_height);
             reader_rt.push_back(shard_width);
@@ -405,7 +405,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
                 uint32_t output_width_in_pages = tt::div_up(num_units_per_row, input_unit_size);
                 uint32_t start_id = (curr_idx_h * output_width_in_pages) + page_id_within_row;
                 KernelDescriptor::RTArgList writer_rt;
-                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(dst_tensor.mesh_buffer().get_reference_buffer());
                 writer_rt.push_back(shard_height);
                 writer_rt.push_back(shard_width);
                 writer_rt.push_back(padded_offset_bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -111,17 +111,9 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
     ncrisc_desc.compile_time_args = std::move(compile_time_args);
 
     // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
-    // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
-    brisc_desc.emplace_common_runtime_args(
-        {input.mesh_buffer().get_reference_buffer(),
-         output.mesh_buffer().get_reference_buffer(),
-         num_shards,
-         shard_id_stride});
-    ncrisc_desc.emplace_common_runtime_args(
-        {input.mesh_buffer().get_reference_buffer(),
-         output.mesh_buffer().get_reference_buffer(),
-         num_shards,
-         shard_id_stride});
+    // arg 0 / arg 1 are the buffer base addresses (binding via MeshTensor).
+    brisc_desc.emplace_common_runtime_args({input, output, num_shards, shard_id_stride});
+    ncrisc_desc.emplace_common_runtime_args({input, output, num_shards, shard_id_stride});
 
     // Per-core unique runtime args: [start_shard_id]
     // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -15,20 +15,18 @@ namespace ttnn::prim {
 template <bool local_is_input>
 ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    auto& output = output_tensor;
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
-
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+    const auto input_accessor_args = TensorAccessorArgs(input);
+    const auto output_accessor_args = TensorAccessorArgs(output);
 
     // Choose buffer and aligned page size based on local_is_input flag
-    auto* local_buffer = local_is_input ? input_buffer : output_buffer;
+    auto* local_buffer =
+        local_is_input ? input.mesh_buffer().get_reference_buffer() : output.mesh_buffer().get_reference_buffer();
     auto aligned_page_size = local_buffer->aligned_page_size();
-    auto other_aligned_page_size =
-        local_is_input ? output_buffer->aligned_page_size() : input_buffer->aligned_page_size();
+    auto other_aligned_page_size = local_is_input ? output.mesh_buffer().get_reference_buffer()->aligned_page_size()
+                                                  : input.mesh_buffer().get_reference_buffer()->aligned_page_size();
 
     // This implementation assumes that input and output grids are the same.
     auto cores_vec = local_buffer->buffer_distribution_spec()->cores_with_data();
@@ -52,15 +50,15 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
         auto output_buffer_type = output.memory_config().memory_layout();
 
         // for block sharded
-        CoreCoord input_shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord input_shard_grid = input.shard_spec()->grid.ranges()[0].grid_size();
         uint32_t input_num_shard_cores = input_shard_grid.x;
-        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (input.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             input_num_shard_cores = input_shard_grid.y;
         }
 
-        CoreCoord output_shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord output_shard_grid = output.shard_spec()->grid.ranges()[0].grid_size();
         uint32_t output_num_shard_cores = output_shard_grid.x;
-        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (output.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             output_num_shard_cores = output_shard_grid.y;
         }
         // for width sharded
@@ -71,11 +69,11 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
         }
 
         source_width =
-            static_cast<uint32_t>(input_buffer->shard_spec().shape()[1] * input.element_size() * input_num_shard_cores);
-        destination_width = static_cast<uint32_t>(
-            output_buffer->shard_spec().shape()[1] * output.element_size() * output_num_shard_cores);
-        uint32_t input_page_size = input_buffer->page_size();
-        uint32_t output_page_size = output_buffer->page_size();
+            static_cast<uint32_t>(input.shard_spec()->shape[1] * input.element_size() * input_num_shard_cores);
+        destination_width =
+            static_cast<uint32_t>(output.shard_spec()->shape[1] * output.element_size() * output_num_shard_cores);
+        uint32_t input_page_size = input.mesh_buffer().page_size();
+        uint32_t output_page_size = output.mesh_buffer().page_size();
         base_page_size = std::gcd(input_page_size, output_page_size);
     }
     auto compile_time_args = input_accessor_args.get_compile_time_args();
@@ -114,8 +112,16 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
 
     // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
     // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
-    brisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
-    ncrisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+    brisc_desc.emplace_common_runtime_args(
+        {input.mesh_buffer().get_reference_buffer(),
+         output.mesh_buffer().get_reference_buffer(),
+         num_shards,
+         shard_id_stride});
+    ncrisc_desc.emplace_common_runtime_args(
+        {input.mesh_buffer().get_reference_buffer(),
+         output.mesh_buffer().get_reference_buffer(),
+         num_shards,
+         shard_id_stride});
 
     // Per-core unique runtime args: [start_shard_id]
     // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -38,21 +38,18 @@ void push_reshard_copy_pages_cb(
 
 ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    auto& output = output_tensor;
-
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
+    const auto& input = tensor_args.input.mesh_tensor();
+    auto& output = output_tensor.mesh_tensor();
 
     auto input_nd_shard_spec = input.memory_config().nd_shard_spec().value();
 
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+    const auto input_accessor_args = TensorAccessorArgs(input);
+    const auto output_accessor_args = TensorAccessorArgs(output);
 
-    auto aligned_page_size = input_buffer->aligned_page_size();
+    auto aligned_page_size = input.mesh_buffer().get_reference_buffer()->aligned_page_size();
 
     // Create grid + cores
-    auto grid_size = input.device()->compute_with_storage_grid_size();
+    auto grid_size = input.device().compute_with_storage_grid_size();
     auto grid = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1))});
     auto cores = corerange_to_cores(grid, std::nullopt, input_nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
@@ -94,13 +91,13 @@ ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
     // Common runtime args: arg 0 is the buffer base address (binding via Buffer*).
     // emplace_common_runtime_args registers a CommonBufferBinding for the framework
     // fast cache-hit path.
-    reader_desc.emplace_common_runtime_args({input_buffer});
-    writer_desc.emplace_common_runtime_args({output_buffer});
+    reader_desc.emplace_common_runtime_args({input.mesh_buffer().get_reference_buffer()});
+    writer_desc.emplace_common_runtime_args({output.mesh_buffer().get_reference_buffer()});
 
     // Per-core unique runtime args: [start_page, end_page]
     uint32_t start_page = 0;
-    uint32_t num_dev_pages =
-        static_cast<uint32_t>(input_buffer->buffer_distribution_spec()->tensor_shape_in_pages().volume());
+    uint32_t num_dev_pages = static_cast<uint32_t>(
+        input.mesh_buffer().get_reference_buffer()->buffer_distribution_spec()->tensor_shape_in_pages().volume());
     uint32_t n_pages_per_core = num_dev_pages / static_cast<uint32_t>(cores.size());
     uint32_t remainder = num_dev_pages % static_cast<uint32_t>(cores.size());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -24,7 +24,7 @@ void push_reshard_generic_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor& bound_buffer_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -33,7 +33,7 @@ void push_reshard_generic_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.tensor = &bound_buffer_tensor;
     desc.cbs.push_back(std::move(cb));
 }
 
@@ -70,13 +70,13 @@ enum class ReshardStridesInRange { ALL_STRIDES, FIRST_HALF };
 
 std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_reshard(
     std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page,
-    Buffer* input_buffer,
-    Buffer* output_buffer) {
+    const MeshTensor& input_buffer_tensor,
+    const MeshTensor& output_buffer_tensor) {
     std::unordered_map<CoreCoord, std::vector<detail::PageStride>> ret_map;
-    auto output_cores = output_buffer->get_buffer_page_mapping()->all_cores;
+    auto output_cores = output_buffer_tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping()->all_cores;
     ret_map.reserve(output_cores.size());
 
-    auto* device = input_buffer->device();
+    auto* device = input_buffer_tensor.mesh_buffer().get_reference_buffer()->device();
     auto full_grid = device->compute_with_storage_grid_size();
     uint32_t output_core_id = 0;
     for (auto output_core : output_cores) {
@@ -197,7 +197,7 @@ std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_re
                     }
 
                     TT_ASSERT(stride.core.x < full_grid.x and stride.core.y < full_grid.y);
-                    TT_ASSERT(data_stride < output_buffer->num_pages());
+                    TT_ASSERT(data_stride < output_buffer_tensor.mesh_buffer().num_pages());
                     uint32_t num_strides = 1;
                     while (stride_it != end and stride_it->has_value()) {
                         bool stride_not_complete = false;
@@ -372,11 +372,14 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> create
 }
 
 std::unordered_map<CoreCoord, std::vector<detail::PageStride>> get_core_page_ranges(
-    Buffer* input_buffer, Buffer* output_buffer) {
-    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
-    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+    const MeshTensor& input_buffer_tensor, const MeshTensor& output_buffer_tensor) {
+    const auto& output_buffer_page_mapping =
+        *output_buffer_tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping();
+    const auto& input_buffer_page_mapping =
+        *input_buffer_tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping();
 
-    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(input_buffer->num_pages());
+    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(
+        input_buffer_tensor.mesh_buffer().num_pages());
     for (auto mapped_page : input_buffer_page_mapping) {
         auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
         host_page_to_input_core_mapping[mapped_page.host_page] = {core, mapped_page.device_page};
@@ -395,29 +398,32 @@ std::unordered_map<CoreCoord, std::vector<detail::PageStride>> get_core_page_ran
         }
         cur_output_core_to_vector_input_core_page[mapped_page.device_page] = {input_core, input_core_page};
     }
-    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+    auto ret_map =
+        create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer_tensor, output_buffer_tensor);
     return ret_map;
 }
 
 std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_core_page_ranges_diff_width(
-    Buffer* input_buffer, Buffer* output_buffer, const Tensor& input) {
-    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
-    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+    const MeshTensor& input_buffer_tensor, const MeshTensor& output_buffer_tensor, const Tensor& input) {
+    const auto& output_buffer_page_mapping =
+        *output_buffer_tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping();
+    const auto& input_buffer_page_mapping =
+        *input_buffer_tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping();
     uint32_t num_rows = 1;
     for (uint32_t i = 0; i < input.logical_shape().rank() - 1; i++) {
         num_rows *= input.logical_shape()[i];
     }
     // Find GCD of page sizes to use as the new base page size
-    uint32_t input_page_size = input_buffer->page_size();
-    uint32_t output_page_size = output_buffer->page_size();
+    uint32_t input_page_size = input_buffer_tensor.mesh_buffer().page_size();
+    uint32_t output_page_size = output_buffer_tensor.mesh_buffer().page_size();
     uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
 
     // Calculate how many base pages make up an input/output page
     uint32_t input_pages_per_original = input_page_size / base_page_size;
     uint32_t output_pages_per_original = output_page_size / base_page_size;
 
-    auto input_width = input_buffer->shard_spec().shape()[1];
-    auto output_width = output_buffer->shard_spec().shape()[1];
+    auto input_width = input_buffer_tensor.shard_spec()->shape[1];
+    auto output_width = output_buffer_tensor.shard_spec()->shape[1];
     auto total_width = input.logical_shape()[-1];
 
     uint32_t total_page_number =
@@ -440,9 +446,9 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
     // find input invalid base pages if applicable
     for (auto mapped_page : input_buffer_page_mapping) {
         auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
-        CoreCoord shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord shard_grid = input_buffer_tensor.shard_spec()->grid.ranges()[0].grid_size();
         bool is_last_in_row = (core.x == shard_grid.x - 1);
-        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (input_buffer_tensor.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             is_last_in_row = (core.y == shard_grid.y - 1);
         }
         uint32_t base_start_page = mapped_page.host_page * input_pages_per_original;
@@ -462,9 +468,9 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
     // find output invalid base pages if applicable
     for (auto mapped_page : output_buffer_page_mapping) {
         auto core = output_buffer_page_mapping.all_cores[mapped_page.core_id];
-        CoreCoord shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord shard_grid = output_buffer_tensor.shard_spec()->grid.ranges()[0].grid_size();
         bool is_last_in_row = (core.x == shard_grid.x - 1);
-        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (output_buffer_tensor.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             is_last_in_row = (core.y == shard_grid.y - 1);
         }
         uint32_t base_start_page = mapped_page.host_page * output_pages_per_original;
@@ -542,7 +548,8 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
         }
     }
 
-    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+    auto ret_map =
+        create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer_tensor, output_buffer_tensor);
 
     auto processed_ret_map = create_stride_of_strides_ret_map(ret_map);
     return processed_ret_map;
@@ -654,13 +661,14 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
-    auto* device = input.device();
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
+    const MeshTensor& input_mesh_tensor = input.mesh_tensor();
+    auto* device = &input_mesh_tensor.mutable_device();
+    const MeshTensor& output_mesh_tensor = output.mesh_tensor();
 
-    auto grid = input_buffer->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
-                                                                : device->compute_with_storage_grid_size();
-    auto input_core_type = input_buffer->core_type();
+    auto grid = input_mesh_tensor.mesh_buffer().device_local_config().buffer_type == BufferType::DRAM
+                    ? device->dram_grid_size()
+                    : device->compute_with_storage_grid_size();
+    auto input_core_type = input_mesh_tensor.mesh_buffer().get_reference_buffer()->core_type();
     uint32_t dst_cb_index = 16;
     auto cores = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(cores));
@@ -668,22 +676,23 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     uint32_t total_size = 0;
     uint32_t page_size = 0;
     uint32_t unit_size = 0;
-    auto output_shard_shape = output.shard_spec().value().shape;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    auto output_shard_shape = output_mesh_tensor.shard_spec().value().shape;
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_mesh_tensor.dtype());
 
-    if (input.layout() == Layout::TILE) {
+    if (input_mesh_tensor.layout() == Layout::TILE) {
         page_size = tt::tile_size(data_format);
         unit_size = page_size;
-        total_size = static_cast<uint32_t>(output.shard_spec().value().numel() / TILE_HW) * unit_size;
+        total_size = static_cast<uint32_t>(output_mesh_tensor.shard_spec().value().numel() / TILE_HW) * unit_size;
     } else {
         // For ROW_MAJOR, use base page size from GCD calculation
-        uint32_t input_page_size = input_buffer->page_size();
-        uint32_t output_page_size = output_buffer->page_size();
+        uint32_t input_page_size = input_mesh_tensor.mesh_buffer().page_size();
+        uint32_t output_page_size = output_mesh_tensor.mesh_buffer().page_size();
         uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
 
         unit_size = base_page_size;
         page_size = base_page_size;
-        total_size = static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output.element_size());
+        total_size =
+            static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output_mesh_tensor.element_size());
     }
 
     ProgramDescriptor desc;
@@ -694,15 +703,16 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         dst_cb_index,
         data_format,
         total_size,
-        output_buffer->page_size(),
+        output_mesh_tensor.mesh_buffer().page_size(),
         all_cores,
-        /*bound_buffer=*/output_buffer);
+        output_mesh_tensor);
 
-    const std::string kernel_source = input_buffer->page_size() != output_buffer->page_size()
-                                          ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader_diff_width.cpp"
-                                          : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader.cpp";
+    const std::string kernel_source =
+        input_mesh_tensor.mesh_buffer().page_size() != output_mesh_tensor.mesh_buffer().page_size()
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+              "reshard_reader_diff_width.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+              "reshard_reader.cpp";
 
     std::vector<uint32_t> compile_args = {
         dst_cb_index, static_cast<uint32_t>(grid.x), static_cast<uint32_t>(grid.y), page_size, unit_size};
@@ -735,15 +745,15 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     for (const auto& core : cores) {
         std::vector<uint32_t> runtime_args_0;
         std::vector<uint32_t> runtime_args_1;
-        if (input_buffer->page_size() != output_buffer->page_size()) {
+        if (input_mesh_tensor.mesh_buffer().page_size() != output_mesh_tensor.mesh_buffer().page_size()) {
             auto output_core_to_page_range_pair =
-                detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
+                detail::get_core_page_ranges_diff_width(input_mesh_tensor, output_mesh_tensor, input);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input_buffer->address(),
+                input_mesh_tensor.address(),
                 0,
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset = runtime_args_0[physical_core_coords.size() + 1];
@@ -751,17 +761,17 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input_buffer->address(),
+                input_mesh_tensor.address(),
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
         } else {
-            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
+            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_mesh_tensor, output_mesh_tensor);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input_buffer->address(),
+                input_mesh_tensor.address(),
                 0,
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset =
@@ -771,7 +781,7 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input_buffer->address(),
+                input_mesh_tensor.address(),
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
         }
@@ -782,7 +792,7 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         rt_args_0.reserve(runtime_args_0.size());
         for (size_t i = 0; i < runtime_args_0.size(); ++i) {
             if (i == grid.x + grid.y) {
-                rt_args_0.push_back(input_buffer);
+                rt_args_0.push_back(input_mesh_tensor.mesh_buffer().get_reference_buffer());
             } else {
                 rt_args_0.push_back(runtime_args_0[i]);
             }
@@ -791,7 +801,7 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         rt_args_1.reserve(runtime_args_1.size());
         for (size_t i = 0; i < runtime_args_1.size(); ++i) {
             if (i == grid.x + grid.y) {
-                rt_args_1.push_back(input_buffer);
+                rt_args_1.push_back(input_mesh_tensor.mesh_buffer().get_reference_buffer());
             } else {
                 rt_args_1.push_back(runtime_args_1[i]);
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -25,7 +25,7 @@ void push_reshard_same_height_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor& bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -34,7 +34,7 @@ void push_reshard_same_height_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.tensor = &bound_tensor;
     desc.cbs.push_back(std::move(cb));
 }
 
@@ -46,17 +46,18 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
-    const auto& remote_tensor = local_is_output ? input : output;
+    const auto& remote_tensor = (local_is_output ? input : output).mesh_tensor();
     const auto local_shard_spec = local_tensor.shard_spec().value();
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
     auto* device = input.device();
 
-    const auto remote_core_type = remote_tensor.buffer()->core_type();
+    const auto remote_core_type = remote_tensor.mesh_buffer().get_reference_buffer()->core_type();
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
     auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
-    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+    auto remote_cores =
+        remote_tensor.mesh_buffer().get_reference_buffer()->buffer_distribution_spec().value().cores_with_data();
 
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
     const uint32_t element_size = tt::datum_size(data_format);
@@ -69,14 +70,12 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
 
     constexpr uint32_t cb_index = tt::CBIndex::c_0;
 
-    auto* local_buffer = local_tensor.buffer();
-    auto* remote_buffer = remote_tensor.buffer();
+    const auto& local_mesh_tensor = local_tensor.mesh_tensor();
 
     ProgramDescriptor desc;
 
     // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_height_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    push_reshard_same_height_cb_pair(desc, cb_index, data_format, total_size, unit_size, all_cores, local_mesh_tensor);
 
     const std::string kernel_name =
         local_is_output
@@ -97,7 +96,7 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
     writer_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
 
-    auto remote_buffer_type = remote_buffer->buffer_type();
+    auto remote_buffer_type = remote_tensor.mesh_buffer().device_local_config().buffer_type;
 
     // Generate all read/write offsets for each core
     auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
@@ -124,14 +123,14 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
         runtime_args_0.push_back(total_num_sticks_kernel_0);
         runtime_args_0.push_back(local_stride_bytes);
         runtime_args_0.push_back(remote_stride_bytes);
-        runtime_args_0.push_back(remote_buffer);
+        runtime_args_0.push_back(remote_tensor.mesh_buffer().get_reference_buffer());
         runtime_args_0.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
 
         KernelDescriptor::RTArgList runtime_args_1;
         runtime_args_1.push_back(total_num_sticks_kernel_1);
         runtime_args_1.push_back(local_stride_bytes);
         runtime_args_1.push_back(remote_stride_bytes);
-        runtime_args_1.push_back(remote_buffer);
+        runtime_args_1.push_back(remote_tensor.mesh_buffer().get_reference_buffer());
         runtime_args_1.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
 
         for (const auto& args : args_for_all_segments) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -26,7 +26,7 @@ void push_reshard_same_width_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor* bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -35,7 +35,7 @@ void push_reshard_same_width_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.tensor = bound_tensor;
     desc.cbs.push_back(std::move(cb));
 }
 
@@ -47,37 +47,41 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
-    const auto& remote_tensor = local_is_output ? input : output;
+    const auto& remote_tensor = local_is_output ? input.mesh_tensor() : output.mesh_tensor();
 
     auto* device = input.device();
 
-    const auto local_shard_spec = local_tensor.shard_spec().value();
+    const auto& local_mesh_tensor = local_tensor.mesh_tensor();
+    const auto local_shard_spec = local_mesh_tensor.shard_spec().value();
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
-    auto remote_core_type = remote_tensor.buffer()->core_type();
+    auto remote_core_type = remote_tensor.mesh_buffer().get_reference_buffer()->core_type();
     constexpr uint32_t cb_index = tt::CBIndex::c_0;
     constexpr uint32_t cb_scratch_index = tt::CBIndex::c_1;
     auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
-    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+    auto remote_cores =
+        remote_tensor.mesh_buffer().get_reference_buffer()->buffer_distribution_spec().value().cores_with_data();
 
     uint32_t unit_size = 0;
     uint32_t local_units_per_shard = 0;
     uint32_t remote_units_per_shard = 0;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_mesh_tensor.dtype());
 
-    uint32_t num_units = local_tensor.buffer()->num_pages();
-    if (local_tensor.layout() == Layout::TILE) {
+    uint32_t num_units = local_mesh_tensor.mesh_buffer().num_pages();
+    if (local_mesh_tensor.layout() == Layout::TILE) {
         unit_size = tt::tile_size(data_format);
         local_units_per_shard = local_shard_spec.numel() / TILE_HW;
         remote_units_per_shard = remote_shard_spec.numel() / TILE_HW;
     } else {
-        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());
+        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_mesh_tensor.element_size());
         local_units_per_shard = local_shard_spec.shape[0];
         remote_units_per_shard = remote_shard_spec.shape[0];
     }
-    uint32_t local_unit_size_padded = tt::align(unit_size, local_tensor.buffer()->alignment());
-    uint32_t remote_unit_size_padded = tt::align(unit_size, remote_tensor.buffer()->alignment());
+    uint32_t local_unit_size_padded =
+        tt::align(unit_size, local_mesh_tensor.mesh_buffer().get_reference_buffer()->alignment());
+    uint32_t remote_unit_size_padded =
+        tt::align(unit_size, remote_tensor.mesh_buffer().get_reference_buffer()->alignment());
     bool unaligned = false;
     if (remote_unit_size_padded != unit_size || local_unit_size_padded != unit_size) {
         unaligned = true;
@@ -89,15 +93,12 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
             : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
 
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
-    auto* local_buffer = local_tensor.buffer();
-    auto* remote_buffer = remote_tensor.buffer();
-    auto remote_buffer_type = remote_buffer->buffer_type();
+    auto remote_buffer_type = remote_tensor.mesh_buffer().device_local_config().buffer_type;
 
     ProgramDescriptor desc;
 
     // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_width_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    push_reshard_same_width_cb_pair(desc, cb_index, data_format, total_size, unit_size, all_cores, &local_mesh_tensor);
 
     if (unaligned) {
         // Scratch CB used by kernels when local/remote alignments differ.
@@ -108,7 +109,7 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
             remote_units_per_shard * remote_unit_size_padded,
             unit_size,
             all_cores,
-            /*bound_buffer=*/nullptr);
+            nullptr);
     }
 
     // Reader/writer kernels share the same source and compile-time args.
@@ -153,7 +154,7 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
             // a std::vector<variant> here and pass via the vector overload of
             // emplace_runtime_args.
             std::vector<std::variant<uint32_t, Buffer*>> kernel_args;
-            kernel_args.emplace_back(remote_buffer);
+            kernel_args.emplace_back(remote_tensor.mesh_buffer().get_reference_buffer());
             kernel_args.emplace_back(uint32_t{0});
             kernel_args.emplace_back(uint32_t{0});
             uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -29,7 +29,7 @@ void push_s2i_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    ttsl::optional_reference<const MeshTensor> bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -38,7 +38,7 @@ void push_s2i_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.tensor = bound_tensor.has_value() ? &(*bound_tensor) : nullptr;
     desc.cbs.push_back(std::move(cb));
 }
 
@@ -48,7 +48,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     const ShardedToInterleavedParams& operation_attributes,
     const ShardedToInterleavedInputs& tensor_args,
     Tensor& output_tensor) {
-    const auto& input = tensor_args.input_tensor;
+    const auto& input = tensor_args.input_tensor.mesh_tensor();
     const auto& output = output_tensor;
     const uint32_t num_slices = operation_attributes.num_slices;
     const uint32_t slice_index = operation_attributes.slice_index;
@@ -66,7 +66,8 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     uint32_t num_units_per_shard_width_last = 0;
 
     tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& output_mesh = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output_mesh.dtype());
 
     auto shard_spec = input.shard_spec().value();
     auto shard_strategy = input.memory_config().memory_layout();
@@ -78,7 +79,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     const auto cores = corerange_to_cores(all_cores, std::nullopt, rm_orientation);
 
     CoreCoord end_core = cores[num_cores - 1];
-    if (output.layout() == Layout::TILE) {
+    if (output_mesh.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
         output_unit_size = tt::tile_size(output_cb_data_format);
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
@@ -93,7 +94,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
             num_units_per_shard_width - (round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
     } else {
         input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
-        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output_mesh.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
@@ -110,7 +111,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
         num_cores_unpadded = div_up(num_units_height, num_units_per_shard_height);
     } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
-        if (output.layout() == Layout::TILE) {
+        if (output_mesh.layout() == Layout::TILE) {
             num_cores_unpadded = div_up(num_units_per_row, num_units_per_shard_width);
         } else {
             num_cores_unpadded = div_up(num_units_per_row, output_unit_size);
@@ -128,11 +129,9 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t out_cb_index = src0_cb_index;
     uint32_t num_input_units = num_units_per_shard;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    uint32_t input_page_size = tt::align(input_unit_size, input.mesh_buffer().get_reference_buffer()->alignment());
+    bool dst_is_dram = output_mesh.mesh_buffer().device_local_config().buffer_type == tt_metal::BufferType::DRAM;
+    bool is_blackhole = (input.device().arch() == tt::ARCH::BLACKHOLE);
 
     ProgramDescriptor desc;
 
@@ -144,11 +143,11 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
         num_input_units * input_page_size,
         input_page_size,
         used_cores,
-        /*bound_buffer=*/src_buffer);
+        input);
 
     if (convert_df) {
         out_cb_index = CBIndex::c_16;
-        uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+        uint32_t output_page_size = tt::align(output_unit_size, output_mesh.mesh_buffer().get_reference_buffer()->alignment());
         push_s2i_cb_pair(
             desc,
             out_cb_index,
@@ -156,7 +155,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
             num_input_units * output_page_size,
             output_page_size,
             used_cores,
-            /*bound_buffer=*/nullptr);
+            std::nullopt);
     }
 
     // Reader kernel (sharded input streamed in via globally-allocated CB).
@@ -173,7 +172,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     writer_desc.core_ranges = used_cores;
     writer_desc.config = WriterConfigDescriptor{};
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
     if (input.layout() == Layout::TILE) {
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
@@ -239,7 +238,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
             }
             // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
             KernelDescriptor::RTArgList writer_rt;
-            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(output_mesh.mesh_buffer().get_reference_buffer());
             writer_rt.push_back(num_units_per_shard_height);
             writer_rt.push_back(num_units_per_shard_width);
             writer_rt.push_back(shard_height);
@@ -282,7 +281,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
                 }
             }
             uint32_t l1_alignment = hal::get_l1_alignment();
-            uint32_t padded_shard_width = tt::align(output_unit_size, dst_buffer->alignment());
+            uint32_t padded_shard_width = tt::align(output_unit_size, output_mesh.mesh_buffer().get_reference_buffer()->alignment());
             if (is_blackhole or is_l1_aligned) {
                 if (!dst_is_dram or is_l1_aligned) {
                     padded_shard_width = tt::align(output_unit_size, l1_alignment);
@@ -290,7 +289,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
             }
             // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
             KernelDescriptor::RTArgList writer_rt;
-            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(output_mesh.mesh_buffer().get_reference_buffer());
             writer_rt.push_back(num_units_per_row);
             writer_rt.push_back(shard_height);
             writer_rt.push_back(shard_width);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -34,10 +34,10 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     const tt::tt_metal::KernelHandle& unary_reader_kernel_id,
     const tt::tt_metal::KernelHandle& unary_writer_kernel_id,
     std::vector<uint32_t>& accumulated_total_per_dim) {
-    auto* const input_buffer = input_tensor.buffer();
-    auto* const output_buffer = output_tensor.buffer();
-    const auto& input_shape = input_tensor.padded_shape();
-    const auto& output_shape = output_tensor.padded_shape();
+    const auto& input_mesh = input_tensor.mesh_tensor();
+    const auto& output_mesh = output_tensor.mesh_tensor();
+    const auto& input_shape = input_mesh.padded_shape();
+    const auto& output_shape = output_mesh.padded_shape();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
@@ -51,7 +51,7 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
     const auto set_common_reader_args =
         [&](uint32_t* reader_common_args, uint32_t* num_unpadded_tiles_per_dim, uint32_t* num_padded_tiles_per_dim)
             __attribute__((always_inline)) {
-                reader_common_args[0] = input_buffer->address();
+                reader_common_args[0] = input_mesh.address();
                 num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
                 num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
                 num_padded_tiles_per_dim[0] = num_padded_Xt;
@@ -149,11 +149,12 @@ inline __attribute__((always_inline)) void set_slice_runtime_args_tile(
         }
 
         if constexpr (initialize_args) {
-            const std::array writer_kernel_args = {output_buffer->address(), num_tiles_per_core, num_tiles_written};
+            const std::array writer_kernel_args = {
+                static_cast<uint32_t>(output_mesh.address()), num_tiles_per_core, num_tiles_written};
             tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
         } else {
             auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];
-            writer_kernel_args[0] = output_buffer->address();
+            writer_kernel_args[0] = output_mesh.address();
             writer_kernel_args[1] = num_tiles_per_core;
             writer_kernel_args[2] = num_tiles_written;
         }
@@ -232,9 +233,11 @@ void SliceTileProgramFactory::override_runtime_arguments(
 tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
+    const auto& input_mesh = input.mesh_tensor();
+    tt::tt_metal::IDevice* device = &input_mesh.mutable_device();
 
-    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+    const auto& output_mesh = output.mesh_tensor();
+    uint32_t num_unpadded_tiles = output_mesh.physical_volume() / TILE_HW;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
@@ -242,15 +245,14 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
             ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
             : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
 
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(
+        output_mesh.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_mesh.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    const auto& input_shape = input.padded_shape();
-    const auto& output_shape = output.padded_shape();
+    const auto& input_shape = input_mesh.padded_shape();
+    const auto& output_shape = output_mesh.padded_shape();
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
 
     // --- CB Descriptor ---
@@ -271,7 +273,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     // --- Reader Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
     std::vector<uint32_t> reader_compile_time_args = {num_dims};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input_mesh).append_to(reader_compile_time_args);
 
     // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
@@ -286,7 +288,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
     std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
-    reader_common_args[0] = src0_buffer->address();
+    reader_common_args[0] = input_mesh.address();
     uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
@@ -353,7 +355,7 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     // --- Writer Kernel Descriptor ---
     // CB index via named compile-time arg (essential for fusion CB remapping).
     std::vector<uint32_t> writer_compile_time_args = {};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
 
     // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
     tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
@@ -371,7 +373,8 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
         }
 
         writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+            core,
+            std::vector<uint32_t>{static_cast<uint32_t>(output_mesh.address()), num_tiles_per_core, num_tiles_written});
         num_tiles_written += num_tiles_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -105,9 +105,8 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
 
     uint32_t row_size_bytes = a.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     ProgramDescriptor desc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -33,8 +33,8 @@ ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
     const uint32_t src0_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
+    const MeshTensor& src_tensor = input.mesh_tensor();
+    const MeshTensor& dst_tensor = output.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -49,7 +49,7 @@ ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
             .data_format = input_cb_data_format,
             .page_size = input_single_tile_size,
         });
-        cb_src0.buffer = src_buffer;
+        cb_src0.tensor = &src_tensor;
         desc.cbs.push_back(std::move(cb_src0));
     }
 
@@ -63,7 +63,7 @@ ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
             .data_format = output_cb_data_format,
             .page_size = output_single_tile_size,
         });
-        cb_output.buffer = dst_buffer;
+        cb_output.tensor = &dst_tensor;
         desc.cbs.push_back(std::move(cb_output));
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -34,8 +34,8 @@ ProgramDescriptor TilizeMultiCoreWidthShardedProgramFactory::create_descriptor(
     const uint32_t src0_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_index = tt::CBIndex::c_16;
 
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src_buffer = input.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     ProgramDescriptor desc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -23,7 +23,6 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -36,7 +35,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     uint32_t page_size = page_shape[0] * page_shape[1];
     uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     IDevice* device = input_tensor.device();
 
     uint32_t num_tensor_pages = input_tensor.physical_volume() / page_size;
@@ -50,8 +49,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -33,12 +33,12 @@ void emit_runtime_args_hc_rm(
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
+    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
+    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
+    auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
-    uint32_t W_bytes = W * input_tensor.element_size();
+    uint32_t W_bytes = W * input_mesh.element_size();
 
     uint32_t max_read_size = 2048;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
@@ -66,10 +66,10 @@ void emit_runtime_args_hc_rm(
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
+            {input_mesh, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
 
         writer_desc.emplace_runtime_args(
-            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+            core, {output_mesh, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -122,7 +122,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, NCH);
 
-    Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src0_cb_index = 0;
@@ -130,7 +130,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                 : num_sticks_per_core_group_2;
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
     auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -287,7 +287,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -331,7 +330,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -343,7 +342,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     std::vector<uint32_t> reader_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -33,17 +33,18 @@ void emit_runtime_args_hc_tiled_interleaved(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const CoreRange& total_cores) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
+    const tt::tt_metal::MeshTensor& input_buffer_meshtensor_rename_me = input_tensor.mesh_tensor();
+    const tt::tt_metal::MeshTensor& output_buffer_meshtensor_rename_me = output_tensor.mesh_tensor();
 
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    auto tile_shape = input_buffer_meshtensor_rename_me.tensor_spec().tile().get_tile_shape();
     auto tile_hw = tile_shape[0] * tile_shape[1];
-    uint32_t num_tensor_tiles = input_tensor.physical_volume() / tile_hw;
-    uint32_t num_output_tiles = output_tensor.physical_volume() / tile_hw;
-    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_tensor.padded_shape()[2] /
+    uint32_t num_tensor_tiles = input_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
+    uint32_t num_output_tiles = output_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
+    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_buffer_meshtensor_rename_me.padded_shape()[2] /
                                                            tile_shape[0]);  // only last row of Ct should have padding
 
-    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size =
+        input_buffer_meshtensor_rename_me.mutable_device().compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
     auto
@@ -85,10 +86,11 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
         reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
+            core, std::vector<uint32_t>{input_buffer_meshtensor_rename_me.address(), num_tiles_per_core, start_idx});
         writer_desc.runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+            std::vector<uint32_t>{
+                output_buffer_meshtensor_rename_me.address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
@@ -104,7 +106,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     const float pad_value = operation_attributes.pad_value;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
@@ -147,7 +148,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         });
     }
 
-    Buffer* src_buffer = input_tensor.buffer();
+    Buffer* src_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     uint32_t element_size = input_tensor.element_size();
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
@@ -203,7 +204,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> writer_compile_time_args = {
         element_size,
         tt::CBIndex::c_0,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -30,14 +30,14 @@ void emit_runtime_args_hc_tiled(
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_tiles_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
+    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
+    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
+    auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
     uint32_t HW = H * W;
-    uint32_t HW_bytes = HW * input_tensor.element_size();
-    uint32_t CHW_bytes = C * HW * input_tensor.element_size();
+    uint32_t HW_bytes = HW * input_mesh.element_size();
+    uint32_t CHW_bytes = C * HW * input_mesh.element_size();
 
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ct = C / TILE_HEIGHT;
@@ -65,7 +65,7 @@ void emit_runtime_args_hc_tiled(
         reader_desc.runtime_args.emplace_back(
             core,
             std::vector<uint32_t>{
-                input_buffer->address(),
+                input_mesh.address(),
                 Wt,
                 H,
                 Ct,
@@ -81,7 +81,7 @@ void emit_runtime_args_hc_tiled(
                 num_tiles_read % Wt});
 
         writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+            core, std::vector<uint32_t>{output_mesh.address(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -94,7 +94,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
@@ -119,8 +118,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     // check if we need to allocate a scratch buffer
@@ -160,7 +158,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
         });
     }
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> reader_compile_time_args;
     reader_compile_time_args.push_back(sub_tile_line_bytes);
     reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -60,7 +60,7 @@ void emit_runtime_args_wh_tiled(
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_tensor.buffer(),
+            {input_tensor.mesh_tensor(),
              num_tiles_per_core,
              tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
              h,
@@ -71,7 +71,7 @@ void emit_runtime_args_wh_tiled(
 
         compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -109,11 +109,11 @@ void emit_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {input_tensor.mesh_tensor(), num_sticks_read, num_hw_blocks_per_core});
 
         compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
+        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_sticks_write, num_hw_blocks_per_core});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
@@ -127,7 +127,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
@@ -144,7 +143,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     IDevice* device = input_tensor.device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
@@ -160,8 +159,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, row_major ? NC : num_tensor_tiles);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -20,7 +20,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -60,7 +59,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = src0_single_tile_size,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -73,7 +72,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = dst_single_tile_size,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -21,7 +21,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -96,7 +95,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
@@ -109,7 +108,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = dst_cb_data_format,
             .page_size = output_page_size,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     // cb_in (double-buffered intermediate)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -116,9 +116,8 @@ ProgramDescriptor UntilizeMultiCoreBlockProgramFactory::create_descriptor(
         row_size_bytes = input_shape[-1] * a.element_size();
     }
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     ProgramDescriptor desc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -30,8 +30,8 @@ ProgramDescriptor UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdentica
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
@@ -49,7 +49,8 @@ ProgramDescriptor UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdentica
     uint32_t num_blocks_per_shard = (shard_height / tile_height) * (shard_vol / (shard_height * shard_width));
     uint32_t num_tiles_per_shard = num_tiles_per_block * num_blocks_per_shard;
 
-    const auto& distribution_spec = a.buffer()->buffer_distribution_spec().value();
+    const auto& distribution_spec =
+        a.mesh_tensor().mesh_buffer().get_reference_buffer()->buffer_distribution_spec().value();
 
     uint32_t total_shards = distribution_spec.num_shards();
     uint32_t num_cores = grid.num_cores();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -29,9 +29,8 @@ ProgramDescriptor UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalP
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -34,8 +34,8 @@ ProgramDescriptor UntilizeMultiCoreNDShardInputProgramFactory::create_descriptor
     tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t tensor_width = a.padded_shape()[-1];
@@ -51,7 +51,8 @@ ProgramDescriptor UntilizeMultiCoreNDShardInputProgramFactory::create_descriptor
     uint32_t input_shard_height = nd_shard_spec.shard_shape[-2];
     uint32_t input_shard_width = nd_shard_spec.shard_shape[-1];
 
-    const auto distribution_spec = a.buffer()->buffer_distribution_spec().value();
+    const auto distribution_spec =
+        a.mesh_tensor().mesh_buffer().get_reference_buffer()->buffer_distribution_spec().value();
 
     uint32_t num_shards = distribution_spec.num_shards();
     const auto page_mapping = distribution_spec.compute_page_mapping();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -68,8 +68,8 @@ ProgramDescriptor UntilizeMultiCoreParallelizeColumnProgramFactory::create_descr
 
     bool row_major = true;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     const uint32_t src0_cb_index = tt::CBIndex::c_0;
     const uint32_t output_cb_index = tt::CBIndex::c_16;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -31,24 +31,23 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
 
     const auto& a = tensor_args.input;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    const auto& src0_tensor = a.mesh_tensor();
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(src0_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& dst_tensor = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_tensor.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::IDevice* device = a.device();
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    tt::tt_metal::IDevice* device = &src0_tensor.mutable_device();
 
-    uint32_t tensor_width = a.padded_shape()[-1];
-    uint32_t tensor_height = a.physical_volume() / tensor_width;
+    uint32_t tensor_width = src0_tensor.padded_shape()[-1];
+    uint32_t tensor_height = src0_tensor.physical_volume() / tensor_width;
 
-    const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
+    const auto& tile_shape = src0_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
 
-    bool input_is_sharded = a.is_sharded();
+    bool input_is_sharded = src0_tensor.is_sharded();
     std::vector<CoreCoord> ordered_cores_with_data;
 
     uint32_t num_tiles_per_row = tensor_width / tile_width;
@@ -73,7 +72,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
     uint32_t input_shard_height = 0;
     uint32_t input_shard_width = 0;
     if (input_is_sharded) {
-        ShardSpec input_shard_spec = a.shard_spec().value();
+        ShardSpec input_shard_spec = src0_tensor.shard_spec().value();
         input_shard_height = input_shard_spec.shape[0];
         input_shard_width = input_shard_spec.shape[1];
         num_compute_cores = input_shard_spec.grid.num_cores();
@@ -113,7 +112,8 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         input_cb_num_tiles =
             (num_input_blocks_per_full_core == 1) ? num_tiles_per_input_block : num_tiles_per_input_block * 2;
     }
-    Buffer* cb_backing_buffer = (input_is_sharded && !use_block_reader) ? src0_buffer : nullptr;
+    Buffer* cb_backing_buffer =
+        (input_is_sharded && !use_block_reader) ? src0_tensor.mesh_buffer().get_reference_buffer() : nullptr;
     constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = input_cb_num_tiles * input_single_tile_size,
@@ -172,23 +172,23 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
             "reader_unary_start_id.cpp";
         std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
-        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+        TensorAccessorArgs(src0_tensor).append_to(reader_compile_time_args);
         reader_desc.compile_time_args = std::move(reader_compile_time_args);
         reader_desc.config = ReaderConfigDescriptor{};
     }
 
     // Writer compile-time args
-    uint32_t output_element_size = output.element_size();
+    uint32_t output_element_size = dst_tensor.element_size();
     uint32_t output_page_width =
         tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
     uint32_t output_num_blocks_across_width = 1;
-    if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
-        if (output.shard_spec().has_value()) {
-            output_page_width = output.shard_spec().value().shape[1];
+    if (dst_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+        dst_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        dst_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+        if (dst_tensor.shard_spec().has_value()) {
+            output_page_width = dst_tensor.shard_spec().value().shape[1];
         } else {
-            output_page_width = output.nd_shard_spec().value().shard_shape[-1];
+            output_page_width = dst_tensor.nd_shard_spec().value().shard_shape[-1];
         }
         output_num_blocks_across_width = tt::div_up(tensor_width, output_page_width);
     }
@@ -206,7 +206,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         (uint32_t)num_cols_per_input_block,
         (uint32_t)num_cols_per_output_block,
     };
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(dst_tensor).append_to(writer_compile_time_args);
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
@@ -228,7 +228,8 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
 
     KernelDescriptor::Defines compute_kernel_defines;
-    if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32 || a.dtype() == DataType::FLOAT32) {
+    if (src0_tensor.dtype() == DataType::INT32 || src0_tensor.dtype() == DataType::UINT32 ||
+        src0_tensor.dtype() == DataType::FLOAT32) {
         compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
 
@@ -289,7 +290,8 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
 
     // Run-time args (full cores)
     // Note: For sharded input, these are the only cores used
-    bool is_row_major = input_is_sharded ? a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR : true;
+    bool is_row_major =
+        input_is_sharded ? src0_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR : true;
     std::vector<CoreCoord> full_cores = input_is_sharded
                                             ? ordered_cores_with_data
                                             : corerange_to_cores(full_compute_core_range, std::nullopt, is_row_major);
@@ -304,7 +306,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         if (input_is_sharded) {
             bool is_last_input_shard_in_row = width_wise_input_block_index == num_input_blocks_across_width - 1;
             if (is_last_input_shard_in_row) {
-                uint32_t input_shard_width = a.shard_spec().value().shape[1];
+                uint32_t input_shard_width = src0_tensor.shard_spec().value().shape[1];
                 num_unpadded_cols_per_input_block =
                     num_cols_per_input_block - (tt::round_up(tensor_width, input_shard_width) - tensor_width);
             }
@@ -313,7 +315,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         // Handle uneven input sharding height wise (reader, compute, writer run-time arg)
         uint32_t num_input_blocks_to_process = num_input_blocks_per_full_core;
         if (input_is_sharded) {
-            uint32_t input_shard_height = a.shard_spec().value().shape[0];
+            uint32_t input_shard_height = src0_tensor.shard_spec().value().shape[0];
             uint32_t height_wise_shard_index = i / num_input_blocks_across_width;
             uint32_t num_shards_height_wise = tt::div_up(tensor_height, input_shard_height);
             bool is_last_input_shard_in_col = height_wise_shard_index == num_shards_height_wise - 1;
@@ -327,12 +329,12 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
         // Reader run-time args
         uint32_t num_tiles_to_read = num_tiles_per_input_block * num_input_blocks_to_process;
         if (use_block_reader) {
-            reader_ref.emplace_runtime_args(core, {src0_buffer, num_input_blocks_to_process});
+            reader_ref.emplace_runtime_args(core, {src0_tensor, num_input_blocks_to_process});
         } else if (input_is_sharded) {
             reader_ref.emplace_runtime_args(core, {num_tiles_to_read});
         } else {
             // Interleaved input
-            reader_ref.emplace_runtime_args(core, {src0_buffer, num_tiles_to_read, tile_start_index});
+            reader_ref.emplace_runtime_args(core, {src0_tensor, num_tiles_to_read, tile_start_index});
         }
 
         // Writer run-time args
@@ -342,7 +344,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
             input_block_global_col_index % num_cols_per_output_block;
         writer_ref.emplace_runtime_args(
             core,
-            {dst_buffer,
+            {dst_tensor,
              num_input_blocks_to_process,
              height_wise_input_block_start_index,
              num_unpadded_cols_per_input_block,
@@ -384,7 +386,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
             input_block_global_col_index % num_cols_per_output_block;
         writer_ref.emplace_runtime_args(
             cliff_core,
-            {dst_buffer,
+            {dst_tensor,
              num_input_blocks_to_process,
              height_wise_input_block_start_index,
              num_unpadded_cols_per_input_block,
@@ -393,7 +395,7 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreProgramFactory::create_descript
 
         // Reader run-time args (always reading interleaved input as cliff core does not exist for sharded input)
         uint32_t num_tiles_to_read = num_tiles_per_input_block * num_input_blocks_to_process;
-        reader_ref.emplace_runtime_args(cliff_core, {src0_buffer, num_tiles_to_read, tile_start_index});
+        reader_ref.emplace_runtime_args(cliff_core, {src0_tensor, num_tiles_to_read, tile_start_index});
 
         // Compute run-time args
         if (cliff_compute_idx >= 0) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -93,8 +93,8 @@ tt::tt_metal::ProgramDescriptor UntilizeMultiCoreSubCoreGridsProgramFactory::cre
         }}},
     });
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> reader_ct_args;
     TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -25,8 +25,8 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     const UntilizeOperationAttributes& operation_attributes,
     const UntilizeTensorArgs& tensor_args,
     const UntilizeTensorReturnValue& tensor_return_value) {
-    const auto& a = tensor_args.input;
-    const auto& output = tensor_return_value;
+    const auto& a = tensor_args.input.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
 
     ProgramDescriptor desc;
@@ -38,9 +38,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.mesh_buffer().get_reference_buffer() != nullptr, "Output buffer should be allocated on device!");
 
     const auto& tile_shape = a.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
@@ -66,7 +64,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     // Determine how much L1 space we can use for input and output CBs,
     // ensuring that we don't intrude into other L1 storage space
     uint32_t max_l1_size =
-        (a.device()->l1_size_per_core() / 2) - a.device()->allocator()->get_base_allocator_addr(HalMemType::L1);
+        (a.device().l1_size_per_core() / 2) - a.device().allocator()->get_base_allocator_addr(HalMemType::L1);
 
     // Determine the max number of tiles that can be in any CB at a given time (1 input CB + 1 output CB = 2 total CBs)
     uint32_t max_tiles_per_cb = max_l1_size / (input_single_tile_size + output_single_tile_size);
@@ -118,7 +116,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
     // Reader compile-time args
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_cb_index};
 
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(a).append_to(reader_compile_time_args);
 
     // Tilized reader
     KernelDescriptor reader_desc;
@@ -141,7 +139,7 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
         (uint32_t)num_tiles_per_block,
         (uint32_t)output_single_block_width_size,
     };
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output).append_to(writer_compile_time_args);
 
     // Untilized writer
     KernelDescriptor writer_desc;
@@ -182,10 +180,10 @@ tt::tt_metal::ProgramDescriptor UntilizeSingleCoreProgramFactory::create_descrip
 
     // Reader run-time args
     uint32_t start_page_id = 0;
-    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_tiles, start_page_id});
+    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {a, num_tiles, start_page_id});
 
     // Writer run-time args
-    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, {dst_buffer});
+    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, {output});
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -165,8 +165,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
             output_cb_data_format);
     }
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // reader

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -83,9 +83,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         }}},
     });
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     // reader
     uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -82,9 +82,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
         }}},
     });
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* src0_buffer = a.mesh_tensor().mesh_buffer().get_reference_buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     /** reader
      */

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -29,31 +29,30 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
 
     // const auto& a = input;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const auto& input_tensor = input.mesh_tensor();
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& output_tensor = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    uint32_t tensor_width = input_tensor.padded_shape()[-1];
+    uint32_t output_tensor_width = output_tensor.padded_shape()[-1];
+    uint32_t output_tensor_height = output_tensor.padded_shape()[-2];
 
-    uint32_t tensor_width = input.padded_shape()[-1];
-    uint32_t output_tensor_width = output.padded_shape()[-1];
-    uint32_t output_tensor_height = output.padded_shape()[-2];
-
-    const auto& tile_shape = input.tensor_spec().tile().get_tile_shape();
+    const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     uint32_t tile_height = tile_shape[0];
     uint32_t tile_width = tile_shape[1];
 
     uint32_t num_tiles_per_input_row = tensor_width / tile_width;
     uint32_t num_tiles_per_output_row = tt::div_up(output_tensor_width, tile_width);
 
-    const auto& nd_shard_spec = input.nd_shard_spec().value();
+    const auto& nd_shard_spec = input_tensor.nd_shard_spec().value();
     uint32_t input_shard_height = nd_shard_spec.shard_shape[-2];
     uint32_t input_shard_width = nd_shard_spec.shard_shape[-1];
 
-    const auto distribution_spec = input.buffer()->buffer_distribution_spec().value();
+    const auto distribution_spec =
+        input_tensor.mesh_buffer().get_reference_buffer()->buffer_distribution_spec().value();
 
     uint32_t num_shards = distribution_spec.num_shards();
     const auto page_mapping = distribution_spec.compute_page_mapping();
@@ -123,7 +122,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
         (uint32_t)num_tiles_per_input_block,
         (uint32_t)num_shards,
         (uint32_t)num_compute_cores};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -134,17 +133,17 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     reader_desc.config = ReaderConfigDescriptor{};
 
     // Writer compile-time args
-    uint32_t output_element_size = output.element_size();
+    uint32_t output_element_size = output_tensor.element_size();
     uint32_t output_page_width =
         output_tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
     uint32_t output_num_blocks_across_width = 1;
-    if (output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-        output.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
-        if (output.shard_spec().has_value()) {
-            output_page_width = output.shard_spec().value().shape[1];
+    if (output_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED ||
+        output_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+        output_tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+        if (output_tensor.shard_spec().has_value()) {
+            output_page_width = output_tensor.shard_spec().value().shape[1];
         } else {
-            output_page_width = output.nd_shard_spec().value().shard_shape[-1];
+            output_page_width = output_tensor.nd_shard_spec().value().shard_shape[-1];
         }
         output_num_blocks_across_width = tt::div_up(output_tensor_width, output_page_width);
     }
@@ -169,22 +168,22 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
         (uint32_t)tile_width,
         (uint32_t)output_tensor_width,
         (uint32_t)output_tensor_height,
-        (uint32_t)input.padded_shape().rank()
+        (uint32_t)input_tensor.padded_shape().rank()
 
     };
     std::vector<uint32_t>
         writer_common_runtime_args;  // Due to tensor squeezing from ND to 4D when the input tensor has rank > 4,
                                      // writer_common_runtime_args will have at most 8 entries.
-    for (const auto dim : output.padded_shape()) {
+    for (const auto dim : output_tensor.padded_shape()) {
         writer_common_runtime_args.push_back(dim);
     }
-    for (const auto dim : input.padded_shape()) {
+    for (const auto dim : input_tensor.padded_shape()) {
         writer_common_runtime_args.push_back(dim);
     }
 
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output_tensor).append_to(writer_compile_time_args);
 
-    TensorAccessorArgs(*src0_buffer)
+    TensorAccessorArgs(input_tensor)
         .append_to(writer_compile_time_args);  // For ND sharded input, we need info on the input buffer distribution
 
     // Writer kernel
@@ -211,7 +210,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     // Compute compile-time args and kernel
     // Note: This condition is always true for sharded input
     KernelDescriptor::Defines compute_kernel_defines;
-    if (input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 || input.dtype() == DataType::FLOAT32) {
+    if (input_tensor.dtype() == DataType::INT32 || input_tensor.dtype() == DataType::UINT32 ||
+        input_tensor.dtype() == DataType::FLOAT32) {
         compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
     }
     KernelDescriptor compute_desc;
@@ -269,10 +269,10 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
             }
         }
         // Reader run-time args
-        reader_desc.emplace_runtime_args(core, {src0_buffer, start_shard_id});
+        reader_desc.emplace_runtime_args(core, {input_tensor, start_shard_id});
 
         // Writer run-time args
-        writer_desc.emplace_runtime_args(core, {dst_buffer, src0_buffer, start_shard_id});
+        writer_desc.emplace_runtime_args(core, {output_tensor, input_tensor, start_shard_id});
         start_shard_id++;
 
         // Compute run-time args

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -94,11 +94,12 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
             .data_format = input_cb_data_format,
             .page_size = input_single_tile_size,
         }}},
-        .buffer = src_sharded ? a.buffer() : nullptr,
+        .buffer = src_sharded ? a.mesh_tensor().mesh_buffer().get_reference_buffer() : nullptr,
     });
 
     uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
-    uint32_t aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
+    uint32_t aligned_page_size =
+        static_cast<uint32_t>(output.mesh_tensor().mesh_buffer().get_reference_buffer()->aligned_page_size());
     constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * output_single_tile_size,
@@ -123,11 +124,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                 .data_format = output_cb_data_format,
                 .page_size = aligned_page_size,
             }}},
-            .buffer = output.buffer(),
+            .tensor = &output.mesh_tensor(),
         });
     }
 
-    Buffer* dst_buffer = output.buffer();
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     /** reader

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -24,11 +24,12 @@ namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::create_descriptor(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
-    const auto& a = input;
+    const auto& a = input.mesh_tensor();
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
     const auto& input_shape = a.padded_shape();
-    const auto& output_shape = output.padded_shape();
+    const auto& output_tensor = output.mesh_tensor();
+    const auto& output_shape = output_tensor.padded_shape();
 
     ProgramDescriptor desc;
 
@@ -37,21 +38,16 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     log_debug(tt::LogOp, "untilize_with_unpadding_single_core");
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
     log_debug(tt::LogOp, "output_cb_data_format: {}", output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-
     int32_t num_tiles = a.physical_volume() / TILE_HW;
 
     // This should allocate a DRAM buffer on the device
-
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     auto input_w = input_shape.rank() >= 4 ? input_shape[-4] : 1;
     auto input_z = input_shape.rank() >= 3 ? input_shape[-3] : 1;
@@ -63,17 +59,18 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     auto output_y = output_shape.rank() >= 2 ? output_shape[-2] : 1;
     auto output_x = output_shape[-1];
 
-    uint32_t padded_stick_size = input_x * output.element_size();  // Assuming bfloat16 dataformat
-    uint32_t unpadded_stick_size = output_x * output.element_size();
+    uint32_t padded_stick_size = input_x * output_tensor.element_size();  // Assuming bfloat16 dataformat
+    uint32_t unpadded_stick_size = output_x * output_tensor.element_size();
 
     constexpr uint32_t alignment = 32;
 
     uint32_t num_tiles_in_row = input_x / TILE_WIDTH;
     // Ensure we don't intrude into storage space
     uint32_t max_l1_size =
-        (a.device()->l1_size_per_core() / 2) - a.device()->allocator()->get_base_allocator_addr(HalMemType::L1);
+        (a.device().l1_size_per_core() / 2) - a.device().allocator()->get_base_allocator_addr(HalMemType::L1);
     // Memory usage is 2 CBs of width W, plus buffer of size alignment + (W * datum size)
-    uint32_t max_X = (max_l1_size - alignment) / (output.element_size() * TILE_HEIGHT * 2 + output.element_size());
+    uint32_t max_X =
+        (max_l1_size - alignment) / (output_tensor.element_size() * TILE_HEIGHT * 2 + output_tensor.element_size());
     uint32_t max_tiles = max_X / TILE_WIDTH;
 
     // Currently need the number of tiles in a row to be divisible by tiles in a block
@@ -89,7 +86,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
         }
     }
     uint32_t block_width = num_tiles_per_block * TILE_WIDTH;
-    uint32_t block_row_size = block_width * output.element_size();
+    uint32_t block_row_size = block_width * output_tensor.element_size();
     uint32_t num_blocks_w_output = unpadded_stick_size / block_row_size;
     uint32_t num_blocks_w_input = padded_stick_size / block_row_size;
     uint32_t block_row_leftover_size = unpadded_stick_size - (num_blocks_w_output * block_row_size);
@@ -127,14 +124,14 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     });
 
     std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(a).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)((
             input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
             input_cb_data_format == tt::DataFormat::Int32)),
         unpadded_stick_size};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output_tensor).append_to(writer_compile_time_args);
 
     // Tilized reader
     KernelDescriptor reader_desc;
@@ -184,10 +181,10 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     };
 
     CoreCoord core_0 = corerange_to_cores(core).at(0);
-    reader_desc.emplace_runtime_args(core_0, {src0_buffer, uint32_t(num_tiles), 0u});
+    reader_desc.emplace_runtime_args(core_0, {a, uint32_t(num_tiles), 0u});
     writer_desc.emplace_runtime_args(
         core_0,
-        {dst_buffer,
+        {output_tensor,
          output_w,
          padded_W_diff_blocks,
          output_z,


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Mechanical migration of the `data_movement` op family program factories to the
`MeshTensor`/`MeshBuffer` APIs, replacing `Buffer`/`.buffer()` usage so the runtime
no longer loses shape and sharding information when passing storage into
runtime/compile arguments (notably `TensorAccessorArgs`).

Candidate program factories (10 directories):

- data_movement/concat
- data_movement/pad
- data_movement/sharded/interleaved_to_sharded
- data_movement/sharded/reshard
- data_movement/sharded/sharded_to_interleaved
- data_movement/slice
- data_movement/tilize
- data_movement/transpose
- data_movement/untilize
- data_movement/untilize_with_unpadding

The following factories are **not** included because they are not yet on the
ProgramDescriptor framework (no `create_descriptor`); they need that migration
first:

- data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
- data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
- data_movement/slice/device/slice_program_factory_rm.cpp
- data_movement/slice/device/slice_program_factory_rm_sharded.cpp
- data_movement/slice/device/slice_program_factory_rm_stride.cpp
- data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp

The full project build (`./build_metal.sh -b RelWithDebInfo --build-all -e
--enable-ccache`) passes with all changes applied.

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure, closely
modelled on `ttnn::Tensor` (the two are designed to be drop-in interchangeable
where appropriate). It lets the runtime capture the shape and sharding information
of the true storage data structure, plumbed through `TensorAccessorArgs` — which is
critical for the upcoming Metal 2.0 refactoring, where gen-2 hardware needs to
understand the shape and sharding of device memory directly. This PR replaces
`ttnn::Tensor`/`Buffer` usage in program factories specifically, where Runtime
Tensor (`MeshTensor`, its device-side part) is the most appropriate abstraction.

#### This refactoring

- **Primary goal:** ensure ops leverage Runtime Tensor so shape/sharding info is no
  longer lost when passing `Buffer` into runtime/compile args.
- **Secondary goal:** complete the migration away from single-device data classes
  (`Buffer` → `MeshTensor`) now that the rest of the infrastructure is
  multi-device-aware.

#### Risk

Minimal regression risk: this is a type-substitution refactor, not a behavioural
change. No control flow or computational logic is modified, and the diff was
machine-reviewed as net-neutral per file.
