### PR TITLE
[skip ci] Disable test_indexed_slice[DataType.BFLOAT16-4-32-6-0] in runtime-integration-tests runtime_fd_python_2

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
@@ -39,6 +39,8 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
     ],
 )
 def test_indexed_slice(seed, B, b, D, tt_dtype, device):
+    if tt_dtype == ttnn.bfloat16 and D == 4 and B == 32 and b == 6 and seed == 0:
+        pytest.skip("Disabled by issue #45513: deterministic TT_THROW in system_memory_manager.cpp:738")
     torch.manual_seed(seed)
 
     dtype = tt_dtype_to_torch_dtype[tt_dtype]


### PR DESCRIPTION
Disable `test_indexed_slice[DataType.BFLOAT16-4-32-6-0]` in `runtime-integration-tests` `runtime_fd_python_2` on `wh_n150_civ2` and `bh_p150b_civ2`. Tracked in issue #45513.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py::test_indexed_slice[DataType.BFLOAT16-4-32-6-0]` [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26868028159/job/79237084600 | [24d9a02f](https://github.com/tenstorrent/tt-metal/commit/24d9a02f) | 2026-06-03 07:09 UTC |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py::test_indexed_slice[DataType.BFLOAT16-4-32-6-0]` [bh_p150b_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26868028159/job/79237084610 | [24d9a02f](https://github.com/tenstorrent/tt-metal/commit/24d9a02f) | 2026-06-03 07:09 UTC |

## Failure

```
FAILED tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py::test_indexed_slice[DataType.BFLOAT16-4-32-6-0]
RuntimeError: TT_THROW @ /project/tt_metal/impl/dispatch/system_memory_manager.cpp:738: tt::exception
TIMEOUT: device timeout, potential hang detected, the device is unrecoverable
```

`indexed_fill_reader` kernel hangs with NCRISC stalls across multiple cores — dispatch timeout fires, device becomes unrecoverable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-20260529)