### PR TITLE
Avoid unused var warnings on non-profiled builds

### DIFF
--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -755,7 +755,7 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))
 
-#define DeviceRecordEvent(event_id) (void(event_id))
+#define DeviceRecordEvent(event_id) (void(sizeof(event_id)))
 
 #define DeviceProfilerInit()
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -751,7 +751,7 @@ __attribute__((noinline)) void trace_only_init() {
 
 #define DeviceTraceOnlyProfilerInit()
 
-#define DeviceZoneSetCounter(counter) (void(counter))
+#define DeviceZoneSetCounter(counter) (void(sizeof(counter)))
 
 #define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -737,6 +737,11 @@ __attribute__((noinline)) void trace_only_init() {
 
 #else
 
+// The void(sizeof(FOO)) idiom (a) ensures FOO is syntactically and
+// semantically sane and (b) means that we avoid 'var-set-but-unused'
+// diagnostics, if the only use of a particular var is here.  The
+// sizeof argument is processed in a non-evaluating context -- no code
+// is generated.
 #define DeviceValidateProfiler(condition) (void(sizeof(condition)))
 
 #define DeviceZoneScopedMainN(name) (void(name))

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -683,11 +683,11 @@ __attribute__((noinline)) void trace_only_init() {
 // Dispatch but disabled
 #else
 
-#define DeviceZoneScopedN(name)
+#define DeviceZoneScopedN(name) (void(sizeof(name)))
 
-#define DeviceTimestampedData(data_id, data)
+#define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))
 
-#define DeviceRecordEvent(event_id)
+#define DeviceRecordEvent(event_id) (void(sizeof(event_id)))
 
 #endif
 
@@ -737,25 +737,25 @@ __attribute__((noinline)) void trace_only_init() {
 
 #else
 
-#define DeviceValidateProfiler(condition)
+#define DeviceValidateProfiler(condition) (void(sizeof(condition)))
 
-#define DeviceZoneScopedMainN(name)
+#define DeviceZoneScopedMainN(name) (void(name))
 
-#define DeviceZoneScopedMainChildN(name)
+#define DeviceZoneScopedMainChildN(name) (void(name))
 
-#define DeviceZoneScopedN(name)
+#define DeviceZoneScopedN(name) (void(name))
 
-#define DeviceZoneScopedSumN1(name)
+#define DeviceZoneScopedSumN1(name) (void(name))
 
-#define DeviceZoneScopedSumN2(name)
+#define DeviceZoneScopedSumN2(name) (void(name))
 
 #define DeviceTraceOnlyProfilerInit()
 
-#define DeviceZoneSetCounter(counter)
+#define DeviceZoneSetCounter(counter) (void(counter))
 
-#define DeviceTimestampedData(data_id, data)
+#define DeviceTimestampedData(data_id, data) (void(sizeof(data_id) + sizeof(data)))
 
-#define DeviceRecordEvent(event_id)
+#define DeviceRecordEvent(event_id) (void(event_id))
 
 #define DeviceProfilerInit()
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Like https://github.com/tenstorrent/tt-metal/pull/45627, but for non-profiled builds we now get is because the profiler macros do not expand the expressions being passed.

This reimplements the inactive profile macros to place the expression inside a sizeof (a non-evaluated context). That's sufficient to squash the warning.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/profiler)