### PR TITLE
[skip ci] Disable swin_s test_e2e_performant / test_e2e_performant_dp in perf-models (TT_FATAL: trace buffer size exceeds trace_region_size)

### DIFF
--- a/models/experimental/swin_s/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_s/tests/perf/test_e2e_performant.py
@@ -62,6 +62,7 @@ def run_e2e_performant(
     [{"l1_small_size": SWIN_S_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
     indirect=True,
 )
+@pytest.mark.skip(reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528")
 def test_e2e_performant(
     device,
     batch_size,
@@ -97,6 +98,7 @@ def test_e2e_performant(
     [{"l1_small_size": SWIN_S_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
     indirect=True,
 )
+@pytest.mark.skip(reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528")
 def test_e2e_performant_dp(
     mesh_device,
     device_batch_size,

--- a/models/experimental/swin_s/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_s/tests/perf/test_e2e_performant.py
@@ -100,7 +100,9 @@ def test_e2e_performant(
     [{"l1_small_size": SWIN_S_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
     indirect=True,
 )
-@pytest.mark.skip(reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528")
+@pytest.mark.skip(
+    reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528"
+)
 def test_e2e_performant_dp(
     mesh_device,
     device_batch_size,

--- a/models/experimental/swin_s/tests/perf/test_e2e_performant.py
+++ b/models/experimental/swin_s/tests/perf/test_e2e_performant.py
@@ -62,7 +62,9 @@ def run_e2e_performant(
     [{"l1_small_size": SWIN_S_L1_SMALL_SIZE, "trace_region_size": 16998400, "num_command_queues": 2}],
     indirect=True,
 )
-@pytest.mark.skip(reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528")
+@pytest.mark.skip(
+    reason="Deterministic TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B (mesh_trace.cpp:78) — tracked in https://github.com/tenstorrent/tt-metal/issues/45528"
+)
 def test_e2e_performant(
     device,
     batch_size,


### PR DESCRIPTION
[skip ci] Disable swin_s test_e2e_performant / test_e2e_performant_dp in perf-models models-perf/other_magic_env N300 WH B0 (TT_FATAL: trace buffer size 23052288B exceeds allocated trace_region_size 16998400B)

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant[device_params0-resolution0-1-DataType.BFLOAT16-DataType.BFLOAT16]` [N300 WH B0] | https://github.com/tenstorrent/tt-metal/actions/runs/26633758989/job/78490360978 | [6d54c53](https://github.com/tenstorrent/tt-metal/commit/6d54c53a3c6ff51f34c2cbb57d1a9d0a8ed28129) | 2026-05-29 11:36 UTC |
| `models/experimental/swin_s/tests/perf/test_e2e_performant.py::test_e2e_performant_dp[wormhole_b0-device_params0-resolution0-1-DataType.BFLOAT16-DataType.BFLOAT16]` [N300 WH B0] | https://github.com/tenstorrent/tt-metal/actions/runs/26633758989/job/78490360978 | [6d54c53](https://github.com/tenstorrent/tt-metal/commit/6d54c53a3c6ff51f34c2cbb57d1a9d0a8ed28129) | 2026-05-29 11:36 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/perf-models-swin-s-trace-region-20260529)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/perf-models-swin-s-trace-region-20260529)