### PR TITLE
Fix DeepSeek MLA SDPA chunk sizes

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -7,6 +7,8 @@ Optimal matmul and SDPA configurations for the MLA module, keyed by local sequen
 and op_unit_tests/test_ring_joint_mla.py.
 
 Production local seq_len values:
+  - 128k total / 8 SP devices = 16384 per device
+  - 100k total / 8 SP devices = 12800 per device
   - 128k total / 32 SP devices = 4096 per device
   - 100k total / 32 SP devices = 3200 per device
 """
@@ -229,16 +231,26 @@ MLA_MATMUL_CONFIG = {
 
 
 MLA_SDPA_CONFIG = {
-    # From test_ring_joint_mla.py test_mla_sdpa_bh_galaxy
-    # 128k total seq_len → 4096 per device
-    4096: {
-        "q_chunk_size": 256,
-        "k_chunk_size": 128,
+    # Tuned for the Galaxy balanced MLA PCC path. The 8x4 max-sl cases hit the issue #45521 fallback.
+    # 128k total seq_len → 16384 per device on 8x4
+    16384: {
+        "q_chunk_size": 128,
+        "k_chunk_size": 320,
     },
-    # 100k total seq_len → 3200 per device
+    # 100k total seq_len → 12800 per device on 8x4
+    12800: {
+        "q_chunk_size": 160,
+        "k_chunk_size": 320,
+    },
+    # 128k total seq_len → 4096 per device on 32x4, or scaled 2x4
+    4096: {
+        "q_chunk_size": 128,
+        "k_chunk_size": 320,
+    },
+    # 100k total seq_len → 3200 per device on 32x4, or scaled 2x4
     3200: {
         "q_chunk_size": 160,
-        "k_chunk_size": 160,
+        "k_chunk_size": 320,
     },
 }
 


### PR DESCRIPTION
## Summary
- add MLA SDPA chunk configs for the 8x4 max-sl local sequence lengths that were falling back to 32/32
- update the existing 32x4/scaled local sequence configs to the tuned chunk sizes

Fixes #45521

## Testing
- `python -m py_compile models/demos/deepseek_v3_d_p/tt/mla/mla_config.py`
- imported `MLA_SDPA_CONFIG` and asserted expected entries for 16384, 12800, 4096, and 3200
- passed `(Galaxy) DeepSeek Prefill tests` with `test-type=mla`: https://github.com/tenstorrent/tt-metal/actions/runs/26705485306

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-45521-mla-sdpa-chunks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-45521-mla-sdpa-chunks)