### PR TITLE
[Fix] Transformers: Do not fully reset inputs if only page table changed.

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -28,6 +28,9 @@ from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 
 
+DECODE_PAGE_TABLE_INPUT_IDX = 3
+
+
 def get_prefill_warmup_sequence_lengths(max_seq_len: int) -> list[int]:
     """
     Returns powers of 2 from 128 up to max_seq_len (inclusive).
@@ -1104,15 +1107,9 @@ class Generator(WarmupForwardMixin):
         self._prev_sampling_on_device = sampling_on_device
         if prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device:
             reset_inputs = True
-        if self.prev_page_table is None:
-            self.prev_page_table = (
-                page_table.clone()
-            )  # Make sure we reference a fresh page table, in case it has changed
-        if torch.any(self.prev_page_table != page_table).item():
-            reset_inputs = True  # doesn't this do what reset_batch does?
-            self.prev_page_table = (
-                page_table.clone()
-            )  # Make sure we reference a fresh page table, in case it has changed
+        page_table_changed = page_table is not None and (
+            self.prev_page_table is None or torch.any(self.prev_page_table != page_table).item()
+        )
 
         if self.model.is_decode_setup is False:
             self.model.switch_mode("decode")
@@ -1150,6 +1147,7 @@ class Generator(WarmupForwardMixin):
             tt_tok, tt_log_probs = self._decode_easy_trace_text(
                 **decode_kwargs,
                 reset_inputs=reset_inputs,
+                page_table_changed=page_table_changed,
                 return_logits=return_logits,
             )
         else:
@@ -1279,6 +1277,7 @@ class Generator(WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         reset_inputs=False,
+        page_table_changed=False,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
         return_logits=False,
@@ -1302,6 +1301,8 @@ class Generator(WarmupForwardMixin):
             self.trace_inputs_decode[return_logits] = device_inputs
             self.trace_output_decode[return_logits] = tt_out_tok
         if reset_inputs:
+            # Full resets are required when host token/position inputs are
+            # authoritative again (host sampling, trace switch, or batch reset).
             host_inputs = self.model.prepare_decode_inputs_host(
                 tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
             )
@@ -1311,6 +1312,20 @@ class Generator(WarmupForwardMixin):
                 device_tensors=self.trace_inputs_decode[return_logits],
                 shard_specs=shard_specs,
             )
+        elif page_table_changed:
+            # With async device sampling, token/position inputs may intentionally
+            # be stale on host: the previous decode updates them on device. Page
+            # tables still need refreshing when new KV blocks are allocated, so
+            # copy only that trace input and preserve device-produced tokens.
+            host_inputs = self.model.prepare_decode_inputs_host(
+                tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
+            )
+            host_page_table = host_inputs[DECODE_PAGE_TABLE_INPUT_IDX]
+            device_page_table = self.trace_inputs_decode[return_logits][DECODE_PAGE_TABLE_INPUT_IDX]
+            if host_page_table is not None:
+                ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
+        if page_table_changed:
+            self.prev_page_table = page_table.clone()
 
         trace_tok_rm = self._decode_forward_trace_text(
             self.trace_ids_decode[return_logits],

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -28,6 +28,9 @@ from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 
 
+# Position of the page table within the decode input tuple produced by
+# LlamaModel.prepare_decode_inputs_host: (tokens, current_pos, rope_idxs, page_table).
+# Used to refresh only the page-table trace input when KV blocks are reallocated.
 DECODE_PAGE_TABLE_INPUT_IDX = 3
 
 
@@ -1114,6 +1117,12 @@ class Generator(WarmupForwardMixin):
         if self.model.is_decode_setup is False:
             self.model.switch_mode("decode")
             reset_inputs = True  # Last step wasn't decode, so we definitely need to load inputs.
+
+        if reset_batch:
+            # A new batch layout (real reset or slot remap) leaves the device
+            # token/current_pos buffers holding the previous batch's values, so
+            # host inputs are authoritative again and must be fully reloaded.
+            reset_inputs = True
 
         kv_cache = kv_cache[0]
         decode_kwargs = {

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -450,10 +450,14 @@ class TtTransformer(LightweightModule):
         self, tokens, current_pos, page_table=None, is_cur_pos_sharded=False, is_page_table_sharded=False
     ):
         """
-        Inputs are torch tensors or python types. Outputs are ttnn tensors on host.
+        Inputs are torch tensors or python types. Outputs are ttnn tensors on host
+        (built with device=None); the sharded flags only affect the host tensor's
+        dtype/layout and its mesh_mapper, not its host/device residency.
         NOTE: Tokens and current_pos are padded to batch
-        NOTE: if is_cur_pos_sharded is True, current_pos_tt is returned as a device tensor
-        NOTE: if is_page_table_sharded is True, page_table is returned as a device tensor
+        NOTE: if is_cur_pos_sharded is True, current_pos_tt is laid out for sharded
+              placement (repeated across cores) but is still returned on host
+        NOTE: if is_page_table_sharded is True, page_table is laid out for sharded
+              placement (uint16, repeated across cores) but is still returned on host
         """
         B = tokens.shape[0]
         # assert current_pos.shape[0] == B, "Batch size mismatch"

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -42,6 +42,10 @@ MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
 
 # Power-of-2 batch sizes supported by trace caching for batched prefill.
 SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
+
+# Position of the page table within the decode input tuple produced by
+# Transformer.prepare_decode_inputs_host: (tokens, current_pos, rope_idxs, page_table).
+# Used to refresh only the page-table trace input when KV blocks are reallocated.
 DECODE_PAGE_TABLE_INPUT_IDX = 3
 
 
@@ -1270,7 +1274,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         }
 
         if enable_trace:
-            tt_decode_output = self._decode_forward_trace_text(**decode_kwargs, reset_batch=mode_switched)
+            # A real batch reset / slot remap (reset_batch) also makes the device
+            # token/current_pos trace buffers stale, not just a prefill->decode
+            # mode switch, so both must force a full traced-input reset.
+            tt_decode_output = self._decode_forward_trace_text(
+                **decode_kwargs, reset_batch=reset_batch or mode_switched
+            )
         else:
             tt_decode_output = self._decode_forward_no_trace_text(**decode_kwargs)
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -42,6 +42,7 @@ MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
 
 # Power-of-2 batch sizes supported by trace caching for batched prefill.
 SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
+DECODE_PAGE_TABLE_INPUT_IDX = 3
 
 
 def max_prefill_chunk_size_cutoff(sequence_length, max_prefill_chunk_size):
@@ -1425,28 +1426,40 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self._prev_sampling_on_device = sampling_on_device
         sampling_mode_changed = prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device
         reset_inputs = reset_batch or not sampling_on_device or sampling_mode_changed
-        if self.prev_page_table is None or any(
-            not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table)
-        ):
-            # If the page table has changed, it means additional pages have been added or inputs are shuffled
-            reset_inputs = True
-            if page_table is not None:
-                self.prev_page_table = tuple(pt.clone() for pt in page_table)
+        page_table_changed = page_table is not None and (
+            self.prev_page_table is None
+            or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
+        )
 
         for i in range(self.data_parallel):
             refresh_trace_inputs = reset_inputs or getattr(
                 self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
             )
-            if not refresh_trace_inputs:
-                continue
-
             user_page_table = page_table[i] if page_table is not None else None
-            host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
 
-            copy_host_to_device(
-                host_tensors=host_inputs_i,
-                device_tensors=self.trace_inputs_decode[sampling_on_device][i],
-            )
+            if refresh_trace_inputs:
+                # Full resets are required when host token/position inputs are
+                # authoritative again, or for models that explicitly opt out of
+                # partial decode trace input refreshes.
+                host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
+                copy_host_to_device(
+                    host_tensors=host_inputs_i,
+                    device_tensors=self.trace_inputs_decode[sampling_on_device][i],
+                )
+            elif page_table_changed:
+                # With async device sampling, token/position inputs may
+                # intentionally be stale on host: the previous decode updates
+                # them on device. Page tables still need refreshing when new KV
+                # blocks are allocated, so copy only that trace input and
+                # preserve device-produced tokens.
+                host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
+                host_page_table = host_inputs_i[DECODE_PAGE_TABLE_INPUT_IDX]
+                device_page_table = self.trace_inputs_decode[sampling_on_device][i][DECODE_PAGE_TABLE_INPUT_IDX]
+                if host_page_table is not None:
+                    ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
+
+        if page_table_changed:
+            self.prev_page_table = tuple(pt.clone() for pt in page_table)
         for i, trace_id in self.trace_ids_decode[sampling_on_device].items():
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         outputs = self.trace_output_decode[sampling_on_device]


### PR DESCRIPTION
### Summary

Fixing https://github.com/tenstorrent/vllm/issues/395

Root caused by @tchedaTT :
Allowing the overlap requires build_model_input to use stale data, but that's mostly valid. As long as reset_inputs is False in the model, it will skip reading from host and use the inputs already on device that were updated by the previous decode step. The bug actually arises when vllm thinks it's "steady state decode" and allows overlap, while the model decides to re-read from host. Both are supposed to be gated by reset_batch = False - interestingly the reset_batch on model side is not the same variable as on the vllm side, but whenever reset_batch in vllm is True, the model will in fact correctly re-read.
Crucially, it will also re-read when the page table changes, and async overlap doesnt take this into account.
So the scenario is actually
step n-1 is the last one finalized
step n is now executing. it is the last step that fits in the previous kv cache block.
we start building input for step n+1. we allocate a new kv block and change the page table. reset_batch isn't set because the batch composition is unchanged. we are sampling on device, so we allow overlap. we build inputs with input_position n and input_tokens from step n-1, but we expect it to be ok because we think the device won't re-read from host.
we dispatch step n+1 with this input.
_decode_forward_trace_text sees the changes page table and sets reset_inputs =True, which re-reads inputs from host (based on step n-1, correct for step n) instead of using the ones already on device (based on step n, correct for step n+1)

The fix:
Page table change no longer causes full inputs reset. Only the page table is updated, while the other inputs are left to the fast stay-on-device flow.

### Testing

* Tier 1+2 E2E: https://github.com/tenstorrent/tt-metal/actions/runs/26879728387
* VLLM nightly: https://github.com/tenstorrent/tt-metal/actions/runs/26882799170

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-async-reset-inputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-async-reset-inputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-async-reset-inputs)