### PR TITLE
[Bug fix] Bump WH BRISC firmware size to 6KB+128 to fit profiler

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 64)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 128)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
PR #44888 ([Feature] GCBs with a DRISC sender) added ~4 bytes of code to `setup_remote_cb_interfaces()` / `update_pages_acked()`, which inlines into the firmware. On Wormhole, when the profiler was enabled, that pushed the BRISC firmware ELF for the  from 0x183c to 0x1844, overflowing the 0x1840 BRISC text region. The result was a hard failure in `test_padded_2d_matmul[tile_count=1375-side=width]`, reported by the regression analysis bot at https://github.com/tenstorrent/tt-metal/actions/runs/26612367174.

Raise `MEM_BRISC_FIRMWARE_SIZE` on Wormhole from `6 * 1024 + 64` (0x1840) to `6 * 1024 + 128` (0x1880). Blackhole is unaffected (it already has 2.5KB of headroom over the WH limit).

### Notes for reviewers
- Only the Wormhole memory map is touched; no kernel/test has the size hardcoded.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/bump-wh-brisc-firmware-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/bump-wh-brisc-firmware-size)