### PR TITLE
ci: reduce number of threads for Quasar compile job from 35 to 20

### DIFF
--- a/.github/workflows/llk-build-quasar.yaml
+++ b/.github/workflows/llk-build-quasar.yaml
@@ -83,7 +83,7 @@ jobs:
           cd tests/python_tests/
 
           echo "Compiling Quasar..."
-          pytest -q --compile-producer -n 35 \
+          pytest -q --compile-producer-n "$(nproc)" \
                 -m "${{ inputs.pytest_markers }}" \
                 --splits $TEST_SPLITS --group ${{ matrix.test_group }} \
                 --override-ini=log_cli=false --tb=short --timeout=60 \

--- a/.github/workflows/llk-build-quasar.yaml
+++ b/.github/workflows/llk-build-quasar.yaml
@@ -83,7 +83,7 @@ jobs:
           cd tests/python_tests/
 
           echo "Compiling Quasar..."
-          pytest -q --compile-producer-n "$(nproc)" \
+          pytest -q --compile-producer -n "$(nproc)" \
                 -m "${{ inputs.pytest_markers }}" \
                 --splits $TEST_SPLITS --group ${{ matrix.test_group }} \
                 --override-ini=log_cli=false --tb=short --timeout=60 \

--- a/.github/workflows/llk-build-quasar.yaml
+++ b/.github/workflows/llk-build-quasar.yaml
@@ -83,7 +83,7 @@ jobs:
           cd tests/python_tests/
 
           echo "Compiling Quasar..."
-          pytest -q --compile-producer -n "$(nproc)" \
+          pytest -q --compile-producer -n 20 \
                 -m "${{ inputs.pytest_markers }}" \
                 --splits $TEST_SPLITS --group ${{ matrix.test_group }} \
                 --override-ini=log_cli=false --tb=short --timeout=60 \


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
At this point, I believe that "Compile for Quasar" failures are happening due to the compile step hammering the box when the number of cores is set too high. Failure is almost certainly resource exhaustion, because per-worker cost (Python + torch + GCC process) scales linearly with -n while RAM/shm do not.

**Before:**
<img width="1010" height="28" alt="image" src="https://github.com/user-attachments/assets/4910f131-c792-47b5-ac0c-c731b6aaee7c" />

**After:**
<img width="1010" height="28" alt="image" src="https://github.com/user-attachments/assets/5053bea4-5112-46fa-a86b-c0bcd7dfb8df" />

So we didn't lose anything, build times seem to be on par.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT-patch-1)