### PR TITLE
[Bug fix] Fix NoC stateful-write/inline-write sanitizer register reads

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -59,6 +59,7 @@ enum watcher_features_t {
     SanitizeEthSrcL1Overflow,
     SanitizeEthDestL1Overflow,
     SanitizeNOCMulticastInvalidRange,
+    SanitizeNOCWriteWithStateBadCoord,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -261,7 +262,8 @@ void RunTestOnCore(
                       "eth_dest_overflow_addr",
                       "use_multicast_semaphore_inc",
                       "mcast_dst_end_x",
-                      "mcast_dst_end_y"}},
+                      "mcast_dst_end_y",
+                      "use_write_with_state"}},
             .hw_config = dm_cfg,
         };
         experimental::WorkUnitSpec wu{
@@ -297,6 +299,7 @@ void RunTestOnCore(
     bool use_multicast_semaphore_inc = false;
     uint32_t mcast_dst_end_x = 0;
     uint32_t mcast_dst_end_y = 0;
+    bool use_write_with_state = false;
     switch (feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -352,6 +355,17 @@ void RunTestOnCore(
             }
             break;
         }
+        case SanitizeNOCWriteWithStateBadCoord:
+            // Stateful write to a non-existent core. The destination coordinate lives in NOC_RET_ADDR; a
+            // sanitizer that mistakenly read NOC_TARG_ADDR would instead see the sender's own (valid) coordinate
+            // and fail to flag the bad target. The zero destination offset keeps the failure deterministic
+            // either way (it never silently succeeds), and the small size forces the one-packet write path.
+            output_buf_noc_xy.x = 26;
+            output_buf_noc_xy.y = 18;
+            output_buffer_addr = 0;
+            buffer_size = 32;
+            use_write_with_state = true;
+            break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -374,7 +388,8 @@ void RunTestOnCore(
         eth_dest_overflow_addr_words,
         use_multicast_semaphore_inc,
         mcast_dst_end_x,
-        mcast_dst_end_y};
+        mcast_dst_end_y,
+        use_write_with_state};
 
     if (is_eth_core) {
         // ETH cores still go through the legacy API.
@@ -401,7 +416,8 @@ void RunTestOnCore(
                        {"eth_dest_overflow_addr", eth_dest_overflow_addr_words},
                        {"use_multicast_semaphore_inc", use_multicast_semaphore_inc},
                        {"mcast_dst_end_x", mcast_dst_end_x},
-                       {"mcast_dst_end_y", mcast_dst_end_y}}}},
+                       {"mcast_dst_end_y", mcast_dst_end_y},
+                       {"use_write_with_state", use_write_with_state}}}},
         }};
         experimental::SetProgramRunArgs(program, params);
     }
@@ -437,6 +453,9 @@ void RunTestOnCore(
     }
     // Note: for multi_dm_race, expected string is built but not used - verification uses regex instead
     switch (feature) {
+        // Stateful write to a bad coordinate reports the same "did not map to any known core" error as a plain
+        // bad-coordinate write; the destination coordinate is reconstructed from NOC_RET_ADDR state registers.
+        case SanitizeNOCWriteWithStateBadCoord:
         case SanitizeNOCAddress:
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast write {} "
@@ -871,6 +890,19 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeMulticastSemaphoreInc) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMulticastInvalidRange);
+        },
+        this->devices_[0]);
+}
+
+// Regression test for the stateful-write NOC sanitizer: a write issued via set_async_write_state +
+// async_write_with_state must be sanitized against the destination coordinate held in NOC_RET_ADDR. A
+// sanitizer that reads NOC_TARG_ADDR instead would see the sender's own (valid) coordinate and report the
+// wrong error (or none), so this test fails unless the destination is reconstructed from NOC_RET_ADDR.
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCWriteWithState) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCWriteWithStateBadCoord);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -60,6 +60,7 @@ enum watcher_features_t {
     SanitizeEthDestL1Overflow,
     SanitizeNOCMulticastInvalidRange,
     SanitizeNOCWriteWithStateBadCoord,
+    SanitizeNOCInlineWriteFromState,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -263,7 +264,8 @@ void RunTestOnCore(
                       "use_multicast_semaphore_inc",
                       "mcast_dst_end_x",
                       "mcast_dst_end_y",
-                      "use_write_with_state"}},
+                      "use_write_with_state",
+                      "use_inline_dw_write_from_state"}},
             .hw_config = dm_cfg,
         };
         experimental::WorkUnitSpec wu{
@@ -300,6 +302,7 @@ void RunTestOnCore(
     uint32_t mcast_dst_end_x = 0;
     uint32_t mcast_dst_end_y = 0;
     bool use_write_with_state = false;
+    bool use_inline_dw_write_from_state = false;
     switch (feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -366,6 +369,15 @@ void RunTestOnCore(
             buffer_size = 32;
             use_write_with_state = true;
             break;
+        case SanitizeNOCInlineWriteFromState:
+            // Bad destination coordinate, but keep the (nonzero) destination offset: this exercises
+            // DEBUG_SANITIZE_NOC_ADDR_FROM_STATE the way cq_noc_inline_dw_write_with_state does, and the
+            // reported offset discriminates the low-bits bug (the fixed sanitizer reports the real offset,
+            // whereas dropping NOC_TARG_ADDR_LO would report offset 0).
+            output_buf_noc_xy.x = 26;
+            output_buf_noc_xy.y = 18;
+            use_inline_dw_write_from_state = true;
+            break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -389,7 +401,8 @@ void RunTestOnCore(
         use_multicast_semaphore_inc,
         mcast_dst_end_x,
         mcast_dst_end_y,
-        use_write_with_state};
+        use_write_with_state,
+        use_inline_dw_write_from_state};
 
     if (is_eth_core) {
         // ETH cores still go through the legacy API.
@@ -417,7 +430,8 @@ void RunTestOnCore(
                        {"use_multicast_semaphore_inc", use_multicast_semaphore_inc},
                        {"mcast_dst_end_x", mcast_dst_end_x},
                        {"mcast_dst_end_y", mcast_dst_end_y},
-                       {"use_write_with_state", use_write_with_state}}}},
+                       {"use_write_with_state", use_write_with_state},
+                       {"use_inline_dw_write_from_state", use_inline_dw_write_from_state}}}},
         }};
         experimental::SetProgramRunArgs(program, params);
     }
@@ -619,6 +633,26 @@ void RunTestOnCore(
                 virtual_core.y,
                 (eth_dest_overflow_addr_words << 4));
         } break;
+        case SanitizeNOCInlineWriteFromState:
+            // Inline dw write sanitized straight from the command-buffer state (DEBUG_SANITIZE_NOC_ADDR_FROM_STATE
+            // uses read semantics with l1_addr 0). The destination coordinate is invalid; [addr=...] is the
+            // reconstructed destination offset, which must be the real offset rather than 0.
+            expected = fmt::format(
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read 4 "
+                "bytes to local L1[{:#08x}] from Unknown core w/ virtual coords {} [addr=0x{:08x}] (NOC target "
+                "address did not map to any known Tensix/Ethernet/DRAM/PCIE core).",
+                device->id(),
+                core_name,
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                risc_name,
+                noc,
+                0,  // l1_addr is 0 for address-only (FROM_STATE) sanitization
+                output_buf_noc_xy.str(),
+                output_buffer_addr);
+            break;
         case SanitizeNOCMulticastInvalidRange: {
             // The watcher device reader formats multicast coords using CoreCoord::str() +
             // "-" + CoreCoord::str(), which (since UMD bump) produces "X1-Y1-X2-Y2".
@@ -903,6 +937,20 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCWriteWithState) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCWriteWithStateBadCoord);
+        },
+        this->devices_[0]);
+}
+
+// Regression test for the inline-dw-write NOC sanitizer, exercised the way cq_noc_inline_dw_write_with_state
+// does: the destination is programmed into the WR_REG command buffer and then sanitized via
+// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. That macro had dropped NOC_TARG_ADDR_LO (the destination offset), so it
+// reconstructed offset 0; this test programs a nonzero offset and checks the reported [addr=...] is the real
+// offset, not 0.
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteFromState) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInlineWriteFromState);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -157,9 +157,6 @@ void kernel_main() {
         uint64_t dst = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
         noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(
             dst, local_buffer[0], 0xF, NCRISC_WR_REG_CMD_BUF, noc_index);
-        // set_state leaves NOC_TARG_ADDR_MID untouched; zero it so the reconstructed 64-bit address is
-        // deterministic (inline writes target a 32-bit L1 destination, i.e. MID == 0).
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, 0);
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, NCRISC_WR_REG_CMD_BUF);
     } else {
         noc.async_write(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -68,6 +68,7 @@ void kernel_main() {
     bool use_multicast_semaphore_inc = static_cast<bool>(get_arg(args::use_multicast_semaphore_inc));
     std::uint32_t mcast_dst_end_x = get_arg(args::mcast_dst_end_x);
     std::uint32_t mcast_dst_end_y = get_arg(args::mcast_dst_end_y);
+    bool use_write_with_state = static_cast<bool>(get_arg(args::use_write_with_state));
 
     // We will assert later. This kernel will hang.
     // Need to signal completion to dispatcher before hanging so that
@@ -132,6 +133,20 @@ void kernel_main() {
     if (use_inline_dw_write) {
         noc.inline_dw_write(
             dst_unicast_endpoint, local_buffer[0], {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
+    } else if (use_write_with_state) {
+        // Stateful write: the destination coordinate is programmed into NOC_RET_ADDR by set_async_write_state.
+        // Exercises DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE, which must reconstruct the
+        // destination from NOC_RET_ADDR (not the sender's own coordinate in NOC_TARG_ADDR). buffer_size is kept
+        // <= NOC_MAX_BURST_SIZE by the host so this takes the one-packet path with a deterministic length.
+        noc.set_async_write_state<Noc::ResponseMode::NON_POSTED, NOC_MAX_BURST_SIZE>(
+            dst_unicast_endpoint, buffer_size, {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
+        noc.async_write_with_state<Noc::ResponseMode::NON_POSTED, NOC_MAX_BURST_SIZE>(
+            local_buffer,
+            dst_unicast_endpoint,
+            buffer_size,
+            {},
+            {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
+        noc.async_write_barrier();
     } else {
         noc.async_write(
             local_buffer,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -69,6 +69,7 @@ void kernel_main() {
     std::uint32_t mcast_dst_end_x = get_arg(args::mcast_dst_end_x);
     std::uint32_t mcast_dst_end_y = get_arg(args::mcast_dst_end_y);
     bool use_write_with_state = static_cast<bool>(get_arg(args::use_write_with_state));
+    bool use_inline_dw_write_from_state = static_cast<bool>(get_arg(args::use_inline_dw_write_from_state));
 
     // We will assert later. This kernel will hang.
     // Need to signal completion to dispatcher before hanging so that
@@ -147,6 +148,19 @@ void kernel_main() {
             {},
             {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
         noc.async_write_barrier();
+    } else if (use_inline_dw_write_from_state) {
+        // Mirror cq_noc_inline_dw_write_with_state: program the inline-write destination into the WR_REG
+        // command buffer, then sanitize it straight from those registers via DEBUG_SANITIZE_NOC_ADDR_FROM_STATE
+        // (the macro under test). The destination coordinate is invalid, so the sanitizer must flag the
+        // programmed target. We never issue the write -- the sanitizer hangs first, matching cq's
+        // sanitize-before-send ordering.
+        uint64_t dst = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
+        noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(
+            dst, local_buffer[0], 0xF, NCRISC_WR_REG_CMD_BUF, noc_index);
+        // set_state leaves NOC_TARG_ADDR_MID untouched; zero it so the reconstructed 64-bit address is
+        // deterministic (inline writes target a 32-bit L1 destination, i.e. MID == 0).
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, 0);
+        DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, NCRISC_WR_REG_CMD_BUF);
     } else {
         noc.async_write(
             local_buffer,

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -675,12 +675,15 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
         NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO),                                             \
         NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_AT_LEN_BE),                                                \
         false);
+// Used for inline writes, whose destination (coordinate + address) lives in NOC_TARG_ADDR. The low 32 bits
+// (NOC_TARG_ADDR_LO) must be OR'd in: a stray comma operator previously discarded them, leaving the local
+// offset reading as 0 and defeating the address check.
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                   \
     DEBUG_SANITIZE_NOC_ADDR(                                                                                  \
         noc_id,                                                                                               \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_MID) << 32) |                      \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO), false),                       \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO)),                              \
         4);
 #define DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, check_linked)                                                     \
     debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
@@ -743,29 +746,30 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
             l,                                                                                                         \
             false);                                                                                                    \
     }
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)            \
-    {                                                                                                           \
-        while (!noc_cmd_buf_ready(noc_id, write_cmd_buf));                                                      \
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                  \
-            noc_id,                                                                                             \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_COORDINATE)                    \
-             << NOC_ADDR_COORD_SHIFT) |                                                                         \
-                ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower, \
-            worker_a,                                                                                           \
-            NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE),                                         \
-            false);                                                                                             \
+// For a (non-inline) write the destination NoC coordinate lives in NOC_RET_ADDR; NOC_TARG_ADDR holds the
+// local source address and the initiating NIU's own coordinate (the write-ack return target). Reconstruct the
+// destination from NOC_RET_ADDR so the sanitizer checks/reports the real target, not the sender's own core.
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)                   \
+    {                                                                                                                  \
+        while (!noc_cmd_buf_ready(noc_id, write_cmd_buf));                                                             \
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                         \
+            noc_id,                                                                                                    \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+                ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_MID) << 32) | noc_a_lower,         \
+            worker_a,                                                                                                  \
+            NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE),                                                \
+            false);                                                                                                    \
     }
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                  \
-    {                                                                                                           \
-        while (!noc_cmd_buf_ready(noc_id, write_cmd_buf));                                                      \
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                  \
-            noc_id,                                                                                             \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_COORDINATE)                    \
-             << NOC_ADDR_COORD_SHIFT) |                                                                         \
-                ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_MID) << 32) | noc_a_lower, \
-            worker_a,                                                                                           \
-            l,                                                                                                  \
-            false);                                                                                             \
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)                         \
+    {                                                                                                                  \
+        while (!noc_cmd_buf_ready(noc_id, write_cmd_buf));                                                             \
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_(                                                                         \
+            noc_id,                                                                                                    \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+                ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_MID) << 32) | noc_a_lower,         \
+            worker_a,                                                                                                  \
+            l,                                                                                                         \
+            false);                                                                                                    \
     }
 #define DEBUG_INSERT_DELAY(transaction_type) debug_insert_delay(transaction_type)
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) debug_throw_on_dram_addr(noc_id, addr, l)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The watcher NoC sanitizer reconstructs each transaction by reading back the NIU
command-buffer registers (see `tt_metal/hw/inc/internal/debug/sanitize.h`). Two of
those reconstructions read the wrong register, so the sanitizer checked/reported a
bogus address.

Per the ISA docs (`tt-isa-documentation/BlackholeA0/NoC/MemoryMap.md`, the
"`NOC_TARG_ADDR` and `NOC_RET_ADDR`" table), the two address registers swap roles
between reads and writes:

| Request | Remote endpoint (the "noc addr") | Local endpoint |
|---|---|---|
| Read | `NOC_TARG_ADDR` (source) | `NOC_RET_ADDR` |
| Write, non-inline | `NOC_RET_ADDR` (dest) | `NOC_TARG_ADDR_LO` = source; `NOC_TARG_ADDR_HI` = ack-return (sender's own coord) |
| Write, inline | `NOC_TARG_ADDR` (dest) | data in `NOC_AT_DATA` |

This is confirmed by the firmware: `ncrisc_noc_write_set_state` programs the write
destination coordinate into `NOC_RET_ADDR_COORDINATE`/`MID` and never touches
`NOC_TARG_ADDR_COORDINATE`.

**Bug 1 — stateful writes reconstructed from the wrong register.**
`DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE` and
`..._WITH_ADDR_STATE` read the destination coordinate from `NOC_TARG_ADDR`. For a
non-inline write that register holds the local source address and the initiating
NIU's own coordinate (the write-ack return target), so the sanitizer checked/
reported the **sender's own core** instead of the real destination — masking
bad-target writes and producing misleading watcher dumps. Fixed to read
`NOC_RET_ADDR`, matching the already-correct non-stateful
`DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE`.

**Bug 2 — inline-write reconstruction dropped the low address bits.**
`DEBUG_SANITIZE_NOC_ADDR_FROM_STATE` (inline dw write path) reads the correct
register (`NOC_TARG_ADDR` for inline writes), but a stray comma operator
`((uint64_t)NOC_CMD_BUF_READ_REG(..., NOC_TARG_ADDR_LO), false)` discarded the
read value and OR'd in `false`, forcing the local offset to `0`. The destination
offset was therefore never validated (and for an L1/overlay target the zeroed
offset can spuriously trip the underflow/mailbox check). Fixed by OR-ing in the
low bits. This macro only compiles under watcher NoC sanitization.

### Notes for reviewers
- Core change is `tt_metal/hw/inc/internal/debug/sanitize.h`; please sanity-check
  the register choices against the ISA table above.
- Two device regression tests were added (both verified to fail on the unfixed
  sanitizer and pass on the fix; both fault deterministically, so no hang/timeout):
  - **`TensixTestWatcherSanitizeNOCWriteWithState`** (Bug 1): a stateful write
    (`set_async_write_state` + `async_write_with_state`) to non-existent core
    `(26,18)` with a zero offset. Unfixed: watcher reports the *sender's* coords
    `1-2` ("overwrites mailboxes"). Fixed: reports the real destination `26-18`
    ("did not map to any known core").
  - **`TensixTestWatcherSanitizeNOCInlineWriteFromState`** (Bug 2): mirrors
    `cq_noc_inline_dw_write_with_state` — the inline-write destination is
    programmed into the WR_REG command buffer (`noc_inline_dw_write_set_state`)
    and then sanitized straight from those registers via
    `DEBUG_SANITIZE_NOC_ADDR_FROM_STATE`. The coordinate is invalid and the offset
    is nonzero, so the reported `[addr=...]` discriminates the bug. Unfixed:
    `[addr=0x00000000]` (offset dropped). Fixed: the real offset
    (`[addr=0x00135000]`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/noc-sanitizer-targ-ret-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/noc-sanitizer-targ-ret-fix)