### PR TITLE
ttnn: quiet default Python logging to INFO, add TTNN_LOGGER_LEVEL knob

### DIFF
--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -17,6 +17,27 @@ from loguru import logger
 import ttnn._ttnn
 
 
+# Quiet ttnn's Python (loguru) logging by default.
+#
+# ttnn previously inherited loguru's out-of-the-box stderr sink, whose default
+# level is DEBUG. As a result, merely importing ttnn printed a large volume of
+# DEBUG output (e.g. the full "Initial ttnn.CONFIG" dump and per-op chatter) on
+# every process launch. For automated / agent-driven workflows that read this
+# output back into context on every command, that noise is a first-order cost.
+#
+# Default to a quiet level (INFO) and let users restore verbosity with a single
+# env var. Precedence (first one set wins) keeps the existing repo conventions:
+#   TTNN_LOGGER_LEVEL  -> ttnn-specific override
+#   TT_LOGGER_LEVEL    -> shared tt-metal logger level
+#   LOGURU_LEVEL       -> loguru's own env var
+# e.g. `TTNN_LOGGER_LEVEL=DEBUG` brings back the previous behavior.
+_TTNN_DEFAULT_LOG_LEVEL = (
+    os.environ.get("TTNN_LOGGER_LEVEL") or os.environ.get("TT_LOGGER_LEVEL") or os.environ.get("LOGURU_LEVEL") or "INFO"
+).upper()
+logger.remove()
+logger.add(sys.stderr, level=_TTNN_DEFAULT_LOG_LEVEL)
+
+
 Config = ttnn._ttnn.core.Config
 CONFIG = ttnn._ttnn.CONFIG
 CONFIG_PATH = None


### PR DESCRIPTION
## What

Quiet ttnn's Python (loguru) logging by default. ttnn imported loguru's `logger` but never configured a sink, so it inherited loguru's default stderr sink whose level is **DEBUG**. Importing ttnn therefore printed a large volume of DEBUG output — most visibly the full `Initial ttnn.CONFIG` dump (`ttnn:<module>:79 - DEBUG ...`) plus per-op chatter — on **every** process launch, with no opt-in.

This PR sets the ttnn loguru sink to **INFO** by default and gates verbosity behind a single env var, following the existing `logger.remove(); logger.add(sys.stderr, level=...)` pattern already used in the repo (e.g. `ttnn/ttnn/distributed/ttrun.py`).

```python
_TTNN_DEFAULT_LOG_LEVEL = (
    os.environ.get("TTNN_LOGGER_LEVEL")
    or os.environ.get("TT_LOGGER_LEVEL")
    or os.environ.get("LOGURU_LEVEL")
    or "INFO"
).upper()
logger.remove()
logger.add(sys.stderr, level=_TTNN_DEFAULT_LOG_LEVEL)
```

Restore the previous behavior with `TTNN_LOGGER_LEVEL=DEBUG` (or `TT_LOGGER_LEVEL` / `LOGURU_LEVEL`).

## Why — #45534

Default DEBUG output is a first-order cost for automated / agent-driven workflows, which read this noise back into context on every command. Across several agent-driven bring-up sessions, **run/console output was the single largest consumer of tokens (58–71%)** — more than reading the entire repo's source, and ~80× amplified by context re-reads. See #45534 for the full motivation.

## Scope

- ✅ ttnn Python (loguru) default level + single env knob — the `ttnn DEBUG Initial ttnn.CONFIG` spam cited in the issue.

Deliberately **out of scope** here (follow-ups under #45534):
- tt-metal **C++ logger** defaults (`TT_METAL_LOGGER_LEVEL`).
- PCI **device-reset banners** (`Resetting all PCI devices...`) — these come from `tt-smi`/UMD, not this repo.

## Open questions for reviewers (why this is a draft)

1. **Sink reset:** `logger.remove()` drops *all* existing loguru sinks (matching `ttrun.py`). Should ttnn instead be gentler (e.g. only adjust if it owns the default sink) to avoid surprising downstream code that configured loguru before importing ttnn?
2. **Default level:** INFO vs WARN? INFO keeps genuinely useful one-line status; WARN is quieter still.
3. **Env var name:** is `TTNN_LOGGER_LEVEL` the right new name, or should ttnn key solely off the existing `TT_LOGGER_LEVEL`?

## Test notes

`python -m py_compile` passes; pre-commit (black etc.) clean. Not yet validated on-device that the `Initial ttnn.CONFIG` line is suppressed at the default level / restored with `TTNN_LOGGER_LEVEL=DEBUG` — flagging for a reviewer with a build, or I can verify on a reserved box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:moconnor/ttnn-quiet-default-logging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=moconnor/ttnn-quiet-default-logging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:moconnor/ttnn-quiet-default-logging)