### PR TITLE
[bug fix] DEVICE_PRINT was using the wrong field name for Quasar

### DIFF
--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1341,7 +1341,7 @@ volatile tt_l1_ptr std::atomic<uint32_t>& get_lock_atomic() {
     return get_device_print_buffer()->aux.lock;
 #else
     // Atomics require the cached L1 alias.
-    return GET_MAILBOX_ADDRESS_DEV_CACHED(dprint_buf.shared_data)->aux.lock;
+    return GET_MAILBOX_ADDRESS_DEV_CACHED(dprint_buf)->aux.lock;
 #endif
 }
 #endif


### PR DESCRIPTION
### PR Category
bug fix

### Summary
Changing the field name to the correct one

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayaacob/fix_device_print)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayaacob/fix_device_print)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayaacob/fix_device_print)