### PR TITLE
ring joint sdpa: bump 8k perf baseline 65.2 -> 65.6

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -791,7 +791,7 @@ EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
     # (ring_size_expected, max_payload_size, payload_id, expected_util)
     # 4-device ring (QuietBox, 4xGalaxy analog)
     (4, 4096, "4k", 65.3),
-    (4, 8192, "8k", 65.2),
+    (4, 8192, "8k", 65.6),
 ]
 
 


### PR DESCRIPTION
Bump ring4-8k exp ring joint SDPA perf-check baseline from 65.2% to 65.6% to match CI-measured 65.66% math util.

https://github.com/tenstorrent/tt-metal/actions/runs/26636767972

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/bump_ring_sdpa_8k_baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/bump_ring_sdpa_8k_baseline)