### PR TITLE
[skip ci] Disable distil-large-v3 performance check in blackhole-demo-tests whisper performance job

### DIFF
--- a/models/demos/audio/whisper/demo/demo.py
+++ b/models/demos/audio/whisper/demo/demo.py
@@ -864,6 +864,13 @@ def test_demo_for_conditional_generation(
         and not use_per_request_params
     )
 
+    if should_check_perf:
+        pytest.skip(
+            "[CI] Tracked in issue #45496: distil-large-v3 performance regression detected on blackhole "
+            "(AssertionError: Performance regression detected) — failing deterministically on main in "
+            "whisper performance [bh_p150_perf] job; ≥5 consecutive failures"
+        )
+
     ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
         input_path,
         mesh_device,


### PR DESCRIPTION
[skip ci] Disable distil-large-v3 performance check in blackhole-demo-tests whisper performance job

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/audio/whisper/demo/demo.py::test_demo_for_conditional_generation[blackhole-device_params0-True-False-None-False-0.0-None-None-None-False-transcribe-English-models/demos/audio/whisper/demo/dataset/conditional_generation-1-distil-whisper/distil-large-v3-1-2]` [bh_p150_perf] | https://github.com/tenstorrent/tt-metal/actions/runs/26619741477/job/78443769654 | [e121020](https://github.com/tenstorrent/tt-metal/commit/e1210204db9b322686e4dff457dd58f705782a8a) | 2026-05-29 06:26 UTC |
