### PR TITLE
Add Nix development shell for tt-metal

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -125,6 +125,19 @@ Install from source if you are a developer who wants to be close to the metal an
 git clone https://github.com/tenstorrent/tt-metal.git --recurse-submodules
 ```
 
+#### Optional: Nix development shell
+
+If you use Nix, you can enter a development shell from the repository root:
+
+```sh
+nix develop
+# or, without flakes:
+nix-shell
+```
+
+The shell exposes the core build toolchain, Python 3.10, and `uv`, and sets
+`TT_METAL_HOME` and `TT_METAL_RUNTIME_ROOT` to the repository root.
+
 #### Step 2. Build the Library:
 
 You have two options for building the library:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "tt-metal development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system: {
+        default = import ./shell.nix {
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        };
+      });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,83 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  python = pkgs.python310;
+  pythonPackages = python.pkgs;
+  llvm = if pkgs ? llvmPackages_20 then pkgs.llvmPackages_20 else pkgs.llvmPackages;
+  runtimeLibs = with pkgs; [
+    openssl
+    libhwloc
+    numactl
+    tbb
+    capstone
+    llvm.libcxx
+    llvm.libcxxabi
+  ];
+in
+pkgs.mkShell {
+  name = "tt-metal-dev-shell";
+
+  packages = [
+    pkgs.git
+    pkgs.coreutils
+    pkgs.gawk
+    pkgs.gnused
+    pkgs.gnugrep
+    pkgs.findutils
+    pkgs.diffutils
+    pkgs.patch
+    pkgs.gnutar
+    pkgs.gzip
+    pkgs.bzip2
+    pkgs.file
+    pkgs.perl
+    pkgs.binutils
+    pkgs.gnumake
+    pkgs.cmake
+    pkgs.ninja
+    pkgs.pkg-config
+    pkgs.pandoc
+    pkgs.xz
+    pkgs.jq
+    pkgs.curl
+    pkgs.wget
+    pkgs.which
+    pkgs.vim
+    pkgs.uv
+    python
+    pythonPackages.pip
+    pythonPackages.setuptools
+    pythonPackages.wheel
+    pythonPackages.virtualenv
+    pythonPackages."setuptools-scm"
+    pkgs.openssl
+    pkgs.libhwloc
+    pkgs.numactl
+    pkgs.tbb
+    pkgs.capstone
+    llvm.clang
+    llvm."clang-tools"
+    llvm.lld
+    llvm.libcxx
+    llvm.libcxxabi
+  ];
+
+  shellHook = ''
+    export TT_METAL_HOME="$PWD"
+    export TT_METAL_RUNTIME_ROOT="$PWD"
+    export PYTHONPATH="$TT_METAL_HOME${PYTHONPATH:+:$PYTHONPATH}"
+    export CC="clang"
+    export CXX="clang++"
+    export VENV_PYTHON_VERSION="3.10"
+    extra_lib_path="${pkgs.lib.makeLibraryPath runtimeLibs}"
+    if [ -n "''${LD_LIBRARY_PATH:-}" ]; then
+      export LD_LIBRARY_PATH="$extra_lib_path:$LD_LIBRARY_PATH"
+    else
+      export LD_LIBRARY_PATH="$extra_lib_path"
+    fi
+
+    echo "tt-metal Nix dev shell ready."
+    echo "Repository root: $TT_METAL_HOME"
+    echo "Suggested next step: ./create_venv.sh --python-version 3.10"
+  '';
+}


### PR DESCRIPTION
Provide a Nix shell and flake entry for tt-metal development, lock nixpkgs for reproducibility, and document the Nix workflow in INSTALLING.md.

Related bounty issue: #45105

Validation performed locally:
- `git diff --check --cached`
- `nix-instantiate --parse shell.nix`
- `nix-instantiate --parse flake.nix`

Notes:
- The PR was created while the issue remained assigned, per the bounty terms.
- `flake.lock` is committed so the flake input is pinned for reproducibility.
- A full `nix flake show` was attempted in this environment but timed out during remote flake evaluation; the shell and flake files themselves parsed successfully.
