### PR TITLE
[skip ci] Disable TestPerfCountersSingleOp.test_performance_counter_columns in sanity-tests profiler-tests

### DIFF
--- a/tests/ttnn/tracy/test_perf_op_report.py
+++ b/tests/ttnn/tracy/test_perf_op_report.py
@@ -201,6 +201,7 @@ matmul_test_perf_counters = {
     indirect=True,
 )
 class TestPerfCountersSingleOp:
+    @pytest.mark.skip(reason="[CI disable] Deterministically failing on wh_n300_civ2 in sanity-tests profiler-tests/Perf op report: subprocess.CalledProcessError exit 4 when capturing perf counters; 3+ consecutive main failures. See PR #45511.")
     def test_performance_counter_columns(self, run_test_do_post_proc):
         res, request = run_test_do_post_proc
         received_columns = get_first_op_columns(res)

--- a/tests/ttnn/tracy/test_perf_op_report.py
+++ b/tests/ttnn/tracy/test_perf_op_report.py
@@ -201,7 +201,9 @@ matmul_test_perf_counters = {
     indirect=True,
 )
 class TestPerfCountersSingleOp:
-    @pytest.mark.skip(reason="[CI disable] Deterministically failing on wh_n300_civ2 in sanity-tests profiler-tests/Perf op report: subprocess.CalledProcessError exit 4 when capturing perf counters; 3+ consecutive main failures. See PR #45511.")
+    @pytest.mark.skip(
+        reason="[CI disable] Deterministically failing on wh_n300_civ2 in sanity-tests profiler-tests/Perf op report: subprocess.CalledProcessError exit 4 when capturing perf counters; 3+ consecutive main failures. See PR #45511."
+    )
     def test_performance_counter_columns(self, run_test_do_post_proc):
         res, request = run_test_do_post_proc
         received_columns = get_first_op_columns(res)


### PR DESCRIPTION
Disable `TestPerfCountersSingleOp::test_performance_counter_columns[Matmul_perf_counters]` in `sanity-tests` profiler-tests `Perf op report [wh_n300_civ2]`.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/ttnn/tracy/test_perf_op_report.py::TestPerfCountersSingleOp::test_performance_counter_columns[Matmul_perf_counters]` [wh_n300_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26628589795/job/78481174299 | [3aa94fc](https://github.com/tenstorrent/tt-metal/commit/3aa94fc4e86fdfd0468c2b1114b0b6256cdac80c) | 2026-05-29 10:22 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/sanity-tests-perf-counters-matmul-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/sanity-tests-perf-counters-matmul-20260529)