### PR TITLE
emule: role-aware L1_SLOT_MASK, per-NOC DRAM bank mapping, mcast include_self

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -185,16 +185,33 @@ extern "C" uint8_t* __emule_noc_resolve(uint32_t x, uint32_t y, uint64_t addr) {
 
 // Resolve a NOC address (encoded 64-bit) to a host pointer.
 // Real firmware encoding: y in bits [47:42], x in bits [41:36], addr in bits [35:0]
+//
+// The L1_SLOT_MASK is applied ONLY for WORKER cores. Two reasons:
+//  1. The mask handles a worker-kernel pattern where the L1 offset is a
+//     truncated host pointer (from `get_write_ptr()`) rather than a
+//     firmware-style L1 offset. Worker L1 slots are 2 MB-aligned, so the
+//     masked low bits recover the in-slot offset.
+//  2. DRAM banks are GB-scale (2 GB on Wormhole views, 4 GB on Blackhole)
+//     and the kernel-side `InterleavedAddrGen<DRAM>::get_noc_addr` produces
+//     an `addr` field that is the true in-bank offset (already includes
+//     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
+//     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
-    uint64_t l1_offset = noc_addr & NOC_LOCAL_MASK;
+    uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;  // 36 bits, raw
+
+    static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
+    static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
 
     if (__emule_core_map) {
         uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
         auto it = __emule_core_map->find(key);
         if (it != __emule_core_map->end()) {
-            return it->second->l1_ptr(static_cast<uint32_t>(l1_offset));
+            uint32_t offset = (it->second->role() == tt_emule::CoreRole::WORKER)
+                                  ? (static_cast<uint32_t>(local_addr) & L1_SLOT_MASK)
+                                  : static_cast<uint32_t>(local_addr);
+            return it->second->l1_ptr(offset);
         }
     }
     return nullptr;
@@ -202,7 +219,15 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
 
 // Resolve multicast: iterate over rectangle of cores and memcpy to each.
 // Real firmware encoding: x_start [53:48], y_start [59:54], x_end [41:36], y_end [47:42], addr [35:0]
-extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src, uint32_t size) {
+//
+// `include_self`: silicon's NOC_CMD_BRCST_SRC_INCLUDE bit. When the API is
+// `noc_async_write_multicast_loopback_src` (or _set_multicast_loopback_src),
+// silicon sets the bit and the sender NIU receives its own packet ->
+// include_self=true. When the API is `noc_async_write_multicast` (non-loopback),
+// silicon clears the bit and the sender NIU drops the packet at itself ->
+// include_self=false. Sender coords come from the TLS that thread launch
+// wires up (my_x[0], my_y[0]).
+extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src, uint32_t size, bool include_self) {
     uint32_t x_end = (mcast_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t y_end = (mcast_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint32_t x_start = (mcast_addr >> (NOC_LOCAL_BITS + 2 * NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
@@ -213,6 +238,8 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
     // than a firmware-style L1 offset.  Worker L1 slots are 2 MB-aligned, so
     // masking with SLOT_MASK extracts the true within-slot offset.  For
     // firmware-style offsets (< 2 MB) this is a no-op.
+    // Multicast targets only WORKER cores (DRAM cores are skipped by the role
+    // check in the delivery loop below), so the mask is L1-correct here.
     static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
     static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
     l1_offset &= L1_SLOT_MASK;
@@ -221,9 +248,17 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
         return;
     }
 
+    // Sender coordinates (from the TLS that thread launch wires up). Used to
+    // skip self when include_self=false (non-loopback multicast).
+    uint32_t self_x = my_x[0];
+    uint32_t self_y = my_y[0];
+
     uint32_t delivered = 0;
     for (uint32_t x = std::min(x_start, x_end); x <= std::max(x_start, x_end); x++) {
         for (uint32_t y = std::min(y_start, y_end); y <= std::max(y_start, y_end); y++) {
+            if (!include_self && x == self_x && y == self_y) {
+                continue;
+            }
             uint64_t key = (uint64_t(x) << 32) | y;
             auto it = __emule_core_map->find(key);
             if (it != __emule_core_map->end() && it->second->role() == tt_emule::CoreRole::WORKER) {
@@ -847,22 +882,31 @@ static void populate_bank_mapping(
     num_dram_channels_out = static_cast<uint32_t>(metal_soc.get_num_dram_views());
 
     // noc_xy encoding: (y << 6) | x (matching Blackhole firmware encoding).
+    // Populate per-NOC preferred coords separately. On Wormhole the NOC-0 and
+    // NOC-1 preferred workers for a given DRAM view differ (e.g. channel 0
+    // NOC0=[2,2], NOC1=[1,1]). On Blackhole they happen to match, so this is
+    // a no-op change there.
     std::memset(dram_bank_to_noc_xy, 0, sizeof(dram_bank_to_noc_xy));
     std::memset(bank_to_dram_offset, 0, sizeof(bank_to_dram_offset));
     for (uint32_t ch = 0; ch < num_dram_channels_out && ch < MAX_NUM_BANKS; ch++) {
-        auto dc = metal_soc.get_preferred_worker_core_for_dram_view(ch, 0 /* NOC 0 */);
-        uint16_t noc_xy = (static_cast<uint16_t>(dc.y) << NOC_NODE_ID_BITS) | static_cast<uint16_t>(dc.x);
-        dram_bank_to_noc_xy[0][ch] = noc_xy;  // NOC 0
-        dram_bank_to_noc_xy[1][ch] = noc_xy;  // NOC 1 (same for emulation)
+        auto dc0 = metal_soc.get_preferred_worker_core_for_dram_view(ch, 0 /* NOC 0 */);
+        auto dc1 = metal_soc.get_preferred_worker_core_for_dram_view(ch, 1 /* NOC 1 */);
+        uint16_t noc_xy0 = (static_cast<uint16_t>(dc0.y) << NOC_NODE_ID_BITS) | static_cast<uint16_t>(dc0.x);
+        uint16_t noc_xy1 = (static_cast<uint16_t>(dc1.y) << NOC_NODE_ID_BITS) | static_cast<uint16_t>(dc1.x);
+        dram_bank_to_noc_xy[0][ch] = noc_xy0;
+        dram_bank_to_noc_xy[1][ch] = noc_xy1;
         bank_to_dram_offset[ch] = static_cast<int32_t>(metal_soc.get_address_offset(ch));
 
         log_debug(
             tt::LogMetal,
-            "  DRAM bank[{}]: core({},{}) noc_xy=0x{:04x} offset=0x{:x}",
+            "  DRAM bank[{}]: NOC0=({},{}) NOC1=({},{}) noc_xy0=0x{:04x} noc_xy1=0x{:04x} offset=0x{:x}",
             ch,
-            dc.x,
-            dc.y,
-            noc_xy,
+            dc0.x,
+            dc0.y,
+            dc1.x,
+            dc1.y,
+            noc_xy0,
+            noc_xy1,
             bank_to_dram_offset[ch]);
     }
 
@@ -1332,13 +1376,18 @@ static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
             }
         }
         // Add DRAM cores (metal_SocDescriptor preferred worker coords)
+        // Register BOTH NOC0 and NOC1 preferred coords — on Wormhole they
+        // differ per channel (e.g. ch0 NOC0=[2,2], NOC1=[1,1]); both must
+        // be in the core_map so __emule_resolve_noc_addr can route either.
         {
             auto& msoc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
             for (uint32_t ch = 0; ch < msoc.get_num_dram_views() && ch < MAX_NUM_BANKS; ch++) {
-                auto dc = msoc.get_preferred_worker_core_for_dram_view(ch, 0);
-                auto* core = sw_emu->get_core(tt_xy_pair(dc.x, dc.y));
-                uint64_t key = (uint64_t(dc.x) << 32) | dc.y;
-                (*core_map)[key] = core;
+                for (uint32_t noc = 0; noc < 2; noc++) {
+                    auto dc = msoc.get_preferred_worker_core_for_dram_view(ch, noc);
+                    auto* core = sw_emu->get_core(tt_xy_pair(dc.x, dc.y));
+                    uint64_t key = (uint64_t(dc.x) << 32) | dc.y;
+                    (*core_map)[key] = core;
+                }
             }
         }
     } else if (!core_map) {

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -192,8 +192,8 @@ extern "C" uint8_t* __emule_noc_resolve(uint32_t x, uint32_t y, uint64_t addr) {
 //     firmware-style L1 offset. Worker L1 slots are 2 MB-aligned, so the
 //     masked low bits recover the in-slot offset.
 //  2. DRAM banks are GB-scale (2 GB on Wormhole views, 4 GB on Blackhole)
-//     and the kernel-side `InterleavedAddrGen<DRAM>::get_noc_addr` produces
-//     an `addr` field that is the true in-bank offset (already includes
+//     and the kernel-side per-bank addrgen helper produces an `addr` field
+//     that is the true in-bank offset (already includes
 //     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
 //     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
@@ -1382,7 +1382,7 @@ static std::unordered_map<uint64_t, tt_emule::Core*>* build_core_map(
         {
             auto& msoc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
             for (uint32_t ch = 0; ch < msoc.get_num_dram_views() && ch < MAX_NUM_BANKS; ch++) {
-                for (uint32_t noc = 0; noc < 2; noc++) {
+                for (uint32_t noc = 0; noc < NUM_NOCS; noc++) {
                     auto dc = msoc.get_preferred_worker_core_for_dram_view(ch, noc);
                     auto* core = sw_emu->get_core(tt_xy_pair(dc.x, dc.y));
                     uint64_t key = (uint64_t(dc.x) << 32) | dc.y;


### PR DESCRIPTION
## Summary

Three host-side fixes to the emulated_program_runner bridge functions:

1. **`__emule_resolve_noc_addr`: role-aware `L1_SLOT_MASK`.** DRAM banks
   are GB-scale (2 GB on Wormhole views, 4 GB on Blackhole). The kernel-
   side `InterleavedAddrGen<DRAM>::get_noc_addr` produces an `addr` field
   that is the true in-bank offset (already includes
   `bank_to_dram_offset[]`). The previous unconditional 2 MB mask
   silently aliased any DRAM access ≥ 2 MB to an offset within the first
   2 MB of the bank, producing zeroed reads / corrupt writes that
   manifested far downstream. The mask is now applied only when the
   resolved core's role is `WORKER`.

2. **Per-NOC DRAM bank mapping.** `populate_bank_mapping` and
   `build_core_map` now pull per-NOC preferred DRAM coords separately.
   On Wormhole the NOC0 and NOC1 preferred workers for a given DRAM
   view differ (e.g. channel 0 NOC0=[2,2], NOC1=[1,1]); kernels that
   select NOC 1 now route correctly. On Blackhole the two NOCs share
   coords and this is a no-op change.

3. **`__emule_multicast_write` `include_self` parameter.** Mirrors
   silicon's `NOC_CMD_BRCST_SRC_INCLUDE` bit:
   `noc_async_write_multicast` (non-loopback) clears the bit so the
   sender NIU drops the packet at itself, while
   `noc_async_write_multicast_loopback_src` sets it. The emulator now
   takes a `bool include_self` argument; when `false`, the sender
   `(my_x[0], my_y[0])` is skipped in the rectangle iteration.

## Test plan

- [x] Edits already exercised in a downstream consumer's emule-mode
      build sweep — sentinel + matmul_fused_act (sigmoid: real-math
      PCC), softmax_k 43/43, rmsnorm 52/52, dsa_sparse_gather_tilize
      3/3, gather_tilize 5/5, and 12+ other test families all green
      with these exact changes applied.
- [x] Wormhole NOC1-path: only behavioral change is per-NOC routing.
      Blackhole NOC1 == NOC0 (identical behavior).
- [x] No tt-metal regression — emule path is opt-in
      (`TT_METAL_EMULE_MODE=1`); silicon and Mock paths untouched.

## Licensing

By submitting this PR I agree my contribution is licensed under the
Apache License 2.0 (see [LICENSE](../LICENSE)).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-dram-modeling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-dram-modeling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-dram-modeling)