### PR TITLE
tt_fabric: Support mesh co-location pinnings in MGD

### DIFF
--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_32stage_4x2_pipeline.textproto
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_32stage_4x2_pipeline.textproto
@@ -1,0 +1,217 @@
+# Thirty-two stage 4×2 (8 ASIC) BH GLX pipeline — same mesh shape as bh_glx_split_4x2 for PGD matching,
+# with 32 FABRIC-linked stages.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] dim_types: [ RING, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 16 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 17 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 18 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 19 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 20 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 21 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 22 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 23 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 24 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 25 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 26 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 27 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 28 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 29 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 30 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 31 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 16 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 16 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 16 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 17 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 17 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 18 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 18 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 19 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 19 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 20 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 20 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 21 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 21 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 22 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 22 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 23 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 23 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 24 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 24 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 25 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 25 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 26 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 26 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 27 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 27 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 28 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 28 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 29 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 29 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 30 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 30 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 31 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 31 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    channels { count: 16 policy: RELAXED }
+    assign_z_direction: true
+  }
+}
+
+mesh_colocation_pinnings { type: HOST mesh_id_a: 0 mesh_id_b: 31 }
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -4522,6 +4522,134 @@ TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Sp4Glx
         << "Mapped Blitz pipeline: at most one host per logical 4×2 mesh (11 stages)";
 }
 
+TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Sp4Glx_Blitz2x4_32Stage) {
+    // Same as BuildPhysicalMultiMeshGraph_WithPGDAndPSD_ThreePod16x8_Blitz2x4 but 32 pipeline stages
+    // (bh_glx_32stage_4x2_pipeline.textproto).
+    using namespace ::tt::tt_fabric;
+
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    ASSERT_NE(tt_metal_home, nullptr) << "TT_METAL_HOME environment variable must be set";
+
+    auto* mock_desc = getenv("TT_METAL_MOCK_CLUSTER_DESC_PATH");
+    if (mock_desc == nullptr) {
+        GTEST_SKIP() << "TT_METAL_MOCK_CLUSTER_DESC_PATH not set - run with tt-run --mock-cluster-rank-binding";
+    }
+
+    tt::tt_metal::PhysicalSystemDescriptor psd = create_psd_from_mock_cluster();
+
+    const std::filesystem::path pgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/physical_groupings/bh_galaxy_physical_grouping_descriptor.textproto";
+    ASSERT_TRUE(std::filesystem::exists(pgd_path)) << "PGD file not found: " << pgd_path;
+    PhysicalGroupingDescriptor pgd{pgd_path};
+
+    constexpr std::size_t kPipelineStages = 32;
+    constexpr std::size_t kAsicsPerStage = 8;
+
+    const std::filesystem::path mgd_path =
+        std::filesystem::path(tt_metal_home) /
+        "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_glx_32stage_4x2_pipeline.textproto";
+    ASSERT_TRUE(std::filesystem::exists(mgd_path)) << "MGD file not found: " << mgd_path;
+    MeshGraphDescriptor mgd{mgd_path};
+
+    const auto physical_multi_mesh_graph = build_physical_multi_mesh_adjacency_graph(psd, pgd, mgd);
+
+    EXPECT_EQ(physical_multi_mesh_graph.mesh_adjacency_graphs_.size(), 64u);
+
+    for (const auto& node : physical_multi_mesh_graph.mesh_level_graph_.get_nodes()) {
+        EXPECT_GT(physical_multi_mesh_graph.mesh_level_graph_.get_neighbors(node).size(), 0);
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        EXPECT_TRUE(physical_multi_mesh_graph.mesh_exit_node_graphs_.contains(mesh_id));
+        EXPECT_GT(physical_multi_mesh_graph.mesh_exit_node_graphs_.at(mesh_id).get_nodes().size(), 0);
+    }
+
+    for (const auto& [mesh_id, adjacency_graph] : physical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        (void)mesh_id;
+        EXPECT_EQ(adjacency_graph.get_nodes().size(), kAsicsPerStage);
+
+        expect_bh_halfpod_tray_pairing_for_graph_nodes(
+            std::string("[ThreePod16x8_Blitz2x4_32Stage] mesh_id=") + std::to_string(*mesh_id), psd, adjacency_graph);
+
+        for (const auto& node : adjacency_graph.get_nodes()) {
+            EXPECT_GE(adjacency_graph.get_neighbors(node).size(), 2u * 2u);
+            EXPECT_LE(adjacency_graph.get_neighbors(node).size(), 3u * 2u);
+        }
+    }
+
+    MeshGraph mesh_graph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, mgd_path.string());
+    const auto logical_multi_mesh_graph = build_logical_multi_mesh_adjacency_graph(mesh_graph);
+
+    EXPECT_EQ(logical_multi_mesh_graph.mesh_adjacency_graphs_.size(), kPipelineStages);
+
+    size_t expected_fabric_nodes = 0;
+    for (const auto& [logical_mesh_id, logical_adj] : logical_multi_mesh_graph.mesh_adjacency_graphs_) {
+        (void)logical_mesh_id;
+        expected_fabric_nodes += logical_adj.get_nodes().size();
+    }
+    ASSERT_EQ(expected_fabric_nodes, kPipelineStages * kAsicsPerStage);
+
+    TopologyMappingConfig config;
+    config.strict_mode = true;
+    config.disable_rank_bindings = false;
+
+    for (const auto& [asic_id, desc] : psd.get_asic_descriptors()) {
+        config.hostname_to_asics[desc.host_name].insert(asic_id);
+    }
+
+    const auto& pinnings = mgd.get_pinnings();
+    for (const auto& [pos, fabric_node] : pinnings) {
+        config.pinnings.emplace_back(pos, fabric_node);
+    }
+
+    if (!config.pinnings.empty()) {
+        const auto& asic_descriptors = psd.get_asic_descriptors();
+        for (const auto& [asic_id, _] : asic_descriptors) {
+            auto tray_id = psd.get_tray_id(asic_id);
+            auto asic_location = psd.get_asic_location(asic_id);
+            config.asic_positions[asic_id] = std::make_pair(tray_id, asic_location);
+        }
+    }
+
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        config.mesh_validation_modes[mesh_id] = mesh_graph.is_intra_mesh_policy_relaxed(mesh_id)
+                                                    ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                                    : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+    }
+
+    config.inter_mesh_validation_mode = mesh_graph.is_inter_mesh_policy_relaxed()
+                                            ? ::tt::tt_fabric::ConnectionValidationMode::RELAXED
+                                            : ::tt::tt_fabric::ConnectionValidationMode::STRICT;
+
+    std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> fabric_node_id_to_mesh_rank;
+    for (const auto& mesh_id : mesh_graph.get_all_mesh_ids()) {
+        for (const auto& [coord, chip_id] : mesh_graph.get_chip_ids(mesh_id)) {
+            (void)coord;
+            FabricNodeId fabric_node_id(mesh_id, chip_id);
+            auto mesh_host_rank = mesh_graph.get_host_rank_for_chip(mesh_id, chip_id);
+            if (mesh_host_rank.has_value()) {
+                fabric_node_id_to_mesh_rank[mesh_id][fabric_node_id] = mesh_host_rank.value();
+            }
+        }
+    }
+
+    std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> asic_id_to_mesh_rank = {};
+
+    const auto mapping_result = map_multi_mesh_to_physical(
+        logical_multi_mesh_graph, physical_multi_mesh_graph, config, asic_id_to_mesh_rank, fabric_node_id_to_mesh_rank);
+    ASSERT_TRUE(mapping_result.success) << mapping_result.error_message;
+
+    EXPECT_EQ(mapping_result.fabric_node_to_asic.size(), expected_fabric_nodes);
+
+    std::set<std::string> hosts_spanning_blitz_mapped;
+    for (const auto& [fabric_node, asic_id] : mapping_result.fabric_node_to_asic) {
+        (void)fabric_node;
+        hosts_spanning_blitz_mapped.insert(psd.get_host_name_for_asic(asic_id));
+    }
+    EXPECT_EQ(hosts_spanning_blitz_mapped.size(), 8u) << "Mapped Blitz pipeline: should span exactly 8 hosts";
+}
+
 TEST_F(TopologyMapperUtilsTest, BuildPhysicalMultiMeshGraph_WithPGDAndPSD_Sp4Glx_BHGalaxy4x4Z) {
     // Test build_physical_multi_mesh_adjacency_graph using PGD and PSD
     // Uses bh_galaxy_4x4_z_mesh_graph_descriptor with 2 meshes of 4x4 (16 nodes each)

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper_utils.cpp
@@ -1106,6 +1106,81 @@ TEST_F(TopologyMapperUtilsTest, Pinning_MapMultiMeshToPhysical_MeshLevelPinnings
     }
 }
 
+// Mesh colocation pinnings: pin two logical meshes so they must map to physical meshes on the same host.
+TEST_F(TopologyMapperUtilsTest, MeshColocationPinning_HostType_PlacesPinnedMeshesOnSameHost) {
+    using namespace ::tt::tt_fabric;
+
+    // Logical topology: 3 meshes, each a 1x2 chain, connected in a line 0-1-2.
+    LogicalMultiMeshGraph logical;
+    std::map<MeshId, std::vector<FabricNodeId>> logical_nodes;
+    for (uint32_t mid = 0; mid < 3; ++mid) {
+        const MeshId m{mid};
+        logical_nodes[m] = {FabricNodeId(m, 0), FabricNodeId(m, 1)};
+        logical.mesh_adjacency_graphs_[m] = AdjacencyGraph<FabricNodeId>(build_chain_adjacency(logical_nodes[m]));
+    }
+    AdjacencyGraph<MeshId>::AdjacencyMap logical_mesh_level;
+    logical_mesh_level[MeshId{0}] = {MeshId{1}};
+    logical_mesh_level[MeshId{1}] = {MeshId{0}, MeshId{2}};
+    logical_mesh_level[MeshId{2}] = {MeshId{1}};
+    logical.mesh_level_graph_ = AdjacencyGraph<MeshId>(logical_mesh_level);
+
+    // Physical topology: 4 meshes, each a 1x2 chain, fully connected at the mesh level so any logical line embeds.
+    PhysicalMultiMeshGraph physical;
+    std::map<MeshId, std::vector<tt::tt_metal::AsicID>> physical_asics;
+    for (uint32_t pid = 0; pid < 4; ++pid) {
+        const MeshId p{pid};
+        physical_asics[p] = {tt::tt_metal::AsicID{1000 + pid * 10}, tt::tt_metal::AsicID{1001 + pid * 10}};
+        physical.mesh_adjacency_graphs_[p] =
+            AdjacencyGraph<tt::tt_metal::AsicID>(build_chain_adjacency(physical_asics[p]));
+    }
+    AdjacencyGraph<MeshId>::AdjacencyMap physical_mesh_level;
+    for (uint32_t a = 0; a < 4; ++a) {
+        for (uint32_t b = 0; b < 4; ++b) {
+            if (a != b) {
+                physical_mesh_level[MeshId{a}].push_back(MeshId{b});
+            }
+        }
+    }
+    physical.mesh_level_graph_ = AdjacencyGraph<MeshId>(physical_mesh_level);
+
+    // Hosts: hostA owns physical meshes 0 and 1; hostB owns physical meshes 2 and 3.
+    TopologyMappingConfig config;
+    config.disable_rank_bindings = true;
+    const std::map<std::string, std::set<MeshId>> host_to_physical_meshes = {
+        {"hostA", {MeshId{0}, MeshId{1}}},
+        {"hostB", {MeshId{2}, MeshId{3}}},
+    };
+    for (const auto& [hostname, phys_meshes] : host_to_physical_meshes) {
+        for (const auto& p : phys_meshes) {
+            for (const auto& asic : physical_asics[p]) {
+                config.hostname_to_asics[hostname].insert(asic);
+            }
+        }
+    }
+
+    // Pin logical meshes 1 and 2 to the same host.
+    config.mesh_colocation_pinnings.push_back(
+        ::tt::tt_fabric::MeshColocationPinning{::tt::tt_fabric::MeshColocationType::Host, MeshId{1}, MeshId{2}});
+
+    const auto result = map_multi_mesh_to_physical(logical, physical, config);
+    ASSERT_TRUE(result.success) << result.error_message;
+    verify_bidirectional_consistency(result);
+
+    // Resolve which host each logical mesh landed on (via its first fabric node's ASIC).
+    auto host_for_asic = [&](tt::tt_metal::AsicID asic) -> std::string {
+        for (const auto& [hostname, asics] : config.hostname_to_asics) {
+            if (asics.contains(asic)) {
+                return hostname;
+            }
+        }
+        return {};
+    };
+    const std::string host_mesh1 = host_for_asic(result.fabric_node_to_asic.at(logical_nodes[MeshId{1}][0]));
+    const std::string host_mesh2 = host_for_asic(result.fabric_node_to_asic.at(logical_nodes[MeshId{2}][0]));
+    EXPECT_FALSE(host_mesh1.empty());
+    EXPECT_EQ(host_mesh1, host_mesh2) << "Same-host pinned logical meshes 1 and 2 must land on the same host";
+}
+
 // =============================================================================
 // Failure Case Tests
 // =============================================================================

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
@@ -37,7 +37,21 @@ enum RoutingDirection : int;
 class LogicalFabricNodeId;
 class PhysicalAsicPosition;
 class AsicPinning;
+class MeshColocationPinning;
 }  // namespace proto
+
+// Grouping within which two logical meshes can be colocated.
+// HOST: both meshes must map to physical ASICs that belong to the same physical host.
+// Additional grouping types (e.g. tray) can be added here as the proto enum is extended.
+enum class MeshColocationType : uint8_t { Host };
+
+// Relational constraint requesting that two logical meshes be colocated within a grouping (see
+// MeshColocationType). Transitive: pinning (A, B) and (B, C) forces A, B and C into one group.
+struct MeshColocationPinning {
+    MeshColocationType type = MeshColocationType::Host;
+    MeshId mesh_id_a;
+    MeshId mesh_id_b;
+};
 
 inline namespace v1_1 {
 using LocalNodeId = uint32_t;   // Scoped to parent (mesh_id, graph_id, device index)
@@ -215,6 +229,10 @@ public:
 
     const std::vector<std::pair<AsicPosition, FabricNodeId>>& get_pinnings() const { return pinnings_; }
 
+    // Mesh colocation pinnings: each entry instructs the solver to colocate two logical meshes
+    // within a grouping (e.g. the same host). See MeshColocationPinning / MeshColocationType.
+    const std::vector<MeshColocationPinning>& get_mesh_colocation_pinnings() const { return mesh_colocation_pinnings_; }
+
 private:
     // Descriptor fast lookup
     std::shared_ptr<const proto::MeshGraphDescriptor> proto_;
@@ -241,6 +259,7 @@ private:
     std::unordered_map<GlobalNodeId, std::vector<ConnectionId>> connections_by_source_device_id_;
 
     std::vector<std::pair<AsicPosition, FabricNodeId>> pinnings_;
+    std::vector<MeshColocationPinning> mesh_colocation_pinnings_;
 
     static void set_defaults(proto::MeshGraphDescriptor& proto);
     static std::vector<std::string> static_validate(
@@ -263,6 +282,8 @@ private:
     static void validate_graph_topology_and_connections(
         const proto::MeshGraphDescriptor& proto, std::vector<std::string>& error_messages);
     static void validate_pinnings(const proto::MeshGraphDescriptor& proto, std::vector<std::string>& error_messages);
+    static void validate_mesh_colocation_pinnings(
+        const proto::MeshGraphDescriptor& proto, std::vector<std::string>& error_messages);
 
     static void validate_legacy_requirements(
         const proto::MeshGraphDescriptor& proto, std::vector<std::string>& error_messages);
@@ -275,6 +296,9 @@ private:
 
     // Populate Pinnings
     void populate_pinnings();
+
+    // Populate Mesh Colocation Pinnings
+    void populate_mesh_colocation_pinnings();
 
     // Populate Instances
     void populate_top_level_instance();

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -58,6 +58,13 @@ struct TopologyMappingConfig {
     // specific logical nodes can be mapped to
     std::vector<PinningConstraint> pinnings;
 
+    // Optional mesh colocation pinnings. Each entry instructs the solver to colocate two logical
+    // meshes within a grouping (see MeshColocationType). For HOST colocation, both meshes are
+    // mapped to physical meshes that belong to one host. Host membership is derived from
+    // hostname_to_asics, so HOST colocation is only enforced when hostname_to_asics is populated.
+    // The relation is transitive: pinning (A, B) and (B, C) forces A, B and C into one group.
+    std::vector<::tt::tt_fabric::MeshColocationPinning> mesh_colocation_pinnings;
+
     // Map from AsicID to (TrayID, ASICLocation) from discovery — required when pinnings are non-empty, and populated
     // for topology mapping anchors (e.g. soft preference for tray 1 / ASIC location 1 on logical mesh 0).
     AsicPositionMap asic_positions;

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -8,6 +8,9 @@
 #include <sstream>
 #include <filesystem>
 #include <algorithm>
+#include <map>
+#include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
@@ -332,6 +335,7 @@ std::vector<std::string> MeshGraphDescriptor::static_validate(
         validate_graph_descriptors(proto, all_errors);
         validate_graph_topology_and_connections(proto, all_errors);
         validate_pinnings(proto, all_errors);
+        validate_mesh_colocation_pinnings(proto, all_errors);
         if (!all_errors.empty()) {
             return all_errors;
         }
@@ -359,6 +363,8 @@ void MeshGraphDescriptor::populate() {
     populate_connections();
 
     populate_pinnings();
+
+    populate_mesh_colocation_pinnings();
 }
 
 void MeshGraphDescriptor::populate_top_level_instance() {
@@ -1590,6 +1596,56 @@ void MeshGraphDescriptor::validate_pinnings(
         // Note: We can't fully validate chip_id range without knowing which mesh descriptor
         // corresponds to which mesh_id, but we can at least check that mesh_id is reasonable
         // More precise validation would require checking the top_level_instance structure
+    }
+}
+
+void MeshGraphDescriptor::populate_mesh_colocation_pinnings() {
+    mesh_colocation_pinnings_.clear();
+
+    // Extract mesh colocation pinnings from the top-level section
+    for (const auto& pinning : proto_->mesh_colocation_pinnings()) {
+        MeshColocationType type = MeshColocationType::Host;
+        switch (pinning.type()) {
+            case proto::MeshColocationPinning::HOST: type = MeshColocationType::Host; break;
+            default: TT_THROW("Invalid mesh colocation pinning type: {}", pinning.type()); break;
+        }
+        mesh_colocation_pinnings_.push_back(
+            MeshColocationPinning{type, MeshId{pinning.mesh_id_a()}, MeshId{pinning.mesh_id_b()}});
+    }
+}
+
+void MeshGraphDescriptor::validate_mesh_colocation_pinnings(
+    const proto::MeshGraphDescriptor& proto, std::vector<std::string>& error_messages) {
+    // Track duplicate pinnings (order-independent, per colocation type)
+    std::set<std::tuple<int, uint32_t, uint32_t>> seen_pairs;
+
+    for (const auto& pinning : proto.mesh_colocation_pinnings()) {
+        const int type = static_cast<int>(pinning.type());
+        uint32_t mesh_id_a = pinning.mesh_id_a();
+        uint32_t mesh_id_b = pinning.mesh_id_b();
+
+        if (pinning.type() == proto::MeshColocationPinning::INVALID_TYPE) {
+            error_messages.push_back(fmt::format(
+                "Mesh colocation pinning for meshes (mesh_id_a: {}, mesh_id_b: {}) has an invalid/unset colocation "
+                "type",
+                mesh_id_a,
+                mesh_id_b));
+            continue;
+        }
+
+        if (mesh_id_a == mesh_id_b) {
+            error_messages.push_back(fmt::format(
+                "Mesh colocation pinning references the same mesh twice (mesh_id: {}); the two meshes must be distinct",
+                mesh_id_a));
+            continue;
+        }
+
+        // Normalize so (a, b) and (b, a) are treated as duplicates
+        auto key = std::make_tuple(type, std::min(mesh_id_a, mesh_id_b), std::max(mesh_id_a, mesh_id_b));
+        if (!seen_pairs.insert(key).second) {
+            error_messages.push_back(fmt::format(
+                "Duplicate mesh colocation pinning for meshes (mesh_id_a: {}, mesh_id_b: {})", mesh_id_a, mesh_id_b));
+        }
     }
 }
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/protobuf/mesh_graph_descriptor.proto
+++ b/tt_metal/fabric/protobuf/mesh_graph_descriptor.proto
@@ -62,6 +62,32 @@ message AsicPinning {
     PhysicalAsicPosition physical_asic_position = 2;
 }
 
+// -----------------------------------------------------------------------------
+// MeshColocationPinning
+// Instructs the topology solver to colocate two logical meshes.
+// Unlike AsicPinning (which pins a single logical fabric node to an exact ASIC position),
+// this is a relational constraint between two meshes: the solver must map both meshes to
+// physical ASICs that belong to the same grouping (e.g. host).
+//
+// Notes:
+// - mesh_id_a and mesh_id_b must be distinct and must refer to mesh instances in the MGD.
+// - The constraint is transitive: pinning (A, B) and (B, C) forces A, B and C onto one host.
+message MeshColocationPinning {
+    enum Type {
+        INVALID_TYPE = 0;
+        HOST = 1;
+    }
+
+    // Type of grouping within which the meshes are to be colocated.
+    Type type = 1;
+
+    // First logical mesh id (matches MeshRef.mesh_id of a mesh instance).
+    uint32 mesh_id_a = 2;
+
+    // Second logical mesh id (matches MeshRef.mesh_id of a mesh instance).
+    uint32 mesh_id_b = 3;
+}
+
 message MeshGraphDescriptor {
     // Reusable mesh templates (definitions) referenced by graphs and instances.
     // Required fields inside each MeshDescriptor: name, arch, device_topology.dims,
@@ -87,6 +113,10 @@ message MeshGraphDescriptor {
     // Top-level pinnings section (separate from descriptors and instances).
     // Maps logical fabric nodes to physical ASIC positions for pinning constraints.
     repeated AsicPinning pinnings = 5;
+
+    // Top-level mesh colocation pinnings (separate from descriptors and instances).
+    // Each entry instructs the solver to colocate two logical meshes.
+    repeated MeshColocationPinning mesh_colocation_pinnings = 6;
 }
 
 // -----------------------------------------------------------------------------

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -470,10 +470,18 @@ void TopologyMapper::build_mapping(const Cluster& cluster) {
 
         // Extract pinnings from MGD and add to config (only if mesh graph descriptor is available)
         if (mesh_graph_.get_mesh_graph_descriptor_path().has_value()) {
-            const auto& pinnings = mesh_graph_.get_mesh_graph_descriptor().get_pinnings();
+            const auto& mgd = mesh_graph_.get_mesh_graph_descriptor();
+            const auto& pinnings = mgd.get_pinnings();
             for (const auto& [pos, fabric_node] : pinnings) {
                 config.pinnings.emplace_back(pos, fabric_node);
             }
+
+            // Extract mesh colocation pinnings from MGD (e.g. colocate two logical meshes on the same host)
+            const auto& mesh_colocation_pinnings = mgd.get_mesh_colocation_pinnings();
+            config.mesh_colocation_pinnings.insert(
+                config.mesh_colocation_pinnings.end(),
+                mesh_colocation_pinnings.begin(),
+                mesh_colocation_pinnings.end());
         }
 
         // Set per-mesh validation modes based on mesh graph policy

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -713,6 +713,43 @@ std::optional<std::string> resolve_local_hostname_from_hostname_asics_map(
     return std::nullopt;
 }
 
+// Partition physical meshes by host using config.hostname_to_asics.
+// Single-host physical meshes are grouped together per host; multi-host physical meshes become their own
+// singleton group (we cannot attribute them to a single host). Physical meshes in `bound_physical_mesh_ids`
+// and meshes with no nodes are skipped.
+std::vector<std::set<MeshId>> build_inter_mesh_host_partitions(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const std::set<MeshId>& bound_physical_mesh_ids) {
+    std::vector<std::set<MeshId>> global_mesh_groups;
+    std::map<std::string, std::size_t> host_group_index;
+    for (const auto& [phys_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
+        if (bound_physical_mesh_ids.contains(phys_mesh_id)) {
+            continue;
+        }
+        if (adj.get_nodes().empty()) {
+            continue;
+        }
+        std::set<std::string> hosts_for_mesh;
+        for (const auto& asic_id : adj.get_nodes()) {
+            auto hostname = hostname_for_asic_from_hostname_map(asic_id, config.hostname_to_asics);
+            if (hostname.has_value()) {
+                hosts_for_mesh.insert(*hostname);
+            }
+        }
+        if (hosts_for_mesh.size() == 1) {
+            auto [it, inserted] = host_group_index.try_emplace(*hosts_for_mesh.begin(), global_mesh_groups.size());
+            if (inserted) {
+                global_mesh_groups.emplace_back();
+            }
+            global_mesh_groups[it->second].insert(phys_mesh_id);
+        } else {
+            global_mesh_groups.push_back({phys_mesh_id});
+        }
+    }
+    return global_mesh_groups;
+}
+
 // Minimal host cover for inter-mesh mapping: partition physical meshes by host, then apply.
 // `rank_bound_logical_to_physical`: logical meshes already fixed by rank bindings → skip those and their physical
 // meshes for host-alignment bias (empty when rank bindings are disabled).
@@ -744,41 +781,27 @@ void add_inter_mesh_minimal_host_cover_from_hostname_map(
         return;
     }
 
-    // Build global_mesh_groups in one pass: one group per host for single-host meshes, singleton for multi-host.
-    std::vector<std::set<MeshId>> global_mesh_groups;
-    std::map<std::string, std::size_t> host_group_index;
-    for (const auto& [phys_mesh_id, adj] : physical_graph.mesh_adjacency_graphs_) {
-        if (bound_physical_mesh_ids.contains(phys_mesh_id)) {
-            continue;
-        }
-        if (adj.get_nodes().empty()) {
-            continue;
-        }
-        std::set<std::string> hosts_for_mesh;
-        for (const auto& asic_id : adj.get_nodes()) {
-            auto hostname = hostname_for_asic_from_hostname_map(asic_id, config.hostname_to_asics);
-            if (hostname.has_value()) {
-                hosts_for_mesh.insert(*hostname);
-            }
-        }
-        if (hosts_for_mesh.size() == 1) {
-            auto [it, inserted] = host_group_index.try_emplace(*hosts_for_mesh.begin(), global_mesh_groups.size());
-            if (inserted) {
-                global_mesh_groups.emplace_back();
-            }
-            global_mesh_groups[it->second].insert(phys_mesh_id);
-        } else {
-            global_mesh_groups.push_back({phys_mesh_id});
-        }
-    }
+    // Build global_mesh_groups: one group per host for single-host meshes, singleton for multi-host.
+    std::vector<std::set<MeshId>> global_mesh_groups =
+        build_inter_mesh_host_partitions(config, physical_graph, bound_physical_mesh_ids);
     if (global_mesh_groups.empty()) {
         return;
     }
 
+    // HOST mesh colocation pinnings own the same-rank-groups mechanism (they impose hard, fine-grained co-host
+    // requirements). When present, this soft minimal-host-cover heuristic must not set same-rank groups, or it
+    // would overwrite/conflict with the pinning constraints. We still emit preferred globals below for packing.
+    const bool host_colocation_pinnings_present = std::any_of(
+        config.mesh_colocation_pinnings.begin(),
+        config.mesh_colocation_pinnings.end(),
+        [](const ::tt::tt_fabric::MeshColocationPinning& p) {
+            return p.type == ::tt::tt_fabric::MeshColocationType::Host;
+        });
+
     const auto [single_group_fits, preferred_globals] =
         ::tt::tt_fabric::PhysicalGroupingDescriptor::find_minimum_coverage_group(
             logical_target_set, global_mesh_groups);
-    if (single_group_fits) {
+    if (single_group_fits && !host_colocation_pinnings_present) {
         std::vector<std::set<MeshId>> target_groups;
         target_groups.push_back(logical_target_set);
         if (inter_mesh_constraints.set_same_rank_groups_constraint(target_groups, global_mesh_groups)) {
@@ -1007,6 +1030,114 @@ void add_logical_mesh_zero_anchor_inter_mesh_preference(
         from_discovery_position_partition.has_value());
 }
 
+// Enforce mesh colocation pinnings at the inter-mesh level.
+//
+// Each pinning (mesh_id_a, mesh_id_b) requires both logical meshes to be colocated within a grouping. Only HOST
+// colocation is currently supported: both meshes must map to physical meshes that belong to a single physical
+// host. Pinnings are transitive: (A, B) and (B, C) merge A, B and C into one co-location group.
+//
+// Implementation: the merged groups become same-rank target groups and the per-host physical-mesh partitions
+// become the global groups. The solver's same-rank-groups feasibility check then guarantees every mesh in a
+// group maps into one host partition (and distinct groups map to distinct hosts). Because inter-mesh mapping is
+// injective (each logical mesh takes a distinct physical mesh), a group of N meshes requires a host with at
+// least N physical meshes.
+void add_inter_mesh_colocation_pinning_constraints(
+    const TopologyMappingConfig& config,
+    const PhysicalMultiMeshGraph& physical_graph,
+    const AdjacencyGraph<MeshId>& mesh_logical_level_graph,
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId>& inter_mesh_constraints) {
+    // Gather the HOST-type colocation pinnings (the only grouping enforced today).
+    std::vector<const ::tt::tt_fabric::MeshColocationPinning*> host_pinnings;
+    for (const auto& pinning : config.mesh_colocation_pinnings) {
+        if (pinning.type == ::tt::tt_fabric::MeshColocationType::Host) {
+            host_pinnings.push_back(&pinning);
+        }
+    }
+    if (host_pinnings.empty()) {
+        return;
+    }
+
+    TT_FATAL(
+        !config.hostname_to_asics.empty(),
+        "HOST mesh colocation pinnings were specified but no host information (hostname_to_asics) is available, so "
+        "the solver cannot determine which physical meshes share a host.");
+
+    const auto& logical_nodes = mesh_logical_level_graph.get_nodes();
+    const std::set<MeshId> logical_mesh_set(logical_nodes.begin(), logical_nodes.end());
+
+    // Union-find over pinned mesh pairs to compute transitive co-location groups.
+    std::map<MeshId, MeshId> parent;
+    std::function<MeshId(MeshId)> find = [&](MeshId m) -> MeshId {
+        auto it = parent.find(m);
+        if (it == parent.end() || it->second == m) {
+            return m;
+        }
+        MeshId root = find(it->second);
+        parent[m] = root;
+        return root;
+    };
+    auto unite = [&](MeshId a, MeshId b) {
+        parent.try_emplace(a, a);
+        parent.try_emplace(b, b);
+        MeshId root_a = find(a);
+        MeshId root_b = find(b);
+        if (root_a != root_b) {
+            parent[root_a] = root_b;
+        }
+    };
+
+    for (const auto* pinning : host_pinnings) {
+        const MeshId mesh_a = pinning->mesh_id_a;
+        const MeshId mesh_b = pinning->mesh_id_b;
+        TT_FATAL(
+            mesh_a != mesh_b,
+            "Mesh colocation pinning references the same mesh twice (mesh_id: {}); the two meshes must be distinct.",
+            mesh_a.get());
+        TT_FATAL(
+            logical_mesh_set.contains(mesh_a) && logical_mesh_set.contains(mesh_b),
+            "Mesh colocation pinning references mesh(es) not present in the logical topology: (mesh_id_a: {}, "
+            "mesh_id_b: {}).",
+            mesh_a.get(),
+            mesh_b.get());
+        unite(mesh_a, mesh_b);
+    }
+
+    // Collect merged groups by root; keep only groups with at least two meshes (singletons are unconstrained).
+    std::map<MeshId, std::set<MeshId>> groups_by_root;
+    for (const auto& [mesh_id, _] : parent) {
+        groups_by_root[find(mesh_id)].insert(mesh_id);
+    }
+    std::vector<std::set<MeshId>> target_groups;
+    for (auto& [_, group] : groups_by_root) {
+        if (group.size() >= 2) {
+            target_groups.push_back(std::move(group));
+        }
+    }
+    if (target_groups.empty()) {
+        return;
+    }
+
+    // Host partitions of physical meshes. We intentionally do not exclude rank-bound physical meshes here: a
+    // pinned mesh may itself be rank-bound, and its required physical mesh must remain in its host partition for
+    // the same-rank feasibility check to succeed.
+    const std::vector<std::set<MeshId>> global_groups =
+        build_inter_mesh_host_partitions(config, physical_graph, /*bound_physical_mesh_ids=*/{});
+
+    if (!inter_mesh_constraints.set_same_rank_groups_constraint(target_groups, global_groups)) {
+        TT_THROW(
+            "HOST mesh colocation pinnings are infeasible: could not place the {} colocation group(s) onto single "
+            "host(s). Ensure each group of N meshes can be covered by a host with at least N physical meshes, and "
+            "that the pinnings are compatible with any rank bindings and ASIC pinnings.",
+            target_groups.size());
+    }
+
+    log_info(
+        tt::LogFabric,
+        "Applied {} HOST mesh colocation group(s) across {} host partition(s)",
+        target_groups.size(),
+        global_groups.size());
+}
+
 // Helper function to build ASIC positions to ASIC IDs map
 std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
     const ::tt::tt_fabric::AdjacencyGraph<tt::tt_metal::AsicID>& physical_graph, const TopologyMappingConfig& config) {
@@ -1039,6 +1170,8 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
             config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, {});
         add_logical_mesh_zero_anchor_inter_mesh_preference(
             config, physical_graph, mesh_logical_level_graph, {}, inter_mesh_constraints);
+        add_inter_mesh_colocation_pinning_constraints(
+            config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints);
         return inter_mesh_constraints;
     }
 
@@ -1098,6 +1231,8 @@ std::map<AsicPosition, std::set<tt::tt_metal::AsicID>> build_asic_positions_map(
         config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints, rank_bound_logical_to_physical);
     add_logical_mesh_zero_anchor_inter_mesh_preference(
         config, physical_graph, mesh_logical_level_graph, rank_bound_logical_to_physical, inter_mesh_constraints);
+    add_inter_mesh_colocation_pinning_constraints(
+        config, physical_graph, mesh_logical_level_graph, inter_mesh_constraints);
     return inter_mesh_constraints;
 }
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
We already constrain the topology solver to take the hardware layout into account when forming meshes (via PGD). However it still has a large degree of freedom on how it lays out those meshes. It may make sense to allow workloads to specify additional layout requirements, on top of connections and individual asic pinnings. Either to achieve better performance or ensure that a given mesh graph is packed into a physical topology in a more predictable (and potentially optimal) way. So, add the ability to specify mesh co-location pinnings in the MGD (for now pinning meshes to the same host).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:p1-0tr/mgd-mesh-colocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=p1-0tr/mgd-mesh-colocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:p1-0tr/mgd-mesh-colocation)