### PR TITLE
Llama 70B vLLM determinism fixes (bug fix)

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -32,9 +32,7 @@ def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     a deterministic but well-mixed device seed without relying on mutable
     per-slot RNG state. The constants below are the SplitMix64 finalizer.
     """
-    value = (int(seed) & _UINT64_MASK) ^ (
-        (int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK
-    )
+    value = (int(seed) & _UINT64_MASK) ^ ((int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK)
     value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _UINT64_MASK
     value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _UINT64_MASK
     value = (value ^ (value >> 31)) & _UINT64_MASK
@@ -371,9 +369,7 @@ class SamplingGenerator:
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
         use_internal_trace = (
-            enable_trace
-            and self.enable_internal_trace
-            and not self.seed_manager.has_active_request_seed()
+            enable_trace and self.enable_internal_trace and not self.seed_manager.has_active_request_seed()
         )
 
         if not use_internal_trace:

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -480,6 +480,8 @@ def format_sampling_params(sampling_params, max_batch_size):
         if temperature[i] == 0:
             temperature[i] = 1.0
             top_k[i] = 1
+            # Device sampling treats p=0 as a first-token cutoff; with k=1
+            # this is the compact argmax representation for greedy rows.
             top_p[i] = 0.0
         else:
             temperature[i] = 1 / temperature[i]
@@ -532,6 +534,7 @@ def broadcast_sampling_params(
         else:
             chosen = value
         if value_is_list:
+            # Preserve list fields as lists even when the selected value is None.
             kwargs[f.name] = [chosen] * slot_len
         elif chosen is None:
             kwargs[f.name] = None
@@ -633,13 +636,13 @@ class SeedManager:
             return None
         if isinstance(seeds, torch.Tensor):
             flat = seeds.reshape(-1)
-            if flat.numel() == 0:
+            if slot < 0 or slot >= flat.numel():
                 return None
-            seed = flat[slot] if flat.numel() > slot else flat[0]
+            seed = flat[slot]
         elif isinstance(seeds, list):
-            if not seeds:
+            if slot < 0 or slot >= len(seeds):
                 return None
-            seed = seeds[slot] if len(seeds) > slot else seeds[0]
+            seed = seeds[slot]
         else:
             seed = seeds
 
@@ -699,17 +702,17 @@ class SeedManager:
             flat_positions = positions.reshape(-1)
 
             def _position(slot):
-                if flat_positions.numel() == 0:
+                if slot < 0 or slot >= flat_positions.numel():
                     return None
-                pos = flat_positions[slot] if flat_positions.numel() > slot else flat_positions[0]
+                pos = flat_positions[slot]
                 return int(pos.item())
 
         elif isinstance(positions, list):
 
             def _position(slot):
-                if not positions:
+                if slot < 0 or slot >= len(positions):
                     return None
-                return int(positions[slot] if len(positions) > slot else positions[0])
+                return int(positions[slot])
 
         else:
 
@@ -833,6 +836,4 @@ class SeedManager:
             torch.tensor(new_seeds), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=self._seed_mapper
         )
         ttnn.copy_host_to_device_tensor(new_seed_tt, self.tt_sampling.seeds_tt_tensor)
-        if self._active_request_seed:
-            ttnn.synchronize_device(self.tt_sampling.mesh_device)
         self._reseted = False

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -18,6 +18,27 @@ from .tt_penalties import TTPenalties
 from .tt_sampling import TTSampling
 
 MAX_UINT32 = 2**32 - 1
+# MAX_UINT32 is reserved as the device skip sentinel; keep real seeds in a bounded positive range.
+DEVICE_SEED_MAX = 1_000_000
+_UINT64_MASK = (1 << 64) - 1
+
+
+def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
+    """Derive a stable per-token device seed from a request seed.
+
+    The device sampling op accepts bounded positive seeds, while vLLM
+    request seeds can be any integer and must be reproducible regardless
+    of batch slot. Hashing (request seed, token counter) gives each token
+    a deterministic but well-mixed device seed without relying on mutable
+    per-slot RNG state. The constants below are the SplitMix64 finalizer.
+    """
+    value = (int(seed) & _UINT64_MASK) ^ (
+        (int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK
+    )
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _UINT64_MASK
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _UINT64_MASK
+    value = (value ^ (value >> 31)) & _UINT64_MASK
+    return (value % DEVICE_SEED_MAX) + 1
 
 
 @dataclass(frozen=True)
@@ -90,7 +111,10 @@ class SamplingGenerator:
 
         self._trace_states: dict[_TraceKey, dict] = {}
         seed_batch_size = self.tt_sampling.max_batch_size * self.tt_sampling._sampling_dp
-        self.seed_manager = SeedManager(self.tt_sampling, max_batch_size=seed_batch_size)
+        self.seed_manager = SeedManager(
+            self.tt_sampling,
+            max_batch_size=seed_batch_size,
+        )
 
     def _new_trace_state(self):
         return {"id": None, "input": None, "output": None, "kwargs": {}}
@@ -344,7 +368,13 @@ class SamplingGenerator:
         penalties_on = self._penalties_active
         log_probs_on = getattr(self, "_log_probs_active", False)
         force_argmax = self.tt_sampling.force_argmax_sampling
-        use_internal_trace = enable_trace and self.enable_internal_trace
+        # Explicit request seeds update a persistent seed tensor every token;
+        # run them directly so trace replay cannot observe stale seed state.
+        use_internal_trace = (
+            enable_trace
+            and self.enable_internal_trace
+            and not self.seed_manager.has_active_request_seed()
+        )
 
         if not use_internal_trace:
             tt_out = self._run_sampling(
@@ -454,6 +484,7 @@ def format_sampling_params(sampling_params, max_batch_size):
         if temperature[i] == 0:
             temperature[i] = 1.0
             top_k[i] = 1
+            top_p[i] = 0.0
         else:
             temperature[i] = 1 / temperature[i]
 
@@ -499,11 +530,14 @@ def broadcast_sampling_params(
     kwargs = {}
     for f in fields(formatted_sampling_params):
         value = getattr(formatted_sampling_params, f.name)
-        if isinstance(value, List):
+        value_is_list = isinstance(value, List)
+        if value_is_list:
             chosen = value[idx] if idx < len(value) else value[0]
         else:
             chosen = value
-        if chosen is None:
+        if value_is_list:
+            kwargs[f.name] = [chosen] * slot_len
+        elif chosen is None:
             kwargs[f.name] = None
         else:
             kwargs[f.name] = [chosen] * slot_len
@@ -551,32 +585,29 @@ class SeedManager:
 
     Tracks which users have explicit seeds set (``_seed_active``) and avoids
     unnecessary host-to-device copies during decode when no seeds are active.
-    On the first call after a reset with no active seeds, pushes MAX_UINT32
-    (SKIP) values so the device skips ``rand_tile_init``, then skips all
-    subsequent decode pushes until the next ``reset_seed``.
     """
 
     def __init__(self, tt_sampling, max_batch_size=32):
         self.max_batch_size = max_batch_size
         self.seeds = [None for _ in range(max_batch_size)]
-        # Pre-allocate RNG objects; actual seeds are set via reset_seed().
+        self.seed_counters = [0 for _ in range(max_batch_size)]
+        # Pre-allocate RNG objects; actual request seeds are set via reset_seed().
         self.rngs = [random.Random(secrets.randbits(64)) for _ in range(max_batch_size)]
         self.tt_sampling = tt_sampling
-        # True when at least one user slot has a non-None seed.
+        # True when at least one user slot has a non-None request seed.
         self._seed_active = False
         # Set to True by reset_seed() so the next get_new_values() pushes
-        # fresh values to the device.  When _seed_active is True this pushes
-        # RNG-derived seeds; when False it pushes random per-user values to
-        # diversify the device RNG state (state 1 in the three-state machine
-        # described in get_new_values).  Cleared after the push.
+        # fresh values to the device. When _seed_active is True this pushes
+        # per-user seeds; when False it pushes varied per-user
+        # values to diversify the device RNG state. Cleared after the push.
         self._reseted = False
         # When True, the next get_new_values() must push MAX_UINT32 (SKIP) so
-        # the device transitions from rand_tile_init to rand_tile (advance).
-        # This is needed after pushing random seeds for unseeded slots during
-        # prefill — without it the device would re-init from the same values
-        # every decode step instead of advancing.
+        # the device transitions from rand_tile_init to rand_tile advance.
         self._needs_skip = False
-        # Mesh mapper for sharding seeds across rows when sampling_dp > 1
+        # True only for the most recent get_new_values() call when at least
+        # one active slot used an explicit request seed.
+        self._active_request_seed = False
+        # Mesh mapper for sharding seeds across rows when sampling_dp > 1.
         if tt_sampling._sampling_dp > 1:
             self._seed_mapper = ttnn.ShardTensor2dMesh(
                 tt_sampling.mesh_device, dims=tt_sampling._param_dims, mesh_shape=tt_sampling.cluster_shape
@@ -584,44 +615,171 @@ class SeedManager:
         else:
             self._seed_mapper = None
 
+    def _next_unseeded_rng_seed(self) -> int:
+        return secrets.randbits(64)
+
+    def _next_unseeded_device_seed(self) -> int:
+        return secrets.randbelow(DEVICE_SEED_MAX) + 1
+
+    def _next_device_seed_from_rng(self, rng: random.Random) -> int:
+        return rng.randint(1, DEVICE_SEED_MAX)
+
+    def _next_device_seed_for_slot(self, slot: int) -> int:
+        request_seed = self.seeds[slot]
+        if request_seed is None:
+            return self._next_device_seed_from_rng(self.rngs[slot])
+        device_seed = _hash_request_seed_to_device_seed(int(request_seed), self.seed_counters[slot])
+        self.seed_counters[slot] += 1
+        return device_seed
+
+    def _seed_from_slot_params(self, seeds, slot: int):
+        if seeds is None:
+            return None
+        if isinstance(seeds, torch.Tensor):
+            flat = seeds.reshape(-1)
+            if flat.numel() == 0:
+                return None
+            seed = flat[slot] if flat.numel() > slot else flat[0]
+        elif isinstance(seeds, list):
+            if not seeds:
+                return None
+            seed = seeds[slot] if len(seeds) > slot else seeds[0]
+        else:
+            seed = seeds
+
+        if seed is None:
+            return None
+        if isinstance(seed, torch.Tensor):
+            if seed.numel() == 0:
+                return None
+            seed = seed.reshape(-1)[0].item()
+        return int(seed)
+
+    def reset_seed_from_slots(self, seeds, user_ids):
+        """Reset decode seed state from slot-indexed sampling params."""
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+        for user in user_ids:
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, slot)
+            self.seeds[slot] = seed
+            self.seed_counters[slot] = 0
+            if seed is None:
+                self.rngs[slot].seed(self._next_unseeded_rng_seed())
+            else:
+                self.rngs[slot].seed(int(seed))
+        self._seed_active = any(s is not None for s in self.seeds)
+        self._reseted = True
+
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> bool:
+        """Reset only active slots whose slot-indexed seed changed."""
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+        reset_slots = []
+        for user in user_ids:
+            slot = int(user)
+            if self._seed_from_slot_params(seeds, slot) != self.seeds[slot]:
+                reset_slots.append(slot)
+        if not reset_slots:
+            return False
+        self.reset_seed_from_slots(seeds, reset_slots)
+        return True
+
+    def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
+        """Make explicit-seed decode independent of persistent slot lifetime.
+
+        vLLM can temporarily remove running requests from the persistent batch
+        while admitting another prefill batch, then re-add them in different
+        slots. For explicit request seeds, deriving the per-token device seed
+        from the absolute decode position keeps the stream reproducible even
+        when the Python-side slot counter was reset or moved.
+        """
+        if positions is None:
+            return
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+
+        if isinstance(positions, torch.Tensor):
+            flat_positions = positions.reshape(-1)
+
+            def _position(slot):
+                if flat_positions.numel() == 0:
+                    return None
+                pos = flat_positions[slot] if flat_positions.numel() > slot else flat_positions[0]
+                return int(pos.item())
+
+        elif isinstance(positions, list):
+
+            def _position(slot):
+                if not positions:
+                    return None
+                return int(positions[slot] if len(positions) > slot else positions[0])
+
+        else:
+
+            def _position(_slot):
+                return int(positions)
+
+        for user in user_ids:
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, slot)
+            if seed is None:
+                continue
+            position = _position(slot)
+            if position is None or position < 0:
+                continue
+            self.seed_counters[slot] = max(0, position + offset)
+
+    def has_active_request_seed(self) -> bool:
+        return self._active_request_seed
+
     def apply_slot_remap(self, remap):
         """Reindex RNG state after batch condense.
 
         ``remap`` is a 1-D int tensor of length ``max_batch_size`` where
         ``remap[i] = j`` means slot *i* now holds the request that was
-        previously at slot *j*.  Identity entries (``remap[i] == i``) are
-        no-ops.  Only non-identity entries trigger a move.
+        previously at slot *j*. Identity entries (``remap[i] == i``) are
+        no-ops. Only non-identity entries trigger a move.
         """
         if not self._seed_active:
             return
         moves = [(int(remap[i]), i) for i in range(len(remap)) if int(remap[i]) != i]
         if not moves:
             return
-        # Snapshot the state we're about to overwrite.
         old_seeds = list(self.seeds)
+        old_counters = list(self.seed_counters)
         old_rngs = list(self.rngs)
+        moved_sources = {old_slot for old_slot, _ in moves}
+        moved_destinations = {new_slot for _, new_slot in moves}
         for old_slot, new_slot in moves:
             self.seeds[new_slot] = old_seeds[old_slot]
+            self.seed_counters[new_slot] = old_counters[old_slot]
             # copy.copy preserves internal RNG state but creates an
-            # independent object so the old slot's reference (still in
-            # self.rngs[old_slot]) does not alias the new one. Without
-            # this, get_new_values() would advance the shared object
-            # twice per decode step (once for each slot).
+            # independent object so the old slot reference does not alias
+            # the new one.
             self.rngs[new_slot] = copy.copy(old_rngs[old_slot])
+        for old_slot in moved_sources - moved_destinations:
+            self.seeds[old_slot] = None
+            self.seed_counters[old_slot] = 0
         self._seed_active = any(s is not None for s in self.seeds)
 
     def reset_seed(self, seeds, user_ids):
         """Update RNG state for the given user slots after a prefill.
 
         Args:
-            seeds: List of seed values (int or None) for each user in ``user_ids``.
+            seeds: Seed values in request order. Accepts a list, tensor, scalar,
+                or None (treated as all unseeded).
             user_ids: Batch slot indices being prefilled.
         """
         for i, user in enumerate(user_ids):
-            self.seeds[user] = seeds[i]
-            # Re-seed the RNG; use random seed as fallback when no explicit seed is given.
-            self.rngs[user].seed(seeds[i] if seeds[i] is not None else secrets.randbits(64))
-        # Mark seeds active only when at least one slot has an explicit seed.
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, i)
+            self.seeds[slot] = seed
+            self.seed_counters[slot] = 0
+            if seed is None:
+                self.rngs[slot].seed(self._next_unseeded_rng_seed())
+            else:
+                self.rngs[slot].seed(int(seed))
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
 
@@ -629,57 +787,48 @@ class SeedManager:
         """Generate and push new seed values to the device.
 
         **Seeded path** (``_seed_active=True``):
-        Advances each slot's host-side RNG and copies the new values to the
-        device every step.  The device calls ``rand_tile_init`` with each
-        user's value, then ``rand_tile`` to produce the sampling tile.
+        Advances each active slot seed state and copies the new values to
+        the device every step. Explicit request seeds produce slot-independent
+        device seeds derived from the request seed and the slot counter. Some
+        decode callers align that counter to the absolute token position so
+        vLLM batch-layout changes cannot reset a request's random stream.
 
         **Unseeded path** (``_seed_active=False``):
         Uses a three-state machine to ensure each user gets a unique device
         RNG state without redundant host-to-device copies during decode:
 
-          State 1 — **init** (``_reseted=True``):
-            Push random per-user values.  The device calls ``rand_tile_init``
-            for every user, giving each one a unique RNG seed.  This prevents
-            stale identical tiles left over from a previous batch (e.g. a
-            replicated seed during an earlier prefill).
+          State 1 - **init** (``_reseted=True``):
+            Push varied per-user values from system entropy.
 
-          State 2 — **transition** (``_needs_skip=True``):
-            Push MAX_UINT32 (SKIP).  The device skips ``rand_tile_init`` and
-            calls only ``rand_tile``, advancing each user's RNG from the
-            varied state established in state 1.  Without this step the
-            device would re-run ``rand_tile_init`` with the same values
-            every decode step, producing identical tiles.
+          State 2 - **transition** (``_needs_skip=True``):
+            Push MAX_UINT32 (SKIP) so the device stops reinitializing and
+            starts advancing via rand_tile().
 
-          State 3 — **steady** (both flags clear):
-            Early-return with no device copy.  The device continues to call
-            ``rand_tile`` each step, advancing the per-user RNG
-            independently.  No host interaction needed.
-
-        ``reset_seed`` always sets ``_reseted=True``, so any new prefill
-        re-enters state 1 to refresh the device RNG.
+          State 3 - **steady** (both flags clear):
+            Early-return with no device copy.
         """
         if empty_slots is None:
-            empty_slots = range(self.max_batch_size)
+            empty_slots = list(range(self.max_batch_size))
+        else:
+            empty_slots = [int(slot) for slot in empty_slots]
+        empty_slot_set = set(empty_slots)
+        self._active_request_seed = any(self.seeds[i] is not None for i in empty_slot_set)
 
         if not self._seed_active:
+            self._active_request_seed = False
             if self._reseted:
-                # State 1 (init): must take precedence over a pending
-                # transition so a new prefill always refreshes the device
-                # RNG with varied per-user values.
-                new_seeds = [random.randint(0, 1000000) for _ in range(self.max_batch_size)]
+                new_seeds = [self._next_unseeded_device_seed() for _ in range(self.max_batch_size)]
                 self._needs_skip = True
             elif self._needs_skip:
-                # State 2 (transition): push SKIP so the device stops calling
-                # rand_tile_init and starts advancing via rand_tile().
                 new_seeds = [MAX_UINT32] * self.max_batch_size
                 self._needs_skip = False
             else:
-                # State 3 (steady): device already has SKIP, rand_tile
-                # advances on its own — no host-to-device copy needed.
                 return
         else:
-            # Advance RNG for each user in empty_slots; non-active slots get MAX_UINT32.
-            new_seeds = [rng.randint(0, 1000000) if i in empty_slots else MAX_UINT32 for i, rng in enumerate(self.rngs)]
+            new_seeds = [
+                self._next_device_seed_for_slot(i) if i in empty_slot_set else MAX_UINT32
+                for i in range(self.max_batch_size)
+            ]
             if replicate_seeds:
                 assert len(empty_slots) == 1, "Cannot replicate seeds if empty_slots is not length 1"
                 new_seeds = self.max_batch_size * [new_seeds[empty_slots[0]]]
@@ -688,4 +837,6 @@ class SeedManager:
             torch.tensor(new_seeds), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=self._seed_mapper
         )
         ttnn.copy_host_to_device_tensor(new_seed_tt, self.tt_sampling.seeds_tt_tensor)
+        if self._active_request_seed:
+            ttnn.synchronize_device(self.tt_sampling.mesh_device)
         self._reseted = False

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -140,6 +140,7 @@ class TTPenalties(LightweightModule):
         self.output_mask = self._alloc_int_buffer(shard_dims=shard_dims)
         self.output_counts_gathered = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
         self.output_counts = self._alloc_int_buffer(shard_dims=shard_dims)
+        self._shard_dims_mask = shard_dims
         self.decode_src = self._alloc_int_buffer(
             host=torch.ones(self._total_batch, 1), shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT
         )
@@ -207,6 +208,18 @@ class TTPenalties(LightweightModule):
             src_tt = ttnn.from_torch(src, dtype=dst.dtype, layout=ttnn.TILE_LAYOUT, device=None)
         ttnn.copy_host_to_device_tensor(src_tt, dst)
 
+    def _copy_int_host_to_device(self, dst: ttnn.Tensor, src: torch.Tensor, shard_dims):
+        mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.cluster_shape)
+        src_tt = ttnn.from_torch(src, dtype=dst.dtype, layout=ttnn.TILE_LAYOUT, device=None, mesh_mapper=mapper)
+        ttnn.copy_host_to_device_tensor(src_tt, dst)
+
+    def _token_counts_host(self, tokens_2d: torch.Tensor) -> torch.Tensor:
+        valid = (tokens_2d >= 0) & (tokens_2d < self.vocab_size)
+        token_ids = torch.where(valid, tokens_2d, torch.zeros_like(tokens_2d)).to(torch.int64)
+        counts = torch.zeros((self._total_batch, self.vocab_size), dtype=torch.int32)
+        counts.scatter_add_(1, token_ids, valid.to(torch.int32))
+        return counts
+
     def reset_params(self, presence: List[float], frequency: List[float], repetition: List[float]):
         presence_tensor = self._pad_params(presence)
         frequency_tensor = self._pad_params(frequency)
@@ -241,24 +254,14 @@ class TTPenalties(LightweightModule):
         return tokens_2d
 
     def reset_prompt_tokens(self, prompt_tokens: torch.Tensor):
-        # Mask out padding positions (-1) instead of inventing a fake token id by expanding vocab_size.
         prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
         prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
 
-        src_host = (prompt_tokens_2d != -1).to(torch.int32)
-        idx_host = torch.where(prompt_tokens_2d == -1, torch.zeros_like(prompt_tokens_2d), prompt_tokens_2d)
-
-        prompt_tokens_tt = self._alloc_int_buffer(
-            host=idx_host,
-            shard_dims=self._shard_dims_gathered,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        src_tt = self._alloc_int_buffer(
-            host=src_host,
-            shard_dims=self._shard_dims_gathered,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-        )
-        self.token_bin_counts_and_mask(new_tokens=prompt_tokens_tt, src=src_tt, mask=self.prompt_mask)
+        # Build reset masks on host to avoid device scatter_add races on
+        # duplicate prompt token ids (common in penalty tests/prompts).
+        prompt_counts = self._token_counts_host(prompt_tokens_2d)
+        prompt_mask = (prompt_counts > 0).to(torch.int32)
+        self._copy_int_host_to_device(self.prompt_mask, prompt_mask, self._shard_dims_mask)
 
     def reset_output_tokens(self, tokens=None):
         # ALWAYS reset output buffers to zero first (this is the core accuracy fix from issue #35731)
@@ -271,40 +274,13 @@ class TTPenalties(LightweightModule):
 
         # THEN optionally repopulate if tokens are provided
         if tokens is not None:
-            # Mask out padding positions (-1) instead of inventing a fake token id by expanding vocab_size.
             tokens_2d = tokens.reshape(-1, tokens.shape[-1])
             tokens_2d = self._pad_batch_to_max(tokens_2d, pad_value=-1)
-            src_host = (tokens_2d != -1).to(torch.int32)
-            idx_host = torch.where(tokens_2d == -1, torch.zeros_like(tokens_2d), tokens_2d)
-
-            mapper = (
-                ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._shard_dims_gathered, mesh_shape=self.cluster_shape)
-                if self._sampling_dp > 1
-                else None
-            )
-            tokens_tt = ttnn.from_torch(
-                idx_host,
-                device=self.mesh_device,
-                dtype=ttnn.uint32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=mapper,
-            )
-            src_tt = ttnn.from_torch(
-                src_host,
-                device=self.mesh_device,
-                dtype=ttnn.int32,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                mesh_mapper=mapper,
-            )
-            self.token_bin_counts_and_mask(
-                new_tokens=tokens_tt,
-                counts=self.output_counts_gathered,
-                src=src_tt,
-                counts_sliced=self.output_counts,
-                mask=self.output_mask,
-            )
-            tokens_tt.deallocate()
-            src_tt.deallocate()
+            output_counts = self._token_counts_host(tokens_2d)
+            output_mask = (output_counts > 0).to(torch.int32)
+            self._copy_int_host_to_device(self.output_counts_gathered, output_counts, self._shard_dims_gathered)
+            self._copy_int_host_to_device(self.output_counts, output_counts, self._shard_dims_mask)
+            self._copy_int_host_to_device(self.output_mask, output_mask, self._shard_dims_mask)
 
     def update_output_tokens(self, new_tokens):
         # Reshape decode token to [batch, 1] for scatter_add.

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -50,15 +50,15 @@ class TTSampling(LightweightModule):
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
 
-        When every user in the batch has k=1 (top-1), p=1.0 (no top-p filter),
+        When every user in the batch has k=1 (top-1), p=0.0 or p=1.0 (no top-p filter),
         and temp=1.0 (no temperature scaling), we can skip the full top-k / top-p /
         temperature / RNG pipeline and use a single all-gather + argmax instead.
         This is significantly faster because argmax needs only one all-gather of the
         full logits tensor vs. three gathers (values, indices, sampled tokens) in the
         normal path.
 
-        Note: p=1.0 here is the *caller's* convention ("keep all tokens"), distinct
-        from the internal device default of p=0 which also means "no filtering."
+        Note: callers may represent greedy rows with p=1.0, while the
+        device argmax-style representation uses p=0.0.
         The model config must also set allow_force_argmax=True for this to activate.
 
         Changing this state between decode steps invalidates captured traces, so
@@ -67,7 +67,7 @@ class TTSampling(LightweightModule):
         return (
             self._allow_force_argmax_sampling
             and is_default_value(k, 1)
-            and is_default_value(p, 1.0)
+            and (is_default_value(p, 1.0) or is_default_value(p, 0.0))
             and is_default_value(temp, 1.0)
         )
 
@@ -130,6 +130,13 @@ class TTSampling(LightweightModule):
         self.sub_core_grids = getattr(args, "sub_core_grids", None)
         self.sub_core_grid_topk = getattr(args, "sub_core_grid_topk", None)
         self.start_core = getattr(args, "start_core", ttnn.CoreCoord(0, 0))
+        self._sampling_sub_core_grids = (
+            ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                self.start_core, self.max_batch_size, self.sub_core_grids, row_wise=True
+            )
+            if self.sub_core_grids is not None
+            else None
+        )
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
@@ -588,7 +595,7 @@ class TTSampling(LightweightModule):
         ttnn.manual_seed(
             seeds=self.seeds_tt_tensor,
             user_ids=self.user_ids_tt_tensor,
-            sub_core_grids=self.sub_core_grids,
+            sub_core_grids=self._sampling_sub_core_grids,
         )
         # Perform the actual sampling with top-k, top-p, and temperature
         tt_out_tok = ttnn.sampling(
@@ -597,11 +604,7 @@ class TTSampling(LightweightModule):
             k=self.k_tensor,
             p=self.p_tensor,
             temp=self.temp_tensor,
-            sub_core_grids=ttnn.num_cores_to_corerangeset_in_subcoregrids(
-                self.start_core, self.max_batch_size, self.sub_core_grids, row_wise=True
-            )
-            if self.sub_core_grids is not None
-            else None,
+            sub_core_grids=self._sampling_sub_core_grids,
             output_tensor=tt_out_tok,
         )
 

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -1,12 +1,20 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
 
 import ttnn
-from models.common.sampling import LogProbsCalculator
+from models.common.sampling import (
+    LogProbsCalculator,
+    SamplingParams,
+    SeedManager,
+    broadcast_sampling_params,
+    format_sampling_params,
+)
 from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
 
@@ -59,6 +67,46 @@ TG_SUB_CORE_GRIDS = ttnn.CoreRangeSet(
     ]
 )
 TG_NUM_TP_DEVICES = 8  # TP dimension for Galaxy
+
+
+def _make_host_only_seed_manager(max_batch_size=4):
+    return SeedManager(SimpleNamespace(_sampling_dp=1), max_batch_size=max_batch_size)
+
+
+def test_seed_manager_seed_params_do_not_fallback_to_slot_zero():
+    seed_manager = _make_host_only_seed_manager()
+
+    assert seed_manager._seed_from_slot_params([11], 0) == 11
+    assert seed_manager._seed_from_slot_params([11], 1) is None
+    assert seed_manager._seed_from_slot_params(torch.tensor([22]), 1) is None
+    assert seed_manager._seed_from_slot_params(33, 3) == 33
+
+
+def test_seed_counter_position_alignment_skips_out_of_bounds_slots():
+    seed_manager = _make_host_only_seed_manager()
+
+    seed_manager.align_seed_counters_to_positions([101, None, 303], [0, 2], [5], offset=1)
+
+    assert seed_manager.seed_counters == [6, 0, 0, 0]
+
+
+def test_broadcast_sampling_params_preserves_none_list_fields():
+    params = SamplingParams(temperature=[1.0, 1.0], top_k=[1, 1], top_p=[1.0, 1.0], seed=[None, 42])
+
+    broadcast = broadcast_sampling_params(params, 0, slot_len=4)
+
+    assert broadcast.seed == [None, None, None, None]
+
+
+def test_format_sampling_params_uses_device_argmax_sentinel_for_greedy_rows():
+    params = format_sampling_params(
+        SamplingParams(temperature=0.0, top_k=32, top_p=0.95),
+        max_batch_size=32,
+    )
+
+    assert params.temperature[0] == 1.0
+    assert params.top_k[0] == 1
+    assert params.top_p[0] == 0.0
 
 
 def _skip_if_not_galaxy(mesh_device):

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -453,9 +453,7 @@ class Generator(WarmupForwardMixin):
         sampling_prompt_tokens = None
         if sampling_params is not None:
             source_prompt_tokens = prompt_tokens if prompt_tokens is not None else tokens
-            max_prompt_tokens_len = (
-                max(int(prompt_lens[idx]) for idx in range(batch)) if batch > 0 else batch_seq_len
-            )
+            max_prompt_tokens_len = max(int(prompt_lens[idx]) for idx in range(batch)) if batch > 0 else batch_seq_len
             sampling_prompt_tokens = torch.full(
                 (self.model_args.max_batch_size, max_prompt_tokens_len),
                 -1,
@@ -1283,9 +1281,7 @@ class Generator(WarmupForwardMixin):
                 temperature_values = [temperature_values]
             if start_pos is not None:
                 active_slots = [
-                    idx
-                    for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist())
-                    if int(pos) >= 0
+                    idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
                 ]
                 temperature_values = [
                     temperature_values[idx]
@@ -1314,9 +1310,7 @@ class Generator(WarmupForwardMixin):
         active_seed_slots = None
         if start_pos is not None:
             active_seed_slots = [
-                idx
-                for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist())
-                if int(pos) >= 0
+                idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
             ]
         decode_kwargs = {
             "current_pos": start_pos,
@@ -1354,9 +1348,7 @@ class Generator(WarmupForwardMixin):
             seed_values = getattr(sampling_params, "seed", None)
             if _seed_debug_enabled():
                 debug_slots = (
-                    active_seed_slots
-                    if active_seed_slots is not None
-                    else list(range(seed_manager.max_batch_size))
+                    active_seed_slots if active_seed_slots is not None else list(range(seed_manager.max_batch_size))
                 )
                 seed_values_list = _as_list(seed_values)
                 seed_slot_pairs = [

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -741,6 +741,8 @@ class Generator(WarmupForwardMixin):
                     if len(values) == 1 and len(slots) > 1:
                         values = values * len(slots)
                     user_vals = values[: len(slots)]
+                    # Pad inactive slots from the last active request, not
+                    # from any extra padding values in the formatted params.
                     filler = user_vals[-1] if user_vals else values[-1]
                     scattered = [filler for _ in range(max_batch)]
                     for val, slot_idx in zip(user_vals, slots):
@@ -815,7 +817,6 @@ class Generator(WarmupForwardMixin):
             else:
                 # tt_logits_batch was concatenated before switching to decode.
                 sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
-                # print("sampling_params_scattered", sampling_params, "empty_slots", empty_slots)
 
                 sampling_module.reset_sampling_params(sampling_params)
                 sampling_module.reset_prompt_tokens(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import ttnn
 import torch
 from loguru import logger
@@ -23,7 +25,7 @@ from models.common.llama_models import (
     CompletionPrediction,
 )
 
-from models.common.sampling import SamplingParams, format_sampling_params
+from models.common.sampling import SamplingParams, broadcast_sampling_params, format_sampling_params
 from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 
@@ -32,6 +34,42 @@ from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 # LlamaModel.prepare_decode_inputs_host: (tokens, current_pos, rope_idxs, page_table).
 # Used to refresh only the page-table trace input when KV blocks are reallocated.
 DECODE_PAGE_TABLE_INPUT_IDX = 3
+
+
+def _seed_debug_enabled() -> bool:
+    return os.getenv("TT_LLAMA_SEED_DEBUG", "").lower() in ("1", "true", "yes", "on")
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, torch.Tensor):
+        return value.reshape(-1).tolist()
+    return value if isinstance(value, list) else [value]
+
+
+def _fill_inactive_params_from_active(params, active_slots, max_batch):
+    active_slots = [int(slot) for slot in active_slots if 0 <= int(slot) < max_batch]
+    if not active_slots:
+        return params
+    active_slot_set = set(active_slots)
+    source_slot = active_slots[-1]
+    updates = {}
+    for f in fields(params):
+        values = getattr(params, f.name)
+        if f.name == "seed" or not isinstance(values, list):
+            updates[f.name] = values
+            continue
+        values = list(values)
+        if not values:
+            updates[f.name] = values
+            continue
+        fill_value = values[source_slot] if source_slot < len(values) else values[-1]
+        for idx in range(min(max_batch, len(values))):
+            if idx not in active_slot_set:
+                values[idx] = fill_value
+        updates[f.name] = values
+    return replace(params, **updates)
 
 
 def get_prefill_warmup_sequence_lengths(max_seq_len: int) -> list[int]:
@@ -176,6 +214,7 @@ class Generator(WarmupForwardMixin):
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
+        self._decode_inputs_need_reset = False
 
     def _set_prefill_column_mask(self, tt_column_mask):
         # Keep mask available on whichever TT_CCL instance attention currently uses.
@@ -411,15 +450,26 @@ class Generator(WarmupForwardMixin):
         if empty_slots is None:
             empty_slots = list(range(batch))
 
-        # If batch >= 16 and padded prompt_lens are all 128, and no cached tokens, use batched prefill
-        use_batched_prefill = False
-        if (
-            batch >= 16
-            and len(set(prefill_seq_lens)) == 1
-            and prefill_seq_lens[0] == 128
-            and (start_pos is None or all(x == 0 for x in start_pos))
-        ):
-            use_batched_prefill = True
+        sampling_prompt_tokens = None
+        if sampling_params is not None:
+            source_prompt_tokens = prompt_tokens if prompt_tokens is not None else tokens
+            max_prompt_tokens_len = (
+                max(int(prompt_lens[idx]) for idx in range(batch)) if batch > 0 else batch_seq_len
+            )
+            sampling_prompt_tokens = torch.full(
+                (self.model_args.max_batch_size, max_prompt_tokens_len),
+                -1,
+                dtype=torch.long,
+                device=source_prompt_tokens.device,
+            )
+            for request_idx, slot in enumerate(empty_slots):
+                if request_idx >= batch:
+                    break
+                slot = int(slot)
+                if slot < 0 or slot >= self.model_args.max_batch_size:
+                    continue
+                seq_len = min(int(prompt_lens[request_idx]), source_prompt_tokens.shape[-1])
+                sampling_prompt_tokens[slot, :seq_len] = source_prompt_tokens[request_idx, :seq_len]
 
         if return_logits:
             tt_out_logits_all_users = torch.zeros(batch, 1, self.model.args.padded_vocab_size)
@@ -429,6 +479,39 @@ class Generator(WarmupForwardMixin):
         # - return_logits=False: produce next-token ids; we only run on-device sampling when logits are not requested
         save_logits_to_host = tt_out_logits_all_users is not None
         do_device_sampling = (not return_logits) and (not save_logits_to_host)
+
+        explicit_seeded_prefill = False
+        seed_values = []
+        requires_slot_stable_prefill = False
+        if do_device_sampling and sampling_params is not None:
+            seed_values = _as_list(getattr(sampling_params, "seed", None))
+            temperature_values = _as_list(getattr(sampling_params, "temperature", None))
+            explicit_seeded_prefill = any(seed is not None for seed in seed_values)
+            requires_slot_stable_prefill = explicit_seeded_prefill or any(
+                float(temp) == 0.0 for temp in temperature_values if temp is not None
+            )
+            if explicit_seeded_prefill and _seed_debug_enabled():
+                seed_slot_pairs = [
+                    (idx, int(slot), seed_values[idx] if idx < len(seed_values) else None)
+                    for idx, slot in enumerate(empty_slots[: len(seed_values)])
+                ]
+                logger.info(
+                    f"SeedDBG Galaxy prefill: empty_slots={empty_slots}, prompt_lens={prompt_lens}, "
+                    f"seed_slot_pairs={seed_slot_pairs}"
+                )
+
+        # If batch >= 16 and padded prompt_lens are all 128, and no cached tokens, use batched prefill.
+        # Seeded or greedy on-device sampling currently requires slot-stable logits, so use the
+        # single-user prefill path for those batches.
+        use_batched_prefill = False
+        if (
+            batch >= 16
+            and len(set(prefill_seq_lens)) == 1
+            and prefill_seq_lens[0] == 128
+            and (start_pos is None or all(x == 0 for x in start_pos))
+            and not requires_slot_stable_prefill
+        ):
+            use_batched_prefill = True
 
         # Accumulate sharded logits (same format as decode, before all-gather) for on-device sampling.
 
@@ -442,6 +525,7 @@ class Generator(WarmupForwardMixin):
             and batch >= 16
             and not use_batched_prefill
             and not any(num_cached_tokens_list)
+            and not requires_slot_stable_prefill
             and 128 in prefill_seq_lens
             and len(set(prefill_seq_lens)) > 1
         )
@@ -471,6 +555,9 @@ class Generator(WarmupForwardMixin):
                 (False, [request_idx], [empty_slots[request_idx]]) for request_idx in range(batch)
             )
 
+        if do_device_sampling and use_batched_prefill:
+            self.tt_logits_accumulated_batched = []
+
         for work_use_batched_prefill, request_indices, request_slots in prefill_work_items:
             request_idx = request_indices[0]
             user_id = request_slots if work_use_batched_prefill else request_slots[0]
@@ -498,6 +585,8 @@ class Generator(WarmupForwardMixin):
                 prefill_seq_len = prefill_seq_lens[request_idx]
 
                 if prefill_seq_len not in self.model.tt_ccl.support_seqlens:
+                    user_enable_trace = False
+                if explicit_seeded_prefill:
                     user_enable_trace = False
 
             padded_batch = 32
@@ -570,9 +659,6 @@ class Generator(WarmupForwardMixin):
             last_token_idx_output = last_token_idx - num_cached if num_cached > 0 else last_token_idx
 
             if user_enable_trace:
-                # For batched prefill, reset to empty list since we use extend()
-                if use_batched_prefill and work_use_batched_prefill and do_device_sampling:
-                    self.tt_logits_accumulated_batched = []
                 tt_tok = self._easy_trace_prefill(**prefill_kwargs, prefill_seq_len=prefill_seq_len)
             else:
                 tt_tok = self.prefill_forward_single_user_text(**prefill_kwargs)
@@ -611,28 +697,44 @@ class Generator(WarmupForwardMixin):
                 else:
                     # Single user: logits list has 1 entry, copy into persistent buffer
                     ttnn.copy(input_a=tt_logits_list[0], input_b=self.tt_logits_accumulated[user_id])
+        if do_device_sampling and not use_batched_prefill and empty_slots:
+            active_prefill_slots = {int(slot) for slot in empty_slots}
+            fill_slot = int(empty_slots[0])
+            for slot in range(self.model_args.max_batch_size):
+                if slot not in active_prefill_slots:
+                    ttnn.copy(
+                        input_a=self.tt_logits_accumulated[fill_slot],
+                        input_b=self.tt_logits_accumulated[slot],
+                    )
+            if explicit_seeded_prefill:
+                ttnn.synchronize_device(self.mesh_device)
+
         prefill_log_probs = None
         # On-device sampling for prefill
         if do_device_sampling:
-            padded_batch = 32
+            max_batch = self.model_args.max_batch_size
 
             # Use batched list for batched prefill, persistent buffer for non-batched
             logits_source = self.tt_logits_accumulated_batched if use_batched_prefill else self.tt_logits_accumulated
+            concat_sub_core_grids = getattr(self.model_args, "sub_core_grids", None)
 
-            # Concatenate along slot dimension -> [1, 1, 1[32], vocab_shard]
-            tt_logits_batch = ttnn.concat(logits_source, dim=2)
-            # Sample using the sampling module
-            # Logits are in sharded format (before all-gather), same as decode
-            # sampling_params are already padded to 32 by format_sampling_params
+            if not explicit_seeded_prefill:
+                # Build the slot batch while the prefill sub-device manager is
+                # still active.  The default concat path is correct for this
+                # interleaved logits layout, but cannot run after switching to
+                # the narrower decode sub-device manager.
+                tt_logits_batch = ttnn.concat(logits_source, dim=2)
+
+            # Sample using the sampling module. Logits are in sharded format
+            # (before all-gather), same as decode.
             self.model.switch_mode("decode")
 
             # Setting sampling module up after switch to decode mode
-            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
+            sampling_params = format_sampling_params(sampling_params, max_batch)
+            sampling_module = self.model.sampling
 
             # Reorder sampling params so values sit in their slot positions (except seed).
             def _scatter_params_to_slots(params, slots):
-                max_batch = self.model_args.max_batch_size
-
                 def _scatter_list(values):
                     if not isinstance(values, list):
                         return values
@@ -641,10 +743,10 @@ class Generator(WarmupForwardMixin):
                     if len(values) == 1 and len(slots) > 1:
                         values = values * len(slots)
                     user_vals = values[: len(slots)]
-                    filler = values[len(slots)] if len(values) > len(slots) else values[-1]
+                    filler = user_vals[-1] if user_vals else values[-1]
                     scattered = [filler for _ in range(max_batch)]
                     for val, slot_idx in zip(user_vals, slots):
-                        scattered[slot_idx] = val
+                        scattered[int(slot_idx)] = val
                     return scattered
 
                 updates = {}
@@ -656,36 +758,96 @@ class Generator(WarmupForwardMixin):
                     updates[f.name] = _scatter_list(getattr(params, f.name))
                 return replace(params, **updates)
 
-            sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
-            # print("sampling_params_scattered", sampling_params, "empty_slots", empty_slots)
-            sampling_module = self.model.sampling
+            if explicit_seeded_prefill:
+                # Seeded prefill must be independent of how vLLM happens to
+                # split concurrent request admission. Sample each request from a
+                # canonical row-0 view while advancing the real slot's seed
+                # counter, so decode continues from the correct per-slot state.
+                sampled_values = []
+                log_prob_values = []
+                slot_output_tokens = torch.full((max_batch, 1), -1, dtype=torch.int32)
+                for request_idx, slot in enumerate(empty_slots):
+                    slot = int(slot)
+                    single_params = broadcast_sampling_params(sampling_params, request_idx, max_batch)
+                    sampling_module.reset_sampling_params(single_params)
+                    if sampling_prompt_tokens is not None:
+                        single_prompt_tokens = sampling_prompt_tokens[slot : slot + 1].repeat(max_batch, 1)
+                    else:
+                        single_prompt_tokens = None
+                    sampling_module.reset_prompt_tokens(single_prompt_tokens)
+                    sampling_module.reset_output_state()
+                    sampling_module.seed_manager.reset_seed(single_params.seed, [slot])
+                    sampling_module.seed_manager.get_new_values([slot], replicate_seeds=True)
 
-            sampling_module.reset_sampling_params(sampling_params)
-            # if prompt_tokens is not None:  # Guard for warmup
-            sampling_module.reset_prompt_tokens(prefill_ids)
-            sampling_module.reset_output_state()
-            sampling_module.seed_manager.reset_seed(sampling_params.seed, empty_slots)
-            sampling_module.seed_manager.get_new_values(empty_slots)
-            tt_sampled, tt_log_probs = sampling_module.sample(
-                tt_logits_batch,
-                tt_out_tok=None,
-                enable_trace=False,  # Don't trace prefill sampling
-            )
-            if isinstance(tt_sampled, tuple):
-                tt_sampled = tt_sampled[0]
-            if isinstance(tt_sampled, list):
-                tt_sampled = tt_sampled[0]
+                    single_logits_batch = ttnn.concat(
+                        [logits_source[slot]] * max_batch,
+                        dim=2,
+                        sub_core_grids=concat_sub_core_grids,
+                    )
+                    tt_sampled, tt_log_probs = sampling_module.sample(
+                        single_logits_batch,
+                        tt_out_tok=None,
+                        enable_trace=False,  # Don't trace prefill sampling
+                    )
+                    if isinstance(tt_sampled, tuple):
+                        tt_sampled = tt_sampled[0]
+                    if isinstance(tt_sampled, list):
+                        tt_sampled = tt_sampled[0]
 
-            sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
+                    sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
+                    sampled_token = sampled_tokens[0, 0, 0, 0]
+                    sampled_values.append(sampled_token)
+                    slot_output_tokens[slot, 0] = sampled_token
 
-            # sampled_tokens has 32 entries ordered by slot.
-            sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
-            output_toks = sampled_tensor[empty_slots]
+                    if tt_log_probs is not None:
+                        log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_log_probs)[0])
+                        log_prob_values.append(log_probs_torch[0, 0, 0, 0])
 
-            if tt_log_probs is not None:
-                tt_lp = tt_log_probs
-                log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
-                prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
+                    ttnn.deallocate(single_logits_batch)
+
+                output_toks = torch.stack(sampled_values).to(torch.int32)
+                if log_prob_values:
+                    prefill_log_probs = torch.stack(log_prob_values)
+
+                slot_sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
+                sampling_module.reset_sampling_params(slot_sampling_params)
+                if sampling_prompt_tokens is not None:
+                    sampling_module.reset_prompt_tokens(sampling_prompt_tokens)
+                sampling_module.reset_output_state(slot_output_tokens)
+            else:
+                # tt_logits_batch was concatenated before switching to decode.
+                sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
+                # print("sampling_params_scattered", sampling_params, "empty_slots", empty_slots)
+
+                sampling_module.reset_sampling_params(sampling_params)
+                sampling_module.reset_prompt_tokens(
+                    sampling_prompt_tokens if sampling_prompt_tokens is not None else prefill_ids
+                )
+                sampling_module.reset_output_state()
+                sampling_module.seed_manager.reset_seed(sampling_params.seed, empty_slots)
+                sampling_module.seed_manager.get_new_values(empty_slots)
+                tt_sampled, tt_log_probs = sampling_module.sample(
+                    tt_logits_batch,
+                    tt_out_tok=None,
+                    enable_trace=False,  # Don't trace prefill sampling
+                )
+                if isinstance(tt_sampled, tuple):
+                    tt_sampled = tt_sampled[0]
+                if isinstance(tt_sampled, list):
+                    tt_sampled = tt_sampled[0]
+
+                sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
+
+                # sampled_tokens has 32 entries ordered by slot.
+                sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
+                output_toks = sampled_tensor[empty_slots]
+
+                if tt_log_probs is not None:
+                    tt_lp = tt_log_probs
+                    log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
+                    prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
+
+        self._decode_inputs_need_reset = True
 
         if return_logits:
             # TODO: the current solution runs the argmax even if we are returning logits
@@ -1110,6 +1272,30 @@ class Generator(WarmupForwardMixin):
         self._prev_sampling_on_device = sampling_on_device
         if prev_sampling_on_device is not None and prev_sampling_on_device != sampling_on_device:
             reset_inputs = True
+        if self._decode_inputs_need_reset:
+            reset_inputs = True
+            self._decode_inputs_need_reset = False
+        if sampling_params is not None:
+            temperature_values = getattr(sampling_params, "temperature", None)
+            if isinstance(temperature_values, torch.Tensor):
+                temperature_values = temperature_values.reshape(-1).tolist()
+            elif not isinstance(temperature_values, list):
+                temperature_values = [temperature_values]
+            if start_pos is not None:
+                active_slots = [
+                    idx
+                    for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist())
+                    if int(pos) >= 0
+                ]
+                temperature_values = [
+                    temperature_values[idx]
+                    for idx in active_slots
+                    if idx < len(temperature_values) and temperature_values[idx] is not None
+                ]
+            has_greedy = any(float(temp) == 0.0 for temp in temperature_values if temp is not None)
+            has_random = any(float(temp) != 0.0 for temp in temperature_values if temp is not None)
+            if has_greedy and has_random:
+                reset_inputs = True
         page_table_changed = page_table is not None and (
             self.prev_page_table is None or torch.any(self.prev_page_table != page_table).item()
         )
@@ -1125,6 +1311,13 @@ class Generator(WarmupForwardMixin):
             reset_inputs = True
 
         kv_cache = kv_cache[0]
+        active_seed_slots = None
+        if start_pos is not None:
+            active_seed_slots = [
+                idx
+                for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist())
+                if int(pos) >= 0
+            ]
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,
@@ -1138,16 +1331,54 @@ class Generator(WarmupForwardMixin):
             sm_bs = self.model.sampling.seed_manager.max_batch_size
             rank_remap = slot_remap[0:sm_bs]
             self.model.sampling.seed_manager.apply_slot_remap(rank_remap)
-        self.model.sampling.seed_manager.get_new_values()
         if reset_inputs and sampling_params is not None:
             # If we have new inputs, we need to set up the sampling module again
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
+            if active_seed_slots is not None:
+                seed_values = _as_list(getattr(sampling_params, "seed", None))
+                has_active_seed = any(
+                    slot < len(seed_values) and seed_values[slot] is not None for slot in active_seed_slots
+                )
+                if has_active_seed:
+                    sampling_params = _fill_inactive_params_from_active(
+                        sampling_params, active_seed_slots, self.model_args.max_batch_size
+                    )
 
             sampling_module = self.model.sampling
             sampling_module.reset_sampling_params(sampling_params)
             if reset_batch:
                 sampling_module.reset_prompt_tokens(prompt_tokens)
                 sampling_module.reset_output_state(output_tokens)
+        seed_manager = self.model.sampling.seed_manager
+        if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
+            seed_values = getattr(sampling_params, "seed", None)
+            if _seed_debug_enabled():
+                debug_slots = (
+                    active_seed_slots
+                    if active_seed_slots is not None
+                    else list(range(seed_manager.max_batch_size))
+                )
+                seed_values_list = _as_list(seed_values)
+                seed_slot_pairs = [
+                    (
+                        slot,
+                        seed_values_list[slot] if slot < len(seed_values_list) else None,
+                        seed_manager.seeds[slot],
+                        seed_manager.seed_counters[slot],
+                    )
+                    for slot in debug_slots
+                ]
+                logger.info(
+                    f"SeedDBG Galaxy decode: reset_batch={reset_batch}, active_seed_slots={active_seed_slots}, "
+                    f"seed_slot_pairs={seed_slot_pairs}"
+                )
+            seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
+            if reset_inputs:
+                seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
+
+        # Advance seeds after parameter copies so seeded sampling observes
+        # one ordered params/seed state for this token.
+        seed_manager.get_new_values(active_seed_slots)
 
         if tt_out_logits_saved is not None:
             decode_kwargs["tt_out_logits_saved"] = tt_out_logits_saved

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1283,9 +1283,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 if start_pos[i] is not None:
                     max_seed_slots = sampling_module.seed_manager.max_batch_size
                     start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
-                    active_seed_slots = [
-                        idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0
-                    ]
+                    active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
                 # Apply slot remap from condense before advancing seeds.
                 if slot_remap is not None:
                     sm_bs = sampling_module.seed_manager.max_batch_size

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1279,12 +1279,19 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     prompt_tokens=model_prompt,
                     output_tokens=model_output,
                 )
+                active_seed_slots = None
+                if start_pos[i] is not None:
+                    max_seed_slots = sampling_module.seed_manager.max_batch_size
+                    start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
+                    active_seed_slots = [
+                        idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0
+                    ]
                 # Apply slot remap from condense before advancing seeds.
                 if slot_remap is not None:
                     sm_bs = sampling_module.seed_manager.max_batch_size
                     rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
                     sampling_module.seed_manager.apply_slot_remap(rank_remap)
-                sampling_module.seed_manager.get_new_values()
+                sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         decode_kwargs = {
             "current_pos": start_pos,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This change fixes intermittent determinism failures in vLLM TT plugin tests for Llama 3.3 70B on Galaxy systems.

The failures were seen mostly in:

- `test_seeding_and_variety.py`
- `test_request_isolation.py`
- `test_tt_penalties.py`

Symptoms included seeded requests producing different outputs across runs, greedy requests occasionally diverging within the same batch, and penalty-enabled requests producing inconsistent results in mixed batches.

### Problem

vLLM treats batch slots as temporary execution rows, not stable request identities. Requests can be removed, re-added, compacted, or moved to different physical slots depending on scheduler decisions, prefill/decode grouping, CI timing, and batch composition.

The TT sampling path had several pieces of state that were effectively tied to physical slot position:

- request seed state
- seed counters
- RNG state
- sampling params
- penalty reset state
- decode trace/input state

That made deterministic behavior sensitive to vLLM scheduling layout. CI exposed this more frequently than local runs because request grouping and slot reuse patterns differ under load.

### Changes

- Slot-stable explicit seed handling

Explicit request seeds now derive per-token device seeds from a stable hash of:

```text
request_seed + token_counter
```

instead of depending only on mutable per-slot RNG progression.

This makes seeded sampling reproducible even if the request moves between physical slots.

- Seed counter and RNG remapping

When vLLM condenses the persistent batch, the TT seed manager now applies `slot_remap`.

```text
remap[new_slot] = old_slot
```

The seed manager moves seed values, seed counters, and RNG state from the old slot to the new slot.

This prevents a request from accidentally inheriting another slot’s sampling stream after compaction.

- Active-slot-only seed advancement

Decode now advances seed state only for active slots. Padded/inactive rows are ignored and receive sentinel values.

This prevents inactive rows from consuming seed steps or carrying stale state into later requests.

- Counter alignment to decode position

For explicit seeds, seed counters can be aligned to absolute decode positions.

This handles cases where vLLM temporarily removes/re-adds requests or resumes them in a different slot. The random stream is tied to the logical token position, not to how long the request happened to live in a physical slot.

- Greedy path normalization

Greedy requests are normalized consistently:

```text
temperature = 1
top_k = 1
top_p = 0
```

This keeps greedy rows on the force-argmax path and avoids accidental interaction with random/top-p sampling behavior.

- Safer prefill sampling

The Galaxy prefill path now avoids unsafe batched prefill behavior for explicit seeded cases.

Explicit seeded prefill requests are sampled through a canonical row-0 view while advancing the real request slot’s seed counter. This makes seeded prefill output independent of physical slot position and vLLM admission grouping.

- Decode input reset after prefill

On-device prefill sampling can switch the model into decode mode and leave cached decode inputs/traces stale.

A new `_decode_inputs_need_reset` flag forces the next decode after prefill to reload decode inputs once.

This addresses CI-only failures where the first decode after prefill could reuse stale inputs because the layout appeared unchanged.

- Sampling sub-core grid fix

`manual_seed` and `ttnn.sampling` now use the intended sampling sub-core grid.

This avoids sub-device/core mismatches and prevents sampling kernels from launching on an unexpected worker grid.

- Concat/sub-device ordering fix

The full-batch prefill logits concat is kept before switching to decode mode, avoiding the decode sub-device mismatch without using the sub-core concat path for the real 32-slot batch.

This addresses the fatal:

```text
Kernel group cores do not match sub device cores for programmable core type TENSIX
```

while avoiding slot/logit instability seen with the broader concat-grid workaround.

- Deterministic penalty reset

Penalty reset logic now builds prompt/output token count masks on host and copies deterministic tensors to device.

This removes device-side scatter-add during reset over duplicate-heavy prompts such as:

```text
a a a a a ...
a b c a b c ...
```

Those duplicate token updates were a likely source of nondeterministic penalty state in mixed penalty batches.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llama_merged_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llama_merged_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llama_merged_fixes)