### PR TITLE
[Bug fix] batch_norm: update running stats after normalization (#41127)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -751,3 +751,66 @@ def test_batch_norm_mixed_precision(
             comp_BN_running_var = tt_updated_var is None
         comp_BN_Output = comp_BN_Output and comp_BN_running_mean and comp_BN_running_var
     assert comp_BN_Output
+
+
+def test_batch_norm_aliased_running_and_affine_tensors(device):
+    """Covers #41127: batch_norm must normalize before updating the running stats.
+
+    A traced graph can pass the same tensor as both running_mean and bias (and as both running_var
+    and weight). Since the running stats are updated in place, doing that update first overwrote
+    weight and bias before batch_norm used them.
+    """
+    input_shape = torch.Size([1, 152, 24, 32])
+    channels = input_shape[1]
+    eps = 9.99999996e-13
+    momentum = 1.0
+
+    # Config matches the traced graph: math_fidelity=hifi4, fp32_dest_acc_en=True.
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+    )
+
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shape, 5, 10, device, is_input=True)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    weight_data = torch.zeros(channels, dtype=torch.bfloat16)
+    bias_data = torch.ones(channels, dtype=torch.bfloat16)
+    weight_tensor = ttnn.from_torch(
+        weight_data.view(1, channels, 1, 1), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    bias_tensor = ttnn.from_torch(
+        bias_data.view(1, channels, 1, 1), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    # Same tensor in two roles: bias_tensor as bias and running_mean, weight_tensor as weight and running_var.
+    tt_output_tensor = ttnn.batch_norm(
+        input_tensor,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        running_mean=bias_tensor,
+        running_var=weight_tensor,
+        training=True,
+        eps=eps,
+        momentum=momentum,
+        compute_kernel_config=compute_config,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor)
+
+    # PyTorch would also overwrite these buffers if we passed the same tensor twice, so the reference
+    # uses separate running stat tensors that start with the same values as bias and weight.
+    running_mean_ref = torch.ones(channels, dtype=torch.bfloat16)
+    running_var_ref = torch.zeros(channels, dtype=torch.bfloat16)
+    torch_output = torch.nn.functional.batch_norm(
+        input=in_data,
+        running_mean=running_mean_ref,
+        running_var=running_var_ref,
+        weight=weight_data,
+        bias=bias_data,
+        training=True,
+        eps=eps,
+        momentum=momentum,
+    )
+    # weight is all zeros, so the normalized term is zeroed out and the output collapses to the
+    # bias (all ones) on both backends - the comparison is therefore exact.
+    assert_numeric_metrics(torch_output, tt_output, pcc_threshold=1.0, rtol=0.0, atol=0.0, frobenius_threshold=0.0)

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -110,8 +110,6 @@ Tensor batch_norm(
         auto mean_sq = operations::normalization::mean_NHW(
             ttnn::square(input, memory_config), memory_config, compute_kernel_config);
         batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
-        ttnn::prim::running_statistics(
-            batch_mean, batch_var, momentum, running_mean, running_var, memory_config, compute_kernel_config);
     } else {
         TT_FATAL(
             (running_mean.has_value() && running_var.has_value()),
@@ -119,8 +117,18 @@ Tensor batch_norm(
         batch_mean = running_mean.value();
         batch_var = running_var.value();
     }
-    return ttnn::prim::batch_norm(
+
+    // Normalize before updating running stats: running_statistics writes running_mean/running_var
+    // in place, which would corrupt weight/bias if the caller aliases those buffers.
+    auto output_tensor = ttnn::prim::batch_norm(
         input, batch_mean, batch_var, eps, weight, bias, output, memory_config, compute_kernel_config);
+
+    if (training) {
+        ttnn::prim::running_statistics(
+            batch_mean, batch_var, momentum, running_mean, running_var, memory_config, compute_kernel_config);
+    }
+
+    return output_tensor;
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
### PR Category
- Bug fix

### Summary
- Closes #41127

In training mode, `batch_norm` was updating `running_mean`/`running_var` *before* computing the normalized output. The running-stats update writes those buffers in place, so when a caller passes the same tensor in two roles - e.g. `running_mean=bias` and `running_var=weight` (which happens in traced graphs) - the update clobbered `weight`/`bias` before the op got to read them, giving wrong results.

The fix reorders things: normalize first, then update the running stats. 


### Notes for reviewers
The main change is in `batch_norm.cpp` - the `running_statistics` call moved below `ttnn::prim::batch_norm` and is now guarded by the `training` flag. Also added a unit test covering the aliased-buffer case (`running_mean=bias`, `running_var=weight`), which fails on the old ordering and passes now.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-batch-norm-training)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-batch-norm-training)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-batch-norm-training)