### PR TITLE
[tt-train] Name device-op param/input structs across ops

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation_types.hpp
@@ -8,16 +8,19 @@
 
 namespace ttml::metal::ops::cross_entropy_bw::device {
 
-struct operation_attributes_t {
+struct CrossEntropyBackwardParams {
     const float scaler{1.0F};
 };
 
-struct tensor_args_t {
+struct CrossEntropyBackwardInputs {
     const ttnn::Tensor& input;
     const ttnn::Tensor& target;
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = CrossEntropyBackwardParams;
+using tensor_args_t = CrossEntropyBackwardInputs;
 
 using tensor_return_value_t = ttnn::Tensor;
 using spec_return_value_t = ttnn::TensorSpec;

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation_types.hpp
@@ -8,14 +8,17 @@
 
 namespace ttml::metal::ops::cross_entropy_fw::device {
 
-struct operation_attributes_t {};
+struct CrossEntropyForwardParams {};
 
-struct tensor_args_t {
+struct CrossEntropyForwardInputs {
     const ttnn::Tensor& input;
     const ttnn::Tensor& target;
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = CrossEntropyForwardParams;
+using tensor_args_t = CrossEntropyForwardInputs;
 
 using tensor_return_value_t = ttnn::Tensor;  // return loss: tensor with shape (N, 1, H, 1)
 using spec_return_value_t = ttnn::TensorSpec;

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation_types.hpp
@@ -10,15 +10,18 @@
 
 namespace ttml::metal::ops::k_split_gram_matmul::device {
 
-struct operation_attributes_t {
+struct KSplitGramMatmulParams {
     ttml::metal::OutputMode output_mode = ttml::metal::OutputMode::UpperTriangle;
     tt::tt_metal::MathFidelity math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
 };
 
-struct tensor_args_t {
+struct KSplitGramMatmulInputs {
     ttnn::Tensor input_tensor;
     std::optional<ttnn::Tensor> preallocated_output = std::nullopt;
 };
+
+using operation_attributes_t = KSplitGramMatmulParams;
+using tensor_args_t = KSplitGramMatmulInputs;
 
 using tensor_return_value_t = ttnn::Tensor;
 using spec_return_value_t = ttnn::TensorSpec;

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation_types.hpp
@@ -9,10 +9,10 @@
 namespace ttml::metal::ops::layernorm_bw::device {
 
 // Attributes for the backward operation (add more if needed)
-struct operation_attributes_t {};
+struct LayerNormBackwardParams {};
 
 // Tensors required for backward
-struct tensor_args_t {
+struct LayerNormBackwardInputs {
     ttnn::Tensor input;
     ttnn::Tensor gamma;                                          // scale parameter (learnable weight)
     ttnn::Tensor mean;                                           // mean from forward pass
@@ -22,6 +22,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_dgamma_components = std::nullopt;  // dgamma components
     std::optional<ttnn::Tensor> preallocated_dbeta_components = std::nullopt;   // dbeta components
 };
+
+using operation_attributes_t = LayerNormBackwardParams;
+using tensor_args_t = LayerNormBackwardInputs;
 
 // Output tensor specs and tensors
 using spec_return_value_t = std::vector<ttnn::TensorSpec>;

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation_types.hpp
@@ -9,13 +9,13 @@
 namespace ttml::metal::ops::layernorm_fw::device {
 
 // Attributes for the forward operation
-struct operation_attributes_t {
+struct LayerNormForwardParams {
     float epsilon;          // epsilon for numerical stability
     bool return_mean_rstd;  // whether to return mean and rstd for backward pass
 };
 
 // Tensors required for forward
-struct tensor_args_t {
+struct LayerNormForwardInputs {
     ttnn::Tensor input;
     ttnn::Tensor gamma;  // scale parameter (learnable weight)
     ttnn::Tensor beta;   // shift parameter (learnable weight)
@@ -23,6 +23,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_mean = std::nullopt;
     std::optional<ttnn::Tensor> preallocated_rstd = std::nullopt;
 };
+
+using operation_attributes_t = LayerNormForwardParams;
+using tensor_args_t = LayerNormForwardInputs;
 
 // Output tensor specs and tensors
 using spec_return_value_t = std::vector<ttnn::TensorSpec>;

--- a/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/profiler_no_op/device/profiler_no_op_device_operation_types.hpp
@@ -8,15 +8,18 @@
 
 namespace ttml::metal::ops::profiler_no_op::device {
 
-struct operation_attributes_t {
+struct ProfilerNoOpParams {
     std::string identifier = "profiler_no_op";
 };
 
-struct tensor_args_t {
+struct ProfilerNoOpInputs {
     const ttnn::Tensor& input;
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = ProfilerNoOpParams;
+using tensor_args_t = ProfilerNoOpInputs;
 
 using tensor_return_value_t = ttnn::Tensor;
 using spec_return_value_t = ttnn::TensorSpec;

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation_types.hpp
@@ -15,7 +15,7 @@ using RingDirection = ttnn_fixed::distributed::RingShiftDirection;
 
 // ============== Backward KV Types ==============
 
-struct operation_attributes_t {
+struct RingSDPABwKVParams {
     uint32_t ring_size = 0;
     uint32_t ring_axis = 0;
     uint32_t step = 0;
@@ -24,7 +24,7 @@ struct operation_attributes_t {
         ttnn_fixed::distributed::RingShiftDirection::Backward;  // Direction K/V is shifting in the ring
 };
 
-struct tensor_args_t {
+struct RingSDPABwKVInputs {
     ttnn::Tensor grad_output;
     ttnn::Tensor u_scaler;  // Precomputed rowsum(dO * O) from Q kernel
     ttnn::Tensor query;
@@ -34,6 +34,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_grad_key;    // Preallocated output buffer
     std::optional<ttnn::Tensor> preallocated_grad_value;  // Preallocated output buffer
 };
+
+using operation_attributes_t = RingSDPABwKVParams;
+using tensor_args_t = RingSDPABwKVInputs;
 
 using tensor_return_value_t = std::tuple<ttnn::Tensor, ttnn::Tensor>;  // [grad_K, grad_V]
 

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation_types.hpp
@@ -15,7 +15,7 @@ using RingDirection = ttnn_fixed::distributed::RingShiftDirection;
 
 // ============== Backward Q Types ==============
 
-struct operation_attributes_t {
+struct RingSDPABwQParams {
     uint32_t ring_size = 0;
     uint32_t ring_axis = 0;
     uint32_t step = 0;
@@ -24,7 +24,7 @@ struct operation_attributes_t {
         ttnn_fixed::distributed::RingShiftDirection::Backward;  // Direction K/V is shifting in the ring
 };
 
-struct tensor_args_t {
+struct RingSDPABwQInputs {
     ttnn::Tensor grad_output;
     ttnn::Tensor attn_output;
     ttnn::Tensor query;
@@ -33,6 +33,9 @@ struct tensor_args_t {
     ttnn::Tensor intermediates;
     std::optional<ttnn::Tensor> preallocated_grad_query;  // Preallocated output buffer
 };
+
+using operation_attributes_t = RingSDPABwQParams;
+using tensor_args_t = RingSDPABwQInputs;
 
 using tensor_return_value_t = std::tuple<ttnn::Tensor, ttnn::Tensor>;  // [grad_Q, u_scaler]
 

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation_types.hpp
@@ -15,7 +15,7 @@ using RingDirection = ttnn_fixed::distributed::RingShiftDirection;
 
 // ============== Forward Pass Types ==============
 
-struct operation_attributes_t {
+struct RingSDPAFwParams {
     uint32_t ring_size = 0;
     uint32_t ring_axis = 0;
     uint32_t step = 0;
@@ -24,13 +24,16 @@ struct operation_attributes_t {
         ttnn_fixed::distributed::RingShiftDirection::Backward;  // Direction K/V is shifting in the ring
 };
 
-struct tensor_args_t {
+struct RingSDPAFwInputs {
     ttnn::Tensor query;
     ttnn::Tensor key;
     ttnn::Tensor value;
     std::optional<ttnn::Tensor> preallocated_output;         // Preallocated output buffer
     std::optional<ttnn::Tensor> preallocated_intermediates;  // Preallocated intermediates buffer
 };
+
+using operation_attributes_t = RingSDPAFwParams;
+using tensor_args_t = RingSDPAFwInputs;
 
 using tensor_return_value_t = std::tuple<ttnn::Tensor, ttnn::Tensor>;  // output, intermediates
 

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
@@ -9,12 +9,12 @@
 namespace ttml::metal::ops::rmsnorm_bw::device {
 
 // Attributes for the backward operation (add more if needed)
-struct operation_attributes_t {
+struct RMSNormBackwardParams {
     float epsilon = 1e-6F;
 };
 
 // Tensors required for backward
-struct tensor_args_t {
+struct RMSNormBackwardInputs {
     ttnn::Tensor input;
     ttnn::Tensor gamma;
     ttnn::Tensor rms;
@@ -22,6 +22,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_da = std::nullopt;
     std::optional<ttnn::Tensor> preallocated_dgamma_components = std::nullopt;
 };
+
+using operation_attributes_t = RMSNormBackwardParams;
+using tensor_args_t = RMSNormBackwardInputs;
 
 // Output tensor specs and tensors
 using spec_return_value_t = std::vector<ttnn::TensorSpec>;

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
@@ -8,18 +8,21 @@
 
 namespace ttml::metal::ops::rmsnorm_fw::device {
 
-struct operation_attributes_t {
+struct RMSNormForwardParams {
     bool return_intermediates{false};
     float epsilon{1e-6F};
 };
 
-struct tensor_args_t {
+struct RMSNormForwardInputs {
     const ttnn::Tensor& input;
     const ttnn::Tensor& gamma;
 
     std::optional<ttnn::Tensor> preallocated_rms;
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = RMSNormForwardParams;
+using tensor_args_t = RMSNormForwardInputs;
 
 using tensor_return_value_t = std::vector<ttnn::Tensor>;
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation_types.hpp
@@ -9,12 +9,12 @@
 
 namespace ttml::metal::ops::sdpa_bw::device::kv {
 
-struct operation_attributes_t {
+struct SDPABackwardKVParams {
     AttentionMaskType mask_type{AttentionMaskType::Arbitrary};
     float dropout_probability{0.0F};
 };
 
-struct tensor_args_t {
+struct SDPABackwardKVInputs {
     const ttnn::Tensor& grad_output;               // Gradient w.r.t. output
     const ttnn::Tensor& query;                     // Input Q (needed for gradients)
     const ttnn::Tensor& key;                       // Input K (needed for gradients)
@@ -27,6 +27,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_grad_key;
     std::optional<ttnn::Tensor> preallocated_grad_value;
 };
+
+using operation_attributes_t = SDPABackwardKVParams;
+using tensor_args_t = SDPABackwardKVInputs;
 
 using tensor_return_value_t = std::tuple<ttnn::Tensor, ttnn::Tensor>;  // [grad_K, grad_V]
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation_types.hpp
@@ -9,12 +9,12 @@
 
 namespace ttml::metal::ops::sdpa_bw::device::q {
 
-struct operation_attributes_t {
+struct SDPABackwardQParams {
     AttentionMaskType mask_type{AttentionMaskType::Arbitrary};
     float dropout_probability{0.0F};
 };
 
-struct tensor_args_t {
+struct SDPABackwardQInputs {
     const ttnn::Tensor& grad_output;               // Gradient w.r.t. output
     const ttnn::Tensor& attn_output;               // sdap forward output (needed for gradients)
     const ttnn::Tensor& query;                     // Input Q (needed for gradients)
@@ -28,6 +28,9 @@ struct tensor_args_t {
     // Preallocated u_scaler tensor for sharing with KV kernel (optional)
     std::optional<ttnn::Tensor> preallocated_u_scaler;
 };
+
+using operation_attributes_t = SDPABackwardQParams;
+using tensor_args_t = SDPABackwardQInputs;
 
 using tensor_return_value_t = std::tuple<ttnn::Tensor, ttnn::Tensor>;  // [grad_Q, u_scaler]
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation_types.hpp
@@ -16,7 +16,7 @@ struct SDPABackwardQParams {
 
 struct SDPABackwardQInputs {
     const ttnn::Tensor& grad_output;               // Gradient w.r.t. output
-    const ttnn::Tensor& attn_output;               // sdap forward output (needed for gradients)
+    const ttnn::Tensor& attn_output;               // sdpa forward output (needed for gradients)
     const ttnn::Tensor& query;                     // Input Q (needed for gradients)
     const ttnn::Tensor& key;                       // Input K (needed for gradients)
     const ttnn::Tensor& value;                     // Input V (needed for gradients)

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation_types.hpp
@@ -9,13 +9,13 @@
 
 namespace ttml::metal::ops::sdpa_fw::device {
 
-struct operation_attributes_t {
+struct SDPAForwardParams {
     bool return_intermediates{false};
     AttentionMaskType mask_type{AttentionMaskType::Causal};
     float dropout_probability{0.0F};
 };
 
-struct tensor_args_t {
+struct SDPAForwardInputs {
     const ttnn::Tensor& query;
     const ttnn::Tensor& key;
     const ttnn::Tensor& value;
@@ -24,6 +24,9 @@ struct tensor_args_t {
     std::optional<ttnn::Tensor> preallocated_intermediate;
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = SDPAForwardParams;
+using tensor_args_t = SDPAForwardInputs;
 
 using tensor_return_value_t = std::vector<ttnn::Tensor>;
 

--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation_types.hpp
@@ -18,18 +18,21 @@ namespace ttml::metal::ops::select_target_logit::device {
 //
 // Real callers pass (local_V, cluster_axis) and leave first_v = 0; first_v exists so
 // single-device unit tests can still exercise non-zero shard windows.
-struct operation_attributes_t {
+struct SelectTargetLogitParams {
     uint32_t first_v{0U};
     uint32_t local_V{0U};
     std::optional<uint32_t> cluster_axis{};
 };
 
-struct tensor_args_t {
+struct SelectTargetLogitInputs {
     const ttnn::Tensor& logit;   // [N, 1, S, local_V] TILE BFLOAT16  (local_V = last_v - first_v)
     const ttnn::Tensor& target;  // [N, S]              ROW_MAJOR UINT32  (global indices)
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = SelectTargetLogitParams;
+using tensor_args_t = SelectTargetLogitInputs;
 
 // output: [N, 1, S, 1] TILE BFLOAT16
 // output[n, 0, s, 0] = logit[n, 0, s, target[n, s] - device_first_v]

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
@@ -9,14 +9,17 @@
 namespace ttml::metal::ops::silu_bw::device {
 
 // Attributes for the backward operation (add more if needed)
-struct operation_attributes_t {};
+struct SiLUBackwardParams {};
 
 // Tensors required for backward
-struct tensor_args_t {
+struct SiLUBackwardInputs {
     ttnn::Tensor input;
     ttnn::Tensor dL_dout;
     std::optional<ttnn::Tensor> preallocated_da = std::nullopt;
 };
+
+using operation_attributes_t = SiLUBackwardParams;
+using tensor_args_t = SiLUBackwardInputs;
 
 // Output tensor specs and tensors
 using spec_return_value_t = std::vector<ttnn::TensorSpec>;

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation_types.hpp
@@ -8,15 +8,18 @@
 
 namespace ttml::metal::ops::softmax::device {
 
-struct operation_attributes_t {
+struct SoftmaxParams {
     const int32_t dim{3U};  // Use last dimension by default
 };
 
-struct tensor_args_t {
+struct SoftmaxInputs {
     const ttnn::Tensor& input;
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = SoftmaxParams;
+using tensor_args_t = SoftmaxInputs;
 
 using tensor_return_value_t = ttnn::Tensor;
 using spec_return_value_t = ttnn::TensorSpec;

--- a/tt-train/sources/ttml/metal/ops/subtract_at_target/device/subtract_at_target_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/subtract_at_target/device/subtract_at_target_device_operation_types.hpp
@@ -18,19 +18,22 @@ namespace ttml::metal::ops::subtract_at_target::device {
 //
 // Real callers pass (local_V, cluster_axis) and leave first_v = 0; first_v exists so
 // single-device unit tests can still exercise non-zero shard windows.
-struct operation_attributes_t {
+struct SubtractAtTargetParams {
     uint32_t first_v{0U};
     uint32_t local_V{0U};
     std::optional<uint32_t> cluster_axis{};
     float subtract_value{1.0F};
 };
 
-struct tensor_args_t {
+struct SubtractAtTargetInputs {
     const ttnn::Tensor& input;   // [N, 1, S, local_V] TILE BFLOAT16
     const ttnn::Tensor& target;  // [N, S]              ROW_MAJOR UINT32  (global indices)
 
     std::optional<ttnn::Tensor> preallocated_output;
 };
+
+using operation_attributes_t = SubtractAtTargetParams;
+using tensor_args_t = SubtractAtTargetInputs;
 
 // output: same shape as input [N, 1, S, local_V] TILE BFLOAT16
 // output[n, 0, s, c] = input[n, 0, s, c] - subtract_value


### PR DESCRIPTION
## Sumary
_Pure rename — type aliases only, no behavior change (18 ops)._

Follow the ttnn convention (tenstorrent/tt-metal#35857): give each device op's operation_attributes_t / tensor_args_t structs descriptive names (<Op>Params / <Op>Inputs) and alias them back to operation_attributes_t / tensor_args_t, so the device-operation framework and all downstream code is unchanged.

Applies to the ops still using the generic struct names; ops that already had descriptive names (polynorm, moe_group, frobenius_normalize, swiglu_elemwise_bw, softmax_backward) are left as-is.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/ttml_op_struct_names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/ttml_op_struct_names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/ttml_op_struct_names)