### PR TITLE
Reimplement ASSERT

### DIFF
--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -81,13 +81,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
     }
 }
 
-// The do... while(0) in this macro allows for it to be called more flexibly, e.g. in an if-else
-// without {}s.
-#define ASSERT(condition, ...)                        \
-    do {                                              \
-        if (not(condition))                           \
-            assert_and_hang(__LINE__, ##__VA_ARGS__); \
-    } while (0)
+#define ASSERT(condition, ...) (void(not(condition) ? assert_and_hang(__LINE__, ##__VA_ARGS__), 0 : 0))
 
 #define ASSERT_ENABLED 1
 #define WATCHER_ASSERT_ENABLED 1
@@ -97,33 +91,21 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
 
 #if defined(LIGHTWEIGHT_KERNEL_ASSERTS)
 
-#define ASSERT(condition, ...)      \
-    do {                            \
-        if (!(condition)) {         \
-            asm volatile("ebreak"); \
-        }                           \
-    } while (0)
+#define ASSERT(condition, ...) (void(not(condition) ? ({ asm("ebreak"); }), 0 : 0))
 
 #define ASSERT_ENABLED 1
 #define LIGHTWEIGHT_ASSERT_ENABLED 1
 #define WATCHER_ASSERT_ENABLED 0
 
-#elif defined(ENABLE_LLK_ASSERT)
+#else
 
-#define ASSERT(condition, ...)
+// Avoid unused variable warnings here.
+#define ASSERT(condition, ...) (void(sizeof(not(condition))))
 
 #define ASSERT_ENABLED 0
 #define LIGHTWEIGHT_ASSERT_ENABLED 0
 #define WATCHER_ASSERT_ENABLED 0
 
-#else  // No asserts enabled
-
-#define ASSERT(condition, ...)
-
-#define ASSERT_ENABLED 0
-#define WATCHER_ASSERT_ENABLED 0
-#define LIGHTWEIGHT_ASSERT_ENABLED 0
-
-#endif  // LIGHTWEIGHT_KERNEL_ASSERTS / ENABLE_LLK_ASSERT
+#endif  // LIGHTWEIGHT_KERNEL_ASSERTS
 
 #endif  // WATCHER_ENABLED


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
one class of var-unused-warning that we now get is because we compute something trivial and then assert on it.  When asserts are disabled, the var isn't used there -- and sometimes that's the only use.

This reimplements our ASSERT macro to place the expression inside a `sizeof` (a non-evaluated context).  That's sufficient to squash the warning.

I took the opportunity to replace the `do ... while` ugliness, so that ASSERT can be used in any expression context.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/assert)