### PR TITLE
[Feature] Add LLK asserts verifying CB page_size == tile_size (#26202)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -14,6 +14,7 @@
 #include "llk_operands.h"
 #include "llk_param_structs.h"
 #include "experimental/llk_unpack_AB_reduce_custom.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;
@@ -72,13 +73,10 @@ inline void llk_unpack_AB_reduce_block_max_row(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t row_start_index) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * row_start_index;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, row_start_index);
+    std::uint32_t base_address_b = llk_unpack_tile_address(operandB_id, 0);
 
-    LLK_ASSERT(
-        cb_access_within_bounds(operandA_id, row_start_index, block_ct_dim), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, row_start_index, block_ct_dim));
 
     _llk_unpack_AB_reduce_block_max_row_<respect_trigger>(address_a, base_address_b);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -15,6 +15,7 @@
 #include "llk_param_structs.h"
 #include "experimental/llk_unpack_AB_reduce_custom.h"
 #include "experimental/llk_unpack_AB_reduce_custom_runtime.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;
@@ -75,15 +76,13 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     bool respect_trigger = false) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * row_start_index;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, row_start_index);
+    std::uint32_t base_address_b = llk_unpack_tile_address(operandB_id, 0);
 
     // This may miss some cases because block_ct_dim should be used instead of 1.
     // That value is not available at this point in time and upstream team is okay
     // with this and does not want to plumb through the value.
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, row_start_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, row_start_index, 1));
 
     _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
 
@@ -24,16 +25,11 @@ inline void llk_unpack_AB_sub_bcast_col_custom(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    const std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    const std::uint32_t address_a = base_address_a + offset_address_a;
+    const std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    const std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    const std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    const std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    const std::uint32_t address_b = base_address_b + offset_address_b;
-
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     _llk_unpack_AB_sub_bcast_col_custom_(address_a, address_b, ct_dim);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_A_custom_api.h
@@ -6,15 +6,14 @@
 #pragma once
 
 #include "experimental/llk_unpack_A_custom.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 inline void llk_unpack_A_custom(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
+    std::uint32_t address = llk_unpack_tile_address(operand_id, tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, tile_index, 1));
 
     WAYPOINT("UPAW");
     _llk_unpack_A_custom_(address);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_cb_tile_access.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_cb_tile_access.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/circular_buffer_interface.h"
+#include "ckernel_globals.h"
+#include "llk_assert.h"
+
+/**
+ * @file
+ * @brief Pack CB / tile access layer (GH #26202).
+ *
+ * Single place that owns how the packer indexes into circular buffers by tile:
+ *   - Production accessor (always run): the per-tile stride used by the packer
+ *     when advancing the write pointer.
+ *   - Validation entry points (run only inside LLK_ASSERT_BLOCK): perform the
+ *     pack CB/tile access checks.
+ *
+ * Background: the LLK uses a CB's @c fifo_page_size as the per-tile byte stride
+ * when indexing tiles. That is only correct when the page size equals the
+ * operand's actual tile size. The real tile size is available independently as
+ * @c pack_tile_size[] (constexpr, 16B words, derived from the operand data
+ * format); @c fifo_page_size for compute is also in 16B words, so the two are
+ * directly comparable.
+ */
+
+namespace ckernel {
+
+/**
+ * @brief Per-tile stride, in 16B words, for pack/write indexing of an output.
+ *
+ * @param cb_id Output (circular buffer) index.
+ * @return The CB's @c fifo_page_size, used as the per-tile stride.
+ */
+FORCE_INLINE std::uint32_t llk_pack_tile_stride(std::uint32_t cb_id) {
+    return get_local_cb_interface(cb_id).fifo_page_size;
+}
+
+/**
+ * @brief Validate that an output's CB page size matches its actual tile size.
+ *
+ * Guards the GH #26202 invariant on which the packer's tile-offset arithmetic
+ * relies. Intended to be invoked through @c LLK_ASSERT_BLOCK.
+ *
+ * @param cb_id Output (circular buffer) index.
+ */
+inline void validate_pack_tile_layout(std::uint32_t cb_id) {
+    LLK_ASSERT(
+        get_local_cb_interface(cb_id).fifo_page_size == static_cast<std::uint32_t>(pack_tile_size[cb_id]),
+        "CB page_size != pack tile_size: tile-offset arithmetic assumes page_size == tile_size (GH #26202)");
+}
+
+/**
+ * @brief Validate a pack/push of tiles into an output CB.
+ *
+ * Runs all pack CB/tile access checks and is intended to be invoked through
+ * @c LLK_ASSERT_BLOCK so the entire call compiles out when asserts are
+ * disabled. Marked @c noinline (mirroring the other LLK validators such as
+ * @c are_packers_configured_correctly) so the check code is emitted once rather
+ * than at every call site.
+ *
+ * Checks:
+ *   - @c fifo_page_size matches the output's actual tile size (GH #26202).
+ *   - The write pointer is not already at or past @c fifo_limit.
+ *   - Pushing @p num_tiles tiles would not advance the write pointer past
+ *     @c fifo_limit.
+ *
+ * @param cb_id     Output (circular buffer) index.
+ * @param num_tiles Number of tiles being pushed.
+ */
+inline __attribute__((noinline)) void validate_pack_tile_push(std::uint32_t cb_id, std::uint32_t num_tiles) {
+    validate_pack_tile_layout(cb_id);
+
+    const auto& cb = get_local_cb_interface(cb_id);
+    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
+    LLK_ASSERT(
+        (cb.fifo_limit - cb.fifo_wr_ptr) >= num_tiles * llk_pack_tile_stride(cb_id),
+        "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "llk_pack_cb_tile_access.h"
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -60,8 +61,7 @@ inline void llk_pack_untilize_init(
     static_assert(diagonal == false, "Diagonal is only supported on WH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
@@ -96,13 +96,13 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_layout(output_id));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(
             pack_tile_addr, num_faces, block_rt * block_ct_dim + tile_dst_rt_offset);
 
-        pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
+        pack_tile_addr += full_ct_dim * ckernel::llk_pack_tile_stride(output_id);
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -61,7 +61,8 @@ inline void llk_pack_untilize_init(
     static_assert(diagonal == false, "Diagonal is only supported on WH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
@@ -96,7 +97,8 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
     LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_layout(output_id));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "llk_unpack_AB.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -43,15 +44,11 @@ inline void llk_unpack_AB(
     [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    std::uint32_t address_b = base_address_b + offset_address_b;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(
         unpack_src_format[operandA_id],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "llk_unpack_AB_reduce.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -31,15 +32,11 @@ inline void llk_unpack_AB_reduce(
     const std::uint32_t tile_index_b) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    std::uint32_t address_b = base_address_b + offset_address_b;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_A.h"
 #include "llk_unpack_common_api.h"
 
@@ -51,11 +52,9 @@ template <
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
+    std::uint32_t address = llk_unpack_tile_address(operand_id, tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, tile_index, 1));
 
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
@@ -79,11 +78,10 @@ template <
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
-    std::uint32_t address = base_address + start_tile_index * offset_address;
+    std::uint32_t offset_address = llk_unpack_tile_stride(operand_id);
+    std::uint32_t address = llk_unpack_tile_address(operand_id, start_tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, start_tile_index, ntiles), "Block tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, start_tile_index, ntiles));
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_cb_tile_access.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_cb_tile_access.h
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/circular_buffer_interface.h"
+#include "ckernel_globals.h"
+#include "llk_assert.h"
+
+/**
+ * @file
+ * @brief Unpack CB / tile access layer (GH #26202).
+ *
+ * Single place that owns how the unpacker indexes into circular buffers by
+ * tile:
+ *   - Production accessors (always run): compute the per-tile stride and L1
+ *     read address used by the unpacker.
+ *   - Validation entry points (run only inside LLK_ASSERT_BLOCK): perform the
+ *     unpack CB/tile access checks.
+ *
+ * Background: the LLK uses a CB's @c fifo_page_size as the per-tile byte stride
+ * when indexing tiles. That is only correct when the page size equals the
+ * operand's actual tile size. The real tile size is available independently as
+ * @c unpack_tile_size[] (constexpr, 16B words, derived from the operand data
+ * format); @c fifo_page_size for compute is also in 16B words, so the two are
+ * directly comparable.
+ */
+
+namespace ckernel {
+
+/**
+ * @brief Per-tile stride, in 16B words, for unpack/read indexing of an operand.
+ *
+ * @param cb_id Operand (circular buffer) index.
+ * @return The CB's @c fifo_page_size, used as the per-tile stride.
+ */
+FORCE_INLINE std::uint32_t llk_unpack_tile_stride(std::uint32_t cb_id) {
+    return get_local_cb_interface(cb_id).fifo_page_size;
+}
+
+/**
+ * @brief L1 read address, in 16B words, of a tile within an operand.
+ *
+ * Centralizes the indexed-read address pattern, including the @c fifo_rd_ptr-1
+ * base adjustment used by the unpacker.
+ *
+ * @param cb_id      Operand (circular buffer) index.
+ * @param tile_index Zero-based tile index within the CB.
+ * @return The L1 address of the requested tile.
+ */
+FORCE_INLINE std::uint32_t llk_unpack_tile_address(std::uint32_t cb_id, std::uint32_t tile_index) {
+    return (get_local_cb_interface(cb_id).fifo_rd_ptr - 1) + llk_unpack_tile_stride(cb_id) * tile_index;
+}
+
+/**
+ * @brief Validate that an operand's CB page size matches its actual tile size.
+ *
+ * Guards the GH #26202 invariant on which the unpacker's tile-offset arithmetic
+ * relies. Intended to be invoked through @c LLK_ASSERT_BLOCK.
+ *
+ * @param cb_id Operand (circular buffer) index.
+ */
+inline void validate_unpack_tile_layout(std::uint32_t cb_id) {
+    LLK_ASSERT(
+        get_local_cb_interface(cb_id).fifo_page_size == static_cast<std::uint32_t>(unpack_tile_size[cb_id]),
+        "CB page_size != unpack tile_size: tile-offset arithmetic assumes page_size == tile_size (GH #26202)");
+}
+
+/**
+ * @brief Validate an indexed unpack/read access.
+ *
+ * Runs all unpack CB/tile access checks and is intended to be invoked through
+ * @c LLK_ASSERT_BLOCK so the entire call compiles out when asserts are
+ * disabled. Marked @c noinline (mirroring the other LLK validators such as
+ * @c is_unpacker_A_configured_correctly) so the check code is emitted once
+ * rather than at every call site.
+ *
+ * Checks:
+ *   - @c fifo_page_size matches the operand's actual tile size (GH #26202).
+ *   - The requested tile range stays within the CB bounds.
+ *
+ * @param cb_id            Operand (circular buffer) index.
+ * @param start_tile_index Zero-based index of the first tile accessed.
+ * @param num_tiles        Number of tiles accessed (defaults to 1).
+ */
+inline __attribute__((noinline)) void validate_unpack_tile_access(
+    std::uint32_t cb_id, std::uint32_t start_tile_index, std::uint32_t num_tiles = 1) {
+    validate_unpack_tile_layout(cb_id);
+    LLK_ASSERT(cb_access_within_bounds(cb_id, start_tile_index, num_tiles), "Indexed tile read exceeds CB boundary");
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_reduce.h"
 
@@ -28,11 +29,9 @@ inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpo
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
+    std::uint32_t address = llk_unpack_tile_address(operand_id, tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, tile_index, 1));
 
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -11,6 +11,7 @@
 #include "stream_interface.h"
 #include "stream_io_map.h"
 #include "llk_assert.h"
+#include "llk_pack_cb_tile_access.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -74,13 +75,10 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     std::uint32_t output = operand;
 
     auto& cb = get_local_cb_interface(output);
-    std::uint32_t num_words = num_tiles * cb.fifo_page_size;
+    // GH #26202: advancing the write pointer uses the per-tile size as the stride.
+    std::uint32_t num_words = num_tiles * ckernel::llk_pack_tile_stride(output);
 
-    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
-
-    std::uint32_t remaining = cb.fifo_limit - cb.fifo_wr_ptr;
-
-    LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+    LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_push(output, num_tiles));
 
     cb.fifo_wr_ptr += num_words;
     cb.fifo_wr_tile_ptr = 0;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -14,6 +14,7 @@
 #include "llk_operands.h"
 #include "llk_param_structs.h"
 #include "experimental/llk_unpack_AB_reduce_custom.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;
@@ -72,10 +73,10 @@ inline void llk_unpack_AB_reduce_block_max_row(
     const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t row_start_index) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * row_start_index;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, row_start_index);
+    std::uint32_t base_address_b = llk_unpack_tile_address(operandB_id, 0);
+
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, row_start_index, block_ct_dim));
 
     _llk_unpack_AB_reduce_block_max_row_<respect_trigger>(address_a, base_address_b);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -15,6 +15,7 @@
 #include "llk_param_structs.h"
 #include "experimental/llk_unpack_AB_reduce_custom.h"
 #include "experimental/llk_unpack_AB_reduce_custom_runtime.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common.h"
 
 using namespace ckernel;
@@ -75,10 +76,13 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
     bool respect_trigger = false) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * row_start_index;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, row_start_index);
+    std::uint32_t base_address_b = llk_unpack_tile_address(operandB_id, 0);
+
+    // This may miss some cases because block_ct_dim should be used instead of 1.
+    // That value is not available at this point in time and upstream team is okay
+    // with this and does not want to plumb through the value.
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, row_start_index, 1));
 
     _llk_unpack_AB_reduce_block_max_row_runtime_(address_a, base_address_b, respect_trigger);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -24,13 +25,11 @@ inline void llk_unpack_AB_sub_bcast_col_custom(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    const std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    const std::uint32_t address_a = base_address_a + offset_address_a;
+    const std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    const std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    const std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    const std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    const std::uint32_t address_b = base_address_b + offset_address_b;
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     _llk_unpack_AB_sub_bcast_col_custom_(address_a, address_b, ct_dim);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_cb_tile_access.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_cb_tile_access.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/circular_buffer_interface.h"
+#include "ckernel_globals.h"
+#include "llk_assert.h"
+
+/**
+ * @file
+ * @brief Pack CB / tile access layer (GH #26202).
+ *
+ * Single place that owns how the packer indexes into circular buffers by tile:
+ *   - Production accessor (always run): the per-tile stride used by the packer
+ *     when advancing the write pointer.
+ *   - Validation entry points (run only inside LLK_ASSERT_BLOCK): perform the
+ *     pack CB/tile access checks.
+ *
+ * Background: the LLK uses a CB's @c fifo_page_size as the per-tile byte stride
+ * when indexing tiles. That is only correct when the page size equals the
+ * operand's actual tile size. The real tile size is available independently as
+ * @c pack_tile_size[] (constexpr, 16B words, derived from the operand data
+ * format); @c fifo_page_size for compute is also in 16B words, so the two are
+ * directly comparable.
+ */
+
+namespace ckernel {
+
+/**
+ * @brief Per-tile stride, in 16B words, for pack/write indexing of an output.
+ *
+ * @param cb_id Output (circular buffer) index.
+ * @return The CB's @c fifo_page_size, used as the per-tile stride.
+ */
+FORCE_INLINE std::uint32_t llk_pack_tile_stride(std::uint32_t cb_id) {
+    return get_local_cb_interface(cb_id).fifo_page_size;
+}
+
+/**
+ * @brief Validate that an output's CB page size matches its actual tile size.
+ *
+ * Guards the GH #26202 invariant on which the packer's tile-offset arithmetic
+ * relies. Intended to be invoked through @c LLK_ASSERT_BLOCK.
+ *
+ * @param cb_id Output (circular buffer) index.
+ */
+inline void validate_pack_tile_layout(std::uint32_t cb_id) {
+    LLK_ASSERT(
+        get_local_cb_interface(cb_id).fifo_page_size == static_cast<std::uint32_t>(pack_tile_size[cb_id]),
+        "CB page_size != pack tile_size: tile-offset arithmetic assumes page_size == tile_size (GH #26202)");
+}
+
+/**
+ * @brief Validate a pack/push of tiles into an output CB.
+ *
+ * Runs all pack CB/tile access checks and is intended to be invoked through
+ * @c LLK_ASSERT_BLOCK so the entire call compiles out when asserts are
+ * disabled. Marked @c noinline (mirroring the other LLK validators such as
+ * @c are_packers_configured_correctly) so the check code is emitted once rather
+ * than at every call site.
+ *
+ * Checks:
+ *   - @c fifo_page_size matches the output's actual tile size (GH #26202).
+ *   - The write pointer is not already at or past @c fifo_limit.
+ *   - Pushing @p num_tiles tiles would not advance the write pointer past
+ *     @c fifo_limit.
+ *
+ * @param cb_id     Output (circular buffer) index.
+ * @param num_tiles Number of tiles being pushed.
+ */
+inline __attribute__((noinline)) void validate_pack_tile_push(std::uint32_t cb_id, std::uint32_t num_tiles) {
+    validate_pack_tile_layout(cb_id);
+
+    const auto& cb = get_local_cb_interface(cb_id);
+    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
+    LLK_ASSERT(
+        (cb.fifo_limit - cb.fifo_wr_ptr) >= num_tiles * llk_pack_tile_stride(cb_id),
+        "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "llk_pack_cb_tile_access.h"
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -60,8 +61,7 @@ inline void llk_pack_untilize_init(
     static_assert(dense == false, "Dense is only supported on BH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
@@ -91,13 +91,13 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_layout(output_id));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
             pack_tile_addr, pack_dst_format[output_id], face_r_dim, block_rt * block_ct_dim + tile_dst_rt_offset);
 
-        pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
+        pack_tile_addr += full_ct_dim * ckernel::llk_pack_tile_stride(output_id);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -61,7 +61,8 @@ inline void llk_pack_untilize_init(
     static_assert(dense == false, "Dense is only supported on BH");
     const std::uint32_t output_id = get_output_id(output);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
@@ -91,7 +92,8 @@ inline void llk_pack_untilize(
             (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
             16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim));
     LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_layout(output_id));
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "llk_unpack_AB.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -43,15 +44,11 @@ inline void llk_unpack_AB(
     [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    std::uint32_t address_b = base_address_b + offset_address_b;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(
         unpack_src_format[operandA_id],

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "llk_unpack_AB_reduce.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -31,15 +32,11 @@ inline void llk_unpack_AB_reduce(
     const std::uint32_t tile_index_b) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
-    std::uint32_t address_a = base_address_a + offset_address_a;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
-    std::uint32_t address_b = base_address_b + offset_address_b;
+    std::uint32_t address_a = llk_unpack_tile_address(operandA_id, tile_index_a);
+    std::uint32_t address_b = llk_unpack_tile_address(operandB_id, tile_index_b);
 
-    LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
-    LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandA_id, tile_index_a, 1));
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operandB_id, tile_index_b, 1));
 
     WAYPOINT("UABW");
     _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "llk_unpack_A.h"
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
@@ -51,11 +52,9 @@ template <
     bool unpack_to_dest = false>
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
+    std::uint32_t address = llk_unpack_tile_address(operand_id, tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, tile_index, 1));
 
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
@@ -79,11 +78,10 @@ template <
 inline void llk_unpack_A_block(
     const std::uint32_t operand, const std::uint32_t start_tile_index, const std::uint32_t ntiles) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size;
-    std::uint32_t address = base_address + start_tile_index * offset_address;
+    std::uint32_t offset_address = llk_unpack_tile_stride(operand_id);
+    std::uint32_t address = llk_unpack_tile_address(operand_id, start_tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, start_tile_index, ntiles), "Block tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, start_tile_index, ntiles));
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_cb_tile_access.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_cb_tile_access.h
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "internal/circular_buffer_interface.h"
+#include "ckernel_globals.h"
+#include "llk_assert.h"
+
+/**
+ * @file
+ * @brief Unpack CB / tile access layer (GH #26202).
+ *
+ * Single place that owns how the unpacker indexes into circular buffers by
+ * tile:
+ *   - Production accessors (always run): compute the per-tile stride and L1
+ *     read address used by the unpacker.
+ *   - Validation entry points (run only inside LLK_ASSERT_BLOCK): perform the
+ *     unpack CB/tile access checks.
+ *
+ * Background: the LLK uses a CB's @c fifo_page_size as the per-tile byte stride
+ * when indexing tiles. That is only correct when the page size equals the
+ * operand's actual tile size. The real tile size is available independently as
+ * @c unpack_tile_size[] (constexpr, 16B words, derived from the operand data
+ * format); @c fifo_page_size for compute is also in 16B words, so the two are
+ * directly comparable.
+ */
+
+namespace ckernel {
+
+/**
+ * @brief Per-tile stride, in 16B words, for unpack/read indexing of an operand.
+ *
+ * @param cb_id Operand (circular buffer) index.
+ * @return The CB's @c fifo_page_size, used as the per-tile stride.
+ */
+FORCE_INLINE std::uint32_t llk_unpack_tile_stride(std::uint32_t cb_id) {
+    return get_local_cb_interface(cb_id).fifo_page_size;
+}
+
+/**
+ * @brief L1 read address, in 16B words, of a tile within an operand.
+ *
+ * Centralizes the indexed-read address pattern, including the @c fifo_rd_ptr-1
+ * base adjustment used by the unpacker.
+ *
+ * @param cb_id      Operand (circular buffer) index.
+ * @param tile_index Zero-based tile index within the CB.
+ * @return The L1 address of the requested tile.
+ */
+FORCE_INLINE std::uint32_t llk_unpack_tile_address(std::uint32_t cb_id, std::uint32_t tile_index) {
+    return (get_local_cb_interface(cb_id).fifo_rd_ptr - 1) + llk_unpack_tile_stride(cb_id) * tile_index;
+}
+
+/**
+ * @brief Validate that an operand's CB page size matches its actual tile size.
+ *
+ * Guards the GH #26202 invariant on which the unpacker's tile-offset arithmetic
+ * relies. Intended to be invoked through @c LLK_ASSERT_BLOCK.
+ *
+ * @param cb_id Operand (circular buffer) index.
+ */
+inline void validate_unpack_tile_layout(std::uint32_t cb_id) {
+    LLK_ASSERT(
+        get_local_cb_interface(cb_id).fifo_page_size == static_cast<std::uint32_t>(unpack_tile_size[cb_id]),
+        "CB page_size != unpack tile_size: tile-offset arithmetic assumes page_size == tile_size (GH #26202)");
+}
+
+/**
+ * @brief Validate an indexed unpack/read access.
+ *
+ * Runs all unpack CB/tile access checks and is intended to be invoked through
+ * @c LLK_ASSERT_BLOCK so the entire call compiles out when asserts are
+ * disabled. Marked @c noinline (mirroring the other LLK validators such as
+ * @c is_unpacker_A_configured_correctly) so the check code is emitted once
+ * rather than at every call site.
+ *
+ * Checks:
+ *   - @c fifo_page_size matches the operand's actual tile size (GH #26202).
+ *   - The requested tile range stays within the CB bounds.
+ *
+ * @param cb_id            Operand (circular buffer) index.
+ * @param start_tile_index Zero-based index of the first tile accessed.
+ * @param num_tiles        Number of tiles accessed (defaults to 1).
+ */
+inline __attribute__((noinline)) void validate_unpack_tile_access(
+    std::uint32_t cb_id, std::uint32_t start_tile_index, std::uint32_t num_tiles = 1) {
+    validate_unpack_tile_layout(cb_id);
+    LLK_ASSERT(cb_access_within_bounds(cb_id, start_tile_index, num_tiles), "Indexed tile read exceeds CB boundary");
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include "llk_unpack_cb_tile_access.h"
 #include "llk_unpack_reduce.h"
 #include "llk_unpack_common_api.h"
 
@@ -28,11 +29,9 @@ inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpo
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
-    std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
-    std::uint32_t address = base_address + offset_address;
+    std::uint32_t address = llk_unpack_tile_address(operand_id, tile_index);
 
-    LLK_ASSERT(cb_access_within_bounds(operand_id, tile_index, 1), "Indexed tile read exceeds CB boundary");
+    LLK_ASSERT_BLOCK(validate_unpack_tile_access(operand_id, tile_index, 1));
 
     WAYPOINT("UPRW");
     _llk_unpack_reduce_<type, dim>(address);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -11,6 +11,7 @@
 #include "stream_io_map.h"
 #include "llk_pack_common.h"
 #include "llk_assert.h"
+#include "llk_pack_cb_tile_access.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 using namespace ckernel;
@@ -74,13 +75,10 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     std::uint32_t output = operand;
 
     auto& cb = get_local_cb_interface(output);
-    std::uint32_t num_words = num_tiles * cb.fifo_page_size;
+    // GH #26202: advancing the write pointer uses the per-tile size as the stride.
+    std::uint32_t num_words = num_tiles * ckernel::llk_pack_tile_stride(output);
 
-    LLK_ASSERT(cb.fifo_wr_ptr < cb.fifo_limit, "CB push_back: fifo_wr_ptr already at or past fifo_limit");
-
-    std::uint32_t remaining = cb.fifo_limit - cb.fifo_wr_ptr;
-
-    LLK_ASSERT(remaining >= num_words, "CB push_back: fifo_wr_ptr would exceed fifo_limit");
+    LLK_ASSERT_BLOCK(ckernel::validate_pack_tile_push(output, num_tiles));
 
     cb.fifo_wr_ptr += num_words;
     cb.fifo_wr_tile_ptr = 0;


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #26202.

The LLK indexes into circular buffers by multiplying a tile index (or tile count) by the CB's `fifo_page_size`, i.e. it uses the page size as the per-tile byte stride (see `llk_unpack_*_api.h`, `llk_io_pack.h`, `llk_pack_untilize_api.h`). This is only correct when a CB's page size equals the operand's actual tile size. That is the common case, but the API never required it and nothing checked it, so a `page_size != tile_size` configuration would silently mis-address tiles.

This PR makes the assumption explicit and guards it:

- Adds a small CB/tile access layer per arch (`llk_unpack_cb_tile_access.h`, `llk_pack_cb_tile_access.h`) that owns the tile-stride/address arithmetic and exposes single `LLK_ASSERT_BLOCK`-invoked validators.
- The validators assert `fifo_page_size == unpack_tile_size[cb]` / `pack_tile_size[cb]` — the JIT-emitted, format-derived tile size that is tracked independently of the page size (both in 16B words for compute, so directly comparable).
- Routes the indexed unpack reads, the pack push path, and the pack-untilize indexing loop through these helpers across **both Blackhole and Wormhole**.

### Notes for reviewers

**Comparison with similar asserts.** The repo already has CB-related asserts, but none of them actually validate the #26202 invariant:

- `cb_access_within_bounds(...)` (unpack indexed reads) and the `llk_io_pack.h` push-overflow asserts (`fifo_wr_ptr < fifo_limit`, `remaining >= num_words`) are *bounds/overflow* guards. Crucially they compute their bounds using the **same** `fifo_page_size` stride against a page-derived `fifo_limit`, so they are self-consistent in page units and can never detect `page_size != tile_size`; they only catch indices/pushes that overrun the CB. The new validators add the missing check by comparing against the independent `*_tile_size[]` arrays. Both kinds of checks now live together in the per-operation validators (e.g. `validate_unpack_tile_access` does page==tile **and** bounds; `validate_pack_tile_push` does page==tile **and** overflow).
- The new validators follow the established LLK validator convention used by `are_packers_configured_correctly` / `is_unpacker_A_configured_correctly`: `noinline void` functions containing the individual `LLK_ASSERT`s, invoked via `LLK_ASSERT_BLOCK` so the whole call (including side effects) compiles out when asserts are disabled. Behavior is unchanged when asserts are off — the production accessors still return `fifo_page_size`.

**Scope.** Converted the tile *indexing* sites (unpack A/AB/reduce/AB_reduce + experimental variants, `llk_push_tiles`, `llk_pack_untilize`). Deliberately left the `fifo_page_size` reads that feed `_llk_*_hw_configure_` as a *tile_size* argument (matmul/tilize/`*_common_api.h`) — those are register-sizing, not CB indexing, and out of this issue's scope.

**Other call-outs.**
- WH experimental kernels previously had no bounds assert at the indexed reads; they gain the validators here for parity with BH.
- `llk_unpack_A_block`'s assert message changes from "Block tile read..." to the generic "Indexed tile read exceeds CB boundary".
- Relies on `fifo_page_size` and `*_tile_size[]` both being in 16B words for compute. Recommend a sanity run with `TT_METAL_LLK_ASSERTS=1` (the `enable-llk-asserts` CI path) on both arches to confirm no false positives on supported configs.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/add_llk_asserts_for_verifying_tile_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/add_llk_asserts_for_verifying_tile_size)