### PR TITLE
no lm head in runner

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -49,6 +49,7 @@ class ttMLA:
         tp_axis: int = 1,
         cache_path: Path | None = None,
         device: ttnn.MeshDevice | None = None,
+        kv_only: bool = False,
     ) -> dict | None:
         """
         Shared logic for converting MLA weights to ttnn with caching.
@@ -110,17 +111,9 @@ class ttMLA:
 
         mem = ttnn.DRAM_MEMORY_CONFIG if device else None
 
-        # 8 ttnn.as_tensor calls
+        # KV-branch weights (always loaded). The kv-only forward path only
+        # needs these; the rest are gated below on `kv_only`.
         result = {
-            "q_a_layernorm": ttnn.as_tensor(
-                q_a_ln,
-                device=device,
-                dtype=ttnn.bfloat16,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-                cache_file_name=_cache_name("q_a_layernorm"),
-            ),
             "kv_a_layernorm": ttnn.as_tensor(
                 kv_a_ln,
                 device=device,
@@ -129,24 +122,6 @@ class ttMLA:
                 memory_config=mem,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
                 cache_file_name=_cache_name("kv_a_layernorm"),
-            ),
-            "q_a_proj": ttnn.as_tensor(
-                q_a_proj,
-                device=device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=mapper_tp0,
-                cache_file_name=_cache_name("q_a_proj"),
-            ),
-            "q_b_proj": ttnn.as_tensor(
-                q_b_proj,
-                device=device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=mapper_tp1,
-                cache_file_name=_cache_name("q_b_proj"),
             ),
             "kv_a_proj_with_mqa": ttnn.as_tensor(
                 kv_a_proj,
@@ -157,34 +132,66 @@ class ttMLA:
                 mesh_mapper=mapper_tp0,
                 cache_file_name=_cache_name("kv_a_proj_with_mqa"),
             ),
-            "wkv_b1": ttnn.as_tensor(
-                wkv_b1,
-                device=device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=mapper_tp1,
-                cache_file_name=_cache_name("wkv_b1"),
-            ),
-            "wkv_b2": ttnn.as_tensor(
-                wkv_b2,
-                device=device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=mapper_tp1,
-                cache_file_name=_cache_name("wkv_b2"),
-            ),
-            "o_proj": ttnn.as_tensor(
-                o_proj,
-                device=device,
-                dtype=ttnn.bfloat8_b,
-                layout=ttnn.TILE_LAYOUT,
-                memory_config=mem,
-                mesh_mapper=mapper_tp0,
-                cache_file_name=_cache_name("o_proj"),
-            ),
         }
+        if not kv_only:
+            result.update(
+                {
+                    "q_a_layernorm": ttnn.as_tensor(
+                        q_a_ln,
+                        device=device,
+                        dtype=ttnn.bfloat16,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                        cache_file_name=_cache_name("q_a_layernorm"),
+                    ),
+                    "q_a_proj": ttnn.as_tensor(
+                        q_a_proj,
+                        device=device,
+                        dtype=ttnn.bfloat8_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=mapper_tp0,
+                        cache_file_name=_cache_name("q_a_proj"),
+                    ),
+                    "q_b_proj": ttnn.as_tensor(
+                        q_b_proj,
+                        device=device,
+                        dtype=ttnn.bfloat8_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=mapper_tp1,
+                        cache_file_name=_cache_name("q_b_proj"),
+                    ),
+                    "wkv_b1": ttnn.as_tensor(
+                        wkv_b1,
+                        device=device,
+                        dtype=ttnn.bfloat8_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=mapper_tp1,
+                        cache_file_name=_cache_name("wkv_b1"),
+                    ),
+                    "wkv_b2": ttnn.as_tensor(
+                        wkv_b2,
+                        device=device,
+                        dtype=ttnn.bfloat8_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=mapper_tp1,
+                        cache_file_name=_cache_name("wkv_b2"),
+                    ),
+                    "o_proj": ttnn.as_tensor(
+                        o_proj,
+                        device=device,
+                        dtype=ttnn.bfloat8_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=mem,
+                        mesh_mapper=mapper_tp0,
+                        cache_file_name=_cache_name("o_proj"),
+                    ),
+                }
+            )
 
         if device is None:
             for v in result.values():
@@ -202,10 +209,11 @@ class ttMLA:
         seq_len: int,
         sp_axis: int = 0,
         tp_axis: int = 1,
+        kv_only: bool = False,
     ):
         """Build TTNN cache for MLA weights using device=None (no device copy)."""
         ttMLA._convert_and_cache_weights(
-            state_dict, mesh_device, config, layer_idx, sp_axis, tp_axis, cache_path, device=None
+            state_dict, mesh_device, config, layer_idx, sp_axis, tp_axis, cache_path, device=None, kv_only=kv_only
         )
 
     def __init__(
@@ -223,10 +231,12 @@ class ttMLA:
         is_chunked: bool = False,
         slot_num: int = 1,
         layer_num: int = 61,
+        kv_only: bool = False,
     ):
         self.config = config
         self.mesh_device = mesh_device
         self.layer_idx = layer_idx
+        self.kv_only = kv_only
         self.is_balanced = is_balanced
         self.weight_cache_path = weight_cache_path
         self.is_chunked = is_chunked
@@ -305,7 +315,11 @@ class ttMLA:
         # holding both would waste DRAM. Both sets are owned once per model by TT_CCL and shared by
         # every layer's MLA (uniform across layers, scratch / no per-layer state) instead of
         # re-allocated per layer.
-        if self.is_chunked:
+        #
+        # kv_only (last layer) never reaches SDPA, so it needs no ring/gather buffers at all.
+        if kv_only:
+            pass
+        elif self.is_chunked:
             # Single combined gathered-KV scratch buffer for ring_mla: K and V both come from the
             # latent kvpe cache, so one (1, 1, seq_len, kvpe_dim) buffer replaces the separate
             # per-K/per-V ring-SDPA buffers (and the dummy joint tensors) used in the other mode.
@@ -336,7 +350,9 @@ class ttMLA:
             self.joint_kv = ring_buffers["joint_kv"]
             self.joint_v = ring_buffers["joint_v"]
 
-        # Load weights to TT device
+        # Load weights to TT device. In kv_only mode the returned dict only
+        # contains kv_a_layernorm / kv_a_proj_with_mqa; the Q-side / V / wo
+        # weights are skipped entirely (saves DRAM + cache reads).
         weights = self._convert_and_cache_weights(
             state_dict,
             mesh_device,
@@ -346,16 +362,18 @@ class ttMLA:
             tp_axis,
             self.weight_cache_path,
             device=mesh_device,
+            kv_only=kv_only,
         )
-        self.q_a_layernorm_weight = weights["q_a_layernorm"]
         self.kv_a_layernorm_weight = weights["kv_a_layernorm"]
-        self.q_a_proj_weight = weights["q_a_proj"]
-        self.q_b_proj_weight = weights["q_b_proj"]
         self.kv_a_proj_with_mqa_weight = weights["kv_a_proj_with_mqa"]
-        self.wkv_b1_weight = weights["wkv_b1"]
-        self.wkv_b2_weight = weights["wkv_b2"]
-        self.o_proj_weight = weights["o_proj"]
-        logger.info(f"Loaded {len(weights)} weights in MLA layer {layer_idx}")
+        if not kv_only:
+            self.q_a_layernorm_weight = weights["q_a_layernorm"]
+            self.q_a_proj_weight = weights["q_a_proj"]
+            self.q_b_proj_weight = weights["q_b_proj"]
+            self.wkv_b1_weight = weights["wkv_b1"]
+            self.wkv_b2_weight = weights["wkv_b2"]
+            self.o_proj_weight = weights["o_proj"]
+        logger.info(f"Loaded {len(weights)} weights in MLA layer {layer_idx} (kv_only={kv_only})")
 
     @staticmethod
     def kv_cache_to_host(kvpe_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice, sp_axis: int = 0):
@@ -375,16 +393,22 @@ class ttMLA:
         ).to(torch.bfloat16)
 
     def get_weight_shapes(self) -> dict[str, tuple]:
-        return {
-            "q_a_proj.weight": tuple(self.q_a_proj_weight.shape),
-            "q_a_layernorm.weight": tuple(self.q_a_layernorm_weight.shape),
-            "q_b_proj.weight": tuple(self.q_b_proj_weight.shape),
+        shapes = {
             "kv_a_proj_with_mqa.weight": tuple(self.kv_a_proj_with_mqa_weight.shape),
             "kv_a_layernorm.weight": tuple(self.kv_a_layernorm_weight.shape),
-            "wkv_b1_weight": tuple(self.wkv_b1_weight.shape),
-            "wkv_b2_weight": tuple(self.wkv_b2_weight.shape),
-            "o_proj.weight": tuple(self.o_proj_weight.shape),
         }
+        if not self.kv_only:
+            shapes.update(
+                {
+                    "q_a_proj.weight": tuple(self.q_a_proj_weight.shape),
+                    "q_a_layernorm.weight": tuple(self.q_a_layernorm_weight.shape),
+                    "q_b_proj.weight": tuple(self.q_b_proj_weight.shape),
+                    "wkv_b1_weight": tuple(self.wkv_b1_weight.shape),
+                    "wkv_b2_weight": tuple(self.wkv_b2_weight.shape),
+                    "o_proj.weight": tuple(self.o_proj_weight.shape),
+                }
+            )
+        return shapes
 
     # Default output dtypes per weight, used when no tuned config exists for the seq_len_local
     MM_DEFAULT_DTYPES = {
@@ -649,6 +673,18 @@ class ttMLA:
         cache_user_id: int = 0,
         return_kv_intermediates: bool = False,
     ) -> ttnn.Tensor:
+        if self.kv_only:
+            return self._forward_kv_only(
+                hidden_states,
+                rope_tensors,
+                kvpe_cache,
+                cache_layer_idx,
+                on_layer_complete,
+                kv_actual_isl=actual_start,
+                actual_end=actual_end,
+                cache_user_id=cache_user_id,
+            )
+
         signpost(header="MLA_START")
         num_heads_local = self.num_heads // self.tp_factor
         seq_len_local = hidden_states.shape[2]
@@ -889,3 +925,99 @@ class ttMLA:
         if return_kv_intermediates:
             return out, kv_intermediates
         return out
+
+    def _forward_kv_only(
+        self,
+        hidden_states: ttnn.Tensor,
+        rope_tensors: dict,
+        kvpe_cache: ttnn.Tensor,
+        cache_layer_idx: int,
+        on_layer_complete: Optional[Callable[[int], None]],
+        kv_actual_isl: int,
+        actual_end: Optional[int],
+        cache_user_id: int,
+    ) -> None:
+        """Last-layer fast path: fill the KV cache (which migration consumes) and fire the
+        migration callback, then stop. Skips Q / SDPA / output projection entirely; the
+        block also skips FFN/MoE/norm/LM head, so no first-token output is produced.
+        """
+        signpost(header="MLA_START")
+        seq_len_local = hidden_states.shape[2]
+
+        tt_kv = ttnn.linear(
+            hidden_states,
+            self.kv_a_proj_with_mqa_weight,
+            compute_kernel_config=self.default_compute_kernel_config,
+            **self._get_mm_kwargs("kv_a_proj_with_mqa", seq_len_local),
+        )
+
+        if self.tp_factor > 1:
+            tt_kv = ttnn.experimental.all_gather_async(
+                tt_kv,
+                dim=1,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+                num_links=self.ccl_num_links,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.ccl_topology,
+                cluster_axis=self.tp_axis,
+            )
+            tt_kv = ttnn.experimental.fast_reduce_nc(
+                tt_kv, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
+            )
+
+        # TODO: split rope and nope, workaround remove with ttnn.narrow or fusion
+        tt_kv_nope = ttnn.slice(tt_kv, [0, 0, 0, 0], [1, 1, seq_len_local, self.kv_lora_rank])
+        tt_kv_rope = ttnn.slice(
+            tt_kv, [0, 0, 0, self.kv_lora_rank], [1, 1, seq_len_local, self.kv_lora_rank + self.qk_rope_head_dim]
+        )
+        ttnn.deallocate(tt_kv)
+
+        tt_kv_nope = ttnn.rms_norm(
+            tt_kv_nope,
+            weight=self.kv_a_layernorm_weight,
+            epsilon=self.config.rms_norm_eps,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.default_compute_kernel_config,
+        )
+
+        # Same rope as the full chunked path (indexed/padded when chunked, single-shot otherwise) so
+        # the KV written to the cache carries the correct per-chunk positional offset.
+        tt_kv_rope = self._apply_rope(tt_kv_rope, rope_tensors, kv_actual_isl)
+
+        # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
+        tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
+        ttnn.deallocate(tt_kv_rope)
+        tt_kvpe = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
+
+        # Write the chunk via the SAME chunked path as _chunked_attn (not a single-shot fill):
+        # update_padded_kv_cache writes at the per-chip offset derived from kv_actual_global.
+        chunk_size_global = seq_len_local * self.sp_factor
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kvpe_cache,
+            tt_kvpe,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self.layer_num,
+            kv_actual_global=kv_actual_isl,
+            cluster_axis=self.sp_axis,
+        )
+
+        # Migration-gated: zero the pad window past actual_end so the decode side reads clean zeros,
+        # then fire the per-layer ack (the populated cache is the only output of a kv-only last layer).
+        if on_layer_complete is not None:
+            assert actual_end is not None, "actual_end required when on_layer_complete is set"
+            ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+                kvpe_cache,
+                cache_user_id,
+                cache_layer_idx,
+                self.layer_num,
+                actual_end,
+                chunk_size_global,
+                self.sp_axis,
+            )
+            ttnn.synchronize_device(self.mesh_device)
+            on_layer_complete(self.layer_idx)
+
+        signpost(header="MLA_END")
+        return None

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -65,7 +65,13 @@ CHUNK_SIZE = int(os.environ.get("PREFILL_CHUNK_SIZE", 5 * 1024))
 MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 4 * CHUNK_SIZE))
 NUM_USERS = int(os.environ.get("PREFILL_NUM_USERS", 2))
 CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
-_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_gate_mode)
+# Model-agnostic gate-mode default comes from the active variant (DEVICE_FP32 for the
+# deepseek_v3_d_p variant; HOST_ALL source default is much slower).
+GATE_FALLBACK_MODE = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_gate_mode)
+# When on (default), the last transformer layer runs kv-only: it fills the KV
+# cache for migration and skips its Q/SDPA/wo, FFN/MoE, final norm, and LM head.
+KV_ONLY_LAST_LAYER = os.environ.get("PREFILL_KV_ONLY_LAST_LAYER", "1") == "1"
+PREFILL_DEBUG = os.environ.get("PREFILL_DEBUG", "0") == "1"
 
 _shutdown = False
 
@@ -84,6 +90,9 @@ def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:
     KV cache. No H2D socket, no SHM, no external producer — single process, for local bring-up / perf.
     Chunked prefill does not sample; the populated KV cache is the output. With PREFILL_STANDALONE_PCC
     the same trace supplies the golden kv_post_transform for validation.
+
+    The pipeline runs the kv-only last layer (no first_token, no LM head); the runner just logs
+    per-iter timing.
 
     Env:
       PREFILL_TRACE_DIR golden trace dir (default: this variant's prefill_trace_default)
@@ -225,7 +234,6 @@ def run_request_loop(pipeline: TtDeepSeekPrefillPipeline, h2d_service: ttnn.H2DS
 
 def _print_config() -> None:
     """Print all env var values at startup so the config is visible in logs."""
-    UNSET = "<NOT SET>"
     rows = [
         ("PREFILL_MODEL_VARIANT", VARIANT.name),
         ("PREFILL_HF_MODEL", os.environ.get("PREFILL_HF_MODEL", VARIANT.hf_model_default)),
@@ -238,7 +246,8 @@ def _print_config() -> None:
         ("PREFILL_CHUNK_SIZE", str(CHUNK_SIZE)),
         ("PREFILL_NUM_USERS", str(NUM_USERS)),
         ("PREFILL_CAPACITY_FACTOR", str(CAPACITY_FACTOR)),
-        ("PREFILL_GATE_FALLBACK_MODE", _gate_mode_name),
+        ("PREFILL_GATE_FALLBACK_MODE", GATE_FALLBACK_MODE),
+        ("PREFILL_KV_ONLY_LAST_LAYER", str(KV_ONLY_LAST_LAYER)),
         ("PREFILL_STANDALONE", os.environ.get("PREFILL_STANDALONE", "0")),
         ("PREFILL_TRACE_DIR", os.environ.get("PREFILL_TRACE_DIR", VARIANT.prefill_trace_default)),
         ("PREFILL_STANDALONE_INPUT", os.environ.get("PREFILL_STANDALONE_INPUT", "<trace default>")),
@@ -289,9 +298,10 @@ def main() -> None:
         num_users=NUM_USERS,
         num_links=2,
         capacity_factor=CAPACITY_FACTOR,
-        gate_fallback_mode=GateComputeMode[_gate_mode_name],
+        gate_fallback_mode=GateComputeMode[GATE_FALLBACK_MODE],
         weight_cache_path=cache_path,
         model_cfg=MODEL_CFG,
+        kv_only_last_layer=KV_ONLY_LAST_LAYER,
     )
 
     pipeline = TtDeepSeekPrefillPipeline(

--- a/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
@@ -42,6 +42,10 @@ class TtPrefillPipelineConfig:
     # (DeepSeekV3Config | KimiK26Config). Drives expert counts, dense-layer
     # count, route groups, etc. in the TT layer code.
     model_cfg: type = DeepSeekV3Config
+    # When True, the last transformer layer runs kv-only: it fills the KV cache
+    # (which migration needs) and skips its Q/SDPA/output projection, FFN/MoE,
+    # the final RMSNorm, and the LM head. `prefill()` then returns None.
+    kv_only_last_layer: bool = False
 
     @property
     def sp_factor(self) -> int:
@@ -123,6 +127,7 @@ class TtDeepSeekPrefillPipeline:
             lm_head_is_column_parallel=True,
             is_chunked=True,
             slot_num=self.config.num_users,
+            kv_only_last_layer=self.config.kv_only_last_layer,
         )
         self.model_built = True
 
@@ -185,6 +190,10 @@ class TtDeepSeekPrefillPipeline:
         boundary, passed straight through to MLA. The caller drives chunked prefill by
         calling this once per chunk, in order; a chunk's KV must be populated before the next reads
         it. If a LayerAck channel is registered (set_layer_ack_channel), the model bumps it per layer.
+
+        Always returns None: no token is sampled. (When `kv_only_last_layer` is set on the config the
+        last layer's compute is stripped down to the KV cache fill, which migration consumes, and the
+        final RMSNorm / LM head / sample are skipped entirely.)
 
         Args:
             input_tensor: one chunk's tokens, SP-sharded uint32 ROW_MAJOR DRAM tensor as produced by

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -78,6 +78,7 @@ class TtPrefillBlock(LightweightModule):
         routed_expert_weights_dtype=ttnn.bfloat4_b,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
+        kv_only: bool = False,
     ):
         """
         Build TTNN cache for this block (norms + MLA + FFN/MoE) without device copy.
@@ -115,7 +116,13 @@ class TtPrefillBlock(LightweightModule):
             seq_len=seq_len,
             sp_axis=sp_axis,
             tp_axis=tp_axis,
+            kv_only=kv_only,
         )
+
+        if kv_only:
+            # The kv-only last layer has no ffn_norm / FFN / MoE.
+            logger.info(f"Cache built for layer {layer_idx} (kv_only)")
+            return
 
         # Build ffn_norm cache
         TtDistributedRmsNorm.build_ttnn_cache(
@@ -189,6 +196,7 @@ class TtPrefillBlock(LightweightModule):
         slot_num: int = 1,
         layer_num: Optional[int] = None,
         max_seq_len: Optional[int] = None,
+        kv_only: bool = False,
     ):
         super().__init__()
         # In chunked prefill the flat KV-cache slot is cache_user_id * layer_num + cache_layer_idx, so
@@ -197,11 +205,15 @@ class TtPrefillBlock(LightweightModule):
         self.mesh_device = mesh_device
         self.num_links = num_links
         self.topology = topology
+        self.kv_only = kv_only
         self.is_moe = layer_idx >= model_cfg.NUM_DENSE_LAYERS
 
         emb_dim = config.hidden_size
 
-        logger.info(f"Building TtPrefillBlock layer_idx={layer_idx} ({'MoE' if self.is_moe else 'dense'})")
+        logger.info(
+            f"Building TtPrefillBlock layer_idx={layer_idx} "
+            f"({'MoE' if self.is_moe else 'dense'}, kv_only={kv_only})"
+        )
 
         # --- Attention norm ---
         self.attn_norm = TtDistributedRmsNorm(
@@ -233,7 +245,12 @@ class TtPrefillBlock(LightweightModule):
             is_chunked=is_chunked,
             slot_num=slot_num,
             layer_num=layer_num,
+            kv_only=kv_only,
         )
+
+        if kv_only:
+            # Last layer: no FFN norm, no FFN/MoE. Forward returns after MLA.
+            return
 
         # --- FFN norm ---
         self.ffn_norm = TtDistributedRmsNorm(
@@ -400,6 +417,13 @@ class TtPrefillBlock(LightweightModule):
         if return_kv_intermediates:
             mla_out, kv_intermediates = mla_out
         ttnn.deallocate(attn_norm_out)
+
+        if self.kv_only:
+            # KV cache filled (by MLA), migration callback fired. The block
+            # output is unused (no FFN, no further layers). Return (None, None)
+            # so the transformer can short-circuit.
+            return None, None
+
         x = ttnn.add(x, mla_out)
         ttnn.deallocate(mla_out)
         if return_kv_intermediates:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -118,12 +118,15 @@ class TtPrefillTransformer(LightweightModule):
         is_chunked: bool = False,
         slot_num: int = 1,
         max_seq_len: Optional[int] = None,
+        kv_only_last_layer: bool = False,
     ):
         super().__init__()
         self.mesh_device = mesh_device
         self.seq_len = seq_len
         self.padding_side = padding_side
         self.is_chunked = is_chunked
+        self.num_layers = num_layers
+        self.kv_only_last_layer = kv_only_last_layer
 
         if not state_dict and not (weight_cache_path and weight_cache_path.exists()):
             raise ValueError(
@@ -145,9 +148,11 @@ class TtPrefillTransformer(LightweightModule):
         )
 
         # --- Transformer layers ---
+        # When `kv_only_last_layer`, the last block is constructed with
+        # `kv_only=True`: only attn_norm + the KV branch of MLA are built.
         self.layers = []
-        for i in range(num_layers):
-            logger.info(f"Building layer {i}/{num_layers}...")
+        for i in range(self.num_layers):
+            is_last = i == self.num_layers - 1
             # Get layer weights or empty dict if loading from cache
             layer_state = state_dict["layers"][i] if state_dict.get("layers") else {}
             layer = TtPrefillBlock(
@@ -173,21 +178,36 @@ class TtPrefillTransformer(LightweightModule):
                 slot_num=slot_num,
                 layer_num=num_layers,
                 max_seq_len=max_seq_len,
+                kv_only=kv_only_last_layer and is_last,
             )
             self.layers.append(layer)
 
-        # --- Final norm ---
-        self.norm = TtDistributedRmsNorm(
-            mesh_device=mesh_device,
-            emb_dim=config.hidden_size,
-            torch_weight=state_dict.get("norm_weight"),  # None if cache exists
-            epsilon=config.rms_norm_eps,
-            cluster_axis=tp_axis,
-            num_links=num_links,
-            topology=topology,
-            weight_cache_path=weight_cache_path,
-            cache_name_prefix="norm",
-        )
+        # --- Final norm + LM Head ---
+        # Both are skipped when `kv_only_last_layer`: there is no output token
+        # to sample. Migration handles downstream signaling.
+        if not kv_only_last_layer:
+            self.norm = TtDistributedRmsNorm(
+                mesh_device=mesh_device,
+                emb_dim=config.hidden_size,
+                torch_weight=state_dict.get("norm_weight"),  # None if cache exists
+                epsilon=config.rms_norm_eps,
+                cluster_axis=tp_axis,
+                num_links=num_links,
+                topology=topology,
+                weight_cache_path=weight_cache_path,
+                cache_name_prefix="norm",
+            )
+            self.lm_head = TtLMHead(
+                mesh_device=mesh_device,
+                emb_dim=config.hidden_size,
+                vocab_size=config.vocab_size,
+                torch_weight=state_dict.get("lm_head_weight"),  # None if cache exists
+                num_links=num_links,
+                topology=topology,
+                is_balanced=is_balanced,
+                weight_cache_path=weight_cache_path,
+                is_column_parallel=lm_head_is_column_parallel,
+            )
 
         # --- RoPE (computed once, reused across all layers) ---
         self.rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
@@ -202,19 +222,6 @@ class TtPrefillTransformer(LightweightModule):
             )
             if is_chunked
             else None
-        )
-
-        # --- LM Head ---
-        self.lm_head = TtLMHead(
-            mesh_device=mesh_device,
-            emb_dim=config.hidden_size,
-            vocab_size=config.vocab_size,
-            torch_weight=state_dict.get("lm_head_weight"),  # None if cache exists
-            num_links=num_links,
-            topology=topology,
-            is_balanced=is_balanced,
-            weight_cache_path=weight_cache_path,
-            is_column_parallel=lm_head_is_column_parallel,
         )
 
         self.is_balanced = is_balanced
@@ -302,6 +309,11 @@ class TtPrefillTransformer(LightweightModule):
                 cache_user_id=cache_user_id,
             )
             signpost(f"forward_layer_{i}_end")
+            if self.kv_only_last_layer and i == len(self.layers) - 1:
+                # Last layer was kv-only — KV cache filled, migration callback
+                # fired, no hidden state flowing forward. Skip norm + lm_head +
+                # sample; no first_token to produce.
+                return None, None, intermediates
             if return_intermediates:
                 ttnn.synchronize_device(self.mesh_device)
                 intermediates[f"layer_{i}"] = self._to_host(h)


### PR DESCRIPTION
removed SDPA, MoE and LM head compute from last layer since IS integration and migration does not need it

we get around **–168 ms** on each model iteration with this change since we are skipping unnecessary compute

### Checklist 

#### T3K and Demo SP Release pipelines have a (Program size (85408) too large for kernel config buffer (70656) on TENSIX) problem that is present on main as well so this PR doesn't introduce degradations

- [ ] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/runs/26749554122)
`deepseek_prefill`
- [ ] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)]()
`deepseek_prefill`
- [ ] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)]()
`deepseek_prefill`
- [ ] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/runs/26749586022)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/kv-only-last-layer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/kv-only-last-layer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/kv-only-last-layer)