### PR TITLE
Bug fix: Fix use-after-free in ShmResourceTracker

### DIFF
--- a/tt_metal/distributed/shm_resource_tracker.cpp
+++ b/tt_metal/distributed/shm_resource_tracker.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_metal/distributed/shm_resource_tracker.hpp"
 
+#include <mutex>
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/format.h>
 
@@ -52,16 +53,6 @@ pid_t extract_pid_from_shm_name(const std::string& filename) {
         return static_cast<pid_t>(std::stol(filename.substr(first + 1, second - first - 1)));
     } catch (...) {
         return 0;
-    }
-}
-
-void atexit_handler() {
-    try {
-        ShmResourceTracker::instance().cleanup_all();
-    } catch (const std::exception& e) {
-        log_warning(LogMetal, "ShmResourceTracker atexit: cleanup failed: {}", e.what());
-    } catch (...) {
-        log_warning(LogMetal, "ShmResourceTracker atexit: cleanup failed with unknown exception");
     }
 }
 
@@ -114,7 +105,6 @@ bool ShmResourceTracker::is_pid_alive(pid_t pid) {
 
 ShmResourceTracker::ShmResourceTracker() : manifest_path_(manifest_path_for_pid(getpid())) {
     cleanup_stale_resources();
-    std::atexit(atexit_handler);
 
     struct sigaction sa{};
     sa.sa_handler = signal_handler;
@@ -122,6 +112,16 @@ ShmResourceTracker::ShmResourceTracker() : manifest_path_(manifest_path_for_pid(
     sa.sa_flags = 0;
     sigaction(SIGINT, &sa, &prev_sigint);
     sigaction(SIGTERM, &sa, &prev_sigterm);
+}
+
+ShmResourceTracker::~ShmResourceTracker() {
+    try {
+        cleanup_all();
+    } catch (const std::exception& e) {
+        log_warning(LogMetal, "ShmResourceTracker cleanup failed: {}", e.what());
+    } catch (...) {
+        log_warning(LogMetal, "ShmResourceTracker cleanup failed with unknown exception");
+    }
 }
 
 ShmResourceTracker& ShmResourceTracker::instance() {

--- a/tt_metal/distributed/shm_resource_tracker.hpp
+++ b/tt_metal/distributed/shm_resource_tracker.hpp
@@ -17,8 +17,8 @@ namespace tt::tt_metal::distributed {
  * Ensures that /dev/shm resources created by H2D/D2H sockets are cleaned up even
  * when the process exits abnormally. Two complementary mechanisms:
  *
- *  1. atexit handler  – cleans up resources on normal exit, uncaught exceptions,
- *     std::exit(), and signals that cause exit() (SIGTERM, SIGINT default handlers).
+ *  1. destructor / signal handler – cleans up resources on normal exit,
+ *     std::exit(), SIGINT, SIGTERM.
  *
  *  2. Stale-PID cleanup – on first use, scans /dev/shm for resources whose owning
  *     PID is no longer alive (handles SIGKILL, hard crashes, power loss).
@@ -29,6 +29,8 @@ namespace tt::tt_metal::distributed {
 class ShmResourceTracker {
 public:
     static ShmResourceTracker& instance();
+
+    ~ShmResourceTracker();
 
     ShmResourceTracker(const ShmResourceTracker&) = delete;
     ShmResourceTracker& operator=(const ShmResourceTracker&) = delete;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes use after free / double free due to atexit handler vs destructor ordering. 

Registering atexit handler in the constructor of a static object would mean the atexit handler would be called after the static object's destructor is called, because the order is based on when the object finished initializing. See C++ std section basic.start.term.

This annoys any discerning libc which tracks double frees and causes abort on exit.

This change just puts the cleanup in the destructor. There isn't a situation in which atexit handler is called that the static object's destructor wouldn't be. Note that original comment in the code is also incorrect, as atexit handler won't be called for uncaught exceptions, since those call std::terminate, nor would it be called for aborts, since those raise sigabrt. Hence I think this is functionally equivalent as having an atexit handler, without all the fuss.

### Notes for reviewers
Is there a specific reason this was an atexit handler to begin with? My understanding is that the behavior of atexit w.r.t. the conditions under which it's invoked is that it's the same as destructors of static-storage-duration objects. If we want to fix the issue while still using atexit, we can call it during `instance()` with a `std::call_once`. LMK which one is preferred.