### PR TITLE
[tt-train] Add shared test_utils::expect_allclose helper

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -216,6 +216,10 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_program_factory.cpp
+    # MLA QKV Assemble Backward (DeepSeek)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
 )
 
 list(APPEND SOURCES ${METAL_OPS_FILES})

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -10,6 +10,7 @@
 #include "ops/k_split_gram_matmul/k_split_gram_matmul.hpp"
 #include "ops/layernorm_bw/layernorm_bw.hpp"
 #include "ops/layernorm_fw/layernorm_fw.hpp"
+#include "ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp"
 #include "ops/mla_qkv_assemble_fw/mla_qkv_assemble_fw.hpp"
 #include "ops/polynorm_fw/polynorm_fw.hpp"
 #include "ops/profiler_no_op/profiler_no_op.hpp"

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/mla_qkv_assemble_bw_kernel.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/tile_move_copy.h"
+
+constexpr uint32_t Tr = get_compile_time_arg_val(0);
+constexpr uint32_t n_heads = get_compile_time_arg_val(1);
+
+constexpr auto cb_dkpe_in = tt::CBIndex::c_3;
+constexpr auto cb_dkpe_out = tt::CBIndex::c_4;
+
+constexpr uint32_t onetile = 1U;
+
+void kernel_main() {
+    const uint32_t num_blocks = get_arg_val<uint32_t>(0);
+
+    binary_op_init_common(cb_dkpe_in, cb_dkpe_in, cb_dkpe_out);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        // DST registers 0..Tr-1 hold the running head-axis sum across the block;
+        // slot Tr is the working temp for each new head's incoming tile.
+        tile_regs_acquire();
+
+        // Head 0: copy the first head's Tr tiles into the accumulator (dst 0..Tr-1).
+        cb_wait_front(cb_dkpe_in, Tr);
+        copy_tile_init(cb_dkpe_in);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            copy_tile(cb_dkpe_in, w, /* dst_idx */ w);
+        }
+        cb_pop_front(cb_dkpe_in, Tr);
+
+        // Heads 1..H-1: load each tile into dst[Tr] and add into dst[w].
+        for (uint32_t h = 1U; h < n_heads; ++h) {
+            cb_wait_front(cb_dkpe_in, Tr);
+            copy_tile_init(cb_dkpe_in);
+            for (uint32_t w = 0U; w < Tr; ++w) {
+                constexpr uint32_t tmp_dst = Tr;
+                copy_tile(cb_dkpe_in, w, /* dst_idx */ tmp_dst);
+                add_binary_tile_init();
+                add_binary_tile(/* dst_a */ w, /* dst_b */ tmp_dst, /* dst_dest */ w);
+            }
+            cb_pop_front(cb_dkpe_in, Tr);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        cb_reserve_back(cb_dkpe_out, Tr);
+        pack_reconfig_data_format(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            pack_tile(/* dst_idx */ w, cb_dkpe_out);
+        }
+        cb_push_back(cb_dkpe_out, Tr);
+
+        tile_regs_release();
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/reader_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    const uint32_t dQ_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dK_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dV_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t sb = get_arg_val<uint32_t>(runtime_args_counter++);              // s-tile-row in current batch
+    uint32_t dQK_block_base = get_arg_val<uint32_t>(runtime_args_counter++);  // head 0 of (b, sb), w=0
+    uint32_t dV_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_in = tt::CBIndex::c_3;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t kq_HtWt = get_compile_time_arg_val(5);  // Ts * Th
+    constexpr uint32_t v_HtWt = get_compile_time_arg_val(6);   // Ts * Tv
+    constexpr uint32_t Ts = get_compile_time_arg_val(7);
+    constexpr uint32_t block_size = get_compile_time_arg_val(8);
+
+    constexpr auto dQ_args = TensorAccessorArgs<9>();
+    constexpr auto dK_args = TensorAccessorArgs<dQ_args.next_compile_time_args_offset()>();
+    constexpr auto dV_args = TensorAccessorArgs<dK_args.next_compile_time_args_offset()>();
+
+    const auto dQ_addr_gen = TensorAccessor(dQ_args, dQ_addr);
+    const auto dK_addr_gen = TensorAccessor(dK_args, dK_addr);
+    const auto dV_addr_gen = TensorAccessor(dV_args, dV_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dkpe_in);
+
+    // End-of-batch jump to advance dQK_block_base across batch boundary:
+    //   from b * H*kq_HtWt + (Ts-1)*Th  →  (b+1) * H*kq_HtWt
+    //   = current + ((H-1)*Ts + 1) * Th
+    constexpr uint32_t end_of_batch_jump_q = ((n_heads - 1U) * Ts + 1U) * Th;
+    constexpr uint32_t end_of_batch_jump_v = ((n_heads - 1U) * Ts + 1U) * Tv;
+
+    // dQ / dK_nope / dV stream in block_size chunks via the shared util; dK_pe (Tr tiles) is read as one
+    // burst into cb_dkpe_in because the compute kernel sums all Tr tiles of a head at once.
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t head_dqk = dQK_block_base + h * kq_HtWt;  // dQ and dK share head_dim
+            const uint32_t head_dv = dV_block_base + h * v_HtWt;
+
+            read_full_row_tiles(cb_dq, dQ_addr_gen, Th, block_size, tile_bytes, head_dqk);
+            read_full_row_tiles(cb_dknope, dK_addr_gen, Tn, block_size, tile_bytes, head_dqk);
+            read_tiles_by_row(cb_dkpe_in, dK_addr_gen, head_dqk + Tn, Tr, tile_bytes, Tr);
+            read_full_row_tiles(cb_dv, dV_addr_gen, Tv, block_size, tile_bytes, head_dv);
+        }
+
+        ++sb;
+        if (sb < Ts) {
+            dQK_block_base += Th;
+            dV_block_base += Tv;
+        } else {
+            sb = 0U;
+            dQK_block_base += end_of_batch_jump_q;
+            dV_block_base += end_of_batch_jump_v;
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/writer_mla_qkv_assemble_bw.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    uint32_t runtime_args_counter = 0U;
+    const uint32_t dq_pre_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dkv_up_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t dk_pe_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dq_pre_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dkv_up_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+    uint32_t dk_pe_block_base = get_arg_val<uint32_t>(runtime_args_counter++);
+
+    constexpr uint32_t cb_dq = tt::CBIndex::c_0;
+    constexpr uint32_t cb_dknope = tt::CBIndex::c_1;
+    constexpr uint32_t cb_dv = tt::CBIndex::c_2;
+    constexpr uint32_t cb_dkpe_out = tt::CBIndex::c_4;
+
+    constexpr uint32_t Th = get_compile_time_arg_val(0);
+    constexpr uint32_t Tn = get_compile_time_arg_val(1);
+    constexpr uint32_t Tr = get_compile_time_arg_val(2);
+    constexpr uint32_t Tv = get_compile_time_arg_val(3);
+    constexpr uint32_t n_heads = get_compile_time_arg_val(4);
+    constexpr uint32_t block_size = get_compile_time_arg_val(5);
+    constexpr uint32_t kv_per_head = Tn + Tv;
+
+    constexpr auto dq_pre_args = TensorAccessorArgs<6>();
+    constexpr auto dkv_up_args = TensorAccessorArgs<dq_pre_args.next_compile_time_args_offset()>();
+    constexpr auto dk_pe_args = TensorAccessorArgs<dkv_up_args.next_compile_time_args_offset()>();
+
+    const auto dq_pre_addr_gen = TensorAccessor(dq_pre_args, dq_pre_addr);
+    const auto dkv_up_addr_gen = TensorAccessor(dkv_up_args, dkv_up_addr);
+    const auto dk_pe_addr_gen = TensorAccessor(dk_pe_args, dk_pe_addr);
+
+    const uint32_t tile_bytes = get_tile_size(cb_dkpe_out);
+
+    for (uint32_t block = 0U; block < num_blocks; ++block) {
+        for (uint32_t h = 0U; h < n_heads; ++h) {
+            const uint32_t dq_head_base = dq_pre_block_base + h * Th;
+            const uint32_t dkv_head_base = dkv_up_block_base + h * kv_per_head;
+
+            // dq_pre ← cb_dq; dkv_up = [dK_nope | dV] ← cb_dknope then cb_dv. All in block_size chunks.
+            write_full_row_tiles(cb_dq, dq_pre_addr_gen, Th, block_size, tile_bytes, dq_head_base);
+            write_full_row_tiles(cb_dknope, dkv_up_addr_gen, Tn, block_size, tile_bytes, dkv_head_base);
+            write_full_row_tiles(cb_dv, dkv_up_addr_gen, Tv, block_size, tile_bytes, dkv_head_base + Tn);
+        }
+
+        // dk_pe ← Tr tiles produced by the compute kernel (head-axis sum); one burst + one barrier.
+        cb_wait_front(cb_dkpe_out, Tr);
+        const uint32_t l1_kpe = get_read_ptr(cb_dkpe_out);
+        for (uint32_t w = 0U; w < Tr; ++w) {
+            noc_async_write_page(dk_pe_block_base + w, dk_pe_addr_gen, l1_kpe + w * tile_bytes);
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_dkpe_out, Tr);
+
+        // Outputs are flat across blocks, so the advance is constant.
+        dq_pre_block_base += n_heads * Th;
+        dkv_up_block_base += n_heads * kv_per_head;
+        dk_pe_block_base += Tr;
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "MLAQKVAssembleBw requires {} to be on device. Got storage type: {}",
+            name,
+            enchantum::to_string(tensor.storage_type()));
+        TT_FATAL(tensor.buffer() != nullptr, "MLAQKVAssembleBw: {} buffer must be allocated.", name);
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "MLAQKVAssembleBw requires {} to be in TILE layout. Got: {}",
+            name,
+            enchantum::to_string(tensor.layout()));
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "MLAQKVAssembleBw requires {} dtype to be BFLOAT16. Got: {}",
+            name,
+            enchantum::to_string(tensor.dtype()));
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "MLAQKVAssembleBw requires {} memory layout to be INTERLEAVED. Got: {}",
+            name,
+            enchantum::to_string(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    check_tensor(dQ, "dQ");
+    check_tensor(dK, "dK");
+    check_tensor(dV, "dV");
+
+    const auto dQ_shape = dQ.padded_shape();
+    const auto dK_shape = dK.padded_shape();
+    const auto dV_shape = dV.padded_shape();
+
+    TT_FATAL(dQ_shape.rank() == 4U, "MLAQKVAssembleBw: dQ must be rank-4");
+    TT_FATAL(dK_shape.rank() == 4U, "MLAQKVAssembleBw: dK must be rank-4");
+    TT_FATAL(dV_shape.rank() == 4U, "MLAQKVAssembleBw: dV must be rank-4");
+
+    TT_FATAL(
+        dQ_shape[0] == dK_shape[0] && dK_shape[0] == dV_shape[0],
+        "MLAQKVAssembleBw: batch dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[0],
+        dK_shape[0],
+        dV_shape[0]);
+    TT_FATAL(
+        dQ_shape[1] == args.n_heads && dK_shape[1] == args.n_heads && dV_shape[1] == args.n_heads,
+        "MLAQKVAssembleBw: dim 1 (heads) must equal n_heads ({}). Got dQ={}, dK={}, dV={}.",
+        args.n_heads,
+        dQ_shape[1],
+        dK_shape[1],
+        dV_shape[1]);
+    TT_FATAL(
+        dQ_shape[2] == dK_shape[2] && dK_shape[2] == dV_shape[2],
+        "MLAQKVAssembleBw: seq dim must match across dQ ({}), dK ({}), dV ({}).",
+        dQ_shape[2],
+        dK_shape[2],
+        dV_shape[2]);
+
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+    TT_FATAL(
+        dQ_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dQ dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dQ_shape[3]);
+    TT_FATAL(
+        dK_shape[3] == qk_head,
+        "MLAQKVAssembleBw: dK dim 3 must equal qk_nope_dim + qk_rope_dim = {}. Got {}",
+        qk_head,
+        dK_shape[3]);
+    TT_FATAL(
+        dV_shape[3] == args.v_dim, "MLAQKVAssembleBw: dV dim 3 must equal v_dim = {}. Got {}", args.v_dim, dV_shape[3]);
+
+    TT_FATAL(
+        args.qk_nope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_nope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_nope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.qk_rope_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.qk_rope_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        args.v_dim % TILE_WIDTH == 0,
+        "MLAQKVAssembleBw: v_dim ({}) must be a multiple of TILE_WIDTH ({}).",
+        args.v_dim,
+        TILE_WIDTH);
+    TT_FATAL(
+        dQ_shape[2] % TILE_HEIGHT == 0,
+        "MLAQKVAssembleBw: S ({}) must be a multiple of TILE_HEIGHT ({}).",
+        dQ_shape[2],
+        TILE_HEIGHT);
+}
+
+MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs;
+    output_specs.reserve(3U);
+
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto dQ_shape = dQ.logical_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t qk_head = args.qk_nope_dim + args.qk_rope_dim;
+
+    const ttnn::Shape dq_pre_shape({B, 1U, S, args.n_heads * qk_head});
+    const ttnn::Shape dkv_up_shape({B, 1U, S, args.n_heads * (args.qk_nope_dim + args.v_dim)});
+    const ttnn::Shape dk_pe_shape({B, 1U, S, args.qk_rope_dim});
+
+    // Each output inherits from its primary input source. Validation requires all three
+    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    auto dq_layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
+    auto dk_layout = tt::tt_metal::TensorLayout(dK.dtype(), tt::tt_metal::Layout::TILE, dK.memory_config());
+    output_specs.emplace_back(dq_pre_shape, dq_layout);
+    output_specs.emplace_back(dkv_up_shape, dk_layout);
+    output_specs.emplace_back(dk_pe_shape, dk_layout);
+
+    return output_specs;
+}
+
+MLAQKVAssembleBwDeviceOperation::tensor_return_value_t MLAQKVAssembleBwDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto specs = compute_output_specs(args, tensor_args);
+    auto* device = tensor_args.dQ.device();
+    return {
+        create_device_tensor(specs[0], device),
+        create_device_tensor(specs[1], device),
+        create_device_tensor(specs[2], device)};
+}
+
+ttsl::hash::hash_t MLAQKVAssembleBwDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    return tt::tt_metal::operation::hash_operation<MLAQKVAssembleBwDeviceOperation>(
+        args,
+        tensor_args.dQ.dtype(),
+        tensor_args.dQ.logical_shape(),
+        tensor_args.dK.logical_shape(),
+        tensor_args.dV.logical_shape());
+}
+
+MLAQKVAssembleBwDeviceOperation::program_factory_t MLAQKVAssembleBwDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return MLAQKVAssembleBwProgramFactory{};
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    using OperationType = ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation;
+
+    auto attrs = OperationType::operation_attributes_t{
+        .n_heads = n_heads,
+        .qk_nope_dim = qk_nope_dim,
+        .qk_rope_dim = qk_rope_dim,
+        .v_dim = v_dim,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.dQ = dQ, .dK = dK, .dV = dV};
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwDeviceOperation {
+    using operation_attributes_t = ttml::metal::ops::mla_qkv_assemble_bw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::mla_qkv_assemble_bw::device::tensor_return_value_t;
+    using program_factory_t = std::variant<MLAQKVAssembleBwProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::mla_qkv_assemble_bw::device::MLAQKVAssembleBwDeviceOperation::tensor_return_value_t
+ttml_mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwParams {
+    uint32_t n_heads{};
+    uint32_t qk_nope_dim{};
+    uint32_t qk_rope_dim{};
+    uint32_t v_dim{};
+};
+
+struct MLAQKVAssembleBwInputs {
+    const ttnn::Tensor& dQ;
+    const ttnn::Tensor& dK;
+    const ttnn::Tensor& dV;
+};
+
+using operation_attributes_t = MLAQKVAssembleBwParams;
+using tensor_args_t = MLAQKVAssembleBwInputs;
+using tensor_return_value_t = std::vector<ttnn::Tensor>;
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw_program_factory.hpp"
+
+#include <cstdint>
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "metal/common/program_utils.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace {
+
+constexpr auto kReaderKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "reader_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/dataflow/"
+    "writer_mla_qkv_assemble_bw.cpp";
+
+constexpr auto kComputeKernelPath =
+    "tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/kernels/compute/"
+    "mla_qkv_assemble_bw_kernel.cpp";
+
+// reader runtime arg indices (for override_runtime_arguments)
+constexpr uint32_t kReaderArgDQAddr = 0;
+constexpr uint32_t kReaderArgDKAddr = 1;
+constexpr uint32_t kReaderArgDVAddr = 2;
+
+// writer runtime arg indices
+constexpr uint32_t kWriterArgDQPreAddr = 0;
+constexpr uint32_t kWriterArgDKVUpAddr = 1;
+constexpr uint32_t kWriterArgDKPeAddr = 2;
+
+// CB indices
+constexpr auto kDQCbIndex = tt::CBIndex::c_0;
+constexpr auto kDKnopeCbIndex = tt::CBIndex::c_1;
+constexpr auto kDVCbIndex = tt::CBIndex::c_2;
+constexpr auto kDKpeInCbIndex = tt::CBIndex::c_3;
+constexpr auto kDKpeOutCbIndex = tt::CBIndex::c_4;
+
+// CB sizing. dQ / dK_nope / dV stream in block_size chunks, double-buffered (2 * block_size) for
+// reader/writer NoC overlap, so L1 use is bounded by block_size rather than head_dim. block_size = 8
+// matches the forward op (knee of the N300 throughput sweep); it is not tied to the DST register limit
+// because the only compute here is the small dk_pe head-axis reduction. See mla_qkv_assemble_fw.
+constexpr uint32_t kCbDoubleBuffer = 2U;
+// On the throughput plateau (N300 sweep over {4,8,16} is flat within noise); not tied to DST registers
+// since the only compute is the small dk_pe head-axis reduction. Matches the forward op.
+constexpr uint32_t block_size = 8U;
+
+}  // namespace
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+using namespace tt::constants;
+
+struct MLAQKVAssembleBwKernels {
+    tt::tt_metal::KernelHandle reader;
+    tt::tt_metal::KernelHandle writer;
+    tt::tt_metal::KernelHandle compute;
+};
+
+static void assign_per_core_runtime_args(
+    tt::tt_metal::Program& program,
+    const MLAQKVAssembleBwKernels& kernels,
+    const tt::tt_metal::Buffer* dQ_buffer,
+    const tt::tt_metal::Buffer* dK_buffer,
+    const tt::tt_metal::Buffer* dV_buffer,
+    const tt::tt_metal::Buffer* dq_pre_buffer,
+    const tt::tt_metal::Buffer* dkv_up_buffer,
+    const tt::tt_metal::Buffer* dk_pe_buffer,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    uint32_t num_blocks_per_core_group_1,
+    uint32_t num_blocks_per_core_group_2,
+    const tt::tt_metal::CoreRangeSet& core_group_1,
+    const tt::tt_metal::CoreRangeSet& core_group_2,
+    uint32_t Ts,
+    uint32_t Th,
+    uint32_t Tn,
+    uint32_t Tr,
+    uint32_t Tv,
+    uint32_t kq_HtWt,
+    uint32_t v_HtWt,
+    uint32_t n_heads) {
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_FATAL(false, "MLAQKVAssembleBw: core not in any work group");
+        }
+
+        // Inputs are head-major: tile_id(b, h, sb, w) = b*H*HtWt + h*HtWt + sb*Wt + w.
+        // dQ and dK share per-head head_dim (validated), so a single base addresses both.
+        const uint32_t b_start = num_blocks_written / Ts;
+        const uint32_t sb_start = num_blocks_written % Ts;
+        const uint32_t dQK_block_base_start = b_start * n_heads * kq_HtWt + sb_start * Th;
+        const uint32_t dV_block_base_start = b_start * n_heads * v_HtWt + sb_start * Tv;
+
+        // Outputs are flat across blocks: head 0 of (b, sb) at (b*Ts + sb) * (per_block_tiles).
+        const uint32_t flat_block_idx = num_blocks_written;
+        const uint32_t dq_pre_block_base_start = flat_block_idx * n_heads * Th;
+        const uint32_t dkv_up_block_base_start = flat_block_idx * n_heads * (Tn + Tv);
+        const uint32_t dk_pe_block_base_start = flat_block_idx * Tr;
+
+        SetRuntimeArgs(
+            program,
+            kernels.reader,
+            core,
+            {dQ_buffer->address(),
+             dK_buffer->address(),
+             dV_buffer->address(),
+             num_blocks_per_core,
+             sb_start,
+             dQK_block_base_start,
+             dV_block_base_start});
+
+        SetRuntimeArgs(
+            program,
+            kernels.writer,
+            core,
+            {dq_pre_buffer->address(),
+             dkv_up_buffer->address(),
+             dk_pe_buffer->address(),
+             num_blocks_per_core,
+             dq_pre_block_base_start,
+             dkv_up_block_base_start,
+             dk_pe_block_base_start});
+
+        SetRuntimeArgs(program, kernels.compute, core, {num_blocks_per_core});
+
+        num_blocks_written += num_blocks_per_core;
+    }
+}
+
+MLAQKVAssembleBwProgramFactory::cached_program_t MLAQKVAssembleBwProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const auto& dQ = tensor_args.dQ;
+    const auto& dK = tensor_args.dK;
+    const auto& dV = tensor_args.dV;
+    auto& dq_pre = output[0];
+    auto& dkv_up = output[1];
+    auto& dk_pe = output[2];
+
+    auto* device = dQ.device();
+    tt::tt_metal::Program program{};
+
+    // ── Tile geometry ──
+    const auto dQ_shape = dQ.padded_shape();
+    const uint32_t B = dQ_shape[0];
+    const uint32_t S = dQ_shape[2];
+    const uint32_t H = args.n_heads;
+
+    const uint32_t Tn = args.qk_nope_dim / TILE_WIDTH;
+    const uint32_t Tr = args.qk_rope_dim / TILE_WIDTH;
+    const uint32_t Tv = args.v_dim / TILE_WIDTH;
+    const uint32_t Th = Tn + Tr;
+    const uint32_t Ts = S / TILE_HEIGHT;
+
+    const uint32_t kq_HtWt = Ts * Th;
+    const uint32_t v_HtWt = Ts * Tv;
+
+    const uint32_t num_blocks = B * Ts;
+
+    // Compute kernel uses Tr persistent dst-register slots as the head-axis accumulator, plus 1 temp
+    // slot. With fp32 dest accumulation the DST holds 8 fp32 tiles, so the bound is Tr + 1 ≤ 8.
+    TT_FATAL(
+        Tr + 1U <= 8U,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) / TILE_W = {} too large for in-register accumulator (max 7).",
+        args.qk_rope_dim,
+        Tr);
+
+    // ── Work split ──
+    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+    // ── CBs ──
+    // Validation guarantees dQ / dK / dV share dtype, so any of them yields the same
+    // data_format. dQ is picked because it's also the source-of-truth for B and S above.
+    const tt::DataFormat data_format = tt::tt_metal::datatype_to_dataformat_converter(dQ.dtype());
+    const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    // dQ / dK_nope / dV are 2 * block_size; the dk_pe staging CBs hold all Tr tiles of a head (the
+    // compute kernel sums them at once), double-buffered so reader/compute/writer pipeline across heads.
+    const uint32_t io_cb_num_tiles = kCbDoubleBuffer * block_size;
+    const uint32_t kpe_cb_num_tiles = kCbDoubleBuffer * Tr;
+
+    [[maybe_unused]] auto cb_dq =
+        create_circular_buffer(program, all_cores, kDQCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dknope =
+        create_circular_buffer(program, all_cores, kDKnopeCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dv =
+        create_circular_buffer(program, all_cores, kDVCbIndex, data_format, single_tile_size, io_cb_num_tiles);
+    [[maybe_unused]] auto cb_dkpe_in =
+        create_circular_buffer(program, all_cores, kDKpeInCbIndex, data_format, single_tile_size, kpe_cb_num_tiles);
+    [[maybe_unused]] auto cb_dkpe_out =
+        create_circular_buffer(program, all_cores, kDKpeOutCbIndex, data_format, single_tile_size, kpe_cb_num_tiles);
+
+    // ── Kernels ──
+    auto* dQ_buffer = dQ.buffer();
+    auto* dK_buffer = dK.buffer();
+    auto* dV_buffer = dV.buffer();
+    auto* dq_pre_buffer = dq_pre.buffer();
+    auto* dkv_up_buffer = dkv_up.buffer();
+    auto* dk_pe_buffer = dk_pe.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {Th, Tn, Tr, Tv, H, kq_HtWt, v_HtWt, Ts, block_size};
+    tt::tt_metal::TensorAccessorArgs(dQ_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dK_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dV_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {Th, Tn, Tr, Tv, H, block_size};
+    tt::tt_metal::TensorAccessorArgs(dq_pre_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dkv_up_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(dk_pe_buffer).append_to(writer_compile_time_args);
+
+    const std::vector<uint32_t> compute_compile_time_args = {Tr, H};
+
+    const std::map<std::string, std::string> defines;
+
+    MLAQKVAssembleBwKernels kernels;
+    kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
+    kernels.writer = create_writer_kernel(program, all_cores, writer_compile_time_args, defines, kWriterKernelPath);
+    // fp32 dest accumulation: the dk_pe head-axis sum adds up to n_heads BF16 tiles, so accumulating in
+    // fp32 (instead of BF16 dest) keeps the gradient accurate for large head counts.
+    kernels.compute = create_compute_kernel(
+        program, all_cores, compute_compile_time_args, defines, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+
+    // ── Runtime args ──
+    assign_per_core_runtime_args(
+        program,
+        kernels,
+        dQ_buffer,
+        dK_buffer,
+        dV_buffer,
+        dq_pre_buffer,
+        dkv_up_buffer,
+        dk_pe_buffer,
+        num_cores,
+        num_cores_y,
+        num_blocks_per_core_group_1,
+        num_blocks_per_core_group_2,
+        core_group_1,
+        core_group_2,
+        Ts,
+        Th,
+        Tn,
+        Tr,
+        Tv,
+        kq_HtWt,
+        v_HtWt,
+        H);
+
+    return cached_program_t{
+        std::move(program),
+        {/* reader_kernel_id  = */ kernels.reader,
+         /* writer_kernel_id  = */ kernels.writer,
+         /* compute_kernel_id = */ kernels.compute,
+         /* num_cores         = */ num_cores,
+         /* num_cores_y       = */ num_cores_y}};
+}
+
+void MLAQKVAssembleBwProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*args*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& shared = cached_program.shared_variables;
+    auto& program = cached_program.program;
+
+    auto* dQ_buffer = tensor_args.dQ.buffer();
+    auto* dK_buffer = tensor_args.dK.buffer();
+    auto* dV_buffer = tensor_args.dV.buffer();
+    auto* dq_pre_buffer = output[0].buffer();
+    auto* dkv_up_buffer = output[1].buffer();
+    auto* dk_pe_buffer = output[2].buffer();
+
+    auto& reader_runtime_args = GetRuntimeArgs(program, shared.reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, shared.writer_kernel_id);
+
+    for (uint32_t i = 0; i < shared.num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i / shared.num_cores_y, i % shared.num_cores_y};
+        {
+            auto& ra = reader_runtime_args[core.x][core.y];
+            ra[kReaderArgDQAddr] = dQ_buffer->address();
+            ra[kReaderArgDKAddr] = dK_buffer->address();
+            ra[kReaderArgDVAddr] = dV_buffer->address();
+        }
+        {
+            auto& ra = writer_runtime_args[core.x][core.y];
+            ra[kWriterArgDQPreAddr] = dq_pre_buffer->address();
+            ra[kWriterArgDKVUpAddr] = dkv_up_buffer->address();
+            ra[kWriterArgDKPeAddr] = dk_pe_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "mla_qkv_assemble_bw_device_operation_types.hpp"
+
+namespace ttml::metal::ops::mla_qkv_assemble_bw::device {
+
+struct MLAQKVAssembleBwProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::KernelHandle compute_kernel_id{};
+        uint32_t num_cores{};
+        uint32_t num_cores_y{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::mla_qkv_assemble_bw::device

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mla_qkv_assemble_bw.hpp"
+
+#include "device/mla_qkv_assemble_bw_device_operation.hpp"
+
+namespace ttml::metal {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim) {
+    auto result = ttnn::prim::ttml_mla_qkv_assemble_bw(dQ, dK, dV, n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+    return {result[0], result[1], result[2]};
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/mla_qkv_assemble_bw.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal {
+
+// Backward kernel for ``mla_qkv_assemble_fw``.
+//
+// Inverts the forward op's tile routing:
+//   - dq_pre  ← head-major dQ packed flat  (reverse of head-split).
+//   - dkv_up  ← head-major [dK_nope | dV] packed flat per head.
+//   - dk_pe   ← Σ_h dK[..., qk_nope:]  (head-axis sum, runs in compute kernel).
+//
+// Shapes (TILE layout, INTERLEAVED memory):
+//   dQ      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dK      : [B, n_heads, S, qk_nope_dim + qk_rope_dim]
+//   dV      : [B, n_heads, S, v_dim]
+//   dq_pre  : [B, 1, S, n_heads * (qk_nope_dim + qk_rope_dim)]   (output)
+//   dkv_up  : [B, 1, S, n_heads * (qk_nope_dim + v_dim)]         (output)
+//   dk_pe   : [B, 1, S, qk_rope_dim]                             (output)
+//
+// Per-head dims and S must be tile-aligned.
+//
+// Returns: {dq_pre, dkv_up, dk_pe}
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> mla_qkv_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t n_heads,
+    uint32_t qk_nope_dim,
+    uint32_t qk_rope_dim,
+    uint32_t v_dim);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -263,8 +263,8 @@ void py_module(nb::module_& m) {
     {
         auto py_mla = static_cast<nb::module_>(m.attr("mla"));
         py_mla.def(
-            "qkv_assemble_fw",
-            &ttml::ops::mla_qkv_assemble_fw,
+            "qkv_assemble",
+            &ttml::ops::mla_qkv_assemble,
             nb::arg("q_pre"),
             nb::arg("kv_up"),
             nb::arg("k_pe"),

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.cpp
@@ -6,14 +6,17 @@
 
 #include <cstdint>
 #include <tuple>
+#include <utility>
 
+#include "autograd/graph.hpp"
+#include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/operations.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttml::ops {
 
-std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble_fw(
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
     const autograd::TensorPtr& q_pre,
     const autograd::TensorPtr& kv_up,
     const autograd::TensorPtr& k_pe,
@@ -21,18 +24,29 @@ std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qk
     uint32_t qk_nope_dim,
     uint32_t qk_rope_dim,
     uint32_t v_dim) {
-    // Forward-only op: it does not register a backward node yet, so it would silently drop gradients.
-    // Fail loudly until the backward lands (see the mla_qkv_assemble_bw follow-up).
-    TT_FATAL(
-        !(q_pre->get_requires_grad() || kv_up->get_requires_grad() || k_pe->get_requires_grad()),
-        "mla_qkv_assemble_fw is forward-only: backward is not implemented, so inputs must not require grad.");
-
     auto [q_raw, k_raw, v_raw] = ttml::metal::mla_qkv_assemble_fw(
         q_pre->get_value(), kv_up->get_value(), k_pe->get_value(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
 
     auto out_q = autograd::create_tensor(q_raw);
     auto out_k = autograd::create_tensor(k_raw);
     auto out_v = autograd::create_tensor(v_raw);
+
+    autograd::GradFunction grad =
+        [q_pre, kv_up, k_pe, out_q, out_k, out_v, n_heads, qk_nope_dim, qk_rope_dim, v_dim]() {
+            auto [dq_pre, dkv_up, dk_pe] = ttml::metal::mla_qkv_assemble_bw(
+                out_q->get_grad(), out_k->get_grad(), out_v->get_grad(), n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+            q_pre->add_grad(dq_pre);
+            kv_up->add_grad(dkv_up);
+            k_pe->add_grad(dk_pe);
+        };
+
+    auto q_node = autograd::add_backward_node(std::move(grad), out_q, q_pre, kv_up, k_pe);
+    if (q_node.has_value()) {
+        out_q->set_node(q_node);
+        // Sync nodes on out_k and out_v ensure dK and dV are populated before grad lambda runs.
+        out_k->set_node(autograd::add_backward_node_always([]() {}, out_k, q_pre, kv_up, k_pe, out_q));
+        out_v->set_node(autograd::add_backward_node_always([]() {}, out_v, q_pre, kv_up, k_pe, out_q));
+    }
 
     return {out_q, out_k, out_v};
 }

--- a/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
+++ b/tt-train/sources/ttml/ops/mla_qkv_assemble_op.hpp
@@ -11,12 +11,11 @@
 
 namespace ttml::ops {
 
-// Fused MLA QKV assembly forward. See ``ttml::metal::mla_qkv_assemble_fw`` for
-// shape semantics. Backward support is intentionally left for a follow-up PR.
+// Autograd-aware fused MLA QKV assembly. Forward and backward each dispatch to a dedicated Metal op
+// (``ttml::metal::mla_qkv_assemble_fw`` / ``mla_qkv_assemble_bw``). See those for shape semantics.
 //
-// Returns {q, k, v}. Q is head-split but NOT yet RoPE'd; the caller
-// applies ``rope_trailing`` afterward.
-std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble_fw(
+// Returns {q, k, v}. Q is head-split but NOT yet RoPE'd; the caller applies ``rope_trailing`` afterward.
+std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> mla_qkv_assemble(
     const autograd::TensorPtr& q_pre,
     const autograd::TensorPtr& kv_up,
     const autograd::TensorPtr& k_pe,

--- a/tt-train/sources/ttml/test_utils/comparison.hpp
+++ b/tt-train/sources/ttml/test_utils/comparison.hpp
@@ -13,15 +13,14 @@
 namespace ttml::test_utils {
 
 // gtest assertion that two xtensor arrays match within tolerances. Pass rtol = atol = 0 for ops whose
-// output is bit-exact (e.g. pure data-movement reorders). The shape check fails hard (ASSERT) so the
-// allclose below does not compare mismatched shapes; the value check is a soft EXPECT.
+// output is bit-exact (e.g. pure data-movement reorders). This is a drop-in for
+// `EXPECT_TRUE(xt::allclose(...))`: like xt::allclose it broadcasts, and adds a labeled message.
 inline void expect_allclose(
     const xt::xarray<float>& actual,
     const xt::xarray<float>& expected,
-    double rtol,
-    double atol,
+    double rtol = 1e-5,
+    double atol = 1e-8,
     const std::string& tag = "") {
-    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
     EXPECT_TRUE(xt::allclose(actual, expected, rtol, atol)) << tag << ": value mismatch";
 }
 

--- a/tt-train/sources/ttml/test_utils/comparison.hpp
+++ b/tt-train/sources/ttml/test_utils/comparison.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <string>
+#include <xtensor-blas/xlinalg.hpp>
+
+namespace ttml::test_utils {
+
+// gtest assertion that two xtensor arrays match within tolerances. Pass rtol = atol = 0 for ops whose
+// output is bit-exact (e.g. pure data-movement reorders). The shape check fails hard (ASSERT) so the
+// allclose below does not compare mismatched shapes; the value check is a soft EXPECT.
+inline void expect_allclose(
+    const xt::xarray<float>& actual,
+    const xt::xarray<float>& expected,
+    double rtol,
+    double atol,
+    const std::string& tag = "") {
+    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
+    EXPECT_TRUE(xt::allclose(actual, expected, rtol, atol)) << tag << ": value mismatch";
+}
+
+// gtest assertion on the scale-invariant relative L2 error ||actual - expected|| / ||expected||.
+// Preferred over elementwise allclose for matmul-heavy ops, where BF16 noise makes per-element
+// tolerances unstable across tensor sizes (see e.g. SwiGLU).
+inline void expect_relative_l2(
+    const xt::xarray<float>& actual, const xt::xarray<float>& expected, double threshold, const std::string& tag = "") {
+    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
+    const xt::xarray<float> diff = actual - expected;
+    const float diff_l2 = std::sqrt(xt::sum(xt::square(diff))());
+    const float ref_l2 = std::sqrt(xt::sum(xt::square(expected))());
+    const float rel_l2 = diff_l2 / (ref_l2 + 1e-12F);
+    EXPECT_LT(rel_l2, threshold) << tag << ": relative L2 error " << rel_l2 << " >= " << threshold;
+}
+
+}  // namespace ttml::test_utils

--- a/tt-train/tests/3rd_party/xtensor_test.cpp
+++ b/tt-train/tests/3rd_party/xtensor_test.cpp
@@ -7,6 +7,7 @@
 #include <ttnn/tensor/xtensor/xtensor_all_includes.hpp>
 
 #include "core/xtensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 
 TEST(XTensorTest, BasicOperations) {
     // Create an xtensor array
@@ -25,5 +26,5 @@ TEST(XTensorTest, BasicOperations) {
     xt::xarray<double> expected = {3.0, 4.0, 5.0, 6.0};
 
     // Verify the result
-    EXPECT_TRUE(xt::allclose(arr2, expected));
+    ttml::test_utils::expect_allclose(arr2, expected);
 }

--- a/tt-train/tests/benchmark/mla_qkv_assemble_benchmark.cpp
+++ b/tt-train/tests/benchmark/mla_qkv_assemble_benchmark.cpp
@@ -5,14 +5,13 @@
 // ============================================================================
 // MLA QKV assemble op-level fusion benchmark
 //
-// Uses Google Benchmark to measure average wall-clock time of the DeepSeek MLA
-// QKV assemble forward for two paths:
-//   composite — split_heads (reshape + transpose) + slice + concat + k_pe broadcast
-//   fused     — the single ttml::metal::mla_qkv_assemble_fw data-movement op
+// Uses Google Benchmark to measure average wall-clock time of the DeepSeek MLA QKV assemble, forward
+// and backward, each for two paths:
+//   composite — split_heads (reshape + transpose) + slice + concat + k_pe broadcast (and its reverse)
+//   fused     — the single ttml::metal::mla_qkv_assemble_fw / mla_qkv_assemble_bw data-movement op
 //
-// This op is forward-only (backward lands in a follow-up), so only the forward
-// assemble is timed. Each measured sample enqueues several assembles and
-// synchronizes once at the end to amortize dispatch latency.
+// Each measured sample enqueues several assembles and synchronizes once at the end to amortize
+// dispatch latency. Results are printed as two tables (forward, backward).
 // ============================================================================
 
 #include <benchmark/benchmark.h>
@@ -28,12 +27,14 @@
 
 #include "autograd/auto_context.hpp"
 #include "benchmark_utils.hpp"
+#include "core/compute_kernel_config.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 
 namespace {
 
@@ -122,11 +123,56 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> composite_assemble(
     return {q, k, v};
 }
 
+// Composite backward: the pre-fusion gradient path (reverse head-split + slice/concat + head-axis sum).
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> composite_assemble_bw(
+    const ttnn::Tensor& dQ,
+    const ttnn::Tensor& dK,
+    const ttnn::Tensor& dV,
+    uint32_t batch,
+    uint32_t seq_len,
+    const ModelShape& shape) {
+    const uint32_t H = shape.n_heads;
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const uint32_t kv_w = shape.qk_nope_dim + shape.v_dim;
+    const ttsl::SmallVector<uint32_t> step = {1U, 1U, 1U, 1U};
+
+    // dq_pre: reverse head-split [B, H, S, qk_head] -> [B, S, H, qk_head] -> [B, 1, S, H*qk_head].
+    const auto dq_pre = ttnn::reshape(ttnn::transpose(dQ, 1, 2), ttnn::Shape({batch, 1U, seq_len, H * qk_head}));
+
+    // dkv_up: concat [dK_nope | dV] per head, then reverse head-split.
+    const auto dk_nope = ttnn::slice(
+        dK,
+        ttsl::SmallVector<uint32_t>{0U, 0U, 0U, 0U},
+        ttsl::SmallVector<uint32_t>{batch, H, seq_len, shape.qk_nope_dim},
+        step);
+    const auto kv_head = ttnn::concat(std::vector<ttnn::Tensor>{dk_nope, dV}, /*dim=*/3);
+    const auto dkv_up = ttnn::reshape(ttnn::transpose(kv_head, 1, 2), ttnn::Shape({batch, 1U, seq_len, H * kv_w}));
+
+    // dk_pe: sum dK's rope suffix over the head axis -> [B, 1, S, qk_rope].
+    const auto dk_rope = ttnn::slice(
+        dK,
+        ttsl::SmallVector<uint32_t>{0U, 0U, 0U, shape.qk_nope_dim},
+        ttsl::SmallVector<uint32_t>{batch, H, seq_len, qk_head},
+        step);
+    const auto dk_pe =
+        ttnn::sum(dk_rope, /*dim=*/1, /*keepdim=*/true, std::nullopt, ttml::core::ComputeKernelConfig::precise());
+    return {dq_pre, dkv_up, dk_pe};
+}
+
 ttnn::Tensor make_input(uint32_t batch, uint32_t seq_len, uint32_t width, uint32_t seed) {
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t count = static_cast<size_t>(batch) * seq_len * width;
     const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
     const ttnn::Shape shape({batch, 1U, seq_len, width});
+    return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
+}
+
+// Head-major [B, H, S, W] input for the backward grads dQ / dK / dV.
+ttnn::Tensor make_input_hm(uint32_t batch, uint32_t n_heads, uint32_t seq_len, uint32_t width, uint32_t seed) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    const size_t count = static_cast<size_t>(batch) * n_heads * seq_len * width;
+    const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
+    const ttnn::Shape shape({batch, n_heads, seq_len, width});
     return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
 }
 
@@ -167,6 +213,44 @@ double run_single(const ModelShape& shape, const SweepConfig& cfg, uint32_t batc
     return std::chrono::duration<double, std::milli>(t1 - t0).count() / cfg.num_measure;
 }
 
+double run_single_bw(
+    const ModelShape& shape, const SweepConfig& cfg, uint32_t batch, uint32_t seq_len, bool use_fused) {
+    auto* const device = &ttml::autograd::ctx().get_device();
+    device->clear_program_cache();
+
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto dQ = make_input_hm(batch, shape.n_heads, seq_len, qk_head, 4004U);
+    const auto dK = make_input_hm(batch, shape.n_heads, seq_len, qk_head, 5005U);
+    const auto dV = make_input_hm(batch, shape.n_heads, seq_len, shape.v_dim, 6006U);
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+    const auto run_step = [&]() {
+        if (use_fused) {
+            auto out = ttml::metal::mla_qkv_assemble_bw(
+                dQ, dK, dV, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
+            benchmark::DoNotOptimize(out);
+        } else {
+            auto out = composite_assemble_bw(dQ, dK, dV, batch, seq_len, shape);
+            benchmark::DoNotOptimize(out);
+        }
+    };
+
+    for (uint32_t step = 0; step < cfg.num_warmup; ++step) {
+        run_step();
+    }
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    for (uint32_t step = 0; step < cfg.num_measure; ++step) {
+        run_step();
+    }
+    tt::tt_metal::distributed::Synchronize(device, std::nullopt);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    ttml::autograd::ctx().reset_graph();
+    return std::chrono::duration<double, std::milli>(t1 - t0).count() / cfg.num_measure;
+}
+
 struct RowSummary {
     std::string model_name;
     uint32_t batch_size = 0;
@@ -174,27 +258,32 @@ struct RowSummary {
     uint32_t n_heads = 0;
     double composite_ms = 0.0;
     double fused_ms = 0.0;
+    double bw_composite_ms = 0.0;
+    double bw_fused_ms = 0.0;
 };
 
-void print_table(const std::vector<RowSummary>& rows) {
+void print_table(const std::string& title, const std::vector<RowSummary>& rows, bool backward) {
     fmt::print("\n");
     fmt::print(
-        "MLA QKV assemble forward (composite vs fused)\n"
-        "| Model        | B     | S     | H     | Composite ms | Fused ms | Saved ms | Speedup | Reduction |\n");
+        "{}\n"
+        "| Model        | B     | S     | H     | Composite ms | Fused ms | Saved ms | Speedup | Reduction |\n",
+        title);
     fmt::print("|--------------|-------|-------|-------|--------------|----------|----------|---------|-----------|\n");
     for (const auto& row : rows) {
-        const double saved_ms = row.composite_ms - row.fused_ms;
+        const double composite_ms = backward ? row.bw_composite_ms : row.composite_ms;
+        const double fused_ms = backward ? row.bw_fused_ms : row.fused_ms;
+        const double saved_ms = composite_ms - fused_ms;
         fmt::print(
             "| {:<12} | {:>5} | {:>5} | {:>5} | {:>12.4f} | {:>8.4f} | {:>8.4f} | {:>6.2f}x | {:>8.2f}% |\n",
             row.model_name,
             row.batch_size,
             row.sequence_length,
             row.n_heads,
-            row.composite_ms,
-            row.fused_ms,
+            composite_ms,
+            fused_ms,
             saved_ms,
-            ttml::benchmark_utils::speedup_x(row.composite_ms, row.fused_ms),
-            ttml::benchmark_utils::reduction_pct(row.composite_ms, row.fused_ms));
+            ttml::benchmark_utils::speedup_x(composite_ms, fused_ms),
+            ttml::benchmark_utils::reduction_pct(composite_ms, fused_ms));
     }
 }
 
@@ -212,6 +301,9 @@ void BM_MLAQKVAssemble(benchmark::State& state) {
     for ([[maybe_unused]] auto _ : state) {
         const double composite_ms = run_single(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/false);
         const double fused_ms = run_single(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/true);
+        const double bw_composite_ms =
+            run_single_bw(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/false);
+        const double bw_fused_ms = run_single_bw(model, g_sweep_cfg, batch_size, sequence_length, /*use_fused=*/true);
 
         g_rows.push_back(RowSummary{
             .model_name = model.name,
@@ -220,12 +312,16 @@ void BM_MLAQKVAssemble(benchmark::State& state) {
             .n_heads = model.n_heads,
             .composite_ms = composite_ms,
             .fused_ms = fused_ms,
+            .bw_composite_ms = bw_composite_ms,
+            .bw_fused_ms = bw_fused_ms,
         });
 
         state.SetIterationTime(fused_ms / 1000.0);
         state.SetLabel(fmt::format("{} B={} S={} H={}", model.name, batch_size, sequence_length, model.n_heads));
         state.counters["Composite_ms"] = composite_ms;
         state.counters["Fused_ms"] = fused_ms;
+        state.counters["BW_composite_ms"] = bw_composite_ms;
+        state.counters["BW_fused_ms"] = bw_fused_ms;
     }
 }
 
@@ -244,14 +340,14 @@ int main(int argc, char** argv) {
         const tt::tt_metal::distributed::MeshShape mesh(1, 1);
         ttml::autograd::ctx().open_device(mesh);
 
-        fmt::print("MLA QKV assemble op-level benchmark (composite vs fused, forward only)\n");
+        fmt::print("MLA QKV assemble op-level benchmark (composite vs fused, forward + backward)\n");
         fmt::print(
             "preset models=deepseek-mla,nano-mla batches=16,32 seq_lens=128,256,512 warmup={} measure={}\n",
             g_sweep_cfg.num_warmup,
             g_sweep_cfg.num_measure);
         fmt::print(
             "Composite path: split_heads (reshape + transpose) + slice + concat + k_pe broadcast.\n"
-            "Each measured sample enqueues multiple forward assembles and synchronizes once at the end.\n");
+            "Each measured sample enqueues multiple assembles and synchronizes once at the end.\n");
 
         benchmark::RegisterBenchmark("MLAQKVAssemble", BM_MLAQKVAssemble)
             ->DenseRange(0, static_cast<int>(g_cases.size()) - 1, 1)
@@ -261,7 +357,8 @@ int main(int argc, char** argv) {
         benchmark::RunSpecifiedBenchmarks();
         benchmark::Shutdown();
 
-        print_table(g_rows);
+        print_table("MLA QKV assemble forward (composite vs fused)", g_rows, /*backward=*/false);
+        print_table("MLA QKV assemble backward (composite vs fused)", g_rows, /*backward=*/true);
 
         ttml::autograd::ctx().close_device();
         return 0;

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -13,6 +13,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
@@ -55,8 +56,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateInt32) {
         ttml::core::from_xtensor<int32_t, ttnn::DataType::INT32>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto xtensors_back = ttml::core::to_xtensor<int32_t>(tensor, ttml::core::IdentityComposer{});
 
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateUInt32) {
@@ -68,8 +69,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateUInt32) {
     auto tensor =
         ttml::core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto xtensors_back = ttml::core::to_xtensor<uint32_t>(tensor, ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicate) {
@@ -81,8 +82,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicate) {
     auto tensor = ttml::core::from_xtensor(xtensor, device, ttnn::Layout::TILE, mapper.get());
     auto xtensors_back = ttml::core::to_xtensor(tensor, ttml::core::IdentityComposer{});
 
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(xtensor, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(xtensor, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorShardAxis3) {
@@ -100,8 +101,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3) {
     xt::xarray<float> chunk0 = xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, 2));
     xt::xarray<float> chunk1 = xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(2, 4));
 
-    EXPECT_TRUE(xt::allclose(chunk0, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(chunk1, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(chunk0, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(chunk1, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorShardAxis2) {
@@ -119,8 +120,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2) {
     xt::xarray<float> chunk0 = xt::view(xtensor, xt::all(), xt::all(), xt::range(0, 1), xt::all());
     xt::xarray<float> chunk1 = xt::view(xtensor, xt::all(), xt::all(), xt::range(1, 2), xt::all());
 
-    EXPECT_TRUE(xt::allclose(chunk0, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(chunk1, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(chunk0, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(chunk1, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
@@ -146,8 +147,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
     std::cout << "xtensors_back[0]: " << xtensors_back[0] << std::endl;
     std::cout << "xtensors_back[1]: " << xtensors_back[1] << std::endl;
     std::cout << "reduced_tensor: " << reduced_tensor << std::endl;
-    EXPECT_TRUE(xt::allclose(reduced_tensor, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(reduced_tensor, xtensors_back[1], /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(reduced_tensor, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(reduced_tensor, xtensors_back[1], /*rtol=*/1e-3, /*atol=*/1e-2);
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateAllReduceBadTiles) {
@@ -170,8 +171,8 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduceBadTiles) {
     auto xtensors_back = ttml::core::to_xtensor(sum_tensor, ttml::core::IdentityComposer{});
     auto reduced_tensor = xtensor + xtensor;
 
-    EXPECT_TRUE(xt::allclose(reduced_tensor, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(reduced_tensor, xtensors_back[1], /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(reduced_tensor, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(reduced_tensor, xtensors_back[1], /*rtol=*/1e-3, /*atol=*/1e-2);
 }
 
 TEST_F(N300UtilsTest, TestXTensorShardAxis2AddScalar) {
@@ -189,8 +190,8 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2AddScalar) {
     xt::xarray<float> chunk0 = xt::view(xtensor, xt::all(), xt::all(), xt::range(0, 1), xt::all());
     xt::xarray<float> chunk1 = xt::view(xtensor, xt::all(), xt::all(), xt::range(1, 2), xt::all());
 
-    EXPECT_TRUE(xt::allclose(chunk0 + scalar, xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(chunk1 + scalar, xtensors_back[1]));
+    ttml::test_utils::expect_allclose(chunk0 + scalar, xtensors_back[0]);
+    ttml::test_utils::expect_allclose(chunk1 + scalar, xtensors_back[1]);
 }
 
 TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
@@ -229,7 +230,7 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
     xt::xarray<float> mul_res = xt::linalg::dot(xtensor_a, xtensor_b);
 
     // (128, 64) X (64, 256) => (128, 256)
-    EXPECT_TRUE(xt::allclose(mul_res, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(mul_res, xtensors_back[0], /*rtol=*/1e-3, /*atol=*/1e-2);
 }
 
 TEST_F(N300UtilsTest, DropoutDifferentSeed) {

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "core/xtensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "tt-metalium/bfloat16.hpp"
 #include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/types.hpp"
@@ -490,7 +491,7 @@ TEST_F(TensorUtilsTest, TestFloatXtensor) {
 
     auto xtensor_back = ttml::core::to_xtensor(tensor);
 
-    EXPECT_TRUE(xt::allclose(xtensor, xtensor_back));
+    ttml::test_utils::expect_allclose(xtensor, xtensor_back);
 }
 
 TEST_F(TensorUtilsTest, TestUint32XTensor) {
@@ -504,7 +505,7 @@ TEST_F(TensorUtilsTest, TestUint32XTensor) {
 
     auto xtensor_back = ttml::core::to_xtensor<uint32_t>(tensor);
 
-    EXPECT_TRUE(xt::allclose(xtensor, xtensor_back));
+    ttml::test_utils::expect_allclose(xtensor, xtensor_back);
 }
 
 TEST_F(TensorUtilsTest, TestBytesToFromTensor) {

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -15,6 +15,7 @@
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/operations/creation/creation.hpp"
@@ -85,7 +86,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
     // (1, 1, out_features, in_features)
@@ -100,8 +101,8 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
         expected_output += bias_xtensor[0];
     }
 
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
@@ -133,7 +134,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
     // (1, 1, out_features, in_features)
@@ -143,8 +144,8 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
     auto test_data_shape = test_data.shape();
 
     auto expected_output = xt::linalg::dot(test_data, xt::transpose(weight_xtensor, {0, 1, 3, 2}));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
@@ -177,7 +178,7 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
     // (1, 1, out_features, in_features)
@@ -188,8 +189,8 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
         expected_output += bias_xtensor[0];
     }
 
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
@@ -221,15 +222,15 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
     // (1, 1, out_features, in_features)
     auto weight_xtensor = ttml::core::to_xtensor<float>(weight->get_value(), *concat_composer);
     auto expected_output = xt::linalg::dot(test_data, xt::transpose(weight_xtensor, {0, 1, 3, 2}));
 
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
@@ -262,7 +263,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer_2 = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 2U);
     auto concat_composer_3 = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
@@ -275,8 +276,8 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasAllGather) {
         expected_output += bias_xtensor;
     }
 
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
@@ -308,7 +309,7 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
     auto output = layer(tensor);
 
     auto output_xtensor = ttml::core::to_xtensor<float>(output->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(output_xtensor[0], output_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto concat_composer_2 = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 2U);
     auto concat_composer_3 = ttnn::distributed::concat_mesh_to_tensor_composer(*device, 3U);
@@ -316,8 +317,8 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasAllGather) {
     auto weight_xtensor = ttml::core::to_xtensor<float>(weight->get_value(), *concat_composer_2);
     auto expected_output = xt::linalg::dot(test_data, xt::transpose(weight_xtensor, {0, 1, 3, 2}));
 
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(expected_output, output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(expected_output, output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
@@ -360,16 +361,16 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNoAllGather) {
         expected_output += bias_xtensor;
     }
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(expected_output, xt::all(), xt::all(), xt::all(), xt::range(0, out_features / 2)),
         output_xtensor[0],
         /* rtol */ 1e-2,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         xt::view(expected_output, xt::all(), xt::all(), xt::all(), xt::range(out_features / 2, out_features)),
         output_xtensor[1],
         /* rtol */ 1e-2,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
@@ -407,16 +408,16 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
     auto expected_output = xt::linalg::dot(test_data, xt::transpose(weight_xtensor, {0, 1, 3, 2}));
     expected_output = expected_output.reshape({1U, 1U, 1U, out_features});
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(expected_output, xt::all(), xt::all(), xt::all(), xt::range(0, out_features / 2)),
         output_xtensor[0],
         /* rtol */ 1e-2,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         xt::view(expected_output, xt::all(), xt::all(), xt::all(), xt::range(out_features / 2, out_features)),
         output_xtensor[1],
         /* rtol */ 1e-2,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
@@ -488,18 +489,18 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
     // LinearLayer weight gradient should be replicated - just take device 0
     auto replicate_layer_weight_gradients = replicate_layer_weight_gradients_vec[0];
 
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[0], row_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[1], row_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[0], row_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[1], row_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 
-    EXPECT_TRUE(xt::allclose(
-        replicate_layer_input_gradients[0], row_parallel_input_gradients[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
-        replicate_layer_input_gradients[1], row_parallel_input_gradients[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(
+        replicate_layer_input_gradients[0], row_parallel_input_gradients[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
+        replicate_layer_input_gradients[1], row_parallel_input_gradients[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 
-    EXPECT_TRUE(xt::allclose(
-        replicate_layer_weight_gradients, row_parallel_weight_gradients, /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(
+        replicate_layer_weight_gradients, row_parallel_weight_gradients, /* rtol */ 1e-2, /* atol */ 1e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
@@ -565,32 +566,32 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
     auto replicate_layer_weight_gradients =
         ttml::core::to_xtensor<float>(replicate_layer_weight->get_grad(), ttml::core::IdentityComposer{});
 
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[0], column_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[1], column_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[0], column_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[1], column_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         replicate_layer_input_gradients[0],
         num_devices * column_parallel_input_gradients[0],
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 5e-2);
+    ttml::test_utils::expect_allclose(
         replicate_layer_input_gradients[1],
         num_devices * column_parallel_input_gradients[1],
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
+        /* atol */ 5e-2);
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         replicate_layer_weight_gradients[0],
         num_devices * column_parallel_weight_gradients,
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 5e-2);
+    ttml::test_utils::expect_allclose(
         replicate_layer_weight_gradients[1],
         num_devices * column_parallel_weight_gradients,
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
+        /* atol */ 5e-2);
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
@@ -657,30 +658,30 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
     auto replicate_layer_weight_gradients =
         ttml::core::to_xtensor<float>(replicate_layer_weight->get_grad(), ttml::core::IdentityComposer{});
 
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[0], column_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2));
-    EXPECT_TRUE(
-        xt::allclose(replicate_output_xtensor[1], column_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[0], column_parallel_output_xtensor[0], /* rtol */ 1e-2, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
+        replicate_output_xtensor[1], column_parallel_output_xtensor[1], /* rtol */ 1e-2, /* atol */ 1e-2);
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         replicate_layer_input_gradients[0],
         num_devices * column_parallel_input_gradients[0],
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 5e-2);
+    ttml::test_utils::expect_allclose(
         replicate_layer_input_gradients[1],
         num_devices * column_parallel_input_gradients[1],
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
+        /* atol */ 5e-2);
 
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         replicate_layer_weight_gradients[0],
         num_devices * column_parallel_weight_gradients,
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 5e-2);
+    ttml::test_utils::expect_allclose(
         replicate_layer_weight_gradients[1],
         num_devices * column_parallel_weight_gradients,
         /* rtol */ 1e-2,
-        /* atol */ 5e-2));
+        /* atol */ 5e-2);
 };

--- a/tt-train/tests/ops/binary_ops_bw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_bw_test.cpp
@@ -10,6 +10,7 @@
 #include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/binary_ops.hpp"
+#include "test_utils/comparison.hpp"
 
 namespace ttml::ops::tests {
 
@@ -44,8 +45,8 @@ TEST_F(BinaryOpsBackwardTest, AddSameShape) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a+b)/da = 1, d(a+b)/db = 1
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-    EXPECT_TRUE(xt::allclose(b_grad, xt::ones_like(data_b)));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a));
+    ttml::test_utils::expect_allclose(b_grad, xt::ones_like(data_b));
 }
 
 TEST_F(BinaryOpsBackwardTest, SubSameShape) {
@@ -63,8 +64,8 @@ TEST_F(BinaryOpsBackwardTest, SubSameShape) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a-b)/da = 1, d(a-b)/db = -1
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
-    EXPECT_TRUE(xt::allclose(b_grad, -xt::ones_like(data_b)));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a));
+    ttml::test_utils::expect_allclose(b_grad, -xt::ones_like(data_b));
 }
 
 TEST_F(BinaryOpsBackwardTest, MulSameShape) {
@@ -82,8 +83,8 @@ TEST_F(BinaryOpsBackwardTest, MulSameShape) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a*b)/da = b, d(a*b)/db = a
-    EXPECT_TRUE(xt::allclose(a_grad, data_b));
-    EXPECT_TRUE(xt::allclose(b_grad, data_a));
+    ttml::test_utils::expect_allclose(a_grad, data_b);
+    ttml::test_utils::expect_allclose(b_grad, data_a);
 }
 
 TEST_F(BinaryOpsBackwardTest, MulScalar) {
@@ -98,7 +99,7 @@ TEST_F(BinaryOpsBackwardTest, MulScalar) {
     auto a_grad = core::to_xtensor(a->get_grad());
 
     // d(a*c)/da = c
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 3.0F));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a) * 3.0F);
 }
 
 TEST_F(BinaryOpsBackwardTest, DivSameShape) {
@@ -118,8 +119,8 @@ TEST_F(BinaryOpsBackwardTest, DivSameShape) {
     // d(a/b)/da = 1/b, d(a/b)/db = -a/b^2
     xt::xarray<float> expected_a_grad = 1.0F / data_b;
     xt::xarray<float> expected_b_grad = -data_a / (data_b * data_b);
-    EXPECT_TRUE(xt::allclose(a_grad, expected_a_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F));
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F));
+    ttml::test_utils::expect_allclose(a_grad, expected_a_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F);
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad, /* rtol */ 1e-2F, /* atol */ 1e-2F);
 }
 
 TEST_F(BinaryOpsBackwardTest, MinSameShape) {
@@ -140,8 +141,8 @@ TEST_F(BinaryOpsBackwardTest, MinSameShape) {
     // grad flows to the winner; ties split 50/50
     xt::xarray<float> expected_a_grad = {{{{1.F, 0.F, 0.5F, 1.F}}}};
     xt::xarray<float> expected_b_grad = {{{{0.F, 1.F, 0.5F, 0.F}}}};
-    EXPECT_TRUE(xt::allclose(a_grad, expected_a_grad, 1e-3F, 1e-3F));
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad, 1e-3F, 1e-3F));
+    ttml::test_utils::expect_allclose(a_grad, expected_a_grad, 1e-3F, 1e-3F);
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad, 1e-3F, 1e-3F);
 }
 
 TEST_F(BinaryOpsBackwardTest, MaxSameShape) {
@@ -162,8 +163,8 @@ TEST_F(BinaryOpsBackwardTest, MaxSameShape) {
     // grad flows to the winner; ties split 50/50
     xt::xarray<float> expected_a_grad = {{{{0.F, 1.F, 0.5F, 0.F}}}};
     xt::xarray<float> expected_b_grad = {{{{1.F, 0.F, 0.5F, 1.F}}}};
-    EXPECT_TRUE(xt::allclose(a_grad, expected_a_grad, 1e-3F, 1e-3F));
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad, 1e-3F, 1e-3F));
+    ttml::test_utils::expect_allclose(a_grad, expected_a_grad, 1e-3F, 1e-3F);
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad, 1e-3F, 1e-3F);
 }
 
 // ============================================================================
@@ -205,14 +206,14 @@ TEST_P(AddBroadcastBackwardTest, GradShapeMatchesInput) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a+b)/da = 1
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a));
 
     // d(a+b)/db = 1, reduced over broadcast dims
     // Each b element accumulates (a_volume / b_volume) copies of 1
     auto a_volume = static_cast<float>(data_a.size());
     auto b_volume = static_cast<float>(data_b.size());
     xt::xarray<float> expected_b_grad = xt::ones_like(data_b) * (a_volume / b_volume);
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad);
 }
 
 TEST_P(SubBroadcastBackwardTest, GradShapeMatchesInput) {
@@ -232,13 +233,13 @@ TEST_P(SubBroadcastBackwardTest, GradShapeMatchesInput) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a-b)/da = 1
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a)));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a));
 
     // d(a-b)/db = -1, reduced over broadcast dims
     auto a_volume = static_cast<float>(data_a.size());
     auto b_volume = static_cast<float>(data_b.size());
     xt::xarray<float> expected_b_grad = -xt::ones_like(data_b) * (a_volume / b_volume);
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad);
 }
 
 TEST_P(MulBroadcastBackwardTest, GradShapeMatchesInput) {
@@ -260,14 +261,14 @@ TEST_P(MulBroadcastBackwardTest, GradShapeMatchesInput) {
     auto b_grad = core::to_xtensor(b->get_grad());
 
     // d(a*b)/da = b (broadcast) -> each element = 2
-    EXPECT_TRUE(xt::allclose(a_grad, xt::ones_like(data_a) * 2.0F));
+    ttml::test_utils::expect_allclose(a_grad, xt::ones_like(data_a) * 2.0F);
 
     // d(a*b)/db = a, reduced over broadcast dims.
     // Each b element sees (a_volume / b_volume) copies of a=3, so b_grad = 3 * (a_volume / b_volume).
     auto a_volume = static_cast<float>(data_a.size());
     auto b_volume = static_cast<float>(data_b.size());
     xt::xarray<float> expected_b_grad = xt::ones_like(data_b) * 3.0F * (a_volume / b_volume);
-    EXPECT_TRUE(xt::allclose(b_grad, expected_b_grad));
+    ttml::test_utils::expect_allclose(b_grad, expected_b_grad);
 }
 
 // Same-rank broadcast: b has a 1 in exactly one dimension

--- a/tt-train/tests/ops/binary_ops_fw_test.cpp
+++ b/tt-train/tests/ops/binary_ops_fw_test.cpp
@@ -8,6 +8,7 @@
 #include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/binary_ops.hpp"
+#include "test_utils/comparison.hpp"
 
 namespace ttml::ops::tests {
 
@@ -35,7 +36,7 @@ TEST_F(BinaryOpsForwardTest, AddSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{6.F, 8.F, 10.F, 12.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, AddBroadcast) {
@@ -53,7 +54,7 @@ TEST_F(BinaryOpsForwardTest, AddBroadcast) {
 
     xt::xarray<float> expected = {11.F, 22.F, 33.F, 44.F, 15.F, 26.F, 37.F, 48.F};
     expected.reshape({2, 1, 1, 4});
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, SubSameShape) {
@@ -68,7 +69,7 @@ TEST_F(BinaryOpsForwardTest, SubSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{4.F, 4.F, 4.F, 4.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, SubBroadcast) {
@@ -85,7 +86,7 @@ TEST_F(BinaryOpsForwardTest, SubBroadcast) {
 
     xt::xarray<float> expected = {9.F, 18.F, 27.F, 36.F, 49.F, 58.F, 67.F, 76.F};
     expected.reshape({2, 1, 1, 4});
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, MulSameShape) {
@@ -100,7 +101,7 @@ TEST_F(BinaryOpsForwardTest, MulSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{4.F, 6.F, 6.F, 4.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, MulBroadcast) {
@@ -117,7 +118,7 @@ TEST_F(BinaryOpsForwardTest, MulBroadcast) {
 
     xt::xarray<float> expected = {2.F, 6.F, 12.F, 20.F, 10.F, 18.F, 28.F, 40.F};
     expected.reshape({2, 1, 1, 4});
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, MulScalar) {
@@ -130,7 +131,7 @@ TEST_F(BinaryOpsForwardTest, MulScalar) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{3.F, 6.F, 9.F, 12.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, DivSameShape) {
@@ -145,7 +146,7 @@ TEST_F(BinaryOpsForwardTest, DivSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{2.F, 2.F, 2.F, 2.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, DivBroadcast) {
@@ -162,7 +163,7 @@ TEST_F(BinaryOpsForwardTest, DivBroadcast) {
 
     xt::xarray<float> expected = {2.F, 3.F, 4.F, 5.F, 6.F, 7.F, 8.F, 9.F};
     expected.reshape({2, 1, 1, 4});
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, MinSameShape) {
@@ -177,7 +178,7 @@ TEST_F(BinaryOpsForwardTest, MinSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{1.F, 2.F, 3.F, 6.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 TEST_F(BinaryOpsForwardTest, MaxSameShape) {
@@ -192,7 +193,7 @@ TEST_F(BinaryOpsForwardTest, MaxSameShape) {
     auto result = core::to_xtensor(out->get_value());
 
     xt::xarray<float> expected = {{{{4.F, 5.F, 3.F, 8.F}}}};
-    EXPECT_TRUE(xt::allclose(result, expected));
+    ttml::test_utils::expect_allclose(result, expected);
 }
 
 }  // namespace ttml::ops::tests

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -17,6 +17,7 @@
 #include "metal/operations.hpp"
 #include "ops/losses.hpp"
 #include "ops/unary_ops.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 class CrossEntropyBackwardTest : public ::testing::Test {
@@ -82,7 +83,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Small_Backward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Batch) {
@@ -115,7 +116,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Batch) {
@@ -148,7 +149,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Backward) {
@@ -181,7 +182,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Backward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
@@ -214,7 +215,7 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
@@ -249,7 +250,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
     auto result_mean_xtensor = core::to_xtensor(result_mean->get_value());
 
     assert((result_none_after_mean_xtensor.shape() == result_mean_xtensor.shape()));
-    EXPECT_TRUE(xt::allclose(result_none_after_mean_xtensor, result_mean_xtensor, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_none_after_mean_xtensor, result_mean_xtensor, 3e-2F, 1e-2F);
     assert((result_none_with_mean_after_grad.shape() == result_mean_grad.shape()));
-    EXPECT_TRUE(xt::allclose(result_none_with_mean_after_grad, result_mean_grad, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_none_with_mean_after_grad, result_mean_grad, 3e-2F, 1e-2F);
 }

--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -14,6 +14,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 class CrossEntropyForwardTest : public ::testing::Test {
@@ -69,7 +70,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Small_Forward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Negetive_Values) {
@@ -93,7 +94,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Negetive_Values) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Batch) {
@@ -119,7 +120,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Batch) {
@@ -145,7 +146,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Forward) {
@@ -171,7 +172,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Forward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(CrossEntropyForwardTest, NIGHTLY_CrossEntropyForward_Huge_Forward) {
@@ -197,5 +198,5 @@ TEST_F(CrossEntropyForwardTest, NIGHTLY_CrossEntropyForward_Huge_Forward) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -13,6 +13,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
@@ -66,8 +67,8 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) +
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size));
 
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-3));
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-3));
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-3);
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-3);
 
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
@@ -86,16 +87,16 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
 
     auto grad_xtensor = ttml::core::to_xtensor<float>(tensor->get_grad(), ttml::core::IdentityComposer{});
     EXPECT_EQ(grad_xtensor[0].shape(), grad_xtensor[1].shape());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[0],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[1],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
@@ -125,8 +126,8 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) +
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size));
 
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 2e-2));
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 2e-2));
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 2e-2);
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 2e-2);
 
     uint32_t seed2 = rng();
     xt::xarray<float> grad_data = ttml::test_utils::make_uniform_xarray<float>(
@@ -143,16 +144,16 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
     auto grad_xtensor = ttml::core::to_xtensor<float>(tensor->get_grad(), ttml::core::IdentityComposer{});
     EXPECT_EQ(grad_xtensor[0].shape(), grad_xtensor[1].shape());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[0],
         /* rtol */ 1e-3,
-        /* atol */ 2e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 2e-2);
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[1],
         /* rtol */ 1e-3,
-        /* atol */ 2e-2));
+        /* atol */ 2e-2);
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
@@ -181,8 +182,8 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) +
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size));
 
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(all_reduce_expected, all_reduce_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     seed = rng();
     xt::xarray<float> grad_data = ttml::test_utils::make_uniform_xarray<float>(
@@ -199,16 +200,16 @@ TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
     auto grad_xtensor = ttml::core::to_xtensor<float>(tensor->get_grad(), ttml::core::IdentityComposer{});
     EXPECT_EQ(grad_xtensor[0].shape(), grad_xtensor[1].shape());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[0],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         grad_data * num_devices_scale,
         grad_xtensor[1],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 }
 
 TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
@@ -230,8 +231,8 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
     auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
 
     auto gathered_xtensor = ttml::core::to_xtensor<float>(gathered_tensor->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(xtensor, gathered_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
@@ -249,16 +250,16 @@ TEST_F(N300CommOpsTest, TestAllGatherNotFullyTiled) {
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
     auto grad_xtensor = ttml::core::to_xtensor<float>(tensor->get_grad(), ttml::core::IdentityComposer{});
     EXPECT_EQ(grad_xtensor[0].shape(), grad_xtensor[1].shape());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(grad_data, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) * num_devices_scale,
         grad_xtensor[0],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         xt::view(grad_data, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size)) * num_devices_scale,
         grad_xtensor[1],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 }
 
 TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
@@ -279,8 +280,8 @@ TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
     auto gathered_tensor = ttml::ops::distributed::all_gather(tensor, 3);
 
     auto gathered_xtensor = ttml::core::to_xtensor<float>(gathered_tensor->get_value(), ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(xtensor, gathered_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(xtensor, gathered_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     seed = rng();
     xt::xarray<float> grad_data = ttml::test_utils::make_uniform_xarray<float>(
@@ -297,16 +298,16 @@ TEST_F(N300CommOpsTest, TestAllGatherFullyTiled) {
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
     auto grad_xtensor = ttml::core::to_xtensor<float>(tensor->get_grad(), ttml::core::IdentityComposer{});
     EXPECT_EQ(grad_xtensor[0].shape(), grad_xtensor[1].shape());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(grad_data, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) * num_devices_scale,
         grad_xtensor[0],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         xt::view(grad_data, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size)) * num_devices_scale,
         grad_xtensor[1],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 }
 
 TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
@@ -330,12 +331,12 @@ TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
     // check forward
     auto xtensors_back = ttml::core::to_xtensor<float>(scattered_tensor->get_value(), ttml::core::IdentityComposer{});
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) * num_devices_scale,
-        xtensors_back[0]));
-    EXPECT_TRUE(xt::allclose(
+        xtensors_back[0]);
+    ttml::test_utils::expect_allclose(
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size)) * num_devices_scale,
-        xtensors_back[1]));
+        xtensors_back[1]);
 
     // check backward
     auto& rng = ttml::autograd::ctx().get_generator();
@@ -356,8 +357,8 @@ TEST_F(N300CommOpsTest, TestScatterNotFullyTiled) {
     EXPECT_TRUE(grad_data.shape() == grad_xtensor[1].shape());
 
     EXPECT_EQ(grad_xtensor[0], grad_xtensor[1]);
-    EXPECT_TRUE(xt::allclose(grad_data, grad_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(grad_data, grad_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(grad_data, grad_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(grad_data, grad_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 }
 
 TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
@@ -377,8 +378,8 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
         ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(xtensor, device, ttnn::Layout::TILE, mapper.get());
 
     auto xtensor_after_replication = ttml::core::to_xtensor<float>(tt_tensor, ttml::core::IdentityComposer{});
-    EXPECT_TRUE(xt::allclose(xtensor, xtensor_after_replication[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(xtensor, xtensor_after_replication[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(xtensor, xtensor_after_replication[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(xtensor, xtensor_after_replication[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 
     auto tensor = ttml::autograd::create_tensor(tt_tensor, /* requires_grad */ true);
     auto scattered_tensor = ttml::ops::distributed::reduce_scatter(tensor, 3);
@@ -386,16 +387,16 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
     // check forward
     auto xtensors_back = ttml::core::to_xtensor<float>(scattered_tensor->get_value(), ttml::core::IdentityComposer{});
     auto num_devices_scale = static_cast<float>(ttml::autograd::ctx().get_device().num_devices());
-    EXPECT_TRUE(xt::allclose(
+    ttml::test_utils::expect_allclose(
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(0, size / 2)) * num_devices_scale,
         xtensors_back[0],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(
+        /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(
         xt::view(xtensor, xt::all(), xt::all(), xt::all(), xt::range(size / 2, size)) * num_devices_scale,
         xtensors_back[1],
         /* rtol */ 1e-3,
-        /* atol */ 1e-2));
+        /* atol */ 1e-2);
 
     // check backward
     seed = rng();
@@ -414,6 +415,6 @@ TEST_F(N300CommOpsTest, TestScatterFullyTiled) {
     EXPECT_TRUE(grad_data.shape() == grad_xtensor[1].shape());
 
     EXPECT_EQ(grad_xtensor[0], grad_xtensor[1]);
-    EXPECT_TRUE(xt::allclose(grad_data, grad_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2));
-    EXPECT_TRUE(xt::allclose(grad_data, grad_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2));
+    ttml::test_utils::expect_allclose(grad_data, grad_xtensor[0], /* rtol */ 1e-3, /* atol */ 1e-2);
+    ttml::test_utils::expect_allclose(grad_data, grad_xtensor[1], /* rtol */ 1e-3, /* atol */ 1e-2);
 }

--- a/tt-train/tests/ops/distributed/ring_sdpa_test.cpp
+++ b/tt-train/tests/ops/distributed/ring_sdpa_test.cpp
@@ -21,6 +21,7 @@
 #include "core/tt_tensor_utils.hpp"
 #include "ops/distributed/ring_attention_sdpa.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/distributed/create_socket.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
@@ -359,8 +360,8 @@ static void TestRingAttention(
         }
     }
 
-    EXPECT_TRUE(xt::allclose(ref_result.output, gathered_output, rtol, atol))
-        << "Ring attention output does not match reference SDPA output";
+    ttml::test_utils::expect_allclose(
+        ref_result.output, gathered_output, rtol, atol, "Ring attention output does not match reference SDPA output");
 
     if (test_backward) {
         const auto grad_seed = rng();
@@ -403,17 +404,17 @@ static void TestRingAttention(
             }
         }
 
-        EXPECT_TRUE(xt::allclose(ref_grads.dQ, gathered_dQ, rtol, atol))
-            << "Ring attention dQ gradient does not match reference";
+        ttml::test_utils::expect_allclose(
+            ref_grads.dQ, gathered_dQ, rtol, atol, "Ring attention dQ gradient does not match reference");
         // K is much less accurate than dQ and dV. Relative error is better though.
         // Also take into account the sampling distribution. Most of our tests sample from
         // zero mean distirbution under which sdpa output is very small making all tests pass easily.
         // U[0, 2] is much trickier to pass tests.
         auto katol = 3.5;
-        EXPECT_TRUE(xt::allclose(ref_grads.dK, gathered_dK, rtol, katol))
-            << "Ring attention dK gradient does not match reference";
-        EXPECT_TRUE(xt::allclose(ref_grads.dV, gathered_dV, rtol, atol))
-            << "Ring attention dV gradient does not match reference";
+        ttml::test_utils::expect_allclose(
+            ref_grads.dK, gathered_dK, rtol, katol, "Ring attention dK gradient does not match reference");
+        ttml::test_utils::expect_allclose(
+            ref_grads.dV, gathered_dV, rtol, atol, "Ring attention dV gradient does not match reference");
     }
 }
 

--- a/tt-train/tests/ops/distributed/vocab_parallel_cross_entropy_loss_test.cpp
+++ b/tt-train/tests/ops/distributed/vocab_parallel_cross_entropy_loss_test.cpp
@@ -13,6 +13,7 @@
 #include "core/tt_tensor_utils.hpp"
 #include "ops/distributed/losses.hpp"
 #include "ops/losses.hpp"
+#include "test_utils/comparison.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
@@ -244,8 +245,8 @@ TEST_F(ShardedCrossEntropyLossTest, BackwardSmall) {
     auto expected_shard0 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
     auto expected_shard1 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
-    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F));
-    EXPECT_TRUE(xt::allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F);
+    ttml::test_utils::expect_allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F);
 }
 
 TEST_F(ShardedCrossEntropyLossTest, BackwardBatch) {
@@ -304,8 +305,8 @@ TEST_F(ShardedCrossEntropyLossTest, BackwardBatch) {
     auto expected_shard0 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
     auto expected_shard1 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
-    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F));
-    EXPECT_TRUE(xt::allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F);
+    ttml::test_utils::expect_allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F);
 }
 
 TEST_F(ShardedCrossEntropyLossTest, BackwardTargetOnSecondShard) {
@@ -356,9 +357,9 @@ TEST_F(ShardedCrossEntropyLossTest, BackwardTargetOnSecondShard) {
     auto expected_shard1 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
     // Shard 0 should have pure softmax (no one_hot subtraction since target is on shard 1)
-    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F);
     // Shard 1 should have softmax - one_hot at position 5
-    EXPECT_TRUE(xt::allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F);
 }
 
 TEST_F(ShardedCrossEntropyLossTest, NonShardedBackwardMatchesReference) {
@@ -412,7 +413,7 @@ TEST_F(ShardedCrossEntropyLossTest, NonShardedBackwardMatchesReference) {
     auto grad_xtensors = core::to_xtensor<float>(logits_ptr->get_grad(), core::IdentityComposer{});
     auto expected_grad = cross_entropy_grad_reference(logits_xt, targets_xt);
 
-    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_grad, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[0], expected_grad, 3e-2F, 1e-2F);
 }
 
 TEST_F(ShardedCrossEntropyLossTest, MatchesNonShardedImplementation) {
@@ -495,8 +496,8 @@ TEST_F(ShardedCrossEntropyLossTest, MatchesNonShardedImplementation) {
     auto ref_shard0 = xt::view(ref_grad_xt[0], xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
     auto ref_shard1 = xt::view(ref_grad_xt[0], xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
-    EXPECT_TRUE(xt::allclose(sharded_grad_xt[0], ref_shard0, 3e-2F, 1e-2F));
-    EXPECT_TRUE(xt::allclose(sharded_grad_xt[1], ref_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(sharded_grad_xt[0], ref_shard0, 3e-2F, 1e-2F);
+    ttml::test_utils::expect_allclose(sharded_grad_xt[1], ref_shard1, 3e-2F, 1e-2F);
 }
 
 // Same correctness check as MatchesNonShardedImplementation, but with an explicit
@@ -594,8 +595,8 @@ TEST_F(ShardedCrossEntropyLossTest, MatchesNonShardedImplementationExplicitClust
     auto ref_shard0 = xt::view(ref_grad_xt[0], xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
     auto ref_shard1 = xt::view(ref_grad_xt[0], xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
-    EXPECT_TRUE(xt::allclose(sharded_grad_xt[0], ref_shard0, 3e-2F, 1e-2F));
-    EXPECT_TRUE(xt::allclose(sharded_grad_xt[1], ref_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(sharded_grad_xt[0], ref_shard0, 3e-2F, 1e-2F);
+    ttml::test_utils::expect_allclose(sharded_grad_xt[1], ref_shard1, 3e-2F, 1e-2F);
 }
 
 // ReduceType::NONE forward: the op should return [B,1,S,1] with the same
@@ -645,8 +646,8 @@ TEST_F(ShardedCrossEntropyLossTest, ForwardNoneReductionMatchesPerPosition) {
     auto loss_xt = core::to_xtensor<float>(loss->get_value(), core::IdentityComposer{});
     auto expected = cross_entropy_loss_reference_per_position(logits_xt, targets_xt);
 
-    EXPECT_TRUE(xt::allclose(loss_xt[0], expected, 3e-2F, 5e-2F));
-    EXPECT_TRUE(xt::allclose(loss_xt[1], expected, 3e-2F, 5e-2F));
+    ttml::test_utils::expect_allclose(loss_xt[0], expected, 3e-2F, 5e-2F);
+    ttml::test_utils::expect_allclose(loss_xt[1], expected, 3e-2F, 5e-2F);
 }
 
 // ReduceType::NONE backward: with a non-uniform per-position upstream grad,
@@ -716,8 +717,8 @@ TEST_F(ShardedCrossEntropyLossTest, BackwardNoneReductionAppliesPerPositionGrad)
     auto expected_shard0 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(0, local_V));
     auto expected_shard1 = xt::view(expected_grad, xt::all(), xt::all(), xt::all(), xt::range(local_V, full_V));
 
-    EXPECT_TRUE(xt::allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F));
-    EXPECT_TRUE(xt::allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad_xtensors[0], expected_shard0, 3e-2F, 1e-2F);
+    ttml::test_utils::expect_allclose(grad_xtensors[1], expected_shard1, 3e-2F, 1e-2F);
 }
 
 // Equivalence sanity-check between the two reductions: explicitly summing the

--- a/tt-train/tests/ops/frobenius_normalize_test.cpp
+++ b/tt-train/tests/ops/frobenius_normalize_test.cpp
@@ -9,6 +9,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 namespace {
@@ -54,7 +55,7 @@ TEST_P(FrobeniusNormalizeTest, MatchesCpuReference) {
     const auto result_tensor = metal::frobenius_normalize(input_tensor, kEps);
     const auto result = core::to_xtensor(result_tensor);
 
-    EXPECT_TRUE(xt::allclose(result, expected, /*rtol=*/1e-2f, /*atol=*/1e-2f));
+    ttml::test_utils::expect_allclose(result, expected, /*rtol=*/1e-2f, /*atol=*/1e-2f);
 }
 
 static std::string CaseName(const ::testing::TestParamInfo<FrobeniusCase>& info) {

--- a/tt-train/tests/ops/k_split_gram_matmul_op_test.cpp
+++ b/tt-train/tests/ops/k_split_gram_matmul_op_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 class KSplitGramMatmulTest : public ::testing::Test {
@@ -147,7 +148,7 @@ TEST_F(KSplitGramMatmulTest, VerificationMirror) {
         for (uint32_t j = 0; j < 32; j++) ref_mirror[i * 32 + j] = ref_upper[j * 32 + i];
     auto ref_xt = xt::adapt(ref_mirror, {32u, 32u});
     auto dev_xt = xt::adapt(dev_mirror, {32u, 32u});
-    EXPECT_TRUE(xt::allclose(ref_xt, dev_xt, kRtol, kOffDiagAtol)) << "Mirror exceeded tolerance";
+    ttml::test_utils::expect_allclose(ref_xt, dev_xt, kRtol, kOffDiagAtol, "Mirror exceeded tolerance");
 }
 
 TEST_F(KSplitGramMatmulTest, PreallocatedOutput) {

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/ops/layernorm_bw/layernorm_bw.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 // Reference implementation using xtensor
@@ -175,9 +176,9 @@ static void CompareKernelVsXArray(
         ASSERT_EQ(dbeta_ref.shape(), metal_dbeta_flat.shape());
 
         // Compare values
-        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 5e-1F));
-        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 5e-1F));
-        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 5e-1F));
+        ttml::test_utils::expect_allclose(metal_dx_flat, dx_ref, 1.0e-3F, 5e-1F);
+        ttml::test_utils::expect_allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 5e-1F);
+        ttml::test_utils::expect_allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 5e-1F);
     }
 }
 

--- a/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_fw_fused_op_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/ops/layernorm_fw/layernorm_fw.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 // Reference implementation using xtensor
@@ -120,9 +121,9 @@ static void CompareKernelVsXArray(
         ASSERT_EQ(rstd_ref.shape(), metal_rstd_flat.shape());
 
         // Compare values
-        EXPECT_TRUE(xt::allclose(metal_y_flat, y_ref, 1.0e-3F, 5e-2F));
-        EXPECT_TRUE(xt::allclose(metal_mu_flat, mu_ref, 1.0e-3F, 5e-2F));
-        EXPECT_TRUE(xt::allclose(metal_rstd_flat, rstd_ref, 1.0e-3F, 5e-2F));
+        ttml::test_utils::expect_allclose(metal_y_flat, y_ref, 1.0e-3F, 5e-2F);
+        ttml::test_utils::expect_allclose(metal_mu_flat, mu_ref, 1.0e-3F, 5e-2F);
+        ttml::test_utils::expect_allclose(metal_rstd_flat, rstd_ref, 1.0e-3F, 5e-2F);
     }
 }
 

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -13,6 +13,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 class MLAQKVAssembleTest : public ::testing::Test {
@@ -49,15 +50,7 @@ ttnn::Tensor make_input(uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint
     return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
 }
 
-void expect_allclose(
-    const xt::xarray<float>& actual,
-    const xt::xarray<float>& expected,
-    double rtol,
-    double atol,
-    const std::string& tag) {
-    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
-    EXPECT_TRUE(xt::allclose(actual, expected, rtol, atol)) << tag << ": value mismatch";
-}
+using ttml::test_utils::expect_allclose;
 
 // ── Forward reference (q, k, v) computed from BF16-rounded packed inputs ───────────────────────────
 struct FwOutputs {

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ops/mla_qkv_assemble_op.hpp"
-
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -13,11 +11,11 @@
 #include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
-#include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
 #include "test_utils/random_data.hpp"
 
-class MLAQKVAssembleForwardTest : public ::testing::Test {
+class MLAQKVAssembleTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite() {
         ttml::autograd::ctx().open_device();
@@ -26,17 +24,12 @@ protected:
     static void TearDownTestSuite() {
         ttml::autograd::ctx().close_device();
     }
-
-    void TearDown() override {
-        ttml::autograd::ctx().reset_graph();
-    }
 };
 
 namespace {
 
-// MLA QKV assemble dimensions for a single test case. All channel dims are
-// multiples of TILE_WIDTH (32) and S is a multiple of TILE_HEIGHT (32) — the
-// op validates this.
+// MLA QKV assemble dimensions for a single test case. All channel dims are multiples of TILE_WIDTH (32)
+// and S is a multiple of TILE_HEIGHT (32).
 struct AssembleShape {
     std::string name;
     uint32_t batch = 0;
@@ -47,101 +40,151 @@ struct AssembleShape {
     uint32_t v_dim = 0;
 };
 
-// Build a [B, 1, S, W] BF16 device tensor filled with deterministic uniform data.
-ttml::autograd::TensorPtr make_input(uint32_t batch, uint32_t seq_len, uint32_t width, uint32_t seed) {
+// Deterministic uniform BF16 device tensor of the given 4D shape.
+ttnn::Tensor make_input(uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3, uint32_t seed) {
     auto* device = &ttml::autograd::ctx().get_device();
-    const size_t count = static_cast<size_t>(batch) * seq_len * width;
+    const size_t count = static_cast<size_t>(d0) * d1 * d2 * d3;
     const auto host = ttml::test_utils::make_uniform_vector<float>(count, -1.0F, 1.0F, seed);
-    const ttnn::Shape shape({batch, 1U, seq_len, width});
-    return ttml::autograd::create_tensor(
-        ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE));
+    const ttnn::Shape shape({d0, d1, d2, d3});
+    return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(host, shape, device, ttnn::Layout::TILE);
 }
 
-// Reference assemble computed from the BF16-rounded inputs (read back via to_xtensor), so the only
-// numeric path is a layout/copy/broadcast — the comparison against the kernel output must be exact.
-//
-// q[b,h,s,d]        = q_pre[b,0,s, h*qk_head + d]                       (head split)
-// k[b,h,s,d<Tn*32]  = kv_up[b,0,s, h*(qk_nope+v_dim) + d]              (k_nope slice)
-// k[b,h,s,d>=Tn*32] = k_pe[b,0,s, d - qk_nope]                          (k_pe broadcast across heads)
-// v[b,h,s,d]        = kv_up[b,0,s, h*(qk_nope+v_dim) + qk_nope + d]    (v slice)
-struct ReferenceOutputs {
+void expect_allclose(
+    const xt::xarray<float>& actual,
+    const xt::xarray<float>& expected,
+    double rtol,
+    double atol,
+    const std::string& tag) {
+    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
+    EXPECT_TRUE(xt::allclose(actual, expected, rtol, atol)) << tag << ": value mismatch";
+}
+
+// ── Forward reference (q, k, v) computed from BF16-rounded packed inputs ───────────────────────────
+struct FwOutputs {
     xt::xarray<float> q;
     xt::xarray<float> k;
     xt::xarray<float> v;
 };
 
-ReferenceOutputs reference_assemble(
-    const ttml::autograd::TensorPtr& q_pre,
-    const ttml::autograd::TensorPtr& kv_up,
-    const ttml::autograd::TensorPtr& k_pe,
-    const AssembleShape& shape) {
+FwOutputs reference_fw(
+    const ttnn::Tensor& q_pre, const ttnn::Tensor& kv_up, const ttnn::Tensor& k_pe, const AssembleShape& shape) {
     const std::size_t B = shape.batch;
     const std::size_t S = shape.seq_len;
     const std::size_t H = shape.n_heads;
     const std::size_t nope = shape.qk_nope_dim;
+    const std::size_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
     const std::size_t kv_w = shape.qk_nope_dim + shape.v_dim;
 
-    // split_heads: [B, 1, S, H*W] -> [B, S, H, W] -> [B, H, S, W].
-    xt::xarray<float> q_pre_bf = ttml::core::to_xtensor(q_pre->get_value());
-    q_pre_bf.reshape({B, S, H, static_cast<std::size_t>(shape.qk_nope_dim + shape.qk_rope_dim)});
-    xt::xarray<float> kv_up_bf = ttml::core::to_xtensor(kv_up->get_value());
+    xt::xarray<float> q_pre_bf = ttml::core::to_xtensor(q_pre);
+    q_pre_bf.reshape({B, S, H, qk_head});
+    xt::xarray<float> kv_up_bf = ttml::core::to_xtensor(kv_up);
     kv_up_bf.reshape({B, S, H, kv_w});
 
-    const xt::xarray<float> q = xt::transpose(q_pre_bf, {0, 2, 1, 3});
     const xt::xarray<float> kv = xt::transpose(kv_up_bf, {0, 2, 1, 3});
-
     const xt::xarray<float> k_nope = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(std::size_t{0}, nope));
-    const xt::xarray<float> v = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(nope, kv_w));
+    const xt::xarray<float> k_pe_b =
+        xt::broadcast(ttml::core::to_xtensor(k_pe), {B, H, S, static_cast<std::size_t>(shape.qk_rope_dim)});
 
-    // Broadcast the shared k_pe [B, 1, S, qk_rope] across heads -> [B, H, S, qk_rope].
-    const xt::xarray<float> k_pe_b = xt::broadcast(
-        ttml::core::to_xtensor(k_pe->get_value()), {B, H, S, static_cast<std::size_t>(shape.qk_rope_dim)});
-
-    ReferenceOutputs ref;
-    ref.q = q;
+    FwOutputs ref;
+    ref.q = xt::transpose(q_pre_bf, {0, 2, 1, 3});
     ref.k = xt::concatenate(xt::xtuple(k_nope, k_pe_b), 3);
-    ref.v = v;
+    ref.v = xt::view(kv, xt::all(), xt::all(), xt::all(), xt::range(nope, kv_w));
     return ref;
 }
 
-void expect_exact(const xt::xarray<float>& actual, const xt::xarray<float>& expected, const std::string& tag) {
-    ASSERT_EQ(actual.shape(), expected.shape()) << tag << ": shape mismatch";
-    // Pure copy/broadcast through identical BF16 values → bit-exact on FP32 readback.
-    EXPECT_TRUE(xt::allclose(actual, expected, /*rtol=*/0.0, /*atol=*/0.0)) << tag << ": value mismatch";
+// ── Backward reference (dq_pre, dkv_up, dk_pe) from head-major grads ────────────────────────────────
+// dq_pre = reverse head-split of dQ; dkv_up = reverse head-split of [dK_nope | dV]; dk_pe = Σ_h dK_rope.
+struct BwOutputs {
+    xt::xarray<float> dq_pre;
+    xt::xarray<float> dkv_up;
+    xt::xarray<float> dk_pe;
+};
+
+BwOutputs reference_bw(
+    const ttnn::Tensor& dQ, const ttnn::Tensor& dK, const ttnn::Tensor& dV, const AssembleShape& shape) {
+    const std::size_t B = shape.batch;
+    const std::size_t S = shape.seq_len;
+    const std::size_t H = shape.n_heads;
+    const std::size_t nope = shape.qk_nope_dim;
+    const std::size_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const std::size_t kv_w = shape.qk_nope_dim + shape.v_dim;
+
+    const xt::xarray<float> dQ_bf = ttml::core::to_xtensor(dQ);  // [B, H, S, qk_head]
+    const xt::xarray<float> dK_bf = ttml::core::to_xtensor(dK);  // [B, H, S, qk_head]
+    const xt::xarray<float> dV_bf = ttml::core::to_xtensor(dV);  // [B, H, S, v_dim]
+
+    BwOutputs ref;
+
+    // dq_pre: [B, H, S, qk_head] -> [B, S, H, qk_head] -> [B, 1, S, H*qk_head]
+    ref.dq_pre = xt::transpose(dQ_bf, {0, 2, 1, 3});
+    ref.dq_pre.reshape({B, 1U, S, H * qk_head});
+
+    // dkv_up: concat([dK_nope | dV]) per head -> reverse head-split.
+    const xt::xarray<float> dK_nope = xt::view(dK_bf, xt::all(), xt::all(), xt::all(), xt::range(std::size_t{0}, nope));
+    xt::xarray<float> kv_head = xt::concatenate(xt::xtuple(dK_nope, dV_bf), 3);  // [B, H, S, kv_w]
+    ref.dkv_up = xt::transpose(kv_head, {0, 2, 1, 3});
+    ref.dkv_up.reshape({B, 1U, S, H * kv_w});
+
+    // dk_pe: sum dK's rope suffix over the head axis -> [B, 1, S, qk_rope].
+    const xt::xarray<float> dK_rope = xt::view(dK_bf, xt::all(), xt::all(), xt::all(), xt::range(nope, qk_head));
+    ref.dk_pe = xt::sum(dK_rope, {1});
+    ref.dk_pe.reshape({B, 1U, S, static_cast<std::size_t>(shape.qk_rope_dim)});
+    return ref;
 }
 
-void run_case(const AssembleShape& shape) {
-    auto q_pre = make_input(shape.batch, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.qk_rope_dim), 1001U);
-    auto kv_up = make_input(shape.batch, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.v_dim), 2002U);
-    auto k_pe = make_input(shape.batch, shape.seq_len, shape.qk_rope_dim, 3003U);
+void run_fw(const AssembleShape& shape) {
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto q_pre = make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * qk_head, 1001U);
+    const auto kv_up =
+        make_input(shape.batch, 1U, shape.seq_len, shape.n_heads * (shape.qk_nope_dim + shape.v_dim), 2002U);
+    const auto k_pe = make_input(shape.batch, 1U, shape.seq_len, shape.qk_rope_dim, 3003U);
 
-    auto [q, k, v] = ttml::ops::mla_qkv_assemble_fw(
+    auto [q, k, v] = ttml::metal::mla_qkv_assemble_fw(
         q_pre, kv_up, k_pe, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
 
-    const auto ref = reference_assemble(q_pre, kv_up, k_pe, shape);
-    expect_exact(ttml::core::to_xtensor(q->get_value()), ref.q, shape.name + "/q");
-    expect_exact(ttml::core::to_xtensor(k->get_value()), ref.k, shape.name + "/k");
-    expect_exact(ttml::core::to_xtensor(v->get_value()), ref.v, shape.name + "/v");
+    const auto ref = reference_fw(q_pre, kv_up, k_pe, shape);
+    // Pure copy/broadcast → bit-exact.
+    expect_allclose(ttml::core::to_xtensor(q), ref.q, 0.0, 0.0, shape.name + " fw/q");
+    expect_allclose(ttml::core::to_xtensor(k), ref.k, 0.0, 0.0, shape.name + " fw/k");
+    expect_allclose(ttml::core::to_xtensor(v), ref.v, 0.0, 0.0, shape.name + " fw/v");
+}
+
+void run_bw(const AssembleShape& shape) {
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    const auto dQ = make_input(shape.batch, shape.n_heads, shape.seq_len, qk_head, 4004U);
+    const auto dK = make_input(shape.batch, shape.n_heads, shape.seq_len, qk_head, 5005U);
+    const auto dV = make_input(shape.batch, shape.n_heads, shape.seq_len, shape.v_dim, 6006U);
+
+    auto [dq_pre, dkv_up, dk_pe] =
+        ttml::metal::mla_qkv_assemble_bw(dQ, dK, dV, shape.n_heads, shape.qk_nope_dim, shape.qk_rope_dim, shape.v_dim);
+
+    const auto ref = reference_bw(dQ, dK, dV, shape);
+    // dq_pre / dkv_up are pure copies → bit-exact; dk_pe is a BF16 head-axis reduction → tolerant.
+    expect_allclose(ttml::core::to_xtensor(dq_pre), ref.dq_pre, 0.0, 0.0, shape.name + " bw/dq_pre");
+    expect_allclose(ttml::core::to_xtensor(dkv_up), ref.dkv_up, 0.0, 0.0, shape.name + " bw/dkv_up");
+    expect_allclose(ttml::core::to_xtensor(dk_pe), ref.dk_pe, /*rtol=*/5e-3, /*atol=*/5e-3, shape.name + " bw/dk_pe");
+}
+
+const std::vector<AssembleShape>& shapes() {
+    static const std::vector<AssembleShape> cases = {
+        {"square_st1", 2, 32, 2, 32, 32, 32},
+        {"square_st2", 2, 64, 2, 32, 32, 32},
+        {"asym_rope2", 2, 64, 4, 128, 64, 128},
+        {"heads8_s96", 1, 96, 8, 64, 32, 64},
+    };
+    return cases;
 }
 
 }  // namespace
 
-// Square head dims, S_t == 1 (single sequence tile row).
-TEST_F(MLAQKVAssembleForwardTest, SquareDimsSingleSeqTile) {
-    run_case({"square_st1", /*B=*/2, /*S=*/32, /*H=*/2, /*nope=*/32, /*rope=*/32, /*v=*/32});
+TEST_F(MLAQKVAssembleTest, ForwardMatchesReference) {
+    for (const auto& shape : shapes()) {
+        run_fw(shape);
+    }
 }
 
-// Square head dims, S_t > 1 (exercises the end-of-batch jump path in the writer).
-TEST_F(MLAQKVAssembleForwardTest, SquareDimsMultiSeqTile) {
-    run_case({"square_st2", /*B=*/2, /*S=*/64, /*H=*/2, /*nope=*/32, /*rope=*/32, /*v=*/32});
-}
-
-// Asymmetric Tn != Tr != Tv with Tr > 1 (broadcast spans multiple rope tiles).
-TEST_F(MLAQKVAssembleForwardTest, AsymmetricDimsRopeMultiTile) {
-    run_case({"asym_rope2", /*B=*/2, /*S=*/64, /*H=*/4, /*nope=*/128, /*rope=*/64, /*v=*/128});
-}
-
-// More heads, single batch, larger S_t.
-TEST_F(MLAQKVAssembleForwardTest, ManyHeadsLargerSeq) {
-    run_case({"heads8_s96", /*B=*/1, /*S=*/96, /*H=*/8, /*nope=*/64, /*rope=*/32, /*v=*/64});
+TEST_F(MLAQKVAssembleTest, BackwardMatchesReference) {
+    for (const auto& shape : shapes()) {
+        run_bw(shape);
+    }
 }

--- a/tt-train/tests/ops/newton_schulz_op_test.cpp
+++ b/tt-train/tests/ops/newton_schulz_op_test.cpp
@@ -12,6 +12,7 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 namespace {
@@ -85,7 +86,7 @@ TEST_F(NewtonSchulzOpTest, MuonCoeff) {
     auto X_tensor = ops::newtonschulz5(G_tensor, 10, 1e-7f);
     auto X_result = core::to_xtensor(X_tensor);
 
-    EXPECT_TRUE(xt::allclose(X_result, G_expected, 5e-2f, 5e-2f));
+    ttml::test_utils::expect_allclose(X_result, G_expected, 5e-2f, 5e-2f);
 }
 
 TEST_F(NewtonSchulzOpTest, OrthogonalityCheck) {
@@ -104,10 +105,10 @@ TEST_F(NewtonSchulzOpTest, OrthogonalityCheck) {
     auto X_tensor = ops::newtonschulz(G_tensor, 10, 1e-7f, a, b, c);
     auto X_result = core::to_xtensor(X_tensor);
 
-    EXPECT_TRUE(xt::allclose(X_result, G_expected, 5e-2f, 5e-2f));
+    ttml::test_utils::expect_allclose(X_result, G_expected, 5e-2f, 5e-2f);
 
     auto X_2d = xt::view(X_result, 0, 0, xt::all(), xt::all());
     auto XXT = xt::linalg::dot(X_2d, xt::transpose(X_2d));
     auto I = xt::eye<float>(32);
-    EXPECT_TRUE(xt::allclose(XXT, I, 5e-2f, 5e-2f));
+    ttml::test_utils::expect_allclose(XXT, I, 5e-2f, 5e-2f);
 }

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -14,6 +14,7 @@
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 class RMSNormOpTest : public ::testing::Test {
@@ -82,12 +83,12 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
             1.0490e-04F,
             -2.0742e-05F,
             2.0981e-04F}}}});
-    EXPECT_TRUE(xt::allclose(example_tensor_grad, expected_example_tensor_grad, 1.0e-3F, 1e-2F));
+    ttml::test_utils::expect_allclose(example_tensor_grad, expected_example_tensor_grad, 1.0e-3F, 1e-2F);
 
     auto gamma_grad = core::to_xtensor(gamma->get_grad());
     auto expected_gamma_grad =
         xt::xarray<float>({{{{0.0334F, 0.1338F, 0.2988F, 0.5352F, 0.0334F, 0.1338F, 0.2988F, 0.5352F}}}});
-    EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F));
+    ttml::test_utils::expect_allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F);
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
@@ -125,7 +126,7 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
           {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}, {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F},
           {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}, {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}}}};
     assert((expected_result.shape() == result_xtensor.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 6e-2F, 1e-8F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 6e-2F, 1e-8F);
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
@@ -150,7 +151,7 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
 
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
     xt::xarray<float> expected_example_tensor_grad = xt::zeros_like(a_xarray);
-    EXPECT_TRUE(xt::allclose(example_tensor_grad, expected_example_tensor_grad, 5e-2F, 1e-3F));
+    ttml::test_utils::expect_allclose(example_tensor_grad, expected_example_tensor_grad, 5e-2F, 1e-3F);
 
     auto gamma_grad = core::to_xtensor(gamma->get_grad());
     xt::xarray<float> expected_gamma_grad = {{{{0.36111F, 0.37644F, 0.39589F, 0.41945F, 0.44712F}}}};
@@ -209,12 +210,12 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
             1.0490e-04F,
             -2.0742e-05F,
             2.0981e-04F}}}});
-    EXPECT_TRUE(xt::allclose(example_tensor_grad, expected_example_tensor_grad, 1.0e-3F, 1e-2F));
+    ttml::test_utils::expect_allclose(example_tensor_grad, expected_example_tensor_grad, 1.0e-3F, 1e-2F);
 
     auto gamma_grad = core::to_xtensor(gamma->get_grad());
     auto expected_gamma_grad =
         xt::xarray<float>({{{{0.0334F, 0.1338F, 0.2988F, 0.5352F, 0.0334F, 0.1338F, 0.2988F, 0.5352F}}}});
-    EXPECT_TRUE(xt::allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F));
+    ttml::test_utils::expect_allclose(gamma_grad, expected_gamma_grad, 1.0e-3F, 1e-2F);
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
@@ -252,7 +253,7 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
           {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}, {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F},
           {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}, {0.98828F, 0.99609F, 1.00000F, 1.00781F, 1.00781F}}}};
     assert((expected_result.shape() == result_xtensor.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 6e-2F, 1e-8F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 6e-2F, 1e-8F);
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Backward_Batch) {
@@ -277,7 +278,7 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Backward_Batch) {
 
     auto example_tensor_grad = core::to_xtensor(example_tensor->get_grad());
     xt::xarray<float> expected_example_tensor_grad = xt::zeros_like(a_xarray);
-    EXPECT_TRUE(xt::allclose(example_tensor_grad, expected_example_tensor_grad, 5e-2F, 1e-3F));
+    ttml::test_utils::expect_allclose(example_tensor_grad, expected_example_tensor_grad, 5e-2F, 1e-3F);
 
     auto gamma_grad = core::to_xtensor(gamma->get_grad());
     xt::xarray<float> expected_gamma_grad = {{{{0.36111F, 0.37644F, 0.39589F, 0.41945F, 0.44712F}}}};
@@ -345,7 +346,7 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
     EXPECT_EQ(result_composite_xtensor.shape(), x_data.shape());
 
     // Compare forward results
-    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_composite_xtensor, 4e-2F, 3e-2F));
+    ttml::test_utils::expect_allclose(result_kernel_xtensor, result_composite_xtensor, 4e-2F, 3e-2F);
     EXPECT_TRUE(xt::all(xt::isfinite(result_kernel_xtensor)));
     EXPECT_TRUE(xt::all(xt::isfinite(result_composite_xtensor)));
 
@@ -376,8 +377,8 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
     EXPECT_TRUE(xt::all(xt::isfinite(gamma_grad_composite)));
 
     // Compare backward results
-    EXPECT_TRUE(xt::allclose(x_grad_kernel, x_grad_composite, 1.0e-3F, 2e-3F));
-    EXPECT_TRUE(xt::allclose(gamma_grad_kernel, gamma_grad_composite, 1.0e-3F, 2e-3F));
+    ttml::test_utils::expect_allclose(x_grad_kernel, x_grad_composite, 1.0e-3F, 2e-3F);
+    ttml::test_utils::expect_allclose(gamma_grad_kernel, gamma_grad_composite, 1.0e-3F, 2e-3F);
 
     autograd::ctx().reset_graph();
 }

--- a/tt-train/tests/ops/rope_test.cpp
+++ b/tt-train/tests/ops/rope_test.cpp
@@ -10,6 +10,7 @@
 #include "modules/positional_embeddings.hpp"
 #include "modules/rotary_embedding.hpp"
 #include "ops/losses.hpp"
+#include "test_utils/comparison.hpp"
 
 namespace ttml::modules::tests {
 
@@ -395,9 +396,11 @@ TEST_F(RoPETest, GeneratedParamsOk) {
         /*sequence_length=*/32,
         /*head_dim=*/32);
 
-    EXPECT_TRUE(xt::allclose(expected_cos, core::to_xtensor(rope_params.cos_cache), /*rtol=*/0.01F, /*atol=*/0.03F));
-    EXPECT_TRUE(xt::allclose(expected_sin, core::to_xtensor(rope_params.sin_cache), /*rtol=*/0.01F, /*atol=*/0.03F));
-    EXPECT_TRUE(xt::allclose(expected_trans_mat, core::to_xtensor(rope_params.trans_mat)));
+    ttml::test_utils::expect_allclose(
+        expected_cos, core::to_xtensor(rope_params.cos_cache), /*rtol=*/0.01F, /*atol=*/0.03F);
+    ttml::test_utils::expect_allclose(
+        expected_sin, core::to_xtensor(rope_params.sin_cache), /*rtol=*/0.01F, /*atol=*/0.03F);
+    ttml::test_utils::expect_allclose(expected_trans_mat, core::to_xtensor(rope_params.trans_mat));
 }
 
 TEST_F(RoPETest, ForwardTest) {
@@ -461,7 +464,7 @@ TEST_F(RoPETest, ForwardTest) {
     auto actual_xq_out_xt = core::to_xtensor(actual_xq_out->get_value());
 
     // Check that outputs match the expected values
-    EXPECT_TRUE(xt::allclose(actual_xq_out_xt, expected_xq_out, 2e-1, 2e-1));
+    ttml::test_utils::expect_allclose(actual_xq_out_xt, expected_xq_out, 2e-1, 2e-1);
 }
 
 TEST_F(RoPETest, BackwardTest) {
@@ -524,7 +527,7 @@ TEST_F(RoPETest, BackwardTest) {
     loss->backward();
 
     auto actual_grad = core::to_xtensor(xq_autograd_tensor->get_grad());
-    EXPECT_TRUE(xt::allclose(actual_grad, expected_grad, 2e-1, 2e-1));
+    ttml::test_utils::expect_allclose(actual_grad, expected_grad, 2e-1, 2e-1);
 }
 
 }  // namespace ttml::modules::tests

--- a/tt-train/tests/ops/select_target_logit_op_test.cpp
+++ b/tt-train/tests/ops/select_target_logit_op_test.cpp
@@ -12,6 +12,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 
 class SelectTargetLogitTest : public ::testing::Test {
 protected:
@@ -62,7 +63,7 @@ TEST_F(SelectTargetLogitTest, SmallFullVocab) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, 0U, 8U);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/1e-3F, /*atol=*/1e-3F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/1e-3F, /*atol=*/1e-3F);
 }
 
 TEST_F(SelectTargetLogitTest, SmallPartialVocab) {
@@ -86,7 +87,7 @@ TEST_F(SelectTargetLogitTest, SmallPartialVocab) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, 4U, 8U);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/1e-3F, /*atol=*/1e-3F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/1e-3F, /*atol=*/1e-3F);
 
     // Explicit checks
     EXPECT_NEAR(result_xt(0, 0, 0, 0), 0.F, 1e-3F);   // out of shard → 0
@@ -124,7 +125,7 @@ TEST_F(SelectTargetLogitTest, BatchedNonAlignedShape) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, 0U, V);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SelectTargetLogitTest, BatchedPartialVocabShard) {
@@ -163,7 +164,7 @@ TEST_F(SelectTargetLogitTest, BatchedPartialVocabShard) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, first_v, last_v);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SelectTargetLogitTest, LargeVocab) {
@@ -191,7 +192,7 @@ TEST_F(SelectTargetLogitTest, LargeVocab) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, 0U, V);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SelectTargetLogitTest, NIGHTLY_LargeBatchLargeVocab) {
@@ -226,5 +227,5 @@ TEST_F(SelectTargetLogitTest, NIGHTLY_LargeBatchLargeVocab) {
     auto expected_xt = select_target_logit_reference(logit_t, target_t, 0U, V);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }

--- a/tt-train/tests/ops/silu_op_test.cpp
+++ b/tt-train/tests/ops/silu_op_test.cpp
@@ -14,6 +14,7 @@
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
 #include "ops/unary_ops.hpp"
+#include "test_utils/comparison.hpp"
 
 class SiLUOpTest : public ::testing::Test {
 protected:
@@ -107,7 +108,7 @@ void CompareKernelVsReference(const xt::xarray<float>& input_data) {
     // Compare forward results
     // NOTE: This comparison does not much make sense for SiLU, because there is no forward SiLU composite if I am not
     // mistaken, but we still do it for consistency.
-    EXPECT_TRUE(xt::allclose(result_kernel_xtensor, result_reference_xtensor, 1.0e-3F, 3e-2F));
+    ttml::test_utils::expect_allclose(result_kernel_xtensor, result_reference_xtensor, 1.0e-3F, 3e-2F);
 
     // Backward pass - create target and compute gradients
     auto target_kernel = autograd::create_tensor(core::zeros_like(result_kernel->get_value()));
@@ -123,7 +124,7 @@ void CompareKernelVsReference(const xt::xarray<float>& input_data) {
     auto input_grad_kernel = core::to_xtensor(input_kernel->get_grad());
     auto input_grad_reference = core::to_xtensor(input_reference->get_grad());
 
-    EXPECT_TRUE(xt::allclose(input_grad_kernel, input_grad_reference, 1.0e-3F, 3e-2F));
+    ttml::test_utils::expect_allclose(input_grad_kernel, input_grad_reference, 1.0e-3F, 3e-2F);
 }
 
 /**

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -14,6 +14,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
@@ -65,7 +66,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
@@ -89,7 +90,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
@@ -113,7 +114,7 @@ TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }
 
 TEST_F(SoftmaxTest, SoftmaxTest_Large_Values) {
@@ -174,5 +175,5 @@ TEST_F(SoftmaxTest, SoftmaxTest_Large_Values) {
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
     assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xtensor, expected_result, 3e-2F, 1e-2F);
 }

--- a/tt-train/tests/ops/subtract_at_target_op_test.cpp
+++ b/tt-train/tests/ops/subtract_at_target_op_test.cpp
@@ -12,6 +12,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
+#include "test_utils/comparison.hpp"
 
 class SubtractAtTargetTest : public ::testing::Test {
 protected:
@@ -80,7 +81,7 @@ TEST_F(SubtractAtTargetTest, SmallFullVocab) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, 0U, 8U);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
     EXPECT_NEAR(result_xt(0, 0, 0, 3), 0.4F - 1.0F, 1e-2F);
     EXPECT_NEAR(result_xt(0, 0, 0, 0), 0.1F, 1e-2F);
 }
@@ -104,7 +105,7 @@ TEST_F(SubtractAtTargetTest, SmallPartialVocab) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, 4U, 8U);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 
     EXPECT_NEAR(result_xt(0, 0, 0, 0), 0.5F, 1e-2F);          // row 0: target out of shard, unchanged
     EXPECT_NEAR(result_xt(0, 0, 1, 1), -0.6F - 1.0F, 1e-2F);  // row 1: local col 1 modified
@@ -129,7 +130,7 @@ TEST_F(SubtractAtTargetTest, BatchedNonAlignedShape) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, 0U, V);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SubtractAtTargetTest, BatchedPartialVocabShard) {
@@ -155,7 +156,7 @@ TEST_F(SubtractAtTargetTest, BatchedPartialVocabShard) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, first_v, last_v);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SubtractAtTargetTest, CustomSubtractValue) {
@@ -184,7 +185,7 @@ TEST_F(SubtractAtTargetTest, CustomSubtractValue) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, 0U, V, subtract_value);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }
 
 TEST_F(SubtractAtTargetTest, CustomSubtractValuePartialVocab) {
@@ -211,5 +212,5 @@ TEST_F(SubtractAtTargetTest, CustomSubtractValuePartialVocab) {
     auto expected_xt = subtract_at_target_reference(input_t, target_t, first_v, last_v, subtract_value);
 
     ASSERT_EQ(result_xt.shape(), expected_xt.shape());
-    EXPECT_TRUE(xt::allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected_xt, /*rtol=*/3e-2F, /*atol=*/1e-2F);
 }

--- a/tt-train/tests/ops/swiglu_op_test.cpp
+++ b/tt-train/tests/ops/swiglu_op_test.cpp
@@ -12,6 +12,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/ops/swiglu_elemwise_bw/swiglu_elemwise_bw.hpp"
+#include "test_utils/comparison.hpp"
 
 class SwiGLUForwardTest : public ::testing::Test {
 protected:
@@ -113,27 +114,10 @@ void CompareKernelVsReference(
     EXPECT_TRUE(xt::all(xt::isfinite(result_kernel_xtensor))) << "SwiGLU kernel result contains NaN or Inf values";
     EXPECT_TRUE(xt::all(xt::isfinite(result_reference))) << "SwiGLU reference result contains NaN or Inf values";
 
-    // We validate using relative L2 error instead of elementwise allclose().
-    //
-    // SwiGLU involves two matmuls + SiLU, so the output magnitude scales with
-    // hidden_dim and tensor size. Combined with BF16 internal math (≈1e-2 relative
-    // noise per element), elementwise tolerances become unstable: they may fail on
-    // large tensors (outliers) or fail on small ones (tiny reference values).
-    //
-    // Relative L2 is scale-invariant and reflects the total numerical deviation of
-    // the tensor, giving consistent results across all shapes. A threshold of 0.01
-    // is standard for BF16 vs FP32 reference comparisons.
-    auto diff = result_kernel_xtensor - result_reference;
-
-    // Compute L2 norms.
-    float diff_l2 = std::sqrt(xt::sum(xt::square(diff))());
-    float ref_l2 = std::sqrt(xt::sum(xt::square(result_reference))());
-    const float eps = 1e-12f;
-    float rel_l2 = diff_l2 / (ref_l2 + eps);
-
-    // Check the error bound.
-    const float tolerance = 1e-2f;
-    EXPECT_LT(rel_l2, tolerance) << "Relative L2 error too large: " << rel_l2 << " (expected < " << tolerance << ")";
+    // Validate with relative L2 instead of elementwise allclose: SwiGLU's two matmuls + SiLU make the
+    // output magnitude scale with hidden_dim and tensor size, so BF16 per-element tolerances are
+    // unstable. Relative L2 is scale-invariant; 0.01 is standard for BF16 vs FP32 references.
+    ttml::test_utils::expect_relative_l2(result_kernel_xtensor, result_reference, /*threshold=*/1e-2, "SwiGLU");
 }
 
 /**

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -21,6 +21,7 @@
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
+#include "test_utils/comparison.hpp"
 
 namespace ttml::ops::tests {
 
@@ -130,12 +131,12 @@ TEST_F(UnaryOpsTest, Exp) {
     auto result_xt = core::to_xtensor(result->get_value());
 
     xt::xarray<float> expected = {{{{1.F, 2.71828F, 0.36788F, 1.64872F}}}};
-    EXPECT_TRUE(xt::allclose(result_xt, expected, 1e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(result_xt, expected, 1e-2F, 1e-2F);
 
     result->backward();
     auto grad = core::to_xtensor(tensor_ptr->get_grad());
     // d(e^x)/dx = e^x, upstream grad is 1
-    EXPECT_TRUE(xt::allclose(grad, expected, 1e-2F, 1e-2F));
+    ttml::test_utils::expect_allclose(grad, expected, 1e-2F, 1e-2F);
 }
 
 TEST_F(UnaryOpsTest, Clip) {
@@ -148,13 +149,13 @@ TEST_F(UnaryOpsTest, Clip) {
     auto result_xt = core::to_xtensor(result->get_value());
 
     xt::xarray<float> expected = {{{{1.F, 2.F, 3.F, 3.F}}}};
-    EXPECT_TRUE(xt::allclose(result_xt, expected));
+    ttml::test_utils::expect_allclose(result_xt, expected);
 
     result->backward();
     auto grad = core::to_xtensor(tensor_ptr->get_grad());
     // grad passes through where lo <= x <= hi, zero otherwise
     xt::xarray<float> expected_grad = {{{{0.F, 1.F, 1.F, 0.F}}}};
-    EXPECT_TRUE(xt::allclose(grad, expected_grad));
+    ttml::test_utils::expect_allclose(grad, expected_grad);
 }
 
 TEST_F(UnaryOpsTest, Silu) {
@@ -181,7 +182,7 @@ TEST_F(UnaryOpsTest, Silu) {
     // Compare forward results - should be identical since forward is the same
     auto kernel_xtensor = core::to_xtensor(result_kernel->get_value());
     auto composite_xtensor = core::to_xtensor(result_composite->get_value());
-    EXPECT_TRUE(xt::allclose(kernel_xtensor, composite_xtensor, 8e-3F, 4e-2F));
+    ttml::test_utils::expect_allclose(kernel_xtensor, composite_xtensor, 8e-3F, 4e-2F);
 
     // Backward pass - create zero targets for MSE loss
     auto target_kernel = autograd::create_tensor(core::zeros_like(result_kernel->get_value()));
@@ -198,7 +199,7 @@ TEST_F(UnaryOpsTest, Silu) {
     // Compare backward gradients - both implementations should produce same gradients
     auto grad_kernel = core::to_xtensor(a_kernel->get_grad());
     auto grad_composite = core::to_xtensor(a_composite->get_grad());
-    EXPECT_TRUE(xt::allclose(grad_kernel, grad_composite, 8e-3F, 4e-2F));
+    ttml::test_utils::expect_allclose(grad_kernel, grad_composite, 8e-3F, 4e-2F);
 }
 
 }  // namespace ttml::ops::tests

--- a/tt-train/tests/optimizers/muon_composite_test.cpp
+++ b/tt-train/tests/optimizers/muon_composite_test.cpp
@@ -11,6 +11,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 
 namespace {
@@ -117,7 +118,7 @@ TEST_P(MuonCorrectnessTest, DeviceMatchesCPU) {
     }
 
     auto w_device = core::to_xtensor(param->get_value());
-    EXPECT_TRUE(xt::allclose(w_device, w_cpu, 1e-2f, 1e-2f));
+    ttml::test_utils::expect_allclose(w_device, w_cpu, 1e-2f, 1e-2f);
 }
 
 static const MuonTestCase kMuonCases[] = {

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -9,6 +9,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -40,5 +41,5 @@ TEST_F(ConcatOpTest, TestConcatLastDim) {
 
     auto ttnn_concat = ttnn::concat(std::vector<ttnn::Tensor>{tensor_a, tensor_b}, 3);
     auto ttnn_concat_xtensor = ttml::core::to_xtensor(ttnn_concat);
-    EXPECT_TRUE(xt::allclose(ttnn_concat_xtensor, expected, 7e-3F, 1e-6F));
+    ttml::test_utils::expect_allclose(ttnn_concat_xtensor, expected, 7e-3F, 1e-6F);
 }

--- a/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/dropout_op_test.cpp
@@ -9,6 +9,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/device.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn/operations/experimental/dropout/dropout.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
@@ -52,8 +53,8 @@ TEST_F(DropoutTest, TestSeed) {
         auto result11_vec = ttml::core::to_xtensor(result11);
         auto result12_vec = ttml::core::to_xtensor(result12);
 
-        EXPECT_TRUE(xt::allclose(result01_vec, result11_vec, /*rtol=*/1e-4, /*atol=*/1e-3));
-        EXPECT_TRUE(xt::allclose(result02_vec, result12_vec, /*rtol=*/1e-4, /*atol=*/1e-3));
+        ttml::test_utils::expect_allclose(result01_vec, result11_vec, /*rtol=*/1e-4, /*atol=*/1e-3);
+        ttml::test_utils::expect_allclose(result02_vec, result12_vec, /*rtol=*/1e-4, /*atol=*/1e-3);
         EXPECT_FALSE(xt::allclose(result01_vec, result02_vec, /*rtol=*/1e-4, /*atol=*/1e-3));
         EXPECT_EQ(num_cache_before, num_cache_after - 1);
     }

--- a/tt-train/tests/ttnn_fixed/matmuls_test.cpp
+++ b/tt-train/tests/ttnn_fixed/matmuls_test.cpp
@@ -13,6 +13,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/device.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 
 class MatmulsTest : public ::testing::Test {
 protected:
@@ -90,7 +91,7 @@ TEST_F(MatmulsTest, MatMulNoTranspose) {
 
     // Compute the expected result using xtensor goldens.
     xt::xarray<float> expected = xt::linalg::dot(a, b);
-    EXPECT_TRUE(xt::allclose(y, expected));
+    ttml::test_utils::expect_allclose(y, expected);
 }
 
 TEST_F(MatmulsTest, MatMulTransposeA) {
@@ -106,7 +107,7 @@ TEST_F(MatmulsTest, MatMulTransposeA) {
 
     // Expected: (a^T) * b.
     xt::xarray<float> expected = xt::linalg::dot(xt::transpose(a), b);
-    EXPECT_TRUE(xt::allclose(y, expected));
+    ttml::test_utils::expect_allclose(y, expected);
 }
 
 TEST_F(MatmulsTest, MatMulTransposeB) {
@@ -122,7 +123,7 @@ TEST_F(MatmulsTest, MatMulTransposeB) {
 
     // Expected: a * (b^T).
     xt::xarray<float> expected = xt::linalg::dot(a, xt::transpose(b));
-    EXPECT_TRUE(xt::allclose(y, expected));
+    ttml::test_utils::expect_allclose(y, expected);
 }
 
 TEST_F(MatmulsTest, MatMulTransposeBoth) {
@@ -138,7 +139,7 @@ TEST_F(MatmulsTest, MatMulTransposeBoth) {
 
     // Expected: (a^T) * (b^T).
     xt::xarray<float> expected = xt::linalg::dot(xt::transpose(a), xt::transpose(b));
-    EXPECT_TRUE(xt::allclose(y, expected));
+    ttml::test_utils::expect_allclose(y, expected);
 }
 
 TEST_F(MatmulsTest, MatMulBackwardNoTranspose) {
@@ -162,8 +163,8 @@ TEST_F(MatmulsTest, MatMulBackwardNoTranspose) {
     xt::xarray<float> expected_grad_a = xt::linalg::dot(out_grad, xt::transpose(b));
     xt::xarray<float> expected_grad_b = xt::linalg::dot(xt::transpose(a), out_grad);
 
-    EXPECT_TRUE(xt::allclose(grad_a, expected_grad_a));
-    EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
+    ttml::test_utils::expect_allclose(grad_a, expected_grad_a);
+    ttml::test_utils::expect_allclose(grad_b, expected_grad_b);
 }
 
 TEST_F(MatmulsTest, MatMulBackwardTransposeA) {
@@ -186,8 +187,8 @@ TEST_F(MatmulsTest, MatMulBackwardTransposeA) {
     xt::xarray<float> expected_grad_a = xt::linalg::dot(b, xt::transpose(out_grad));
     xt::xarray<float> expected_grad_b = xt::linalg::dot(a, out_grad);
 
-    EXPECT_TRUE(xt::allclose(grad_a, expected_grad_a));
-    EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
+    ttml::test_utils::expect_allclose(grad_a, expected_grad_a);
+    ttml::test_utils::expect_allclose(grad_b, expected_grad_b);
 }
 
 TEST_F(MatmulsTest, MatMulBackwardTransposeB) {
@@ -210,8 +211,8 @@ TEST_F(MatmulsTest, MatMulBackwardTransposeB) {
     xt::xarray<float> expected_grad_a = xt::linalg::dot(out_grad, b);
     xt::xarray<float> expected_grad_b = xt::linalg::dot(xt::transpose(out_grad), a);
 
-    EXPECT_TRUE(xt::allclose(grad_a, expected_grad_a));
-    EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
+    ttml::test_utils::expect_allclose(grad_a, expected_grad_a);
+    ttml::test_utils::expect_allclose(grad_b, expected_grad_b);
 }
 
 TEST_F(MatmulsTest, MatMulBackwardTransposeBoth) {
@@ -234,7 +235,7 @@ TEST_F(MatmulsTest, MatMulBackwardTransposeBoth) {
     xt::xarray<float> expected_grad_a = xt::linalg::dot(xt::transpose(b), xt::transpose(out_grad));
     xt::xarray<float> expected_grad_b = xt::linalg::dot(xt::transpose(out_grad), xt::transpose(a));
 
-    EXPECT_TRUE(xt::allclose(grad_a, expected_grad_a));
-    EXPECT_TRUE(xt::allclose(grad_b, expected_grad_b));
+    ttml::test_utils::expect_allclose(grad_a, expected_grad_a);
+    ttml::test_utils::expect_allclose(grad_b, expected_grad_b);
 }
 }  // namespace ttml::ttnn_fixed::tests

--- a/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
@@ -15,6 +15,7 @@
 #include "core/device.hpp"
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/comparison.hpp"
 #include "test_utils/random_data.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
@@ -49,9 +50,9 @@ TEST_F(ReduceOpTest, TestMeanDim0) {
     auto mean_ttnn = ttml::core::to_xtensor(ttnn_mean_dim0);
     auto mean_moreh = ttml::core::to_xtensor(moreh_mean_dim0);
 
-    EXPECT_TRUE(xt::allclose(mean_ttnn, mean_moreh, /*rtol=*/7e-2, /*atol=*/1e-3));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(mean_ttnn, mean_moreh, /*rtol=*/7e-2, /*atol=*/1e-3);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2);
 }
 
 TEST_F(ReduceOpTest, TestSumDim0) {
@@ -72,9 +73,9 @@ TEST_F(ReduceOpTest, TestSumDim0) {
     auto sum_ttnn = ttml::core::to_xtensor(ttnn_sum_dim0);
     auto sum_moreh = ttml::core::to_xtensor(moreh_sum_dim0);
 
-    EXPECT_TRUE(xt::allclose(sum_ttnn, sum_moreh, /*rtol=*/1e-4, /*atol=*/1e-3));
-    EXPECT_TRUE(xt::allclose(sum_xtensor, sum_ttnn, /*rtol=*/1e-2, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(sum_xtensor, sum_moreh, /*rtol=*/1e-2, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(sum_ttnn, sum_moreh, /*rtol=*/1e-4, /*atol=*/1e-3);
+    ttml::test_utils::expect_allclose(sum_xtensor, sum_ttnn, /*rtol=*/1e-2, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(sum_xtensor, sum_moreh, /*rtol=*/1e-2, /*atol=*/1e-2);
 }
 
 TEST_F(ReduceOpTest, TestMeanDim3) {
@@ -94,9 +95,9 @@ TEST_F(ReduceOpTest, TestMeanDim3) {
 
     auto mean_ttnn = ttml::core::to_xtensor(ttnn_mean_dim3);
     auto mean_moreh = ttml::core::to_xtensor(moreh_mean_dim3);
-    EXPECT_TRUE(xt::allclose(mean_ttnn, mean_moreh, /*rtol=*/1e-4, /*atol=*/1e-3));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(mean_ttnn, mean_moreh, /*rtol=*/1e-4, /*atol=*/1e-3);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2);
 }
 
 TEST_F(ReduceOpTest, TestSumDim3) {
@@ -117,9 +118,9 @@ TEST_F(ReduceOpTest, TestSumDim3) {
     auto sum_ttnn = ttml::core::to_xtensor(ttnn_sum_dim3);
     auto sum_moreh = ttml::core::to_xtensor(moreh_sum_dim3);
 
-    EXPECT_TRUE(xt::allclose(sum_ttnn, sum_moreh, /*rtol=*/1e-4, /*atol=*/1e-3));
-    EXPECT_TRUE(xt::allclose(sum_xtensor, sum_ttnn, /*rtol=*/1e-2, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(sum_xtensor, sum_moreh, /*rtol=*/1e-2, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(sum_ttnn, sum_moreh, /*rtol=*/1e-4, /*atol=*/1e-3);
+    ttml::test_utils::expect_allclose(sum_xtensor, sum_ttnn, /*rtol=*/1e-2, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(sum_xtensor, sum_moreh, /*rtol=*/1e-2, /*atol=*/1e-2);
 }
 
 TEST_F(ReduceOpTest, TestMeanLargeDim3) {
@@ -140,7 +141,7 @@ TEST_F(ReduceOpTest, TestMeanLargeDim3) {
     auto mean_ttnn = ttml::core::to_xtensor(ttnn_mean_dim3);
     auto mean_moreh = ttml::core::to_xtensor(moreh_mean_dim3);
 
-    EXPECT_TRUE(xt::allclose(mean_ttnn, mean_moreh, /*rtol=*/1e-4, /*atol=*/1e-3));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2));
-    EXPECT_TRUE(xt::allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2));
+    ttml::test_utils::expect_allclose(mean_ttnn, mean_moreh, /*rtol=*/1e-4, /*atol=*/1e-3);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_ttnn, /*rtol=*/1e-3, /*atol=*/1e-2);
+    ttml::test_utils::expect_allclose(mean_xtensor, mean_moreh, /*rtol=*/1e-3, /*atol=*/1e-2);
 }


### PR DESCRIPTION
Extract a reusable xtensor allclose gtest assertion into test_utils/comparison.hpp and use it from the MLA QKV assemble test. Intended to replace the per-test inline compare helpers (e.g. moe group/ungroup, swiglu) in follow-up changes.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/test_expect_allclose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/test_expect_allclose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/test_expect_allclose)