### PR TITLE
[skip ci] Disable test_all_to_all_combine_no_trace in blackhole-e2e-tests ccl nightly tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_combine_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_combine_bh.py
@@ -149,6 +149,7 @@ def test_all_to_all_combine_trace(
 @pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.skip(reason="[CI] Tracked in issue #45493: outputs all-zeros (AssertionError: Equal check failed k=0,b=0,s=0 test_tensor=[0,0,...]) across all parametrizations, failing deterministically on main")
 def test_all_to_all_combine_no_trace(
     bh_1d_mesh_device,
     mesh_shape,

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_combine_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_combine_bh.py
@@ -149,7 +149,9 @@ def test_all_to_all_combine_trace(
 @pytest.mark.parametrize("input_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG], ids=["dram", "l1"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
-@pytest.mark.skip(reason="[CI] Tracked in issue #45493: outputs all-zeros (AssertionError: Equal check failed k=0,b=0,s=0 test_tensor=[0,0,...]) across all parametrizations, failing deterministically on main")
+@pytest.mark.skip(
+    reason="[CI] Tracked in issue #45493: outputs all-zeros (AssertionError: Equal check failed k=0,b=0,s=0 test_tensor=[0,0,...]) across all parametrizations, failing deterministically on main"
+)
 def test_all_to_all_combine_no_trace(
     bh_1d_mesh_device,
     mesh_shape,


### PR DESCRIPTION
[skip ci] Disable test_all_to_all_combine_no_trace in blackhole-e2e-tests ccl nightly tests

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `test_all_to_all_combine_no_trace[...fabric_1d_line_axis_0]` (all mem/local_reduce combos) [bh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26628343995/job/78499713107 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:43 UTC |
| `test_all_to_all_combine_no_trace[...fabric_1d_ring_axis_0]` (all mem/local_reduce combos) [bh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26628343995/job/78499713107 | [ee5df35](https://github.com/tenstorrent/tt-metal/commit/ee5df35e32105209e769898f597c4d6b46f5fa06) | 2026-05-29 09:43 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-e2e-tests-all-to-all-combine-no-trace-20260529)