### PR TITLE
bumping exalens to 0.3.20

### DIFF
--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -25,7 +25,6 @@ Owner:
 
 from triage import triage_singleton, ScriptConfig, TTTriageError, log_warning, run_script
 from parse_inspector_logs import get_data as get_logs_data, get_log_directory
-from mpi4py import MPI
 import asyncio
 import capnp
 import os
@@ -170,18 +169,13 @@ def run(args, context) -> InspectorData:
     rank: int | None = None
 
     if not args["--inspector-disable-rank"]:
-        # If MPI is available, add rank to the RPC host and port
+        # If MPI rank is available, add rank to the RPC host and port
         try:
-            size = MPI.COMM_WORLD.Get_size()
-            if size > 1:
-                rank = MPI.COMM_WORLD.Get_rank()
-            else:
-                rank_env = os.environ.get("TT_RUN_RANK")
-                if rank_env is not None:
-                    rank = int(rank_env)
+            rank_env = os.environ.get("TT_RUN_RANK")
+            if rank_env is not None:
+                rank = int(rank_env)
         except Exception as e:
-            # If MPI is not available or fails, fall back to rank-less mode without aborting.
-            log_warning(f"Warning: MPI is not available or failed to initialize, running in rank-less mode. Error: {e}")
+            log_warning(f"Warning: MPI rank is not available or failed to parse, running in rank-less mode. Error: {e}")
             pass
 
     # First try to connect to Inspector RPC

--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,4 +1,3 @@
 pycapnp==2.0.0
-mpi4py>=4.1.1
 tt-umd==0.9.5; platform_machine == "x86_64"
-tt-exalens==0.3.19; platform_machine == "x86_64"
+tt-exalens==0.3.20; platform_machine == "x86_64"

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -50,7 +50,7 @@ from ttexalens.context import Context
 from ttexalens.device import Device
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.umd_device import TimeoutDeviceRegisterError
-from ttexalens.hardware.risc_debug import RiscHaltError
+from ttexalens.exceptions import RiscHaltError
 import utils
 from metal_device_id_mapping import run as get_metal_device_id_mapping, MetalDeviceIdMapping
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -62,7 +62,6 @@ _triage_requirements_path = str(Path(__file__).resolve().parent / "requirements.
 try:
     from ttexalens.tt_exalens_init import init_ttexalens, init_ttexalens_remote
     import capnp
-    from mpi4py import MPI
 except ImportError as e:
     RST = "\033[0m" if utils.should_use_color() else ""
     GREEN = "\033[32m" if utils.should_use_color() else ""  # For instructions


### PR DESCRIPTION
Yesterdays bump of pyelftools to 0.33 broke tt-exalens (they changed API). We pinned all dependencies of tt-exalens to specific version to avoid this happening in future.

Removing MPI dependency from tt-triage because it doesn't work with our custom MPI version and delays tt-triage start by 5 seconds.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/exalens_bump_0_3_20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/exalens_bump_0_3_20)