### PR TITLE
Stabilize high-parallel JIT test runners

### DIFF
--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -26,8 +26,10 @@
 #include <cstring>
 #include <thread>
 
+#include "common/host_threading.hpp"
+
 namespace tt::tt_metal::detail {
-inline static const size_t EXECUTOR_NTHREADS = std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1;
+inline static const size_t EXECUTOR_NTHREADS = get_host_worker_threads();
 
 using Executor = tf::Executor;
 using ExecTask = tf::Task;

--- a/tt_metal/common/host_threading.hpp
+++ b/tt_metal/common/host_threading.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdlib>
+#include <thread>
+
+namespace tt::tt_metal::detail {
+
+inline size_t hardware_concurrency_or_one() {
+    return std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1;
+}
+
+inline size_t get_host_worker_threads() {
+    const char* value = std::getenv("TT_METAL_HOST_WORKER_THREADS");
+    if (value == nullptr || value[0] == '\0') {
+        return hardware_concurrency_or_one();
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    unsigned long parsed = std::strtoul(value, &end, 10);
+    if (errno != 0 || end == value || *end != '\0' || parsed == 0) {
+        return hardware_concurrency_or_one();
+    }
+    return static_cast<size_t>(parsed);
+}
+
+}  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/jit_server/jit_compile_service.hpp
+++ b/tt_metal/impl/jit_server/jit_compile_service.hpp
@@ -12,6 +12,7 @@
 
 #include <taskflow/taskflow.hpp>
 
+#include "common/host_threading.hpp"
 #include "impl/jit_server/in_flight_compile_deduper.hpp"
 #include "impl/jit_server/rpc.capnp.h"
 #include "impl/jit_server/types.hpp"
@@ -34,7 +35,7 @@ private:
     CompileCallback compile_callback_;
     UploadFirmwareCallback upload_fw_callback_;
     InFlightCompileDeduper<CompileResponse> compile_deduper_;
-    tf::Executor thread_pool_{std::max(1u, std::thread::hardware_concurrency())};
+    tf::Executor thread_pool_{tt::tt_metal::detail::get_host_worker_threads()};
 };
 
 }  // namespace tt::tt_metal::jit_server

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -102,6 +102,10 @@ namespace {
 
 using namespace tt::tt_metal;
 
+std::filesystem::path kernel_genfiles_lock_path(const JitBuildOptions& build_options) {
+    return std::filesystem::path(build_options.path) / ".jit_genfiles.lock";
+}
+
 size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable_core_type) {
     if (programmable_core_type == HalProgrammableCoreType::TENSIX) {
         return device->allocator_impl()->get_config().l1_unreserved_base -
@@ -243,6 +247,7 @@ std::string ensure_kernel_binaries(
 
     jit_build_once(kernel_hash, [&] {
         try {
+            tt::jit_build::utils::ScopedFileLock genfiles_lock(kernel_genfiles_lock_path(build_options));
             jit_build_genfiles_descriptors(build_env.build_env, build_options);
             kernel->generate_binaries(device, build_options);
         } catch (std::runtime_error& ex) {
@@ -2134,6 +2139,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                 validate_kernel_placement(force_slow_dispatch, kernel);
                 auto [build_options, kernel_hash] = prep_kernel(kernel);
                 coordinator.submit(kernel_hash, [&]() {
+                    tt::jit_build::utils::ScopedFileLock genfiles_lock(kernel_genfiles_lock_path(build_options));
                     generate_kernel_source_files(device, build_options, kernel);
                     return build_kernel_descriptor(device, kernel, build_options, kernel_hash);
                 });

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -74,6 +74,67 @@ void hard_link_or_copy(const std::filesystem::path& target, const std::filesyste
     }
 }
 
+fs::path dependency_hash_path(const fs::path& path) {
+    fs::path hash_path = path;
+    hash_path += ".dephash";
+    return hash_path;
+}
+
+bool cache_entry_valid(const std::string& out_dir, const std::string& artifact) {
+    return fs::exists(fs::path(out_dir) / artifact) && jit_build::dependencies_up_to_date(out_dir, artifact);
+}
+
+void remove_artifact_and_hash(const fs::path& path) {
+    fs::remove(path);
+    fs::remove(dependency_hash_path(path));
+}
+
+void publish_artifact_and_hash(const fs::path& src_path, const fs::path& dst_path) {
+    fs::rename(src_path, dst_path);
+
+    fs::path src_hash_path = dependency_hash_path(src_path);
+    fs::path dst_hash_path = dependency_hash_path(dst_path);
+    if (fs::exists(src_hash_path)) {
+        fs::rename(src_hash_path, dst_hash_path);
+    } else {
+        fs::remove(dst_hash_path);
+    }
+}
+
+void publish_compiled_object(
+    const std::string& out_dir,
+    const std::string& obj,
+    const fs::path& src_path,
+    const fs::path& dst_path,
+    bool skip_if_current) {
+    if (skip_if_current && cache_entry_valid(out_dir, obj)) {
+        remove_artifact_and_hash(src_path);
+        return;
+    }
+    publish_artifact_and_hash(src_path, dst_path);
+}
+
+void publish_linked_elf(
+    const std::string& out_dir,
+    const std::string& elf_name,
+    const fs::path& temp_elf_path,
+    const fs::path& temp_hash_path,
+    bool skip_if_current) {
+    if (skip_if_current && cache_entry_valid(out_dir, elf_name)) {
+        fs::remove(temp_elf_path);
+        fs::remove(temp_hash_path);
+        return;
+    }
+
+    fs::rename(temp_elf_path, elf_name);
+    fs::path final_hash_path = dependency_hash_path(elf_name);
+    if (fs::exists(temp_hash_path)) {
+        fs::rename(temp_hash_path, final_hash_path);
+    } else {
+        fs::remove(final_hash_path);
+    }
+}
+
 }  // namespace
 
 std::string get_default_root_path() {
@@ -708,24 +769,26 @@ void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings
     cmd += this->extra_link_objs_;
     cmd += link_objs;
     std::string elf_name = out_dir + this->target_name_ + ".elf";
-    jit_build::utils::FileRenamer elf_file(elf_name);
-    cmd += "-o " + elf_file.path();
+    std::string temp_elf_name = jit_build::utils::FileRenamer::generate_temp_path(elf_name);
+    cmd += "-o " + temp_elf_name;
     if (env_.get_rtoptions().get_log_kernels_compilation_commands()) {
         log_info(tt::LogBuildKernels, "    g++ link cmd: {}", cmd);
     }
     jit_build::utils::FileRenamer log_file(elf_name + ".log");
     fs::remove(log_file.path());
     if (!tt::jit_build::utils::run_command(cmd, log_file.path(), env_.get_rtoptions().get_dump_build_commands())) {
+        fs::remove(temp_elf_name);
         build_failure(this->target_name_, "link", cmd, log_file.path());
     }
-    jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
-    std::ofstream hash_file(dephash_file.path());
+    std::string temp_hash_name = jit_build::utils::FileRenamer::generate_temp_path(elf_name + ".dephash");
+    std::ofstream hash_file(temp_hash_name);
     jit_build::write_dependency_hashes({{elf_name, std::move(link_deps)}}, out_dir, elf_name, hash_file);
     hash_file.close();
     if (hash_file.fail()) {
         // Don't leave incomplete hash file
-        std::filesystem::remove(dephash_file.path());
+        std::filesystem::remove(temp_hash_name);
     }
+    publish_linked_elf(out_dir, elf_name, temp_elf_name, temp_hash_name, !env_.get_rtoptions().get_force_jit_compile());
 }
 
 // Given this elf (A) and a later elf (B):
@@ -846,10 +909,8 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
             src_path.replace_filename(this->temp_objs_[i]);
             dst_path.replace_filename(this->objs_[i]);
             if (compiled.test(i)) {
-                fs::rename(src_path, dst_path);
-                src_path += ".dephash";
-                dst_path += ".dephash";
-                fs::rename(src_path, dst_path);
+                publish_compiled_object(
+                    out_dir, this->objs_[i], src_path, dst_path, !env_.get_rtoptions().get_force_jit_compile());
             } else {
                 fs::remove(src_path);
             }

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -15,12 +15,14 @@
 #include <iostream>
 #include <mutex>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <vector>
 
 #include <fcntl.h>
 #include <spawn.h>
+#include <sys/file.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -172,6 +174,42 @@ void create_file(const std::string& file_path_str) {
 
     std::ofstream ofs(file_path);
     ofs.close();
+}
+
+ScopedFileLock::ScopedFileLock(const std::filesystem::path& lock_path) {
+    namespace fs = std::filesystem;
+
+    const auto parent = lock_path.parent_path();
+    if (!parent.empty()) {
+        fs::create_directories(parent);
+    }
+
+    fd_ = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0644);
+    if (fd_ < 0) {
+        throw std::runtime_error(fmt::format("Cannot open lock file {}: {}", lock_path.string(), std::strerror(errno)));
+    }
+
+    while (flock(fd_, LOCK_EX) < 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        const std::string error = std::strerror(errno);
+        close(fd_);
+        fd_ = -1;
+        throw std::runtime_error(fmt::format("Cannot lock file {}: {}", lock_path.string(), error));
+    }
+}
+
+ScopedFileLock::~ScopedFileLock() {
+    if (fd_ < 0) {
+        return;
+    }
+    if (flock(fd_, LOCK_UN) != 0) {
+        log_error(tt::LogBuildKernels, "Failed to unlock file: {}", std::strerror(errno));
+    }
+    if (close(fd_) != 0) {
+        log_error(tt::LogBuildKernels, "Failed to close lock file: {}", std::strerror(errno));
+    }
 }
 
 uint64_t FileRenamer::unique_id_ = []() {

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -26,6 +26,19 @@ std::vector<std::string> tokenize_flags(const std::string& flags);
 
 void create_file(const std::string& file_path_str);
 
+class ScopedFileLock {
+public:
+    explicit ScopedFileLock(const std::filesystem::path& lock_path);
+    ScopedFileLock(const ScopedFileLock&) = delete;
+    ScopedFileLock& operator=(const ScopedFileLock&) = delete;
+    ScopedFileLock(ScopedFileLock&&) = delete;
+    ScopedFileLock& operator=(ScopedFileLock&&) = delete;
+    ~ScopedFileLock();
+
+private:
+    int fd_ = -1;
+};
+
 // Read the entire contents of a binary file into a byte vector.
 // Throws std::runtime_error if the file cannot be read or if the read is incomplete.
 std::vector<std::uint8_t> read_file_bytes(const std::string& path);

--- a/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
+++ b/tt_metal/tools/jit_compile_server/jit_compile_server.cpp
@@ -214,6 +214,12 @@ void compile_one(
     fs::remove(temp_d_path);
 }
 
+void publish_linked_elf(
+    const std::string& out_dir,
+    const std::string& elf_name,
+    const fs::path& temp_elf_path,
+    const fs::path& temp_hash_path);
+
 void link_one(
     const std::string& gpp,
     const tt::tt_metal::jit_server::TargetRecipe& target,
@@ -237,22 +243,80 @@ void link_one(
     append_tokenized(args, target.extra_link_objs);
     args.insert(args.end(), link_obj_paths.begin(), link_obj_paths.end());
     std::string elf_name = out_dir + target.target_name + ".elf";
-    tt::jit_build::utils::FileRenamer elf_file(elf_name);
+    std::string temp_elf_name = tt::jit_build::utils::FileRenamer::generate_temp_path(elf_name);
     args.push_back("-o");
-    args.push_back(elf_file.path());
+    args.push_back(temp_elf_name);
 
     tt::jit_build::utils::FileRenamer log_file(elf_name + ".log");
     fs::remove(log_file.path());
     if (!tt::jit_build::utils::exec_command(args, out_dir, log_file.path())) {
+        fs::remove(temp_elf_name);
         build_failure(target.target_name, "link", format_args(args), log_file.path());
     }
 
-    tt::jit_build::utils::FileRenamer dephash_file(elf_name + ".dephash");
-    std::ofstream hash_file(dephash_file.path());
+    std::string temp_hash_name = tt::jit_build::utils::FileRenamer::generate_temp_path(elf_name + ".dephash");
+    std::ofstream hash_file(temp_hash_name);
     tt::jit_build::write_dependency_hashes({{elf_name, std::move(link_deps)}}, out_dir, elf_name, hash_file);
     hash_file.close();
     if (hash_file.fail()) {
-        fs::remove(dephash_file.path());
+        fs::remove(temp_hash_name);
+    }
+    publish_linked_elf(out_dir, elf_name, temp_elf_name, temp_hash_name);
+}
+
+fs::path dependency_hash_path(const fs::path& path) {
+    fs::path hash_path = path;
+    hash_path += ".dephash";
+    return hash_path;
+}
+
+bool cache_entry_valid(const std::string& out_dir, const std::string& artifact) {
+    return fs::exists(fs::path(out_dir) / artifact) && tt::jit_build::dependencies_up_to_date(out_dir, artifact);
+}
+
+void remove_artifact_and_hash(const fs::path& path) {
+    fs::remove(path);
+    fs::remove(dependency_hash_path(path));
+}
+
+void publish_artifact_and_hash(const fs::path& src_path, const fs::path& dst_path) {
+    fs::rename(src_path, dst_path);
+
+    fs::path src_hash_path = dependency_hash_path(src_path);
+    fs::path dst_hash_path = dependency_hash_path(dst_path);
+    if (fs::exists(src_hash_path)) {
+        fs::rename(src_hash_path, dst_hash_path);
+    } else {
+        fs::remove(dst_hash_path);
+    }
+}
+
+void publish_compiled_object(
+    const std::string& out_dir, const std::string& obj, const fs::path& src_path, const fs::path& dst_path) {
+    if (cache_entry_valid(out_dir, obj)) {
+        remove_artifact_and_hash(src_path);
+        return;
+    }
+    publish_artifact_and_hash(src_path, dst_path);
+}
+
+void publish_linked_elf(
+    const std::string& out_dir,
+    const std::string& elf_name,
+    const fs::path& temp_elf_path,
+    const fs::path& temp_hash_path) {
+    if (cache_entry_valid(out_dir, elf_name)) {
+        fs::remove(temp_elf_path);
+        fs::remove(temp_hash_path);
+        return;
+    }
+
+    fs::rename(temp_elf_path, elf_name);
+    fs::path final_hash_path = dependency_hash_path(elf_name);
+    if (fs::exists(temp_hash_path)) {
+        fs::rename(temp_hash_path, final_hash_path);
+    } else {
+        fs::remove(final_hash_path);
     }
 }
 
@@ -321,8 +385,7 @@ void build_target(
         fs::path src_path = out_dir + temp_objs[i];
         fs::path dst_path = out_dir + target.objs[i];
         if (compiled[i]) {
-            fs::rename(src_path, dst_path);
-            fs::rename(fs::path(src_path).concat(".dephash"), fs::path(dst_path).concat(".dephash"));
+            publish_compiled_object(out_dir, target.objs[i], src_path, dst_path);
         } else if (fs::exists(src_path)) {
             fs::remove(src_path);
         }
@@ -360,8 +423,10 @@ tt::tt_metal::jit_server::CompileResponse compile_callback(const tt::tt_metal::j
             request.generated_files.size(),
             outstanding);
 
+        const fs::path genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
+        tt::jit_build::utils::ScopedFileLock genfiles_lock(genfiles_dir / ".jit_genfiles.lock");
+
         if (!request.generated_files.empty()) {
-            const fs::path genfiles_dir = kernel_cache_dir(request.build_key, request.kernel_name);
             fs::create_directories(genfiles_dir);
             for (const auto& file : request.generated_files) {
                 std::string target_path = (genfiles_dir / file.name).string();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -7,6 +7,7 @@
 #include "conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp"
+#include "tt_metal/common/host_threading.hpp"
 #include <tt_stl/assert.hpp>
 #include <cstdint>
 #include <tt-logger/tt-logger.hpp>
@@ -51,7 +52,7 @@ private:
         if (!threading_enabled) {
             return 1;
         }
-        uint32_t hw_concurrency = std::thread::hardware_concurrency();
+        uint32_t hw_concurrency = static_cast<uint32_t>(tt::tt_metal::detail::get_host_worker_threads());
         // Use sqrt to balance 2D parallelization: total threads = out_threads × in_threads ≈ sqrt(hw_concurrency - 1)²
         // This prevents oversubscription while maintaining good load distribution across both channel dimensions
         return std::max(1u, static_cast<uint32_t>(std::sqrt(hw_concurrency - 1)));


### PR DESCRIPTION
## Summary
- Add a shared host-thread helper that honors `TT_METAL_HOST_WORKER_THREADS` and falls back to hardware concurrency.
- Use it for tt-metal executor pools, the JIT compile service pool, and TTNN conv2d weight-prep threading.
- Make JIT cache artifact publication race-safe under high parallel pytest runners:
  - publish objects/ELFs before their `.dephash` readiness markers;
  - tolerate missing generated `.dephash` files by treating the artifact as uncached instead of throwing;
  - discard late temporary artifacts when another worker already published a valid final cache entry.
- Default behavior remains unchanged unless `TT_METAL_HOST_WORKER_THREADS` is set.

## Validation
- `git diff --check`
- pre-commit hooks from `git commit --amend`
- `./build_metal.sh --release --enable-lto`
- BH TTNN cold-cache no-retry smoke: `scripts/sweep_ttnn_ops.py -j 256 --no-prewarm-cache --cache-race-retries 0 --metal-host-worker-threads 1 --path tests/ttnn/unit_tests/operations/data_movement/test_full.py --max-tests 128 --arch blackhole` -> 128 PASS / 0 FAIL in 232s, with zero `cannot rename`, `cannot map elf file`, fatal Python, resource-exhaustion, or `.dephash` signatures.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/host-worker-thread-cap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/host-worker-thread-cap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/host-worker-thread-cap)
