### PR TITLE
BSPM-on-SRAM: unify SRAM hot-expert allocation + demo wiring

### DIFF
--- a/models/demos/deepseek_v3_b1/circular_buffer_utils.py
+++ b/models/demos/deepseek_v3_b1/circular_buffer_utils.py
@@ -212,7 +212,109 @@ def record_cb_metadata(cb_descriptors):
     return cb_metadata
 
 
-def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
+def record_cb_metadata_per_coord(cb_descriptors_replicated, cb_descriptors_per_coord, cb_size_overrides=None):
+    """
+    Extract per-mesh-coord CB config metadata.
+
+    Mirrors :func:`record_cb_metadata` but keyed by ``(mesh_row, mesh_col)`` —
+    needed when some CBs (e.g., BSPM-SRAM weight CBs) have per-device-different
+    L1 addresses.  Each coord's metadata is the merge of:
+        - ``cb_descriptors_replicated``: same on every device.
+        - ``cb_descriptors_per_coord[coord]``: this device's per-coord descs.
+
+    Args:
+        cb_descriptors_replicated: List of CBDescriptors identical on all devices.
+        cb_descriptors_per_coord: ``dict[(mesh_row, mesh_col)] -> list[CBDescriptor]``
+            holding the per-device CBDescriptors that differ across devices.
+        cb_size_overrides: optional ``{cb_id: (total_size, num_pages, page_size)}``
+            forced size triple recorded in place of the desc-derived values, only
+            for CBs listed in ``cb_descriptors_per_coord`` (the per-coord ones).
+            Real per-(device, core) addresses are still queried from each desc;
+            only the size fields are uniformized.
+
+            Use case: BSPM-SRAM produces per-(device, core)-different packed
+            byte sizes, but the kernel's ``cb_wait_front(cb_in1, 1)`` requires
+            ``num_pages >= 1`` and the framework's "received" counter is seeded
+            from ``num_pages`` at ``setup_sharded_buffer``.  All-bfp0 cores'
+            placeholder buffer (64 B < 576 B page_size) would otherwise record
+            ``num_pages=0`` → ``cb_wait_front`` blocks → kernel hangs.
+
+    Returns:
+        ``dict[(mesh_row, mesh_col)] -> dict[cb_id, list[(addr, total_size,
+        num_pages, page_size, core_ranges)]]`` — the per-coord equivalent of
+        :func:`record_cb_metadata`'s output.
+    """
+    overrides = cb_size_overrides or {}
+    replicated_meta = record_cb_metadata(cb_descriptors_replicated)
+    out = {}
+    for coord, per_coord_descs in cb_descriptors_per_coord.items():
+        # Shallow-copy replicated entries — tuples are immutable so list copy
+        # is enough to keep per-coord mutations isolated.
+        per_coord_meta = {cb_id: list(entries) for cb_id, entries in replicated_meta.items()}
+        for desc in per_coord_descs:
+            for fmt in desc.format_descriptors:
+                cb_id = fmt.buffer_index
+                addr = ttnn.get_cb_address(desc)
+                assert addr != 0, f"CB {cb_id} has address 0, which means it's not backed by a tensor"
+                if cb_id in overrides:
+                    total_size, num_pages, page_size = overrides[cb_id]
+                else:
+                    total_size = desc.total_size
+                    page_size = fmt.page_size
+                    num_pages = total_size // page_size
+                per_coord_meta.setdefault(cb_id, []).append((addr, total_size, num_pages, page_size, desc.core_ranges))
+        out[coord] = per_coord_meta
+    return out
+
+
+def _fill_config_block(config_block, cb_metadata, core_to_idx, _diag_label=None):
+    """Write per-core CB config words into a pre-allocated ``(num_cores, WORDS_PER_CORE)`` block.
+
+    Helper shared between the replicated and per-coord paths of
+    :func:`build_cb_reconfig_tensor`.  ``config_block`` is mutated in place.
+    """
+    _diag_writes = []  # (cb_id, (core.x, core.y), addr) — for ordering audit
+    for cb_id, entries in cb_metadata.items():
+        for addr, total_size, num_pages, page_size, core_ranges in entries:
+            cb_cores = ttnn.corerange_to_cores(core_ranges, row_wise=True)
+            for core in cb_cores:
+                key = (core.x, core.y)
+                if key not in core_to_idx:
+                    continue
+                core_idx = core_to_idx[key]
+                base = cb_id * 4
+                # Detect double-write to same (cb_id, core) — would indicate
+                # ordering bug where two entries claim the same CB slot on the
+                # same core (e.g., replicated overwriting per-coord or vice
+                # versa).  Loguru only here, in diag path.
+                if config_block[core_idx, base + 0] != 0 and _diag_label is not None:
+                    from loguru import logger as _diag_logger
+
+                    _diag_logger.warning(
+                        "[reconfig diag {}] double-write cb{} at core({}, {}): "
+                        "prev addr=0x{:x} new addr=0x{:x} prev pages={} new pages={}",
+                        _diag_label,
+                        cb_id,
+                        core.x,
+                        core.y,
+                        int(config_block[core_idx, base + 0]),
+                        addr,
+                        int(config_block[core_idx, base + 2]),
+                        num_pages,
+                    )
+                config_block[core_idx, base + 0] = addr
+                config_block[core_idx, base + 1] = total_size
+                config_block[core_idx, base + 2] = num_pages
+                config_block[core_idx, base + 3] = page_size
+                if cb_id < 32:
+                    config_block[core_idx, 256] |= 1 << cb_id
+                else:
+                    config_block[core_idx, 257] |= 1 << (cb_id - 32)
+                _diag_writes.append((cb_id, key, int(addr), int(total_size), int(num_pages)))
+    return _diag_writes
+
+
+def build_cb_reconfig_tensor(cb_metadata=None, full_device_grid=None, mesh_device=None, *, cb_metadata_per_coord=None):
     """
     Build an L1-sharded tensor containing per-core CB config data for reconfig.
 
@@ -229,56 +331,71 @@ def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
         Words 258-259: cross-RISC sync semaphores (initialized to 0, used at runtime)
         Words 260-263: reserved (zeros)
 
+    Provide exactly one of ``cb_metadata`` (replicated mode — same config on
+    every device, distributed via ``ReplicateTensorToMesh``) or
+    ``cb_metadata_per_coord`` (per-device mode — addresses differ across the
+    mesh, e.g., under BSPM SRAM; distributed via ``ShardTensor2dMesh``).
+
     Args:
-        cb_metadata: dict mapping cb_id → list of (addr, total_size, num_pages, page_size, core_ranges)
-        full_device_grid: CoreRangeSet covering all cores on the device
-        mesh_device: Device or MeshDevice to place the tensor on
+        cb_metadata: Replicated mode — ``dict[cb_id] -> list[(addr, total_size,
+            num_pages, page_size, core_ranges)]``.
+        full_device_grid: CoreRangeSet covering all cores on the device.
+        mesh_device: Device or MeshDevice to place the tensor on.
+        cb_metadata_per_coord: Per-device mode — ``dict[(mesh_row, mesh_col)] ->
+            <replicated cb_metadata shape>``; see :func:`record_cb_metadata_per_coord`.
 
     Returns:
-        ttnn.Tensor: HEIGHT_SHARDED L1 tensor with 1 shard (264 uint32) per core
+        ttnn.Tensor: HEIGHT_SHARDED L1 tensor with 1 shard (264 uint32) per core.
     """
     import torch
 
+    assert (cb_metadata is None) != (
+        cb_metadata_per_coord is None
+    ), "Provide exactly one of cb_metadata (replicated) or cb_metadata_per_coord (per-device)"
+
     all_cores = ttnn.corerange_to_cores(full_device_grid, row_wise=True)
     num_cores = len(all_cores)
-
-    # Build (x, y) → index map for fast lookup
     core_to_idx = {(c.x, c.y): idx for idx, c in enumerate(all_cores)}
-
-    # 264 words per core: 64 CBs * 4 words + 2 mask words + 6 padding
     WORDS_PER_CORE = 264
-    config = torch.zeros((num_cores, WORDS_PER_CORE), dtype=torch.uint32)
-
-    for cb_id, entries in cb_metadata.items():
-        for addr, total_size, num_pages, page_size, core_ranges in entries:
-            cb_cores = ttnn.corerange_to_cores(core_ranges, row_wise=True)
-            for core in cb_cores:
-                key = (core.x, core.y)
-                if key not in core_to_idx:
-                    continue
-                core_idx = core_to_idx[key]
-                base = cb_id * 4
-                config[core_idx, base + 0] = addr
-                config[core_idx, base + 1] = total_size
-                config[core_idx, base + 2] = num_pages
-                config[core_idx, base + 3] = page_size
-                if cb_id < 32:
-                    config[core_idx, 256] |= 1 << cb_id
-                else:
-                    config[core_idx, 257] |= 1 << (cb_id - 32)
-
-    num_devices = mesh_device.get_num_devices() if hasattr(mesh_device, "get_num_devices") else 1
-    mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if num_devices > 1 else None
-    from_torch_kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
 
     shard_spec = ttnn.ShardSpec(full_device_grid, (1, WORDS_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
 
+    if cb_metadata is not None:
+        # Replicated path: one (num_cores, WORDS_PER_CORE) block, replicated across mesh.
+        config = torch.zeros((num_cores, WORDS_PER_CORE), dtype=torch.uint32)
+        _fill_config_block(config, cb_metadata, core_to_idx)
+
+        num_devices = mesh_device.get_num_devices() if hasattr(mesh_device, "get_num_devices") else 1
+        mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if num_devices > 1 else None
+        from_torch_kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
+        return ttnn.from_torch(
+            config,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=mem_config,
+            **from_torch_kwargs,
+        )
+
+    # Per-device path: build a (mesh_rows * num_cores, mesh_cols * WORDS_PER_CORE)
+    # source so ShardTensor2dMesh splits both axes — each device (r, c) ends up
+    # with its own (num_cores, WORDS_PER_CORE) block.  Mirrors the layout used
+    # by ShardTensor2dMesh callers elsewhere (e.g. transforms/moe.py:466).
+    coords = list(cb_metadata_per_coord.keys())
+    mesh_rows = max(r for r, _ in coords) + 1
+    mesh_cols = max(c for _, c in coords) + 1
+    source = torch.zeros((mesh_rows * num_cores, mesh_cols * WORDS_PER_CORE), dtype=torch.uint32)
+    for (mr, mc), per_cb in cb_metadata_per_coord.items():
+        block = source[mr * num_cores : (mr + 1) * num_cores, mc * WORDS_PER_CORE : (mc + 1) * WORDS_PER_CORE]
+        _fill_config_block(block, per_cb, core_to_idx, _diag_label=f"coord({mr},{mc})")
+
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
     return ttnn.from_torch(
-        config,
+        source,
         dtype=ttnn.uint32,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,
         memory_config=mem_config,
-        **from_torch_kwargs,
+        mesh_mapper=mesh_mapper,
     )

--- a/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
@@ -344,6 +344,7 @@ class CompressedTensor:
         assignment_memory_config=None,
         tile_hw: int = DEFAULT_TILE_HW,
         min_shard_bytes: int = 0,
+        per_core_allocation: bool = False,
         mesh_mapper_config=None,
         keep_packed_data: bool = False,
         move_to_device: bool = True,
@@ -364,6 +365,7 @@ class CompressedTensor:
             assignment_memory_config=assignment_memory_config,
             tile_hw=tile_hw,
             min_shard_bytes=min_shard_bytes,
+            per_core_allocation=per_core_allocation,
             mesh_mapper_config=mesh_mapper_config,
             keep_packed_data=keep_packed_data,
             move_to_device=move_to_device,
@@ -1366,14 +1368,22 @@ class CompressedTensor:
 
             per_core = {}
             for (core, _page_indices), core_tile_data, raw_size in zip(shard_mapping, shard_data, shard_data_sizes):
-                if raw_size == 0:
+                # Apply min_shard_bytes floor — all-bfp0 cores have raw_size=0
+                # (bfp0 packs to zero bytes per tile_utils.bfp_tile_packed_size)
+                # but still need a valid L1 address for downstream
+                # get_data_l1_address_per_core queries. Caller passes a non-zero
+                # min_shard_bytes to allocate a placeholder buffer instead of
+                # skipping. With min_shard_bytes=0 (default) the original
+                # skip-empty behavior is preserved.
+                effective_size = max(raw_size, self._min_shard_bytes)
+                if effective_size == 0:
                     continue
-                aligned_size = _align(raw_size, alignment)
+                aligned_size = _align(effective_size, alignment)
                 core_bytes = list(core_tile_data)
                 pad = aligned_size - raw_size
                 if pad > 0:
                     core_bytes.append(np.zeros(pad, dtype=np.uint8))
-                flat = np.concatenate(core_bytes)
+                flat = np.concatenate(core_bytes) if core_bytes else np.zeros(aligned_size, dtype=np.uint8)
 
                 core_torch = torch.from_numpy(flat.copy()).reshape(1, aligned_size)
                 core_shard_spec = ttnn.ShardSpec(

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -132,6 +132,14 @@ def create_parser() -> argparse.ArgumentParser:
         help="Maximum number of SRAM-pinned hot experts per MoE layer (top-N by routing frequency).",
     )
     parser.add_argument(
+        "--enable-sram-bspm",
+        action="store_true",
+        help=(
+            "Use the BSPM precision map for SRAM hot expert weights too "
+            "(default: uniform BFP4). Requires --bspm-dir to be set."
+        ),
+    )
+    parser.add_argument(
         "--launch-only",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -203,6 +211,7 @@ def run_demo(
     sram_hot_experts_ceiling: int = 64,
     bspm_dir: Path | None = None,
     bspm_budget: float = 3.5,
+    enable_sram_bspm: bool = False,
 ) -> None:
     """Run the pod pipeline. Requires 4, 16, or 64 distributed processes."""
     configure_runtime_env(enable_sram_hot_experts=enable_sram_hot_experts)
@@ -234,6 +243,7 @@ def run_demo(
             sram_hot_experts_ceiling=sram_hot_experts_ceiling,
             bspm_dir=bspm_dir,
             bspm_budget=bspm_budget,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
         my_mesh_id = mesh_device.get_system_mesh_id()
@@ -333,6 +343,7 @@ def main(argv: list[str] | None = None) -> int:
         sram_hot_experts_ceiling=args.sram_hot_experts_ceiling,
         bspm_dir=args.bspm_dir,
         bspm_budget=args.bspm_budget,
+        enable_sram_bspm=args.enable_sram_bspm,
     )
     print(end="", file=sys.stdout, flush=True)
     return 0

--- a/models/demos/deepseek_v3_b1/demo/decoder_stage.py
+++ b/models/demos/deepseek_v3_b1/demo/decoder_stage.py
@@ -730,6 +730,7 @@ class DecoderStage(StageKind):
         upstream_fifo_pages: int = DEFAULT_ACTIVATION_FIFO_PAGES,
         downstream_fifo_pages: int = DEFAULT_ACTIVATION_FIFO_PAGES,
         host_loopback: bool = False,
+        enable_sram_bspm: bool = False,
     ) -> None:
         if not isinstance(weights, (DeepSeekV3MoELayerWeights, DeepSeekV3DenseLayerWeights)):
             raise ValueError(
@@ -754,6 +755,7 @@ class DecoderStage(StageKind):
         self._upstream_fifo_pages = upstream_fifo_pages
         self._downstream_fifo_pages = downstream_fifo_pages
         self._host_loopback = host_loopback
+        self._enable_sram_bspm = enable_sram_bspm
         self._num_links_bcast = 1
         self._num_links_allreduce = 2
         self._state: dict[str, Any] = {}
@@ -888,6 +890,7 @@ class DecoderStage(StageKind):
             persistent_mode=self._persistent_mode,
             termination_semaphore=self._state.get("termination_semaphore"),
             is_torus=self._is_torus,
+            enable_sram_bspm=self._enable_sram_bspm,
         )
 
     def setup(self, ctx: StageContext, pipeline_block: PipelineBlock) -> None:
@@ -915,6 +918,16 @@ class DecoderStage(StageKind):
         # weights were allocated. Without this, sram_*_proj is in L1 but no
         # gate index has bit-15 set, so the SRAM kernel filter sees zero
         # SRAM-flagged experts every iter and the SRAM path never fires.
+        #
+        # TODO (BSPM-SRAM): under enable_sram_bspm, SRAM CT sizes diverge per
+        # device and must be allocated AFTER SDPA buffer (allocated below in
+        # create_decoder_block_tensors) so SDPA addresses stay uniform across
+        # the mesh.  The unit test test_decoder_block.py shows the deferred
+        # pattern: prepare_moe_layer_weights(sram_expert_ids=[]) →
+        # create_decoder_block_tensors → build_sram_routed_proj_cts →
+        # _dataclass_replace + d.update.  Wiring this through the weight
+        # provider (so the stage receives a "deferred SRAM build" descriptor
+        # instead of pre-allocated SRAM CTs) is a follow-up.
         if self._is_moe:
             # MoE: prepare_moe_layer_weights populates sram_slots.slot_experts with
             # the L1-fit-truncated subset of sram_hot_experts. None when SRAM
@@ -1209,6 +1222,7 @@ class MoEDecoderStage(DecoderStage):
         upstream_fifo_pages: int = DEFAULT_ACTIVATION_FIFO_PAGES,
         downstream_fifo_pages: int = DEFAULT_ACTIVATION_FIFO_PAGES,
         host_loopback: bool = False,
+        enable_sram_bspm: bool = False,
     ) -> None:
         super().__init__(
             weights=weights,
@@ -1225,6 +1239,7 @@ class MoEDecoderStage(DecoderStage):
             upstream_fifo_pages=upstream_fifo_pages,
             downstream_fifo_pages=downstream_fifo_pages,
             host_loopback=host_loopback,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
 

--- a/models/demos/deepseek_v3_b1/demo/model_pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/model_pipeline.py
@@ -57,6 +57,7 @@ class ModelPipeline:
         bspm_dir: Path | None = None,
         bspm_variant: str = "B",
         bspm_budget: float = 3.5,
+        enable_sram_bspm: bool = False,
     ):
         logger.info(
             "Initializing DeepSeek V3 B1 pod pipeline (weights={}, lm_head_fp32={}, lm_head_persistent_mode={}, speculative_decode={})",
@@ -89,7 +90,6 @@ class ModelPipeline:
             if model_path is None:
                 raise ValueError("weights_mode='real' requires model_path")
             if enable_sram_hot_experts:
-                from models.demos.deepseek_v3_b1.compressed_tensor.assigner import CompressedTensorAssigner
                 from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import (
                     SramExpertCoreGrids,
                     _load_routing_frequencies,
@@ -112,7 +112,6 @@ class ModelPipeline:
                     model_path,
                     sram_hot_experts=sram_hot_experts,
                     sram_core_grids=SramExpertCoreGrids.shared_expert_mirror(),
-                    sram_assigner=CompressedTensorAssigner(formats=["bfp4"]),
                     worker_l1_size=_worker_l1_size_for_rank(
                         num_procs,
                         enable_speculative_decode=enable_speculative_decode,
@@ -120,6 +119,7 @@ class ModelPipeline:
                     bspm_dir=bspm_dir,
                     bspm_variant=bspm_variant,
                     bspm_budget=bspm_budget,
+                    enable_sram_bspm=enable_sram_bspm,
                 )
             else:
                 provider = CacheWeightProvider(
@@ -128,6 +128,7 @@ class ModelPipeline:
                     bspm_dir=bspm_dir,
                     bspm_variant=bspm_variant,
                     bspm_budget=bspm_budget,
+                    enable_sram_bspm=enable_sram_bspm,
                 )
         elif weights_mode == "state_dict":
             if model_path is None:
@@ -137,12 +138,14 @@ class ModelPipeline:
                 bspm_dir=bspm_dir,
                 bspm_variant=bspm_variant,
                 bspm_budget=bspm_budget,
+                enable_sram_bspm=enable_sram_bspm,
             )
         elif weights_mode == "synthetic":
             provider = SyntheticWeightProvider(
                 bspm_dir=bspm_dir,
                 bspm_variant=bspm_variant,
                 bspm_budget=bspm_budget,
+                enable_sram_bspm=enable_sram_bspm,
             )
         else:
             raise ValueError(f"Unknown weights_mode: {weights_mode!r}")
@@ -156,6 +159,7 @@ class ModelPipeline:
             enable_mtp=enable_speculative_decode,
             enable_speculative_decode=enable_speculative_decode,
             num_slots=num_slots,
+            enable_sram_bspm=enable_sram_bspm,
         )
         if config.num_stages != num_procs:
             raise RuntimeError(f"Pipeline configuration has {config.num_stages} stages but {num_procs} processes")

--- a/models/demos/deepseek_v3_b1/demo/pipeline.py
+++ b/models/demos/deepseek_v3_b1/demo/pipeline.py
@@ -218,6 +218,7 @@ def create_single_pod_spec_decode_pipeline_configuration(
     dense_layer_id_override: int | None = None,
     moe_layer_id_override: int | None = None,
     num_slots: int = 64,
+    enable_sram_bspm: bool = False,
 ) -> PipelineConfiguration:
     """16-stage single-pod: Embed -> Dense(0,1,2) -> Decoder(3..12) -> LMHead -> Token fwd.
 
@@ -269,6 +270,7 @@ def create_single_pod_spec_decode_pipeline_configuration(
             num_slots=num_slots,
             upstream_fifo_pages=upstream_fifo_pages,
             downstream_fifo_pages=downstream_fifo_pages,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
     dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
@@ -349,6 +351,7 @@ def create_sp4_pipeline_configuration(
     dense_layer_id_override: int | None = None,
     moe_layer_id_override: int | None = None,
     num_slots: int = 64,
+    enable_sram_bspm: bool = False,
 ) -> PipelineConfiguration:
     """64-stage super-pod: Embed -> Dense(0,1,2) -> Decoder(3..60) -> LMHead -> Token fwd.
 
@@ -400,6 +403,7 @@ def create_sp4_pipeline_configuration(
             num_slots=num_slots,
             upstream_fifo_pages=upstream_fifo_pages,
             downstream_fifo_pages=downstream_fifo_pages,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
     dense_ids = (dense_layer_id_override,) * 3 if dense_layer_id_override is not None else (0, 1, 2)
@@ -434,6 +438,7 @@ def create_pipeline_configuration_from_num_procs(
     dense_layer_id_override: int | None = None,
     moe_layer_id_override: int | None = None,
     num_slots: int = 64,
+    enable_sram_bspm: bool = False,
 ) -> PipelineConfiguration:
     """Pick topology from process count (4 -> single_galaxy, 16 -> single_pod, 64 -> sp4)."""
     if num_procs == 4:
@@ -442,6 +447,7 @@ def create_pipeline_configuration_from_num_procs(
             fp32_dest_acc_en=fp32_dest_acc_en,
             persistent_mode=persistent_mode,
             enable_mtp=enable_mtp,
+            enable_sram_bspm=enable_sram_bspm,
         )
     if num_procs == 16:
         if enable_speculative_decode:
@@ -455,6 +461,7 @@ def create_pipeline_configuration_from_num_procs(
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
             num_slots=num_slots,
+            enable_sram_bspm=enable_sram_bspm,
         )
     if num_procs == 64:
         return create_sp4_pipeline_configuration(
@@ -466,6 +473,7 @@ def create_pipeline_configuration_from_num_procs(
             dense_layer_id_override=dense_layer_id_override,
             moe_layer_id_override=moe_layer_id_override,
             num_slots=num_slots,
+            enable_sram_bspm=enable_sram_bspm,
         )
     raise ValueError(f"Unsupported num_procs: {num_procs}")
 

--- a/models/demos/deepseek_v3_b1/demo/weight_provider.py
+++ b/models/demos/deepseek_v3_b1/demo/weight_provider.py
@@ -17,7 +17,6 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
-from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions
 from models.demos.deepseek_v3_b1.weights.cache import BspmVariant, CacheConfig, CacheContext, TensorCache
 from models.demos.deepseek_v3_b1.weights.prepare import (
@@ -264,11 +263,11 @@ class CacheWeightProvider:
         schema_version: int = 1,
         sram_hot_experts: SramHotExpertConfig | None = None,
         sram_core_grids: SramExpertCoreGrids | None = None,
-        sram_assigner: CompressedTensorAssigner | None = None,
         worker_l1_size: int | None = None,
         bspm_dir: Path | None = None,
         bspm_variant: BspmVariant | str = BspmVariant.B,
         bspm_budget: float = 3.5,
+        enable_sram_bspm: bool = False,
     ) -> None:
         cache_path = Path(cache_path)
         model_path = Path(model_path)
@@ -281,11 +280,11 @@ class CacheWeightProvider:
         self._hf_revision = hf_revision
         self._sram_hot_experts = sram_hot_experts
         self._sram_core_grids = sram_core_grids
-        self._sram_assigner = sram_assigner
         self._worker_l1_size = worker_l1_size
         self._bspm_dir = Path(bspm_dir) if bspm_dir is not None else None
         self._bspm_variant = BspmVariant(bspm_variant)
         self._bspm_budget = bspm_budget
+        self._enable_sram_bspm = enable_sram_bspm
 
     def _cache_config(self, device: ttnn.MeshDevice) -> CacheConfig:
         context = CacheContext(
@@ -344,11 +343,11 @@ class CacheWeightProvider:
             cache_config=self._cache_config(device),
             sram_hot_experts=self._sram_hot_experts,
             sram_core_grids=self._sram_core_grids,
-            sram_assigner=self._sram_assigner,
             worker_l1_size=self._worker_l1_size,
             bspm_dir=self._bspm_dir,
             bspm_variant=self._bspm_variant,
             bspm_budget=self._bspm_budget,
+            enable_sram_bspm=self._enable_sram_bspm,
             compressed_tp8=True,
             sram_expert_ids=resolve_sram_expert_ids(
                 layer_id,
@@ -407,19 +406,19 @@ class SyntheticWeightProvider:
         *,
         sram_hot_experts: SramHotExpertConfig | None = None,
         sram_core_grids: SramExpertCoreGrids | None = None,
-        sram_assigner: CompressedTensorAssigner | None = None,
         worker_l1_size: int | None = None,
         bspm_dir: Path | None = None,
         bspm_variant: BspmVariant | str = BspmVariant.B,
         bspm_budget: float = 3.5,
+        enable_sram_bspm: bool = False,
     ) -> None:
         self._sram_hot_experts = sram_hot_experts
         self._sram_core_grids = sram_core_grids
-        self._sram_assigner = sram_assigner
         self._worker_l1_size = worker_l1_size
         self._bspm_dir = Path(bspm_dir) if bspm_dir is not None else None
         self._bspm_variant = BspmVariant(bspm_variant)
         self._bspm_budget = bspm_budget
+        self._enable_sram_bspm = enable_sram_bspm
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
         g = torch.Generator().manual_seed(42)
@@ -460,11 +459,11 @@ class SyntheticWeightProvider:
             move_to_device=True,
             sram_hot_experts=self._sram_hot_experts,
             sram_core_grids=self._sram_core_grids,
-            sram_assigner=self._sram_assigner,
             worker_l1_size=self._worker_l1_size,
             bspm_dir=self._bspm_dir,
             bspm_variant=self._bspm_variant,
             bspm_budget=self._bspm_budget,
+            enable_sram_bspm=self._enable_sram_bspm,
             compressed_tp8=True,
             sram_expert_ids=resolve_sram_expert_ids(
                 layer_id,
@@ -511,11 +510,11 @@ class StateDictWeightProvider:
         *,
         sram_hot_experts: SramHotExpertConfig | None = None,
         sram_core_grids: SramExpertCoreGrids | None = None,
-        sram_assigner: CompressedTensorAssigner | None = None,
         worker_l1_size: int | None = None,
         bspm_dir: Path | None = None,
         bspm_variant: BspmVariant | str = BspmVariant.B,
         bspm_budget: float = 3.5,
+        enable_sram_bspm: bool = False,
     ) -> None:
         model_path = Path(model_path)
         assert model_path.exists(), f"Model path does not exist: {model_path}"
@@ -523,11 +522,11 @@ class StateDictWeightProvider:
         self._state_dict = LazyStateDict(model_path)
         self._sram_hot_experts = sram_hot_experts
         self._sram_core_grids = sram_core_grids
-        self._sram_assigner = sram_assigner
         self._worker_l1_size = worker_l1_size
         self._bspm_dir = Path(bspm_dir) if bspm_dir is not None else None
         self._bspm_variant = BspmVariant(bspm_variant)
         self._bspm_budget = bspm_budget
+        self._enable_sram_bspm = enable_sram_bspm
 
     def load_embedding(self, device: ttnn.MeshDevice) -> DeepSeekV3EmbeddingLayerWeights:
         return prepare_embedding_weights(self._state_dict, device, move_to_device=True)
@@ -554,11 +553,11 @@ class StateDictWeightProvider:
             move_to_device=True,
             sram_hot_experts=self._sram_hot_experts,
             sram_core_grids=self._sram_core_grids,
-            sram_assigner=self._sram_assigner,
             worker_l1_size=self._worker_l1_size,
             bspm_dir=self._bspm_dir,
             bspm_variant=self._bspm_variant,
             bspm_budget=self._bspm_budget,
+            enable_sram_bspm=self._enable_sram_bspm,
             compressed_tp8=True,
             sram_expert_ids=resolve_sram_expert_ids(
                 layer_id,

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/kernels/decoder_block_kernel.cpp
@@ -2424,10 +2424,10 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_gate_proj_cb_out_sram"),
                 /*compact_in0=*/0,
                 get_named_compile_time_arg_val("enable_routing"),
-                // TODO: switch back to /*use_compression=*/1 once SRAM experts
-                // can carry BSPM mixed-precision tiles. For now SRAM is uniform
-                // BFP4, so the plain custom_mm path is correct and faster.
-                /*use_compression=*/0>;
+                // Host-driven: 1 when enable_sram_bspm=True (BSPM mixed precision,
+                // compressed_custom_mm path); 0 when uniform BFP4 (plain
+                // custom_mm fast path). Both gate/up/down share this single arg.
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM up_proj Matmul Expert (compute, TRISC) — mirror of gate_proj.
             using SramUpProjCTArgs = deepseek_b1_ops::MatmulExpertCompressedSRAM::ComputeCTArgs<
@@ -2449,9 +2449,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_up_proj_cb_out_sram"),
                 /*compact_in0=*/0,
                 get_named_compile_time_arg_val("enable_routing"),
-                // TODO: switch back to /*use_compression=*/1 once SRAM experts
-                // can carry BSPM mixed-precision tiles.
-                /*use_compression=*/0>;
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM down_proj Matmul Expert (compute, TRISC) — accum_experts=1 + compact_in0=1.
             using SramDownProjCTArgs = deepseek_b1_ops::MatmulExpertCompressedSRAM::ComputeCTArgs<
@@ -2473,9 +2471,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_down_proj_cb_out_sram"),
                 get_named_compile_time_arg_val("sram_down_proj_compact_in0"),
                 get_named_compile_time_arg_val("enable_routing"),
-                // TODO: switch back to /*use_compression=*/1 once SRAM experts
-                // can carry BSPM mixed-precision tiles.
-                /*use_compression=*/0>;
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM gather (A/B) compute — no-op for TRISC, but the lambda body
             // references moe.routed.sram_{a,b}g_args so the member must exist.

--- a/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/decoder_block/op.py
@@ -204,6 +204,7 @@ class DecoderBlock:
         persistent_mode=False,
         termination_semaphore=None,
         is_torus=True,
+        enable_sram_bspm=False,
     ):
         """Build io_tensors and mesh_program_descriptor without executing.
 
@@ -289,6 +290,7 @@ class DecoderBlock:
             reduce_semaphores=reduce_semaphores,
             reduce_root_coord=reduce_root_coord,
             reconfig_moe_cbs=True,
+            enable_sram_bspm=enable_sram_bspm,
             semaphores=moe_semaphores,
             noc_mode=noc_mode,
             cb_id_context=moe_cb_id_context,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -1239,7 +1239,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_gate_proj_k_offset"),
                 get_named_compile_time_arg_val("sram_gate_proj_cb_out_sram"),
                 /*compact_in0=*/0,
-                get_named_compile_time_arg_val("enable_routing")>;  // → enable_indexing
+                get_named_compile_time_arg_val("enable_routing"),  // → enable_indexing
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM up_proj Matmul Expert (compute, TRISC) — mirror of gate_proj.
             using SramUpProjCTArgs = deepseek_b1_ops::MatmulExpertCompressedSRAM::ComputeCTArgs<
@@ -1260,7 +1261,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_up_proj_k_offset"),
                 get_named_compile_time_arg_val("sram_up_proj_cb_out_sram"),
                 /*compact_in0=*/0,
-                get_named_compile_time_arg_val("enable_routing")>;  // → enable_indexing
+                get_named_compile_time_arg_val("enable_routing"),  // → enable_indexing
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM down_proj Matmul Expert (compute, TRISC) — accum_experts=1 +
             // compact_in0=1 path. Reads compact mcast dst (n_sram_active face
@@ -1284,7 +1286,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sram_down_proj_k_offset"),
                 get_named_compile_time_arg_val("sram_down_proj_cb_out_sram"),
                 get_named_compile_time_arg_val("sram_down_proj_compact_in0"),
-                get_named_compile_time_arg_val("enable_routing")>;  // → enable_indexing
+                get_named_compile_time_arg_val("enable_routing"),  // → enable_indexing
+                get_named_compile_time_arg_val("sram_use_compression")>;
 
             // SRAM extended GatedReduce (compute, sender_core only).
             // tiles_per_k = 8 K-partial faces per output face. k_num_tiles is

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -29,6 +29,7 @@ from models.demos.deepseek_v3_b1.circular_buffer_utils import (
     build_cb_reconfig_tensor,
     cb_descriptor_from_overlapped_tensor,
     record_cb_metadata,
+    record_cb_metadata_per_coord,
 )
 from models.demos.deepseek_v3_b1.fused_ops.face_view_utils import FACE_HEIGHT, FACE_WIDTH, can_use_face_view
 from models.demos.deepseek_v3_b1.micro_ops.reduce_to_one_b1.op import MESH_LEAF, MESH_ROOT1, MESH_ROOT2, MESH_ROOT3
@@ -152,6 +153,10 @@ class MoeContext:
 
     # CB reconfig
     reconfig_moe_cbs: bool = False
+    # SRAM BSPM divergence: when True, per-device SRAM weight CBs have
+    # different L1 addresses across the mesh.  Forces the reconfig tensor
+    # to be sharded per-device (ShardTensor2dMesh) instead of replicated.
+    enable_sram_bspm: bool = False
 
 
 @dataclass
@@ -350,6 +355,11 @@ class _MoeRoutedExpertContext:
     sram_down_proj_cb_in1_descriptors_per_device: Any = None
     sram_down_proj_cb_out_descriptor: Any = None
 
+    # When 1, SRAM matmul kernels take the compressed_custom_mm path (per-tile
+    # BSPM format codes). When 0, they take the plain custom_mm path (uniform
+    # BFP4). Threaded into kernel CT args as sram_use_compression.
+    sram_use_compression: int = 0
+
     # Merged down output CB — receives either eltwise_add(sram_down, shared_down)
     # when n_sram_active > 0, or a copy of shared_down_matmul_out when n_sram_active = 0.
     # Replaces shared_down_matmul_out_cb as residual_add's in0.
@@ -508,7 +518,8 @@ class MoeRoutedExpertOp:
             dict with:
               - ``per_core_n``, ``Kt``, ``subblock_k``, ``num_subblocks_k`` (matmul dims)
               - ``in1_backing_tensor`` (replicated L1 CB backing; buffer_address seeds cb_in1)
-              - ``meta_tensors`` (dict[MeshCoordinate -> dict[core_idx -> L1 uint32 tensor]])
+              - ``meta_tensors`` (dict[MeshCoordinate -> (offset_tensor, bs_tensor)];
+                under lockstep refactor, the SAME mesh tensor pair for every coord)
               - ``fmt_dram_tensor`` (replicated DRAM fmt tensor)
               - ``fmt_dram_addr`` / ``fmt_per_expert_bytes`` / ``fmt_per_core_bytes``
               - ``expert_offsets_l1_addr_per_device`` (dict[MeshCoordinate -> list[(core, addr)]])
@@ -771,7 +782,7 @@ class MoeRoutedExpertOp:
                 tensor dicts: {coord: {core_idx: tensor}})
               - ``sram_fmt_l1_addr_per_device`` /
                 ``sram_base_addrs_l1_addr_per_device`` (per-device per-core
-                L1 byte addresses, ready for upload_per_core_uint32_tensor)
+                L1 byte addresses)
               - ``sram_k_offsets`` (per-core K-slice offset values, None when
                 no K-slicing)
               - ``cb_in1_size_bytes`` (per-core SRAM weight region size)
@@ -794,9 +805,17 @@ class MoeRoutedExpertOp:
                 "accum_experts": 1 if accum_experts else 0,
             }
 
-        # Build fmt + base_addrs tables per device per core. Mirrors
-        # _build_sram_fmt_data in test_matmul_expert.py.
-        sram_fmt_tensors, sram_base_addr_tensors = create_expert_fmt_tensors(
+        # Build fmt + base_addrs tables as TWO mesh tensors (one each), each
+        # HEIGHT_SHARDED on core_grid + ShardTensor2dMesh across the mesh +
+        # lockstep-allocated.  Lockstep gives a uniform L1 base across the
+        # mesh, so per-core L1 addresses are uniform across devices (the
+        # CONTENT varies per device via ShardTensor2dMesh; only the ADDRESS is
+        # uniform).  Replaces the prior pattern of 130 single-core per_core
+        # allocated tensors per projection per device, which (a) exhausted
+        # the per-core allocator slot table and (b) produced divergent
+        # per-(device, core) addresses under BSPM-SRAM L1 frontier
+        # divergence.
+        sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs = create_expert_fmt_tensors(
             sram_cts_list, mesh_device, core_grid, num_tiles_k, per_core_n
         )
 
@@ -810,17 +829,24 @@ class MoeRoutedExpertOp:
         if num_tiles_k < Kt:
             n_parallel = len(cores) * num_tiles_k // Kt
             sram_k_offsets = [(cores[i], (i // n_parallel) * num_tiles_k) for i in range(len(cores))]
-        sram_fmt_l1_addr_per_device = {}
-        sram_base_addrs_l1_addr_per_device = {}
-        for coord in sram_fmt_tensors:
-            sram_fmt_l1_addr_per_device[coord] = [
-                (cores[i], sram_fmt_tensors[coord][i].experimental_per_core_buffer_address(cores[i]))
-                for i in range(len(cores))
-            ]
-            sram_base_addrs_l1_addr_per_device[coord] = [
-                (cores[i], sram_base_addr_tensors[coord][i].experimental_per_core_buffer_address(cores[i]))
-                for i in range(len(cores))
-            ]
+
+        # Per-device dicts now hold IDENTICAL per-core lists for every coord
+        # (lockstep → uniform addresses across mesh).  Kept as dicts to
+        # preserve the existing API consumed by _build_compile_time_args /
+        # _setup_per_device_args without churn.
+        mesh_shape = mesh_device.shape
+        _fmt_addr_tuples = [(cores[i], sram_fmt_l1_addrs[i]) for i in range(len(cores))]
+        _base_addr_tuples = [(cores[i], sram_base_addrs_l1_addrs[i]) for i in range(len(cores))]
+        sram_fmt_l1_addr_per_device = {
+            ttnn.MeshCoordinate(r, c): _fmt_addr_tuples
+            for r in range(int(mesh_shape[0]))
+            for c in range(int(mesh_shape[1]))
+        }
+        sram_base_addrs_l1_addr_per_device = {
+            ttnn.MeshCoordinate(r, c): _base_addr_tuples
+            for r in range(int(mesh_shape[0]))
+            for c in range(int(mesh_shape[1]))
+        }
 
         # Per-tile fmt metadata word count. Matches DRAM path's
         # _meta_words_for_tiles convention used by the canonical fmt encoder.
@@ -849,8 +875,10 @@ class MoeRoutedExpertOp:
             "meta_words_per_expert": meta_words_per_expert,
             "accum_experts": 1 if accum_experts else 0,
             "num_active_experts": num_active_experts,
-            "sram_fmt_tensors": sram_fmt_tensors,
-            "sram_base_addr_tensors": sram_base_addr_tensors,
+            # Single mesh tensors (one each), kept alive in the params dict so
+            # they aren't garbage-collected during MoeOp's lifetime.
+            "sram_fmt_tensors": sram_fmt_tensor,
+            "sram_base_addr_tensors": sram_base_addr_tensor,
             "sram_fmt_l1_addr_per_device": sram_fmt_l1_addr_per_device,
             "sram_base_addrs_l1_addr_per_device": sram_base_addrs_l1_addr_per_device,
             "sram_k_offsets": sram_k_offsets,
@@ -1172,6 +1200,11 @@ class MoeRoutedExpertOp:
         # width-sharded on 112 cores → (256, 64) per core. accum_experts=True so
         # the kernel sums across SRAM-flagged TopK winners. None = skipped.
         sram_down_proj_weights_tensor=None,
+        # When True, SRAM expert weights carry per-tile BSPM mixed precision and
+        # the kernel must use the compressed_custom_mm path (use_compression=1).
+        # When False (default), SRAM is uniform BFP4 and the plain custom_mm
+        # fast path is used (use_compression=0).
+        enable_sram_bspm=False,
     ):
         """Compute all dimensions, grids, setup params, CB descriptors, and per-core values.
 
@@ -1690,6 +1723,15 @@ class MoeRoutedExpertOp:
             for coord in sram_gate_proj_params["sram_fmt_l1_addr_per_device"]:
                 _descs = _ct0.cb_descriptor_from_compressed_tensor(sram_gate_proj_cb_in1, device_coord=coord)
                 for _desc in _descs:
+                    # Override desc to report a uniform 1-page (576 B) cb_in1
+                    # extent across (device, core).  The actual L1 buffer is
+                    # >= 576 B (per min_shard_bytes=576 in build_sram_expert_
+                    # weights for the cb_in1 backing expert), so this lie is
+                    # safe — the framework sees a smaller window than the
+                    # real buffer.  Kernel reads tile bytes via fmt metadata
+                    # (compressed_custom_mm path), so the smaller window
+                    # doesn't affect data reads.
+                    _desc.total_size = _bfp4_tile_size
                     _desc.format_descriptors = [
                         ttnn.CBFormatDescriptor(
                             buffer_index=sram_gate_proj_cb_in1,
@@ -1753,6 +1795,8 @@ class MoeRoutedExpertOp:
             for coord in sram_up_proj_params["sram_fmt_l1_addr_per_device"]:
                 _descs_up = _ct0_up.cb_descriptor_from_compressed_tensor(sram_up_proj_cb_in1, device_coord=coord)
                 for _desc in _descs_up:
+                    # Uniform 576 B cb_in1 extent (= 1 bfp4 page); see gate.
+                    _desc.total_size = _bfp4_tile_size
                     _desc.format_descriptors = [
                         ttnn.CBFormatDescriptor(
                             buffer_index=sram_up_proj_cb_in1,
@@ -1809,6 +1853,8 @@ class MoeRoutedExpertOp:
             for coord in sram_down_proj_params["sram_fmt_l1_addr_per_device"]:
                 _descs_dn = _ct0_dn.cb_descriptor_from_compressed_tensor(sram_down_proj_cb_in1, device_coord=coord)
                 for _desc in _descs_dn:
+                    # Uniform 576 B cb_in1 extent (= 1 bfp4 page); see gate.
+                    _desc.total_size = _bfp4_tile_size
                     _desc.format_descriptors = [
                         ttnn.CBFormatDescriptor(
                             buffer_index=sram_down_proj_cb_in1,
@@ -2391,6 +2437,7 @@ class MoeRoutedExpertOp:
             sram_gather_data_size_bytes=sram_gather_data_size_bytes,
             sram_gather_expert_dst_stride=sram_gather_expert_dst_stride,
             sram_gather_total_tiles=sram_gather_total_tiles,
+            sram_use_compression=1 if enable_sram_bspm else 0,
             sram_ag_receiver_semaphore_addr=sem_addrs[MoeSem.SRAM_AG_GATHER],
             sram_bg_receiver_semaphore_addr=sem_addrs[MoeSem.SRAM_BG_GATHER],
         )
@@ -2890,7 +2937,7 @@ class MoeRoutedExpertOp:
         # ---- SRAM routed gate_proj CT args (always emitted; gated at runtime) ----
         # Default values are placeholders; the kernel's Op call is `if constexpr false`
         # no-op when sram_gate_proj_active=0. Real values come in when the caller
-        # builds SRAM weights via build_sram_expert_weights + setup_matmul_expert_sram.
+        # builds SRAM weights via build_sram_routed_proj_cts + setup_matmul_expert_sram.
         # Per-core values (fmt_l1_addr, base_addrs_l1_addr, k_offset) emitted via
         # _build_core_descriptors with default 0 → all-cores 0 by default.
         sgp = ctx.sram_gate_proj_params or {}
@@ -2918,6 +2965,9 @@ class MoeRoutedExpertOp:
             ("sram_gate_proj_in0_page_size", sgp.get("in0_page_size", 0)),
             ("sram_gate_proj_accum_experts", sgp.get("accum_experts", 0)),
             ("sram_gate_proj_cb_out_sram", 0),
+            # Shared by gate/up/down kernel CTArgs (use_compression). 1=BSPM
+            # compressed_custom_mm path; 0=uniform BFP4 plain custom_mm path.
+            ("sram_use_compression", ctx.sram_use_compression),
         ]
         ncrisc_named_compile_time_args += sram_uniform_args
         trisc_named_compile_time_args += sram_uniform_args
@@ -6230,6 +6280,7 @@ class MoeOp:
         bcast_sender_coord=None,
         socket=None,
         reconfig_moe_cbs=False,
+        enable_sram_bspm=False,
         semaphores=None,
         noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
         cb_id_context=None,
@@ -6300,6 +6351,7 @@ class MoeOp:
             sram_gate_proj_weights_tensor=sram_gate_proj_weights_tensor,
             sram_up_proj_weights_tensor=sram_up_proj_weights_tensor,
             sram_down_proj_weights_tensor=sram_down_proj_weights_tensor,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
         device_tensor = ttnn.get_device_tensors(shared_residual_mcast_src_tensor)[0]
@@ -6363,6 +6415,7 @@ class MoeOp:
             enable_reduce_to_one=routed_ctx.enable_reduce_to_one,
             enable_bcast=routed_ctx.enable_bcast,
             reconfig_moe_cbs=reconfig_moe_cbs,
+            enable_sram_bspm=enable_sram_bspm,
             # IO tensors
             gate_mm_weights_tensor=gate_mm_weights_tensor,
             gate_bias_tensor=gate_bias_tensor,
@@ -6425,18 +6478,93 @@ class MoeOp:
             # reset_stream_regs skips these CBs and setup_sharded_buffer's iter-2
             # cb_reserve_back blocks because iter-1's push (received=1, acked=0,
             # cap=1) was never reset.
-            sram_metadata_descs = []
+            #
+            # Replicated path (uniform SRAM): all coords share the same per-core
+            # addresses, so flattening to a single list is safe.
+            #
+            # Per-coord path (BSPM SRAM, enable_sram_bspm=True): each device has
+            # different SRAM weight CB addresses, so we keep the coord key and
+            # build a per-device reconfig tensor via ShardTensor2dMesh.
             rctx = self.ctx.routed_ctx
-            for per_dev_attr in (
-                "sram_gate_proj_cb_in1_descriptors_per_device",
-                "sram_up_proj_cb_in1_descriptors_per_device",
-                "sram_down_proj_cb_in1_descriptors_per_device",
-            ):
-                per_dev = getattr(rctx, per_dev_attr, None) or {}
-                for descs in per_dev.values():
-                    if descs:
-                        sram_metadata_descs.extend(descs)
-            self.cb_metadata = record_cb_metadata(cb_descriptors + sram_metadata_descs)
+            sram_descs_per_coord = {}
+            if self.ctx.enable_sram_bspm:
+                for per_dev_attr in (
+                    "sram_gate_proj_cb_in1_descriptors_per_device",
+                    "sram_up_proj_cb_in1_descriptors_per_device",
+                    "sram_down_proj_cb_in1_descriptors_per_device",
+                ):
+                    per_dev = getattr(rctx, per_dev_attr, None) or {}
+                    for coord, descs in per_dev.items():
+                        if descs:
+                            sram_descs_per_coord.setdefault(coord, []).extend(descs)
+            # Take per-coord path only if we actually have per-(device, core) SRAM
+            # descs.  Defensive: if enable_sram_bspm=True was set but the SRAM
+            # weights came from the auto-fit path (uniform across devices), we
+            # have no per-coord descs and must fall back to the replicated path.
+            if self.ctx.enable_sram_bspm and sram_descs_per_coord:
+                # cb_in1 descriptors already carry uniform (total_size=576,
+                # page_size=576) — set at desc creation time in setup_matmul_
+                # expert_sram for gate/up/down.  No reconfig-time override
+                # needed; record_cb_metadata_per_coord reads desc.total_size
+                # directly and gets the uniform value.
+                self.cb_metadata = None
+                self.cb_metadata_per_coord = record_cb_metadata_per_coord(cb_descriptors, sram_descs_per_coord)
+                # BSPM-SRAM diagnostic: surface (device, core, cb) combinations
+                # where the placeholder buffer kicked in (num_pages=0 or
+                # total_size < page_size).  These are the all-bfp0 cores from
+                # min_shard_bytes — if the kernel does any cb_wait/cb_reserve
+                # on those CBs, num_pages=0 hangs.  Hang is non-deterministic
+                # across runs, suggesting an underlying race or uninitialized
+                # memory rather than a fixed-core bug.
+                from loguru import logger as _diag_logger
+
+                _sram_cb_ids = set()
+                for _descs in sram_descs_per_coord.values():
+                    for _desc in _descs:
+                        for _fmt in _desc.format_descriptors:
+                            _sram_cb_ids.add(_fmt.buffer_index)
+                _sram_cb_ids = sorted(_sram_cb_ids)
+                _placeholder_hits = []
+                for coord in sorted(self.cb_metadata_per_coord.keys(), key=lambda c: (c[0], c[1])):
+                    per_cb = self.cb_metadata_per_coord[coord]
+                    for cb_id in _sram_cb_ids:
+                        for addr, total_size, num_pages, page_size, core_ranges in per_cb.get(cb_id, []):
+                            if num_pages == 0 or total_size < page_size:
+                                for c in ttnn.corerange_to_cores(core_ranges, row_wise=True):
+                                    _placeholder_hits.append(
+                                        (coord, (c.x, c.y), cb_id, addr, total_size, num_pages, page_size)
+                                    )
+                if _placeholder_hits:
+                    _diag_logger.warning(
+                        "[BSPM-SRAM diag] {} placeholder-buffer (num_pages=0) SRAM CB entries detected:",
+                        len(_placeholder_hits),
+                    )
+                    for coord, core, cb_id, addr, total_size, num_pages, page_size in _placeholder_hits:
+                        _diag_logger.warning(
+                            "  coord={} core{} cb{}: addr=0x{:x} size={} pages={} ps={}",
+                            coord,
+                            core,
+                            cb_id,
+                            addr,
+                            total_size,
+                            num_pages,
+                            page_size,
+                        )
+                else:
+                    _diag_logger.info("[BSPM-SRAM diag] No placeholder-buffer SRAM CB entries (all cores have data).")
+            else:
+                sram_metadata_descs = []
+                for per_dev_attr in (
+                    "sram_gate_proj_cb_in1_descriptors_per_device",
+                    "sram_up_proj_cb_in1_descriptors_per_device",
+                    "sram_down_proj_cb_in1_descriptors_per_device",
+                ):
+                    per_dev = getattr(rctx, per_dev_attr, None) or {}
+                    for descs in per_dev.values():
+                        if descs:
+                            sram_metadata_descs.extend(descs)
+                self.cb_metadata = record_cb_metadata(cb_descriptors + sram_metadata_descs)
+                self.cb_metadata_per_coord = None
         return cb_descriptors
 
     def _build_dummy_cb_descs(self):
@@ -6449,10 +6577,21 @@ class MoeOp:
         return self.cb_id_manager.build_dummy_cb_descriptors(self.ctx.full_device_grid)
 
     def _build_cb_reconfig_tensor(self):
-        """Build L1-sharded CB reconfig tensor using shared utility."""
-        self.reconfig_tensor = build_cb_reconfig_tensor(
-            self.cb_metadata, self.ctx.full_device_grid, self.ctx.mesh_device
-        )
+        """Build L1-sharded CB reconfig tensor using shared utility.
+
+        Dispatches between replicated and per-device modes based on whether
+        SRAM BSPM is enabled — see :meth:`_build_cb_descriptors`.
+        """
+        if self.cb_metadata_per_coord is not None:
+            self.reconfig_tensor = build_cb_reconfig_tensor(
+                full_device_grid=self.ctx.full_device_grid,
+                mesh_device=self.ctx.mesh_device,
+                cb_metadata_per_coord=self.cb_metadata_per_coord,
+            )
+        else:
+            self.reconfig_tensor = build_cb_reconfig_tensor(
+                self.cb_metadata, self.ctx.full_device_grid, self.ctx.mesh_device
+            )
 
     def _build_core_descriptors(self):
         """Build combined core descriptors for routed + shared expert."""
@@ -6543,9 +6682,15 @@ class MoeOp:
             if proj_params["in1_backing_tensor"] is not None:
                 io_tensors.append(proj_params["in1_backing_tensor"])
             io_tensors.append(proj_params["fmt_dram_tensor"])
-            for offset_t, bsize_t in proj_params["meta_tensors_per_device"].values():
-                io_tensors += list(offset_t.values())
-                io_tensors += list(bsize_t.values())
+            # Lockstep refactor: meta_tensors_per_device[coord] = (offset_tensor,
+            # bs_tensor) — the SAME mesh tensor for every coord (shared across
+            # devices).  Add to io_tensors once for keep-alive.
+            _meta_map = proj_params["meta_tensors_per_device"]
+            if _meta_map:
+                _first_coord = next(iter(_meta_map))
+                _offset_t, _bsize_t = _meta_map[_first_coord]
+                io_tensors.append(_offset_t)
+                io_tensors.append(_bsize_t)
         if ctx.final_output_tensor is not None:
             io_tensors += [ctx.final_output_tensor]
         io_tensors += [
@@ -6677,6 +6822,27 @@ class MoeOp:
                 "sram_gate_proj_fmt_l1_addr": sgp["sram_fmt_l1_addr_per_device"][coord],
                 "sram_gate_proj_base_addrs_l1_addr": sgp["sram_base_addrs_l1_addr_per_device"][coord],
             }
+            # Host-side diag: dump per-(device, core) values fed into the kernel
+            # CT-arg override.  Cross-reference with kernel DPRINT
+            # "[SRAM-CT-arg cb_in1=...] fmt=0x... base=0x..." — mismatch
+            # means PerCoreCompileTimeDescriptor isn't routing per-core values.
+            if self.ctx.enable_sram_bspm:
+                from loguru import logger as _diag_logger
+
+                _gate_cb_in1 = routed_ctx.sram_gate_proj_cb_in1
+                for (_core, _fmt_addr), (_, _base_addr) in zip(
+                    sram_overrides["sram_gate_proj_fmt_l1_addr"],
+                    sram_overrides["sram_gate_proj_base_addrs_l1_addr"],
+                ):
+                    _diag_logger.info(
+                        "[SRAM-CT-arg host cb_in1={}] coord={} core=({}, {}) fmt=0x{:x} base=0x{:x}",
+                        _gate_cb_in1,
+                        coord,
+                        _core.x,
+                        _core.y,
+                        _fmt_addr,
+                        _base_addr,
+                    )
             for i, desc in enumerate(self.device_per_core_descs):
                 name = desc.named_compile_time_arg
                 if name in sram_overrides:
@@ -6804,6 +6970,7 @@ class MoeOp:
         # SRAM routed down_proj weights — runs on the 112 shared mcast receiver
         # cores. None = no SRAM down_proj; kernel skips uniformly.
         sram_down_proj_weights_tensor=None,
+        enable_sram_bspm=False,
     ):
         """
         Execute the full fused MoE operation (routed + shared expert).
@@ -6882,6 +7049,7 @@ class MoeOp:
             sram_gate_proj_weights_tensor=sram_gate_proj_weights_tensor,
             sram_up_proj_weights_tensor=sram_up_proj_weights_tensor,
             sram_down_proj_weights_tensor=sram_down_proj_weights_tensor,
+            enable_sram_bspm=enable_sram_bspm,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul_expert/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul_expert/op.py
@@ -1288,8 +1288,13 @@ class ExpertKernel:
         sram_per_core_n: int = 0,
         sram_k_per_core: int = 0,
         sram_core_grid=None,  # CoreRangeSet for SRAM cores, or None if no SRAM.
-        sram_fmt_tensors: dict = None,  # from create_expert_fmt_tensors(), keyed by MeshCoordinate.
-        sram_base_addr_tensors: dict = None,  # from create_expert_fmt_tensors(), keyed by MeshCoordinate.
+        # Lockstep mesh tensors from create_expert_fmt_tensors() — single tensor each
+        # (ShardTensor2dMesh across the mesh, HEIGHT_SHARDED on core_grid).  Uniform
+        # L1 base address across mesh; per-core content varies via per-device slab.
+        sram_fmt_tensor: ttnn.Tensor = None,
+        sram_base_addr_tensor: ttnn.Tensor = None,
+        sram_fmt_l1_addrs: list = None,  # list[int] per-core L1 addrs, uniform across mesh.
+        sram_base_addrs_l1_addrs: list = None,
         sram_k_offsets: list = None,  # [(CoreCoord, k_offset_tiles), ...] for K-sliced SRAM.
         n_parallel_per_bank: int = 1,
         k_parallel_per_bank: int = 1,
@@ -1329,7 +1334,10 @@ class ExpertKernel:
             assert sram_per_core_n > 0, "sram_per_core_n must be set when has_sram=True"
             assert sram_k_per_core > 0, "sram_k_per_core must be set when has_sram=True"
             assert sram_core_grid is not None, "sram_core_grid must be set when has_sram=True"
-            assert sram_fmt_tensors is not None, "sram_fmt_tensors must be set when has_sram=True"
+            assert sram_fmt_tensor is not None, "sram_fmt_tensor must be set when has_sram=True"
+            assert sram_base_addr_tensor is not None, "sram_base_addr_tensor must be set when has_sram=True"
+            assert sram_fmt_l1_addrs is not None, "sram_fmt_l1_addrs must be set when has_sram=True"
+            assert sram_base_addrs_l1_addrs is not None, "sram_base_addrs_l1_addrs must be set when has_sram=True"
             assert sram_output_tensor is not None, "sram_output_tensor must be set when has_sram=True"
 
         if not tp_expert:
@@ -1359,28 +1367,17 @@ class ExpertKernel:
                 sram_out_dev = sram_out_per_device[dev_idx]
                 idx_dev = index_per_device[dev_idx]
 
-                # SRAM fmt + base addrs for this device.
+                # SRAM fmt + base addrs for this device.  Lockstep tensors give
+                # uniform L1 addrs across the mesh, so we pair the pre-computed
+                # per-core address lists with cores in row-major order (matches
+                # create_expert_fmt_tensors's row_wise=True iteration).
                 sram_fmt_l1 = []
                 sram_base_addrs_l1 = []
-                sram_fmt_tensors_dev = {}
-                sram_base_addr_tensors_dev = {}
                 if has_sram:
-                    sram_fmt_tensors_dev = sram_fmt_tensors[coord]
-                    sram_base_addr_tensors_dev = sram_base_addr_tensors[coord]
-                    sram_cores_list = ttnn.corerange_to_cores(sram_core_grid)
-                    sram_fmt_l1 = [
-                        (
-                            sram_cores_list[i],
-                            sram_fmt_tensors_dev[i].experimental_per_core_buffer_address(sram_cores_list[i]),
-                        )
-                        for i in range(len(sram_cores_list))
-                    ]
+                    sram_cores_list = ttnn.corerange_to_cores(sram_core_grid, row_wise=True)
+                    sram_fmt_l1 = [(sram_cores_list[i], sram_fmt_l1_addrs[i]) for i in range(len(sram_cores_list))]
                     sram_base_addrs_l1 = [
-                        (
-                            sram_cores_list[i],
-                            sram_base_addr_tensors_dev[i].experimental_per_core_buffer_address(sram_cores_list[i]),
-                        )
-                        for i in range(len(sram_cores_list))
+                        (sram_cores_list[i], sram_base_addrs_l1_addrs[i]) for i in range(len(sram_cores_list))
                     ]
 
                 # DRAM for this device. _partial_sem / _pipeline_sem are carried
@@ -1452,12 +1449,23 @@ class ExpertKernel:
                 mesh_program[ttnn.MeshCoordinateRange(coord, coord)] = program
 
         # --- Collect all live tensors ---
+        # Lockstep mesh tensors: one tensor each across the whole mesh.  Keep
+        # them alive via a single reference (not per-device per-core).
         all_ct_data = [t for ct in (sram_cts + dram_cts) for t in ct.get_data_tensors()]
-        all_sram_fmt = [t for per_dev in sram_fmt_tensors.values() for t in per_dev.values()]
-        all_sram_base = [t for per_dev in (sram_base_addr_tensors or {}).values() for t in per_dev.values()]
+        all_sram_fmt = [sram_fmt_tensor] if sram_fmt_tensor is not None else []
+        all_sram_base = [sram_base_addr_tensor] if sram_base_addr_tensor is not None else []
         per_device_dram = []
+        # offset_t / bsize_t are single mesh tensors (post-lockstep refactor), the
+        # SAME object for every coord under the lockstep design.  Dedup by id() so
+        # we keep each unique tensor alive exactly once.
+        _seen_meta = set()
         for in1_backing, (offset_t, bsize_t), fmt_info, *_ in dram_meta_tensors.values():
-            per_device_dram.extend([in1_backing, *offset_t.values(), *bsize_t.values(), fmt_info["fmt_dram_tensor"]])
+            per_device_dram.append(in1_backing)
+            for t in (offset_t, bsize_t):
+                if id(t) not in _seen_meta:
+                    _seen_meta.add(id(t))
+                    per_device_dram.append(t)
+            per_device_dram.append(fmt_info["fmt_dram_tensor"])
         io_tensors = [
             a_tensor,
             *all_ct_data,

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul_expert/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul_expert/op.py
@@ -91,78 +91,92 @@ def _compute_expert_subblock_metadata(
     return block_sizes, tile_infos
 
 
-def upload_per_core_uint32_tensor(device, all_cores, per_core_data, entries_per_core):
-    """Create one single-core HEIGHT_SHARDED L1 tensor per core from uint32 data.
+def upload_lockstep_meta_tensors_multi_device(
+    mesh_device,
+    all_cores,
+    per_device_offset_data,
+    per_device_block_size_data,
+    offset_entries_per_core,
+    block_size_entries_per_core,
+):
+    """Create two LOCKSTEP ShardTensor2dMesh tensors holding per-(device, core) expert metadata.
+
+    Replaces the per-(device, core) upload_per_core_uint32/uint16_tensor pattern used in
+    create_dram_expert_metadata.  The mesh allocator picks ONE L1 base address valid on
+    every device → a single CT-arg value works on all 8 devices, removing the BSPM-SRAM
+    frontier divergence that broke per_core_allocation tensors allocated post-SRAM.
 
     Args:
-        all_cores: flat list of CoreCoord, index-aligned with per_core_data keys.
-        per_core_data: dict {core_idx: list[int]} of uint32 values per core.
-        entries_per_core: number of uint32 entries per core.
+        mesh_device: MeshDevice.
+        all_cores: list[CoreCoord] in HEIGHT_SHARDED ROW_MAJOR order
+            (use ttnn.corerange_to_cores(grid, row_wise=True)).
+        per_device_offset_data: {MeshCoordinate: {core_idx: list[uint32]}}.
+        per_device_block_size_data: {MeshCoordinate: {core_idx: list[uint16]}}.
+        offset_entries_per_core / block_size_entries_per_core: entries per core (= num experts
+            etc.); determines aligned shard size.
+
     Returns:
-        dict {core_idx: ttnn.Tensor}: per-core device tensors.
+        (offset_tensor, block_size_tensor, offset_l1_addr, block_size_l1_addr).
+        Each l1_addr is a single int — the same address on every (device, core).
     """
-    raw_size = entries_per_core * 4
+    num_cores = len(all_cores)
     dram_alignment = ttnn._ttnn.bfp_utils.get_dram_alignment()
-    aligned_size = _align(max(raw_size, dram_alignment), dram_alignment)
-    tensors = {}
-    for core_idx, core in enumerate(all_cores):
-        data_np = np.array(per_core_data[core_idx], dtype=np.uint32).view(np.uint8)
-        pad = aligned_size - raw_size
-        if pad > 0:
-            data_np = np.concatenate([data_np, np.zeros(pad, dtype=np.uint8)])
-        core_torch = torch.from_numpy(data_np.copy()).reshape(1, aligned_size)
-        core_shard_spec = ttnn.ShardSpec(
-            ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
-            [1, aligned_size],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        core_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            core_shard_spec,
-        )
-        core_mem_config.experimental_set_per_core_allocation(True)
-        tensors[core_idx] = ttnn.from_torch(
-            core_torch,
-            dtype=ttnn.uint8,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device,
-            memory_config=core_mem_config,
-        )
-    return tensors
 
+    offset_raw_bytes = offset_entries_per_core * 4
+    offset_aligned = _align(max(offset_raw_bytes, dram_alignment), dram_alignment)
 
-def upload_per_core_uint16_tensor(device, all_cores, per_core_data, entries_per_core):
-    """Create one single-core HEIGHT_SHARDED L1 tensor per core from uint16 data."""
-    raw_size = entries_per_core * 2
-    dram_alignment = ttnn._ttnn.bfp_utils.get_dram_alignment()
-    aligned_size = _align(max(raw_size, dram_alignment), dram_alignment)
-    tensors = {}
-    for core_idx, core in enumerate(all_cores):
-        data_np = np.array(per_core_data[core_idx], dtype=np.uint16).view(np.uint8)
-        pad = aligned_size - raw_size
-        if pad > 0:
-            data_np = np.concatenate([data_np, np.zeros(pad, dtype=np.uint8)])
-        core_torch = torch.from_numpy(data_np.copy()).reshape(1, aligned_size)
-        core_shard_spec = ttnn.ShardSpec(
-            ttnn.CoreRangeSet([ttnn.CoreRange(core, core)]),
-            [1, aligned_size],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        core_mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            core_shard_spec,
-        )
-        core_mem_config.experimental_set_per_core_allocation(True)
-        tensors[core_idx] = ttnn.from_torch(
-            core_torch,
-            dtype=ttnn.uint8,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device,
-            memory_config=core_mem_config,
-        )
-    return tensors
+    bs_raw_bytes = block_size_entries_per_core * 2
+    bs_aligned = _align(max(bs_raw_bytes, dram_alignment), dram_alignment)
+
+    mesh_shape = mesh_device.shape
+    mesh_rows, mesh_cols = int(mesh_shape[0]), int(mesh_shape[1])
+
+    offset_data = torch.zeros((mesh_rows, mesh_cols, num_cores, offset_aligned), dtype=torch.uint8)
+    bs_data = torch.zeros((mesh_rows, mesh_cols, num_cores, bs_aligned), dtype=torch.uint8)
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            coord = ttnn.MeshCoordinate(row, col)
+            off_per_core = per_device_offset_data[coord]
+            bs_per_core = per_device_block_size_data[coord]
+            for core_idx in range(num_cores):
+                off_np = np.array(off_per_core[core_idx], dtype=np.uint32).view(np.uint8)
+                bs_np = np.array(bs_per_core[core_idx], dtype=np.uint16).view(np.uint8)
+                if len(off_np) > 0:
+                    offset_data[row, col, core_idx, : len(off_np)] = torch.from_numpy(off_np.copy())
+                if len(bs_np) > 0:
+                    bs_data[row, col, core_idx, : len(bs_np)] = torch.from_numpy(bs_np.copy())
+
+    offset_2d = offset_data.permute(0, 2, 1, 3).reshape(mesh_rows * num_cores, mesh_cols * offset_aligned).contiguous()
+    bs_2d = bs_data.permute(0, 2, 1, 3).reshape(mesh_rows * num_cores, mesh_cols * bs_aligned).contiguous()
+
+    core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in all_cores])
+
+    offset_shard = ttnn.ShardSpec(core_range_set, [1, offset_aligned], ttnn.ShardOrientation.ROW_MAJOR)
+    offset_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, offset_shard)
+
+    bs_shard = ttnn.ShardSpec(core_range_set, [1, bs_aligned], ttnn.ShardOrientation.ROW_MAJOR)
+    bs_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, bs_shard)
+
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
+
+    offset_tensor = ttnn.from_torch(
+        offset_2d,
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=offset_mem,
+        mesh_mapper=mesh_mapper,
+    )
+    bs_tensor = ttnn.from_torch(
+        bs_2d,
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=bs_mem,
+        mesh_mapper=mesh_mapper,
+    )
+
+    return (offset_tensor, bs_tensor, offset_tensor.buffer_address(), bs_tensor.buffer_address())
 
 
 def _pack_tile_metadata(
@@ -208,11 +222,23 @@ def _pack_tile_metadata(
 
 
 def create_expert_fmt_tensors(cts: list, mesh_device, core_grid, num_tiles_k: int, out_w: int):
-    """Create per-device per-core format metadata and base address tensors.
+    """Create per-(device, core) format metadata and base address tables.
 
-    Returns two L1 tables per core:
-      - fmt_tensors: packed 3-bit metadata [num_experts * meta_words] uint32s
-      - base_addr_tensors: [num_experts] uint32s (weight base byte addr per expert)
+    Builds TWO mesh tensors (one for fmt metadata, one for per-expert base
+    addresses), each HEIGHT_SHARDED on ``core_grid`` (1 row per core) and
+    distributed across the mesh via ``ShardTensor2dMesh``.  Under lockstep
+    allocation (no per_core_allocation), the L1 base address is uniform
+    across the mesh — each device's tensor lands at the same L1 offset,
+    and within a device every core gets ``base + core_idx * row_size``.
+
+    This is the safe pattern for post-BSPM-SRAM L1 allocations: any
+    divergence in per-(device, core) L1 frontier (from BSPM-compressed SRAM
+    CTs above) is absorbed by the lockstep allocator picking a uniform
+    address that fits on every device.  The tensor CONTENT still varies
+    per (device, core) — that comes from the ShardTensor2dMesh per-device
+    slice — but the ADDRESS is identical, removing the need for per-(device,
+    core) CT-arg routing (the addresses become uniform per-core CT-arg
+    values valid on every device).
 
     Args:
         cts: List of CompressedTensor, one per SRAM expert.
@@ -222,19 +248,41 @@ def create_expert_fmt_tensors(cts: list, mesh_device, core_grid, num_tiles_k: in
         out_w: N tiles per core per expert.
 
     Returns:
-        (fmt_dict, base_addr_dict) where each is {MeshCoordinate: {core_idx: ttnn.Tensor}}
+        ``(fmt_tensor, base_tensor, fmt_l1_addrs, base_l1_addrs)``:
+          - ``fmt_tensor``, ``base_tensor``: kept-alive mesh tensors (the
+            caller stashes them so they aren't garbage-collected).
+          - ``fmt_l1_addrs``, ``base_l1_addrs``: ``list[int]`` of per-core
+            L1 addresses, indexed by ``corerange_to_cores(core_grid)`` order.
+            Uniform across all devices in the mesh.
     """
     mesh_shape = mesh_device.shape
-    all_cores = ttnn.corerange_to_cores(core_grid)
+    mesh_rows, mesh_cols = int(mesh_shape[0]), int(mesh_shape[1])
+    # row_wise=True so the core-iteration order matches HEIGHT_SHARDED
+    # ROW_MAJOR's shard-to-core assignment (= core_idx i ↔ i-th core when
+    # iterating the CoreRangeSet row-by-row).  Critical: source[r, c, i, :]
+    # in the ShardTensor2dMesh layout must correspond to the same `cores[i]`
+    # that the kernel runs on.
+    all_cores = ttnn.corerange_to_cores(core_grid, row_wise=True)
+    num_cores = len(all_cores)
+    num_experts = len(cts)
     dram_alignment = ttnn._ttnn.bfp_utils.get_dram_alignment()
 
-    fmt_result = {}
-    base_result = {}
-    for row in range(mesh_shape[0]):
-        for col in range(mesh_shape[1]):
+    # Compute aligned per-core row sizes.  meta_words_per_expert × num_experts ×
+    # 4 bytes/uint32 = fmt raw bytes per core.  num_experts × 4 = base raw.
+    meta_words_per_expert = _meta_words_for_tiles(num_tiles_k * out_w)
+    fmt_raw_bytes = num_experts * meta_words_per_expert * 4
+    fmt_aligned = _align(max(fmt_raw_bytes, dram_alignment), dram_alignment)
+    base_raw_bytes = num_experts * 4
+    base_aligned = _align(max(base_raw_bytes, dram_alignment), dram_alignment)
+
+    # Build per-(device, core) content tensors.  Each (device, core) slot gets
+    # the actual BSPM-derived metadata + base addresses for that core on that
+    # device.
+    fmt_data = torch.zeros((mesh_rows, mesh_cols, num_cores, fmt_aligned), dtype=torch.uint8)
+    base_data = torch.zeros((mesh_rows, mesh_cols, num_cores, base_aligned), dtype=torch.uint8)
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
             coord = ttnn.MeshCoordinate(row, col)
-            fmt_tensors = {}
-            base_tensors = {}
             for core_idx, core_coord in enumerate(all_cores):
                 all_meta = []
                 base_addrs = []
@@ -243,52 +291,55 @@ def create_expert_fmt_tensors(cts: list, mesh_device, core_grid, num_tiles_k: in
                     shard_assignment = ct.get_assignment_per_shard(core_coord, device_coord=coord)
                     words, _ = _pack_tile_metadata(shard_assignment, out_w)
                     all_meta.extend(words)
-
-                # Upload fmt metadata.
                 fmt_np = np.array(all_meta, dtype=np.uint32).view(np.uint8)
-                fmt_raw = len(fmt_np)
-                fmt_aligned = _align(max(fmt_raw, dram_alignment), dram_alignment)
-                if fmt_aligned > fmt_raw:
-                    fmt_np = np.concatenate([fmt_np, np.zeros(fmt_aligned - fmt_raw, dtype=np.uint8)])
-                fmt_torch = torch.from_numpy(fmt_np.copy()).reshape(1, fmt_aligned)
-                fmt_shard = ttnn.ShardSpec(
-                    ttnn.CoreRangeSet([ttnn.CoreRange(core_coord, core_coord)]),
-                    [1, fmt_aligned],
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                )
-                fmt_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard)
-                fmt_mem.experimental_set_per_core_allocation(True)
-                fmt_tensors[core_idx] = ttnn._ttnn.tensor.experimental_to_single_device(
-                    ttnn.from_torch(fmt_torch, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT),
-                    mesh_device,
-                    coord,
-                    fmt_mem,
-                )
-
-                # Upload base addresses.
                 base_np = np.array(base_addrs, dtype=np.uint32).view(np.uint8)
-                base_raw = len(base_np)
-                base_aligned = _align(max(base_raw, dram_alignment), dram_alignment)
-                if base_aligned > base_raw:
-                    base_np = np.concatenate([base_np, np.zeros(base_aligned - base_raw, dtype=np.uint8)])
-                base_torch = torch.from_numpy(base_np.copy()).reshape(1, base_aligned)
-                base_shard = ttnn.ShardSpec(
-                    ttnn.CoreRangeSet([ttnn.CoreRange(core_coord, core_coord)]),
-                    [1, base_aligned],
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                )
-                base_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, base_shard)
-                base_mem.experimental_set_per_core_allocation(True)
-                base_tensors[core_idx] = ttnn._ttnn.tensor.experimental_to_single_device(
-                    ttnn.from_torch(base_torch, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT),
-                    mesh_device,
-                    coord,
-                    base_mem,
-                )
+                if len(fmt_np) > 0:
+                    fmt_data[row, col, core_idx, : len(fmt_np)] = torch.from_numpy(fmt_np.copy())
+                if len(base_np) > 0:
+                    base_data[row, col, core_idx, : len(base_np)] = torch.from_numpy(base_np.copy())
 
-            fmt_result[coord] = fmt_tensors
-            base_result[coord] = base_tensors
-    return fmt_result, base_result
+    # Reshape to (mesh_rows*num_cores, mesh_cols*row_size) for ShardTensor2dMesh
+    # dims=(0, 1) — splits dim 0 by mesh_rows, dim 1 by mesh_cols.  Each device
+    # ends up with (num_cores, row_size) sharded HEIGHT_SHARDED on core_grid.
+    fmt_2d = fmt_data.permute(0, 2, 1, 3).reshape(mesh_rows * num_cores, mesh_cols * fmt_aligned).contiguous()
+    base_2d = base_data.permute(0, 2, 1, 3).reshape(mesh_rows * num_cores, mesh_cols * base_aligned).contiguous()
+
+    fmt_shard = ttnn.ShardSpec(core_grid, [1, fmt_aligned], ttnn.ShardOrientation.ROW_MAJOR)
+    fmt_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, fmt_shard)
+
+    base_shard = ttnn.ShardSpec(core_grid, [1, base_aligned], ttnn.ShardOrientation.ROW_MAJOR)
+    base_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, base_shard)
+
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
+
+    fmt_tensor = ttnn.from_torch(
+        fmt_2d,
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=fmt_mem,
+        mesh_mapper=mesh_mapper,
+    )
+    base_tensor = ttnn.from_torch(
+        base_2d,
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=base_mem,
+        mesh_mapper=mesh_mapper,
+    )
+
+    # Per-core L1 addresses.  Under HEIGHT_SHARDED + lockstep, every core in
+    # the shard grid has its own row at THE SAME L1 base address (the
+    # ShardTensor2dMesh content is laid out so each core sees its OWN row at
+    # the shared address — different physical L1 bytes, same logical address).
+    # So fmt_l1_addrs[i] == fmt_base_l1 for every core; ditto for base.
+    fmt_base_l1 = fmt_tensor.buffer_address()
+    base_base_l1 = base_tensor.buffer_address()
+    fmt_l1_addrs = [fmt_base_l1] * num_cores
+    base_l1_addrs = [base_base_l1] * num_cores
+
+    return fmt_tensor, base_tensor, fmt_l1_addrs, base_l1_addrs
 
 
 def _build_program_for_device(
@@ -627,9 +678,16 @@ def create_dram_expert_metadata(
       fmt_words_per_expert = num_iterations × meta_words_per_block (packed 3-bit format)
       Slot offset = (global_expert_id × num_iterations) % num_buffers.
 
+    Returns RAW per-core data (no tensor upload).  Caller is responsible for
+    aggregating across the mesh and uploading via
+    :func:`upload_lockstep_meta_tensors_multi_device` (lockstep ShardTensor2dMesh
+    — avoids the per_core_allocation address divergence triggered by BSPM SRAM).
+
     Returns:
-        ((offset_tensors, block_size_tensors), per_core_fmt,
-         (expert_offsets_l1_addrs, block_sizes_l1_addrs), per_core_values)
+        (per_core_expert_offsets, per_core_block_sizes, block_size_entries_per_core,
+         per_core_fmt, per_core_values)
+        where per_core_expert_offsets / per_core_block_sizes are dicts
+        ``{core_idx: list[int]}``.
     """
     num_experts = num_total_experts
     num_banks = len(primary_worker_cores)
@@ -757,26 +815,12 @@ def create_dram_expert_metadata(
             next_core_noc_x_core_values.append((core, next_noc.x))
             next_core_noc_y_core_values.append((core, next_noc.y))
 
-    # Upload expert offsets (uint32) and block sizes (uint16) as separate L1 tensors.
-    offset_tensors = upload_per_core_uint32_tensor(device, compute_cores_list, per_core_expert_offsets, num_experts)
-    block_size_tensors = upload_per_core_uint16_tensor(
-        device, compute_cores_list, per_core_block_sizes, num_experts * num_iterations_local
-    )
-
-    expert_offsets_l1_addr_core_values = [
-        (
-            compute_cores_list[i],
-            offset_tensors[i].experimental_per_core_buffer_address(compute_cores_list[i]),
-        )
-        for i in range(num_total_cores)
-    ]
-    block_sizes_l1_addr_core_values = [
-        (
-            compute_cores_list[i],
-            block_size_tensors[i].experimental_per_core_buffer_address(compute_cores_list[i]),
-        )
-        for i in range(num_total_cores)
-    ]
+    # NOTE: We no longer upload per-core tensors here.  Caller aggregates per-device
+    # data and uploads a single LOCKSTEP ShardTensor2dMesh tensor pair (see
+    # upload_lockstep_meta_tensors_multi_device).  This is required to avoid the
+    # BSPM-SRAM frontier-divergence bug that breaks per_core_allocation tensors
+    # allocated post-SRAM.
+    block_size_entries_per_core = num_experts * num_iterations_local
 
     per_core_values = {
         "bank_id": bank_id_core_values,
@@ -788,9 +832,10 @@ def create_dram_expert_metadata(
     }
 
     return (
-        (offset_tensors, block_size_tensors),
+        per_core_expert_offsets,
+        per_core_block_sizes,
+        block_size_entries_per_core,
         per_core_fmt,
-        (expert_offsets_l1_addr_core_values, block_sizes_l1_addr_core_values),
         per_core_values,
     )
 
@@ -1067,14 +1112,24 @@ def create_dram_expert_tensors_multi_device(
     fmt_bytes_per_bank = cores_per_dram_bank * fmt_bytes_per_core
     num_banks = len(primary_cores_list)
 
-    per_device_results = {}
+    # Phase 1a: gather raw per-device data from create_dram_expert_metadata (no upload).
+    per_device_offset_data = {}
+    per_device_block_size_data = {}
+    per_device_per_core_values = {}
     per_device_fmt_bank_data = {}
+    block_size_entries_per_core = None
 
     for row in range(mesh_shape[0]):
         for col in range(mesh_shape[1]):
             coord = ttnn.MeshCoordinate(row, col)
-            logger.info(f"  Creating metadata for device ({row},{col})...")
-            meta_tensors, per_core_fmt, l1_addrs, per_core_values = create_dram_expert_metadata(
+            logger.info(f"  Computing metadata for device ({row},{col})...")
+            (
+                per_core_expert_offsets,
+                per_core_block_sizes,
+                bs_entries,
+                per_core_fmt,
+                per_core_values,
+            ) = create_dram_expert_metadata(
                 mesh_device,
                 cts,
                 compute_cores_list,
@@ -1093,7 +1148,11 @@ def create_dram_expert_tensors_multi_device(
                 device_coord=coord,
                 k_parallel_per_bank=k_parallel_per_bank,
             )
-            per_device_results[coord] = (meta_tensors, l1_addrs, per_core_values)
+            per_device_offset_data[coord] = per_core_expert_offsets
+            per_device_block_size_data[coord] = per_core_block_sizes
+            per_device_per_core_values[coord] = per_core_values
+            if block_size_entries_per_core is None:
+                block_size_entries_per_core = bs_entries
 
             per_device_fmt_bank_data[coord] = _pack_fmt_bank_data(
                 per_core_fmt,
@@ -1103,6 +1162,37 @@ def create_dram_expert_tensors_multi_device(
                 fmt_words_per_expert,
                 fmt_bytes_per_expert,
             )
+
+    # Phase 1b: upload metadata as a SINGLE lockstep ShardTensor2dMesh tensor pair
+    # (one for offsets, one for block sizes).  The mesh allocator picks ONE L1
+    # base address valid on every device — uniform CT-arg values across all 8
+    # devices, immune to BSPM-SRAM frontier divergence.
+    (
+        offset_tensor_shared,
+        block_size_tensor_shared,
+        offset_l1_addr_shared,
+        block_size_l1_addr_shared,
+    ) = upload_lockstep_meta_tensors_multi_device(
+        mesh_device,
+        compute_cores_list,
+        per_device_offset_data,
+        per_device_block_size_data,
+        offset_entries_per_core=num_total_experts,
+        block_size_entries_per_core=block_size_entries_per_core,
+    )
+
+    # Build per-device results.  Tensor refs are SHARED (same mesh tensor on every
+    # device); l1_addr is the same value for every core (lockstep buffer_address).
+    per_device_results = {}
+    for row in range(mesh_shape[0]):
+        for col in range(mesh_shape[1]):
+            coord = ttnn.MeshCoordinate(row, col)
+            l1_addrs = (
+                [(c, offset_l1_addr_shared) for c in compute_cores_list],
+                [(c, block_size_l1_addr_shared) for c in compute_cores_list],
+            )
+            meta_tensors = (offset_tensor_shared, block_size_tensor_shared)
+            per_device_results[coord] = (meta_tensors, l1_addrs, per_device_per_core_values[coord])
 
     fmt_sizes = dict(
         fmt_bytes_per_expert=fmt_bytes_per_expert,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_sram_slots.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_compressed_sram_slots.py
@@ -26,18 +26,14 @@ from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, Comp
 from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import quantize_dequantize_bfp
 from models.demos.deepseek_v3_b1.micro_ops.matmul_expert.op import create_expert_fmt_tensors, encode_expert_indices
 from models.demos.deepseek_v3_b1.weights.cache import CacheConfig, CacheContext, TensorCache
-from models.demos.deepseek_v3_b1.weights.sram_slots import (
-    SramCompressedExpertSlots,
-    _build_l1_compressed_tensor,
-    _MemoryConfigSpec,
-    prepare_compressed_sram_slots,
-)
+from models.demos.deepseek_v3_b1.weights.sram_slots import SramCompressedExpertSlots, prepare_compressed_sram_slots
 from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import (
     SramExpertCoreGrids,
     SramHotExpertConfig,
     _predict_expert_per_core_bytes,
     build_sram_hot_expert_config,
     compute_expert_l1_bytes,
+    reduce_per_device_max,
 )
 
 TILE_W = 32
@@ -81,6 +77,36 @@ def _make_assigner(formats=None):
     if formats is None:
         formats = ["bfp8", "bfp4"]
     return CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=formats)
+
+
+def _make_mixed_assignment_provider(state_dict: dict, layer_idx: int, K: int, N: int, formats=None):
+    """Build an ``assignment_provider`` that mirrors the old ``_make_assigner``
+    mixed-precision (PCC threshold) coverage through the new API.
+
+    For each (eid, proj_idx) it pre-runs ``CompressedTensorAssigner`` on the
+    state-dict weight and caches the resulting tile-format codes.  Returns a
+    closure ``(eid, proj_idx) -> np.ndarray`` for ``prepare_compressed_sram_slots``.
+    """
+    assigner = _make_assigner(formats=formats)
+
+    def _qdq(x, fmt_str):
+        return quantize_dequantize_bfp(x, {"bfp8": 7, "bfp4": 3, "bfp2": 1, "bfp0": 0}[fmt_str])
+
+    proj_keys = ("gate_proj", "up_proj", "down_proj")
+    cache: dict[tuple[int, int], np.ndarray] = {}
+    for proj_idx, proj_name in enumerate(proj_keys):
+        suffix = f"mlp.experts."
+        for key, w in state_dict.items():
+            if f".layers.{layer_idx}.{suffix}" not in key or not key.endswith(f".{proj_name}.weight"):
+                continue
+            eid = int(key.split(".experts.")[1].split(".")[0])
+            # HF layout is (out_features, in_features); compute layout is (K, N).
+            cache[(eid, proj_idx)] = assigner.assign(w.T.contiguous(), _qdq).assignment
+
+    def _provider(expert_idx: int, proj_idx: int) -> np.ndarray:
+        return cache[(expert_idx, proj_idx)]
+
+    return _provider
 
 
 def _l1_top_addr(device) -> int:
@@ -144,16 +170,31 @@ N = 256
 NUM_CORES = N // TILE_W  # 8 — each core holds (K, 32) shard
 
 
-def test_build_l1_compressed_tensor(device):
-    """_build_l1_compressed_tensor creates a per-core L1 CT with valid addresses."""
+def test_build_sram_routed_proj_ct(device):
+    """build_sram_routed_proj_ct creates a per-core L1 CT with valid addresses
+    (mixed-precision assigner-derived assignment, single-device TP=1 degenerate case)."""
+    from models.demos.deepseek_v3_b1.weights.sram_slots import build_sram_routed_proj_ct
+
     core_grid = _build_sram_core_grid(device, NUM_CORES)
     assigner = _make_assigner()
 
+    def _qdq(x, fmt_str):
+        return quantize_dequantize_bfp(x, {"bfp8": 7, "bfp4": 3, "bfp2": 1, "bfp0": 0}[fmt_str])
+
     torch.manual_seed(42)
     weight = torch.randn(K, N).float()
+    assignment = assigner.assign(weight, _qdq).assignment
 
-    spec = _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grid)
-    ct = _build_l1_compressed_tensor(weight, spec, assigner=assigner, device=device)
+    ct = build_sram_routed_proj_ct(
+        mesh_device=device,
+        full_torch_weight_per_device=[weight],
+        core_grid=core_grid,
+        num_tiles_k=K // TILE_W,
+        n_parallel=NUM_CORES,
+        per_core_N=(N // TILE_W) // NUM_CORES,
+        is_cb_backing_expert=True,
+        bspm_assignment_per_device=[assignment],
+    )
     assert isinstance(ct, CompressedTensor)
 
     cores = ttnn.corerange_to_cores(core_grid)
@@ -180,7 +221,7 @@ def test_prepare_compressed_sram_slots(device):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=SramExpertCoreGrids.uniform(core_grid),
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K, N),
         move_to_device=True,
         **_no_trim_budget(device),
     )
@@ -221,26 +262,24 @@ def test_sram_slot_fmt_tensors(device):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=SramExpertCoreGrids.uniform(core_grid),
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K, N),
         move_to_device=True,
         **_no_trim_budget(device),
     )
 
     num_tiles_k = K // TILE_W
     per_core_n_tiles = N // NUM_CORES // TILE_W
-    fmt_tensors, base_addr_tensors = create_expert_fmt_tensors(
+    fmt_tensor, base_tensor, fmt_l1_addrs, base_l1_addrs = create_expert_fmt_tensors(
         slots.gate_proj, device, core_grid, num_tiles_k, per_core_n_tiles
     )
 
-    assert len(fmt_tensors) > 0
-    assert len(base_addr_tensors) == len(fmt_tensors)
-    for coord, core_tensors in fmt_tensors.items():
-        assert len(core_tensors) == NUM_CORES, f"Expected {NUM_CORES} core entries, got {len(core_tensors)}"
-        for idx, t in core_tensors.items():
-            assert ttnn.is_tensor_storage_on_device(t), f"fmt tensor core {idx} not on device"
-        for idx, t in base_addr_tensors[coord].items():
-            assert ttnn.is_tensor_storage_on_device(t), f"base_addr tensor core {idx} not on device"
-    logger.info(f"fmt_tensors created for {len(fmt_tensors)} device coords, {NUM_CORES} cores each")
+    assert ttnn.is_tensor_storage_on_device(fmt_tensor), "fmt tensor not on device"
+    assert ttnn.is_tensor_storage_on_device(base_tensor), "base_addr tensor not on device"
+    assert len(fmt_l1_addrs) == NUM_CORES, f"Expected {NUM_CORES} fmt L1 addrs, got {len(fmt_l1_addrs)}"
+    assert len(base_l1_addrs) == NUM_CORES, f"Expected {NUM_CORES} base L1 addrs, got {len(base_l1_addrs)}"
+    assert all(a > 0 for a in fmt_l1_addrs), "fmt L1 addrs must be non-zero"
+    assert all(a > 0 for a in base_l1_addrs), "base L1 addrs must be non-zero"
+    logger.info(f"fmt/base mesh tensors created with {NUM_CORES} per-core L1 addrs each")
 
 
 def test_sram_slot_selection_meta(device):
@@ -294,7 +333,7 @@ def test_sram_hot_expert_config_per_layer(device):
         layer_idx=3,
         initial_expert_indices=config[3],
         core_grids=uniform_grids,
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd3, 3, K, N),
         move_to_device=True,
         **_no_trim_budget(device),
     )
@@ -309,7 +348,7 @@ def test_sram_hot_expert_config_per_layer(device):
         layer_idx=7,
         initial_expert_indices=config[7],
         core_grids=uniform_grids,
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd7, 7, K, N),
         move_to_device=True,
         **_no_trim_budget(device),
     )
@@ -343,15 +382,18 @@ def _predict_one_expert_max_bytes(layer_idx, expert_idx, K, N, assigner, core_gr
     gate_full = sd[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight"].T.contiguous()
     up_full = sd[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.up_proj.weight"].T.contiguous()
     down_full = sd[f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight"].T.contiguous()
-    per_core = _predict_expert_per_core_bytes(
+    num_cores = core_grids.gate.num_cores()
+    per_device_per_core = _predict_expert_per_core_bytes(
         expert_idx,
         gate_full,
         up_full,
         down_full,
         core_grids,
+        (num_cores, num_cores, num_cores),  # uniform grid → all WIDTH_SHARDED (k_par=1)
         assigner=assigner,
         assignment_provider=None,
     )
+    per_core = reduce_per_device_max(per_device_per_core)
     return max(per_core.values()) if per_core else 0
 
 
@@ -390,7 +432,7 @@ def test_prepare_compressed_sram_slots_trim_stops_under_cap(device):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=grids,
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K_local, N_local),
         move_to_device=True,
         boundary_addr=boundary_addr,
         initial_lowest_addr={},  # no baseline allocations; bootstrap from l1_top
@@ -446,7 +488,7 @@ def test_prepare_compressed_sram_slots_trim_fits_all_under_large_cap(device):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=grids,
-        assigner=_make_assigner(),
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K_local, N_local),
         move_to_device=True,
         boundary_addr=boundary_addr,
         initial_lowest_addr={},
@@ -487,7 +529,8 @@ def test_compute_expert_l1_bytes():
         assignments.append(result.assignment)
         shapes.append(tuple(w.shape))
 
-    computed = compute_expert_l1_bytes(assignments, shapes, core_grids)
+    n_par_triple = (num_cores, num_cores, num_cores)  # uniform grid → all WIDTH_SHARDED
+    computed = compute_expert_l1_bytes(assignments, shapes, core_grids, n_par_triple)
     assert computed > 0, "L1 bytes must be positive"
 
     # Conservative estimate: sum of independent per-projection maxes
@@ -516,7 +559,7 @@ def test_compute_expert_l1_bytes():
     assert computed <= conservative, f"Tightened {computed} must be <= conservative {conservative}"
 
     # Determinism
-    computed2 = compute_expert_l1_bytes(assignments, shapes, core_grids)
+    computed2 = compute_expert_l1_bytes(assignments, shapes, core_grids, n_par_triple)
     assert computed == computed2, "compute_expert_l1_bytes must be deterministic"
 
     logger.info(f"compute_expert_l1_bytes: {computed} bytes (conservative: {conservative})")
@@ -532,8 +575,9 @@ def test_compute_expert_l1_bytes_uniform_assignment():
 
     assignments = [uniform_bfp8, uniform_bfp8, uniform_bfp8]
     shapes = [(K, N), (K, N), (K, N)]
+    num_cores = core_grid.num_cores()
 
-    computed = compute_expert_l1_bytes(assignments, shapes, core_grids)
+    computed = compute_expert_l1_bytes(assignments, shapes, core_grids, (num_cores, num_cores, num_cores))
 
     from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import bfp_tile_packed_size
 
@@ -602,7 +646,7 @@ def test_build_sram_hot_expert_config_multi_layer():
 #   deepseek-r1-0528/layer_4/precision_eval/precision_map_B_3.5.bspm
 #
 # The layer-4 Variant-B 3.5 b/e assignment has 0 bfp8 tiles — the exact
-# condition that exercises the BSPM path through _build_l1_compressed_tensor
+# condition that exercises the BSPM path through build_sram_routed_proj_ct
 # and prepare_compressed_sram_slots.
 # ---------------------------------------------------------------------------
 
@@ -663,20 +707,19 @@ def _make_bspm_core_grids(device) -> SramExpertCoreGrids:
     return SramExpertCoreGrids(gate=gate_grid, up=gate_grid, down=down_grid)
 
 
-def test_build_l1_compressed_tensor_bspm(device):
-    """_build_l1_compressed_tensor with a real BSPM gate_proj assignment (0 bfp8 tiles).
+def test_build_sram_routed_proj_ct_bspm(device):
+    """build_sram_routed_proj_ct with a real BSPM gate_proj assignment (0 bfp8 tiles).
 
-    Exercises the assignment= path in _build_l1_compressed_tensor using the layer-4
-    Variant-B 3.5 b/e BSPM assignment for expert 0.  Verifies the CT is allocated in
-    L1 with 0 bfp8 tiles and valid per-core addresses.
+    Layer-4 Variant-B 3.5 b/e BSPM assignment for expert 0.  Verifies the CT
+    is allocated in L1 with 0 bfp8 tiles and valid per-core addresses.
     Requires BSPM_RESULTS_DIR.
     """
     from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
+    from models.demos.deepseek_v3_b1.weights.sram_slots import build_sram_routed_proj_ct
 
     bspm_path = _get_bspm_path()
     K, N = _GATE_UP_SHAPE
     core_grid = _build_sram_core_grid(device, _GATE_UP_NUM_CORES)
-
     assignment = load_bspm_for_expert(
         str(bspm_path), expert_idx=0, proj_idx=_PROJ_GATE, tile_rows=K // TILE_W, tile_cols=N // TILE_W
     )
@@ -684,9 +727,16 @@ def test_build_l1_compressed_tensor_bspm(device):
     torch.manual_seed(0)
     weight = torch.randn(K, N).float()
 
-    spec = _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grid)
-    ct = _build_l1_compressed_tensor(weight, spec, assignment=assignment, device=device)
-
+    ct = build_sram_routed_proj_ct(
+        mesh_device=device,
+        full_torch_weight_per_device=[weight],
+        core_grid=core_grid,
+        num_tiles_k=K // TILE_W,
+        n_parallel=_GATE_UP_NUM_CORES,
+        per_core_N=(N // TILE_W) // _GATE_UP_NUM_CORES,
+        is_cb_backing_expert=True,
+        bspm_assignment_per_device=[assignment],
+    )
     assert isinstance(ct, CompressedTensor)
     assert (
         ct.tile_counts.get("bfp8", 0) == 0
@@ -697,22 +747,21 @@ def test_build_l1_compressed_tensor_bspm(device):
     for c in cores:
         addr = ct.get_data_l1_address_per_core(c)
         assert addr > 0, f"core ({c.x},{c.y}) has invalid L1 address"
-
     logger.info(f"BSPM gate_proj L1 CT tile_counts: {ct.tile_counts} on {len(cores)} cores")
 
 
-def test_build_l1_compressed_tensor_bspm_down_proj(device):
-    """_build_l1_compressed_tensor with real BSPM down_proj assignment (K=2048, N=7168).
+def test_build_sram_routed_proj_ct_bspm_down_proj(device):
+    """build_sram_routed_proj_ct with real BSPM down_proj assignment (K=2048, N=7168).
 
     28 cores: N=7168/28=256 cols/core → 8 tile-cols (tile-aligned).
     Requires BSPM_RESULTS_DIR.
     """
     from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_expert
+    from models.demos.deepseek_v3_b1.weights.sram_slots import build_sram_routed_proj_ct
 
     bspm_path = _get_bspm_path()
     K, N = _DOWN_SHAPE
     core_grid = _build_sram_core_grid(device, _DOWN_NUM_CORES)
-
     assignment = load_bspm_for_expert(
         str(bspm_path), expert_idx=0, proj_idx=_PROJ_DOWN, tile_rows=K // TILE_W, tile_cols=N // TILE_W
     )
@@ -720,9 +769,16 @@ def test_build_l1_compressed_tensor_bspm_down_proj(device):
     torch.manual_seed(1)
     weight = torch.randn(K, N).float()
 
-    spec = _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grid)
-    ct = _build_l1_compressed_tensor(weight, spec, assignment=assignment, device=device)
-
+    ct = build_sram_routed_proj_ct(
+        mesh_device=device,
+        full_torch_weight_per_device=[weight],
+        core_grid=core_grid,
+        num_tiles_k=K // TILE_W,
+        n_parallel=_DOWN_NUM_CORES,
+        per_core_N=(N // TILE_W) // _DOWN_NUM_CORES,
+        is_cb_backing_expert=True,
+        bspm_assignment_per_device=[assignment],
+    )
     assert isinstance(ct, CompressedTensor)
     assert ct.tile_counts.get("bfp8", 0) == 0, f"Real BSPM 3.5 b/e should have 0 bfp8 tiles, got {ct.tile_counts}"
     assert ct.tile_counts.get("bfp4", 0) > 0, f"Expected bfp4 tiles, got {ct.tile_counts}"
@@ -731,7 +787,6 @@ def test_build_l1_compressed_tensor_bspm_down_proj(device):
     for c in cores:
         addr = ct.get_data_l1_address_per_core(c)
         assert addr > 0, f"core ({c.x},{c.y}) has invalid L1 address"
-
     logger.info(f"BSPM down_proj L1 CT tile_counts: {ct.tile_counts} on {len(cores)} cores")
 
 
@@ -867,8 +922,9 @@ def test_compute_expert_l1_bytes_bspm():
         ]
     )
     core_grids = SramExpertCoreGrids(gate=gate_grid, up=gate_grid, down=down_grid)
+    n_par_triple = (gate_grid.num_cores(), gate_grid.num_cores(), down_grid.num_cores())
 
-    computed = compute_expert_l1_bytes(assignments, shapes, core_grids)
+    computed = compute_expert_l1_bytes(assignments, shapes, core_grids, n_par_triple)
     assert computed > 0, "L1 bytes must be positive for a non-empty BSPM assignment"
 
     # All-bfp8 upper bound: every tile at bfp8 cost.
@@ -911,24 +967,17 @@ def _sram_cache_context() -> CacheContext:
 
 @requires_hybrid_allocator
 def test_prepare_compressed_sram_slots_cache_roundtrip(device, tmp_path):
-    """TensorCache round-trip for prepare_compressed_sram_slots.
+    """TensorCache round-trip for prepare_compressed_sram_slots through the
+    new build_sram_routed_proj_ct path.
 
-    - Cold miss: each (expert, projection) writes its own ``shards.bin`` +
-      ``metadata.json`` under ``objects/<id[:2]>/<id>/``.
-    - Warm hit: same call returns the same set of slots without writing
-      anything new on disk.
-    - Reconstructed CompressedTensors agree with the cold pack on shape
-      and per-tile assignment codes (byte-equivalent assignment).
-
-    Gated on ``TT_METAL_ALLOCATOR_MODE_HYBRID=1`` because the slots are
-    per-core L1 ``CompressedTensor`` objects; without hybrid mode the
-    allocator throws TT_FATAL deep inside ``ttnn.from_torch``.
+    Cold miss persists shards.bin + metadata.json per (expert, projection);
+    warm hit returns the same slots without writing new files; reconstructed
+    CompressedTensors round-trip byte-for-byte on assignment.
     """
     layer_idx = 7
     expert_indices = [0, 5, 10]
     sd = _make_state_dict(layer_idx, expert_indices, K=K, N=N)
     core_grid = _build_sram_core_grid(device, NUM_CORES)
-    assigner = _make_assigner()
     cache_config = CacheConfig(cache=TensorCache(tmp_path), context=_sram_cache_context())
 
     # --- Cold miss ----------------------------------------------------------
@@ -938,7 +987,7 @@ def test_prepare_compressed_sram_slots_cache_roundtrip(device, tmp_path):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=SramExpertCoreGrids.uniform(core_grid),
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K, N),
         move_to_device=True,
         cache_config=cache_config,
         **_no_trim_budget(device),
@@ -965,7 +1014,7 @@ def test_prepare_compressed_sram_slots_cache_roundtrip(device, tmp_path):
         layer_idx=layer_idx,
         initial_expert_indices=expert_indices,
         core_grids=SramExpertCoreGrids.uniform(core_grid),
-        assigner=assigner,
+        assignment_provider=_make_mixed_assignment_provider(sd, layer_idx, K, N),
         move_to_device=True,
         cache_config=cache_config,
         **_no_trim_budget(device),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/per_core_allocation/test_matmul_expert.py
@@ -1085,20 +1085,21 @@ def _build_index_tensor(active_expert_ids, mesh_device, compute_core_grid, num_c
 
 
 def _build_sram_fmt_data(sram_cts, mesh_device, sram_core_grid, sram_k_per_core, sram_per_core_n, Kt):
-    """Build SRAM format tensors and K-offset core values."""
+    """Build SRAM format tensors (lockstep mesh tensors + uniform L1 addrs) and K-offset core values."""
     from models.demos.deepseek_v3_b1.micro_ops.matmul_expert.op import create_expert_fmt_tensors
 
-    sram_fmt_tensors, sram_base_addr_tensors = create_expert_fmt_tensors(
+    sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs = create_expert_fmt_tensors(
         sram_cts, mesh_device, sram_core_grid, sram_k_per_core, sram_per_core_n
     )
 
     sram_k_offsets = None
     if sram_k_per_core < Kt:
-        sram_cores = ttnn.corerange_to_cores(sram_core_grid)
+        # row_wise=True matches create_expert_fmt_tensors's core iteration order.
+        sram_cores = ttnn.corerange_to_cores(sram_core_grid, row_wise=True)
         n_parallel = len(sram_cores) * sram_k_per_core // Kt
         sram_k_offsets = [(sram_cores[i], (i // n_parallel) * sram_k_per_core) for i in range(len(sram_cores))]
 
-    return sram_fmt_tensors, sram_base_addr_tensors, sram_k_offsets
+    return sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs, sram_k_offsets
 
 
 # ---------------------------------------------------------------------------
@@ -1294,10 +1295,10 @@ def _run_standard(
         dram_fuse_silu=dram_fuse_silu,
     )
 
-    sram_fmt_tensors, sram_base_addr_tensors, sram_k_offsets = (
+    sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs, sram_k_offsets = (
         _build_sram_fmt_data(sram_cts, mesh_device, sram_core_grid, Kt, sram_per_core_N, Kt)
         if has_sram
-        else ({}, {}, None)
+        else (None, None, None, None, None)
     )
     result = ExpertKernel.op(
         a_tensor,
@@ -1313,8 +1314,10 @@ def _run_standard(
         dram_per_core_n=dram_per_core_N,
         has_sram=has_sram,
         sram_core_grid=sram_core_grid,
-        sram_fmt_tensors=sram_fmt_tensors,
-        sram_base_addr_tensors=sram_base_addr_tensors,
+        sram_fmt_tensor=sram_fmt_tensor,
+        sram_base_addr_tensor=sram_base_addr_tensor,
+        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
         sram_k_offsets=sram_k_offsets,
         n_parallel_per_bank=n_parallel_per_bank,
         k_parallel_per_bank=k_parallel_per_bank,
@@ -1530,10 +1533,10 @@ def _run_accum(
         tile_w,
     )
 
-    sram_fmt_tensors, sram_base_addr_tensors, sram_k_offsets = (
+    sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs, sram_k_offsets = (
         _build_sram_fmt_data(sram_cts, mesh_device, sram_core_grid, Kt, sram_per_core_N, Kt)
         if has_sram
-        else ({}, {}, None)
+        else (None, None, None, None, None)
     )
     result = ExpertKernel.op(
         a_tensor,
@@ -1549,8 +1552,10 @@ def _run_accum(
         dram_per_core_n=dram_per_core_N,
         has_sram=has_sram,
         sram_core_grid=sram_core_grid,
-        sram_fmt_tensors=sram_fmt_tensors,
-        sram_base_addr_tensors=sram_base_addr_tensors,
+        sram_fmt_tensor=sram_fmt_tensor,
+        sram_base_addr_tensor=sram_base_addr_tensor,
+        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
         sram_k_offsets=sram_k_offsets,
         n_parallel_per_bank=n_parallel_per_bank,
         accum_experts=True,
@@ -1740,7 +1745,7 @@ def _run_slice_k(
         dram_fuse_silu=dram_fuse_silu,
     )
 
-    sram_fmt_tensors, sram_base_addr_tensors, sram_k_offsets = (
+    sram_fmt_tensor, sram_base_addr_tensor, sram_fmt_l1_addrs, sram_base_addrs_l1_addrs, sram_k_offsets = (
         _build_sram_fmt_data(
             sram_cts,
             mesh_device,
@@ -1750,7 +1755,7 @@ def _run_slice_k(
             Kt,
         )
         if has_sram
-        else ({}, {}, None)
+        else (None, None, None, None, None)
     )
     result = ExpertKernel.op(
         a_tensor,
@@ -1766,8 +1771,10 @@ def _run_slice_k(
         dram_per_core_n=dram_per_core_N,
         has_sram=has_sram,
         sram_core_grid=sram_core_grid,
-        sram_fmt_tensors=sram_fmt_tensors,
-        sram_base_addr_tensors=sram_base_addr_tensors,
+        sram_fmt_tensor=sram_fmt_tensor,
+        sram_base_addr_tensor=sram_base_addr_tensor,
+        sram_fmt_l1_addrs=sram_fmt_l1_addrs,
+        sram_base_addrs_l1_addrs=sram_base_addrs_l1_addrs,
         sram_k_offsets=sram_k_offsets,
         n_parallel_per_bank=n_parallel_per_bank,
         k_parallel_per_bank=k_parallel_per_bank,
@@ -2739,7 +2746,10 @@ def _run_dram_bspm(
         expert_selection_meta=expert_selection_meta,
         has_sram=False,
         sram_core_grid=None,
-        sram_fmt_tensors={},
+        sram_fmt_tensor=None,
+        sram_base_addr_tensor=None,
+        sram_fmt_l1_addrs=None,
+        sram_base_addrs_l1_addrs=None,
         sram_k_offsets=None,
         cores_per_dram_bank=cores_per_dram_bank,
         sram_per_core_n=0,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_decoder_block.py
@@ -20,7 +20,6 @@ from loguru import logger
 import ttnn
 from conftest import requires_hybrid_allocator
 from models.common.utility_functions import comp_pcc
-from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
 from models.demos.deepseek_v3_b1.demo.decoder_stage import create_decoder_block_tensors
 from models.demos.deepseek_v3_b1.demo.weight_provider import resolve_sram_expert_ids
 from models.demos.deepseek_v3_b1.fused_ops.attention_block.op import AttentionBlock
@@ -60,7 +59,7 @@ _SRAM_HOT_EXPERTS_CEILING = 64
 
 
 def _build_sram_hot_expert_kwargs(state_dict, submesh, layer_idx: int):
-    """Build the ``(sram_hot_experts, sram_core_grids, sram_assigner)`` triple.
+    """Build the ``(sram_hot_experts, sram_core_grids)`` pair.
 
     Core grids come from :meth:`SramExpertCoreGrids.shared_expert_mirror` (same
     CRS as shared-expert gate/up/down in ``overlap_configs``).
@@ -72,14 +71,6 @@ def _build_sram_hot_expert_kwargs(state_dict, submesh, layer_idx: int):
     budgeting is applied here.
     """
     sram_core_grids = SramExpertCoreGrids.shared_expert_mirror()
-    # Routed experts in DRAM are already BFP4 (see prepare_routed_expert_weights);
-    # force the SRAM copies to match so every tile is the expected 25 KiB/expert
-    # binding-core footprint -- this is the lever that unlocks the 26+ expert
-    # target under the 960 KiB combined attn+SRAM cap.  Dropping BFP8 from the
-    # format list makes the assigner pick BFP4 on every tile regardless of PCC;
-    # add BFP2 back if accuracy drops unacceptably.
-    sram_assigner = CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"])
-
     freqs = _load_routing_frequencies()
     full_config = build_sram_hot_expert_config([layer_idx], freqs)
     sram_hot_experts = {k: v[:_SRAM_HOT_EXPERTS_CEILING] for k, v in full_config.items()}
@@ -88,7 +79,7 @@ def _build_sram_hot_expert_kwargs(state_dict, submesh, layer_idx: int):
         layer_idx,
         len(sram_hot_experts.get(layer_idx, [])),
     )
-    return sram_hot_experts, sram_core_grids, sram_assigner
+    return sram_hot_experts, sram_core_grids
 
 
 def _optional_bspm_dir():
@@ -360,15 +351,6 @@ _KNOWN_DECODER_MOE_FAILURE_SKIPS = {
     (6644, True, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43118",
     (9916, True, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43118",
     (11664, True, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43118",
-    (0, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (127, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (511, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (1023, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (2047, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (4096, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (6644, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (9916, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
-    (11664, False, False): "DecoderBlock MoE golden tensor creation segfaults. Issue: #43122",
 }
 
 
@@ -560,6 +542,17 @@ def skip_known_decoder_moe_failure(
         pytest.param("t8_all_picked", marks=pytest.mark.skip_post_commit),
     ],
 )
+# enable_sram_bspm: opt-in BSPM mixed precision for SRAM experts. Independent
+# of DRAM BSPM (which is always on when BSPM_DIR is set). When True, the test
+# uses the deferred SRAM build pattern so SDPA buffer lands at uniform L1
+# addresses before SRAM CTs allocate below it.
+@pytest.mark.parametrize(
+    "enable_sram_bspm",
+    [
+        pytest.param(False, id="sram_bspm_off"),
+        pytest.param(True, id="sram_bspm_on", marks=pytest.mark.skip_post_commit),
+    ],
+)
 @pytest.mark.parametrize(
     "enable_routing, use_hardcoded_expert_index, num_routed_experts",
     [
@@ -609,6 +602,7 @@ def test_decoder(
     num_internal_iterations,
     expert_upload_mode,
     sram_scenario,
+    enable_sram_bspm,
     enable_routing,
     use_hardcoded_expert_index,
     num_routed_experts,
@@ -687,11 +681,8 @@ def test_decoder(
     # present -- skip SRAM for them.
     sram_hot_experts = None
     sram_core_grids = None
-    sram_assigner = None
     if effective_num_routed_experts == 256:
-        sram_hot_experts, sram_core_grids, sram_assigner = _build_sram_hot_expert_kwargs(
-            state_dict, submesh, ROUTED_EXPERT_LAYER_IDX
-        )
+        sram_hot_experts, sram_core_grids = _build_sram_hot_expert_kwargs(state_dict, submesh, ROUTED_EXPERT_LAYER_IDX)
 
     # SRAM placement scenarios — feeds the SRAM kernel pipeline via sram_expert_ids.
     #   "default":  no override; sram_hot_experts (built above when 256-experts) is
@@ -715,7 +706,6 @@ def test_decoder(
         # Disable sram_slots build so SRAM truly doesn't fire.
         sram_hot_experts = None
         sram_core_grids = None
-        sram_assigner = None
     elif rigged_expert_ids is not None:
         winners = [grp * 32 + e for grp in rigged_group_ids for e in rigged_expert_ids[grp]]
         non_winners = [eid for eid in range(256) if eid not in winners]
@@ -802,6 +792,21 @@ def test_decoder(
     # This test only builds candidates for ``ROUTED_EXPERT_LAYER_IDX`` (see
     # ``_build_sram_hot_expert_kwargs``), so the dict has a single key; multi-layer
     # callers use the same shape with more entries.
+    #
+    # Deferred SRAM alloc under enable_sram_bspm: when BSPM-SRAM is on, SRAM CT
+    # sizes diverge per device → if allocated before create_decoder_block_tensors,
+    # SDPA buffer (allocated after) lands at per-device-different L1 addresses,
+    # breaking MLA's uniform-address assumption. Build DRAM weights first, then
+    # SDPA via create_decoder_block_tensors, then SRAM CTs (which land below the
+    # uniform SDPA address). Under uniform-BFP4 the direct path is fine (SRAM
+    # sizes are uniform per device). The parametrized flag requires BSPM_DIR
+    # to be set (otherwise there's no BSPM source to use).
+    if enable_sram_bspm and _optional_bspm_dir() is None:
+        pytest.skip("enable_sram_bspm=True requires BSPM_DIR env var to be set")
+    # Unified path: prepare_moe_layer_weights handles both explicit-list and
+    # auto-fit SRAM scenarios via prepare_compressed_sram_slots.
+    _prep_sram_ids = sram_expert_ids
+    _prep_enable_sram_bspm = enable_sram_bspm
     layer_weights = prepare_moe_layer_weights(
         submesh,
         state_dict,
@@ -810,11 +815,11 @@ def test_decoder(
         move_to_device=True,
         sram_hot_experts=sram_hot_experts,
         sram_core_grids=sram_core_grids,
-        sram_assigner=sram_assigner,
-        worker_l1_size=device_params.get("worker_l1_size") if sram_hot_experts is not None else None,
+        worker_l1_size=device_params.get("worker_l1_size"),
         compressed_tp8=True,
         bspm_dir=_optional_bspm_dir(),
-        sram_expert_ids=sram_expert_ids,
+        enable_sram_bspm=_prep_enable_sram_bspm,
+        sram_expert_ids=_prep_sram_ids,
     )
 
     # When no explicit override (the "default" scenario) and sram_slots got built,
@@ -1014,6 +1019,7 @@ def test_decoder(
         fabric_config=device_params["fabric_config"],
         persistent_next_iter_semaphore=persistent_next_iter_semaphore,
         persistent_mode=False,
+        enable_sram_bspm=enable_sram_bspm,
     )
     for i in range(num_iters):
         moe_final_output_tensor, attention_block_output_tensor = DecoderBlock.execute(*decoder_program_context)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -24,13 +24,13 @@ from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
 from models.demos.deepseek_v3_b1.weights.prepare import (
-    build_sram_expert_weights,
     create_gate_bias_tensor,
     create_gate_indices_tensor,
     prepare_attention_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
 )
+from models.demos.deepseek_v3_b1.weights.sram_slots import build_sram_routed_proj_cts
 
 
 # ============================================================================
@@ -521,7 +521,6 @@ def create_routed_expert_tensors(
     sram_up_proj_weights = None
     sram_down_proj_weights = None
     if sram_expert_ids:
-        from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
         from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RE
 
         moe_tp = device.shape[0] * device.shape[1]
@@ -539,15 +538,14 @@ def create_routed_expert_tensors(
         sram_gate_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in a_cores])
         sram_up_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in b_cores])
         _sram_per_core_N = (N_per_dev // 32) // 8  # 1 N-tile per core
-        sram_gate_proj_weights = build_sram_expert_weights(
+        sram_gate_proj_weights = build_sram_routed_proj_cts(
+            mesh_device=device,
             sram_expert_ids=sram_expert_ids,
             full_torch_weights_per_device=full_torch_per_device,
-            assigner=CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"]),
-            mesh_device=device,
             core_grid=sram_gate_core_grid,
-            sram_k_per_core=(_RE.K // 32) // 8,  # 28 (K=7168, k_parallel=8)
-            sram_n_parallel=8,  # cores per K-slice
-            sram_per_core_N=_sram_per_core_N,
+            num_tiles_k=(_RE.K // 32) // 8,  # 28 (K=7168, k_parallel=8)
+            n_parallel=8,  # cores per K-slice
+            per_core_N=_sram_per_core_N,
         )
 
         # SRAM up_proj weights: same shape as gate_proj (K, N); use up_proj_weights_dict.
@@ -560,15 +558,14 @@ def create_routed_expert_tensors(
             ]
             for eid in sram_expert_ids
         }
-        sram_up_proj_weights = build_sram_expert_weights(
+        sram_up_proj_weights = build_sram_routed_proj_cts(
+            mesh_device=device,
             sram_expert_ids=sram_expert_ids,
             full_torch_weights_per_device=full_torch_per_device_up,
-            assigner=CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"]),
-            mesh_device=device,
             core_grid=sram_up_core_grid,
-            sram_k_per_core=(_RE.K // 32) // 8,
-            sram_n_parallel=8,
-            sram_per_core_N=_sram_per_core_N,
+            num_tiles_k=(_RE.K // 32) // 8,
+            n_parallel=8,
+            per_core_N=_sram_per_core_N,
         )
 
         # SRAM down_proj weights: per-expert (K=GATE_PROJ_N=2048, N=K=7168). Mesh
@@ -589,15 +586,14 @@ def create_routed_expert_tensors(
         }
         sram_down_core_grid = DownProj.build_matmul_core_grid()  # 112 cores
         _sram_down_per_core_N = (_RE.K // 32) // DownProj.NUM_MATMUL_CORES  # 7168 / 32 / 112 = 2 tiles
-        sram_down_proj_weights = build_sram_expert_weights(
+        sram_down_proj_weights = build_sram_routed_proj_cts(
+            mesh_device=device,
             sram_expert_ids=sram_expert_ids,
             full_torch_weights_per_device=full_torch_per_device_down,
-            assigner=CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"]),
-            mesh_device=device,
             core_grid=sram_down_core_grid,
-            sram_k_per_core=K_per_dev_down // 32,  # 8 tiles
-            sram_n_parallel=DownProj.NUM_MATMUL_CORES,  # all 112 cores in same K-slice
-            sram_per_core_N=_sram_down_per_core_N,  # 2 tiles
+            num_tiles_k=K_per_dev_down // 32,  # 8 tiles
+            n_parallel=DownProj.NUM_MATMUL_CORES,  # all 112 cores in same K-slice
+            per_core_N=_sram_down_per_core_N,  # 2 tiles
         )
 
         # SRAM gate/up/down proj cb_out tensors are now overlaid onto the SDPA

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -704,7 +704,7 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
 
 # Bit-15 marks an expert ID as SRAM-resident; the low 15 bits carry the slot index.
 # See create_gate_indices_tensor docstring for the wire-encoding contract that
-# build_sram_expert_weights and the kernel-side filter both depend on.
+# build_sram_routed_proj_cts and the kernel-side filter both depend on.
 _SRAM_BIT = 1 << 15
 
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_tensor_cache.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_tensor_cache.py
@@ -887,7 +887,7 @@ def _make_sram_assigner(formats=("bfp8", "bfp4"), threshold: float = 0.993):
 
 
 def _make_sram_l1_per_core_mem_config(K: int, N: int, core_grid: ttnn.CoreRangeSet) -> ttnn.MemoryConfig:
-    """Build a WIDTH_SHARDED L1 mem_config matching ``_build_l1_compressed_tensor`` shape rules."""
+    """Build a WIDTH_SHARDED L1 mem_config matching ``build_sram_routed_proj_ct`` shape rules."""
     num_cores = core_grid.num_cores()
     assert N % num_cores == 0, f"N ({N}) must divide num_cores ({num_cores})"
     per_core_N = N // num_cores

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_weight_provider.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_weight_provider.py
@@ -43,7 +43,6 @@ from loguru import logger
 import ttnn
 from conftest import requires_hybrid_allocator
 from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.compressed_tensor.assigner import CompressedTensorAssigner
 from models.demos.deepseek_v3_b1.demo.mesh_device_context import DEFAULT_WORKER_L1_SIZE, _worker_l1_size_for_rank
 from models.demos.deepseek_v3_b1.demo.weight_provider import CacheWeightProvider
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_prepare_weights import _deallocate_layer
@@ -172,7 +171,6 @@ def test_cache_weight_provider_load_moe_layer_sram_perf(bh_2d_mesh_device: Any, 
         hf_model_path,
         sram_hot_experts=sram_hot_experts,
         sram_core_grids=SramExpertCoreGrids.shared_expert_mirror(),
-        sram_assigner=CompressedTensorAssigner(formats=["bfp4"]),
         worker_l1_size=worker_l1_size,
         bspm_dir=bspm_dir,
         bspm_budget=bspm_budget,

--- a/models/demos/deepseek_v3_b1/weights/prepare.py
+++ b/models/demos/deepseek_v3_b1/weights/prepare.py
@@ -29,6 +29,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.model_dimensions import LogicalModelDimensions as D
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RoutedExpert
 from models.demos.deepseek_v3_b1.weights.cache import (
     BspmVariant,
     CacheConfig,
@@ -57,14 +58,18 @@ from models.demos.deepseek_v3_b1.weights.sram_slots import (
     _compute_sram_trim_budget,
     prepare_compressed_sram_slots,
 )
-from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import SramExpertCoreGrids, SramHotExpertConfig
+from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import (
+    SramExpertCoreGrids,
+    SramHotExpertConfig,
+    make_sram_assignment_provider,
+)
 from models.demos.deepseek_v3_b1.weights.upload import UploadableMixin, eager_upload_l1_lockstep
 
 Q_AB_KV_A_SPEC = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 O_PROJ_GATE_MM_NORMS_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 KV_B12_SPEC = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
 GATE_UP_SPEC = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.fusion_group_spec()
-from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor
 from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
 from models.demos.deepseek_v3_b1.weights.transforms.attention import preprocess_kv_b12, preprocess_q_ab_kv_a
 from models.demos.deepseek_v3_b1.weights.transforms.tp4_attention import (
@@ -684,9 +689,9 @@ def create_gate_indices_tensor(
 
         Position in sram_expert_ids is the slot index — this list IS the
         single source of truth for SRAM placement and must match the slab
-        ordering used by build_sram_expert_weights (and friends). A mismatch
-        means slot s in the index points at some other slot's weights, silently
-        producing wrong outputs.
+        ordering used by build_sram_routed_proj_cts. A mismatch means slot s
+        in the index points at some other slot's weights, silently producing
+        wrong outputs.
 
         Default empty preserves Phase 1B behavior (identity arange).
 
@@ -730,202 +735,6 @@ def create_gate_indices_tensor(
         tile=ttnn.Tile([16, 16]),
         **kwargs,
     )
-
-
-def build_sram_expert_weights(
-    sram_expert_ids: list,
-    full_torch_weights_per_device: dict[int, list[torch.Tensor]],
-    assigner: Any,
-    mesh_device: Any,
-    core_grid: ttnn.CoreRangeSet,
-    sram_k_per_core: int,
-    sram_n_parallel: int,
-    sram_per_core_N: int,
-    *,
-    tile_w: int = 32,
-    per_expert_assignment_per_device: dict[int, list[np.ndarray]] | None = None,
-) -> list:
-    """Build T L1-allocated CompressedTensors for SRAM-resident routed experts.
-
-    Mirrors ``_build_sram_cts_slice_k`` from
-    ``test_matmul_expert.py::per_core_allocation``. Layout is selected by
-    ``k_parallel_factor = num_sram_cores // sram_n_parallel``:
-      * ``k_parallel > 1`` (gate/up at TP8: 8 K-slices × 8 N-slices = 64 cores)
-        → HEIGHT_SHARDED. Per-core shards stacked along H via K-major slab
-        ordering.
-      * ``k_parallel == 1`` (down at TP8: 112 cores, K replicated, N split)
-        → WIDTH_SHARDED. Per-device data passes through as-is; ttnn handles
-        per-core slicing along W.
-    Each core holds a ``[sram_k_per_core × tile_w, sram_per_core_N × tile_w]``
-    slab per expert in either case.
-
-    Slot ordering: returned CTs are in the same order as ``sram_expert_ids``,
-    so slot s corresponds to global expert ``sram_expert_ids[s]``. This MUST
-    match the encoding in ``create_gate_indices_tensor(sram_expert_ids=...)``
-    or downstream lookups will read the wrong expert's weights.
-
-    Args:
-        sram_expert_ids: list of global expert IDs in slot order (e.g.
-            ``[42, 77, 198]``). Length T = number of SRAM-resident experts.
-        full_torch_weights_per_device: mapping keyed by **global expert id**
-            (NOT slot index) → list of per-device ``torch.Tensor`` of shape
-            ``(K, N_per_device)``. Access is ``full_torch_weights_per_device[eid][dev_idx]``.
-            Caller is responsible for the full-set torch source (typically from
-            state_dict + TP8 column-shard).
-        assigner: precision assigner used by CompressedTensor (e.g.
-            ``UniformPrecisionAssigner(ttnn.bfloat4_b)``).
-        mesh_device: TP8 mesh device.
-        core_grid: CoreRangeSet hosting the SRAM matmul (e.g. 64 shared
-            gate cores).
-        sram_k_per_core: K tiles per core (this core's K-slice length).
-            Must satisfy ``sram_k_per_core × n_parallel × k_parallel == Kt``.
-        sram_n_parallel: N parallelism factor (cores per K-slice). With
-            64-core ``k_parallel × n_parallel = 64`` and N_per_device = 32
-            elements, ``sram_n_parallel = 8``, ``sram_per_core_N = 1``.
-        sram_per_core_N: N tiles per core per expert (typically 1 for
-            DeepSeek V3 routed gate/up at TP8).
-        tile_w: tile width in elements (default 32).
-        per_expert_assignment_per_device: optional BSPM precision map per
-            expert per device. ``{eid: [per_device_assignment, ...]}`` where
-            each per-device assignment is a 2D ``(K_tiles, N_tiles)`` int8
-            array matching the per-device weight shape. When provided,
-            bypasses ``assigner`` and uses the pre-computed assignment
-            directly (mirrors the DRAM BSPM path). When ``None`` falls
-            back to the assigner-driven uniform path.
-
-    Returns:
-        list[CompressedTensor] of length ``len(sram_expert_ids)``, in slot
-        order. Each CT is per-device sharded (PlacementShard along device
-        axes 0 and 1) and per-core L1-sharded on ``core_grid``.
-    """
-    from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import CompressedTensor
-
-    num_sram_cores = len(ttnn.corerange_to_cores(core_grid))
-    assert (
-        num_sram_cores % sram_n_parallel == 0
-    ), f"num_sram_cores={num_sram_cores} must be divisible by sram_n_parallel={sram_n_parallel}"
-
-    mesh_shape = mesh_device.shape
-    mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
-    num_devices = mesh_rows * mesh_cols
-
-    # Layout selection:
-    #   k_parallel_factor = num_sram_cores // sram_n_parallel
-    #
-    #   k_parallel > 1  → cores split K AND N (gate/up at TP8: 8 K-slices × 8 N-slices = 64
-    #                     cores). HEIGHT_SHARDED with the per-core shards stacked along H
-    #                     (cat-along-K). Logical tensor shape (num_cores × K_per_core, N_per_core).
-    #
-    #   k_parallel == 1 → K is replicated across all cores (down at TP8: 112 cores each see
-    #                     full K=256, split N=7168 → 64-col slice per core). WIDTH_SHARDED
-    #                     with the per-core shards arranged along W. Logical tensor shape
-    #                     (K, num_cores × N_per_core) = the actual per-device (K, N_full),
-    #                     so no shuffle is needed — per-device data goes in as-is.
-    k_parallel_factor = num_sram_cores // sram_n_parallel
-    is_width_sharded = k_parallel_factor == 1
-
-    if is_width_sharded:
-        sram_b_mem = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.BufferType.L1,
-            ttnn.ShardSpec(
-                core_grid,
-                [sram_k_per_core * tile_w, sram_per_core_N * tile_w],
-                ttnn.ShardOrientation.ROW_MAJOR,
-            ),
-        )
-    else:
-        sram_b_mem = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            ttnn.ShardSpec(
-                core_grid,
-                [sram_k_per_core * tile_w, sram_per_core_N * tile_w],
-                ttnn.ShardOrientation.ROW_MAJOR,
-            ),
-        )
-
-    def _shuffle_assignment_per_device(asg_per_dev: np.ndarray) -> np.ndarray:
-        """Reorder a (K_tiles, N_tiles) per-device BSPM assignment to match the
-        per-core layout. For WIDTH_SHARDED (K replicated), the per-device
-        assignment IS the logical layout; no shuffle. For HEIGHT_SHARDED, fold
-        the (k_slice, n_slice) shards cat-along-K."""
-        if is_width_sharded:
-            return asg_per_dev
-        shards = []
-        for i in range(num_sram_cores):
-            k_idx = i // sram_n_parallel
-            n_idx = i % sram_n_parallel
-            k_start = k_idx * sram_k_per_core
-            k_end = k_start + sram_k_per_core
-            n_start = n_idx * sram_per_core_N
-            n_end = n_start + sram_per_core_N
-            shards.append(asg_per_dev[k_start:k_end, n_start:n_end])
-        return np.concatenate(shards, axis=0)
-
-    sram_cts = []
-    for eidx in sram_expert_ids:
-        per_dev_shards = []
-        for dev_idx in range(num_devices):
-            b_full = full_torch_weights_per_device[eidx][dev_idx]
-            if is_width_sharded:
-                # Per-device data is already (K, N_full) = WIDTH_SHARDED logical
-                # shape. No reshuffling — the N-axis sharding across cores happens
-                # automatically when ttnn assigns the WIDTH_SHARDED memory_config.
-                per_dev_shards.append(b_full)
-            else:
-                # HEIGHT_SHARDED: slice into (k_slice, n_slice) per-core shards in
-                # row-major (k-major) ordering, cat along K to produce a single-device
-                # tensor of shape (num_cores × K_per_core, N_per_core).
-                shards = []
-                for i in range(num_sram_cores):
-                    k_idx = i // sram_n_parallel
-                    n_idx = i % sram_n_parallel
-                    k_start = k_idx * sram_k_per_core * tile_w
-                    k_end = k_start + sram_k_per_core * tile_w
-                    n_start = n_idx * sram_per_core_N * tile_w
-                    n_end = n_start + sram_per_core_N * tile_w
-                    shards.append(b_full[k_start:k_end, n_start:n_end])
-                per_dev_shards.append(torch.cat(shards, dim=0))
-        if is_width_sharded:
-            b_4d = torch.stack(per_dev_shards).reshape(
-                mesh_rows,
-                mesh_cols,
-                sram_k_per_core * tile_w,
-                num_sram_cores * sram_per_core_N * tile_w,
-            )
-        else:
-            b_4d = torch.stack(per_dev_shards).reshape(
-                mesh_rows,
-                mesh_cols,
-                num_sram_cores * sram_k_per_core * tile_w,
-                sram_per_core_N * tile_w,
-            )
-        if per_expert_assignment_per_device is not None:
-            asg_per_dev_list = per_expert_assignment_per_device[eidx]
-            shuffled = [_shuffle_assignment_per_device(asg) for asg in asg_per_dev_list]
-            # WIDTH_SHARDED: stack per-device assignments along W (no K-fold).
-            # HEIGHT_SHARDED: stack along H (matches the cat-along-K weight shuffle).
-            full_assignment = np.concatenate(shuffled, axis=(1 if is_width_sharded else 0))
-            ct = CompressedTensor(
-                b_4d,
-                full_assignment,
-                device=mesh_device,
-                memory_config=sram_b_mem,
-                per_core_allocation=True,
-                mesh_mapper_config=ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)]),
-            )
-        else:
-            ct = CompressedTensor.from_torch(
-                b_4d,
-                assigner,
-                device=mesh_device,
-                memory_config=sram_b_mem,
-                per_core_allocation=True,
-                mesh_mapper_config=ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)]),
-            )
-        sram_cts.append(ct)
-    return sram_cts
 
 
 def prepare_attention_weights(
@@ -1935,6 +1744,97 @@ def prepare_routed_expert_weights(
         )
 
 
+def _build_dense_sram_routed_weights(
+    device,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    sram_expert_ids: list[int],
+) -> tuple[list, list, list]:
+    """Build SRAM-resident gate/up/down CompressedTensors for dense-MLP chunks.
+
+    Dense layers split their MLP into a shared portion (first MOE_INTERMEDIATE_SIZE
+    cols/rows) + 8 routed-equivalent chunks. ``sram_expert_ids`` selects which chunks
+    go to SRAM by chunk index [0..7]; each chunk has the same shape as a MoE routed
+    expert, so the SRAM weight layout matches the MoE SRAM path exactly.
+
+    Uniform BFP4 (no BSPM) — dense path uses the same uniform assignment as the
+    DRAM dense build (prepare_dense_routed_experts_compressed_tp8).
+    """
+    if not sram_expert_ids:
+        return [], [], []
+
+    from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+    from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
+    from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RE
+    from models.demos.deepseek_v3_b1.weights.sram_slots import build_sram_routed_proj_cts
+
+    moe_tp = device.shape[0] * device.shape[1]
+    N_per_dev = _RE.GATE_PROJ_N // moe_tp
+    K_per_dev_down = _RE.GATE_PROJ_N // moe_tp
+    tile_w = _RE.TILE_W
+    _dn_shared = D.MOE_INTERMEDIATE_SIZE
+    _dn_expert_n = D.MOE_INTERMEDIATE_SIZE
+
+    a_cores, b_cores = SharedExpertOp.build_ab_grids()
+    sram_gate_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in a_cores])
+    sram_up_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in b_cores])
+    sram_down_core_grid = DownProj.build_matmul_core_grid()
+
+    _sram_per_core_N = (N_per_dev // tile_w) // 8
+    _sram_down_per_core_N = (_RE.K // tile_w) // DownProj.NUM_MATMUL_CORES
+
+    def _per_device_gate_up_dense(proj_name: str) -> dict[int, list[torch.Tensor]]:
+        full_kn = state_dict[_key(layer_idx, f"mlp.{proj_name}.weight")].T.contiguous()  # (K, N_full)
+        out: dict[int, list[torch.Tensor]] = {}
+        for chunk_idx in sram_expert_ids:
+            start = _dn_shared + chunk_idx * _dn_expert_n
+            end = start + _dn_expert_n
+            chunk_kn = full_kn[:, start:end].contiguous()  # (K, _dn_expert_n)
+            out[chunk_idx] = [chunk_kn[:, d * N_per_dev : (d + 1) * N_per_dev].contiguous() for d in range(moe_tp)]
+        return out
+
+    def _per_device_down_dense() -> dict[int, list[torch.Tensor]]:
+        full_kn = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()  # (K_full, N_HIDDEN)
+        out: dict[int, list[torch.Tensor]] = {}
+        for chunk_idx in sram_expert_ids:
+            start = _dn_shared + chunk_idx * _dn_expert_n
+            end = start + _dn_expert_n
+            chunk_kn = full_kn[start:end, :].contiguous()  # (_dn_expert_n, N_HIDDEN)
+            out[chunk_idx] = [
+                chunk_kn[d * K_per_dev_down : (d + 1) * K_per_dev_down, :].contiguous() for d in range(moe_tp)
+            ]
+        return out
+
+    sram_gate = build_sram_routed_proj_cts(
+        mesh_device=device,
+        sram_expert_ids=sram_expert_ids,
+        full_torch_weights_per_device=_per_device_gate_up_dense("gate_proj"),
+        core_grid=sram_gate_core_grid,
+        num_tiles_k=(_RE.K // tile_w) // 8,
+        n_parallel=8,
+        per_core_N=_sram_per_core_N,
+    )
+    sram_up = build_sram_routed_proj_cts(
+        mesh_device=device,
+        sram_expert_ids=sram_expert_ids,
+        full_torch_weights_per_device=_per_device_gate_up_dense("up_proj"),
+        core_grid=sram_up_core_grid,
+        num_tiles_k=(_RE.K // tile_w) // 8,
+        n_parallel=8,
+        per_core_N=_sram_per_core_N,
+    )
+    sram_down = build_sram_routed_proj_cts(
+        mesh_device=device,
+        sram_expert_ids=sram_expert_ids,
+        full_torch_weights_per_device=_per_device_down_dense(),
+        core_grid=sram_down_core_grid,
+        num_tiles_k=K_per_dev_down // tile_w,
+        n_parallel=DownProj.NUM_MATMUL_CORES,
+        per_core_N=_sram_down_per_core_N,
+    )
+    return sram_gate, sram_up, sram_down
+
+
 def prepare_dense_layer_weights(
     device,
     state_dict: dict[str, torch.Tensor],
@@ -2022,272 +1922,6 @@ _COMBINED_ATTN_SRAM_CAP_BYTES = 960 * 1024
 _SHARED_EXPERT_FIELDS = ("shared_gate_proj", "shared_up_proj", "shared_down_proj")
 
 
-def _build_moe_sram_routed_weights(
-    device,
-    state_dict: dict[str, torch.Tensor],
-    layer_idx: int,
-    sram_expert_ids: list[int],
-    *,
-    bspm_path: Path | None = None,
-) -> tuple[list, list, list]:
-    """Build SRAM-resident gate/up/down CompressedTensors for the given routed expert IDs.
-
-    Mirrors the SRAM-build path in test_moe_mlp.create_routed_expert_tensors and
-    the DRAM BSPM resolution in prepare_moe_routed_experts_bspm_tp8. Sources HF
-    weights from state_dict, per-device shards for TP8, and feeds each slot
-    through build_sram_expert_weights.
-
-    ``bspm_path``: when provided (and the file exists), the per-tile precision
-    map for each expert/projection is sliced per-device and fed to
-    ``build_sram_expert_weights`` so the SRAM CT carries the same BSPM bit
-    pattern as the DRAM CT for the same expert. When ``None``, falls back to
-    uniform BFP4 — matching the DRAM fallback path.
-
-    Returns (sram_gate_list, sram_up_list, sram_down_list), each of length T in slot
-    order. Empty lists when sram_expert_ids is empty.
-    """
-    if not sram_expert_ids:
-        return [], [], []
-
-    # Local imports to avoid prepare.py → fused_ops circular dependency at module load.
-    from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
-    from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
-    from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
-    from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RE
-
-    moe_tp = device.shape[0] * device.shape[1]
-    N_per_dev = _RE.GATE_PROJ_N // moe_tp  # column-shard for gate/up
-    K_per_dev_down = _RE.GATE_PROJ_N // moe_tp  # row-shard for down (K-dim)
-    tile_w = _RE.TILE_W
-
-    a_cores, b_cores = SharedExpertOp.build_ab_grids()
-    sram_gate_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in a_cores])
-    sram_up_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in b_cores])
-    sram_down_core_grid = DownProj.build_matmul_core_grid()  # 112 cores
-
-    _sram_per_core_N = (N_per_dev // tile_w) // 8  # gate/up: 1 N-tile per core at TP8
-    _sram_down_per_core_N = (_RE.K // tile_w) // DownProj.NUM_MATMUL_CORES  # down: 2 tiles per core
-
-    assigner = CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"])
-
-    # BSPM resolution — mirrors prepare_moe_routed_experts_bspm_tp8.
-    bspm_data = None
-    if bspm_path is not None:
-        bspm_path = Path(bspm_path)
-        if not bspm_path.exists():
-            raise FileNotFoundError(
-                f"BSPM file required for SRAM-resident experts at layer {layer_idx} but not found: {bspm_path}. "
-                f"Pass bspm_dir=None to use uniform BFP4 fallback."
-            )
-        logger.info("Loading BSPM for SRAM experts at layer {}: {}", layer_idx, bspm_path)
-        bspm_data = load_bspm_for_layer(str(bspm_path))
-
-    def _full_bspm_assignment_per_expert(proj_idx: int, N_full: int, K_full: int) -> dict[int, np.ndarray] | None:
-        """Return (K_tiles, N_tiles_padded) BSPM assignment for each SRAM expert,
-        or None when BSPM is disabled."""
-        if bspm_data is None:
-            return None
-        num_banks = device.dram_grid_size().x
-        N_padded_full = ((N_full + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
-        tiles_h_full = K_full // tile_w
-        tiles_w_full_padded = N_padded_full // tile_w
-        out: dict[int, np.ndarray] = {}
-        for eid in sram_expert_ids:
-            if eid >= bspm_data["n_experts"]:
-                raise ValueError(f"SRAM expert {eid} out of range for BSPM (n_experts={bspm_data['n_experts']})")
-            out[eid] = np.ascontiguousarray(
-                bspm_data["codes"][eid, proj_idx].reshape(tiles_w_full_padded, tiles_h_full).T
-            )
-        return out
-
-    def _slice_assignment_per_device(
-        full_per_expert: dict[int, np.ndarray] | None,
-        shard_dim: int,
-        per_dev_tiles: int,
-    ) -> dict[int, list[np.ndarray]] | None:
-        """Slice each (K_tiles, N_tiles_padded) full-tensor assignment along
-        ``shard_dim`` (0=K, 1=N) into per-device chunks. Drops BSPM padding
-        in the cross-shard direction so it matches the per-device weight grid."""
-        if full_per_expert is None:
-            return None
-        out: dict[int, list[np.ndarray]] = {}
-        for eid, full in full_per_expert.items():
-            per_dev = []
-            for d in range(moe_tp):
-                if shard_dim == 1:
-                    per_dev.append(np.ascontiguousarray(full[:, d * per_dev_tiles : (d + 1) * per_dev_tiles]))
-                else:
-                    per_dev.append(np.ascontiguousarray(full[d * per_dev_tiles : (d + 1) * per_dev_tiles, :]))
-            out[eid] = per_dev
-        return out
-
-    def _per_device_gate_up(weight_key: str) -> dict[int, list[torch.Tensor]]:
-        out: dict[int, list[torch.Tensor]] = {}
-        for eid in sram_expert_ids:
-            w = state_dict[_key(layer_idx, f"mlp.experts.{eid}.{weight_key}")]
-            # HF shape (GATE_PROJ_N, K) → (K, GATE_PROJ_N), then column-shard N across devices.
-            w_kn = w.T.contiguous().reshape(_RE.K, _RE.GATE_PROJ_N)
-            out[eid] = [w_kn[:, d * N_per_dev : (d + 1) * N_per_dev].contiguous() for d in range(moe_tp)]
-        return out
-
-    def _per_device_down() -> dict[int, list[torch.Tensor]]:
-        out: dict[int, list[torch.Tensor]] = {}
-        for eid in sram_expert_ids:
-            w = state_dict[_key(layer_idx, f"mlp.experts.{eid}.down_proj.weight")]
-            # HF shape (K, GATE_PROJ_N) → (GATE_PROJ_N, K), then row-shard K-dim across devices.
-            w_kn = w.T.contiguous().reshape(_RE.GATE_PROJ_N, _RE.K)
-            out[eid] = [w_kn[d * K_per_dev_down : (d + 1) * K_per_dev_down, :].contiguous() for d in range(moe_tp)]
-        return out
-
-    # gate_proj_idx=0, up_proj_idx=1, down_proj_idx=2 (matches prepare_moe_routed_experts_bspm_tp8 proj_specs).
-    gate_asg = _slice_assignment_per_device(
-        _full_bspm_assignment_per_expert(0, _RE.GATE_PROJ_N, _RE.K),
-        shard_dim=1,
-        per_dev_tiles=N_per_dev // tile_w,
-    )
-    up_asg = _slice_assignment_per_device(
-        _full_bspm_assignment_per_expert(1, _RE.GATE_PROJ_N, _RE.K),
-        shard_dim=1,
-        per_dev_tiles=N_per_dev // tile_w,
-    )
-    down_asg = _slice_assignment_per_device(
-        _full_bspm_assignment_per_expert(2, _RE.K, _RE.GATE_PROJ_N),
-        shard_dim=0,
-        per_dev_tiles=K_per_dev_down // tile_w,
-    )
-
-    sram_gate = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_gate_up("gate_proj.weight"),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_gate_core_grid,
-        sram_k_per_core=(_RE.K // tile_w) // 8,
-        sram_n_parallel=8,
-        sram_per_core_N=_sram_per_core_N,
-        per_expert_assignment_per_device=gate_asg,
-    )
-    sram_up = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_gate_up("up_proj.weight"),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_up_core_grid,
-        sram_k_per_core=(_RE.K // tile_w) // 8,
-        sram_n_parallel=8,
-        sram_per_core_N=_sram_per_core_N,
-        per_expert_assignment_per_device=up_asg,
-    )
-    sram_down = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_down(),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_down_core_grid,
-        sram_k_per_core=K_per_dev_down // tile_w,
-        sram_n_parallel=DownProj.NUM_MATMUL_CORES,
-        sram_per_core_N=_sram_down_per_core_N,
-        per_expert_assignment_per_device=down_asg,
-    )
-    return sram_gate, sram_up, sram_down
-
-
-def _build_dense_sram_routed_weights(
-    device,
-    state_dict: dict[str, torch.Tensor],
-    layer_idx: int,
-    sram_expert_ids: list[int],
-) -> tuple[list, list, list]:
-    """Build SRAM-resident gate/up/down CompressedTensors for dense-MLP chunks.
-
-    Dense layers split their MLP into a shared portion (first MOE_INTERMEDIATE_SIZE
-    cols/rows) + 8 routed-equivalent chunks. ``sram_expert_ids`` selects which chunks
-    go to SRAM by chunk index [0..7]; each chunk has the same shape as a MoE routed
-    expert, so the SRAM weight layout matches the MoE SRAM path exactly.
-
-    Uniform BFP4 (no BSPM) — dense path uses the same uniform assignment as the
-    DRAM dense build (prepare_dense_routed_experts_compressed_tp8).
-    """
-    if not sram_expert_ids:
-        return [], [], []
-
-    from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
-    from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
-    from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
-    from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RE
-
-    moe_tp = device.shape[0] * device.shape[1]
-    N_per_dev = _RE.GATE_PROJ_N // moe_tp
-    K_per_dev_down = _RE.GATE_PROJ_N // moe_tp
-    tile_w = _RE.TILE_W
-    _dn_shared = D.MOE_INTERMEDIATE_SIZE
-    _dn_expert_n = D.MOE_INTERMEDIATE_SIZE
-
-    a_cores, b_cores = SharedExpertOp.build_ab_grids()
-    sram_gate_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in a_cores])
-    sram_up_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in b_cores])
-    sram_down_core_grid = DownProj.build_matmul_core_grid()
-
-    _sram_per_core_N = (N_per_dev // tile_w) // 8
-    _sram_down_per_core_N = (_RE.K // tile_w) // DownProj.NUM_MATMUL_CORES
-
-    assigner = CompressedTensorAssigner(metric="pcc", threshold=0.993, formats=["bfp4"])
-
-    def _per_device_gate_up_dense(proj_name: str) -> dict[int, list[torch.Tensor]]:
-        full_kn = state_dict[_key(layer_idx, f"mlp.{proj_name}.weight")].T.contiguous()  # (K, N_full)
-        out: dict[int, list[torch.Tensor]] = {}
-        for chunk_idx in sram_expert_ids:
-            start = _dn_shared + chunk_idx * _dn_expert_n
-            end = start + _dn_expert_n
-            chunk_kn = full_kn[:, start:end].contiguous()  # (K, _dn_expert_n)
-            out[chunk_idx] = [chunk_kn[:, d * N_per_dev : (d + 1) * N_per_dev].contiguous() for d in range(moe_tp)]
-        return out
-
-    def _per_device_down_dense() -> dict[int, list[torch.Tensor]]:
-        full_kn = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()  # (K_full, N_HIDDEN)
-        out: dict[int, list[torch.Tensor]] = {}
-        for chunk_idx in sram_expert_ids:
-            start = _dn_shared + chunk_idx * _dn_expert_n
-            end = start + _dn_expert_n
-            chunk_kn = full_kn[start:end, :].contiguous()  # (_dn_expert_n, N_HIDDEN)
-            out[chunk_idx] = [
-                chunk_kn[d * K_per_dev_down : (d + 1) * K_per_dev_down, :].contiguous() for d in range(moe_tp)
-            ]
-        return out
-
-    sram_gate = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_gate_up_dense("gate_proj"),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_gate_core_grid,
-        sram_k_per_core=(_RE.K // tile_w) // 8,
-        sram_n_parallel=8,
-        sram_per_core_N=_sram_per_core_N,
-    )
-    sram_up = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_gate_up_dense("up_proj"),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_up_core_grid,
-        sram_k_per_core=(_RE.K // tile_w) // 8,
-        sram_n_parallel=8,
-        sram_per_core_N=_sram_per_core_N,
-    )
-    sram_down = build_sram_expert_weights(
-        sram_expert_ids=sram_expert_ids,
-        full_torch_weights_per_device=_per_device_down_dense(),
-        assigner=assigner,
-        mesh_device=device,
-        core_grid=sram_down_core_grid,
-        sram_k_per_core=K_per_dev_down // tile_w,
-        sram_n_parallel=DownProj.NUM_MATMUL_CORES,
-        sram_per_core_N=_sram_down_per_core_N,
-    )
-    return sram_gate, sram_up, sram_down
-
-
 def prepare_moe_layer_weights(
     device,
     state_dict: dict[str, torch.Tensor],
@@ -2299,9 +1933,9 @@ def prepare_moe_layer_weights(
     bspm_dir: Path | None = None,
     bspm_variant: BspmVariant = BspmVariant.B,
     bspm_budget: float = 3.5,
+    enable_sram_bspm: bool = False,
     sram_hot_experts: SramHotExpertConfig | None = None,
     sram_core_grids: SramExpertCoreGrids | None = None,
-    sram_assigner: CompressedTensorAssigner | None = None,
     worker_l1_size: int | None = None,
     combined_attn_sram_cap_bytes: int = _COMBINED_ATTN_SRAM_CAP_BYTES,
     compressed_tp8: bool = False,
@@ -2341,6 +1975,13 @@ def prepare_moe_layer_weights(
     matmul pipeline (sram_gate_proj/up_proj/down_proj fields on the returned
     weights object). Independent of ``sram_hot_experts`` — both paths can be
     populated simultaneously to feed both abstractions.
+
+    ``enable_sram_bspm``: when True, SRAM-resident routed experts use the same
+    BSPM tile-format map as the DRAM path (sourced from ``bspm_dir``); requires
+    ``bspm_dir`` to be set.  When False (default), SRAM experts use uniform
+    BFP4 regardless of ``bspm_dir`` — this preserves the LLK plain custom_mm
+    fast path and per-device-uniform SRAM weight CB sizes assumed by the
+    replicated cb_config tensor.  Independent of DRAM BSPM enablement.
     """
     logger.info("Preparing MoE layer {}...", layer_idx)
     t0 = time.perf_counter()
@@ -2368,16 +2009,30 @@ def prepare_moe_layer_weights(
         bspm_budget=bspm_budget,
         compressed_tp8=compressed_tp8,
     )
-    # SRAM uses uniform BFP4 regardless of bspm_dir. DRAM uses BSPM (resolved
-    # inside prepare_routed_expert_weights above). Decoupling keeps L1 SRAM
-    # weight CBs at deterministic per-device sizes — needed by the replicated
-    # cb_config tensor (see project_reconfig_cb_per_device_addrs.md).
-    sram_gate, sram_up, sram_down = _build_moe_sram_routed_weights(
-        device,
-        state_dict,
-        layer_idx,
-        list(sram_expert_ids),
-    )
+    # SRAM BSPM is opt-in via enable_sram_bspm — independent of DRAM BSPM
+    # (which is always on when bspm_dir is set, resolved inside
+    # prepare_routed_expert_weights above).  When False (default), SRAM uses
+    # uniform BFP4 so L1 SRAM weight CBs stay deterministic per-device —
+    # needed by the replicated cb_config tensor (see
+    # project_reconfig_cb_per_device_addrs.md).  When True, the BSPM file
+    # is resolved the same way the DRAM path resolves it.
+    sram_bspm_path: Path | None = None
+    if enable_sram_bspm:
+        assert bspm_dir is not None, (
+            "enable_sram_bspm=True requires bspm_dir to be set (BSPM source). "
+            "Pass enable_sram_bspm=False to use uniform BFP4 for SRAM experts."
+        )
+        sram_bspm_path = (
+            Path(bspm_dir)
+            / f"layer_{layer_idx}"
+            / "precision_eval"
+            / f"precision_map_{bspm_variant}_{bspm_budget:.1f}.bspm"
+        )
+    # Explicit-list SRAM build is now ALSO handled via prepare_compressed_sram_slots
+    # below (unified path).  Starts empty here; populated post-sram_slots-call.
+    sram_gate: list = []
+    sram_up: list = []
+    sram_down: list = []
     assert isinstance(attn.gate_mm, OverlappedTensor)
     assert attn.gate_bias is not None
     assert isinstance(routed, MoERoutedExpertWeights)
@@ -2407,18 +2062,26 @@ def prepare_moe_layer_weights(
         sram_down_proj=sram_down,
     )
 
-    # Skip sram_slots build when caller passed an explicit ``sram_expert_ids``:
-    # the kernel pipeline already allocated weights for the override list above
-    # via ``_build_moe_sram_routed_weights``, and building sram_slots from
-    # ``sram_hot_experts`` would double-allocate per-core L1 for a *different*
-    # expert set. Override wins; sram_slots only builds when nothing was passed
-    # so the "default" path can derive its expert list from L1-fit-truncated
-    # ``sram_slots.slot_experts``.
+    # Unified SRAM build path: BOTH explicit-list and auto-fit route through
+    # prepare_compressed_sram_slots.  Explicit list uses no-trim boundary
+    # (allocate all requested experts); auto-fit uses address-budget trim.
     sram_expert_indices = (sram_hot_experts or {}).get(layer_idx)
-    if sram_expert_indices and not sram_expert_ids:
-        assert sram_core_grids is not None, "sram_core_grids required when sram_hot_experts specifies this layer"
-        assert sram_assigner is not None, "sram_assigner required when sram_hot_experts specifies this layer"
-        assert worker_l1_size is not None, "worker_l1_size required when sram_hot_experts specifies this layer"
+    _explicit_sram_ids = list(sram_expert_ids) if sram_expert_ids else None
+    _should_run_sram_slots = (sram_expert_indices and not sram_expert_ids) or _explicit_sram_ids is not None
+    if _should_run_sram_slots:
+        # Fill missing kwargs with sensible defaults for the explicit-list case
+        # (callers like test_decoder_block's rigged_groupsN scenarios don't pass them).
+        if sram_core_grids is None:
+            from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import SramExpertCoreGrids as _SECG
+
+            sram_core_grids = _SECG.shared_expert_mirror()
+        if worker_l1_size is None:
+            # Explicit-list scenarios may omit worker_l1_size since they use a
+            # no-trim boundary; derive from device for the trim-budget call.
+            assert (
+                _explicit_sram_ids is not None
+            ), "worker_l1_size required when running auto-fit (use explicit sram_expert_ids for no-trim)"
+            worker_l1_size = ttnn.get_memory_view(device, ttnn.BufferType.L1).total_bytes_per_bank
 
         # Attn-first regime: stage attention's L1 lockstep tensors on device
         # *now* so the SRAM trim sees real allocator addresses for them.
@@ -2474,13 +2137,32 @@ def prepare_moe_layer_weights(
             below_cap_reserve,
         )
 
+        # BSPM available → load .bspm and slice per (expert, projection).
+        # Otherwise → uniform BFP4.  Same allocator path either way.
+        _sram_bspm_assignment_provider = make_sram_assignment_provider(
+            bspm_path=sram_bspm_path,
+            num_banks=device.dram_grid_size().x,
+            layer_idx=layer_idx,
+            tile_w=_RoutedExpert.TILE_W,
+        )
+
+        # Explicit-list scenarios override `initial_expert_indices` and use a
+        # no-trim boundary (allocator's own floor) so every requested expert
+        # is allocated regardless of L1 fit prediction.
+        if _explicit_sram_ids is not None:
+            _slot_initial_indices = _explicit_sram_ids
+            _slot_boundary = ttnn.get_allocator_base_address(device, ttnn.BufferType.L1)
+        else:
+            _slot_initial_indices = sram_expert_indices
+            _slot_boundary = boundary_addr
+
         sram_slots = prepare_compressed_sram_slots(
             device=device,
             state_dict=state_dict,
             layer_idx=layer_idx,
-            initial_expert_indices=sram_expert_indices,
+            initial_expert_indices=_slot_initial_indices,
             core_grids=sram_core_grids,
-            assigner=sram_assigner,
+            assignment_provider=_sram_bspm_assignment_provider,
             # SRAM slots are per-core L1 CompressedTensors and must be
             # allocated directly on device; there is no host-stage path
             # (two_phase_upload carries them through unchanged via the
@@ -2488,27 +2170,19 @@ def prepare_moe_layer_weights(
             # independent of `move_to_device`, which controls the DRAM
             # weight path.
             move_to_device=True,
-            boundary_addr=boundary_addr,
+            boundary_addr=_slot_boundary,
             initial_lowest_addr=attn_lowest_addr,
             l1_top_addr=l1_top_addr,
             cache_config=cache_config,
         )
         result = _dataclass_replace(result, sram_slots=sram_slots)
 
-        # If the caller didn't pass an explicit `sram_expert_ids`, alias the
-        # kernel-pipeline weight fields directly to the per-core L1 CTs that
-        # `prepare_compressed_sram_slots` already allocated.
-        # Layout compatibility:
-        #   gate/up: both paths produce HEIGHT_SHARDED `(K/k_par, N/n_par)` per
-        #            core on 64 cores. Identical metadata, alias is a no-op cast.
-        #   down:    both paths now produce WIDTH_SHARDED `(K, N_full/num_cores)`
-        #            per core on 112 cores. Identical metadata (after the
-        #            `build_sram_expert_weights` WIDTH_SHARDED branch).
-        # Single-allocation: kernel reads `sram_slots.*_proj` directly; no
-        # rebuild via `_build_moe_sram_routed_weights`. The empty-list call to
-        # `_build_moe_sram_routed_weights` at the top of `prepare_moe_layer_weights`
-        # early-returned ([],[],[]) so this aliasing is the first population.
-        if not sram_expert_ids and sram_slots.num_slots > 0:
+        # Alias the kernel-pipeline weight fields directly to the per-core L1
+        # CTs that `prepare_compressed_sram_slots` already allocated.  Layout:
+        # gate/up HEIGHT_SHARDED (K/k_par, N/n_par) on 64 cores;
+        # down WIDTH_SHARDED (K, N_full/num_cores) on 112 cores.  Single-
+        # allocation: kernel reads `sram_slots.*_proj` directly.
+        if sram_slots.num_slots > 0:
             result = _dataclass_replace(
                 result,
                 sram_gate_proj=sram_slots.gate_proj,

--- a/models/demos/deepseek_v3_b1/weights/sram_slots.py
+++ b/models/demos/deepseek_v3_b1/weights/sram_slots.py
@@ -7,9 +7,10 @@
 This module owns everything that turns a ranked candidate list of routed
 experts into a populated :class:`SramCompressedExpertSlots` on device:
 
-  * the four per-projection per-core L1 ``CompressedTensor`` builders
-    (``_build_l1_compressed_tensor*``) plus the cache-vs-direct dispatcher
-    :func:`_route_l1_compressed_tensor`,
+  * the per-projection per-core L1 ``CompressedTensor`` builder
+    :func:`build_sram_routed_proj_ct` (with batch wrapper
+    :func:`build_sram_routed_proj_cts`) — includes the optional disk-cache
+    dispatch via :func:`get_or_create_sram_compressed_expert`,
   * the address-based trim machinery (:func:`_compute_sram_trim_budget`,
     :func:`_refresh_lowest_addr_from_alloc`, the per-core L1 footprint /
     lowest-address introspection helpers),
@@ -40,20 +41,19 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensor, CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.compressed_tensor import BFP_MANT_BITS, CompressedTensor
+from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import bfp_tile_packed_size
 from models.demos.deepseek_v3_b1.weights.cache import CacheConfig, SourceTensorSelection, SramCompressedTensorTarget
 from models.demos.deepseek_v3_b1.weights.cache.sram_compressed_cache import (
-    assigner_fingerprint,
     get_or_create_sram_compressed_expert,
     to_canonical_mesh_mapper,
 )
 from models.demos.deepseek_v3_b1.weights.overlap.spec import _core_list
-from models.demos.deepseek_v3_b1.weights.transforms.moe import preprocess_gate_up, shared_down_torch_for_cache
+from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 from models.demos.deepseek_v3_b1.weights.transforms.sram_experts import (
     SramExpertCoreGrids,
-    _MemoryConfigSpec,
     _predict_expert_per_core_bytes,
-    sram_projection_specs,
+    reduce_per_device_max,
 )
 
 
@@ -164,19 +164,6 @@ def per_core_l1_usage_on_cores(
     return per_core
 
 
-def max_per_core_l1_usage_on_cores(
-    tensors: list[Any],
-    target_cores: set[tuple[int, int]] | list[tuple[int, int]],
-) -> int:
-    """Max L1 bytes already reserved on any core in ``target_cores``.
-
-    Scalar wrapper around :func:`per_core_l1_usage_on_cores`; returns 0 when
-    no reservation touches ``target_cores``.
-    """
-    per_core = per_core_l1_usage_on_cores(tensors, target_cores)
-    return max(per_core.values(), default=0)
-
-
 def per_core_l1_lowest_addr_on_cores(
     tensors: list[Any],
     target_cores: set[tuple[int, int]] | list[tuple[int, int]],
@@ -241,158 +228,6 @@ def per_core_l1_lowest_addr_on_cores(
 
 # ---------------------------------------------------------------------------
 # Per-core L1 CompressedTensor builders (cache-aware)
-# ---------------------------------------------------------------------------
-
-
-def _route_l1_compressed_tensor(
-    weight: torch.Tensor,
-    *,
-    memory_config,
-    per_core_allocation: bool,
-    mesh_mapper_config,
-    assigner: CompressedTensorAssigner | None = None,
-    assignment: np.ndarray | None = None,
-    device,
-    tile_hw: int,
-    cache_config: CacheConfig | None,
-    sram_cache_target_name: str | None,
-    sram_cache_source_keys: tuple[str, ...] | None,
-) -> CompressedTensor:
-    """Build one per-core L1 CompressedTensor, optionally routing through the SRAM disk cache.
-
-    When ``cache_config`` is a :class:`TensorCache`-backed config and a
-    cache target name + source keys are provided, the call is dispatched to
-    :func:`get_or_create_sram_compressed_expert` — warm runs hydrate the
-    CompressedTensor from a content-addressed object on disk and skip the
-    BFP pack pipeline entirely.  Otherwise, falls back to the legacy direct
-    construction (``CompressedTensor.from_torch`` / ``from_bspm``) so
-    behaviour is unchanged when no cache is wired in.
-    """
-    assert (assigner is None) != (assignment is None), "Provide exactly one of assigner / assignment"
-    use_cache = cache_config is not None and sram_cache_target_name is not None and sram_cache_source_keys is not None
-    if not use_cache:
-        # Direct cold construction — preserves pre-cache behaviour for
-        # callers that don't wire in a CacheConfig (unit tests, ephemeral
-        # paths).  Mirrors the original ``_build_l1_compressed_tensor*``
-        # branches; the BSPM path here historically does **not** request
-        # ``per_core_allocation`` / ``mesh_mapper_config`` (TP=1 only),
-        # so we keep that quirk here.
-        if assigner is not None:
-            return CompressedTensor.from_torch(
-                weight.float(),
-                assigner,
-                device=device,
-                memory_config=memory_config,
-                per_core_allocation=per_core_allocation,
-                mesh_mapper_config=mesh_mapper_config,
-            )
-        return CompressedTensor.from_bspm(
-            weight.float(),
-            assignment,
-            device=device,
-            memory_config=memory_config,
-        )
-
-    target = SramCompressedTensorTarget(
-        name=sram_cache_target_name,
-        tensor_shape=tuple(int(d) for d in weight.shape),
-        tile_hw=tile_hw,
-        memory_config=memory_config,
-        per_core_allocation=per_core_allocation,
-        mesh_mapper_config=to_canonical_mesh_mapper(mesh_mapper_config),
-        assigner_fingerprint=assigner_fingerprint(assigner) if assigner is not None else "",
-        assignment_hash=hashlib.sha256(np.ascontiguousarray(assignment).tobytes()).hexdigest()[:16]
-        if assignment is not None
-        else "",
-    )
-    fp = cache_config.context.fingerprint(
-        source=SourceTensorSelection(names=tuple(sram_cache_source_keys)),
-        target=target,
-    )
-    return get_or_create_sram_compressed_expert(
-        cache_config.cache,
-        fp,
-        device,
-        weight_provider=lambda w=weight: w,
-        assigner=assigner,
-        assignment=assignment,
-        memory_config=memory_config,
-        per_core_allocation=per_core_allocation,
-        mesh_mapper_config=mesh_mapper_config,
-        tile_hw=tile_hw,
-    )
-
-
-def _build_l1_compressed_tensor(
-    weight: torch.Tensor,
-    spec: _MemoryConfigSpec,
-    *,
-    assigner: CompressedTensorAssigner | None = None,
-    assignment: np.ndarray | None = None,
-    device=None,
-    mesh_mapper_config=None,
-    tile_hw: int = 32,
-    cache_config: CacheConfig | None = None,
-    sram_cache_target_name: str | None = None,
-    sram_cache_source_keys: tuple[str, ...] | None = None,
-) -> CompressedTensor:
-    """Create a single per-core L1 CompressedTensor for one expert projection.
-
-    The ``(layout, core_range_set, shard_shape)`` decision lives on
-    ``spec``: WIDTH_SHARDED with auto-derived ``(K, N // num_cores)`` for
-    the TP=1 fallback (legacy gate/up/down), HEIGHT_SHARDED with explicit
-    ``(sh, sw)`` for the shared-expert TP>1 gate/up after
-    :func:`preprocess_gate_up`, and WIDTH_SHARDED with explicit
-    ``(K_per_dev, N_per_core)`` for the shared-expert TP>1 down after
-    :func:`shared_down_torch_for_cache`.  Exactly one of *assigner* or
-    *assignment* must be provided.
-
-    Args:
-        weight: Float weight tensor.  Shape varies with ``spec``:
-                * WIDTH_SHARDED auto-derive (``shard_shape=None``):
-                  ``(K, N)`` (2D) or
-                  ``(mesh_rows, mesh_cols, K_per_device, N_per_device)``
-                  (4D, mesh-pre-sharded).
-                * Explicit shard shape: 2D per-device tensor whose dims
-                  match the upstream preprocess (e.g. ``(num_cores * sh,
-                  sw)`` after :func:`preprocess_gate_up`, or
-                  ``(K_per_dev, N_down)`` after
-                  :func:`shared_down_torch_for_cache`).
-        spec: ``_MemoryConfigSpec`` describing the on-device layout.
-        assigner: ``CompressedTensorAssigner`` (mutually exclusive with *assignment*).
-        assignment: Pre-computed BSPM tile-level assignment array (mutually
-                    exclusive with *assigner*).
-        device: Device / mesh to allocate on (``None`` keeps host-only).
-        mesh_mapper_config: ``ttnn.MeshMapperConfig`` for multi-device.
-                            Only honoured on the assigner path; the BSPM
-                            path historically does not request multi-device
-                            sharding (TP=1 only).
-        tile_hw: Tile dimension for alignment check (default 32).
-    """
-    assert (assigner is None) != (assignment is None), "Provide exactly one of assigner or assignment"
-
-    mem_config = spec.materialize(weight, tile_hw=tile_hw)
-
-    return _route_l1_compressed_tensor(
-        weight,
-        memory_config=mem_config,
-        # per_core_allocation is on for the assigner path (mixed-precision
-        # needs per-core sizing) and off for the BSPM path (legacy
-        # single-device behaviour).
-        per_core_allocation=(assigner is not None),
-        mesh_mapper_config=mesh_mapper_config if assigner is not None else None,
-        assigner=assigner,
-        assignment=assignment,
-        device=device,
-        tile_hw=tile_hw,
-        cache_config=cache_config,
-        sram_cache_target_name=sram_cache_target_name,
-        sram_cache_source_keys=sram_cache_source_keys,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Address-based trim helpers
 # ---------------------------------------------------------------------------
 
 
@@ -467,128 +302,223 @@ def _refresh_lowest_addr_from_alloc(
                 curr_addr[c_xy] = new_addr
 
 
+def build_sram_routed_proj_cts(
+    mesh_device,
+    sram_expert_ids: list,
+    full_torch_weights_per_device: dict,
+    core_grid: ttnn.CoreRangeSet,
+    num_tiles_k: int,
+    n_parallel: int,
+    per_core_N: int,
+    *,
+    tile_w: int = 32,
+    assignment_per_expert: dict | None = None,
+    cache_config: CacheConfig | None = None,
+    cache_target_name_fn: "Callable[[int], str] | None" = None,
+    cache_source_keys_fn: "Callable[[int], tuple[str, ...]] | None" = None,
+) -> list[CompressedTensor]:
+    """Batch wrapper around :func:`build_sram_routed_proj_ct` for a list of experts.
+
+    Each slot's CT is built via :func:`build_sram_routed_proj_ct` with
+    ``is_cb_backing_expert=(slot_idx == 0)``.  When ``assignment_per_expert`` is
+    ``None``, every (expert, device) gets a uniform-BFP4 constant assignment
+    (BFP4 = index 1 in COMPRESSED_FORMATS); otherwise the per-(expert, device)
+    arrays come from the caller (e.g. BSPM file).
+
+    Optional per-slot disk cache identity: provide ``cache_config`` plus
+    ``cache_target_name_fn(eid) -> str`` and ``cache_source_keys_fn(eid) -> tuple``
+    to persist the post-pack byte buffers under a content-addressed key.
+    """
+    moe_tp = mesh_device.shape[0] * mesh_device.shape[1]
+    cts: list[CompressedTensor] = []
+    for slot_idx, eid in enumerate(sram_expert_ids):
+        weights = full_torch_weights_per_device[eid]
+        if assignment_per_expert is None:
+            per_dev_asgn = [
+                np.full((weights[d].shape[0] // tile_w, weights[d].shape[1] // tile_w), 1, dtype=np.int8)
+                for d in range(moe_tp)
+            ]
+        else:
+            per_dev_asgn = assignment_per_expert[eid]
+        cts.append(
+            build_sram_routed_proj_ct(
+                mesh_device=mesh_device,
+                full_torch_weight_per_device=weights,
+                core_grid=core_grid,
+                num_tiles_k=num_tiles_k,
+                n_parallel=n_parallel,
+                per_core_N=per_core_N,
+                is_cb_backing_expert=(slot_idx == 0),
+                bspm_assignment_per_device=per_dev_asgn,
+                tile_w=tile_w,
+                cache_config=cache_config,
+                cache_target_name=cache_target_name_fn(eid) if cache_target_name_fn else None,
+                cache_source_keys=cache_source_keys_fn(eid) if cache_source_keys_fn else None,
+            )
+        )
+    return cts
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
 
+def build_sram_routed_proj_ct(
+    *,
+    mesh_device,
+    full_torch_weight_per_device: list[torch.Tensor],
+    core_grid: ttnn.CoreRangeSet,
+    num_tiles_k: int,
+    n_parallel: int,
+    per_core_N: int,
+    is_cb_backing_expert: bool,
+    bspm_assignment_per_device: list[np.ndarray],
+    tile_w: int = 32,
+    cache_config: CacheConfig | None = None,
+    cache_target_name: str | None = None,
+    cache_source_keys: tuple[str, ...] | None = None,
+) -> CompressedTensor:
+    """Build one per-expert, per-projection SRAM L1 CompressedTensor.
+
+    Assignment-based: caller provides per-(device) tile assignment.  For
+    uniform-BFP4 the assignment is a constant array filled with the BFP4 format
+    index (= 1 in COMPRESSED_FORMATS); for BSPM the assignment comes from a
+    .bspm file.
+
+    Layout decision:
+      * ``k_parallel_factor = num_cores // n_parallel == 1`` → WIDTH_SHARDED
+        (down projection at TP8).
+      * else → HEIGHT_SHARDED with per-core shards stacked along H in row-major
+        ``(k_idx, n_idx)`` order (gate/up at TP8).
+
+    Disk cache: when ``cache_config`` is disk-backed AND ``cache_target_name`` +
+    ``cache_source_keys`` are provided, the post-pack byte buffers are persisted
+    so warm runs hydrate without re-packing.  Ephemeral cache configs and
+    missing cache identity → cold pack (no persistence).
+    """
+    assert bspm_assignment_per_device is not None, "assignment required"
+    num_sram_cores = len(ttnn.corerange_to_cores(core_grid))
+    assert num_sram_cores % n_parallel == 0
+    mesh_shape = mesh_device.shape
+    mesh_rows, mesh_cols = mesh_shape[0], mesh_shape[1]
+    num_devices = mesh_rows * mesh_cols
+    assert len(full_torch_weight_per_device) == num_devices
+
+    k_parallel_factor = num_sram_cores // n_parallel
+    is_width_sharded = k_parallel_factor == 1
+
+    if is_width_sharded:
+        sram_b_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                core_grid,
+                [num_tiles_k * tile_w, per_core_N * tile_w],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+    else:
+        sram_b_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                core_grid,
+                [num_tiles_k * tile_w, per_core_N * tile_w],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+    per_dev_shards = []
+    for dev_idx in range(num_devices):
+        b_full = full_torch_weight_per_device[dev_idx]
+        if is_width_sharded:
+            per_dev_shards.append(b_full)
+        else:
+            shards = []
+            for i in range(num_sram_cores):
+                k_idx = i // n_parallel
+                n_idx = i % n_parallel
+                k_start = k_idx * num_tiles_k * tile_w
+                k_end = k_start + num_tiles_k * tile_w
+                n_start = n_idx * per_core_N * tile_w
+                n_end = n_start + per_core_N * tile_w
+                shards.append(b_full[k_start:k_end, n_start:n_end])
+            per_dev_shards.append(torch.cat(shards, dim=0))
+
+    if is_width_sharded:
+        b_4d = torch.stack(per_dev_shards).reshape(
+            mesh_rows, mesh_cols, num_tiles_k * tile_w, num_sram_cores * per_core_N * tile_w
+        )
+    else:
+        b_4d = torch.stack(per_dev_shards).reshape(
+            mesh_rows, mesh_cols, num_sram_cores * num_tiles_k * tile_w, per_core_N * tile_w
+        )
+
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)])
+    min_shard_bytes = bfp_tile_packed_size(BFP_MANT_BITS["bfp4"], tile_w) if is_cb_backing_expert else 1
+
+    # Shuffle per-device assignment to match the per-core layout above.
+    shuffled = []
+    for asg_per_dev in bspm_assignment_per_device:
+        if is_width_sharded:
+            shuffled.append(asg_per_dev)
+        else:
+            parts = []
+            for i in range(num_sram_cores):
+                k_idx = i // n_parallel
+                n_idx = i % n_parallel
+                k_start = k_idx * num_tiles_k
+                k_end = k_start + num_tiles_k
+                n_start = n_idx * per_core_N
+                n_end = n_start + per_core_N
+                parts.append(asg_per_dev[k_start:k_end, n_start:n_end])
+            shuffled.append(np.concatenate(parts, axis=0))
+    full_assignment = np.concatenate(shuffled, axis=0)
+
+    use_cache = cache_config is not None and cache_target_name is not None and cache_source_keys is not None
+    if use_cache:
+        target = SramCompressedTensorTarget(
+            name=cache_target_name,
+            tensor_shape=tuple(int(d) for d in b_4d.shape),
+            tile_hw=tile_w,
+            memory_config=sram_b_mem,
+            per_core_allocation=True,
+            mesh_mapper_config=to_canonical_mesh_mapper(mesh_mapper_config),
+            assigner_fingerprint="",
+            assignment_hash=hashlib.sha256(np.ascontiguousarray(full_assignment).tobytes()).hexdigest()[:16],
+        )
+        fp = cache_config.context.fingerprint(
+            source=SourceTensorSelection(names=tuple(cache_source_keys)),
+            target=target,
+        )
+        return get_or_create_sram_compressed_expert(
+            cache_config.cache,
+            fp,
+            mesh_device,
+            weight_provider=lambda: b_4d,
+            assignment=full_assignment,
+            memory_config=sram_b_mem,
+            per_core_allocation=True,
+            mesh_mapper_config=mesh_mapper_config,
+            tile_hw=tile_w,
+            min_shard_bytes=min_shard_bytes,
+        )
+
+    return CompressedTensor(
+        b_4d,
+        full_assignment,
+        device=mesh_device,
+        memory_config=sram_b_mem,
+        per_core_allocation=True,
+        mesh_mapper_config=mesh_mapper_config,
+        min_shard_bytes=min_shard_bytes,
+    )
+
+
 def _key(layer_idx: int, suffix: str) -> str:
     """Build the HF state-dict key for a per-layer tensor."""
     return f"model.layers.{layer_idx}.{suffix}"
-
-
-def _shard_for_mesh(w: torch.Tensor, mesh_rows: int, mesh_cols: int) -> torch.Tensor:
-    """Reshape ``(K, N)`` -> ``(mesh_rows, mesh_cols, K/rows, N/cols)`` for TP>1.
-
-    Identity for TP=1; under multi-device meshes splits ``K`` along
-    ``mesh_rows`` and ``N`` along ``mesh_cols`` so a subsequent
-    ``mesh_mapper_config=[Shard(0), Shard(1)]`` walks the resulting 4D tensor
-    into per-device ``(K/rows, N/cols)`` slabs.  Used by the TP=1 fallback
-    builders (``_build_l1_compressed_tensor``); the TP>1 shared-expert paths
-    do their own preprocessing via ``preprocess_gate_up`` /
-    ``shared_down_torch_for_cache``.
-    """
-    if mesh_rows == 1 and mesh_cols == 1:
-        return w
-    K, N = w.shape
-    assert K % mesh_rows == 0, f"K ({K}) must be divisible by mesh_rows ({mesh_rows})"
-    assert N % mesh_cols == 0, f"N ({N}) must be divisible by mesh_cols ({mesh_cols})"
-    return w.reshape(mesh_rows, K // mesh_rows, mesh_cols, N // mesh_cols).permute(0, 2, 1, 3).contiguous()
-
-
-@dataclass(frozen=True)
-class _ProjBuildPlan:
-    """Per-projection build inputs for one expert in ``prepare_compressed_sram_slots``.
-
-    Bundles the ``(weight, spec, cache identity)`` tuple driving one
-    :func:`_build_l1_compressed_tensor` call.  :func:`_expert_build_plans`
-    returns three plans per expert (gate, up, down), hiding the TP>1 vs TP=1
-    layout split behind a single uniform call shape — the loop body in
-    :func:`prepare_compressed_sram_slots` no longer has to fork on layout.
-
-    Fields:
-      proj_idx: 0=gate, 1=up, 2=down — also the index ``assignment_provider``
-        is keyed on under TP=1.
-      weight: Already preprocessed for the chosen layout (``preprocess_gate_up``
-        output under TP>1 gate/up; ``shared_down_torch_for_cache`` output under
-        TP>1 down; ``_shard_for_mesh`` output under TP=1).
-      spec: :class:`_MemoryConfigSpec` describing the on-device layout
-        (``(layout, core_range_set, shard_shape)``).
-      cache_name / source_key: Per-projection cache identity (target name
-        plus the single HF state-dict key it consumes).
-      use_assignment_provider: When ``True`` and an ``assignment_provider`` is
-        wired into :func:`prepare_compressed_sram_slots`, that provider
-        supplies the assignment for this plan; otherwise the call falls back
-        to the shared ``assigner``.  Currently ``True`` only on the TP=1
-        fallback.
-    """
-
-    proj_idx: int
-    weight: torch.Tensor
-    spec: _MemoryConfigSpec
-    cache_name: str
-    source_key: str
-    use_assignment_provider: bool = False
-
-
-def _expert_build_plans(
-    *,
-    layer_idx: int,
-    expert_idx: int,
-    gate_full: torch.Tensor,
-    up_full: torch.Tensor,
-    down_raw: torch.Tensor,
-    gate_key: str,
-    up_key: str,
-    down_key: str,
-    grids: SramExpertCoreGrids,
-    use_shared_expert_layout: bool,
-    moe_tp: int,
-    mesh_rows: int,
-    mesh_cols: int,
-) -> tuple[_ProjBuildPlan, _ProjBuildPlan, _ProjBuildPlan]:
-    """Build the (gate, up, down) :class:`_ProjBuildPlan` triple for one expert.
-
-    The per-projection layout decision (``_MemoryConfigSpec`` per name) is
-    delegated to :func:`sram_projection_specs` -- single source of truth
-    shared with the cost predictor in
-    :mod:`models.demos.deepseek_v3_b1.weights.transforms.sram_experts`.
-    Weight preprocessing branches on TP layout: under TP>1 gate/up ride
-    :func:`preprocess_gate_up`'s reshuffle output and down rides
-    :func:`shared_down_torch_for_cache`; under TP=1 all three use the
-    :func:`_shard_for_mesh` mesh-presharding pre-pass.
-    """
-
-    def name(proj: str) -> str:
-        return f"sram_layer{layer_idx}_expert{expert_idx}_{proj}_proj"
-
-    specs = sram_projection_specs(grids, (mesh_rows, mesh_cols))
-    keys = {"gate": gate_key, "up": up_key, "down": down_key}
-
-    if use_shared_expert_layout:
-        pp = preprocess_gate_up(gate_full, up_full, moe_tp, mesh_rows, mesh_cols)
-        down_pp = shared_down_torch_for_cache(down_raw, moe_tp, (mesh_rows, mesh_cols))
-        weights = {"gate": pp["shared_gate_proj"], "up": pp["shared_up_proj"], "down": down_pp}
-        use_provider = False
-    else:
-        weights = {
-            "gate": _shard_for_mesh(gate_full, mesh_rows, mesh_cols),
-            "up": _shard_for_mesh(up_full, mesh_rows, mesh_cols),
-            "down": _shard_for_mesh(down_raw, mesh_rows, mesh_cols),
-        }
-        use_provider = True
-
-    return tuple(
-        _ProjBuildPlan(
-            proj_idx=i,
-            weight=weights[proj],
-            spec=specs[proj],
-            cache_name=name(proj),
-            source_key=keys[proj],
-            use_assignment_provider=use_provider,
-        )
-        for i, proj in enumerate(("gate", "up", "down"))
-    )
 
 
 def prepare_compressed_sram_slots(
@@ -597,12 +527,11 @@ def prepare_compressed_sram_slots(
     layer_idx: int,
     initial_expert_indices: list[int],
     core_grids: SramExpertCoreGrids,
-    assigner: CompressedTensorAssigner | None = None,
     *,
+    assignment_provider: Callable[[int, int], np.ndarray],
     boundary_addr: int,
     initial_lowest_addr: dict[tuple[int, int], int],
     l1_top_addr: int,
-    assignment_provider: Callable[[int, int], np.ndarray] | None = None,
     move_to_device: bool = True,
     tile_hw: int = 32,
     cache_config: CacheConfig | None = None,
@@ -665,7 +594,7 @@ def prepare_compressed_sram_slots(
         move_to_device: Whether to place tensors on device.
         tile_hw: Tile dimension for cost prediction (default 32).
     """
-    assert (assigner is None) != (assignment_provider is None), "Provide exactly one of assigner or assignment_provider"
+    assert assignment_provider is not None, "assignment_provider required"
     assert l1_top_addr > boundary_addr, f"l1_top_addr ({l1_top_addr}) must be > boundary_addr ({boundary_addr})"
     # Per-core L1 CompressedTensors cannot be host-staged; they must be
     # allocated directly on device.  Catch this early to surface a clear
@@ -684,13 +613,11 @@ def prepare_compressed_sram_slots(
     up_cts: list[CompressedTensor] = []
     down_cts: list[CompressedTensor] = []
 
-    # Match the shared-expert TP8 convention (see `_shared_down_tensor_target`
-    # and `preprocess_gate_up`): expert weights are 2D-sharded across the 4x2
-    # mesh with dim-0 (K) split along mesh_rows and dim-1 (N) split along
-    # mesh_cols.  This reduces per-core L1 footprint by ~2.4x vs full replicate,
-    # letting ~2-3x more hot experts fit per core. The consuming kernel must
-    # emit a cross-mesh_rows reduce at the down output (shared expert's
-    # existing pipeline already does this).
+    # Mesh layout: expert weights are 2D-sharded across the (mesh_rows,
+    # mesh_cols) mesh with dim-0 (K) split along mesh_rows and dim-1 (N)
+    # split along mesh_cols.  Reduces per-core L1 footprint by ~2.4x vs
+    # full replicate.  The consuming kernel must emit a cross-mesh_rows
+    # reduce at the down output.
     mesh_mapper_config = None
     mesh_rows, mesh_cols = 1, 1
     if device_for_torch is not None:
@@ -701,18 +628,29 @@ def prepare_compressed_sram_slots(
             mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)])
 
     moe_tp = mesh_rows * mesh_cols
-    # Under TP>1 we adopt the shared-expert gate/up layout: HEIGHT_SHARDED on
-    # 64 cores with the `reshuffle_block_to_height_sharded` block permutation
-    # + TP stacking via `preprocess_gate_up`.  The per-core shard is the
-    # natively tile-aligned (sh, sw) = (896, 32) — unlike WIDTH_SHARDED on 64
-    # cores which would need per_core_N=16 (not tile-aligned) for gate/up.
-    # See sram_experts_plan.md (phase 2) for the full rationale.
-    #
-    # Single-device tests (e.g. `test_prepare_compressed_sram_slots` with
-    # synthetic K=N=256 weights) don't match the shared expert's
-    # (7168, 256)-per-device geometry, so we keep the old WIDTH_SHARDED path
-    # there.  Real deployment is TP8 so this branch is exercised end-to-end.
-    use_shared_expert_gate_up = moe_tp > 1
+    # Layout: TP>1 gate/up at 64 cores → HEIGHT_SHARDED (k_par=8, n_par=8)
+    # with per-core tile-aligned (sh, sw) = (896, 32); TP>1 down at 112
+    # cores → WIDTH_SHARDED (k_par=1, n_par=112).  TP=1 degenerates with
+    # mesh_rows=mesh_cols=1 through the same build_sram_routed_proj_ct
+    # path (only used by host-only unit tests).
+
+    # Per-projection n_parallel decision — loop-invariant; matches the
+    # triple passed to :func:`build_sram_routed_proj_ct` below.  Hoisted out
+    # of the loop so the predictor and allocator share the exact same value.
+    num_gate_cores = len(ttnn.corerange_to_cores(grids.gate))
+    num_up_cores = len(ttnn.corerange_to_cores(grids.up))
+    num_down_cores = len(ttnn.corerange_to_cores(grids.down))
+    # Gate/up follow the shared-expert HEIGHT_SHARDED overlap layout when
+    # the grid matches that spec's core count (k_par, n_par from the spec
+    # itself — no magic numbers).  Otherwise fall back to WIDTH_SHARDED
+    # (k_par=1, n_par=num_cores).  Down is always WIDTH_SHARDED.
+    _OVERLAP_GATE_CORES = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.gate_core_range_set.num_cores()
+    _OVERLAP_UP_CORES = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.up_core_range_set.num_cores()
+    _OVERLAP_N_PARALLEL = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.n_parallel
+    gate_n_parallel = _OVERLAP_N_PARALLEL if num_gate_cores == _OVERLAP_GATE_CORES else num_gate_cores
+    up_n_parallel = _OVERLAP_N_PARALLEL if num_up_cores == _OVERLAP_UP_CORES else num_up_cores
+    down_n_parallel = num_down_cores
+    n_parallel_per_proj = (gate_n_parallel, up_n_parallel, down_n_parallel)
 
     # Address-boundary trim state: only tracks per-core lowest occupied L1
     # address (bootstrapped from real allocator state via the attention prep).
@@ -736,19 +674,26 @@ def prepare_compressed_sram_slots(
         # memcpy was previously paid twice (predict arg + build site).
         down_raw = state_dict[down_key].T.contiguous()
 
-        # Predict the next expert's per-core L1 cost (host-side, one-step
-        # lookahead) so we can stop *before* an over-budget allocation.
-        predicted_delta = _predict_expert_per_core_bytes(
+        # Predict the next expert's per-device per-core L1 cost (host-side,
+        # one-step lookahead) so we can stop *before* an over-budget
+        # allocation.  Reduce via max-over-devices so the chosen expert
+        # count fits the worst-case device under BSPM (where different
+        # devices receive different tile-format slabs).  Under uniform BFP4
+        # the reduction is a no-op (every device has identical per-core
+        # bytes).
+        predicted_delta_per_device = _predict_expert_per_core_bytes(
             expert_idx,
             gate_full,
             up_full,
             down_raw,
             grids,
-            assigner=assigner,
+            assigner=None,
             assignment_provider=assignment_provider,
             tile_hw=tile_hw,
             mesh_shape=mesh_shape_for_predict,
+            n_parallel_per_proj=n_parallel_per_proj,
         )
+        predicted_delta = reduce_per_device_max(predicted_delta_per_device)
         # Cores untouched so far are assumed empty: their next allocation
         # would land just below ``l1_top_addr`` (top-down growth).
         overflow_core = next(
@@ -770,58 +715,107 @@ def prepare_compressed_sram_slots(
             )
             break
 
-        # Per-projection SRAM disk-cache identity, layout decision, and
-        # weight preprocessing all live in ``_expert_build_plans``: under
-        # TP>1 each projection rides the shared-expert pipeline
-        # (HEIGHT_SHARDED gate/up via ``preprocess_gate_up``,
-        # WIDTH_SHARDED shared-down via ``shared_down_torch_for_cache``);
-        # under TP=1 all three use the WIDTH_SHARDED legacy fallback.
-        #
-        # Caveat (activation K mismatch under TP>1): routed expert
-        # activations arrive at ``K_dev=512`` (from the TP8 gate/up
-        # outputs), but the down layout expects ``K_dev=256`` inputs.
-        # Bridging that mismatch (extra K-slab reshuffle on activations,
-        # or per-core ``sram_k_offsets`` indirection) is a Phase 4 /
-        # kernel-side concern.  See sram_experts_plan.md "Risks/caveats"
-        # for details.
-        plans = _expert_build_plans(
-            layer_idx=layer_idx,
-            expert_idx=expert_idx,
-            gate_full=gate_full,
-            up_full=up_full,
-            down_raw=down_raw,
-            gate_key=gate_key,
-            up_key=up_key,
-            down_key=down_key,
-            grids=grids,
-            use_shared_expert_layout=use_shared_expert_gate_up,
-            moe_tp=moe_tp,
-            mesh_rows=mesh_rows,
-            mesh_cols=mesh_cols,
+        # Per-projection layout & per-slot CT construction via
+        # :func:`build_sram_routed_proj_ct` (uniform for TP=1 and TP>1).
+        _is_cb_backing = len(selected_experts) == 0
+        # Per-expert per-device weight slabs.  Hoisted n_parallel_per_proj
+        # above drives k_par; per_core_N / num_tiles_k fall out of the
+        # (K, N_per_dev) split.
+        gate_full_kn = gate_full.reshape(gate_full.shape[0], gate_full.shape[1])
+        up_full_kn = up_full.reshape(up_full.shape[0], up_full.shape[1])
+        down_full_kn = down_raw.reshape(down_raw.shape[0], down_raw.shape[1])
+        K_gate, N_gate_full = gate_full_kn.shape
+        K_up, N_up_full = up_full_kn.shape
+        K_down_full, N_down = down_full_kn.shape
+        N_gate_per_dev = N_gate_full // moe_tp
+        N_up_per_dev = N_up_full // moe_tp
+        K_down_per_dev = K_down_full // moe_tp
+        gate_per_dev = [
+            gate_full_kn[:, d * N_gate_per_dev : (d + 1) * N_gate_per_dev].contiguous() for d in range(moe_tp)
+        ]
+        up_per_dev = [up_full_kn[:, d * N_up_per_dev : (d + 1) * N_up_per_dev].contiguous() for d in range(moe_tp)]
+        down_per_dev = [
+            down_full_kn[d * K_down_per_dev : (d + 1) * K_down_per_dev, :].contiguous() for d in range(moe_tp)
+        ]
+        gate_k_parallel = num_gate_cores // gate_n_parallel
+        up_k_parallel = num_up_cores // up_n_parallel
+        gate_num_tiles_k = K_gate // tile_hw // gate_k_parallel
+        up_num_tiles_k = K_up // tile_hw // up_k_parallel
+        gate_per_core_N = N_gate_per_dev // tile_hw // gate_n_parallel
+        up_per_core_N = N_up_per_dev // tile_hw // up_n_parallel
+        down_num_tiles_k = K_down_per_dev // tile_hw
+        down_per_core_N = N_down // tile_hw // num_down_cores
+
+        def _bspm_per_dev(proj_idx: int, full_assignment) -> list[np.ndarray]:
+            """Slice the full BSPM assignment along the per-TP-device shard axis."""
+            if full_assignment is None:
+                return None
+            if proj_idx in (0, 1):
+                # gate/up: column-shard N across devices.
+                n_tiles_per_dev = full_assignment.shape[1] // moe_tp
+                return [
+                    np.ascontiguousarray(full_assignment[:, d * n_tiles_per_dev : (d + 1) * n_tiles_per_dev])
+                    for d in range(moe_tp)
+                ]
+            # down: row-shard K across devices.
+            k_tiles_per_dev = full_assignment.shape[0] // moe_tp
+            return [
+                np.ascontiguousarray(full_assignment[d * k_tiles_per_dev : (d + 1) * k_tiles_per_dev, :])
+                for d in range(moe_tp)
+            ]
+
+        gate_assignment_full = assignment_provider(expert_idx, 0)
+        up_assignment_full = assignment_provider(expert_idx, 1)
+        down_assignment_full = assignment_provider(expert_idx, 2)
+
+        def _cache_target_name(_proj: str, _eid: int = expert_idx) -> str:
+            return f"sram_layer{layer_idx}_expert{_eid}_{_proj}_proj"
+
+        def _cache_source_keys(_proj: str, _eid: int = expert_idx) -> tuple[str, ...]:
+            return (_key(layer_idx, f"mlp.experts.{_eid}.{_proj}_proj.weight"),)
+
+        gate_ct = build_sram_routed_proj_ct(
+            mesh_device=device_for_torch,
+            full_torch_weight_per_device=gate_per_dev,
+            core_grid=grids.gate,
+            num_tiles_k=gate_num_tiles_k,
+            n_parallel=gate_n_parallel,
+            per_core_N=gate_per_core_N,
+            is_cb_backing_expert=_is_cb_backing,
+            bspm_assignment_per_device=_bspm_per_dev(0, gate_assignment_full),
+            cache_config=cache_config,
+            cache_target_name=_cache_target_name("gate"),
+            cache_source_keys=_cache_source_keys("gate"),
         )
-        out_lists = (gate_cts, up_cts, down_cts)
-        for plan, out in zip(plans, out_lists):
-            if plan.use_assignment_provider and assignment_provider is not None:
-                # TP=1 + BSPM provider: precomputed tile assignment per (expert, projection).
-                # The builder's own asserter still enforces "exactly one of assigner/assignment".
-                assigner_arg = None
-                assignment_arg = assignment_provider(expert_idx, plan.proj_idx)
-            else:
-                assigner_arg = assigner
-                assignment_arg = None
-            out.append(
-                _build_l1_compressed_tensor(
-                    plan.weight,
-                    plan.spec,
-                    assigner=assigner_arg,
-                    assignment=assignment_arg,
-                    device=device_for_torch,
-                    mesh_mapper_config=mesh_mapper_config,
-                    cache_config=cache_config,
-                    sram_cache_target_name=plan.cache_name,
-                    sram_cache_source_keys=(plan.source_key,),
-                )
-            )
+        up_ct = build_sram_routed_proj_ct(
+            mesh_device=device_for_torch,
+            full_torch_weight_per_device=up_per_dev,
+            core_grid=grids.up,
+            num_tiles_k=up_num_tiles_k,
+            n_parallel=up_n_parallel,
+            per_core_N=up_per_core_N,
+            is_cb_backing_expert=_is_cb_backing,
+            bspm_assignment_per_device=_bspm_per_dev(1, up_assignment_full),
+            cache_config=cache_config,
+            cache_target_name=_cache_target_name("up"),
+            cache_source_keys=_cache_source_keys("up"),
+        )
+        down_ct = build_sram_routed_proj_ct(
+            mesh_device=device_for_torch,
+            full_torch_weight_per_device=down_per_dev,
+            core_grid=grids.down,
+            num_tiles_k=down_num_tiles_k,
+            n_parallel=down_n_parallel,
+            per_core_N=down_per_core_N,
+            is_cb_backing_expert=_is_cb_backing,
+            bspm_assignment_per_device=_bspm_per_dev(2, down_assignment_full),
+            cache_config=cache_config,
+            cache_target_name=_cache_target_name("down"),
+            cache_source_keys=_cache_source_keys("down"),
+        )
+        gate_cts.append(gate_ct)
+        up_cts.append(up_ct)
+        down_cts.append(down_ct)
         selected_experts.append(expert_idx)
         logger.debug("  SRAM slot {} ← expert {} prepared", slot_idx, expert_idx)
 

--- a/models/demos/deepseek_v3_b1/weights/transforms/sram_experts.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/sram_experts.py
@@ -34,7 +34,9 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_b1.compressed_tensor import CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.compressed_tensor import COMPRESSED_FORMATS, CompressedTensorAssigner
+from models.demos.deepseek_v3_b1.compressed_tensor.bspm_loader import load_bspm_for_layer
+from models.demos.deepseek_v3_b1.model_dimensions import RoutedExpert as _RoutedExpert
 from models.demos.deepseek_v3_b1.weights.specs.overlap_configs import (
     DOWN_PROJ_SINGLE_DEVICE_SPEC,
     GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
@@ -88,133 +90,15 @@ class SramExpertCoreGrids:
         Uses :data:`GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC` for gate/up and
         :meth:`DOWN_PROJ_SINGLE_DEVICE_SPEC.build_matmul_core_grid` for down —
         the same canonical ``CoreRangeSet`` objects ``prepare_compressed_sram_slots``
-        assumes under TP>1 (HEIGHT_SHARDED gate/up after ``preprocess_gate_up``,
-        WIDTH_SHARDED down after ``shared_down_torch_for_cache``).  Call sites
-        (tests, demos) should prefer this over re-stitching CRS from overlap_configs.
+        passes to :func:`build_sram_routed_proj_ct` under TP>1 (HEIGHT_SHARDED
+        gate/up, WIDTH_SHARDED down).  Call sites (tests, demos) should prefer
+        this over re-stitching CRS from overlap_configs.
         """
         return cls(
             gate=GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.gate_core_range_set,
             up=GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC.up_core_range_set,
             down=DOWN_PROJ_SINGLE_DEVICE_SPEC.build_matmul_core_grid(),
         )
-
-
-# Shared-expert down projection per-device shard dimensions, mirrored from
-# :func:`shared_down_torch_for_cache` in ``weights/transforms/moe.py``.  The
-# function hardcodes ``K_down_per_device=256`` and ``N_per_core=64`` for the
-# shared expert's ``DOWN_PROJ_SINGLE_DEVICE_SPEC`` (112 matmul cores → total
-# per-device N = 7168).  SRAM hot experts reuse this layout verbatim under
-# TP>1 so the kernel can share shared expert's data-movement code.  Update
-# these constants only if the shared-expert down spec changes.
-_SHARED_EXPERT_DOWN_K_PER_DEV = 256
-_SHARED_EXPERT_DOWN_N_PER_CORE = 64
-
-
-@dataclass(frozen=True)
-class _MemoryConfigSpec:
-    """Per-projection L1 memory layout spec for SRAM hot experts.
-
-    Captures the ``(layout, core_range_set, shard_shape)`` triple needed to
-    construct a ``ttnn.MemoryConfig``.  Single source of truth shared between
-    the cost predictor (:func:`compute_expert_l1_bytes_per_core`) and the
-    on-device allocator (``_expert_build_plans`` /
-    :func:`_build_l1_compressed_tensor` in
-    :mod:`models.demos.deepseek_v3_b1.weights.sram_slots`); per-projection
-    instances are produced by :func:`sram_projection_specs`.
-
-    Fields:
-      layout: ``WIDTH_SHARDED`` (gate/up/down under TP=1; shared-down under
-        TP>1) or ``HEIGHT_SHARDED`` (shared-gate/up under TP>1).
-      core_range_set: ``CoreRangeSet`` to bind the shard to.
-      shard_shape: Per-core ``(sh, sw)`` shard shape, or ``None`` for the
-        WIDTH_SHARDED auto-derive path used by the TP=1 fallback (computes
-        ``(K, N // num_cores)`` from the weight's shape).  Auto-derive is
-        only valid for ``WIDTH_SHARDED``; explicit shapes are required
-        everywhere else (HEIGHT_SHARDED, or the shared-down WIDTH_SHARDED
-        whose 2D weight dims already encode the mesh split, see
-        :func:`shared_down_torch_for_cache`).
-    """
-
-    layout: ttnn.TensorMemoryLayout
-    core_range_set: ttnn.CoreRangeSet
-    shard_shape: tuple[int, int] | None = None
-
-    def materialize(self, weight: torch.Tensor, *, tile_hw: int) -> ttnn.MemoryConfig:
-        """Resolve the spec against *weight* into a concrete ``ttnn.MemoryConfig``.
-
-        For ``shard_shape=None`` (TP=1 WIDTH_SHARDED auto-derive only) the
-        per-core shape is ``(K, N // num_cores)`` taken from ``weight.shape``;
-        ``weight.ndim==4`` is supported for the mesh-pre-sharded
-        ``(mesh_rows, mesh_cols, K_per_device, N_per_device)`` carrier.
-        Otherwise the explicit ``shard_shape`` is used verbatim.
-        """
-        if self.shard_shape is None:
-            assert (
-                self.layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
-            ), f"auto-derived shard shape only supported for WIDTH_SHARDED; got {self.layout}"
-            num_cores = self.core_range_set.num_cores()
-            if weight.ndim == 4:
-                K, N = weight.shape[2], weight.shape[3]
-            else:
-                K, N = weight.shape[0], weight.shape[1]
-            assert N % num_cores == 0, f"N ({N}) must be divisible by num_cores ({num_cores})"
-            per_core_N = N // num_cores
-            assert per_core_N % tile_hw == 0, (
-                f"per_core_N ({per_core_N}) must be a multiple of tile_hw ({tile_hw}); "
-                f"got N={N} on {num_cores} cores. Shrink the per-device core grid or "
-                f"pick a mesh mapper whose per-device N stays tile-aligned."
-            )
-            assert K % tile_hw == 0, f"K ({K}) must be a multiple of tile_hw ({tile_hw})"
-            sh, sw = K, per_core_N
-        else:
-            sh, sw = self.shard_shape
-            assert sh % tile_hw == 0, f"shard height ({sh}) must be a multiple of tile_hw ({tile_hw})"
-            assert sw % tile_hw == 0, f"shard width ({sw}) must be a multiple of tile_hw ({tile_hw})"
-        shard_spec = ttnn.ShardSpec(self.core_range_set, [sh, sw], ttnn.ShardOrientation.ROW_MAJOR)
-        return ttnn.MemoryConfig(self.layout, ttnn.BufferType.L1, shard_spec)
-
-
-def sram_projection_specs(
-    core_grids: SramExpertCoreGrids,
-    mesh_shape: tuple[int, int],
-) -> dict[str, _MemoryConfigSpec]:
-    """Return one :class:`_MemoryConfigSpec` per projection (gate / up / down).
-
-    Single source of truth for the SRAM hot expert TP-layout decision shared
-    between cost prediction (:func:`compute_expert_l1_bytes_per_core`) and
-    on-device allocation (``prepare_compressed_sram_slots``).
-
-    Under TP>1: HEIGHT_SHARDED gate/up via :func:`preprocess_gate_up`'s
-    reshuffle output, WIDTH_SHARDED shared-down via
-    :func:`shared_down_torch_for_cache`'s K-reshape output.  Under TP=1:
-    WIDTH_SHARDED everything with auto-derived ``(K, N // num_cores)`` shards
-    from the per-projection ``core_grids``.
-    """
-    moe_tp = mesh_shape[0] * mesh_shape[1]
-    if moe_tp > 1:
-        cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-        return {
-            "gate": _MemoryConfigSpec(
-                layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-                core_range_set=cfg.gate_core_range_set,
-                shard_shape=cfg.shard_shape,
-            ),
-            "up": _MemoryConfigSpec(
-                layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-                core_range_set=cfg.up_core_range_set,
-                shard_shape=cfg.shard_shape,
-            ),
-            "down": _MemoryConfigSpec(
-                layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-                core_range_set=core_grids.down,
-                shard_shape=(_SHARED_EXPERT_DOWN_K_PER_DEV, _SHARED_EXPERT_DOWN_N_PER_CORE),
-            ),
-        }
-    return {
-        "gate": _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grids.gate),
-        "up": _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grids.up),
-        "down": _MemoryConfigSpec(layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set=core_grids.down),
-    }
 
 
 def _quantize_dequantize_bfp_fn(x, fmt_str):
@@ -258,19 +142,87 @@ def _expert_assignments_and_shapes(
     return assignments, shapes
 
 
+_BFP4_FMT_IDX = COMPRESSED_FORMATS.index("bfp4")
+# (K, N) full-tensor shapes per projection (0=gate, 1=up, 2=down) in routed
+# expert compute layout.  Drives the assignment_provider's full-tile-grid sizing.
+_PROJ_SHAPES = (
+    (_RoutedExpert.K, _RoutedExpert.GATE_PROJ_N),  # gate
+    (_RoutedExpert.K, _RoutedExpert.GATE_PROJ_N),  # up
+    (_RoutedExpert.GATE_PROJ_N, _RoutedExpert.K),  # down
+)
+
+
+def _proj_tile_shape(proj_idx: int, num_banks: int, tile_w: int) -> tuple[int, int]:
+    """``(tiles_h_full, tiles_w_full_padded)`` for one projection.
+
+    Padding rounds the N axis up to a full ``num_banks * tile_w`` row so the
+    BSPM tile grid matches the DRAM-side padded layout (see CompressedTensor
+    bank-aligned packing).
+    """
+    K_full, N_full = _PROJ_SHAPES[proj_idx]
+    pad_step = num_banks * tile_w
+    N_padded_full = ((N_full + pad_step - 1) // pad_step) * pad_step
+    return K_full // tile_w, N_padded_full // tile_w
+
+
+def make_sram_assignment_provider(
+    *,
+    bspm_path: Path | None,
+    num_banks: int,
+    layer_idx: int,
+    tile_w: int = 32,
+) -> Callable[[int, int], np.ndarray]:
+    """Build the ``(expert_idx, proj_idx) -> assignment`` closure consumed by
+    :func:`prepare_compressed_sram_slots`.
+
+    Two modes, same allocator path:
+
+    * **With BSPM** (``bspm_path`` set): load codes from the .bspm file once,
+      then slice per (expert, projection).  Per-tile precision varies per
+      expert/projection.
+    * **Without BSPM**: return a constant array of BFP4 format indices
+      sized to the projection's full padded tile grid.  Every tile is
+      uniform BFP4.
+
+    Both modes return a 2D ``(tiles_h_full, tiles_w_full_padded)`` int array
+    matching the projection's bank-aligned layout.
+    """
+    if bspm_path is not None:
+        logger.info("Loading BSPM for SRAM auto-fit at layer {}: {}", layer_idx, bspm_path)
+        bspm_data = load_bspm_for_layer(str(bspm_path))
+
+        def _provider(expert_idx: int, proj_idx: int) -> np.ndarray:
+            tiles_h_full, tiles_w_full_padded = _proj_tile_shape(proj_idx, num_banks, tile_w)
+            assert (
+                expert_idx < bspm_data["n_experts"]
+            ), f"SRAM expert {expert_idx} out of range for BSPM (n_experts={bspm_data['n_experts']})"
+            return np.ascontiguousarray(
+                bspm_data["codes"][expert_idx, proj_idx].reshape(tiles_w_full_padded, tiles_h_full).T
+            )
+
+        return _provider
+
+    def _uniform_bfp4_provider(expert_idx: int, proj_idx: int) -> np.ndarray:
+        tiles_h_full, tiles_w_full_padded = _proj_tile_shape(proj_idx, num_banks, tile_w)
+        return np.full((tiles_h_full, tiles_w_full_padded), _BFP4_FMT_IDX, dtype=np.int8)
+
+    return _uniform_bfp4_provider
+
+
 def _predict_expert_per_core_bytes(
     expert_idx: int,
     gate_full: torch.Tensor,
     up_full: torch.Tensor,
     down_full: torch.Tensor,
     core_grids: SramExpertCoreGrids,
+    n_parallel_per_proj: tuple[int, int, int],
     *,
     assigner: CompressedTensorAssigner | None,
     assignment_provider: Callable[[int, int], np.ndarray] | None,
     tile_hw: int = 32,
     mesh_shape: tuple[int, int] = (1, 1),
-) -> dict[tuple[int, int], int]:
-    """Predict per-core L1 byte cost of a single expert (host-side lookahead).
+) -> dict[tuple[int, int], dict[tuple[int, int], int]]:
+    """Predict per-device, per-core L1 byte cost of a single expert.
 
     Wraps :func:`_expert_assignments_and_shapes` +
     :func:`compute_expert_l1_bytes_per_core` so the trim loop in
@@ -279,6 +231,14 @@ def _predict_expert_per_core_bytes(
     ``CompressedTensor.from_torch`` during the actual allocation -- worth
     the duplicated CPU work since predicting and allocating live in
     different code paths today.
+
+    See :func:`compute_expert_l1_bytes_per_core` for ``n_parallel_per_proj``
+    semantics — production callers should pass the same triple they pass to
+    :func:`build_sram_routed_proj_ct` so the two stay in lock-step.
+
+    Returns ``dict[(mesh_row, mesh_col) -> dict[(x, y) -> bytes]]``; under
+    uniform BFP4 all devices match, under BSPM they diverge and callers
+    must reduce via max-over-devices for a uniform-across-devices placement.
     """
     assignments, shapes = _expert_assignments_and_shapes(
         expert_idx,
@@ -288,24 +248,65 @@ def _predict_expert_per_core_bytes(
         assigner=assigner,
         assignment_provider=assignment_provider,
     )
-    return compute_expert_l1_bytes_per_core(assignments, shapes, core_grids, tile_hw=tile_hw, mesh_shape=mesh_shape)
+    return compute_expert_l1_bytes_per_core(
+        assignments,
+        shapes,
+        core_grids,
+        n_parallel_per_proj,
+        tile_hw=tile_hw,
+        mesh_shape=mesh_shape,
+    )
+
+
+def reduce_per_device_max(
+    per_device_totals: dict[tuple[int, int], dict[tuple[int, int], int]],
+) -> dict[tuple[int, int], int]:
+    """Reduce per-device per-core bytes via max-over-devices.
+
+    Picks the worst-case (largest) byte total for each core across all
+    mesh coordinates -- the right reduction for a uniform-across-devices
+    SRAM trim budget under BSPM, where different devices receive different
+    tile-format slabs and would otherwise diverge on expert count.
+    """
+    out: dict[tuple[int, int], int] = {}
+    for dev_totals in per_device_totals.values():
+        for core_xy, byte_cnt in dev_totals.items():
+            prev = out.get(core_xy, 0)
+            if byte_cnt > prev:
+                out[core_xy] = byte_cnt
+    return out
 
 
 def compute_expert_l1_bytes_per_core(
     assignments: list[np.ndarray],
     tensor_shapes: list[tuple[int, int]],
     core_grids: SramExpertCoreGrids,
+    n_parallel_per_proj: tuple[int, int, int],
     tile_hw: int = 32,
     mesh_shape: tuple[int, int] = (1, 1),
-) -> dict[tuple[int, int], int]:
-    """Per-core L1 byte cost for one expert across all projections.
+) -> dict[tuple[int, int], dict[tuple[int, int], int]]:
+    """Per-device, per-core L1 byte cost for one expert across all projections.
 
-    Each projection's shard-to-core tile mapping is computed via
-    ``compute_shard_page_mapping``, then per-tile byte sizes (determined by
-    the assignment codes) are summed per ``(core.x, core.y)``.  The per-core
-    totals are accumulated across all projections and returned keyed by
-    ``(x, y)``.  Cores that hold no shard for a given projection simply
-    contribute zero bytes for that projection.
+    Mirrors :func:`build_sram_routed_proj_ct`'s geometry exactly so the trim
+    loop can stop *before* an over-budget allocation.  Per-projection layout
+    is driven by ``n_parallel_per_proj`` (same triple the caller passes to
+    :func:`build_sram_routed_proj_ct`):
+
+      * ``k_par = num_cores // n_par`` ⇒ HEIGHT_SHARDED block stack when
+        ``k_par > 1``, WIDTH_SHARDED single-row when ``k_par == 1``.
+      * Per-core block is ``(K_per_dev/k_par, N_per_dev/n_par)`` in tiles,
+        indexed as ``(k_idx, n_idx) = (i // n_par, i % n_par)`` for the
+        i-th core in row-major ``corerange_to_cores`` order — identical to
+        the allocator's per-core slab assignment.
+
+    Per-device shard axis:
+      * gate / up — column-shard ``N`` across ``moe_tp`` devices.
+      * down — row-shard ``K`` across ``moe_tp`` devices.
+
+    Under uniform BFP4 every device's per-core dict is identical.  Under
+    BSPM the format-code distribution differs per device, so the trim loop
+    must reduce via :func:`reduce_per_device_max` for a uniform-across-
+    devices placement.
 
     Args:
         assignments: 3 projection assignment arrays in order
@@ -317,17 +318,19 @@ def compute_expert_l1_bytes_per_core(
         core_grids: :class:`SramExpertCoreGrids` giving one grid per
             projection.  Use :meth:`SramExpertCoreGrids.uniform` for symmetric
             unit-test weights.  The grids refer to **per-device** cores.
+        n_parallel_per_proj: ``(gate, up, down)`` triple of ``n_parallel``
+            values — same values the caller passes to
+            :func:`build_sram_routed_proj_ct`.
         tile_hw: Tile dimension (default 32).
         mesh_shape: ``(mesh_rows, mesh_cols)`` for TP-sharded SRAM slots
-            mirroring the shared-expert TP8 layout (dim-0 split along
-            mesh_rows, dim-1 split along mesh_cols).  Defaults to ``(1, 1)``
-            (no TP).
+            (dim-0 split along mesh_rows, dim-1 split along mesh_cols).
+            Defaults to ``(1, 1)`` (no TP).
 
     Returns:
-        ``dict[(core.x, core.y) -> bytes]`` summed across all projections.
-        Use :func:`compute_expert_l1_bytes` for the scalar max-per-core cost.
+        ``dict[(mesh_row, mesh_col) -> dict[(core.x, core.y) -> bytes]]``
+        summed across all projections.  Use :func:`compute_expert_l1_bytes`
+        for the scalar worst-case cost across all devices and cores.
     """
-    from models.demos.deepseek_v3_b1.compressed_tensor.compressed_tensor import compute_shard_page_mapping
     from models.demos.deepseek_v3_b1.compressed_tensor.tile_utils import bfp_tile_packed_size
 
     _MANT_BITS = {0: 7, 1: 3, 2: 1, 3: 0}
@@ -340,135 +343,95 @@ def compute_expert_l1_bytes_per_core(
         "compute_expert_l1_bytes expects exactly 3 projections in order [gate, up, down], "
         f"got {len(assignments)} assignments / {len(tensor_shapes)} shapes"
     )
-    projection_names = ("gate", "up", "down")
     mesh_rows, mesh_cols = mesh_shape
     moe_tp = mesh_rows * mesh_cols
-    # Single-source TP-layout decision: ``sram_projection_specs`` returns the
-    # same per-projection ``_MemoryConfigSpec`` triple consumed by the
-    # on-device allocator in ``prepare_compressed_sram_slots``.  Branching
-    # below is driven entirely by ``spec.layout`` / ``spec.shard_shape`` so
-    # the predictor and allocator cannot disagree on layout policy.
-    specs = sram_projection_specs(core_grids, mesh_shape)
+    per_proj_grids = (core_grids.gate, core_grids.up, core_grids.down)
+    per_proj_is_down = (False, False, True)
 
-    per_core_totals: dict[tuple[int, int], int] = {}
+    per_device_totals: dict[tuple[int, int], dict[tuple[int, int], int]] = {
+        (r, c): {} for r in range(mesh_rows) for c in range(mesh_cols)
+    }
 
-    for assignment, (K, N), proj_name in zip(assignments, tensor_shapes, projection_names):
-        spec = specs[proj_name]
-        if spec.layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
-            # Shared-expert HEIGHT_SHARDED gate/up (TP>1 only).  Each device
-            # holds ONE tp slab of the logical (K, N): full K, per_device_n =
-            # N/moe_tp columns.  Within the slab,
-            # ``reshuffle_block_to_height_sharded`` splits into k_par * n_par
-            # blocks, permutes by ``_crs_shard_permutation`` to match CRS
-            # iteration order, and stacks along height.  We approximate
-            # max-per-core bytes using tp_idx=0's slab (device (0, 0));
-            # different tp slabs can differ slightly in tile-format
-            # distribution but the per-core block structure is identical.
-            cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
-            sh, sw = spec.shard_shape
-            k_par, n_par = cfg.k_parallel, cfg.n_parallel
-            sh_tiles = sh // tile_hw
-            sw_tiles = sw // tile_hw
-            core_range_set = spec.core_range_set
-            num_cores = core_range_set.num_cores()
-            assert (
-                num_cores == k_par * n_par
-            ), f"shared-expert {proj_name} grid must have {k_par * n_par} cores; got {num_cores}"
-            assert (
-                K == cfg.gate_proj_shape[0]
-            ), f"shared-expert {proj_name} requires K == {cfg.gate_proj_shape[0]}; got {K}"
-            per_device_n = cfg.gate_proj_shape[1]
-            assert N == per_device_n * moe_tp, (
-                f"shared-expert {proj_name} requires N == {per_device_n * moe_tp} "
-                f"(per_device_n={per_device_n} * moe_tp={moe_tp}); got {N}"
-            )
+    for proj_idx, (assignment, (K, N), grid, is_down) in enumerate(
+        zip(assignments, tensor_shapes, per_proj_grids, per_proj_is_down)
+    ):
+        cores = ttnn.corerange_to_cores(grid, row_wise=True)
+        num_cores = len(cores)
+        n_par = n_parallel_per_proj[proj_idx]
+        assert (
+            n_par > 0 and num_cores % n_par == 0
+        ), f"n_parallel ({n_par}) must divide num_cores ({num_cores}) for projection {proj_idx}"
+        k_par = num_cores // n_par
 
-            # Extract tp_idx=0 slab (first per_device_n cols) and apply the
-            # reshuffle permutation to obtain the per-core block order that
-            # matches the on-device HEIGHT_SHARDED memory config.
-            per_device_n_tiles = n_par * sw_tiles
-            assignment_dev = assignment[:, :per_device_n_tiles]
-            a = assignment_dev.reshape(k_par, sh_tiles, n_par, sw_tiles).transpose(0, 2, 1, 3).copy()
-            block_shards = a.reshape(k_par * n_par, sh_tiles, sw_tiles)
-            perm = cfg._crs_shard_permutation(core_range_set)
-            reshuffled_flat = block_shards[list(perm)].reshape(-1, sw_tiles).ravel()
-
-            shard_spec = ttnn.ShardSpec(core_range_set, [sh, sw], ttnn.ShardOrientation.ROW_MAJOR)
-            mem_config = ttnn.MemoryConfig(spec.layout, ttnn.BufferType.L1, shard_spec)
-            stacked_h = num_cores * sh
-            shard_mapping = compute_shard_page_mapping([stacked_h, sw], mem_config, tile_hw)
-
-            for core, page_indices in shard_mapping:
-                shard_bytes = int(tile_byte_lut[reshuffled_flat[list(page_indices)]].sum())
-                key = (core.x, core.y)
-                per_core_totals[key] = per_core_totals.get(key, 0) + shard_bytes
-            continue
-
-        # WIDTH_SHARDED path.  Covers:
-        #   (a) shared-expert down under TP>1 (``spec.shard_shape`` is the
-        #       explicit (K_per_dev=256, N_per_core=64) pair): per-device
-        #       slab = assignment[0:8, 0:224] (tp_idx=0, device (0, 0) in
-        #       logical tile coords -- strided across mesh rows/cols but
-        #       the per-core max-bytes is identical on all devices).
-        #   (b) single-device (TP=1) gate/up/down (``spec.shard_shape`` is
-        #       None): top-left (K, N) slab with per_core_N = N / num_cores.
-        num_cores = spec.core_range_set.num_cores()
-        if spec.shard_shape is not None:
-            K_dev, per_core_N = spec.shard_shape
-            N_dev = per_core_N * num_cores
-            expected_down_shape = (K_dev * moe_tp, per_core_N * num_cores)
-            assert (K, N) == expected_down_shape, (
-                f"shared-expert down requires logical (K, N) == {expected_down_shape} "
-                f"(K_per_dev * moe_tp, N_per_core * num_cores); got ({K}, {N})"
-            )
+        if is_down:
+            assert K % mesh_rows == 0, f"down K ({K}) must be divisible by mesh_rows ({mesh_rows})"
+            K_per_dev = K // mesh_rows
+            N_per_dev = N
         else:
-            assert K % mesh_rows == 0, f"K ({K}) must be divisible by mesh_rows ({mesh_rows})"
-            assert N % mesh_cols == 0, f"N ({N}) must be divisible by mesh_cols ({mesh_cols})"
-            K_dev = K // mesh_rows
-            N_dev = N // mesh_cols
-            per_core_N = N_dev // num_cores
+            K_per_dev = K
+            assert N % mesh_cols == 0, f"gate/up N ({N}) must be divisible by mesh_cols ({mesh_cols})"
+            N_per_dev = N // mesh_cols
 
-        shard_spec = ttnn.ShardSpec(spec.core_range_set, [K_dev, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
-        mem_config = ttnn.MemoryConfig(spec.layout, ttnn.BufferType.L1, shard_spec)
-        shard_mapping = compute_shard_page_mapping([K_dev, N_dev], mem_config, tile_hw)
+        K_per_dev_tiles = K_per_dev // tile_hw
+        N_per_dev_tiles = N_per_dev // tile_hw
+        assert K_per_dev_tiles % k_par == 0, f"K_per_dev_tiles ({K_per_dev_tiles}) not divisible by k_par ({k_par})"
+        assert N_per_dev_tiles % n_par == 0, f"N_per_dev_tiles ({N_per_dev_tiles}) not divisible by n_par ({n_par})"
+        K_block_tiles = K_per_dev_tiles // k_par
+        N_block_tiles = N_per_dev_tiles // n_par
 
-        # Per-device assignment slab in logical tile coords.  For device
-        # (0, 0) both the legacy and shared-expert-down paths reduce to the
-        # top-left ``(K_dev_tiles, N_dev_tiles)`` block (the shared-expert
-        # K-reshape trick strides K-rows across devices but device (0, 0)
-        # always lands on logical tile rows [0, K_per_dev/tile_hw)).
-        K_dev_tiles = K_dev // tile_hw
-        N_dev_tiles = N_dev // tile_hw
-        assignment_dev = assignment[:K_dev_tiles, :N_dev_tiles]
-        assignment_flat = assignment_dev.ravel()
+        for tp_idx in range(moe_tp):
+            tp_coord = (tp_idx // mesh_cols, tp_idx % mesh_cols)
+            if is_down:
+                # Row-shard K across devices.
+                assignment_dev = assignment[tp_idx * K_per_dev_tiles : (tp_idx + 1) * K_per_dev_tiles, :N_per_dev_tiles]
+            else:
+                # Column-shard N across devices.
+                assignment_dev = assignment[:K_per_dev_tiles, tp_idx * N_per_dev_tiles : (tp_idx + 1) * N_per_dev_tiles]
 
-        for core, page_indices in shard_mapping:
-            shard_bytes = int(tile_byte_lut[assignment_flat[list(page_indices)]].sum())
-            key = (core.x, core.y)
-            per_core_totals[key] = per_core_totals.get(key, 0) + shard_bytes
+            dev_totals = per_device_totals[tp_coord]
+            for i, core in enumerate(cores):
+                k_idx = i // n_par
+                n_idx = i % n_par
+                block = assignment_dev[
+                    k_idx * K_block_tiles : (k_idx + 1) * K_block_tiles,
+                    n_idx * N_block_tiles : (n_idx + 1) * N_block_tiles,
+                ]
+                shard_bytes = int(tile_byte_lut[block.ravel()].sum())
+                key = (core.x, core.y)
+                dev_totals[key] = dev_totals.get(key, 0) + shard_bytes
 
-    return per_core_totals
+    return per_device_totals
 
 
 def compute_expert_l1_bytes(
     assignments: list[np.ndarray],
     tensor_shapes: list[tuple[int, int]],
     core_grids: SramExpertCoreGrids,
+    n_parallel_per_proj: tuple[int, int, int],
     tile_hw: int = 32,
     mesh_shape: tuple[int, int] = (1, 1),
 ) -> int:
-    """Max per-core L1 byte cost for one expert across all projections.
+    """Max per-core L1 byte cost for one expert across all devices and projections.
 
     Scalar wrapper around :func:`compute_expert_l1_bytes_per_core`; returns
-    the byte total on the most loaded core (or 0 when no projection lands on
-    any core).  Retained as a diagnostic/summary helper; the per-core dict
-    form is what ``prepare_compressed_sram_slots`` uses for
-    attention-plus-SRAM budget accounting against real allocator addresses.
+    the worst-case byte total across every (device, core) (or 0 when no
+    projection lands on any core).  Retained as a diagnostic/summary helper;
+    the per-device per-core dict form is what ``prepare_compressed_sram_slots``
+    uses for attention-plus-SRAM budget accounting against real allocator
+    addresses.
     """
-    per_core = compute_expert_l1_bytes_per_core(
-        assignments, tensor_shapes, core_grids, tile_hw=tile_hw, mesh_shape=mesh_shape
+    per_device = compute_expert_l1_bytes_per_core(
+        assignments,
+        tensor_shapes,
+        core_grids,
+        tile_hw=tile_hw,
+        mesh_shape=mesh_shape,
+        n_parallel_per_proj=n_parallel_per_proj,
     )
-    return max(per_core.values()) if per_core else 0
+    return max(
+        (b for per_core in per_device.values() for b in per_core.values()),
+        default=0,
+    )
 
 
 def _load_routing_frequencies(path: Path | None = None) -> dict[int, list[int]]:

--- a/models/demos/deepseek_v3_b1/weights/transforms/sram_experts.py
+++ b/models/demos/deepseek_v3_b1/weights/transforms/sram_experts.py
@@ -363,14 +363,19 @@ def compute_expert_l1_bytes_per_core(
         ), f"n_parallel ({n_par}) must divide num_cores ({num_cores}) for projection {proj_idx}"
         k_par = num_cores // n_par
 
+        # Allocator (``prepare_compressed_sram_slots``) slices linearly by
+        # ``moe_tp`` (= mesh_rows * mesh_cols), assigning the d-th N-slab
+        # (gate/up) or K-slab (down) to linear device d.  Predictor MUST
+        # divide by ``moe_tp`` — dividing by ``mesh_cols`` / ``mesh_rows``
+        # would under-slice on a 4×2 mesh and overestimate per-core bytes.
         if is_down:
-            assert K % mesh_rows == 0, f"down K ({K}) must be divisible by mesh_rows ({mesh_rows})"
-            K_per_dev = K // mesh_rows
+            assert K % moe_tp == 0, f"down K ({K}) must be divisible by moe_tp ({moe_tp})"
+            K_per_dev = K // moe_tp
             N_per_dev = N
         else:
             K_per_dev = K
-            assert N % mesh_cols == 0, f"gate/up N ({N}) must be divisible by mesh_cols ({mesh_cols})"
-            N_per_dev = N // mesh_cols
+            assert N % moe_tp == 0, f"gate/up N ({N}) must be divisible by moe_tp ({moe_tp})"
+            N_per_dev = N // moe_tp
 
         K_per_dev_tiles = K_per_dev // tile_hw
         N_per_dev_tiles = N_per_dev // tile_hw


### PR DESCRIPTION
Adds end-to-end BSPM-on-SRAM support for routed MoE experts and unifies all SRAM hot-expert allocation under a single device-side path.

Allocation refactor (sram_slots.py / prepare.py):
  * Single atomic builder ``build_sram_routed_proj_ct`` constructs one per-(expert, projection) per-core L1 ``CompressedTensor`` from a tile-level assignment array.  Uniform-BFP4 mode supplies a constant all-1s array; BSPM mode supplies the per-tile precision codes loaded from a .bspm file.
  * Two entry points share the atomic builder:
      - ``prepare_compressed_sram_slots`` — auto-fit + L1 address-budget trim (MoE prod path, test_decoder_block).
      - ``build_sram_routed_proj_cts`` — batch wrapper, no trim (dense MLP + test_moe_mlp).
  * ``prepare_moe_layer_weights`` constructs the assignment_provider closure (BSPM-loaded or uniform-BFP4 fallback) and passes it through.

DRAM expert metadata lockstep (matmul_expert/op.py):
  * Replaces 768 per-(device, core) ``experimental_to_single_device`` allocations with a single mesh-wide ShardTensor2dMesh tensor pair (offsets + block sizes).  Eliminates post-SRAM L1 address divergence that broke mailbox/CB coherence under BSPM.

Kernel-side wiring (moe/op.py, decoder_block/op.py, kernels):
  * ``enable_sram_bspm`` flows from prepare → MoeOp → CT arg ``sram_use_compression`` so kernels pick the correct LLK path (compressed_custom_mm for BSPM, plain custom_mm for uniform BFP4).
  * CB descriptors switch to per-(mesh_coord) record_cb_metadata_per_coord
    + per-device reconfig tensor under BSPM (per-device SRAM weight CB addresses diverge).

Demo wiring (demo/*):
  * New ``--enable-sram-bspm`` CLI flag (default off, opt-in).
  * Threaded through CacheWeightProvider / SyntheticWeightProvider / StateDictWeightProvider → prepare_moe_layer_weights.
  * Threaded through DecoderStage / MoEDecoderStage → DecoderBlock.get_program_context so the kernel-side sram_use_compression CT arg matches the weight packing mode.
  * Pipeline configs forward the flag in single_pod_spec_decode + sp4.

Removed legacy helpers: build_moe_sram_routed_weights, build_sram_expert_weights, _route_l1_compressed_tensor, _build_l1_compressed_tensor, _expert_build_plans, _ProjBuildPlan, the assigner code path inside prepare_compressed_sram_slots, the SRAM disk-cache round-trip + TP=1 unit tests that depended on those.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/bspm-sram2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/bspm-sram2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/bspm-sram2)