### PR TITLE
[emule] Uplift Fixes

### DIFF
--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -162,11 +162,15 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
             // resulting ELFs export symbols (e.g. __fw_export_text_end) that kernel linker scripts
             // depend on -- without them, JIT-compiling kernels on a mock device fails with
             // "non constant or forward reference address expression". So we run it for mock as
-            // well as real devices, EXCEPT when the mock arch has no firmware sources packaged
-            // (currently Quasar): there cc1plus would fatal on missing source files. Kernel JIT
-            // on Quasar mock is not yet supported and would require a separate sources fix.
-            const bool skip_fw_build =
-                cluster_.is_mock_or_emulated() && !mock_firmware_sources_available_for(cluster_.arch());
+            // well as real devices, with two exceptions:
+            //   1. Mock devices whose arch has no firmware sources packaged (currently Quasar).
+            //      cc1plus would fatal on missing source files; mock kernel JIT on Quasar is not
+            //      yet supported and would require a separate sources fix.
+            //   2. Emule devices on any arch. Emule's kernel JIT uses an x86 toolchain, so the
+            //      riscv firmware ELFs are never linked or consumed.
+            const bool skip_fw_build = cluster_.get_target_device_type() == tt::TargetDevice::Emule ||
+                                       (cluster_.get_target_device_type() == tt::TargetDevice::Mock &&
+                                        !mock_firmware_sources_available_for(cluster_.arch()));
             if (!skip_fw_build) {
                 BuildEnvManager::get_instance().build_firmware(device_id);
             }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -544,7 +544,10 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     kernel.process_semaphore_local_accessor_handles(
         [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
     kernel.process_tensor_binding_handles(
-        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off) {
+        // Match the genfiles.cpp pattern: drop num_runtime_field_crta_words. Emule
+        // doesn't yet support dynamic-shape Metal 2.0 bindings — static-shape
+        // kernels (the existing test corpus) pass 0 here and behave unchanged.
+        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off, uint32_t /*num_rt_words*/) {
             s.ta_accessors.push_back({name, cta_off, addr_crta_off});
         });
     return s;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -544,10 +544,24 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     kernel.process_semaphore_local_accessor_handles(
         [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
     kernel.process_tensor_binding_handles(
-        // Match the genfiles.cpp pattern: drop num_runtime_field_crta_words. Emule
-        // doesn't yet support dynamic-shape Metal 2.0 bindings — static-shape
-        // kernels (the existing test corpus) pass 0 here and behave unchanged.
-        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off, uint32_t /*num_rt_words*/) {
+        // Match the genfiles.cpp pattern: drop num_runtime_field_crta_words. Emule's
+        // snapshot doesn't yet model per-binding runtime CRTA words, and the
+        // downstream `named_crta_words` math in emit_metal2_namespaces still assumes
+        // 1 word per binding — so a dynamic-shape kernel would silently get its
+        // CRTAs decoded at the wrong offsets. Static-shape kernels pass
+        // num_rt_words == 0 and are unaffected. Fail loudly on dynamic-shape until
+        // snapshot + cache key + get_common_vararg offset math are wired up to
+        // consume the per-binding count.
+        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off, uint32_t num_rt_words) {
+            TT_FATAL(
+                num_rt_words == 0,
+                "Emule does not yet support dynamic-shape Metal 2.0 tensor bindings "
+                "(binding '{}' has num_runtime_field_crta_words={}). Wire the per-"
+                "binding word count through Metal2BindingsSnapshot::TaEntry, the "
+                "cache key, and emit_metal2_namespaces' get_common_vararg base "
+                "before enabling this path.",
+                name,
+                num_rt_words);
             s.ta_accessors.push_back({name, cta_off, addr_crta_off});
         });
     return s;


### PR DESCRIPTION
## PR Category

Bug fix

## Summary

Two emule-gated fixes for breakage introduced by recent upstream changes. Both slipped past `main` CI because it doesn't build with `TT_METAL_USE_EMULE=ON`.

1. **`process_tensor_binding_handles` callback signature.** #45106 added a 4th `uint32_t num_runtime_field_crta_words` parameter to the callback in `kernel.hpp` and updated `genfiles.cpp`, but missed `tt_metal/impl/emulation/emulated_program_runner.cpp:547`. Every emule build now fails to compile. Match `genfiles.cpp:120`: accept the new parameter and drop it.

2. **Skip `build_firmware()` on Emule devices.** #43754 began invoking `build_firmware()` for emule devices alongside mock. Emule's kernel JIT uses an x86 toolchain and never links the resulting riscv firmware ELFs. Split the gate so emule skips outright; mock + WH/BH continues to build firmware as before.

## Testing

Local 3-arch tt-emule regression against this branch matches baseline (wormhole 30/9, blackhole 19/0, quasar 105/9; all failures allowlisted). Companion tt-emule pin uplift PR: https://github.com/tenstorrent/tt-emule/pull/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-dispatch-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-dispatch-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-dispatch-fix)