### PR TITLE
[Clean up] Replace diff noc txn template args with one NocOptions enum

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/device_api_migration_guide.md
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/device_api_migration_guide.md
@@ -9,6 +9,7 @@ This guide helps developers migrate from legacy data movement APIs to the new De
 3. [Key Classes](#key-classes)
 4. [Migration Patterns](#migration-patterns)
    - [NoC Operations](#noc-operations)
+   - [NocOptVals Struct](#nocoptvals-struct)
    - [Circular Buffer Operations](#circular-buffer-operations)
    - [Semaphore Operations](#semaphore-operations)
    - [Memory Access](#memory-access)
@@ -151,7 +152,77 @@ noc.async_write(
 noc.async_write_barrier();
 ```
 
+#### Async Read with State (Optimized Repeated Reads)
+
+Use `set_async_read_state` to pre-program the source location, page size, (and optionally the transaction id and/or virtual channel) into hardware registers once, then call `async_read_with_state` in a tight loop — the hardware retains state between calls.
+
+**Legacy API:**
+```cpp
+uint64_t src_noc_addr = get_noc_addr(noc_x, noc_y, base_addr);
+noc_async_read_set_state(src_noc_addr, page_size);
+for (uint32_t i = 0; i < num_pages; i++) {
+    noc_async_read_with_state(src_base + i * page_size, dst_base + i * page_size, page_size);
+}
+noc_async_read_barrier();
+```
+
+**New API (default options):**
+```cpp
+Noc noc;
+UnicastEndpoint src;
+CoreLocalMem<uint32_t> dst(dst_l1_addr);
+
+noc.set_async_read_state(
+    src, page_size, {.noc_x = x, .noc_y = y, .addr = base_addr}
+);
+for (uint32_t i = 0; i < num_pages; i++) {
+    noc.async_read_with_state(
+        src, dst, page_size,
+        {.addr = src_base + i * page_size},
+        {.addr = dst_base + i * page_size}
+    );
+}
+noc.async_read_barrier();
+```
+
+**New API (custom virtual channel via `NocOptVals`):**
+```cpp
+noc.set_async_read_state<NocOptions::CUSTOM_VC>(
+    src, page_size, {.noc_x = x, .noc_y = y, .addr = base_addr},
+    NocOptVals{.vc = my_vc}
+);
+for (uint32_t i = 0; i < num_pages; i++) {
+    noc.async_read_with_state<NocOptions::CUSTOM_VC>(
+        src, dst, page_size,
+        {.addr = src_base + i * page_size},
+        {.addr = dst_base + i * page_size},
+        NocOptVals{.vc = my_vc}
+    );
+}
+noc.async_read_barrier();
+```
+
+**New API (transaction ID via `NocOptVals`):**
+
+```cpp
+noc.set_async_read_state<NocOptions::TXN_ID>(
+    src, page_size, {.noc_x = x, .noc_y = y, .addr = base_addr},
+    NocOptVals{.trid = curr_trid}
+);
+for (uint32_t i = 0; i < num_pages; i++) {
+    noc.async_read_with_state<NocOptions::TXN_ID>(
+        src, dst, page_size,
+        {.addr = src_base + i * page_size},
+        {.addr = dst_base + i * page_size},
+        NocOptVals{.trid = curr_trid}
+    );
+}
+noc.async_read_barrier<NocOptions::TXN_ID>({.trid = curr_trid});
+```
+
 #### Async Write with State (Optimized Repeated Writes)
+
+Use `set_async_write_state` to program the destination location, page size, and virtual channel into hardware registers once, then call `async_write_with_state` in a tight loop.
 
 **Legacy API:**
 ```cpp
@@ -162,18 +233,32 @@ for (...) {
 }
 ```
 
-**New API:**
+**New API (default options):**
 ```cpp
 Noc noc;
 UnicastEndpoint dst;
 CoreLocalMem<uint32_t> src(src_addr);
 
-noc.set_async_write_state<Noc::ResponseMode::NON_POSTED>(
+noc.set_async_write_state(
     dst, size_bytes, {.noc_x = x, .noc_y = y, .addr = base_addr}
 );
 for (...) {
-    noc.async_write_with_state<Noc::ResponseMode::NON_POSTED>(
+    noc.async_write_with_state(
         src, dst, size_bytes, {.offset_bytes = src_offset}, {.addr = dst_offset}
+    );
+}
+```
+
+**New API (custom virtual channel via `NocOptVals`):**
+```cpp
+noc.set_async_write_state<NocOptions::CUSTOM_VC>(
+    dst, size_bytes, {.noc_x = x, .noc_y = y, .addr = base_addr},
+    NocOptVals{.vc = my_vc}
+);
+for (...) {
+    noc.async_write_with_state<NocOptions::CUSTOM_VC>(
+        src, dst, size_bytes, {.offset_bytes = src_offset}, {.addr = dst_offset},
+        NocOptVals{.vc = my_vc}
     );
 }
 ```
@@ -192,7 +277,7 @@ Noc noc;
 CoreLocalMem<uint32_t> src(src_l1_addr);
 CircularBuffer cb(cb_id);  // Or any destination with mcast traits
 
-noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>(
+noc.async_write_multicast(
     src,
     cb,
     size_bytes,
@@ -208,19 +293,39 @@ noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>(
 **New API (Transaction IDs):**
 ```cpp
 Noc noc;
-constexpr uint32_t trid = 0;
+constexpr uint8_t trid = 1;
 
 // Write with transaction ID
-noc.async_write<Noc::TxnIdMode::ENABLED>(
+noc.async_write<NocOptions::TXN_ID>(
     src, dst, size_bytes, src_args, dst_args,
-    NOC_UNICAST_WRITE_VC, trid
+    NocOptVals{.trid = trid}
 );
 
 // Barrier on specific transaction ID
-noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid);
+noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid});
 ```
 
 ---
+
+### NocOptVals Struct
+
+`NocOptVals` is an aggregate struct that carries the runtime values for optional `NocOptions` flags. It is accepted as the last argument of all stateful and trid-aware `Noc` APIs. Fields are only inspected when the matching flag is set in the template `opts` parameter.
+
+```cpp
+struct NocOptVals {
+    uint32_t vc   = NOC_UNICAST_WRITE_VC;  // used when NocOptions::CUSTOM_VC
+    uint32_t trid = 0;                     // used when NocOptions::TXN_ID
+};
+```
+
+**Usage summary:**
+
+| Scenario | Template `opts` | `NocOptVals` arg |
+|---|---|---|
+| Default vc, no trid | omit / `NocOptions::DEFAULT` | omit / `{}` |
+| Custom vc | `NocOptions::CUSTOM_VC` | `NocOptVals{.vc = v}` |
+| Transaction ID barrier/read/write | `NocOptions::TXN_ID` | `NocOptVals{.trid = t}` |
+| Custom vc + trid | `NocOptions::TXN_ID \| NocOptions::CUSTOM_VC` | `NocOptVals{.vc = v, .trid = t}` |
 
 ### Circular Buffer Operations
 
@@ -343,12 +448,12 @@ noc_semaphore_set_multicast(local_sem_addr, mcast_addr, num_dests);
 ```cpp
 Noc noc;
 Semaphore<> sem(sem_id);
-sem.set_multicast<Noc::McastMode::EXCLUDE_SRC>(
+sem.set_multicast<NocOptions::DEFAULT>(
     noc, x0, y0, x1, y1, num_dests
 );
 
 // Include source in multicast:
-sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
     noc, x0, y0, x1, y1, num_dests
 );
 ```

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -141,7 +141,7 @@ void run_single_dfb_program(
         if (dfb_config.num_producers > 1 || dfb_config.num_consumers > 1) {
             GTEST_SKIP() << "WH/BH DFB supports only 1 DM producer (BRISC) and 1 DM consumer (NCRISC)";
         }
-        // Implicit sync (Noc::TxnIdMode::ENABLED) is declared only under #ifdef ARCH_QUASAR
+        // Implicit sync (NocOptions::TXN_ID) is declared only under #ifdef ARCH_QUASAR
         // in api/dataflow/noc.h. Force it off so the device-side kernel's
         // `if constexpr (implicit_sync)` branch is dead code on WH/BH.
         dfb_config.enable_producer_implicit_sync = false;

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
                 // Cycle through virtual channels 0 to (num_virtual_channels - 1)
                 uint32_t current_virtual_channel = i % num_virtual_channels;
 
-                noc.async_read(
+                noc.async_read<NocOptions::CUSTOM_VC>(
                     unicast_endpoint,
                     unicast_endpoint,
                     bytes_per_transaction_per_subordinate,
@@ -52,7 +52,7 @@ void kernel_main() {
                     {
                         .addr = master_l1_local_address,
                     },
-                    current_virtual_channel);
+                    NocOptVals{.vc = current_virtual_channel});
             }
         }
         noc.async_read_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
                 // Cycle through virtual channels 0 to (num_virtual_channels - 1)
                 uint32_t current_virtual_channel = i % num_virtual_channels;
 
-                noc.async_write(
+                noc.async_write<NocOptions::CUSTOM_VC>(
                     unicast_endpoint,
                     unicast_endpoint,
                     bytes_per_transaction_per_master,
@@ -52,7 +52,7 @@ void kernel_main() {
                         .noc_y = subordinate_y_coord,
                         .addr = subordinate_l1_local_address,
                     },
-                    current_virtual_channel);
+                    NocOptVals{.vc = current_virtual_channel});
             }
         }
         noc.async_write_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/kernels/dram_sharded_read_trid_2_0.cpp
@@ -36,20 +36,20 @@ void kernel_main() {
             dst_addr = l1_addr;
             for (uint32_t bank_id = 0; bank_id < num_banks; bank_id++) {
                 for (uint32_t i = 0; i < pages_per_bank; i++) {
-                    noc.async_read<Noc::TxnIdMode::ENABLED, NOC_MAX_BURST_SIZE>(
+                    noc.async_read<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
                         dram_bank,
                         unicast_endpoint,
                         page_size_bytes,
                         {.bank_id = bank_id, .addr = src_addr + i * page_size_bytes},
                         {.addr = dst_addr},
-                        curr_trid);
+                        NocOptVals{.trid = curr_trid});
                     dst_addr += page_size_bytes;
                 }
                 curr_trid = (curr_trid % (num_of_trids - 1)) + 1;  // keep trid between 1 and num_of_trids-1
             }
         }
         for (uint32_t t = 1; t < num_of_trids; t++) {
-            noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(t);
+            noc.async_read_barrier<NocOptions::TXN_ID>({.trid = t});
         }
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary_2_0.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            noc.async_write(
+            noc.async_write<NocOptions::CUSTOM_VC>(
                 unicast_endpoint,
                 AllocatorBank<bank_type>(),
                 bytes_per_transaction,
@@ -43,7 +43,7 @@ void kernel_main() {
                     .bank_id = dram_channel,
                     .addr = dram_addr,
                 },
-                virtual_channel);
+                NocOptVals{.vc = virtual_channel});
         }
         noc.async_write_barrier();
     }

--- a/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_api_latency/kernels/multicast_write_2_0.cpp
@@ -29,7 +29,7 @@ void kernel_main() {
     UnicastEndpoint unicast_endpoint;
     MulticastEndpoint mcast_endpoint;
     constexpr auto mcast_mode =
-        loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+        loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
     {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t i = 0; i < num_transactions; i++) {

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
@@ -156,8 +156,8 @@ void kernel_main() {
             mcast_end_y = tmp;
         }
 
-        constexpr Noc::McastMode mcast_mode =
-            loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+        constexpr NocOptions mcast_mode =
+            loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
 
         {
             DeviceZoneScopedN("RISCV0");
@@ -202,8 +202,8 @@ void kernel_main() {
             mcast_end_y = tmp;
         }
 
-        constexpr Noc::McastMode mcast_mode =
-            loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+        constexpr NocOptions mcast_mode =
+            loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
 
         {
             DeviceZoneScopedN("RISCV0");

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor_2_0.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_of_transactions; i++) {
             // Cycle through virtual channels 0 to (num_virtual_channels - 1)
             uint32_t current_virtual_channel = i % num_virtual_channels;
-            noc.async_read(
+            noc.async_read<NocOptions::CUSTOM_VC>(
                 unicast_endpoint,
                 unicast_endpoint,
                 transaction_size_bytes,
@@ -37,7 +37,7 @@ void kernel_main() {
                 {
                     .addr = l1_local_addr,
                 },
-                current_virtual_channel);
+                NocOptVals{.vc = current_virtual_channel});
         }
         noc.async_read_barrier();
     }

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/reader_stateful_vc_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/reader_stateful_vc_2_0.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies set_async_read_state + async_read_with_state with NocOptions::CUSTOM_VC and NocOptVals{.vc}.
+// Mirrors read_one_packet_2_0.cpp but explicitly selects a non-default virtual channel via the new
+// NocOptVals struct.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    constexpr uint32_t num_packets = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+
+    uint32_t master_l1_addr = get_arg_val<uint32_t>(0);
+    uint32_t subordinate_l1_addr = get_arg_val<uint32_t>(1);
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(2);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t custom_vc = (NOC_UNICAST_WRITE_VC + 1) % 4;
+
+    Noc noc(noc_index);
+    UnicastEndpoint unicast_endpoint;
+
+    DeviceTimestampedData("Number of transactions", num_packets);
+    DeviceTimestampedData("Transaction size in bytes", packet_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+            unicast_endpoint,
+            packet_size_bytes,
+            {.noc_x = responder_x_coord, .noc_y = responder_y_coord, .addr = subordinate_l1_addr},
+            NocOptVals{.vc = custom_vc});
+
+        for (uint32_t i = 0; i < num_packets; i++) {
+            noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                unicast_endpoint,
+                unicast_endpoint,
+                packet_size_bytes,
+                {.noc_x = responder_x_coord, .noc_y = responder_y_coord, .addr = subordinate_l1_addr},
+                {.addr = master_l1_addr},
+                NocOptVals{.vc = custom_vc});
+        }
+        noc.async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/writer_stateful_vc_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/kernels/writer_stateful_vc_2_0.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies set_async_write_state + async_write_with_state with NocOptions::CUSTOM_VC and NocOptVals{.vc}.
+// Mirrors write_one_packet_2_0.cpp but explicitly selects a non-default virtual channel via the new
+// NocOptVals struct.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    constexpr uint32_t num_packets = get_compile_time_arg_val(0);
+    constexpr uint32_t packet_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+
+    uint32_t master_l1_addr = get_arg_val<uint32_t>(0);
+    uint32_t subordinate_l1_addr = get_arg_val<uint32_t>(1);
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(2);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t custom_vc = (NOC_UNICAST_WRITE_VC + 1) % 4;
+
+    Noc noc(noc_index);
+    UnicastEndpoint unicast_endpoint;
+
+    DeviceTimestampedData("Number of transactions", num_packets);
+    DeviceTimestampedData("Transaction size in bytes", packet_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        noc.set_async_write_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+            unicast_endpoint,
+            packet_size_bytes,
+            {.noc_x = responder_x_coord, .noc_y = responder_y_coord, .addr = subordinate_l1_addr},
+            NocOptVals{.vc = custom_vc});
+
+        for (uint32_t i = 0; i < num_packets; i++) {
+            noc.async_write_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                unicast_endpoint,
+                unicast_endpoint,
+                packet_size_bytes,
+                {.addr = master_l1_addr},
+                {.noc_x = responder_x_coord, .noc_y = responder_y_coord, .addr = subordinate_l1_addr},
+                NocOptVals{.vc = custom_vc});
+        }
+        noc.async_write_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -28,6 +28,7 @@ struct OnePacketConfig {
     uint32_t packet_size_bytes = 0;
     bool read = true;
     bool use_2_0 = false;
+    bool use_stateful_vc = false;  // exercises NocOptions::CUSTOM_VC via NocOptVals
 };
 
 /// @brief Does OneToOne or OneFromOne but with one_packet read/write
@@ -70,15 +71,19 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OnePac
         (uint32_t)test_config.num_packets, (uint32_t)test_config.packet_size_bytes, (uint32_t)test_config.test_id};
 
     std::string kernels_dir = "tests/tt_metal/tt_metal/data_movement/one_packet/kernels/";
-    std::string read_kernel_filename = "read_one_packet";
-    std::string write_kernel_filename = "write_one_packet";
-    if (test_config.read) {
-        kernels_dir += read_kernel_filename;
+    if (test_config.use_stateful_vc) {
+        kernels_dir += test_config.read ? "reader_stateful_vc_2_0" : "writer_stateful_vc_2_0";
     } else {
-        kernels_dir += write_kernel_filename;
-    }
-    if (test_config.use_2_0) {
-        kernels_dir += "_2_0";
+        std::string read_kernel_filename = "read_one_packet";
+        std::string write_kernel_filename = "write_one_packet";
+        if (test_config.read) {
+            kernels_dir += read_kernel_filename;
+        } else {
+            kernels_dir += write_kernel_filename;
+        }
+        if (test_config.use_2_0) {
+            kernels_dir += "_2_0";
+        }
     }
     kernels_dir += ".cpp";
 
@@ -402,6 +407,68 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
             };
 
             // Run
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
+// NocOptions::CUSTOM_VC via NocOptVals — set_async_read_state + async_read_with_state
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementNocApiStatefulReadCustomVc) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->impl().get_device(0);
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_packet_size_bytes =
+        device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_packets = 256;
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    for (uint32_t num_packets = 1; num_packets <= max_packets; num_packets *= 4) {
+        for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
+             packet_size_bytes *= 2) {
+            unit_tests::dm::one_packet::OnePacketConfig test_config = {
+                .test_id = 86,
+                .master_core_coord = master_core_coord,
+                .subordinate_core_coord = subordinate_core_coord,
+                .num_packets = num_packets,
+                .packet_size_bytes = packet_size_bytes,
+                .read = true,
+                .use_stateful_vc = true,
+            };
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
+// NocOptions::CUSTOM_VC via NocOptVals — set_async_write_state + async_write_with_state
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementNocApiStatefulWriteCustomVc) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->impl().get_device(0);
+    auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_packet_size_bytes =
+        device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+    uint32_t max_packets = 256;
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord subordinate_core_coord = {0, 1};
+
+    for (uint32_t num_packets = 1; num_packets <= max_packets; num_packets *= 4) {
+        for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
+             packet_size_bytes *= 2) {
+            unit_tests::dm::one_packet::OnePacketConfig test_config = {
+                .test_id = 87,
+                .master_core_coord = master_core_coord,
+                .subordinate_core_coord = subordinate_core_coord,
+                .num_packets = num_packets,
+                .packet_size_bytes = packet_size_bytes,
+                .read = false,
+                .use_stateful_vc = true,
+            };
             EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_2_0.cpp
@@ -41,8 +41,8 @@ void kernel_main() {
     UnicastEndpoint unicast_endpoint;
     MulticastEndpoint multicast_endpoint;
 
-    constexpr Noc::McastMode include_src =
-        loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+    constexpr NocOptions include_src =
+        loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
 
     {
         DeviceZoneScopedN("RISCV0");

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_2_0.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
                 // Cycle through virtual channels 0 to (num_virtual_channels - 1)
                 uint32_t current_virtual_channel = i % num_virtual_channels;
 
-                noc.async_write(
+                noc.async_write<NocOptions::CUSTOM_VC>(
                     unicast_endpoint,
                     unicast_endpoint,
                     bytes_per_transaction,
@@ -50,7 +50,7 @@ void kernel_main() {
                         .noc_y = dest_coord_y,
                         .addr = sub_base_addr,
                     },
-                    current_virtual_channel);
+                    NocOptVals{.vc = current_virtual_channel});
             }
         }
         noc.async_write_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender_2_0.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_of_transactions; i++) {
             // Cycle through virtual channels 0 to (num_virtual_channels - 1)
             uint32_t current_virtual_channel = i % num_virtual_channels;
-            noc.async_write(
+            noc.async_write<NocOptions::CUSTOM_VC>(
                 unicast_endpoint,
                 unicast_endpoint,
                 bytes_per_transaction,
@@ -40,7 +40,7 @@ void kernel_main() {
                     .noc_y = receiver_y_coord,
                     .addr = l1_local_addr,
                 },
-                current_virtual_channel);
+                NocOptVals{.vc = current_virtual_channel});
         }
         noc.async_write_barrier();
     }

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_nonblocking_poll_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_nonblocking_poll_2_0.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Issues num_trids one-packet reads, each tagged with a distinct transaction ID (1..num_trids).
+// Polls noc.is_read_trid_flushed() for each slot in a state machine instead of stalling on a
+// full barrier, demonstrating that completed slots can be processed while others are in flight.
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_base_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_trids_raw = get_compile_time_arg_val(1);
+    constexpr uint32_t num_trids = num_trids_raw < 16 ? num_trids_raw : 15;  // trid 0 reserved
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_sub0_coords = get_compile_time_arg_val(4);
+
+    constexpr uint32_t src_x = packed_sub0_coords >> 16;
+    constexpr uint32_t src_y = packed_sub0_coords & 0xFFFF;
+
+    Noc noc(noc_index);
+    UnicastEndpoint src;
+    CoreLocalMem<uint32_t> dst(l1_base_addr);
+
+    // Issue all reads upfront, each with a unique trid (1-indexed to avoid trid 0).
+    for (uint32_t i = 1; i <= num_trids; i++) {
+        noc.async_read<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+            src,
+            dst,
+            bytes_per_page,
+            {.noc_x = src_x, .noc_y = src_y, .addr = l1_base_addr + (i - 1) * bytes_per_page},
+            {.offset_bytes = (i - 1) * bytes_per_page},
+            NocOptVals{.trid = i});
+    }
+
+    // Poll each slot independently; don't stall on a full barrier.
+    uint32_t done_mask = 0;
+    constexpr uint32_t expected_mask = (1u << num_trids) - 1;
+    while (done_mask != expected_mask) {
+        for (uint32_t i = 1; i <= num_trids; i++) {
+            uint32_t bit = 1u << (i - 1);
+            if (!(done_mask & bit) && noc.is_read_trid_flushed(i)) {
+                done_mask |= bit;
+            }
+        }
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of trids", num_trids);
+    DeviceTimestampedData("Bytes per page", bytes_per_page);
+}

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_stateful_trid_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_stateful_trid_2_0.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Programs source coordinates, page size, and transaction ID into hardware registers once via
+// set_async_read_state<ENABLED>, then issues num_pages back-to-back reads via
+// async_read_with_state<ENABLED> each inheriting the sticky NOC_PACKET_TAG trid set during
+// set_state.  Waits on the per-trid barrier rather than a full read barrier.
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+
+void kernel_main() {
+    constexpr uint32_t l1_base_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(1);
+    constexpr uint32_t bytes_per_page = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t packed_sub0_coords = get_compile_time_arg_val(4);
+
+    constexpr uint32_t src_x = packed_sub0_coords >> 16;
+    constexpr uint32_t src_y = packed_sub0_coords & 0xFFFF;
+
+    constexpr uint8_t trid = 1;
+
+    Noc noc(noc_index);
+    UnicastEndpoint src;
+    CoreLocalMem<uint32_t> dst(l1_base_addr);
+
+    noc.set_async_read_state<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+        src,
+        bytes_per_page,
+        {.noc_x = src_x, .noc_y = src_y, .addr = l1_base_addr},
+        NocOptVals{.trid = trid});
+
+    for (uint32_t i = 0; i < num_pages; i++) {
+        noc.async_read_with_state<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+            src,
+            dst,
+            bytes_per_page,
+            {.noc_x = src_x, .noc_y = src_y, .addr = l1_base_addr + i * bytes_per_page},
+            {.offset_bytes = i * bytes_per_page},
+            NocOptVals{.trid = trid});
+    }
+
+    noc.async_read_barrier<NocOptions::TXN_ID>({.trid = trid});
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of pages", num_pages);
+    DeviceTimestampedData("Bytes per page", bytes_per_page);
+}

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -186,6 +186,89 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Transa
 
     return is_equal;
 }
+/// @brief Runs a 2-core read-only test: master_core reads num_trids*bytes_per_page bytes from
+/// sub0_core using the provided kernel, then verifies the data matches.
+/// The kernel receives compile_args = {l1_base_addr, num_trids, bytes_per_page, test_id, packed_sub0, 0}.
+bool run_dm_read(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    const TransactionIdConfig& test_config,
+    const std::string& kernel_path) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t total_bytes = test_config.num_of_trids * test_config.bytes_per_page;
+
+    L1AddressInfo master_l1_info =
+        unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.master_core_coord);
+    L1AddressInfo sub0_l1_info =
+        unit_tests::dm::get_l1_address_and_size(mesh_device, test_config.sub0_core_coord);
+
+    if (master_l1_info.base_address != sub0_l1_info.base_address ||
+        master_l1_info.size != sub0_l1_info.size) {
+        log_error(LogTest, "Mismatch in L1 address or size between master and sub0 cores");
+        return false;
+    }
+    if (master_l1_info.size < total_bytes) {
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+
+    uint32_t l1_base_address = master_l1_info.base_address;
+    CoreCoord physical_sub0 = device->worker_core_from_logical_core(test_config.sub0_core_coord);
+    uint32_t packed_sub0 = (physical_sub0.x << 16) | (physical_sub0.y & 0xFFFF);
+
+    vector<uint32_t> compile_args = {
+        l1_base_address,
+        test_config.num_of_trids,
+        test_config.bytes_per_page,
+        test_config.test_id,
+        packed_sub0,
+        0};
+
+    CreateKernel(
+        program,
+        kernel_path,
+        test_config.master_core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = test_config.noc_id,
+            .compile_args = compile_args});
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    size_t element_size_bytes = sizeof(bfloat16);
+    uint32_t num_elements = total_bytes / element_size_bytes;
+
+    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, num_elements, chrono::system_clock::now().time_since_epoch().count());
+
+    detail::WriteToDeviceL1(device, test_config.sub0_core_coord, l1_base_address, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+
+    vector<uint32_t> packed_output;
+    detail::ReadFromDeviceL1(device, test_config.master_core_coord, l1_base_address, total_bytes, packed_output);
+
+    bool is_equal = (packed_output == packed_input);
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed");
+        log_info(LogTest, "Golden vector");
+        print_vector<uint32_t>(packed_input);
+        log_info(LogTest, "Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+    return is_equal;
+}
+
 }  // namespace unit_tests::dm::transaction_id
 
 /* ========== TEST CASES ========== */
@@ -427,6 +510,77 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOn
 
             // Run
             EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementNocApiIsReadTridFlushed) {
+    uint32_t test_id = 620;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->impl().get_device(0);
+
+    auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
+
+    for (uint32_t num_trids : {1u, 4u, 8u, 15u}) {
+        if (num_trids * bytes_per_page > max_transmittable_bytes) {
+            continue;
+        }
+        unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
+            .test_id = test_id,
+            .master_core_coord = master_core_coord,
+            .sub0_core_coord = sub0_core_coord,
+            .num_of_trids = num_trids,
+            .bytes_per_page = bytes_per_page,
+            .l1_data_format = DataFormat::Float16_b,
+        };
+
+        EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm_read(
+            mesh_device,
+            test_config,
+            "tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_nonblocking_poll_2_0.cpp"));
+    }
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementNocApiStatefulReadWithTrid) {
+    uint32_t test_id = 621;
+
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->impl().get_device(0);
+
+    auto [min_bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    // Kernel uses max_page_size = NOC_MAX_BURST_SIZE (one-packet path only).
+    const uint32_t max_bytes_per_page =
+        device->arch() == tt::ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord sub0_core_coord = {0, device->compute_with_storage_grid_size().y - 1};
+
+    for (uint32_t bytes_per_page = min_bytes_per_page; bytes_per_page <= max_bytes_per_page;
+         bytes_per_page *= 2) {
+        for (uint32_t num_pages : {1u, 4u, 8u}) {
+            if (num_pages * bytes_per_page > max_transmittable_bytes) {
+                continue;
+            }
+            unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
+                .test_id = test_id,
+                .master_core_coord = master_core_coord,
+                .sub0_core_coord = sub0_core_coord,
+                .num_of_trids = num_pages,  // reused as num_pages for the stateful kernel
+                .bytes_per_page = bytes_per_page,
+                .l1_data_format = DataFormat::Float16_b,
+            };
+
+            EXPECT_TRUE(unit_tests::dm::transaction_id::run_dm_read(
+                mesh_device,
+                test_config,
+                "tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_stateful_trid_2_0.cpp"));
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/core_local_mem_api.cpp
@@ -78,7 +78,7 @@ void kernel_main() {
     // Try sending with NoC API
     Noc noc;
     UnicastEndpoint unicast_endpoint;
-    noc.async_write(
+    noc.async_write<NocOptions::CUSTOM_VC>(
         mem,
         unicast_endpoint,
         num_bytes,
@@ -88,7 +88,7 @@ void kernel_main() {
             .noc_y = neighbor_worker_core_y,
             .addr = src_addr,
         },
-        0);
+        NocOptVals{.vc = 0});
     noc.async_write_barrier();
 
     // Try clear data here before reading from neighbor core

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
         // DPRINT("consumer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            noc.async_write<Noc::TxnIdMode::ENABLED>(dfb, tensor_accessor, {}, {.page_id = page_id});
+            noc.async_write<NocOptions::TXN_ID>(dfb, tensor_accessor, {}, {.page_id = page_id});
 #endif
         } else {
             dfb.wait_front(1);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
         const uint32_t page_id = chunk_offset + tile_id;
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            noc.async_write<Noc::TxnIdMode::ENABLED>(
+            noc.async_write<NocOptions::TXN_ID>(
                 dfb, tensor_accessor, {}, {.page_id = page_id});
 #endif
         } else {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            noc.async_write<Noc::TxnIdMode::ENABLED>(
+            noc.async_write<NocOptions::TXN_ID>(
                 dfb, tensor_accessor, {}, {.page_id = tile_id});
 #endif
         } else {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
         const uint32_t page_id = chunk_offset + tile_id;
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            noc.async_read<Noc::TxnIdMode::ENABLED>(
+            noc.async_read<NocOptions::TXN_ID>(
                 tensor_accessor, dfb, {.page_id = page_id}, {});
 #endif
         } else {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
         // DPRINT("producer tile id {} page id {}\n", tile_id, page_id);
         if constexpr (implicit_sync) {
 #ifdef ARCH_QUASAR
-            noc.async_read<Noc::TxnIdMode::ENABLED>(tensor_accessor, dfb, {.page_id = page_id}, {});
+            noc.async_read<NocOptions::TXN_ID>(tensor_accessor, dfb, {.page_id = page_id}, {});
 #endif
         } else {
             dfb.reserve_back(1);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
@@ -30,12 +30,12 @@
 #include "experimental/kernel_args.h"
 #include "api/kernel_thread_globals.h"
 
-// The implicit_sync=true branch uses Noc::TxnIdMode::ENABLED, which is declared
+// The implicit_sync=true branch uses NocOptions::TXN_ID, which is declared
 // only under #ifdef ARCH_QUASAR in api/dataflow/noc.h. This kernel is only used
 // by Quasar-only sequential-DFB harnesses, so the branch is unreachable on Gen1.
 #ifdef ARCH_QUASAR
 #define DFB_SEQ_CONSUME_IMPLICIT_SYNC(dfb_, tensor_accessor_, page_id_) \
-    noc.async_write<Noc::TxnIdMode::ENABLED>((dfb_), (tensor_accessor_), {}, {.page_id = (page_id_)})
+    noc.async_write<NocOptions::TXN_ID>((dfb_), (tensor_accessor_), {}, {.page_id = (page_id_)})
 #else
 #define DFB_SEQ_CONSUME_IMPLICIT_SYNC(dfb_, tensor_accessor_, page_id_) ((void)0)
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
@@ -32,12 +32,12 @@
 // Single per-DFB unrolled body.  All variables (num_entries_per_producer,
 // implicit_sync, num_producers, producer_idx, noc) are visible from kernel_main.
 //
-// The implicit_sync=true branch uses Noc::TxnIdMode::ENABLED, which is declared
+// The implicit_sync=true branch uses NocOptions::TXN_ID, which is declared
 // only under #ifdef ARCH_QUASAR in api/dataflow/noc.h. This kernel is only used
 // by Quasar-only sequential-DFB harnesses, so the branch is unreachable on Gen1.
 #ifdef ARCH_QUASAR
 #define DFB_SEQ_PRODUCE_IMPLICIT_SYNC(tensor_accessor_, dfb_, page_id_) \
-    noc.async_read<Noc::TxnIdMode::ENABLED>((tensor_accessor_), (dfb_), {.page_id = (page_id_)}, {})
+    noc.async_read<NocOptions::TXN_ID>((tensor_accessor_), (dfb_), {.page_id = (page_id_)}, {})
 #else
 #define DFB_SEQ_PRODUCE_IMPLICIT_SYNC(tensor_accessor_, dfb_, page_id_) ((void)0)
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast_include_src.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast_include_src.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
 
     // multicast local L1 buffer to all destination cores
     MulticastEndpoint dst_mcast_endpoint;
-    noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
         local_buffer,
         dst_mcast_endpoint,
         src_buffer_size,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 #ifdef ARCH_QUASAR
                         // Quasar: implicit-sync read. The DFB credit advances via the per-trid
                         // completion ISR; no reserve_back / barrier / push_back required.
-                        noc.async_read<Noc::TxnIdMode::ENABLED>(s0, dfb0, {.page_id = itileA}, {});
+                        noc.async_read<NocOptions::TXN_ID>(s0, dfb0, {.page_id = itileA}, {});
 #else
                         dfb0.reserve_back(onetile);
                         noc.async_read(s0, dfb0, entry_size0, {.page_id = itileA}, {});
@@ -62,7 +62,7 @@ void kernel_main() {
                     // Read B's tile at (kt, nt)
                     if (mt % num_readers == reader_id && kt % num_readers == reader_id) {
 #ifdef ARCH_QUASAR
-                        noc.async_read<Noc::TxnIdMode::ENABLED>(s1, dfb1, {.page_id = itileB}, {});
+                        noc.async_read<NocOptions::TXN_ID>(s1, dfb1, {.page_id = itileB}, {});
 #else
                         dfb1.reserve_back(onetile);
                         noc.async_read(s1, dfb1, entry_size1, {.page_id = itileB}, {});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary_2_0.cpp
@@ -47,8 +47,8 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
-        // Noc::TxnIdMode::ENABLED is only declared on Quasar.
-        noc.async_read<Noc::TxnIdMode::ENABLED>(src_dram, dfb, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
+        // NocOptions::TXN_ID uses the DFB-integrated trid path on Quasar.
+        noc.async_read<NocOptions::TXN_ID>(src_dram, dfb, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});
 #else
         dfb.reserve_back(ublock_size_tiles);
         noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = tlocal_src_addr}, {});

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary_2_0.cpp
@@ -45,8 +45,8 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
 #ifdef ARCH_QUASAR
-        // Noc::TxnIdMode::ENABLED is only declared on Quasar.
-        noc.async_write<Noc::TxnIdMode::ENABLED>(dfb, dst_dram, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
+        // NocOptions::TXN_ID uses the DFB-integrated trid path on Quasar.
+        noc.async_write<NocOptions::TXN_ID>(dfb, dst_dram, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
 #else
         dfb.wait_front(ublock_size_tiles);
         noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = tlocal_dst_addr});
@@ -60,7 +60,7 @@ void kernel_main() {
 
 #ifdef ARCH_QUASAR
     // write_barrier is required on Quasar to flush transactions enqueued via
-    // Noc::TxnIdMode::ENABLED before the kernel exits.
+    // NocOptions::TXN_ID before the kernel exits.
     dfb.write_barrier(noc);
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
 #ifdef ARCH_QUASAR
                     // Quasar: implicit-sync write. The DFB credit advances via the per-trid
                     // completion ISR; no wait_front / barrier / pop_front required.
-                    noc.async_write<Noc::TxnIdMode::ENABLED>(dfb, s, {}, {.page_id = itileC});
+                    noc.async_write<NocOptions::TXN_ID>(dfb, s, {}, {.page_id = itileC});
 #else
                     dfb.wait_front(onetile);
                     noc.async_write(dfb, s, entry_size, {}, {.page_id = itileC});

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
@@ -82,31 +82,27 @@ void kernel_main() {
     // Maintains 2 outstanding DMAs throughout (interleaved consume/refill)
     for (uint32_t i = 0; i < total_iters - 1; i++) {
         experimental::dma_async_read_wait_n(tx_stream, 1);                        // A[i] ready (oldest)
-        noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_A);  // prev A acked
-        noc.async_write<Noc::TxnIdMode::ENABLED>(
+        noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_A});  // prev A acked
+        noc.async_write<NocOptions::TXN_ID>(
             src,
             dst,
             half_buffer_bytes,
             {.addr = dst_A},
             {.noc_x = tensix_noc_x_start, .noc_y = tensix_noc_y_start, .addr = tensix_dst_A},
-            NOC_UNICAST_WRITE_VC,
-            trid_A);
-        noc.async_writes_flushed<Noc::ResponseMode::NON_POSTED, Noc::BarrierMode::TXN_ID>(
-            trid_A);
+            NocOptVals{.trid = trid_A});
+        noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = trid_A});
         experimental::dma_async_read(tx_stream, src_A, dst_A, half_buffer_bytes);  // refill A
 
         experimental::dma_async_read_wait_n(tx_stream, 1);                        // B[i] ready (oldest now)
-        noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_B);  // prev B acked
-        noc.async_write<Noc::TxnIdMode::ENABLED>(
+        noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_B});  // prev B acked
+        noc.async_write<NocOptions::TXN_ID>(
             src,
             dst,
             half_buffer_bytes,
             {.addr = dst_B},
             {.noc_x = tensix_noc_x_start, .noc_y = tensix_noc_y_start, .addr = tensix_dst_B},
-            NOC_UNICAST_WRITE_VC,
-            trid_B);
-        noc.async_writes_flushed<Noc::ResponseMode::NON_POSTED, Noc::BarrierMode::TXN_ID>(
-            trid_B);
+            NocOptVals{.trid = trid_B});
+        noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = trid_B});
         experimental::dma_async_read(tx_stream, src_B, dst_B, half_buffer_bytes);  // refill B
         src_A += num_bytes;
         src_B += num_bytes;
@@ -114,8 +110,8 @@ void kernel_main() {
 
     // Final A: oldest of the two outstanding reads is A[last].
     experimental::dma_async_read_wait_n(tx_stream, 1);                        // A[last] ready
-    noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_A);  // prev A acked
-    noc.async_write<Noc::TxnIdMode::ENABLED>(
+    noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_A});  // prev A acked
+    noc.async_write<NocOptions::TXN_ID>(
         src,
         dst,
         half_buffer_bytes,
@@ -126,8 +122,8 @@ void kernel_main() {
 
     // Final B: drain the remaining outstanding read.
     experimental::dma_async_read_wait_n(tx_stream, 0);                        // B[last] ready
-    noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_B);  // prev B acked
-    noc.async_write<Noc::TxnIdMode::ENABLED>(
+    noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_B});  // prev B acked
+    noc.async_write<NocOptions::TXN_ID>(
         src,
         dst,
         half_buffer_bytes,
@@ -137,8 +133,8 @@ void kernel_main() {
         trid_B);
 
     // Drain: wait for the final two NOC writes to be acked.
-    noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_A);
-    noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid_B);
+    noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_A});
+    noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_B});
 
     uint64_t end = get_timestamp();
     uint64_t total_time = end - start;

--- a/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/tensix_read_from_drisc.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
     UnicastEndpoint src;
     Noc noc;
     uint32_t reg_addr = STREAM_REG_ADDR(stream_id, stream_reg);
-    noc.inline_dw_write<Noc::TxnIdMode::DISABLED, InlineWriteDst::REG>(
+    noc.inline_dw_write<NocOptions::INLINE_REG>(
         src, value_to_write, {.noc_x = drisc_noc_x, .noc_y = drisc_noc_y, .addr = reg_addr});
     noc.async_write_barrier();
 

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -110,7 +110,7 @@ public:
 
 #ifndef COMPILE_FOR_TRISC
     // This should not be used on WH/BH if the read into/write out of the DFB uses transaction ids because the transaction ids are not tracked.
-    // Instead, use noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(trid)
+    // Instead, use noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid})
     void write_barrier(const Noc &noc) const { write_barrier_impl(noc); }
 #endif
 

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -22,6 +22,51 @@ struct noc_traits_t {
 };
 
 /**
+ * @brief Compile-time bit-flags that control optional NoC transaction behaviours.
+ *
+ * Flags can be OR-combined at a template call site:
+ *   noc.async_write<NocOptions::TXN_ID | NocOptions::CUSTOM_VC>(...)
+ *
+ * | Flag            |Meaning                                                                                       |
+ * |-----------------|----------------------------------------------------------------------------------------------|
+ * | TXN_ID          | Tag transaction or barrier with NocOptVals::trid (default: 0)                                   |
+ * | POSTED          | Fire-and-forget; no ack expected from receiver (default: false (non-posted))                    |
+ * | CUSTOM_VC       | Use NocOptVals::vc instead of default VC                                                        |
+ * | MCAST_INCL_SRC  | Multicast loopback: include sender in mcast group (default: false)                           |
+ * | INLINE_L1       | inline_dw_write targets L1 memory                                                            |
+ * | INLINE_REG      | inline_dw_write targets a stream register                                                    |
+ */
+enum class NocOptions : uint32_t {
+    DEFAULT        = 0,
+    TXN_ID         = 1u << 0,
+    POSTED         = 1u << 1,
+    CUSTOM_VC      = 1u << 2,
+    MCAST_INCL_SRC = 1u << 3,
+    INLINE_L1      = 1u << 4,
+    INLINE_REG     = 1u << 5,
+};
+
+constexpr NocOptions operator|(NocOptions a, NocOptions b) noexcept {
+    return static_cast<NocOptions>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+
+constexpr bool has_flag(NocOptions opts, NocOptions flag) noexcept {
+    return (static_cast<uint32_t>(opts) & static_cast<uint32_t>(flag)) != 0;
+}
+
+/**
+ * @brief Runtime values associated with optional NocOptions flags.
+ *
+ * Fields are only inspected when the corresponding NocOptions flag is set:
+ *   - vc  : used when NocOptions::CUSTOM_VC is set
+ *   - trid: used when NocOptions::TXN_ID is set
+ */
+struct NocOptVals {
+    uint32_t vc   = NOC_UNICAST_WRITE_VC;
+    uint32_t trid = 0;
+};
+
+/**
  * @brief Noc class that provides a high-level interface for asynchronous read and write operations.
  *
  * It abstracts the details of source and destination address calculations.
@@ -29,16 +74,6 @@ struct noc_traits_t {
 class Noc {
 public:
     enum class AddressType { NOC, LOCAL_L1 };
-
-    enum class TxnIdMode { ENABLED, DISABLED };
-
-    enum class ResponseMode { NON_POSTED, POSTED };
-
-    enum class BarrierMode { TXN_ID, FULL };
-
-    enum class McastMode { INCLUDE_SRC, EXCLUDE_SRC };
-
-    enum class VcSelection { DEFAULT, CUSTOM };
 
     static constexpr uint32_t INVALID_TXN_ID = 0xFFFFFFFF;
 
@@ -99,14 +134,14 @@ public:
      * @param size_bytes Size of the data transfer in bytes
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
-     * @param read_req_vc Virtual channel to use for the read request (default: NOC_UNICAST_WRITE_VC)
-     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
-     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC;
+     *                 noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
      */
     template <
-        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         bool enable_noc_tracing = true,
         typename Src,
@@ -117,44 +152,51 @@ public:
         uint32_t size_bytes,
         const src_args_t<Src>& src_args,
         const dst_args_t<Dst>& dst_args,
-        uint32_t read_req_vc = NOC_UNICAST_WRITE_VC,
-        uint32_t trid = INVALID_TXN_ID) const {
-        if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
-            noc_async_read_set_trid(trid, noc_id_);
-            while (noc_available_transactions(noc_id_, trid) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2)) {
+        const NocOptVals& noc_opts = {}) const {
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            noc_async_read_set_trid(noc_opts.trid, noc_id_);
+            while (noc_available_transactions(noc_id_, noc_opts.trid) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2)) {
                 // Busy-wait until sufficient transactions are available for the configured transaction ID.
             }
         }
+        const uint32_t req_vc = has_flag(opts, NocOptions::CUSTOM_VC)
+                                    ? static_cast<uint32_t>(noc_opts.vc)
+                                    : NOC_UNICAST_WRITE_VC;
         noc_async_read<max_page_size, enable_noc_tracing>(
             get_src_ptr<AddressType::NOC>(src, src_args),
             get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
             size_bytes,
             noc_id_,
-            read_req_vc
-        );
+            req_vc);
     }
 
     /**
-     * @brief Sets the stateful registers for an asynchronous read from a specified source
+     * @brief Sets the stateful registers for an asynchronous read from a specified source.
      *
-     * This is used to set up state for async_read_with_state, use async_read instead if state preservation is not
-     * needed.
+     * This is used to set up state for async_read_with_state; use async_read instead if state
+     * preservation is not needed.
+     *
+     * When NocOptions::TXN_ID is set, noc_opts.trid is written to the sticky NOC_PACKET_TAG register
+     * once here so that every subsequent async_read_with_state<NocOptions::TXN_ID> in the block
+     * inherits it.
      *
      * @see async_read_with_state and async_read_barrier.
      *
      * @param src Source object (e.g., TensorAccessor)
      * @param size_bytes Size of the data transfer in bytes
      * @param src_args Additional arguments for source address calculation
-     * @param vc Virtual channel to use for the read request when vc_selection is CUSTOM (default: 0)
-     * @tparam vc_selection Whether to use a custom specified virtual channel (default: DEFAULT)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC;
+     *                 noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      */
     template <
-        VcSelection vc_selection = VcSelection::DEFAULT,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         typename Src>
     void set_async_read_state(
-        const Src& src, uint32_t size_bytes, const src_args_t<Src>& src_args, uint8_t vc = 0) const {
+        const Src& src, uint32_t size_bytes, const src_args_t<Src>& src_args,
+        const NocOptVals& noc_opts = {}) const {
         auto src_noc_addr = get_src_ptr<AddressType::NOC>(src, src_args);
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         RECORD_NOC_EVENT_WITH_ADDR(
@@ -162,36 +204,43 @@ public:
             0,
             src_noc_addr,
             size_bytes,
-            (vc_selection == VcSelection::CUSTOM) ? static_cast<int8_t>(vc) : -1,
+            has_flag(opts, NocOptions::CUSTOM_VC) ? static_cast<int8_t>(noc_opts.vc) : -1,
             false,
             noc_id_);
 
         WAYPOINT("NASW");
-        ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, vc_selection == VcSelection::CUSTOM>(
-            noc_id_, read_cmd_buf, src_noc_addr, size_bytes, vc);
+        ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, has_flag(opts, NocOptions::CUSTOM_VC)>(
+            noc_id_, read_cmd_buf, src_noc_addr, size_bytes, noc_opts.vc);
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            noc_async_read_set_trid(noc_opts.trid, noc_id_);
+        }
         WAYPOINT("NASD");
     }
 
     /**
-     * @brief Initiates an asynchronous read from a specified source based on previously set state
+     * @brief Initiates an asynchronous read from a specified source based on previously set state.
      *
-     * This must be preceded by a call to set_async_read_state where Src is at same noc location as the one used in
-     * set_async_read_state
+     * This must be preceded by a call to set_async_read_state where Src is at the same NoC location.
+     *
+     * When NocOptions::TXN_ID is set (requires max_page_size <= NOC_MAX_BURST_SIZE), noc_opts.trid
+     * must match the trid passed to set_async_read_state. The NOC_PACKET_TAG register is sticky —
+     * it was set once in set_async_read_state and is not re-written here.
      *
      * @see set_async_read_state and async_read_barrier.
      *
      * @param src Source object (e.g., TensorAccessor)
      * @param dst Destination object (e.g., local L1 memory)
-     * @param size_bytes Size of the data transfer in bytes, this must be equal to the value set in set_async_read_state
-     * if max_page_size <= NOC_MAX_BURST_SIZE
+     * @param size_bytes Size of the data transfer in bytes; must equal the value set in
+     *                   set_async_read_state if max_page_size <= NOC_MAX_BURST_SIZE
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
-     * @param vc Virtual channel to use for the read request when vc_selection is CUSTOM (default: 0)
-     * @tparam vc_selection Whether to use a custom specified virtual channel (default: DEFAULT)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC;
+     *                 noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      */
     template <
-        VcSelection vc_selection = VcSelection::DEFAULT,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         typename Src,
         typename Dst>
@@ -201,13 +250,24 @@ public:
         uint32_t size_bytes,
         const src_args_t<Src>& src_args,
         const dst_args_t<Dst>& dst_args,
-        uint8_t vc = 0) const {
+        const NocOptVals& noc_opts = {}) const {
         // TODO (#33966): Need to make sure set state was called and with same template params
-        if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-            noc_async_read_one_packet_with_state<true, vc_selection == VcSelection::CUSTOM>(
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            static_assert(
+                max_page_size <= NOC_MAX_BURST_SIZE,
+                "NocOptions::TXN_ID for async_read_with_state requires one-packet mode "
+                "(max_page_size <= NOC_MAX_BURST_SIZE)");
+            noc_async_read_one_packet_with_state_with_trid(
+                0,
                 (uint32_t)get_src_ptr<AddressType::NOC>(src, src_args),
                 get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
-                vc,
+                noc_opts.trid,
+                noc_id_);
+        } else if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+            noc_async_read_one_packet_with_state<true, has_flag(opts, NocOptions::CUSTOM_VC)>(
+                (uint32_t)get_src_ptr<AddressType::NOC>(src, src_args),
+                get_dst_ptr<AddressType::LOCAL_L1>(dst, dst_args),
+                noc_opts.vc,
                 noc_id_);
         } else {
             noc_async_read_with_state(
@@ -227,17 +287,14 @@ public:
      * @param size_bytes Size of the data transfer in bytes
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
-     * @param vc Virtual channel to use for the write transaction (default: NOC_UNICAST_WRITE_VC)
-     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
-     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
-     * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
-     * NON_POSTED)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC;
+     *                 noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
      */
     template <
-        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
-        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         bool enable_noc_tracing = true,
         typename Src,
@@ -248,15 +305,13 @@ public:
         uint32_t size_bytes,
         const src_args_t<Src>& src_args,
         const dst_args_t<Dst>& dst_args,
-        uint32_t vc = NOC_UNICAST_WRITE_VC,
-        uint32_t trid = INVALID_TXN_ID) const {
-        constexpr bool posted = response_mode == ResponseMode::POSTED;
+        const NocOptVals& noc_opts = {}) const {
+        constexpr bool posted = has_flag(opts, NocOptions::POSTED);
 
-        if constexpr (txn_id_mode == TxnIdMode::ENABLED) {
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
             // TODO (#31535): Need to add check in ncrisc_noc_fast_write_any_len to ensure outstanding transaction
             // register does not overflow
             WAYPOINT("NAWW");
-            ASSERT(trid != INVALID_TXN_ID);
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
             if constexpr (enable_noc_tracing) {
@@ -265,6 +320,9 @@ public:
             }
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_noc_addr, src_addr, size_bytes);
             constexpr bool one_packet = max_page_size <= NOC_MAX_BURST_SIZE;
+            const uint32_t vc = has_flag(opts, NocOptions::CUSTOM_VC)
+                                    ? static_cast<uint32_t>(noc_opts.vc)
+                                    : NOC_UNICAST_WRITE_VC;
             ncrisc_noc_fast_write_any_len<noc_mode, true, one_packet>(
                 noc_id_,
                 write_cmd_buf,
@@ -277,9 +335,12 @@ public:
                 1,      // num_dests
                 true,   // multicast_path_reserve
                 posted,
-                trid);
+                noc_opts.trid);
             WAYPOINT("NWPD");
         } else {
+            const uint32_t vc = has_flag(opts, NocOptions::CUSTOM_VC)
+                                    ? static_cast<uint32_t>(noc_opts.vc)
+                                    : NOC_UNICAST_WRITE_VC;
             noc_async_write<max_page_size, enable_noc_tracing, posted>(
                 get_src_ptr<AddressType::LOCAL_L1>(src, src_args),
                 get_dst_ptr<AddressType::NOC>(dst, dst_args),
@@ -302,19 +363,16 @@ public:
      * @param num_dsts Number of destinations that the multicast source is targeting
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
-     * @param linked
-     * @param trid Transaction ID to use when transaction id mode is enabled (default: INVALID_TXN_ID)
-     * @tparam mcast_mode Indicates whether the sender is included in the multicast destinations
-     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
-     * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
-     * NON_POSTED)
+     * @param linked Whether to link this operation with the next (default: false)
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT).
+     *             NocOptions::MCAST_INCL_SRC includes the sender in the multicast group.
+     *             NocOptions::TXN_ID is not supported (static_assert).
+     *             NocOptions::POSTED is not supported (static_assert).
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      * @tparam enable_noc_tracing Enable NoC tracing for debugging (default: true)
      */
     template <
-        McastMode mcast_mode = McastMode::EXCLUDE_SRC,
-        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
-        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         bool enable_noc_tracing = true,
         typename Src,
@@ -326,74 +384,88 @@ public:
         uint32_t num_dsts,
         const src_args_t<Src>& src_args,
         const dst_args_mcast_t<Dst>& dst_args,
-        bool linked = false,
-        uint32_t trid = INVALID_TXN_ID) const {
-        static_assert(txn_id_mode == TxnIdMode::DISABLED, "Mcasts with transaction id are not supported yet");
+        bool linked = false) const {
+        static_assert(!has_flag(opts, NocOptions::TXN_ID), "Mcasts with transaction id are not supported yet");
         static_assert(
-            response_mode == ResponseMode::NON_POSTED,
+            !has_flag(opts, NocOptions::POSTED),
             "Mcasts with posted transactions are not supported");  // TODO: Make this an arch specific assertion
 
         auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
         auto dst_noc_addr = get_dst_ptr_mcast<AddressType::NOC>(dst, dst_args);
-        if constexpr (mcast_mode == McastMode::INCLUDE_SRC) {
+        if constexpr (has_flag(opts, NocOptions::MCAST_INCL_SRC)) {
             noc_async_write_multicast_loopback_src(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
-        } else if constexpr (mcast_mode == McastMode::EXCLUDE_SRC) {
+        } else {
             noc_async_write_multicast<max_page_size>(src_addr, dst_noc_addr, size_bytes, num_dsts, linked, noc_id_);
         }
     }
 
     /**
-     * @brief Sets the stateful registers for an asynchronous write
+     * @brief Sets the stateful registers for an asynchronous write.
      *
-     * This function is used to set up the state for async_write_with_state, async_write can be used if state
-     * preservation is not needed
+     * This function is used to set up the state for async_write_with_state; async_write can be used
+     * if state preservation is not needed.
+     *
+     * NocOptions::TXN_ID is not supported for stateful writes (no underlying 1.0 primitive exists);
+     * use async_write<NocOptions::TXN_ID> for non-stateful writes with a transaction ID.
      *
      * @see async_write_with_state and async_write_barrier.
      *
      * @param dst Destination object (e.g., local L1 memory)
      * @param size_bytes Size of the data transfer in bytes
      * @param dst_args Additional arguments for destination address calculation
-     * @param vc Virtual channel to use for the write request (default: NOC_UNICAST_WRITE_VC)
-     * @tparam response_mode Whether the write is posted or non-posted (default: NON_POSTED)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT).
+     *             NocOptions::TXN_ID is not supported (static_assert).
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      */
     template <
-        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         typename Dst>
     void set_async_write_state(
-        const Dst& dst, uint32_t size_bytes, const dst_args_t<Dst>& dst_args, uint8_t vc = NOC_UNICAST_WRITE_VC) const {
+        const Dst& dst, uint32_t size_bytes, const dst_args_t<Dst>& dst_args,
+        const NocOptVals& noc_opts = {}) const {
+        static_assert(
+            !has_flag(opts, NocOptions::TXN_ID),
+            "NocOptions::TXN_ID is not supported for set_async_write_state; "
+            "use async_write<NocOptions::TXN_ID> for non-stateful writes with a transaction ID");
+        constexpr bool posted = has_flag(opts, NocOptions::POSTED);
         DEBUG_SANITIZE_NO_LINKED_TRANSACTION(noc_id_, DEBUG_SANITIZE_NOC_UNICAST);
         auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
-        constexpr bool posted = response_mode == ResponseMode::POSTED;
-        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size_bytes, vc, posted, noc_id_);
+        RECORD_NOC_EVENT_WITH_ADDR(
+            NocEventType::WRITE_SET_STATE, 0, dst_noc_addr, size_bytes, noc_opts.vc, posted, noc_id_);
 
         WAYPOINT("NWPW");
         ncrisc_noc_write_set_state<posted, max_page_size <= NOC_MAX_BURST_SIZE>(
-            noc_id_, write_cmd_buf, dst_noc_addr, size_bytes, vc);
+            noc_id_, write_cmd_buf, dst_noc_addr, size_bytes, noc_opts.vc);
         WAYPOINT("NWPD");
     }
 
     /**
-     * @brief Initiates an asynchronous write to a specified destination based on previously set state
+     * @brief Initiates an asynchronous write to a specified destination based on previously set state.
      *
-     * This must be preceded by a call to set_async_write_state where Dst is at same noc location as the one used in
-     * set_async_write_state
+     * This must be preceded by a call to set_async_write_state where Dst is at the same NoC location.
+     *
+     * NocOptions::TXN_ID is not supported for stateful writes. The noc_opts parameter is accepted for
+     * API symmetry with async_read_with_state but its vc field is not used (vc is sticky from
+     * set_async_write_state).
      *
      * @see set_async_write_state and async_write_barrier.
      *
      * @param src Source object (e.g., local L1 memory)
      * @param dst Destination object (e.g., TensorAccessor)
-     * @param size_bytes Size of the data transfer in bytes, this must be equal to the value set in
-     * set_async_write_state if max_page_size <= NOC_MAX_BURST_SIZE
+     * @param size_bytes Size of the data transfer in bytes; must equal the value set in
+     *                   set_async_write_state if max_page_size <= NOC_MAX_BURST_SIZE
      * @param src_args Additional arguments for source address calculation
      * @param dst_args Additional arguments for destination address calculation
-     * @param vc Virtual channel to use for the write request (default: NOC_UNICAST_WRITE_VC)
-     * @tparam response_mode Whether the write is posted or non-posted (default: NON_POSTED)
+     * @param noc_opts Optional NoC parameters (default: {}); accepted for symmetry, vc is sticky from
+     *                 set_async_write_state
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT).
+     *             NocOptions::TXN_ID is not supported (static_assert).
      * @tparam max_page_size Maximum page size for the transfer (default: NOC_MAX_BURST_SIZE + 1)
      */
     template <
-        ResponseMode response_mode = ResponseMode::NON_POSTED,
+        NocOptions opts = NocOptions::DEFAULT,
         uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1,
         typename Src,
         typename Dst>
@@ -403,8 +475,12 @@ public:
         uint32_t size_bytes,
         const src_args_t<Src>& src_args,
         const dst_args_t<Dst>& dst_args,
-        uint8_t vc = NOC_UNICAST_WRITE_VC) const {
-        constexpr bool posted = response_mode == ResponseMode::POSTED;
+        const NocOptVals& noc_opts = {}) const {
+        static_assert(
+            !has_flag(opts, NocOptions::TXN_ID),
+            "NocOptions::TXN_ID is not supported for async_write_with_state; "
+            "use async_write<NocOptions::TXN_ID> for non-stateful writes with a transaction ID");
+        constexpr bool posted = has_flag(opts, NocOptions::POSTED);
 
         if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
             noc_async_write_one_packet_with_state<posted>(
@@ -444,38 +520,42 @@ public:
      * @param val The value to be written
      * @param dst_args Additional arguments for destination address calculation
      * @param be Byte-enable mask controls which bytes are written to at an L1 destination
-     * @param vc Virtual channel to use for the transaction
-     * @param trid Transaction ID to use for the transaction (default: INVALID_TXN_ID)
-     * @tparam txn_id_mode Whether transaction id will be used for the noc transaction (default: DISABLED)
-     * @tparam dst_type Whether the write is targeting L1 or a Stream Register
-     * @tparam response_mode Posted noc transactions do not get ack from receiver, non-posted ones do (default:
-     * NON_POSTED)
+     * @param noc_opts Optional NoC parameters: noc_opts.vc used when NocOptions::CUSTOM_VC (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT).
+     *             NocOptions::TXN_ID is not supported (static_assert).
+     *             NocOptions::INLINE_L1 targets L1; otherwise targets stream register.
+     *             NocOptions::POSTED uses fire-and-forget semantics.
      */
-    template <
-        TxnIdMode txn_id_mode = TxnIdMode::DISABLED,
-        InlineWriteDst dst_type = InlineWriteDst::DEFAULT,
-        ResponseMode response_mode = ResponseMode::NON_POSTED,
-        typename Dst>
+    template <NocOptions opts = NocOptions::DEFAULT, typename Dst>
     void inline_dw_write(
         const Dst& dst,
         uint32_t val,
         const dst_args_t<Dst>& dst_args,
         uint8_t be = 0xF,
-        uint32_t vc = NOC_UNICAST_WRITE_VC,
-        uint32_t trid = INVALID_TXN_ID) const {
-        static_assert(txn_id_mode == TxnIdMode::DISABLED);
+        const NocOptVals& noc_opts = {}) const {
+        static_assert(!has_flag(opts, NocOptions::TXN_ID), "TxnId is not supported for inline_dw_write");
+        static_assert(
+            !(has_flag(opts, NocOptions::INLINE_L1) && has_flag(opts, NocOptions::INLINE_REG)),
+            "INLINE_L1 and INLINE_REG are mutually exclusive in inline_dw_write");
         static_assert(!std::is_same_v<Dst, MulticastEndpoint>);  // Can be removed when #30023 is resolved
         WAYPOINT("NWIW");
         auto dst_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
         DEBUG_SANITIZE_NOC_ADDR(noc_id_, dst_addr, 4);
         DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id_, dst_addr, 4);
+
+        constexpr auto dst_type = has_flag(opts, NocOptions::INLINE_L1)  ? InlineWriteDst::L1
+                                : has_flag(opts, NocOptions::INLINE_REG) ? InlineWriteDst::REG
+                                                                         : InlineWriteDst::DEFAULT;
 #if defined(ARCH_BLACKHOLE) && defined(WATCHER_ENABLED)
-        if constexpr (dst_type == InlineWriteDst::L1) {
+        if constexpr (has_flag(opts, NocOptions::INLINE_L1)) {
             uint32_t src_addr = noc_get_interim_inline_value_addr(noc_id_, dst_addr);
             DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id_, dst_addr, src_addr, 4);
         }
 #endif
 
+        const uint32_t vc = has_flag(opts, NocOptions::CUSTOM_VC)
+                                ? static_cast<uint32_t>(noc_opts.vc)
+                                : NOC_UNICAST_WRITE_VC;
         noc_fast_write_dw_inline<noc_mode, dst_type>(
             noc_id_,
             write_at_cmd_buf,
@@ -484,73 +564,87 @@ public:
             be,
             vc,
             std::is_same_v<Dst, MulticastEndpoint>,
-            response_mode == ResponseMode::POSTED);
+            has_flag(opts, NocOptions::POSTED));
         WAYPOINT("NWID");
     }
 
-    /** @brief Initiates a read barrier for synchronization.
+    /**
+     * @brief Non-blocking poll: returns true if all reads tagged with the given transaction ID have completed.
+     *
+     * Equivalent to checking whether the hardware outstanding-reads counter for trid has reached zero.
+     * Intended for implementing non-blocking, per-slot progress tracking — issue reads with different trids,
+     * then poll each slot independently rather than stalling on a full barrier.
+     *
+     * @param trid Transaction ID to check (must match what was passed to async_read<NocOptions::TXN_ID>)
+     */
+    bool is_read_trid_flushed(uint32_t trid) const {
+        return ncrisc_noc_read_with_transaction_id_flushed(noc_id_, trid);
+    }
+
+    /** @brief Waits for all outstanding read transactions to complete.
      *
      * This blocking call waits for all the outstanding enqueued read transactions
      * issued on the current Tensix core to complete.
      * After returning from this call there will be no outstanding read transactions for this noc for the current core.
      *
-     * @param trid Transaction ID to wait on for outstanding reads (default: INVALID_TXN_ID for full barrier)
-     * @tparam barrier_type Indicates whether to issue a full barrier or on a transaction id
+     * When NocOptions::TXN_ID is set, only waits for reads tagged with noc_opts.trid.
+     *
+     * @param noc_opts Optional NoC parameters: noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      */
-    template <BarrierMode barrier_type = BarrierMode::FULL>
-    void async_read_barrier(uint32_t trid = INVALID_TXN_ID) const {
-        if constexpr (barrier_type == BarrierMode::FULL) {
+    template <NocOptions opts = NocOptions::DEFAULT>
+    void async_read_barrier(const NocOptVals& noc_opts = {}) const {
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            noc_async_read_barrier_with_trid(noc_opts.trid, noc_id_);
+        } else {
             noc_async_read_barrier(noc_id_);
-        } else if constexpr (barrier_type == BarrierMode::TXN_ID) {
-            ASSERT(trid != INVALID_TXN_ID);
-            noc_async_read_barrier_with_trid(trid, noc_id_);
         }
     }
 
-    /** @brief Initiates a write barrier for synchronization.
+    /** @brief Waits for all outstanding write transactions to complete.
      *
      * This blocking call waits for all the outstanding enqueued write transactions
      * issued on the current Tensix core to complete.
      * After returning from this call there will be no outstanding write transactions for this noc for the current core.
      *
-     * @param trid Transaction ID to wait on for outstanding writes (default: INVALID_TXN_ID for full barrier)
-     * @tparam barrier_type Indicates whether to issue a full barrier or on a transaction id
+     * When NocOptions::TXN_ID is set, only waits for writes tagged with noc_opts.trid.
+     *
+     * @param noc_opts Optional NoC parameters: noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      */
-    template <BarrierMode barrier_type = BarrierMode::FULL>
-    void async_write_barrier(uint32_t trid = INVALID_TXN_ID) const {
-        if constexpr (barrier_type == BarrierMode::FULL) {
+    template <NocOptions opts = NocOptions::DEFAULT>
+    void async_write_barrier(const NocOptVals& noc_opts = {}) const {
+        if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            noc_async_write_barrier_with_trid(noc_opts.trid, noc_id_);
+        } else {
             noc_async_write_barrier(noc_id_);
-        } else if constexpr (barrier_type == BarrierMode::TXN_ID) {
-            ASSERT(trid != INVALID_TXN_ID);
-            noc_async_write_barrier_with_trid(trid, noc_id_);
         }
     }
 
-    /** @brief Waits for all outstanding write transactions to be flushed.
+    /** @brief Waits for all outstanding write transactions to be flushed (departed, not necessarily completed).
      *
      * This blocking call waits for all the outstanding enqueued write transactions
      * issued on the current Tensix core to depart, but will not wait for them to complete.
-     * Can wait on posted or non-posted transactions.
      *
-     * @param trid Transaction ID to wait on for outstanding writes (default: INVALID_TXN_ID for full barrier)
-     * @tparam response_mode Indicates whether to wait for outstanding posted or non-posted transactions (default:
-     * NON_POSTED)
-     * @tparam barrier_type Indicates whether to issue a full barrier or on a transaction id
+     * When NocOptions::POSTED is set, waits for posted (fire-and-forget) writes to flush.
+     * When NocOptions::TXN_ID is set, only waits for writes tagged with noc_opts.trid.
+     *
+     * @param noc_opts Optional NoC parameters: noc_opts.trid used when NocOptions::TXN_ID (default: {})
+     * @tparam opts Bit-flag combination of NocOptions (default: DEFAULT)
      */
     // TODO (#31405): there is no variant of this for transaction ids. Use
     // ncrisc_noc_nonposted_write_with_transaction_id_sent but none for dynamic noc version exists atm.
-    template <ResponseMode response_mode = ResponseMode::NON_POSTED, BarrierMode barrier_type = BarrierMode::FULL>
-    void async_writes_flushed(uint32_t trid = INVALID_TXN_ID) const {
-        if constexpr (response_mode == ResponseMode::POSTED) {
-            static_assert(barrier_type == BarrierMode::FULL);
+    template <NocOptions opts = NocOptions::DEFAULT>
+    void async_writes_flushed(const NocOptVals& noc_opts = {}) const {
+        if constexpr (has_flag(opts, NocOptions::POSTED)) {
+            static_assert(!has_flag(opts, NocOptions::TXN_ID), "Posted writes flushed does not support TXN_ID");
             noc_async_posted_writes_flushed(noc_id_);
-        } else {  // ResponseMode::NON_POSTED
-            if constexpr (barrier_type == BarrierMode::FULL) {
-                noc_async_writes_flushed(noc_id_);
-            } else if constexpr (barrier_type == BarrierMode::TXN_ID) {
+        } else {  // non-posted
+            if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
                 static_assert(noc_mode != DM_DYNAMIC_NOC);  // TODO make an issue for this
-                ASSERT(trid != INVALID_TXN_ID);
-                noc_async_write_flushed_with_trid(trid, noc_id_);
+                noc_async_write_flushed_with_trid(noc_opts.trid, noc_id_);
+            } else {
+                noc_async_writes_flushed(noc_id_);
             }
         }
     }
@@ -577,13 +671,13 @@ public:
     /**
      * @brief Implicit-sync read into a DataflowBuffer.
      *
-     * Selects this overload when TxnIdMode::ENABLED is specified and the destination is a DataflowBuffer
-     * No txn id is accepted here because the DataflowBuffer manages txn_ids internally
-     * via its private prepare/commit helpers
+     * Selects this overload when NocOptions::TXN_ID is specified and the destination is a DataflowBuffer.
+     * No trid is accepted here because the DataflowBuffer manages txn_ids internally
+     * via its private prepare/commit helpers.
      * Size of the read is not accepted here because the DataflowBuffer provides parameters for the read internally.
      */
-    template <TxnIdMode txn_id_mode, typename Src>
-    std::enable_if_t<txn_id_mode == TxnIdMode::ENABLED>
+    template <NocOptions opts, typename Src>
+    std::enable_if_t<has_flag(opts, NocOptions::TXN_ID)>
     async_read(
         const Src& src,
         DataflowBuffer& dst,
@@ -593,13 +687,13 @@ public:
     /**
      * @brief Implicit-sync write from a DataflowBuffer.
      *
-     * Selects this overload when TxnIdMode::ENABLED is specified and the source is a
-     * DataflowBuffer. No txn id is accepted here because the DataflowBuffer manages txn_ids internally
+     * Selects this overload when NocOptions::TXN_ID is specified and the source is a DataflowBuffer.
+     * No trid is accepted here because the DataflowBuffer manages txn_ids internally
      * via its private prepare/commit helpers.
      * Size of the write is not accepted here because the DataflowBuffer provides parameters for the write internally.
      */
-    template <TxnIdMode txn_id_mode, typename Dst>
-    std::enable_if_t<txn_id_mode == TxnIdMode::ENABLED>
+    template <NocOptions opts, typename Dst>
+    std::enable_if_t<has_flag(opts, NocOptions::TXN_ID)>
     async_write(
         DataflowBuffer& src,
         const Dst& dst,

--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -148,9 +148,10 @@ public:
      * @param noc_y_end The ending Y coordinate of the region (inclusive).
      * @param num_dests The number of destination cores in the region.
      * @param linked Whether to link this operation with the next (default is false).
-     * @tparam mcast_mode Indicates whether to include the sender in the multicast (default is EXCLUDE_SRC)
+     * @tparam opts NocOptions flags; set NocOptions::MCAST_INCL_SRC to include the sender in the multicast
+     *             (default is NocOptions::DEFAULT which excludes sender)
      */
-    template <Noc::McastMode mcast_mode = Noc::McastMode::EXCLUDE_SRC>
+    template <NocOptions opts = NocOptions::DEFAULT>
     void set_multicast(
         const Noc& noc,
         uint32_t noc_x_start,
@@ -162,9 +163,9 @@ public:
         const uint64_t multicast_addr =
             get_noc_multicast_addr(noc_x_start, noc_y_start, noc_x_end, noc_y_end, noc.get_noc_id());
         const uintptr_t src_l1_addr = get_l1_addr();
-        if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
+        if constexpr (has_flag(opts, NocOptions::MCAST_INCL_SRC)) {
             noc_semaphore_set_multicast_loopback_src(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
-        } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
+        } else {
             noc_semaphore_set_multicast(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         }
     }
@@ -183,10 +184,11 @@ public:
      * @param noc_y_end The ending Y coordinate of the region (inclusive).
      * @param num_dests The number of destination cores in the region.
      * @param linked Whether to link this operation with the next (default is false).
-     * @tparam mcast_mode Indicates whether to include the sender in the multicast (default is EXCLUDE_SRC).
+     * @tparam opts NocOptions flags; set NocOptions::MCAST_INCL_SRC to include the sender in the multicast
+     *             (default is NocOptions::DEFAULT which excludes sender)
      * @tparam dst_core_type Programmable core type of the destination (defaults to this Semaphore's core_type).
      */
-    template <Noc::McastMode mcast_mode = Noc::McastMode::EXCLUDE_SRC, ProgrammableCoreType dst_core_type = core_type>
+    template <NocOptions opts = NocOptions::DEFAULT, ProgrammableCoreType dst_core_type = core_type>
     void relay_multicast(
         const Noc& noc,
         const Semaphore<dst_core_type>& dst_sem,
@@ -200,9 +202,9 @@ public:
         const uint64_t multicast_addr = ::get_noc_multicast_addr(
             noc_x_start, noc_y_start, noc_x_end, noc_y_end, dst_sem.get_l1_addr(), noc.get_noc_id());
         const uintptr_t src_l1_addr = get_l1_addr();
-        if constexpr (mcast_mode == Noc::McastMode::INCLUDE_SRC) {
+        if constexpr (has_flag(opts, NocOptions::MCAST_INCL_SRC)) {
             noc_semaphore_set_multicast_loopback_src(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
-        } else if constexpr (mcast_mode == Noc::McastMode::EXCLUDE_SRC) {
+        } else {
             noc_semaphore_set_multicast(src_l1_addr, multicast_addr, num_dests, linked, noc.get_noc_id());
         }
     }

--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -566,7 +566,7 @@ public:
      * @param noc The NoC to use for the remote pointer update
      * @param page_size The new page size
      * @param noc_mode The NoC mode to use for the remote pointer update
-     * @param posted Whether to use posted semaphore inc
+     * @param posted Whether to use posted semaphore inc (default: true)
      * @param cmd_buf The command buffer to use for the remote pointer update
      */
     template <RemotePointerUpdate update_remote_pointer = RemotePointerUpdate::UPDATE_OVER_NOC>
@@ -574,14 +574,14 @@ public:
         Noc& noc,
         uint32_t page_size,
         uint8_t noc_mode = detail::default_noc_mode,
-        Noc::ResponseMode response_mode = Noc::ResponseMode::POSTED,
+        bool posted = true,
         uint8_t cmd_buf = detail::default_cmd_buf) {
         resize_remote_sender_cb_interface<update_remote_pointer == RemotePointerUpdate::UPDATE_OVER_NOC>(
             remote_cb_index_,
             page_size,
             noc.get_noc_id(),
             noc_mode,
-            response_mode == Noc::ResponseMode::POSTED,
+            posted,
             cmd_buf);
     }
 

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -293,7 +293,7 @@ inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
         return;
     } else {
         for (uint8_t i = 0; i < local_dfb_interface_.num_txn_ids; i++) {
-            noc.async_write_barrier<Noc::BarrierMode::TXN_ID>(local_dfb_interface_.txn_ids[i]);
+            noc.async_write_barrier<NocOptions::TXN_ID>({.trid = local_dfb_interface_.txn_ids[i]});
         }
     }
 }
@@ -362,8 +362,8 @@ inline void DataflowBuffer::commit_implicit_write() {
 // These are member functions of Noc but must be defined here because they need the complete
 // DataflowBuffer type (circular dependency: dataflow_buffer.h includes noc.h, not vice versa).
 
-template <Noc::TxnIdMode txn_id_mode, typename Src>
-std::enable_if_t<txn_id_mode == Noc::TxnIdMode::ENABLED>
+template <NocOptions opts, typename Src>
+std::enable_if_t<has_flag(opts, NocOptions::TXN_ID)>
 Noc::async_read(
     const Src& src,
     DataflowBuffer& dst,
@@ -382,8 +382,8 @@ Noc::async_read(
     dst.commit_implicit_read();
 }
 
-template <Noc::TxnIdMode txn_id_mode, typename Dst>
-std::enable_if_t<txn_id_mode == Noc::TxnIdMode::ENABLED>
+template <NocOptions opts, typename Dst>
+std::enable_if_t<has_flag(opts, NocOptions::TXN_ID)>
 Noc::async_write(
     DataflowBuffer& src,
     const Dst& dst,
@@ -406,7 +406,7 @@ Noc::async_write(
         false,   // linked
         1,       // num_dests
         true,    // multicast_path_reserve
-        false,   // posted == false (Noc::ResponseMode::NON_POSTED)
+        false,   // posted == false (NocOptions::POSTED not set)
         txn_id);
     src.commit_implicit_write();
 }

--- a/ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp
@@ -55,10 +55,10 @@ FORCE_INLINE void zero_tile(uint32_t write_addr) {
     UnicastEndpoint ep;
     const auto zeros_src = local_noc_addr(MEM_ZEROS_BASE, noc.get_noc_id());
 
-    noc.set_async_read_state<Noc::VcSelection::DEFAULT, MEM_ZEROS_SIZE>(ep, MEM_ZEROS_SIZE, zeros_src);
+    noc.set_async_read_state<NocOptions::DEFAULT, MEM_ZEROS_SIZE>(ep, MEM_ZEROS_SIZE, zeros_src);
 
     for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(
+        noc.async_read_with_state<NocOptions::DEFAULT, 1>(
             ep, ::CoreLocalMem<uint32_t>(write_addr), 0, zeros_src, {});
         write_addr += MEM_ZEROS_SIZE;
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -224,7 +224,7 @@ void kernel_main() {
 
                     // Multicast tilized activations to all reader cores (including self)
                     mcast_dst.addr = act_cb.get_write_ptr();
-                    noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                         tilized_src,
                         mcast_ep,
                         act_mcast_sender_size_bytes,
@@ -243,7 +243,7 @@ void kernel_main() {
                     // API uses the semaphore itself as both source and destination, so we can't
                     // clear the local value and wait for loopback — use write barrier instead.
                     act_mcast_receiver_sem.set(VALID);
-                    act_mcast_receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+                    act_mcast_receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                         noc,
                         mcast_rect.noc_x_start,
                         mcast_rect.noc_y_start,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -31,7 +31,7 @@ void multicast_data(
     auto src = use<CircularBuffer::AddrSelector::READ_PTR>(src_cb);
     if (is_receiver_core) {
         if constexpr (act_mcast_num_cores > 0) {
-            noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+            noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                 src, mcast_ep, total_bytes, act_mcast_num_cores + 1, {.offset_bytes = src_offset}, dst, true);
         } else {
             // Sender is the only receiver — can't use multicast loopback (hangs with 0 destinations)
@@ -293,7 +293,7 @@ void kernel_main() {
                         // We should also multicast VALID flag to destinations for receiver semaphore
                         if constexpr (act_mcast_num_cores) {
                             act_mcast_receiver_sem.set(VALID);
-                            act_mcast_receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+                            act_mcast_receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                                 noc,
                                 act_mcast_rect.noc_x_start,
                                 act_mcast_rect.noc_y_start,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -88,7 +88,7 @@ void kernel_main() {
                 CoreLocalMem<uint32_t> dst_mem(data_location);
                 // Use TensorAccessor directly to avoid address truncation
                 // Template parameter preserves one-packet fast path for page-sized transfers
-                noc.async_read<Noc::TxnIdMode::DISABLED, original_page_size_bytes>(
+                noc.async_read<NocOptions::DEFAULT, original_page_size_bytes>(
                     s,
                     dst_mem,
                     original_page_size_bytes,
@@ -117,10 +117,7 @@ void kernel_main() {
                     CoreLocalMem<uint32_t> src_mem(data_location);
                     // Use TensorAccessor directly to avoid address truncation
                     // Template parameter preserves one-packet fast path for page-sized transfers
-                    noc.async_write<
-                        Noc::TxnIdMode::DISABLED,
-                        Noc::ResponseMode::NON_POSTED,
-                        original_page_size_bytes>(
+                    noc.async_write<NocOptions::DEFAULT, original_page_size_bytes>(
                         src_mem,
                         d,
                         original_page_size_bytes,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -91,7 +91,7 @@ void kernel_main() {
         CoreLocalMem<uint32_t> dst_mem(data_location);
         // Use TensorAccessor directly to avoid address truncation
         // Template parameter preserves one-packet fast path for page-sized transfers
-        noc.async_read<Noc::TxnIdMode::DISABLED, original_page_size_bytes>(
+        noc.async_read<NocOptions::DEFAULT, original_page_size_bytes>(
             s, dst_mem, original_page_size_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
         cur_page_size = original_page_size_bytes;
         noc.async_read_barrier();
@@ -126,10 +126,7 @@ void kernel_main() {
             CoreLocalMem<uint32_t> src_mem(data_location);
             // Use TensorAccessor directly to avoid address truncation
             // Template parameter preserves one-packet fast path for writes up to max_write_size
-            noc.async_write<
-                Noc::TxnIdMode::DISABLED,
-                Noc::ResponseMode::NON_POSTED,
-                max_write_size>(
+            noc.async_write<NocOptions::DEFAULT, max_write_size>(
                 src_mem,
                 d,
                 to_write,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/kernels/writer.cpp
@@ -216,7 +216,7 @@ void kernel_main() {
                         const uint32_t weight_block_bytes = weight_tiles * tile_bytes;
                         const uint32_t local_addr = cb_weight.get_write_ptr();
                         MulticastEndpoint mcast_dst;
-                        noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>(
+                        noc.async_write_multicast(
                             use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_weight),
                             mcast_dst,
                             weight_block_bytes,
@@ -236,7 +236,7 @@ void kernel_main() {
                         // not a destination, so the data already in cb_weight from the DRAM read
                         // is what compute consumes.
                         weights_mcast_receiver_sem.set(VALID);
-                        weights_mcast_receiver_sem.set_multicast<Noc::McastMode::EXCLUDE_SRC>(
+                        weights_mcast_receiver_sem.set_multicast(
                             noc,
                             mcast_bbox_start_x,
                             mcast_bbox_start_y,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -240,7 +240,7 @@ void kernel_main() {
                                     if (in1_sender_in_receiver_grid) {
                                         // if sender is in receiver grid, num_dests will include source, since we are
                                         // copying to a different local CB as well
-                                        noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                        noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                                             mcast_src,
                                             cb_in1_obj,
                                             in1_mcast_sender_size_bytes,
@@ -254,7 +254,7 @@ void kernel_main() {
                                     } else {
                                         // if sender is not in receiver grid, do a regular multicast but from
                                         // in1_sharded_cb_addr
-                                        noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>(
+                                        noc.async_write_multicast(
                                             mcast_src,
                                             cb_in1_obj,
                                             in1_mcast_sender_size_bytes,
@@ -269,7 +269,7 @@ void kernel_main() {
                                 } else {  // mcast from l1_write_addr_in1 which is populated locally by copying from in1
                                           // sharded or interleaved
                                     CoreLocalMem<uint32_t> mcast_src(l1_write_addr_in1);
-                                    noc.async_write_multicast<Noc::McastMode::EXCLUDE_SRC>(
+                                    noc.async_write_multicast(
                                         mcast_src,
                                         cb_in1_obj,
                                         in1_mcast_sender_size_bytes,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -175,7 +175,7 @@ void kernel_main() {
                 }
 #ifndef SKIP_MCAST
                 MulticastEndpoint mcast_dst;
-                noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                     CoreLocalMem<uint32_t>(local_read_addr),
                     mcast_dst,
                     in0_block_size_bytes,
@@ -191,7 +191,7 @@ void kernel_main() {
                 // Set local semaphore to VALID. For single-core configurations, this is all we need.
                 receiver_sem.set(VALID);
                 if constexpr (in0_mcast_num_cores > 1) {
-                    receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+                    receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                         noc,
                         in0_mcast_dest_noc_start_x,
                         in0_mcast_dest_noc_start_y,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -267,7 +267,7 @@ void kernel_main() {
                                 } else {
                                     // multicast to every core in receiver grid
                                     MulticastEndpoint mcast_dst;
-                                    noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                                         CoreLocalMem<uint32_t>(in0_tensor_read_addr),
                                         mcast_dst,
                                         in0_block_size_bytes,
@@ -285,7 +285,7 @@ void kernel_main() {
                             // We should also multicast the flag to destinations
                             receiver_sem.set(VALID);
                             if constexpr (in0_mcast_num_cores > 1) {
-                                receiver_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+                                receiver_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                                     noc,
                                     in0_mcast_dest_noc_start_x,
                                     in0_mcast_dest_noc_start_y,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -176,15 +176,16 @@ void kernel_main() {
                     for (uint32_t w = 0; w < in1_block_width_num_pages; ++w) {
                         uint32_t curr_page_size =
                             w == in1_block_width_num_pages - 1 ? in1_block_page_size_last : in1_block_page_size;
-                        noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
-                            dram_bank, curr_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
-                        noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                        noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                            dram_bank, curr_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr},
+                            NocOptVals{.vc = vc});
+                        noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                             dram_bank,
                             CoreLocalMem<uint32_t>(l1_write_addr_in1),
                             curr_page_size,
                             {.bank_id = dram_bank_id, .addr = in1_tensor_addr + curr_l1_read_addr_in1},
                             {},
-                            vc);
+                            NocOptVals{.vc = vc});
                         curr_l1_read_addr_in1 += curr_page_size;
                         l1_write_addr_in1 += curr_page_size;
                     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -73,8 +73,8 @@ void kernel_main() {
     constexpr DataFormat in1_data_format = get_dataformat(cb_id_in1);
 
     AllocatorBank<AllocatorBankType::DRAM> dram_bank;
-    noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
-        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, vc);
+    noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+        dram_bank, in1_page_size, {.bank_id = dram_bank_id, .addr = in1_tensor_addr}, NocOptVals{.vc = vc});
 
 #ifdef ARCH_GRAYSKULL
     for (uint32_t block = 0; block < num_blocks; ++block) {
@@ -83,13 +83,13 @@ void kernel_main() {
         l1_write_addr_in1 = cb_in1.get_write_ptr();
 
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+            noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                 dram_bank,
                 CoreLocalMem<uint32_t>(l1_write_addr_in1),
                 in1_page_size,
                 {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
                 {},
-                vc);
+                NocOptVals{.vc = vc});
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
@@ -110,20 +110,19 @@ void kernel_main() {
     l1_write_addr_in1 = l1_write_addr_in1_start;
     for (uint32_t block = 0; block < num_blocks; ++block) {
         for (uint32_t h = 0; h < in1_num_pages; ++h) {
-            noc.async_read<Noc::TxnIdMode::ENABLED, NOC_MAX_BURST_SIZE>(
+            noc.async_read<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
                 dram_bank,
                 CoreLocalMem<uint32_t>(l1_write_addr_in1),
                 in1_page_size,
                 {.bank_id = dram_bank_id, .addr = in1_tensor_addr + l1_read_addr_in1},
                 {},
-                vc,
-                curr_block_trid);
+                NocOptVals{.vc = vc, .trid = curr_block_trid});
             l1_read_addr_in1 += in1_page_size;
             l1_write_addr_in1 += in1_page_size;
         }
 
         if (num_free_blocks_in_buffer == 2) {
-            noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
+            noc.async_read_barrier<NocOptions::TXN_ID>({.trid = static_cast<uint8_t>(block_trid_to_wait)});
             cb_in1.push_back(in1_block_num_tiles);
             // wait for next block trid
             block_trid_to_wait = block_trid_to_wait == 3 ? 1 : (block_trid_to_wait + 1);
@@ -143,7 +142,7 @@ void kernel_main() {
         l1_write_addr_in1 = l1_write_addr_in1_start + l1_write_addr_in1_offset;
     }
     // last block to wait
-    noc.async_read_barrier<Noc::BarrierMode::TXN_ID>(block_trid_to_wait);
+    noc.async_read_barrier<NocOptions::TXN_ID>({.trid = static_cast<uint8_t>(block_trid_to_wait)});
     cb_in1.push_back(in1_block_num_tiles);
 #endif
 
@@ -153,17 +152,17 @@ void kernel_main() {
     uint32_t l1_write_addr_in3 = cb_in3.get_write_ptr();
     uint32_t l1_read_addr_in3 = 0;
 
-    noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
-        dram_bank, in3_page_size, {.bank_id = dram_bank_id, .addr = in3_tensor_addr}, vc);
+    noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+        dram_bank, in3_page_size, {.bank_id = dram_bank_id, .addr = in3_tensor_addr}, NocOptVals{.vc = vc});
 
     for (uint32_t h = 0; h < in3_num_pages; ++h) {
-        noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+        noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
             dram_bank,
             CoreLocalMem<uint32_t>(l1_write_addr_in3),
             in3_page_size,
             {.bank_id = dram_bank_id, .addr = in3_tensor_addr + l1_read_addr_in3},
             {},
-            vc);
+            NocOptVals{.vc = vc});
         l1_read_addr_in3 += in3_page_size;
         l1_write_addr_in3 += in3_page_size;
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -297,11 +297,11 @@ void kernel_main() {
                             if (i == 0) {
                                 shard_base_addr += dram_tensor_start_offset;
                             }
-                            noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                 dram_bank,
                                 in1_single_tile_size_bytes,
                                 {.bank_id = shard_bank_id, .addr = shard_base_addr},
-                                vc);
+                                NocOptVals{.vc = vc});
 
                             uint32_t l1_read_addr_in1 = l1_read_addr_in1_offset;
                             uint32_t l1_write_addr_in1 = cb_in1.get_write_ptr() + l1_write_addr_in1_offset;
@@ -314,14 +314,14 @@ void kernel_main() {
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
                                     noc.async_read_with_state<
-                                        Noc::VcSelection::CUSTOM,
+                                        NocOptions::CUSTOM_VC,
                                         NOC_MAX_BURST_SIZE>(
                                         dram_bank,
                                         CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
                                         in1_single_tile_size_bytes,
                                         {.bank_id = shard_bank_id, .addr = shard_base_addr + l1_read_addr_in1_temp},
                                         {},
-                                        vc);
+                                        NocOptVals{.vc = vc});
                                     l1_read_addr_in1_temp += in1_single_tile_size_bytes;
                                     l1_write_addr_in1_temp += in1_single_tile_size_bytes;
                                 }
@@ -498,11 +498,11 @@ void kernel_main() {
                                                         bias_single_tile_size_bytes;
                             }
 
-                            noc.set_async_read_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                            noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                 bias_dram_bank,
                                 bias_single_tile_size_bytes,
                                 {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
-                                vc);
+                                NocOptVals{.vc = vc});
 
                             uint32_t l1_read_addr_in3 = 0;
                             l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
@@ -513,13 +513,13 @@ void kernel_main() {
                                 in1_single_tile_size_bytes;
 
                             for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc.async_read_with_state<Noc::VcSelection::CUSTOM, NOC_MAX_BURST_SIZE>(
+                                noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                     bias_dram_bank,
                                     CoreLocalMem<uint32_t>(l1_write_addr_in3),
                                     bias_single_tile_size_bytes,
                                     {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
                                     {},
-                                    vc);
+                                    NocOptVals{.vc = vc});
                                 l1_read_addr_in3 += bias_single_tile_size_bytes;
                                 l1_write_addr_in3 += bias_single_tile_size_bytes;
                                 in3_block_size_bytes += bias_single_tile_size_bytes;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -181,13 +181,13 @@ void kernel_main() {
 
                 UnicastEndpoint remote_ep;
                 for (uint32_t i = 1; i < num_mcast_cores; ++i) {
-                    noc.async_read<Noc::TxnIdMode::DISABLED, NOC_L1_READ_ALIGNMENT_BYTES>(
+                    noc.async_read<NocOptions::DEFAULT, NOC_L1_READ_ALIGNMENT_BYTES>(
                         remote_ep,
                         CoreLocalMem<uint32_t>(global_means_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
                         NOC_L1_READ_ALIGNMENT_BYTES,
                         {.noc_x = noc_coord_x[i], .noc_y = noc_coord_y[i], .addr = global_means_ptr},
                         {});
-                    noc.async_read<Noc::TxnIdMode::DISABLED, NOC_L1_READ_ALIGNMENT_BYTES>(
+                    noc.async_read<NocOptions::DEFAULT, NOC_L1_READ_ALIGNMENT_BYTES>(
                         remote_ep,
                         CoreLocalMem<uint32_t>(global_vars_ptr + i * NOC_L1_READ_ALIGNMENT_BYTES),
                         NOC_L1_READ_ALIGNMENT_BYTES,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -162,7 +162,7 @@ void kernel_main() {
                 cb_external_obj.reserve_back(num_blocks_first_stage * num_tiles_scaler);
                 uint32_t write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
-                    noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                    noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                         remote_ep,
                         cb_external_obj,
                         num_tiles_scaler * single_tile_size_bytes,
@@ -189,7 +189,7 @@ void kernel_main() {
                         cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                            noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                            noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                                 remote_ep,
                                 cb_external_obj,
                                 num_tiles_scaler * single_tile_size_bytes,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -155,7 +155,7 @@ void kernel_main() {
                 write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_first_stage; block++) {
                     for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; tile_idx++) {
-                        noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                        noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                             remote_ep,
                             cb_external_obj,
                             single_tile_size_bytes,
@@ -181,7 +181,7 @@ void kernel_main() {
 
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                            noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                            noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                                 remote_ep,
                                 cb_external_obj,
                                 single_tile_size_bytes,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -163,7 +163,7 @@ void kernel_main() {
             cb_external_obj.reserve_back(num_blocks_first_stage * num_tiles_scaler);
             uint32_t write_offset = 0;
             for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
-                noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                     remote_ep,
                     cb_external_obj,
                     num_tiles_scaler * single_tile_size_bytes,
@@ -188,7 +188,7 @@ void kernel_main() {
                 cb_external_obj.reserve_back((num_blocks_second_stage - 1) * num_tiles_scaler);
                 write_offset = 0;
                 for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                    noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                    noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                         remote_ep,
                         cb_external_obj,
                         num_tiles_scaler * single_tile_size_bytes,
@@ -231,7 +231,7 @@ void kernel_main() {
             uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1 ? num_tiles_per_worker_last_bytes
                                                                                        : num_tiles_per_worker_bytes;
             if constexpr (num_tiles_per_worker_bytes * gather_tiles_scaler <= NOC_MAX_BURST_SIZE) {
-                noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                     remote_ep,
                     cb_ex_global_obj,
                     num_tiles_scaler * num_tiles_bytes,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
 
     const auto& global_semaphore_set = [&]() __attribute__((always_inline)) {
         reduce_sender_sem.set(VALID);
-        reduce_sender_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+        reduce_sender_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
             noc,
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,
@@ -52,7 +52,7 @@ void kernel_main() {
         [&](CircularBuffer& cb_ex_obj, CircularBuffer& cb_ex_global_obj_inner)
             __attribute__((always_inline)) {
                 uint32_t l1_read_addr_ex_global = cb_ex_global_obj_inner.get_read_ptr();
-                noc.async_write_multicast<Noc::McastMode::INCLUDE_SRC>(
+                noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
                     cb_ex_obj,
                     mcast_ep,
                     stats_tiles * num_tiles_per_worker_bytes,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -130,7 +130,7 @@ void kernel_main() {
                     write_offset = 0;
                     for (uint32_t block = 0; block < num_blocks_first_stage; ++block) {
                         for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
-                            noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                            noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                                 remote_ep,
                                 cb_external_obj,
                                 single_tile_size_bytes,
@@ -157,7 +157,7 @@ void kernel_main() {
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
                             for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
-                                noc.async_read<Noc::TxnIdMode::DISABLED, NOC_MAX_BURST_SIZE>(
+                                noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                                     remote_ep,
                                     cb_external_obj,
                                     single_tile_size_bytes,

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
@@ -30,7 +30,7 @@ using CB = CircularBuffer;
 
 // Single-packet convenience wrappers for set_async_read_state / async_read_with_state.
 // These wrappers put max_page_size first so callers don't need to spell out
-// VcSelection::DEFAULT every time.
+// NocOptions::DEFAULT every time.
 
 // Helper to create UnicastEndpoint src_args for local L1 self-reads.
 // Must use my_x/my_y for the correct NOC — NOC 0 and NOC 1 have different coordinate spaces.
@@ -44,7 +44,7 @@ template <uint32_t transfer_size>
 FORCE_INLINE void set_read_state(Noc noc, uint32_t src_addr) {
     static_assert(transfer_size <= NOC_MAX_BURST_SIZE, "Use noc.async_read for multi-packet transfers");
     UnicastEndpoint ep;
-    noc.set_async_read_state<Noc::VcSelection::DEFAULT, transfer_size>(
+    noc.set_async_read_state<NocOptions::DEFAULT, transfer_size>(
         ep, transfer_size, local_addr(src_addr, noc.get_noc_id()));
 }
 
@@ -54,7 +54,7 @@ FORCE_INLINE void set_read_state(Noc noc, uint32_t src_addr) {
 template <uint32_t transfer_size = 1>
 FORCE_INLINE void read_with_state(Noc noc, uint32_t dst_addr, uint32_t src_addr) {
     UnicastEndpoint ep;
-    noc.async_read_with_state<Noc::VcSelection::DEFAULT, transfer_size>(
+    noc.async_read_with_state<NocOptions::DEFAULT, transfer_size>(
         ep, CoreLocalMem<uint32_t>(dst_addr), transfer_size, local_addr(src_addr, noc.get_noc_id()), {});
 }
 
@@ -63,7 +63,7 @@ template <typename Dst>
 FORCE_INLINE void read_with_state(
     Noc noc, const Dst& dst, uint32_t src_addr, const typename noc_traits_t<Dst>::dst_args_type& dst_args) {
     UnicastEndpoint ep;
-    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(
+    noc.async_read_with_state<NocOptions::DEFAULT, 1>(
         ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), dst_args);
 }
 
@@ -71,7 +71,7 @@ FORCE_INLINE void read_with_state(
 template <typename Dst>
 FORCE_INLINE void read_with_state(Noc noc, const Dst& dst, uint32_t src_addr) {
     UnicastEndpoint ep;
-    noc.async_read_with_state<Noc::VcSelection::DEFAULT, 1>(ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), {});
+    noc.async_read_with_state<NocOptions::DEFAULT, 1>(ep, dst, 0, local_addr(src_addr, noc.get_noc_id()), {});
 }
 
 // Set the active transaction id (NOC_PACKET_TAG) for subsequent async_read* calls on this
@@ -83,7 +83,7 @@ FORCE_INLINE void set_read_trid(Noc noc, uint32_t trid) { noc_async_read_set_tri
 // Block until reads tagged `trid` on this noc are flushed.  Other in-flight reads with
 // different trids continue independently.
 FORCE_INLINE void async_read_barrier_with_trid(Noc noc, uint32_t trid) {
-    noc.template async_read_barrier<Noc::BarrierMode::TXN_ID>(trid);
+    noc.template async_read_barrier<NocOptions::TXN_ID>({.trid = trid});
 }
 
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -361,12 +361,12 @@ void kernel_main() {
 
             if constexpr (num_cores > 1) {
                 if (k > 0) {
-                    start_sem.set_multicast<Noc::McastMode::INCLUDE_SRC>(
+                    start_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                         noc, start_core_x0, start_core_y0, end_core_x0, end_core_y0, num_cores0);
                 }
 
                 if (num_cores1 > 0) {
-                    start_sem.set_multicast<Noc::McastMode::EXCLUDE_SRC>(
+                    start_sem.set_multicast(
                         noc, start_core_x1, start_core_y1, end_core_x1, end_core_y1, num_cores1);
                 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
         // Coordinate multicast reception
         // Enable all local cores to send their data simultaneously by broadcasting
         // the receiver semaphore state. This allows for efficient parallel transmission.
-        receiver_sem.set_multicast<Noc::McastMode::EXCLUDE_SRC>(
+        receiver_sem.set_multicast(
             noc, noc_start_x, noc_start_y, noc_end_x, noc_end_y, num_dests);
         noc.async_write_barrier();
 


### PR DESCRIPTION
### Summary
Functions in `noc.h` accepted a lot of different template args which gets annoying. This pr introduces `NocOptions` to dictate how to set up the noc transactions. Callers can provide bitmask of different `NocOptions`.  

This enables noc.set_aync_read_state to accept trid. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/stateful-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/stateful-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/stateful-noc)