### PR TITLE
[skip ci] Disable T3K Fabric Mux BW bandwidth regression tests in metal-run-microbenchmarks

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py
@@ -224,6 +224,12 @@ def test_mux_bw_full_size_channels(
     num_full_size_channel_iters,
     num_iters_between_teardown_checks,
 ):
+    if num_full_size_channels == 4:
+        pytest.skip(
+            "[CI] Tracked in issue #45497: bandwidth regression for 4 full-size channels "
+            "(expected 15.3975 B/c, actual ~14.80 B/c) — failing deterministically on T3K main; "
+            "≥3 consecutive failures in metal-run-microbenchmarks T3K ubench - Fabric Mux BW"
+        )
     test_name = "full_size_channels"
     run_mux_benchmark_test(
         test_name,
@@ -352,6 +358,12 @@ def test_mux_bw_both_channel_types(
     num_full_size_channel_iters,
     num_iters_between_teardown_checks,
 ):
+    if num_full_size_channels == 4 and num_header_only_channels == 1:
+        pytest.skip(
+            "[CI] Tracked in issue #45497: bandwidth regression for 4 full-size + 1 header-only channels "
+            "(expected 10.9333 B/c, actual ~10.37 B/c) — failing deterministically on T3K main; "
+            "≥3 consecutive failures in metal-run-microbenchmarks T3K ubench - Fabric Mux BW"
+        )
     test_name = "both_channel_types"
     run_mux_benchmark_test(
         test_name,


### PR DESCRIPTION
[skip ci] Disable two specific bandwidth regression parametrizations in the `metal-run-microbenchmarks` pipeline's `run-microbenchmarks / T3K ubench - Fabric Mux BW` job. These tests fail deterministically with `AssertionError: Bandwidth mismatch` across ≥3 consecutive `metal-run-microbenchmarks` main runs.

Tracking issue: #45497

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py::test_mux_bw_full_size_channels[32-1-4096-10000-0-8-0-4]` | https://github.com/tenstorrent/tt-metal/actions/runs/26587701074/job/78345243752 | [ad73db7](https://github.com/tenstorrent/tt-metal/commit/ad73db77a3e135d225f9efe333e45ef9810387b0) | 2026-05-28 18:34 UTC |
| `tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py::test_mux_bw_both_channel_types[32-1-4096-10000-8-8-1-4]` | https://github.com/tenstorrent/tt-metal/actions/runs/26587701074/job/78345243752 | [ad73db7](https://github.com/tenstorrent/tt-metal/commit/ad73db77a3e135d225f9efe333e45ef9810387b0) | 2026-05-28 18:34 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/metal-run-microbenchmarks-fabric-mux-bw-20260529)