### PR TITLE
ci: switch bh-qb-ge to bh-quietbox-2, update model mount paths

### DIFF
--- a/.github/blackhole_demo_systems.yaml
+++ b/.github/blackhole_demo_systems.yaml
@@ -7,7 +7,7 @@
 # Each entry must carry:
 #   sku                  — matches a key under skus: in .github/sku_config.yaml
 #   name                 — workflow_dispatch system-type display name
-#   weights-cache-mode   — one of: local-disk, cloud-mlperf, lfc
+#   weights-cache-mode   — one of: local-disk, cloud-mlperf, lfc, yyz4-mnt-models
 #   num_devices          — informational; for run-page disambiguation only
 
 systems:
@@ -41,5 +41,5 @@ systems:
     num_devices: 2
   - sku: bh_quietbox_2
     name: "QuietBox 2 (2xP300)"
-    weights-cache-mode: local-disk
+    weights-cache-mode: yyz4-mnt-models
     num_devices: 4

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -206,7 +206,7 @@ skus:
 
   bh_quietbox_2:
     runs_on:
-      - BH-QB-GE
+      - BH-Quietbox-2
       - pipeline-perf
       - in-service
 

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -180,7 +180,7 @@ models:
     bh_p150b_civ2: 55
     bh_p150: 60
     bh_p300: 50
-    bh_quietbox_2: 210
+    bh_quietbox_2: 235
     bh_galaxy: 78
   unit:
     wh_llmbox: 175

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -290,6 +290,7 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+      use-artifacts-from-run: 26770732783
 
   # ── Tier 1 ────────────────────────────────────────────────────────
   t1-unit-tests:

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -290,7 +290,7 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      use-artifacts-from-run: 26770732783
+      use-artifacts-from-run: 26770671053
 
   # ── Tier 1 ────────────────────────────────────────────────────────
   t1-unit-tests:

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -290,7 +290,6 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      use-artifacts-from-run: 26770671053
 
   # ── Tier 1 ────────────────────────────────────────────────────────
   t1-unit-tests:

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -114,8 +114,9 @@ jobs:
         # from .github/blackhole_demo_systems.yaml during matrix build.
         # If weights-cache-mode is lfc, we don't mount the model cache volume — weights download via LFC (P300s in CIv1-style env on Proxmox with LFC endpoint)
         # If weights-cache-mode is cloud-mlperf, mount from /mnt/MLPerf/huggingface (canonical HF cache root, shared with the Wormhole pipelines)
+        # If weights-cache-mode is yyz4-mnt-models, mount from /mnt/models/huggingface (YYZ4 Exabox nfs storage mount)
         # If weights-cache-mode is local-disk, mount from /localdev/blackhole_demos/huggingface_data (CIv1 GH VLAN, not on Cloud)
-        - "${{ matrix.test-group['weights-cache-mode'] != 'lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && '/mnt/MLPerf/huggingface' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || '/no_hf_cache' }}"
+        - "${{ matrix.test-group['weights-cache-mode'] != 'lfc' && format('{0}:/localdev/blackhole_demos/huggingface_data{1}', matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && '/mnt/MLPerf/huggingface' || matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && '/mnt/models/huggingface' || '/localdev/blackhole_demos/huggingface_data', inputs.regenerate-ttnn-cache == true && ':rw' || ':ro') || '/no_hf_cache' }}"
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
       run:

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -173,7 +173,7 @@ jobs:
         if: ${{ !startsWith(matrix.test-group.sku, 'bh_p100') && !startsWith(matrix.test-group.sku, 'bh_p150') }}
         timeout-minutes: 10
         with:
-          runner-label: ${{ (matrix.test-group.sku == 'bh_deskbox' && 'BH-DeskBox') || (matrix.test-group.sku == 'bh_loudbox' && 'BH-LoudBox') || (matrix.test-group.sku == 'bh_llmbox' && 'BH-LLMBox') || (matrix.test-group.sku == 'bh_quietbox_2' && 'BH-QB-GE') || (matrix.test-group.sku == 'bh_p300' && 'P300-viommu') || '' }}
+          runner-label: ${{ matrix.test-group.sku == 'bh_deskbox' && 'BH-DeskBox' || '' }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -415,7 +415,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [ "BH-LLMBox", "BH-LoudBox", "P300-viommu"]
+        test-group: [ "BH-Quietbox-2", "P300-viommu"]
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/.github/workflows/job_configs/upstream-tests.json
+++ b/.github/workflows/job_configs/upstream-tests.json
@@ -8,14 +8,6 @@
       "test_job": "test-wh-6u-image",
       "image_outputs": ["wh-6u-image-tag", "wh-6u-profiler-image-tag"]
     },
-    "bh-llmbox": {
-      "test_job": "test-bh-multicard-image",
-      "image_outputs": ["bh-llmbox-image-tag"]
-    },
-    "bh-deskbox": {
-      "test_job": "test-bh-multicard-image",
-      "image_outputs": ["bh-deskbox-image-tag"]
-    },
     "bh-loudbox": {
       "test_job": "test-bh-multicard-image",
       "image_outputs": ["bh-loudbox-image-tag"]

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -56,7 +56,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            ./.github/blackhole_demo_systems.yaml
       - name: Apply model filters
         id: apply-filters
         run: |
@@ -89,7 +90,13 @@ jobs:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        HF_HUB_OFFLINE: 1
+        # Only the per-runner BH cache modes (local-disk, lfc) need HF online
+        # so first-use can populate the cache. Shared NFS modes (cloud-mlperf
+        # for BH and the implicit WH mount) keep HF offline — those are :ro
+        # and HF would try to write metadata (refs/main, .no_exist markers)
+        # on every HEAD call even when the cache already has the model,
+        # crashing with `OSError [Errno 30] Read-only file system`.
+        HF_HUB_OFFLINE: ${{ (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '0' || '1' }}
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -96,7 +96,14 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+        # bh_p150 / bh_loudbox / bh_galaxy[_perf] and the WH SKUs run on machines
+        # that host the canonical HF / tt_cache layout under /mnt/MLPerf, so the
+        # standard mount works as-is. bh_quietbox_2 uses QB2's in YYZ4 with a NFS mount
+        # whose equivalent layout lives at /mnt/models/huggingface
+        # — map that host path onto /mnt/MLPerf/huggingface inside the container
+        # so a single test cmd referencing /mnt/MLPerf/... resolves on both
+        # cache modes.
+        - ${{ matrix.test-group.sku == 'bh_quietbox_2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -96,14 +96,18 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        # bh_p150 / bh_loudbox / bh_galaxy[_perf] and the WH SKUs run on machines
-        # that host the canonical HF / tt_cache layout under /mnt/MLPerf, so the
-        # standard mount works as-is. bh_quietbox_2 uses QB2's in YYZ4 with a NFS mount
-        # whose equivalent layout lives at /mnt/models/huggingface
-        # — map that host path onto /mnt/MLPerf/huggingface inside the container
-        # so a single test cmd referencing /mnt/MLPerf/... resolves on both
-        # cache modes.
-        - ${{ matrix.test-group.sku == 'bh_quietbox_2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+        # Mount the HF / tt_cache root so it always appears inside the container
+        # at /mnt/MLPerf/huggingface, regardless of which BH cache mode the
+        # runner uses. Host source comes from matrix.test-group['weights-cache-mode']
+        # (populated from .github/blackhole_demo_systems.yaml by prepare_test_matrix.py):
+        #   cloud-mlperf            → host /mnt/MLPerf/huggingface (shared NFS)
+        #   local-disk / lfc        → host /localdev/blackhole_demos/huggingface_data (per-runner)
+        #   yyz4-mnt-models         → host /mnt/models/huggingface (YYZ4 Exabox nfs storage mount)
+        #   (no mode → WH SKU)      → host /mnt/MLPerf (whole tree; preserves access to
+        #                             /mnt/MLPerf/tt_dnn-models still used by one WH entry)
+        # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
+        # shared NFS honors mlperf-read-only.
+        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -120,11 +120,12 @@ jobs:
         # (populated from .github/blackhole_demo_systems.yaml by prepare_test_matrix.py):
         #   cloud-mlperf            → host /mnt/MLPerf/huggingface (shared NFS)
         #   local-disk / lfc        → host /localdev/blackhole_demos/huggingface_data (per-runner)
+        #   yyz4-mnt-models         → host /mnt/models/huggingface (YYZ4 Exabox nfs storage mount)
         #   (no mode → WH SKU)      → host /mnt/MLPerf (whole tree; preserves access to
         #                             /mnt/MLPerf/tt_dnn-models still used by one WH entry)
         # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
         # shared NFS honors mlperf-read-only.
-        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -64,7 +64,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            ./.github/blackhole_demo_systems.yaml
       - name: Apply tier and model filters
         id: apply-filters
         run: |
@@ -99,7 +100,13 @@ jobs:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        HF_HUB_OFFLINE: 1
+        # Only the per-runner BH cache modes (local-disk, lfc) need HF online
+        # so first-use can populate the cache. Shared NFS modes (cloud-mlperf
+        # for BH and the implicit WH mount) keep HF offline — those are :ro
+        # and HF would try to write metadata (refs/main, .no_exist markers)
+        # on every HEAD call even when the cache already has the model,
+        # crashing with `OSError [Errno 30] Read-only file system`.
+        HF_HUB_OFFLINE: ${{ (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '0' || '1' }}
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -106,7 +106,14 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf${{ inputs.mlperf-read-only && ':ro' || ':rw' }}
+        # bh_p150 / bh_loudbox / bh_galaxy[_perf] and the WH SKUs run on machines
+        # that host the canonical HF / tt_cache layout under /mnt/MLPerf, so the
+        # standard mount works as-is. bh_quietbox_2 uses QB2's in YYZ4 with a NFS mount
+        # whose equivalent layout lives at /mnt/models/huggingface
+        # — map that host path onto /mnt/MLPerf/huggingface inside the container
+        # so a single test cmd referencing /mnt/MLPerf/... resolves on both
+        # cache modes.
+        - ${{ matrix.test-group.sku == 'bh_quietbox_2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -106,14 +106,18 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        # bh_p150 / bh_loudbox / bh_galaxy[_perf] and the WH SKUs run on machines
-        # that host the canonical HF / tt_cache layout under /mnt/MLPerf, so the
-        # standard mount works as-is. bh_quietbox_2 uses QB2's in YYZ4 with a NFS mount
-        # whose equivalent layout lives at /mnt/models/huggingface
-        # — map that host path onto /mnt/MLPerf/huggingface inside the container
-        # so a single test cmd referencing /mnt/MLPerf/... resolves on both
-        # cache modes.
-        - ${{ matrix.test-group.sku == 'bh_quietbox_2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+        # Mount the HF / tt_cache root so it always appears inside the container
+        # at /mnt/MLPerf/huggingface, regardless of which BH cache mode the
+        # runner uses. Host source comes from matrix.test-group['weights-cache-mode']
+        # (populated from .github/blackhole_demo_systems.yaml by prepare_test_matrix.py):
+        #   cloud-mlperf            → host /mnt/MLPerf/huggingface (shared NFS)
+        #   local-disk / lfc        → host /localdev/blackhole_demos/huggingface_data (per-runner)
+        #   yyz4-mnt-models         → host /mnt/models/huggingface (YYZ4 Exabox nfs storage mount)
+        #   (no mode → WH SKU)      → host /mnt/MLPerf (whole tree; preserves access to
+        #                             /mnt/MLPerf/tt_dnn-models still used by one WH entry)
+        # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
+        # shared NFS honors mlperf-read-only.
+        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -120,11 +120,12 @@ jobs:
         # (populated from .github/blackhole_demo_systems.yaml by prepare_test_matrix.py):
         #   cloud-mlperf            → host /mnt/MLPerf/huggingface (shared NFS)
         #   local-disk / lfc        → host /localdev/blackhole_demos/huggingface_data (per-runner)
+        #   yyz4-mnt-models         → host /mnt/models/huggingface (YYZ4 Exabox nfs storage mount)
         #   (no mode → WH SKU)      → host /mnt/MLPerf (whole tree; preserves access to
         #                             /mnt/MLPerf/tt_dnn-models still used by one WH entry)
         # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
         # shared NFS honors mlperf-read-only.
-        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+        - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
     defaults:
       run:

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -56,11 +56,11 @@ on:
         type: boolean
         default: true
         description: "Run tests on P300-viommu"
-      bh-runner-qb-ge:
+      bh-runner-quietbox-2:
         required: false
         type: boolean
         default: true
-        description: "Run tests on BH-QB-GE"
+        description: "Run tests on BH-Quietbox-2"
 
 jobs:
   # Wormhole N300 - Fabric tests
@@ -265,8 +265,8 @@ jobs:
             runner_items+=('{"name":"P300 unit tests","runner-label":"P300-viommu"}')
           fi
 
-          if [[ "${{ inputs.bh-runner-qb-ge }}" == "true" ]]; then
-            runner_items+=('{"name":"QuietBox Global Edition unit tests","runner-label":"BH-QB-GE"}')
+          if [[ "${{ inputs.bh-runner-quietbox-2 }}" == "true" ]]; then
+            runner_items+=('{"name":"Quietbox 2 unit tests","runner-label":"BH-Quietbox-2"}')
           fi
 
           # If no runners selected, fail the job with an error

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -58,8 +58,8 @@ on:
         required: false
         default: true
         type: boolean
-      bh-runner-qb-ge:
-        description: 'Run tests on BH-QB-GE'
+      bh-runner-quietbox-2:
+        description: 'Run tests on BH-Quietbox-2'
         required: false
         default: true
         type: boolean
@@ -121,7 +121,7 @@ jobs:
             bh_deskbox="${{ inputs.bh-runner-deskbox }}"
             bh_loudbox="${{ inputs.bh-runner-loudbox }}"
             bh_p300="${{ inputs.bh-runner-p300 }}"
-            bh_qb_ge="${{ inputs.bh-runner-qb-ge }}"
+            bh_quietbox_2="${{ inputs.bh-runner-quietbox-2 }}"
           else
             # Default to true for workflow_call and push events
             run_wh_n300="true"
@@ -132,7 +132,7 @@ jobs:
             bh_deskbox="true"
             bh_loudbox="true"
             bh_p300="true"
-            bh_qb_ge="true"
+            bh_quietbox_2="true"
           fi
 
           if [[ "$run_wh_n300" == "true" ]]; then
@@ -150,19 +150,19 @@ jobs:
           if [[ "$run_bh" == "true" ]]; then
             # Add blackhole test configurations for each selected runner
             if [[ "$bh_llmbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":true,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-qb-ge":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":true,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_deskbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":true,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-qb-ge":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":true,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_loudbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":true,"bh-runner-p300":false,"bh-runner-qb-ge":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":true,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_p300" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":true,"bh-runner-qb-ge":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":true,"bh-runner-quietbox-2":false}')
             fi
-            if [[ "$bh_qb_ge" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-qb-ge":true}')
+            if [[ "$bh_quietbox_2" == "true" ]]; then
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":true}')
             fi
           fi
 
@@ -204,7 +204,7 @@ jobs:
       bh-runner-deskbox: ${{ matrix.test-config.bh-runner-deskbox || false }}
       bh-runner-loudbox: ${{ matrix.test-config.bh-runner-loudbox || false }}
       bh-runner-p300: ${{ matrix.test-config.bh-runner-p300 || false }}
-      bh-runner-qb-ge: ${{ matrix.test-config.bh-runner-qb-ge || false }}
+      bh-runner-quietbox-2: ${{ matrix.test-config.bh-runner-quietbox-2 || false }}
   fabric-perf-tests:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-wh-t3k-perf-tests != false || github.event_name == 'push' }}
     needs: build-artifact

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -43,8 +43,6 @@ env:
   WH_6U_PROFILER_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-profiler-tests-wh-6u
   BLACKHOLE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh
   BLACKHOLE_PROFILER_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-profiler-tests-bh
-  BLACKHOLE_LLMBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-llmbox
-  BLACKHOLE_DESKBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-deskbox
   BLACKHOLE_LOUDBOX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-loudbox
   BLACKHOLE_P300_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300
   BLACKHOLE_QB_GE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge
@@ -71,8 +69,6 @@ jobs:
       wh-6u-profiler-image-tag: ${{ steps.set-image-tags.outputs.wh-6u-profiler-image-tag }}
       bh-image-tag: ${{ steps.set-image-tags.outputs.bh-image-tag }}
       bh-profiler-image-tag: ${{ steps.set-image-tags.outputs.bh-profiler-image-tag }}
-      bh-llmbox-image-tag: ${{ steps.set-image-tags.outputs.bh-llmbox-image-tag }}
-      bh-deskbox-image-tag: ${{ steps.set-image-tags.outputs.bh-deskbox-image-tag }}
       bh-loudbox-image-tag: ${{ steps.set-image-tags.outputs.bh-loudbox-image-tag }}
       bh-p300-image-tag: ${{ steps.set-image-tags.outputs.bh-p300-image-tag }}
       bh-qb-ge-image-tag: ${{ steps.set-image-tags.outputs.bh-qb-ge-image-tag }}
@@ -94,10 +90,6 @@ jobs:
             >> "$GITHUB_OUTPUT"
           echo "bh-image-tag=${{ env.BLACKHOLE_IMAGE_NAME }}:${image_suffix}" >> "$GITHUB_OUTPUT"
           echo "bh-profiler-image-tag=${{ env.BLACKHOLE_PROFILER_IMAGE_NAME }}:${image_suffix}" \
-            >> "$GITHUB_OUTPUT"
-          echo "bh-llmbox-image-tag=${{ env.BLACKHOLE_LLMBOX_IMAGE_NAME }}:${image_suffix}" \
-            >> "$GITHUB_OUTPUT"
-          echo "bh-deskbox-image-tag=${{ env.BLACKHOLE_DESKBOX_IMAGE_NAME }}:${image_suffix}" \
             >> "$GITHUB_OUTPUT"
           echo "bh-loudbox-image-tag=${{ env.BLACKHOLE_LOUDBOX_IMAGE_NAME }}:${image_suffix}" \
             >> "$GITHUB_OUTPUT"
@@ -144,20 +136,6 @@ jobs:
             hw-topology: blackhole
             build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
             wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
-            dockerfile: dockerfile/upstream_test_images/Dockerfile
-            test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
-            hw-topology: blackhole_llmbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-            techdebt-install-ttt-reqs: true
-          - image-tag: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
-            dockerfile: dockerfile/upstream_test_images/Dockerfile
-            test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
-            hw-topology: blackhole_deskbox
-            build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-            wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-            techdebt-install-ttt-reqs: true
           - image-tag: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
             dockerfile: dockerfile/upstream_test_images/Dockerfile
             test-command: dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -303,18 +281,14 @@ jobs:
       fail-fast: false
       matrix:
         bh-config:
-          - runner-label: BH-LLMBox
-            image-name: ${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}
-            extra-tag: pipeline-perf
-          - runner-label: BH-DeskBox
-            image-name: ${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}
-            extra-tag: pipeline-functional
           - runner-label: BH-LoudBox
             image-name: ${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}
             extra-tag: pipeline-functional
-          - runner-label: BH-QB-GE
+            hf-home: /mnt/MLPerf/huggingface
+          - runner-label: BH-Quietbox-2
             image-name: ${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}
             extra-tag: pipeline-perf
+            hf-home: /mnt/models/huggingface
     runs-on:
       - ${{ matrix.bh-config.runner-label }}
       - in-service
@@ -323,16 +297,9 @@ jobs:
       - name: Run image
         timeout-minutes: 30
         env:
-          # For different environments, BH VLAN vs. cloud
-          HF_HOME: >-
-            ${{ matrix.bh-config.extra-tag == 'pipeline-perf'
-            && '/localdev/blackhole_demos/huggingface_data'
-            || '/mnt/MLPerf/huggingface' }}
+          HF_HOME: ${{ matrix.bh-config.hf-home }}
           HF_MODEL: meta-llama/Llama-3.1-8B-Instruct
-          TT_CACHE_PATH: >-
-            ${{ matrix.bh-config.extra-tag == 'pipeline-perf'
-            && '/localdev/blackhole_demos/huggingface_data/tt_cache'
-            || '/mnt/MLPerf/huggingface/tt_cache' }}/meta-llama--Llama-3.1-8B-Instruct
+          TT_CACHE_PATH: ${{ matrix.bh-config.hf-home }}/tt_cache/meta-llama--Llama-3.1-8B-Instruct
         run: |
           docker run --network none -v /dev/hugepages-1G:/dev/hugepages-1G \
             --device /dev/tenstorrent -v $HF_HOME:$HF_HOME:ro \
@@ -454,8 +421,6 @@ jobs:
             ["bh-profiler-image-tag"]="${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}"
             ["wh-6u-image-tag"]="${{ needs.get-image-tags.outputs.wh-6u-image-tag }}"
             ["wh-6u-profiler-image-tag"]="${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}"
-            ["bh-llmbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-llmbox-image-tag }}"
-            ["bh-deskbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-deskbox-image-tag }}"
             ["bh-loudbox-image-tag"]="${{ needs.get-image-tags.outputs.bh-loudbox-image-tag }}"
             ["bh-p300-image-tag"]="${{ needs.get-image-tags.outputs.bh-p300-image-tag }}"
             ["bh-qb-ge-image-tag"]="${{ needs.get-image-tags.outputs.bh-qb-ge-image-tag }}"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -70,11 +70,11 @@ jobs:
           #     "owner_id": "U08TJ70UFRT"
           #   },
           #   {
-          #     "name": "[BH-QB-GE] Gemma4-31B",
+          #     "name": "[BH-QB-2] Gemma4-31B",
           #     "model": "google/gemma-4-31B-it",
           #     "server-timeout": 20,
           #     "benchmark-timeout": 5,
-          #     "runner-label": "BH-QB-GE",
+          #     "runner-label": "BH-Quietbox-2",
           #     "arch": "arch-blackhole",
           #     "mesh-device": "P150x4",
           #     "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
@@ -140,11 +140,11 @@ jobs:
               "owner_id": "U08TJ70UFRT"
             },
             {
-              "name": "[BH-QB-GE] Gemma4-26B-A4B",
+              "name": "[BH-QB-2] Gemma4-26B-A4B",
               "model": "google/gemma-4-26B-A4B-it",
               "server-timeout": 15,
               "benchmark-timeout": 5,
-              "runner-label": "BH-QB-GE",
+              "runner-label": "BH-Quietbox-2",
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -238,11 +238,11 @@ jobs:
               "owner_id": "U08GELBB1AP"
             },
             {
-              "name": "[BH-QB-GE] Llama-3.1-8B-Instruct",
+              "name": "[BH-QB-2] Llama-3.1-8B-Instruct",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 10,
               "benchmark-timeout": 10,
-              "runner-label": "BH-QB-GE",
+              "runner-label": "BH-Quietbox-2",
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
               "tt-config": "{\"trace_region_size\": 76000000}",
@@ -399,7 +399,7 @@ jobs:
       - ${{ matrix.test-group.arch }}
       - in-service
       # topology-6u tag is used for WH galaxies. Currently pipeline-perf machines have mlperf access and pipeline-functional machines do not.
-      - ${{ ((matrix.test-group.runner-label == 'BH-QB-GE' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
+      - ${{ ((matrix.test-group.runner-label == 'BH-Quietbox-2' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -423,9 +423,9 @@ jobs:
         - /dev/hugepages-1G:/dev/hugepages-1G
         # ``mlperf-read-only`` workflow input toggles ro/rw. Default ro for safety;
         # uncheck the box at dispatch time when a model needs tt_cache first-use
-        # write-through. BH-QB-GE uses a local override path (not the shared
+        # write-through. BH-Quietbox-2 uses a different network mount (/mnt/models, not the shared
         # /mnt/MLPerf) so the same toggle applies to either physical mount source.
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && format('/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+        - ${{ (matrix.test-group.runner-label == 'BH-Quietbox-2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -405,7 +405,7 @@
       timeout: 15
       tier: 2
     bh_quietbox_2:
-      timeout: 15
+      timeout: 30
       tier: 2
     # bh_galaxy_perf: temporarily disabled — Blackhole Galaxy fabric / ethernet
     # bring-up hits an unrecoverable hang at open_mesh_device (FabricFirmwareInitializer
@@ -432,7 +432,7 @@
       timeout: 15
       tier: 2
     bh_quietbox_2:
-      timeout: 15
+      timeout: 30
       tier: 2
     # bh_galaxy_perf: temporarily disabled — same Blackhole Galaxy fabric / ethernet
     # hang as 26B-A4B above. Re-enable once root-caused.
@@ -530,7 +530,7 @@
       timeout: 30
       tier: 1
     bh_quietbox_2:
-      timeout: 25
+      timeout: 45
       tier: 1
     bh_galaxy:
       timeout: 30

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -405,7 +405,7 @@
       timeout: 15
       tier: 2
     bh_quietbox_2:
-      timeout: 30
+      timeout: 25
       tier: 2
     # bh_galaxy_perf: temporarily disabled — Blackhole Galaxy fabric / ethernet
     # bring-up hits an unrecoverable hang at open_mesh_device (FabricFirmwareInitializer
@@ -530,7 +530,7 @@
       timeout: 30
       tier: 1
     bh_quietbox_2:
-      timeout: 45
+      timeout: 35
       tier: 1
     bh_galaxy:
       timeout: 30


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://tenstorrent.atlassian.net/browse/MINFRA-447

QB2 runners moved to systems in YYZ4 with a dedicated NFS mount under `/mnt/models`
Existing QB2 runners used their local disk for weights so the path to mount into containers for CI needs to be updated.

Change the label in CI from `BH-QB-GE` to `BH-Quietbox-2` to match product name (upstream container name is unchanged)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Weights and ttnn caches have been regenerated for existing QB2 blackhole demo models under `/mnt/models/huggingface/hub` and `/mnt/models/huggingface/tt_cache` , mirroring MLPerf setup.

Blackhole post commit:
https://github.com/tenstorrent/tt-metal/actions/runs/26672158777

Blackhole demos:  (mochi is failing on main)
https://github.com/tenstorrent/tt-metal/actions/runs/26670930400
llama70b https://github.com/tenstorrent/tt-metal/actions/runs/26671597092
wan2.2 https://github.com/tenstorrent/tt-metal/actions/runs/26672388299

Upstream: 
https://github.com/tenstorrent/tt-metal/actions/runs/26673939190

TM fabric: 
https://github.com/tenstorrent/tt-metal/actions/runs/26672248412

VLLM nightly:
llama3.1-8b QB2 https://github.com/tenstorrent/tt-metal/actions/runs/26765578495
gemma4 https://github.com/tenstorrent/tt-metal/actions/runs/26770671053 (to be fixed in future vllm bump)

All models tests (SKU = bh_quietbox_2):
https://github.com/tenstorrent/tt-metal/actions/runs/26782475950
[after rebase, in progress]: https://github.com/tenstorrent/tt-metal/actions/runs/26825174823

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/yyz4-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/yyz4-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/yyz4-qb2)