### PR TITLE
[tt-train] Fused MLA QKV assemble backward op

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -221,6 +221,10 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
+    # MLA QKV Assemble Backward (DeepSeek)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
 )
 
 list(APPEND SOURCES ${METAL_OPS_FILES})

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -10,6 +10,7 @@
 #include "ops/k_split_gram_matmul/k_split_gram_matmul.hpp"
 #include "ops/layernorm_bw/layernorm_bw.hpp"
 #include "ops/layernorm_fw/layernorm_fw.hpp"
+#include "ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp"
 #include "ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp"
 #include "ops/polynorm_fw/polynorm_fw.hpp"
 #include "ops/profiler_no_op/profiler_no_op.hpp"

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+
+constexpr uint32_t Tr = get_compile_time_arg_val(0);
+constexpr uint32_t n_heads = get_compile_time_arg_val(1);
+
+constexpr auto cb_dkpe_in = tt::CBIndex::c_3;
+constexpr auto cb_dkpe_out = tt::CBIndex::c_4;
+
+constexpr uint32_t onetile = 1U;
+
+void kernel_main() {
+    const uint32_t num_blocks = get_arg_val<uint32_t>(0);
+
+    binary_op_init_common(cb_dkpe_in, cb_dkpe_in, cb_dkpe_out);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        // DST registers 0..Tr-1 hold the running head-axis sum across the block;
+        // slot Tr is the working temp for each new head's incoming tile.
+        tile_regs_acquire();
+
+        // Head 0: copy the first head's Tr tiles into the accumulator (dst 0..Tr-1).
+        cb_wait_front(cb_dkpe_in, Tr);
+        copy_tile_init(cb_dkpe_in);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            copy_tile(cb_dkpe_in, w, /* dst_idx */ w);
+        }
+        cb_pop_front(cb_dkpe_in, Tr);
+
+        // Heads 1..H-1: load each tile into dst[Tr] and add into dst[w].
+        for (uint32_t h = 1U; h < n_heads; ++h) {
+            cb_wait_front(cb_dkpe_in, Tr);
+            copy_tile_init(cb_dkpe_in);
+            for (uint32_t w = 0U; w < Tr; ++w) {
+                constexpr uint32_t tmp_dst = Tr;
+                copy_tile(cb_dkpe_in, w, /* dst_idx */ tmp_dst);
+                add_binary_tile_init();
+                add_binary_tile(/* dst_a */ w, /* dst_b */ tmp_dst, /* dst_dest */ w);
+            }
+            cb_pop_front(cb_dkpe_in, Tr);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        cb_reserve_back(cb_dkpe_out, Tr);
+        pack_reconfig_data_format(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            pack_tile(/* dst_idx */ w, cb_dkpe_out);
+        }
+        cb_push_back(cb_dkpe_out, Tr);
+
+        tile_regs_release();
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    const uint32_t dQ_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dK_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dV_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);              // s-tile-row in current batch
+    uint32_t dQK_block_base = get_arg_val<uint32_t>(runtime_args_counter++);  // head 0 of (b, sb), w=0
+    uint32_t dV_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_in = tt::CBIndex::c_3;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t kq_HtWt = get_compile_time_arg_val(5);  // Ts * Th
+    constexpr uint32_t v_HtWt = get_compile_time_arg_val(6);   // Ts * Tv
+    constexpr uint32_t Ts = get_compile_time_arg_val(7);
+    constexpr uint32_t block_size = get_compile_time_arg_val(8);
+
+    constexpr auto dQ_args = TensorAccessorArgs<9>();
+    constexpr auto dK_args = TensorAccessorArgs<dQ_args.next_compile_time_args_offset()>();
+    constexpr auto dV_args = TensorAccessorArgs<dK_args.next_compile_time_args_offset()>();
+
+    const auto dQ_addr_gen = TensorAccessor(dQ_args, dQ_addr);
+    const auto dK_addr_gen = TensorAccessor(dK_args, dK_addr);
+    const auto dV_addr_gen = TensorAccessor(dV_args, dV_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dkpe_in);
+
+    // End-of-batch jump to advance dQK_block_base across batch boundary:
+    //   from b * H*kq_HtWt + (Ts-1)*Th  →  (b+1) * H*kq_HtWt
+    //   = current + ((H-1)*Ts + 1) * Th
+    constexpr uint32_t end_of_batch_jump_q = ((n_heads - 1U) * Ts + 1U) * Th;
+    constexpr uint32_t end_of_batch_jump_v = ((n_heads - 1U) * Ts + 1U) * Tv;
+
+    // dQ / dK_nope / dV stream in block_size chunks via the shared util; dK_pe (Tr tiles) is read as one
+    // burst into cb_dkpe_in because the compute kernel sums all Tr tiles of a head at once.
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t head_dqk = dQK_block_base + h * kq_HtWt;  // dQ and dK share head_dim
+            const uint32_t head_dv = dV_block_base + h * v_HtWt;
+
+            read_full_row_tiles(cb_dq, dQ_addr_gen, Th, block_size, tile_bytes, head_dqk);
+            read_full_row_tiles(cb_dknope, dK_addr_gen, Tn, block_size, tile_bytes, head_dqk);
+            read_tiles_by_row(cb_dkpe_in, dK_addr_gen, head_dqk + Tn, Tr, tile_bytes, Tr);
+            read_full_row_tiles(cb_dv, dV_addr_gen, Tv, block_size, tile_bytes, head_dv);
+        }
+
+        ++sb;
+        if (sb < Ts) {
+            dQK_block_base += Th;
+            dV_block_base += Tv;
+        } else {
+            sb = 0U;
+            dQK_block_base += end_of_batch_jump_q;
+            dV_block_base += end_of_batch_jump_v;
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    const uint32_t dq_pre_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dkv_up_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dk_pe_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dq_pre_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dkv_up_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dk_pe_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_out = tt::CBIndex::c_4;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t block_size = get_compile_time_arg_val(5);
+    constexpr uint32_t kv_per_head = Tn + Tv;
+
+    constexpr auto dq_pre_args = TensorAccessorArgs<6>();
+    constexpr auto dkv_up_args = TensorAccessorArgs<dq_pre_args.next_compile_time_args_offset()>();
+    constexpr auto dk_pe_args = TensorAccessorArgs<dkv_up_args.next_compile_time_args_offset()>();
+
+    const auto dq_pre_addr_gen = TensorAccessor(dq_pre_args, dq_pre_addr);
+    const auto dkv_up_addr_gen = TensorAccessor(dkv_up_args, dkv_up_addr);
+    const auto dk_pe_addr_gen = TensorAccessor(dk_pe_args, dk_pe_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dkpe_out);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t dq_head_base = dq_pre_block_base + h * Th;
+            const uint32_t dkv_head_base = dkv_up_block_base + h * kv_per_head;
+
+            // dq_pre ← cb_dq; dkv_up = [dK_nope | dV] ← cb_dknope then cb_dv. All in block_size chunks.
+            write_full_row_tiles(cb_dq, dq_pre_addr_gen, Th, block_size, tile_bytes, dq_head_base);
+            write_full_row_tiles(cb_dknope, dkv_up_addr_gen, Tn, block_size, tile_bytes, dkv_head_base);
+            write_full_row_tiles(cb_dv, dkv_up_addr_gen, Tv, block_size, tile_bytes, dkv_head_base + Tn);
+        }
+
+        // dk_pe ← Tr tiles produced by the compute kernel (head-axis sum); one burst + one barrier.
+        cb_wait_front(cb_dkpe_out, Tr);
+        const uint32_t l1_kpe = get_read_ptr(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            noc_async_write_page(dk_pe_block_base + w, dk_pe_addr_gen, l1_kpe + w * tile_bytes);
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_dkpe_out, Tr);
+
+        // Outputs are flat across blocks, so the advance is constant.
+        dq_pre_block_base += n_heads * Th;
+        dkv_up_block_base += n_heads * kv_per_head;
+        dk_pe_block_base += Tr;
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "MLAQKVAssembleBw requires {} to be on device. Got storage type: {}",
+            name,
+            enchantum::to_string(tensor.storage_type()));
+        TT_FATAL(tensor.buffer() != nullptr, "MLAQKVAssembleBw: {} buffer must be allocated.", name);
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "MLAQKVAssembleBw requires {} to be in TILE layout. Got: {}",
+            name,
+            enchantum::to_string(tensor.layout()));
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "MLAQKVAssembleBw requires {} dtype to be BFLOAT16. Got: {}",
+            name,
+            enchantum::to_string(tensor.dtype()));
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "MLAQKVAssembleBw requires {} memory layout to be INTERLEAVED. Got: {}",
+            name,
+            enchantum::to_string(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    check_tensor(dQ, "dQ");
+    check_tensor(dK, "dK");
+    check_tensor(dV, "dV");
+
+    const auto dQ_shape = dQ.padded_shape();
+    const auto dK_shape = dK.padded_shape();
+    const auto dV_shape = dV.padded_shape();
+
+    TT_FATAL(dQ_shape.rank() == 4U, "MLAQKVAssembleBw: dQ must be rank-4");
+    TT_FATAL(dK_shape.rank() == 4U, "MLAQKVAssembleBw: dK must be rank-4");
+    TT_FATAL(dV_shape.rank() == 4U, "MLAQKVAssembleBw: dV must be rank-4");
+
+    TT_FATAL(
+        dQ_shape[0] == dK_shape[0] && dK_shape[0] == dV_shape[0],
+        "MLAQKVAssembleBw: batch dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[0],
+        dK_shape[0],
+        dV_shape[0]);
+    TT_FATAL(
+        dQ_shape[1] == args.n_heads && dK_shape[1] == args.n_heads && dV_shape[1] == args.n_heads,
+        "MLAQKVAssembleBw: dim 1 (heads) must equal n_heads ({}). Got dQ={}, dK={}, dV={}.",
+        args.n_heads,
+        dQ_shape[1],
+        dK_shape[1],
+        dV_shape[1]);
+    TT_FATAL(
+        dQ_shape[2] == dK_shape[2] && dK_shape[2] == dV_shape[2],
+        "MLAQKVAssembleBw: seq dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[2],
+        dK_shape[2],
+        dV_shape[2]);
+
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+    TT_FATAL(
+        dQ_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dQ dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dQ_shape[3]);
+    TT_FATAL(
+        dK_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dK dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dK_shape[3]);
+    TT_FATAL(
+        dV_shape[3] == args.v_dim, "MLAQKVAssembleBw: dV dim 3 must equal v_dim = {}. Got {}", args.v_dim, dV_shape[3]);
+
+    TT_FATAL(
+        args.qk_nope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_nope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_nope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.qk_rope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_rope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.v_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: v_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.v_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        dQ_shape[2] % TILE_HEIGHT == 0,
+        "MLAQKVAssembleBw: S ({}) must be a multiple of TILE_HEIGHT ({}).",
+        dQ_shape[2],
+        TILE_HEIGHT);
+}
+
+MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(3U);
+
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto dQ_shape = dQ.logical_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+
+    const ttnn::Shape dq_pre_shape({B, 1U, S, args.n_heads * qk_head});
+    const ttnn::Shape dkv_up_shape({B, 1U, S, args.n_heads * (args.qk_nope_dim + args.v_dim)});
+    const ttnn::Shape dk_pe_shape({B, 1U, S, args.qk_rope_dim});
+
+    // Each output inherits from its primary input source. Validation requires all three
+    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    auto dq_layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
+    auto dk_layout = tt::tt_metal::TensorLayout(dK.dtype(), tt::tt_metal::Layout::TILE, dK.memory_config());
+    output_specs.emplace_back(dq_pre_shape, dq_layout);
+    output_specs.emplace_back(dkv_up_shape, dk_layout);
+    output_specs.emplace_back(dk_pe_shape, dk_layout);
+
+    return output_specs;
+}
+
+MLAQKVAssembleBwDeviceOperation::tensor_return_value_t MLAQKVAssembleBwDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    auto* device = tensor_args.dQ.device();
+    return {
+        create_device_tensor(specs[0], device),
+        create_device_tensor(specs[1], device),
+        create_device_tensor(specs[2], device)};
+}
+
+ttsl::hash::hash_t MLAQKVAssembleBwDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return tt::tt_metal::operation::hash_operation<MLAQKVAssembleBwDeviceOperation>(
+        args,
+        tensor_args.dQ.dtype(),
+        tensor_args.dQ.logical_shape(),
+        tensor_args.dK.logical_shape(),
+        tensor_args.dV.logical_shape());
+}
+
+MLAQKVAssembleBwDeviceOperation::program_factory_t MLAQKVAssembleBwDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return MLAQKVAssembleBwProgramFactory{};
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    using OperationType = ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation;
+
+    auto attrs = OperationType::operation_attributes_t{
+        .n_heads = n_heads,
+        .qk_nope_dim = qk_nope_dim,
+        .qk_rope_dim = qk_rope_dim,
+        .v_dim = v_dim,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.dQ = dQ, .dK = dK, .dV = dV};
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -46,6 +46,12 @@ void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
     check_tensor(dK, "dK");
     check_tensor(dV, "dV");
 
+    // The program launches on dQ.device() and feeds raw buffer addresses from all three inputs into
+    // the TensorAccessors, so mixed-device inputs must fail here rather than dispatch invalid addresses.
+    TT_FATAL(
+        dQ.device() == dK.device() && dK.device() == dV.device(),
+        "MLAQKVAssembleBw: dQ, dK, and dV must be on the same device.");
+
     const auto dQ_shape = dQ.padded_shape();
     const auto dK_shape = dK.padded_shape();
     const auto dV_shape = dV.padded_shape();

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwDeviceOperation {
+    using operation_attributes_t = ttml::metal::ops::mla_qkv_assemble_bw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_return_value_t;
+    using program_factory_t = std::variant<MLAQKVAssembleBwProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwParams {
+    uint32_t n_heads{};
+    uint32_t qk_nope_dim{};
+    uint32_t qk_rope_dim{};
+    uint32_t v_dim{};
+};
+
+struct MLAQKVAssembleBwInputs {
+    const ttnn::Tensor& dQ;
+    const ttnn::Tensor& dK;
+    const ttnn::Tensor& dV;
+};
+
+using operation_attributes_t = MLAQKVAssembleBwParams;
+using tensor_args_t = MLAQKVAssembleBwInputs;
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+#include <cstdint>
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "metal/common/program_utils.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace {
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "reader_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "writer_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kComputeKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/"
+    "mla_qkv_assemble_bw_kernel.cpp";
+
+// reader runtime arg indices (for override_runtime_arguments)
+constexpr uint32_t kReaderArgDQAddr = 0;
+constexpr uint32_t kReaderArgDKAddr = 1;
+constexpr uint32_t kReaderArgDVAddr = 2;
+
+// writer runtime arg indices
+constexpr uint32_t kWriterArgDQPreAddr = 0;
+constexpr uint32_t kWriterArgDKVUpAddr = 1;
+constexpr uint32_t kWriterArgDKPeAddr = 2;
+
+// CB indices
+constexpr auto kDQCbIndex = tt::CBIndex::c_0;
+constexpr auto kDKnopeCbIndex = tt::CBIndex::c_1;
+constexpr auto kDVCbIndex = tt::CBIndex::c_2;
+constexpr auto kDKpeInCbIndex = tt::CBIndex::c_3;
+constexpr auto kDKpeOutCbIndex = tt::CBIndex::c_4;
+
+// CB sizing. dQ / dK_nope / dV stream in block_size chunks, double-buffered (2 * block_size) for
+// reader/writer NoC overlap, so L1 use is bounded by block_size rather than head_dim. block_size = 8
+// matches the forward op (knee of the N300 throughput sweep); it is not tied to the DST register limit
+// because the only compute here is the small dk_pe head-axis reduction. See mla_qkv_assemble_fw.
+constexpr uint32_t kCbDoubleBuffer = 2U;
+// On the throughput plateau (N300 sweep over {4,8,16} is flat within noise); not tied to DST registers
+// since the only compute is the small dk_pe head-axis reduction. Matches the forward op.
+constexpr uint32_t block_size = 8U;
+
+}  // namespace
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+using namespace tt::constants;
+
+struct MLAQKVAssembleBwKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+    tt::tt_metal::KernelHandle compute;
+};
+
+static void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const MLAQKVAssembleBwKernels& kernels,
+    const tt::tt_metal::Buffer* dQ_buffer,
+    const tt::tt_metal::Buffer* dK_buffer,
+    const tt::tt_metal::Buffer* dV_buffer,
+    const tt::tt_metal::Buffer* dq_pre_buffer,
+    const tt::tt_metal::Buffer* dkv_up_buffer,
+    const tt::tt_metal::Buffer* dk_pe_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_blocks_per_core_group_1,
+    uint32_t num_blocks_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2,
+    uint32_t Ts,
+    uint32_t Th,
+    uint32_t Tn,
+    uint32_t Tr,
+    uint32_t Tv,
+    uint32_t kq_HtWt,
+    uint32_t v_HtWt,
+    uint32_t n_heads) {
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_FATAL(false, "MLAQKVAssembleBw: core not in any work group");
+        }
+
+        // Inputs are head-major: tile_id(b, h, sb, w) = b*H*HtWt + h*HtWt + sb*Wt + w.
+        // dQ and dK share per-head head_dim (validated), so a single base addresses both.
+        const uint32_t b_start = num_blocks_written / Ts;
+        const uint32_t sb_start = num_blocks_written % Ts;
+        const uint32_t dQK_block_base_start = b_start * n_heads * kq_HtWt + sb_start * Th;
+        const uint32_t dV_block_base_start = b_start * n_heads * v_HtWt + sb_start * Tv;
+
+        // Outputs are flat across blocks: head 0 of (b, sb) at (b*Ts + sb) * (per_block_tiles).
+        const uint32_t flat_block_idx = num_blocks_written;
+        const uint32_t dq_pre_block_base_start = flat_block_idx * n_heads * Th;
+        const uint32_t dkv_up_block_base_start = flat_block_idx * n_heads * (Tn + Tv);
+        const uint32_t dk_pe_block_base_start = flat_block_idx * Tr;
+
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {dQ_buffer->address(),
+             dK_buffer->address(),
+             dV_buffer->address(),
+             num_blocks_per_core,
+             sb_start,
+             dQK_block_base_start,
+             dV_block_base_start});
+
+        SetRuntimeArgs(
+            program,
+            kernels.writer,
+            core,
+            {dq_pre_buffer->address(),
+             dkv_up_buffer->address(),
+             dk_pe_buffer->address(),
+             num_blocks_per_core,
+             dq_pre_block_base_start,
+             dkv_up_block_base_start,
+             dk_pe_block_base_start});
+
+        SetRuntimeArgs(program, kernels.compute, core, {num_blocks_per_core});
+
+        num_blocks_written += num_blocks_per_core;
+    }
+}
+
+MLAQKVAssembleBwProgramFactory::cached_program_t MLAQKVAssembleBwProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    auto& dq_pre = output[0];
+    auto& dkv_up = output[1];
+    auto& dk_pe = output[2];
+
+    auto* device = dQ.device();
+    tt::tt_metal::Program program{};
+
+    // ── Tile geometry ──
+    const auto dQ_shape = dQ.padded_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t H = args.n_heads;
+
+    const uint32_t Tn = args.qk_nope_dim / TILE_WIDTH;
+    const uint32_t Tr = args.qk_rope_dim / TILE_WIDTH;
+    const uint32_t Tv = args.v_dim / TILE_WIDTH;
+    const uint32_t Th = Tn + Tr;
+    const uint32_t Ts = S / TILE_HEIGHT;
+
+    const uint32_t kq_HtWt = Ts * Th;
+    const uint32_t v_HtWt = Ts * Tv;
+
+    const uint32_t num_blocks = B * Ts;
+
+    // Compute kernel uses Tr persistent dst-register slots as the head-axis accumulator, plus 1 temp
+    // slot. With fp32 dest accumulation the DST holds 8 fp32 tiles, so the bound is Tr + 1 ≤ 8.
+    TT_FATAL(
+        Tr + 1U <= 8U,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) / TILE_W = {} too large for in-register accumulator (max 7).",
+        args.qk_rope_dim,
+        Tr);
+
+    // ── Work split ──
+    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+    // ── CBs ──
+    // Validation guarantees dQ / dK / dV share dtype, so any of them yields the same
+    // data_format. dQ is picked because it's also the source-of-truth for B and S above.
+    const tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dQ.dtype());
+    const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    // dQ / dK_nope / dV are 2 * block_size; the dk_pe staging CBs hold all Tr tiles of a head (the
+    // compute kernel sums them at once), double-buffered so reader/compute/writer pipeline across heads.
+    const uint32_t io_cb_num_tiles = kCbDoubleBuffer * block_size;
+    const uint32_t kpe_cb_num_tiles = kCbDoubleBuffer * Tr;
+
+    [[maybe_unused]] auto cb_dq =
+        create_circular_buffer(program, all_cores, kDQCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dknope =
+        create_circular_buffer(program, all_cores, kDKnopeCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dv =
+        create_circular_buffer(program, all_cores, kDVCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dkpe_in =
+        create_circular_buffer(program, all_cores, kDKpeInCbIndex, data_format, single_tile_size, kpe_cb_num_tiles);
+    [[maybe_unused]] auto cb_dkpe_out =
+        create_circular_buffer(program, all_cores, kDKpeOutCbIndex, data_format, single_tile_size, kpe_cb_num_tiles);
+
+    // ── Kernels ──
+    auto* dQ_buffer = dQ.buffer();
+    auto* dK_buffer = dK.buffer();
+    auto* dV_buffer = dV.buffer();
+    auto* dq_pre_buffer = dq_pre.buffer();
+    auto* dkv_up_buffer = dkv_up.buffer();
+    auto* dk_pe_buffer = dk_pe.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {Th, Tn, Tr, Tv, H, kq_HtWt, v_HtWt, Ts, block_size};
+    tt::tt_metal::TensorAccessorArgs(dQ_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dK_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dV_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {Th, Tn, Tr, Tv, H, block_size};
+    tt::tt_metal::TensorAccessorArgs(dq_pre_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dkv_up_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dk_pe_buffer).append_to(writer_compile_time_args);
+
+    const std::vector<uint32_t> compute_compile_time_args = {Tr, H};
+
+    const std::map<std::string, std::string> defines;
+
+    MLAQKVAssembleBwKernels kernels;
+    kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
+    kernels.writer = create_writer_kernel(program, all_cores, writer_compile_time_args, defines, kWriterKernelPath);
+    // fp32 dest accumulation: the dk_pe head-axis sum adds up to n_heads BF16 tiles, so accumulating in
+    // fp32 (instead of BF16 dest) keeps the gradient accurate for large head counts.
+    kernels.compute = create_compute_kernel(
+        program, all_cores, compute_compile_time_args, defines, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+
+    // ── Runtime args ──
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        dQ_buffer,
+        dK_buffer,
+        dV_buffer,
+        dq_pre_buffer,
+        dkv_up_buffer,
+        dk_pe_buffer,
+        num_cores,
+        num_cores_y,
+        num_blocks_per_core_group_1,
+        num_blocks_per_core_group_2,
+        core_group_1,
+        core_group_2,
+        Ts,
+        Th,
+        Tn,
+        Tr,
+        Tv,
+        kq_HtWt,
+        v_HtWt,
+        H);
+
+    return cached_program_t{
+        std::move(program),
+        {/* reader_kernel_id  = */ kernels.reader,
+         /* writer_kernel_id  = */ kernels.writer,
+         /* compute_kernel_id = */ kernels.compute,
+         /* num_cores         = */ num_cores,
+         /* num_cores_y       = */ num_cores_y}};
+}
+
+void MLAQKVAssembleBwProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*args*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& shared = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto* dQ_buffer = tensor_args.dQ.buffer();
+    auto* dK_buffer = tensor_args.dK.buffer();
+    auto* dV_buffer = tensor_args.dV.buffer();
+    auto* dq_pre_buffer = output[0].buffer();
+    auto* dkv_up_buffer = output[1].buffer();
+    auto* dk_pe_buffer = output[2].buffer();
+
+    auto& reader_runtime_args = GetRuntimeArgs(program, shared.reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, shared.writer_kernel_id);
+
+    for (uint32_t i = 0; i < shared.num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i / shared.num_cores_y, i % shared.num_cores_y};
+        {
+            auto& ra = reader_runtime_args[core.x][core.y];
+            ra[kReaderArgDQAddr] = dQ_buffer->address();
+            ra[kReaderArgDKAddr] = dK_buffer->address();
+            ra[kReaderArgDVAddr] = dV_buffer->address();
+        }
+        {
+            auto& ra = writer_runtime_args[core.x][core.y];
+            ra[kWriterArgDQPreAddr] = dq_pre_buffer->address();
+            ra[kWriterArgDKVUpAddr] = dkv_up_buffer->address();
+            ra[kWriterArgDKPeAddr] = dk_pe_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::KernelHandle compute_kernel_id{};
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw.hpp"
+
+#include "device/mla_qkv_assemble_bw_device_operation.hpp"
+
+namespace ttml::metal {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    auto result = ttnn::prim::ttml_mla_qkv_assemble_bw(dQ, dK, dV, n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+    return {result[0], result[1], result[2]};
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal {
+
+// Backward kernel for ``mla_qkv_assemble_fw``.
+//
+// Inverts the forward op's tile routing:
+//   - dq_pre  ← head-major dQ packed flat  (reverse of head-split).
+//   - dkv_up  ← head-major [dK_nope | dV] packed flat per head.
+//   - dk_pe   ← Σ_h dK[..., qk_nope:]  (head-axis sum, runs in compute kernel).
+//
+// Shapes (TILE layout, INTERLEAVED memory):
+//   dQ      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dK      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dV      : [B, n_heads, S, v_dim]
+//   dq_pre  : [B, 1, S, n_heads * (qk_nope_dim + qk_rope_dim)]   (output)
+//   dkv_up  : [B, 1, S, n_heads * (qk_nope_dim + v_dim)]         (output)
+//   dk_pe   : [B, 1, S, qk_rope_dim]                             (output)
+//
+// Per-head dims and S must be tile-aligned.
+//
+// Returns: {dq_pre, dkv_up, dk_pe}
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -264,8 +264,8 @@ void py_module(nb::module_& m) {
     {
         auto py_mla = static_cast<nb::module_>(m.attr("mla"));
         py_mla.def(
-            "qkv_assemble_fw",
-            &ttml::ops::mla_qkv_assemble_fw,
+            "qkv_assemble",
+            &ttml::ops::mla_qkv_assemble,
             nb::arg("q_pre"),
             nb::arg("kv_up"),
             nb::arg("k_pe"),

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
@@ -6,14 +6,17 @@
 
 #include <cstdint>
 #include <tuple>
+#include <utility>
 
+#include "autograd/graph.hpp"
+#include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/operations.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::ops {
 
-std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble_fw(
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
     const autograd::TensorPtr& q_pre,
     const autograd::TensorPtr& kv_up,
     const autograd::TensorPtr& k_pe,
@@ -21,18 +24,29 @@ std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qk
     uint32_t qk_nope_dim,
     uint32_t qk_rope_dim,
     uint32_t v_dim) {
-    // Forward-only op: it does not register a backward node yet, so it would silently drop gradients.
-    // Fail loudly until the backward lands (see the mla_qkv_assemble_bw follow-up).
-    TT_FATAL(
-        !(q_pre->get_requires_grad() || kv_up->get_requires_grad() || k_pe->get_requires_grad()),
-        "mla_qkv_assemble_fw is forward-only: backward is not implemented, so inputs must not require grad.");
-
     auto [q_raw, k_raw, v_raw] = ttml::metal::mla_qkv_assemble_fw(
         q_pre->get_value(), kv_up->get_value(), k_pe->get_value(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
 
     auto out_q = autograd::create_tensor(q_raw);
     auto out_k = autograd::create_tensor(k_raw);
     auto out_v = autograd::create_tensor(v_raw);
+
+    autograd::GradFunction grad =
+        [q_pre, kv_up, k_pe, out_q, out_k, out_v, n_heads, qk_nope_dim, qk_rope_dim, v_dim]() {
+            auto [dq_pre, dkv_up, dk_pe] = ttml::metal::mla_qkv_assemble_bw(
+                out_q->get_grad(), out_k->get_grad(), out_v->get_grad(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+            q_pre->add_grad(dq_pre);
+            kv_up->add_grad(dkv_up);
+            k_pe->add_grad(dk_pe);
+        };
+
+    auto q_node = autograd::add_backward_node(std::move(grad), out_q, q_pre, kv_up, k_pe);
+    if (q_node.has_value()) {
+        out_q->set_node(q_node);
+        // Sync nodes on out_k and out_v ensure dK and dV are populated before grad lambda runs.
+        out_k->set_node(autograd::add_backward_node_always([]() {}, out_k, q_pre, kv_up, k_pe, out_q));
+        out_v->set_node(autograd::add_backward_node_always([]() {}, out_v, q_pre, kv_up, k_pe, out_q));
+    }
 
     return {out_q, out_k, out_v};
 }

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
@@ -11,12 +11,11 @@
 
 namespace ttml::ops {
 
-// Fused MLA QKV assembly forward. See ``ttml::metal::mla_qkv_assemble_fw`` for
-// shape semantics. Backward support is intentionally left for a follow-up PR.
+// Autograd-aware fused MLA QKV assembly. Forward and backward each dispatch to a dedicated Metal op
+// (``ttml::metal::mla_qkv_assemble_fw`` / ``mla_qkv_assemble_bw``). See those for shape semantics.
 //
-// Returns {q, k, v}. Q is head-split but NOT yet RoPE'd; the caller
-// applies ``rope_trailing`` afterward.
-std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble_fw(
+// Returns {q, k, v}. Q is head-split but NOT yet RoPE'd; the caller applies ``rope_trailing`` afterward.
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
     const autograd::TensorPtr& q_pre,
     const autograd::TensorPtr& kv_up,
     const autograd::TensorPtr& k_pe,

--- a/tt-train/tests/benchmark/mla_qkv_assemble_benchmark.cpp
+++ b/tt-train/tests/benchmark/mla_qkv_assemble_benchmark.cpp
@@ -5,14 +5,13 @@
 // ============================================================================
 // MLA QKV assemble op-level fusion benchmark
 //
-// Uses Google Benchmark to measure average wall-clock time of the DeepSeek MLA
-// QKV assemble forward for two paths:
-//   composite — split_heads (reshape + transpose) + slice + concat + k_pe broadcast
-//   fused     — the single ttml::metal::mla_qkv_assemble_fw data-movement op
+// Uses Google Benchmark to measure average wall-clock time of the DeepSeek MLA QKV assemble, forward
+// and backward, each for two paths:
+//   composite — split_heads (reshape + transpose) + slice + concat + k_pe broadcast (and its reverse)
+//   fused     — the single ttml::metal::mla_qkv_assemble_fw / mla_qkv_assemble_bw data-movement op
 //
-// This op is forward-only (backward lands in a follow-up), so only the forward
-// assemble is timed. Each measured sample enqueues several assembles and
-// synchronizes once at the end to amortize dispatch latency.
+// Each measured sample enqueues several assembles and synchronizes once at the end to amortize
+// dispatch latency. Results are printed as two tables (forward, backward).
 // ============================================================================
 
 #include <benchmark/benchmark.h>
@@ -28,12 +27,14 @@
 
 #include "autograd/auto_context.hpp"
 #include "benchmark_utils.hpp"
+#include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 
 namespace {
 
@@ -122,11 +123,56 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> composite_assemble(
     return {q, k, v};
 }
 
+// Composite backward: the pre-fusion gradient path (reverse head-split + slice/concat + head-axis sum).
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> composite_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t batch,
+    uint32_t seq_len,
+    const ModelShape& shape) {
+    const uint32_t H = shape.n_heads;
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const uint32_t kv_w = shape.qk_nope_dim + shape.v_dim;
+    const ttsl::SmallVector<uint32_t> step = {1U, 1U, 1U, 1U};
+
+    // dq_pre: reverse head-split [B, H, S, qk_head] -> [B, S, H, qk_head] -> [B, 1, S, H*qk_head].
+    const auto dq_pre = ttnn::reshape(ttnn::transpose(dQ, 1, 2), ttnn::Shape({batch, 1U, seq_len, H * qk_head}));
+
+    // dkv_up: concat [dK_nope | dV] per head, then reverse head-split.
+    const auto dk_nope = ttnn::slice(
+        dK,
+        ttsl::SmallVector<uint32_t>{0U, 0U, 0U, 0U},
+        ttsl::SmallVector<uint32_t>{batch, H, seq_len, shape.qk_nope_dim},
+        step);
+    const auto kv_head = ttnn::concat(std::vector<ttnn::Tensor>{dk_nope, dV}, /*dim=*/3);
+    const auto dkv_up = ttnn::reshape(ttnn::transpose(kv_head, 1, 2), ttnn::Shape({batch, 1U, seq_len, H * kv_w}));
+
+    // dk_pe: sum dK's rope suffix over the head axis -> [B, 1, S, qk_rope].
+    const auto dk_rope = ttnn::slice(
+        dK,
+        ttsl::SmallVector<uint32_t>{0U, 0U, 0U, shape.qk_nope_dim},
+        ttsl::SmallVector<uint32_t>{batch, H, seq_len, qk_head},
+        step);
+    const auto dk_pe =
+        ttnn::sum(dk_rope, /*dim=*/1, /*keepdim=*/true, std::nullopt, ttml::core::ComputeKernelConfig::precise());
+    return {dq_pre, dkv_up, dk_pe};
+}
+
 ttnn::Tensor make_input(uint32_t batch, uint32_t seq_len, uint32_t width, uint32_t seed) {
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t count = static_cast<size_t>(batch) * seq_len * width;
     const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
     const ttnn::Shape shape({batch, 1U, seq_len, width});
+    return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
+}
+
+// Head-major [B, H, S, W] input for the backward grads dQ / dK / dV.
+ttnn::Tensor make_input_hm(uint32_t batch, uint32_t n_heads, uint32_t seq_len, uint32_t width, uint32_t seed) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    const size_t count = static_cast<size_t>(batch) * n_heads * seq_len * width;
+    const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
+    const ttnn::Shape shape({batch, n_heads, seq_len, width});
     return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
 }
 
@@ -167,6 +213,44 @@ double run_single(const ModelShape& shape, const SweepConfig& cfg, uint32_t batc
     return std::chrono::duration<double, std::milli>(t1 - t0).count() / cfg.num_measure;
 }
 
+double run_single_bw(
+    const ModelShape& shape, const SweepConfig& cfg, uint32_t batch, uint32_t seq_len, bool use_fused) {
+    auto* const device = &ttml::autograd::ctx().get_device();
+    device->clear_program_cache();
+
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto dQ = make_input_hm(batch, shape.n_heads, seq_len, qk_head, 4004U);
+    const auto dK = make_input_hm(batch, shape.n_heads, seq_len, qk_head, 5005U);
+    const auto dV = make_input_hm(batch, shape.n_heads, seq_len, shape.v_dim, 6006U);
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+    const auto run_step = [&]() {
+        if (use_fused) {
+            auto out = ttml::metal::mla_qkv_assemble_bw(
+                dQ, dK, dV, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
+            benchmark::DoNotOptimize(out);
+        } else {
+            auto out = composite_assemble_bw(dQ, dK, dV, batch, seq_len, shape);
+            benchmark::DoNotOptimize(out);
+        }
+    };
+
+    for (uint32_t step = 0; step < cfg.num_warmup; ++step) {
+        run_step();
+    }
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    for (uint32_t step = 0; step < cfg.num_measure; ++step) {
+        run_step();
+    }
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    ttml::autograd::ctx().reset_graph();
+    return std::chrono::duration<double, std::milli>(t1 - t0).count() / cfg.num_measure;
+}
+
 struct RowSummary {
     std::string model_name;
     uint32_t batch_size = 0;
@@ -174,27 +258,32 @@ struct RowSummary {
     uint32_t n_heads = 0;
     double composite_ms = 0.0;
     double fused_ms = 0.0;
+    double bw_composite_ms = 0.0;
+    double bw_fused_ms = 0.0;
 };
 
-void print_table(const std::vector<RowSummary>& rows) {
+void print_table(const std::string& title, const std::vector<RowSummary>& rows, bool backward) {
     fmt::print("\n");
     fmt::print(
-        "MLA QKV assemble forward (composite vs fused)\n"
-        "| Model        | B     | S     | H     | Composite ms | Fused ms | Saved ms | Speedup | Reduction |\n");
+        "{}\n"
+        "| Model        | B     | S     | H     | Composite ms | Fused ms | Saved ms | Speedup | Reduction |\n",
+        title);
     fmt::print("|--------------|-------|-------|-------|--------------|----------|----------|---------|-----------|\n");
     for (const auto& row : rows) {
-        const double saved_ms = row.composite_ms - row.fused_ms;
+        const double composite_ms = backward ? row.bw_composite_ms : row.composite_ms;
+        const double fused_ms = backward ? row.bw_fused_ms : row.fused_ms;
+        const double saved_ms = composite_ms - fused_ms;
         fmt::print(
             "| {:<12} | {:>5} | {:>5} | {:>5} | {:>12.4f} | {:>8.4f} | {:>8.4f} | {:>6.2f}x | {:>8.2f}% |\n",
             row.model_name,
             row.batch_size,
             row.sequence_length,
             row.n_heads,
-            row.composite_ms,
-            row.fused_ms,
+            composite_ms,
+            fused_ms,
             saved_ms,
-            ttml::benchmark_utils::speedup_x(row.composite_ms, row.fused_ms),
-            ttml::benchmark_utils::reduction_pct(row.composite_ms, row.fused_ms));
+            ttml::benchmark_utils::speedup_x(composite_ms, fused_ms),
+            ttml::benchmark_utils::reduction_pct(composite_ms, fused_ms));
     }
 }
 
@@ -212,6 +301,9 @@ void BM_MLAQKVAssemble(benchmark::State& state) {
     for ([[maybe_unused]] auto _ : state) {
         const double composite_ms = run_single(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/false);
         const double fused_ms = run_single(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/true);
+        const double bw_composite_ms =
+            run_single_bw(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/false);
+        const double bw_fused_ms = run_single_bw(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/true);
 
         g_rows.push_back(RowSummary{
             .model_name = model.name,
@@ -220,12 +312,16 @@ void BM_MLAQKVAssemble(benchmark::State& state) {
             .n_heads = model.n_heads,
             .composite_ms = composite_ms,
             .fused_ms = fused_ms,
+            .bw_composite_ms = bw_composite_ms,
+            .bw_fused_ms = bw_fused_ms,
         });
 
         state.SetIterationTime(fused_ms / 1000.0);
         state.SetLabel(fmt::format("{} B={} S={} H={}", model.name, batch_size, sequence_length, model.n_heads));
         state.counters["Composite_ms"] = composite_ms;
         state.counters["Fused_ms"] = fused_ms;
+        state.counters["BW_composite_ms"] = bw_composite_ms;
+        state.counters["BW_fused_ms"] = bw_fused_ms;
     }
 }
 
@@ -244,14 +340,14 @@ int main(int argc, char** argv) {
         const tt::tt_metal::distributed::MeshShape mesh(1, 1);
         ttml::autograd::ctx().open_device(mesh);
 
-        fmt::print("MLA QKV assemble op-level benchmark (composite vs fused, forward only)\n");
+        fmt::print("MLA QKV assemble op-level benchmark (composite vs fused, forward + backward)\n");
         fmt::print(
             "preset models=deepseek-mla,nano-mla batches=16,32 seq_lens=128,256,512 warmup={} measure={}\n",
             g_sweep_cfg.num_warmup,
             g_sweep_cfg.num_measure);
         fmt::print(
             "Composite path: split_heads (reshape + transpose) + slice + concat + k_pe broadcast.\n"
-            "Each measured sample enqueues multiple forward assembles and synchronizes once at the end.\n");
+            "Each measured sample enqueues multiple assembles and synchronizes once at the end.\n");
 
         benchmark::RegisterBenchmark("MLAQKVAssemble", BM_MLAQKVAssemble)
             ->DenseRange(0, static_cast<int>(g_cases.size()) - 1, 1)
@@ -261,7 +357,8 @@ int main(int argc, char** argv) {
         benchmark::RunSpecifiedBenchmarks();
         benchmark::Shutdown();
 
-        print_table(g_rows);
+        print_table("MLA QKV assemble forward (composite vs fused)", g_rows, /*backward=*/false);
+        print_table("MLA QKV assemble backward (composite vs fused)", g_rows, /*backward=*/true);
 
         ttml::autograd::ctx().close_device();
         return 0;

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ops/mla_qkv_assemble_op.hpp"
-
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -13,11 +11,11 @@
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
-#include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
 #include "test_utils/random_data.hpp"
 
-class MLAQKVAssembleForwardTest : public ::testing::Test {
+class MLAQKVAssembleTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
         ttml::autograd::ctx().open_device();
@@ -26,17 +24,12 @@ protected:
     static void TearDownTestSuite() {
         ttml::autograd::ctx().close_device();
     }
-
-    void TearDown() override {
-        ttml::autograd::ctx().reset_graph();
-    }
 };
 
 namespace {
 
-// MLA QKV assemble dimensions for a single test case. All channel dims are
-// multiples of TILE_WIDTH (32) and S is a multiple of TILE_HEIGHT (32) — the
-// op validates this.
+// MLA QKV assemble dimensions for a single test case. All channel dims are multiples of TILE_WIDTH (32)
+// and S is a multiple of TILE_HEIGHT (32).
 struct AssembleShape {
     std::string name;
     uint32_t batch = 0;
@@ -47,101 +40,142 @@ struct AssembleShape {
     uint32_t v_dim = 0;
 };
 
-// Build a [B, 1, S, W] BF16 device tensor filled with deterministic uniform data.
-ttml::autograd::TensorPtr make_input(uint32_t batch, uint32_t seq_len, uint32_t width, uint32_t seed) {
+// Deterministic uniform BF16 device tensor of the given 4D shape.
+ttnn::Tensor make_input(uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t seed) {
     auto* device = &ttml::autograd::ctx().get_device();
-    const size_t count = static_cast<size_t>(batch) * seq_len * width;
+    const size_t count = static_cast<size_t>(d0) * d1 * d2 * d3;
     const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
-    const ttnn::Shape shape({batch, 1U, seq_len, width});
-    return ttml::autograd::create_tensor(
-        ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE));
+    const ttnn::Shape shape({d0, d1, d2, d3});
+    return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
 }
 
-// Reference assemble computed from the BF16-rounded inputs (read back via to_xtensor), so the only
-// numeric path is a layout/copy/broadcast — the comparison against the kernel output must be exact.
-//
-// q[b,h,s,d]        = q_pre[b,0,s, h*qk_head + d]                       (head split)
-// k[b,h,s,d<Tn*32]  = kv_up[b,0,s, h*(qk_nope+v_dim) + d]              (k_nope slice)
-// k[b,h,s,d>=Tn*32] = k_pe[b,0,s, d - qk_nope]                          (k_pe broadcast across heads)
-// v[b,h,s,d]        = kv_up[b,0,s, h*(qk_nope+v_dim) + qk_nope + d]    (v slice)
-struct ReferenceOutputs {
+// ── Forward reference (q, k, v) computed from BF16-rounded packed inputs ───────────────────────────
+struct FwOutputs {
     xt::xarray<float> q;
     xt::xarray<float> k;
     xt::xarray<float> v;
 };
 
-ReferenceOutputs reference_assemble(
-    const ttml::autograd::TensorPtr& q_pre,
-    const ttml::autograd::TensorPtr& kv_up,
-    const ttml::autograd::TensorPtr& k_pe,
-    const AssembleShape& shape) {
+FwOutputs reference_fw(
+    const ttnn::Tensor& q_pre, const ttnn::Tensor& kv_up, const ttnn::Tensor& k_pe, const AssembleShape& shape) {
     const std::size_t B = shape.batch;
     const std::size_t S = shape.seq_len;
     const std::size_t H = shape.n_heads;
     const std::size_t nope = shape.qk_nope_dim;
+    const std::size_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
     const std::size_t kv_w = shape.qk_nope_dim + shape.v_dim;
 
-    // split_heads: [B, 1, S, H*W] -> [B, S, H, W] -> [B, H, S, W].
-    xt::xarray<float> q_pre_bf = ttml::core::to_xtensor(q_pre->get_value());
-    q_pre_bf.reshape({B, S, H, static_cast<std::size_t>(shape.qk_nope_dim + shape.qk_rope_dim)});
-    xt::xarray<float> kv_up_bf = ttml::core::to_xtensor(kv_up->get_value());
+    xt::xarray<float> q_pre_bf = ttml::core::to_xtensor(q_pre);
+    q_pre_bf.reshape({B, S, H, qk_head});
+    xt::xarray<float> kv_up_bf = ttml::core::to_xtensor(kv_up);
     kv_up_bf.reshape({B, S, H, kv_w});
 
-    const xt::xarray<float> q = xt::transpose(q_pre_bf, {0, 2, 1, 3});
     const xt::xarray<float> kv = xt::transpose(kv_up_bf, {0, 2, 1, 3});
-
     const xt::xarray<float> k_nope = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(std::size_t{0}, nope));
-    const xt::xarray<float> v = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(nope, kv_w));
+    const xt::xarray<float> k_pe_b =
+        xt::broadcast(ttml::core::to_xtensor(k_pe), {B, H, S, static_cast<std::size_t>(shape.qk_rope_dim)});
 
-    // Broadcast the shared k_pe [B, 1, S, qk_rope] across heads -> [B, H, S, qk_rope].
-    const xt::xarray<float> k_pe_b = xt::broadcast(
-        ttml::core::to_xtensor(k_pe->get_value()), {B, H, S, static_cast<std::size_t>(shape.qk_rope_dim)});
-
-    ReferenceOutputs ref;
-    ref.q = q;
+    FwOutputs ref;
+    ref.q = xt::transpose(q_pre_bf, {0, 2, 1, 3});
     ref.k = xt::concatenate(xt::xtuple(k_nope, k_pe_b), 3);
-    ref.v = v;
+    ref.v = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(nope, kv_w));
     return ref;
 }
 
-void expect_exact(const xt::xarray<float>& actual, const xt::xarray<float>& expected, const std::string& tag) {
-    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
-    // Pure copy/broadcast through identical BF16 values → bit-exact on FP32 readback.
-    EXPECT_TRUE(xt::allclose(actual, expected, /*rtol=*/0.0, /*atol=*/0.0)) << tag << ": value mismatch";
+// ── Backward reference (dq_pre, dkv_up, dk_pe) from head-major grads ────────────────────────────────
+// dq_pre = reverse head-split of dQ; dkv_up = reverse head-split of [dK_nope | dV]; dk_pe = Σ_h dK_rope.
+struct BwOutputs {
+    xt::xarray<float> dq_pre;
+    xt::xarray<float> dkv_up;
+    xt::xarray<float> dk_pe;
+};
+
+BwOutputs reference_bw(
+    const ttnn::Tensor& dQ, const ttnn::Tensor& dK, const ttnn::Tensor& dV, const AssembleShape& shape) {
+    const std::size_t B = shape.batch;
+    const std::size_t S = shape.seq_len;
+    const std::size_t H = shape.n_heads;
+    const std::size_t nope = shape.qk_nope_dim;
+    const std::size_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const std::size_t kv_w = shape.qk_nope_dim + shape.v_dim;
+
+    const xt::xarray<float> dQ_bf = ttml::core::to_xtensor(dQ);  // [B, H, S, qk_head]
+    const xt::xarray<float> dK_bf = ttml::core::to_xtensor(dK);  // [B, H, S, qk_head]
+    const xt::xarray<float> dV_bf = ttml::core::to_xtensor(dV);  // [B, H, S, v_dim]
+
+    BwOutputs ref;
+
+    // dq_pre: [B, H, S, qk_head] -> [B, S, H, qk_head] -> [B, 1, S, H*qk_head]
+    ref.dq_pre = xt::transpose(dQ_bf, {0, 2, 1, 3});
+    ref.dq_pre.reshape({B, 1U, S, H * qk_head});
+
+    // dkv_up: concat([dK_nope | dV]) per head -> reverse head-split.
+    const xt::xarray<float> dK_nope = xt::view(dK_bf, xt::all(), xt::all(), xt::all(), xt::range(std::size_t{0}, nope));
+    xt::xarray<float> kv_head = xt::concatenate(xt::xtuple(dK_nope, dV_bf), 3);  // [B, H, S, kv_w]
+    ref.dkv_up = xt::transpose(kv_head, {0, 2, 1, 3});
+    ref.dkv_up.reshape({B, 1U, S, H * kv_w});
+
+    // dk_pe: sum dK's rope suffix over the head axis -> [B, 1, S, qk_rope].
+    const xt::xarray<float> dK_rope = xt::view(dK_bf, xt::all(), xt::all(), xt::all(), xt::range(nope, qk_head));
+    ref.dk_pe = xt::sum(dK_rope, {1});
+    ref.dk_pe.reshape({B, 1U, S, static_cast<std::size_t>(shape.qk_rope_dim)});
+    return ref;
 }
 
-void run_case(const AssembleShape& shape) {
-    auto q_pre = make_input(shape.batch, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.qk_rope_dim), 1001U);
-    auto kv_up = make_input(shape.batch, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.v_dim), 2002U);
-    auto k_pe = make_input(shape.batch, shape.seq_len, shape.qk_rope_dim, 3003U);
+void run_fw(const AssembleShape& shape) {
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto q_pre = make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * qk_head, 1001U);
+    const auto kv_up =
+        make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.v_dim), 2002U);
+    const auto k_pe = make_input(shape.batch, 1U, shape.seq_len, shape.qk_rope_dim, 3003U);
 
-    auto [q, k, v] = ttml::ops::mla_qkv_assemble_fw(
+    auto [q, k, v] = ttml::metal::mla_qkv_assemble_fw(
         q_pre, kv_up, k_pe, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
 
-    const auto ref = reference_assemble(q_pre, kv_up, k_pe, shape);
-    expect_exact(ttml::core::to_xtensor(q->get_value()), ref.q, shape.name + "/q");
-    expect_exact(ttml::core::to_xtensor(k->get_value()), ref.k, shape.name + "/k");
-    expect_exact(ttml::core::to_xtensor(v->get_value()), ref.v, shape.name + "/v");
+    const auto ref = reference_fw(q_pre, kv_up, k_pe, shape);
+    // Pure copy/broadcast → bit-exact.
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(q), ref.q, 0.0, 0.0)) << shape.name << " fw/q";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(k), ref.k, 0.0, 0.0)) << shape.name << " fw/k";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(v), ref.v, 0.0, 0.0)) << shape.name << " fw/v";
+}
+
+void run_bw(const AssembleShape& shape) {
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto dQ = make_input(shape.batch, shape.n_heads, shape.seq_len, qk_head, 4004U);
+    const auto dK = make_input(shape.batch, shape.n_heads, shape.seq_len, qk_head, 5005U);
+    const auto dV = make_input(shape.batch, shape.n_heads, shape.seq_len, shape.v_dim, 6006U);
+
+    auto [dq_pre, dkv_up, dk_pe] =
+        ttml::metal::mla_qkv_assemble_bw(dQ, dK, dV, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
+
+    const auto ref = reference_bw(dQ, dK, dV, shape);
+    // dq_pre / dkv_up are pure copies → bit-exact; dk_pe is a BF16 head-axis reduction → tolerant.
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(dq_pre), ref.dq_pre, 0.0, 0.0)) << shape.name << " bw/dq_pre";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(dkv_up), ref.dkv_up, 0.0, 0.0)) << shape.name << " bw/dkv_up";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(dk_pe), ref.dk_pe, /*rtol=*/5e-3, /*atol=*/5e-3))
+        << shape.name << " bw/dk_pe";
+}
+
+const std::vector<AssembleShape>& shapes() {
+    static const std::vector<AssembleShape> cases = {
+        {"square_st1", 2, 32, 2, 32, 32, 32},
+        {"square_st2", 2, 64, 2, 32, 32, 32},
+        {"asym_rope2", 2, 64, 4, 128, 64, 128},
+        {"heads8_s96", 1, 96, 8, 64, 32, 64},
+    };
+    return cases;
 }
 
 }  // namespace
 
-// Square head dims, S_t == 1 (single sequence tile row).
-TEST_F(MLAQKVAssembleForwardTest, SquareDimsSingleSeqTile) {
-    run_case({"square_st1", /*B=*/2, /*S=*/32, /*H=*/2, /*nope=*/32, /*rope=*/32, /*v=*/32});
+TEST_F(MLAQKVAssembleTest, ForwardMatchesReference) {
+    for (const auto& shape : shapes()) {
+        run_fw(shape);
+    }
 }
 
-// Square head dims, S_t > 1 (exercises the end-of-batch jump path in the writer).
-TEST_F(MLAQKVAssembleForwardTest, SquareDimsMultiSeqTile) {
-    run_case({"square_st2", /*B=*/2, /*S=*/64, /*H=*/2, /*nope=*/32, /*rope=*/32, /*v=*/32});
-}
-
-// Asymmetric Tn != Tr != Tv with Tr > 1 (broadcast spans multiple rope tiles).
-TEST_F(MLAQKVAssembleForwardTest, AsymmetricDimsRopeMultiTile) {
-    run_case({"asym_rope2", /*B=*/2, /*S=*/64, /*H=*/4, /*nope=*/128, /*rope=*/64, /*v=*/128});
-}
-
-// More heads, single batch, larger S_t.
-TEST_F(MLAQKVAssembleForwardTest, ManyHeadsLargerSeq) {
-    run_case({"heads8_s96", /*B=*/1, /*S=*/96, /*H=*/8, /*nope=*/64, /*rope=*/32, /*v=*/64});
+TEST_F(MLAQKVAssembleTest, BackwardMatchesReference) {
+    for (const auto& shape : shapes()) {
+        run_bw(shape);
+    }
 }

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ops/mla_qkv_assemble_op.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -13,6 +15,8 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "ops/binary_ops.hpp"
+#include "ops/unary_ops.hpp"
 #include "test_utils/random_data.hpp"
 
 class MLAQKVAssembleTest : public ::testing::Test {
@@ -23,6 +27,10 @@ protected:
 
     static void TearDownTestSuite() {
         ttml::autograd::ctx().close_device();
+    }
+
+    void TearDown() override {
+        ttml::autograd::ctx().reset_graph();
     }
 };
 
@@ -156,6 +164,30 @@ void run_bw(const AssembleShape& shape) {
         << shape.name << " bw/dk_pe";
 }
 
+void run_autograd_wrapper_bw(const AssembleShape& shape) {
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    auto q_pre = ttml::autograd::create_tensor(
+        make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * qk_head, 7007U), /*requires_grad=*/true);
+    auto kv_up = ttml::autograd::create_tensor(
+        make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.v_dim), 8008U),
+        /*requires_grad=*/true);
+    auto k_pe = ttml::autograd::create_tensor(
+        make_input(shape.batch, 1U, shape.seq_len, shape.qk_rope_dim, 9009U), /*requires_grad=*/true);
+
+    auto [q, k, v] = ttml::ops::mla_qkv_assemble(
+        q_pre, kv_up, k_pe, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
+    auto loss = ttml::ops::add(ttml::ops::add(ttml::ops::mean(q), ttml::ops::mean(k)), ttml::ops::mean(v));
+    loss->backward();
+
+    const auto ref = reference_bw(q->get_grad(), k->get_grad(), v->get_grad(), shape);
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(q_pre->get_grad()), ref.dq_pre, 0.0, 0.0))
+        << shape.name << " autograd/dq_pre";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(kv_up->get_grad()), ref.dkv_up, 0.0, 0.0))
+        << shape.name << " autograd/dkv_up";
+    EXPECT_TRUE(xt::allclose(ttml::core::to_xtensor(k_pe->get_grad()), ref.dk_pe, /*rtol=*/5e-3, /*atol=*/5e-3))
+        << shape.name << " autograd/dk_pe";
+}
+
 const std::vector<AssembleShape>& shapes() {
     static const std::vector<AssembleShape> cases = {
         {"square_st1", 2, 32, 2, 32, 32, 32},
@@ -178,4 +210,8 @@ TEST_F(MLAQKVAssembleTest, BackwardMatchesReference) {
     for (const auto& shape : shapes()) {
         run_bw(shape);
     }
+}
+
+TEST_F(MLAQKVAssembleTest, AutogradWrapperBackwardMatchesReference) {
+    run_autograd_wrapper_bw({"wrapper_heads4", 2, 64, 4, 64, 32, 64});
 }


### PR DESCRIPTION
## What this is

This PR adds the backward of the fused DeepSeek MLA QKV assemble (`mla_qkv_assemble_bw`) and the autograd-aware `ttml::ops::mla_qkv_assemble` wrapper that ties forward and backward together. It stacks on the forward PR (`mla_qkv_assemble_fw`).

Given the upstream gradients `dQ`, `dK`, `dV` (head-major), the op produces the gradients of the packed projection outputs:

- `dq_pre` — reverse head-split of `dQ`.
- `dkv_up` — reverse head-split of `[dK_nope | dV]` per head.
- `dk_pe` — sum of `dK`'s rope suffix over the head axis (because the forward broadcast the shared `k_pe` to every head).

`dq_pre` and `dkv_up` are pure data movement (the transpose of the forward's demux/concat); `dk_pe` is the only compute — a head-axis reduction.

## Why we need it

It makes the fused assemble op differentiable, so MLA can eventually replace its composite `split_heads + slice + concat + k_pe broadcast` (and the corresponding autograd) with one fused forward and one fused backward. This PR does **not** plug the op into `mla.py` yet — that is a separate change once both forward and backward are reviewed.

## How it works

- Reader streams `dQ` / `dK_nope` / `dV` DRAM→L1 in `block_size` chunks via the shared dataflow utils; the writer writes `dq_pre` / `dkv_up` L1→DRAM the same way. The two engines run on separate NoCs and overlap (no per-tile barriers).
- The circular buffers are double-buffered (`2 * block_size`), so L1 use is bounded by `block_size` (= 8, matching the forward op), not by `head_dim`.
- `dK`'s rope suffix is streamed into a small compute kernel that sums it across heads to form `dk_pe`. The reduction accumulates in **fp32 dest** so the gradient stays accurate for large head counts.

## Impact

Op-level benchmark `mla_qkv_assemble_benchmark` (N300, BF16) — fused op vs the composite gradient path (reverse head-split + slice/concat + head-axis sum). Numbers are from this benchmark, not a training run.

| Model        | B  | S   | H  | Composite ms | Fused ms | Speedup | Reduction |
|--------------|---:|----:|---:|-------------:|---------:|--------:|----------:|
| deepseek-mla | 16 | 128 | 16 |       8.6133 |   0.3725 |  23.12x |    95.67% |
| deepseek-mla | 16 | 256 | 16 |      17.0208 |   0.7705 |  22.09x |    95.47% |
| deepseek-mla | 16 | 512 | 16 |      33.4289 |   1.3697 |  24.41x |    95.90% |
| deepseek-mla | 32 | 128 | 16 |      17.0231 |   0.7850 |  21.68x |    95.39% |
| deepseek-mla | 32 | 256 | 16 |      33.4411 |   1.3823 |  24.19x |    95.87% |
| deepseek-mla | 32 | 512 | 16 |      66.9974 |   2.5967 |  25.80x |    96.12% |
| nano-mla     | 16 | 128 |  8 |       2.4969 |   0.1007 |  24.79x |    95.97% |
| nano-mla     | 16 | 256 |  8 |       4.4449 |   0.2212 |  20.09x |    95.02% |
| nano-mla     | 16 | 512 |  8 |       8.9187 |   0.4426 |  20.15x |    95.04% |
| nano-mla     | 32 | 128 |  8 |       4.4387 |   0.2218 |  20.01x |    95.00% |
| nano-mla     | 32 | 256 |  8 |       8.9204 |   0.4487 |  19.88x |    94.97% |
| nano-mla     | 32 | 512 |  8 |      17.8779 |   0.6760 |  26.45x |    96.22% |

`deepseek-mla` = per-head `qk_nope=128, qk_rope=64, v=128`, 16 heads; `nano-mla` = `64/32/64`, 8 heads.

**The fused backward is ~20–26× faster than the composite gradient path (~95–96% less time).** The forward numbers are unchanged from the forward PR (the same benchmark now prints both tables).

## Correctness

C++ parity test (`MLAQKVAssembleTest`) compares both kernels against exact xtensor references over square dims, multiple sequence tiles, asymmetric `qk_nope/qk_rope/v`, and 8 heads. `dq_pre` and `dkv_up` are pure copies → bit-exact (`rtol = atol = 0`); `dk_pe` is a BF16 head-axis reduction (accumulated in fp32) → compared at `rtol = atol = 5e-3`, just above the single-BF16-rounding floor of ~0.4%. All pass.

## Scope

- Stacks on the forward PR; adds the backward metal op and the differentiable `mla_qkv_assemble` wrapper (which supersedes the forward-only guarded wrapper).
- Not yet wired into `mla.py` — that is a separate PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/mla_qk_assemble_bw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/mla_qk_assemble_bw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/mla_qk_assemble_bw)
