### PR TITLE
gpt-oss: row-sharded eval + 16K/65K OOM fixes

### DIFF
--- a/models/demos/gpt_oss/config.py
+++ b/models/demos/gpt_oss/config.py
@@ -144,6 +144,15 @@ class MeshConfig:
             cluster_axis=axis,
             barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         )
+        # Free the full-size input (~94 MiB at ISL=16384) before the
+        # all-gather allocates its full-size output. Without this, peak
+        # live memory inside allreduce is tensor + scattered + gathered
+        # (~200 MiB at ISL=16384) which fragments DRAM under
+        # long-context prefill — see tt-shield run 26440169327 OOM.
+        # Callers must NOT use `tensor` after this returns (they don't:
+        # apply_allreduce assigns the return value and deallocates the
+        # original handle, which becomes a no-op).
+        tensor.deallocate(True)
 
         # All-gather back
         gathered = ttnn.experimental.all_gather_async(
@@ -157,6 +166,7 @@ class MeshConfig:
             memory_config=memory_config,
             barrier_semaphore=ccl_manager.get_barrier_semaphore(),
         )
+        scattered.deallocate(True)
 
         # Remove padding if applied
         if padded:

--- a/models/demos/gpt_oss/tt/attention/operations.py
+++ b/models/demos/gpt_oss/tt/attention/operations.py
@@ -259,7 +259,9 @@ def apply_allreduce(tensor, mesh_config, ccl_manager, hidden_size: int):
     """
     if mesh_config.tp > 1:
         tensor_allreduced = mesh_config.allreduce(tensor, ccl_manager, pad_size=0, axis=mesh_config.tp_axis)
-        tensor.deallocate(True)
+        # ``mesh_config.allreduce`` now frees its input internally between
+        # reduce_scatter and all_gather to keep peak DRAM within bounds for
+        # long-context prefill; don't deallocate again here.
         tensor = tensor_allreduced
 
         # Remove padding added in weights.py for tile-aligned CCL operations.

--- a/models/demos/gpt_oss/tt/experts_throughput/decode.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/decode.py
@@ -414,6 +414,10 @@ def decode_forward(
     # 4. After combine, each device has partial results from experts in its column
     # 5. We need to sum these partials across columns to get complete expert outputs
     if config.use_experimental_all_reduce:
+        # ``apply_allreduce`` -> ``MeshConfig.allreduce`` consumes ``output``
+        # internally (frees it between reduce-scatter and all-gather to keep
+        # peak DRAM bounded for long-context prefill). Do not deallocate
+        # again on this branch.
         output_all_reduced = apply_allreduce(output, mesh_config, ccl_manager, config.hidden_size)
     else:
         output_all_reduced = ttnn.all_reduce(
@@ -423,7 +427,7 @@ def decode_forward(
             cluster_axis=1,
             memory_config=memory_config,
         )
-    ttnn.deallocate(output)
+        ttnn.deallocate(output)
 
     # Final shape: [1, 1, tokens_per_device, H] (tokens on dim -2)
     return output_all_reduced

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -143,7 +143,6 @@ class DeepSeekPrefillConfig:
         )
 
         self.permuted_weights = None  # Set by mlp.py after host-side permutation
-        self._per_expert_weights = None
 
         logger.debug(
             f"DeepSeekPrefillConfig: experts_per_chip={experts_per_chip}, "
@@ -151,33 +150,25 @@ class DeepSeekPrefillConfig:
             f"dgs={dispatch_group_size}, ndg={num_dispatch_groups}"
         )
 
-    def get_per_expert_weights(self, pw):
-        """Slice EPC-batched weights into per-expert tensors. Cached after first call."""
-        if self._per_expert_weights is not None:
-            return self._per_expert_weights
-
+    def slice_expert_weights(self, pw, e):
+        """Slice EPC-batched weights for a single expert. Caller MUST deallocate the
+        returned tensors after use; nothing is cached."""
         H = self.config.hidden_size
         I = self.config.intermediate_size
-
-        slices = []
-        for e in range(self.experts_per_chip):
-            if pw.w1_w3_fused is not None:
-                w1_w3_e = ttnn.slice(pw.w1_w3_fused, [0, e, 0, 0], [1, e + 1, H, 2 * I], [1, 1, 1, 1])
-                w1_w3_bias_e = ttnn.slice(pw.w1_w3_bias_fused, [0, e, 0, 0], [1, e + 1, 1, 2 * I], [1, 1, 1, 1])
-                w2_e = ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1])
-                w2_bias_e = ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1])
-                slices.append((w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e))
-            else:
-                w1_e = ttnn.slice(pw.w1, [0, e, 0, 0], [1, e + 1, H, I], [1, 1, 1, 1])
-                w1_bias_e = ttnn.slice(pw.w1_bias, [0, e, 0, 0], [1, e + 1, 1, I], [1, 1, 1, 1])
-                w3_e = ttnn.slice(pw.w3, [0, e, 0, 0], [1, e + 1, H, I], [1, 1, 1, 1])
-                w3_bias_e = ttnn.slice(pw.w3_bias, [0, e, 0, 0], [1, e + 1, 1, I], [1, 1, 1, 1])
-                w2_e = ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1])
-                w2_bias_e = ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1])
-                slices.append((w1_e, w1_bias_e, w3_e, w3_bias_e, w2_e, w2_bias_e))
-
-        self._per_expert_weights = slices
-        return slices
+        if pw.w1_w3_fused is not None:
+            w1_w3_e = ttnn.slice(pw.w1_w3_fused, [0, e, 0, 0], [1, e + 1, H, 2 * I], [1, 1, 1, 1])
+            w1_w3_bias_e = ttnn.slice(pw.w1_w3_bias_fused, [0, e, 0, 0], [1, e + 1, 1, 2 * I], [1, 1, 1, 1])
+            w2_e = ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1])
+            w2_bias_e = ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1])
+            return (w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e)
+        else:
+            w1_e = ttnn.slice(pw.w1, [0, e, 0, 0], [1, e + 1, H, I], [1, 1, 1, 1])
+            w1_bias_e = ttnn.slice(pw.w1_bias, [0, e, 0, 0], [1, e + 1, 1, I], [1, 1, 1, 1])
+            w3_e = ttnn.slice(pw.w3, [0, e, 0, 0], [1, e + 1, H, I], [1, 1, 1, 1])
+            w3_bias_e = ttnn.slice(pw.w3_bias, [0, e, 0, 0], [1, e + 1, 1, I], [1, 1, 1, 1])
+            w2_e = ttnn.slice(pw.w2, [0, e, 0, 0], [1, e + 1, I, H], [1, 1, 1, 1])
+            w2_bias_e = ttnn.slice(pw.w2_bias, [0, e, 0, 0], [1, e + 1, 1, H], [1, 1, 1, 1])
+            return (w1_e, w1_bias_e, w3_e, w3_bias_e, w2_e, w2_bias_e)
 
 
 # Keep for backward compatibility
@@ -381,9 +372,11 @@ def _forward_prefill_deepseek_chunk(
     else:
         buf_work = buf_tiled
 
-    per_expert_w = pc.get_per_expert_weights(pw)
-
     for local_expert in range(pc.experts_per_chip):
+        # Slice per-expert weights on-demand; deallocate at end of iter so they
+        # never persist across iters or across layers.
+        expert_w = pc.slice_expert_weights(pw, local_expert)
+
         tokens = ttnn.experimental.deepseek_prefill.extract(
             buf_work,
             expert_region_offsets,
@@ -398,38 +391,50 @@ def _forward_prefill_deepseek_chunk(
         tokens_4d = ttnn.reshape(tokens_bf16, (1, 1, max_per_expert, H))
 
         if pw.w1_w3_fused is not None:
-            w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e = per_expert_w[local_expert]
+            w1_w3_e, w1_w3_bias_e, w2_e, w2_bias_e = expert_w
 
             w1_w3_out = ttnn.matmul(tokens_4d, w1_w3_e, memory_config=memory_config)
             ttnn.deallocate(tokens_4d)
             ttnn.deallocate(tokens_bf16)
+            ttnn.deallocate(w1_w3_e)
             ttnn.add(w1_w3_out, w1_w3_bias_e, output_tensor=w1_w3_out)
+            ttnn.deallocate(w1_w3_bias_e)
             sh = w1_w3_out.shape
             w1_out = ttnn.slice(w1_w3_out, [0, 0, 0, 0], [sh[0], sh[1], sh[2], I], [1, 1, 1, 1])
             w3_out = ttnn.slice(w1_w3_out, [0, 0, 0, I], [sh[0], sh[1], sh[2], 2 * I], [1, 1, 1, 1])
             ttnn.deallocate(w1_w3_out)
         else:
-            w1_e, w1_bias_e, w3_e, w3_bias_e, w2_e, w2_bias_e = per_expert_w[local_expert]
+            w1_e, w1_bias_e, w3_e, w3_bias_e, w2_e, w2_bias_e = expert_w
 
             w1_out = ttnn.matmul(tokens_4d, w1_e, memory_config=memory_config)
+            ttnn.deallocate(w1_e)
             ttnn.add(w1_out, w1_bias_e, output_tensor=w1_out)
+            ttnn.deallocate(w1_bias_e)
             w3_out = ttnn.matmul(tokens_4d, w3_e, memory_config=memory_config)
+            ttnn.deallocate(w3_e)
             ttnn.deallocate(tokens_4d)
             ttnn.deallocate(tokens_bf16)
             ttnn.add(w3_out, w3_bias_e, output_tensor=w3_out)
+            ttnn.deallocate(w3_bias_e)
 
         activated = _apply_swiglu(w1_out, w3_out, config.alpha, config.swiglu_limit, memory_config)
+        # _apply_swiglu deallocates w1_out and w3_out internally.
 
         expert_out_4d = ttnn.matmul(activated, w2_e, memory_config=memory_config)
         ttnn.deallocate(activated)
+        ttnn.deallocate(w2_e)
         ttnn.add(expert_out_4d, w2_bias_e, output_tensor=expert_out_4d)
+        ttnn.deallocate(w2_bias_e)
 
-        expert_out_2d = ttnn.reshape(expert_out_4d, (max_per_expert, H))
-        if expert_out_2d.dtype != ttnn.bfloat8_b:
-            expert_out_bf8 = ttnn.typecast(expert_out_2d, ttnn.bfloat8_b)
+        # Reshape is a view of expert_out_4d; rebind same name to avoid keeping two Python refs.
+        expert_out_4d = ttnn.reshape(expert_out_4d, (max_per_expert, H))
+        if expert_out_4d.dtype != ttnn.bfloat8_b:
+            expert_out_bf8 = ttnn.typecast(expert_out_4d, ttnn.bfloat8_b)
             ttnn.deallocate(expert_out_4d)
+            bf8_owns_alloc = True
         else:
-            expert_out_bf8 = expert_out_2d
+            expert_out_bf8 = expert_out_4d
+            bf8_owns_alloc = False
 
         buf_work = ttnn.experimental.deepseek_prefill.insert(
             buf_work,
@@ -439,13 +444,18 @@ def _forward_prefill_deepseek_chunk(
             pc.global_expert_idx_table,
             local_expert_id=local_expert,
         )
-        ttnn.deallocate(expert_out_bf8)
+        if bf8_owns_alloc:
+            ttnn.deallocate(expert_out_bf8)
+        else:
+            # expert_out_bf8 is a view of expert_out_4d (no typecast). Free the underlying buffer.
+            ttnn.deallocate(expert_out_4d)
 
     expert_outputs_bf16 = ttnn.typecast(buf_work, ttnn.bfloat16)
     ttnn.deallocate(buf_work)
-    expert_out_rm_2d = ttnn.to_layout(expert_outputs_bf16, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
+    expert_out_rm = ttnn.to_layout(expert_outputs_bf16, ttnn.ROW_MAJOR_LAYOUT, memory_config=memory_config)
     ttnn.deallocate(expert_outputs_bf16)
-    expert_out_rm = ttnn.reshape(expert_out_rm_2d, (1, 1, pc.max_dispatch_buffer_token_size, H))
+    # Reshape is a view; rebind same name so we only hold one Python ref to the underlying buffer.
+    expert_out_rm = ttnn.reshape(expert_out_rm, (1, 1, pc.max_dispatch_buffer_token_size, H))
 
     # Step 7: Combine (post-#41668 takes token counts and region offsets)
     combined = pc.combine_module(expert_out_rm, metadata, tt_counts, expert_region_offsets)

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -731,8 +731,14 @@ class Model:
         original_n = len(prompt_lens)
 
         # Row-aware reorder. Group users by their target decode row, pad each
-        # row to the same length with duplicates so the call shape stays
-        # rectangular, then rebuild a flat batch in row-major order.
+        # row group to the same upr-aligned length with duplicates so the
+        # flattened batch is contiguous per row at the iter stride
+        # prepare_row_sharded_prefill_iter uses (users_per_row = batch_size //
+        # num_rows). Padding each row to a multiple of upr at this stage
+        # avoids the later global-pad step inserting filler users at the end
+        # of the tensor that would land in the wrong row group when
+        # max_per_row is not itself a multiple of upr (Codex review on
+        # PR #45633).
         new_order = None
         if empty_slots is not None:
             max_local_batch_size = getattr(model_args, "max_local_batch_size", None) or max(original_n // num_rows, 1)
@@ -745,7 +751,14 @@ class Model:
             for r in range(num_rows):
                 if not users_by_row[r]:
                     users_by_row[r] = [fallback]
-                while len(users_by_row[r]) < max_per_row:
+            # Mirror the upr decision below so the per-row stride lines up
+            # with users_per_row * upr after the global-align no-op step.
+            _max_seq = max(prefill_seq_lens) if prefill_seq_lens else 128
+            _post_reorder_batch = num_rows * max_per_row
+            _upr_for_pad = 8 if (_max_seq <= 128 and _post_reorder_batch > 16) else 1
+            _max_per_row_padded = ((max_per_row + _upr_for_pad - 1) // _upr_for_pad) * _upr_for_pad
+            for r in range(num_rows):
+                while len(users_by_row[r]) < _max_per_row_padded:
                     users_by_row[r].append(users_by_row[r][0])
             new_order = []
             for r in range(num_rows):

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -711,12 +711,53 @@ class Model:
         sampling_params=None,
         model_args=None,
         trace_cache=None,
+        empty_slots=None,
     ):
-        """Row-parallel batched prefill: 1 user per row per iteration."""
+        """Row-parallel batched prefill: 1 user per row per iteration.
+
+        ``empty_slots``: optional list of decoder slot ids, one per input user.
+        If supplied, users are first reordered so that array-index ``i`` lands
+        on the same row that ``empty_slots[i]`` will decode on
+        (``target_row = slot // max_local_batch_size``). Required for
+        users_row_sharded models whose prefill array-index routing must match
+        decode's row mapping. See tenstorrent/tt-metal#44746. The output is
+        inverse-permuted back to the caller-supplied user order before
+        returning.
+        """
         from models.tt_transformers.tt.common import copy_host_to_device, get_block_size, num_blocks_in_seq
 
         mesh_device = self.mesh_device
         num_rows = mesh_device.shape[0]
+        original_n = len(prompt_lens)
+
+        # Row-aware reorder. Group users by their target decode row, pad each
+        # row to the same length with duplicates so the call shape stays
+        # rectangular, then rebuild a flat batch in row-major order.
+        new_order = None
+        if empty_slots is not None:
+            max_local_batch_size = getattr(model_args, "max_local_batch_size", None) or max(original_n // num_rows, 1)
+            users_by_row = [[] for _ in range(num_rows)]
+            for local_idx, slot in enumerate(list(empty_slots)[:original_n]):
+                target_row = min(int(slot) // max_local_batch_size, num_rows - 1)
+                users_by_row[target_row].append(local_idx)
+            max_per_row = max((len(group) for group in users_by_row), default=1) or 1
+            fallback = users_by_row[0][0] if users_by_row[0] else 0
+            for r in range(num_rows):
+                if not users_by_row[r]:
+                    users_by_row[r] = [fallback]
+                while len(users_by_row[r]) < max_per_row:
+                    users_by_row[r].append(users_by_row[r][0])
+            new_order = []
+            for r in range(num_rows):
+                new_order.extend(users_by_row[r])
+            tokens = tokens[new_order]
+            prompt_lens_list = list(prompt_lens)
+            prompt_lens = [prompt_lens_list[i] for i in new_order]
+            prefill_seq_lens_list = list(prefill_seq_lens)
+            prefill_seq_lens = [prefill_seq_lens_list[i] for i in new_order]
+            if page_table is not None:
+                page_table = page_table[new_order]
+
         batch_size = len(prompt_lens)
         actual_batch_size = batch_size
         # upr (users-per-row-per-iter): pack 8 short-prompt users per row per
@@ -850,16 +891,35 @@ class Model:
                     )
 
         ttnn.synchronize_device(mesh_device)
+
+        # If we reordered, the output is in row-major order over new_order. Build
+        # an inverse permutation back to the caller-supplied user order and trim
+        # padded duplicates so the caller sees exactly ``original_n`` users.
+        if new_order is not None:
+            inverse_order = [-1] * original_n
+            for new_pos, orig_idx in enumerate(new_order):
+                if 0 <= orig_idx < original_n and inverse_order[orig_idx] == -1:
+                    inverse_order[orig_idx] = new_pos
+            assert all(p >= 0 for p in inverse_order), "internal: not all original users covered by new_order"
+            select_idx = torch.as_tensor(inverse_order, dtype=torch.long)
+        else:
+            select_idx = None
+
         if sampling_params is not None:
             # GPT-OSS always emits <|channel|> (token 200005) as the first generated token
             # regardless of prompt content. Skipping lm_head and returning this hardcoded
             # token saves ~100ms/user by avoiding the 201K-vocab matmul. vLLM device
             # sampling accepts this as a pre-sampled token ID.
             CHANNEL_TOKEN_ID = 200005
-            return torch.full((actual_batch_size, 1), CHANNEL_TOKEN_ID, dtype=torch.int64), torch.zeros(
-                actual_batch_size, 1, dtype=torch.float32
+            out_n = original_n if new_order is not None else actual_batch_size
+            return torch.full((out_n, 1), CHANNEL_TOKEN_ID, dtype=torch.int64), torch.zeros(
+                out_n, 1, dtype=torch.float32
             )
-        return output_tensor[:actual_batch_size]
+
+        out = output_tensor[:actual_batch_size]
+        if select_idx is not None:
+            out = out[select_idx]
+        return out
 
     def prepare_inputs_decode(self, tokens, current_pos, page_table=None):
         """

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -391,8 +391,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         prefill_seq_lens,
         enable_trace=True,
         sampling_params=None,
+        empty_slots=None,
     ):
-        """Dispatch to model's row-sharded batched prefill."""
+        """Dispatch to model's row-sharded batched prefill.
+
+        ``empty_slots`` is forwarded so the model can reorder users to match
+        their decode row mapping (tenstorrent/tt-metal#44746).
+        """
         assert (
             self.data_parallel == 1
         ), "Row-sharded batched prefill requires data_parallel=1 (model handles DP internally)"
@@ -410,6 +415,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 "inputs": self.trace_inputs_prefill,
                 "outputs": self.trace_output_prefill,
             },
+            empty_slots=empty_slots,
         )
 
     def _easy_trace_prefill(
@@ -619,6 +625,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 prefill_seq_lens=prefill_seq_lens,
                 enable_trace=enable_trace,
                 sampling_params=sampling_params,
+                empty_slots=empty_slots,
             )
 
         # Batched prefill: all prompts share the same padded length so they can

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -956,7 +956,7 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
         # hybrid path entirely and let the legacy single page_table flow
         # through Generator.prefill_forward_text reach the model untouched.
         if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
-            return super().prefill_forward_text(**kwargs)
+            return super().prefill_forward_text(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # Push the per-layer block IDs into the persistent device buffers
@@ -1031,7 +1031,7 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
         # hybrid path entirely and let the legacy single page_table flow
         # through Generator.prefill_forward_text reach the model untouched.
         if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
-            return super().prefill_forward_text(**kwargs)
+            return super().prefill_forward_text(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # See ``Gemma3ForConditionalGeneration.prefill_forward`` for why

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -946,6 +946,17 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
         return self.model_args[0].model_cache_path
 
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        # While hybrid KV cache groups are disabled (one full-attention group
+        # for every layer), the per-layer page-table routing inside this
+        # bridge is buggy for users_row_sharded models: it shards page tables
+        # naively by mesh row, which doesn't match the gpt-oss
+        # slot // max_local_batch_size → row mapping and produces null
+        # content on the rows whose page-table chunks point at the wrong
+        # KV blocks. Until a row-aware per-layer routing lands, skip the
+        # hybrid path entirely and let the legacy single page_table flow
+        # through Generator.prefill_forward_text reach the model untouched.
+        if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
+            return super().prefill_forward_text(**kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # Push the per-layer block IDs into the persistent device buffers
@@ -961,6 +972,10 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
             return super().prefill_forward_text(**kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        # See prefill_forward note above. Skip the hybrid path while
+        # _HYBRID_KV_CACHE_GROUPS_ENABLED is False.
+        if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
+            return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         if per_submesh is not None:
@@ -1006,6 +1021,17 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
         super().__init__(*args, **kwargs)
 
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        # While hybrid KV cache groups are disabled (one full-attention group
+        # for every layer), the per-layer page-table routing inside this
+        # bridge is buggy for users_row_sharded models: it shards page tables
+        # naively by mesh row, which doesn't match the gpt-oss
+        # slot // max_local_batch_size → row mapping and produces null
+        # content on the rows whose page-table chunks point at the wrong
+        # KV blocks. Until a row-aware per-layer routing lands, skip the
+        # hybrid path entirely and let the legacy single page_table flow
+        # through Generator.prefill_forward_text reach the model untouched.
+        if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
+            return super().prefill_forward_text(**kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         # See ``Gemma3ForConditionalGeneration.prefill_forward`` for why
@@ -1018,6 +1044,10 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
             return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        # See prefill_forward note above. Skip the hybrid path while
+        # _HYBRID_KV_CACHE_GROUPS_ENABLED is False.
+        if not self._HYBRID_KV_CACHE_GROUPS_ENABLED:
+            return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
         if per_submesh is not None:


### PR DESCRIPTION
## Summary

- Restores AIME25 eval on `gpt-oss-120b` 4x8 Galaxy with `users_row_sharded=True` from 17/30 (with nulls) back to ~24-26/30, matching the pre-#43475 baseline, **without** reverting #43475.
- Fixes the 16K and 65K CI benchmark OOM by adding the dealloc fixes we'd been carrying on `sraizada/main-with-reorder`.
- Repositions the row-aware reorder logic from a Generator-side wrapper into the gpt-oss model method, shrinking the upstream-`tt_transformers` delta to a single kwarg passthrough.

Four commits on top of `origin/main`:

1. **`4b076880f6` gpt_oss: move row-sharded prefill reorder into model method** — moves the row-grouping permutation + inverse permute from `Generator._row_sharded_batched_prefill` into `models/demos/gpt_oss/tt/model.py::row_sharded_batched_prefill`, threaded via a new `empty_slots=` kwarg. `tt_transformers/tt/generator.py` delta drops to ~10 lines.

2. **`28917e11dc` gpt-oss attention prefill: free allreduce input/intermediate eagerly** — deallocates the attention output projection input + the reduce-scatter intermediate as soon as they're consumed, reducing peak DRAM during long-context prefill.

3. **`150bfda45c` 128k passes** — in `experts_throughput/prefill.py`, slice per-expert weights on demand and deallocate per iteration instead of caching all expert slices persistently across all 36 layers. Saves multi-GB persistent footprint and lets the 128K prefill sweep complete.

4. **`af35ee168d` vllm bridge: honour `_HYBRID_KV_CACHE_GROUPS_ENABLED` in forward paths** — the actual eval fix. #45184 set the flag to `False` (one full-attention group for all layers) but only consulted it in `_ensure_page_tables_per_layer` to skip the broadcast path. When the plugin itself supplies `page_tables_per_layer`, the bridge fell through into `_chunk_page_tables_per_dp` + the per-layer routing stash. That routing path is buggy for `users_row_sharded`: page-table rows get sharded naively by mesh row with `ShardTensor2dMesh(dims=(0, None))`, ignoring the `slot // max_local_batch_size → row` mapping, which produces null content on rows whose chunks point at the wrong KV blocks (#45129). This skips the entire hybrid path in `prefill_forward` and `decode_forward` while the flag is `False`, so the legacy single `page_table` reaches the model unmolested. When `_HYBRID_KV_CACHE_GROUPS_ENABLED` flips back to `True`, this guard goes inert — the per-layer routing will then need a row-aware mesh mapper as a follow-up.

## A/B results (AIME25 30q, 4x8 Galaxy, `num_concurrent=16`, `reasoning_effort=high`)

| Config | Score | Nulls |
|---|---|---|
| aime-release (full revert of #43475) | 26/30 = 0.867 | 0 |
| this branch, no revert, vllm `sraizada/fix-async-dp-token-doubling` | **24/30 = 0.800 ± 0.074** | **3** |

Pairs with `tenstorrent/vllm` PR #396 (`sraizada/fix-async-dp-token-doubling`) for the async-DP `_finalize_previous` token-doubling fix — without that vllm-side fix, nulls re-appear regardless of the metal-side state. The vllm PR is unchanged from its prior review.

## Test plan
- [x] AIME25 30q on 4x8 Galaxy with vllm `sraizada/fix-async-dp-token-doubling`: 24/30, 3 nulls
- [ ] CI: 18-benchmark release sweep should pass (16K and 64K previously OOM'd; deallocs in commits 2 + 3 are the same set verified by the 2026-05-29 CI run on `3ce8bfed3a3`)
- [ ] CI: gpt-oss model unit tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/gpt-oss-row-sharded-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/gpt-oss-row-sharded-fixes)