### PR TITLE
[Feature]: Adding noc_traits_t for type-erased tensor accessor

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_all_pages_abstract_wrapper.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_all_pages_abstract_wrapper.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copies all pages from input to output tensor using AbstractTensorAccessorWrapper
+ * with the Device 2.0 Noc API (noc.async_read / noc.async_write).
+ *
+ * Builds a heterogeneous tuple of src/dst TensorAccessors, wraps them via
+ * make_abstract_tensor_accessor_wrappers, and selects src/dst at runtime by index.
+ */
+
+#include <cstdint>
+
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    auto args_src = TensorAccessorArgs<0, 0>();
+    auto args_dst = TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
+
+    const uint32_t cb_id = get_compile_time_arg_val(args_dst.next_compile_time_args_offset());
+    const uint32_t page_size = get_compile_time_arg_val(args_dst.next_compile_time_args_offset() + 1);
+    const uint32_t tensor_volume = get_compile_time_arg_val(args_dst.next_compile_time_args_offset() + 2);
+
+    const uint32_t input_base_address = get_common_arg_val<uint32_t>(0);
+    const uint32_t output_base_address = get_common_arg_val<uint32_t>(1);
+
+    const auto tensor_accessor_src = TensorAccessor(args_src, input_base_address);
+    const auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address);
+    const auto tensor_accessors_tuple = std::make_tuple(tensor_accessor_src, tensor_accessor_dst);
+    const auto abstract_tensor_accessor_wrappers = make_abstract_tensor_accessor_wrappers(tensor_accessors_tuple);
+
+    Noc noc(noc_index);
+    CircularBuffer cb(cb_id);
+
+    for (uint32_t page_id = 0; page_id < tensor_volume; ++page_id) {
+        cb.reserve_back(1);
+        noc.async_read(
+            abstract_tensor_accessor_wrappers[0],
+            cb,
+            page_size,
+            {.page_id = page_id},
+            {});
+        noc.async_read_barrier();
+        cb.push_back(1);
+
+        cb.wait_front(1);
+        noc.async_write(
+            cb,
+            abstract_tensor_accessor_wrappers[1],
+            page_size,
+            {},
+            {.page_id = page_id});
+        noc.async_write_barrier();
+        cb.pop_front(1);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -406,6 +406,73 @@ static void test_single_core_copy(
     EXPECT_EQ(output_vec, src);
 }
 
+template <typename T>
+static void test_single_core_copy_abstract_wrapper(
+    const CopyParams& params, tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    MemoryConfig mem_config = MemoryConfig(TensorMemoryLayout::INTERLEAVED, params.buffer_type);
+    TensorSpec tensor_spec(params.tensor_shape, TensorLayout(params.dtype, PageConfig(params.layout), mem_config));
+
+    const auto src = tt::test_utils::generate_uniform_random_vector<T>(0, UINT8_MAX, params.tensor_shape.volume());
+
+    auto input_tensor = Tensor::from_vector(src, tensor_spec, mesh_device);
+    auto output_tensor = Tensor::from_vector(std::vector<T>(params.tensor_shape.volume()), tensor_spec, mesh_device);
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto aligned_page_size = input_buffer->aligned_page_size();
+    if (output_buffer->aligned_page_size() != aligned_page_size) {
+        GTEST_SKIP() << "Input and output buffers must have the same aligned page size!";
+    }
+
+    auto program = CreateProgram();
+
+    constexpr CoreCoord grid = {0, 0};
+    const auto data_format = datatype_to_dataformat_converter(params.dtype);
+
+    constexpr auto num_tiles = 2;
+    CBHandle cb_idx = tt::CBIndex::c_0;
+    auto cb_config = CircularBufferConfig(aligned_page_size * num_tiles, {{cb_idx, data_format}})
+                         .set_page_size(cb_idx, aligned_page_size);
+    CreateCircularBuffer(program, grid, cb_config);
+
+    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
+    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+
+    std::vector<uint32_t> compile_time_args = input_accessor_args.get_compile_time_args();
+    const auto output_compile_time_args = output_accessor_args.get_compile_time_args();
+    compile_time_args.insert(
+        compile_time_args.end(), output_compile_time_args.begin(), output_compile_time_args.end());
+    compile_time_args.push_back(cb_idx);
+    compile_time_args.push_back(aligned_page_size);
+    compile_time_args.push_back(input_buffer->num_pages());
+
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/copy_all_pages_abstract_wrapper.cpp",
+        grid,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_time_args,
+        });
+
+    std::vector<uint32_t> runtime_args{
+        input_buffer->address(),
+        output_buffer->address(),
+    };
+    SetCommonRuntimeArgs(program, kernel_id, runtime_args);
+
+    auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
+    mesh_workload.add_program(tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
+    EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, true);
+
+    auto output_tensor_cpu = output_tensor.cpu(true);
+    Tensor output_tensor_device = ttnn::distributed::get_device_tensors(output_tensor_cpu).front();
+    auto output_vec = output_tensor_device.to_vector<T>();
+
+    EXPECT_EQ(output_vec, src);
+}
+
 }  // namespace tensor_accessor_device_tests
 
 using namespace tensor_accessor_device_tests;
@@ -714,6 +781,17 @@ TEST_P(InterleavedAccessorTestsCopyOnDevice, SingleCoreCopyAllPages) {
         case DataType::UINT8: test_single_core_copy<uint8_t>(params, mesh_device_.get(), true); break;
         case DataType::UINT16: test_single_core_copy<uint16_t>(params, mesh_device_.get(), true); break;
         case DataType::BFLOAT16: test_single_core_copy<bfloat16>(params, mesh_device_.get(), true); break;
+        default: TT_THROW("Unsupported data type");
+    }
+}
+
+TEST_P(InterleavedAccessorTestsCopyOnDevice, SingleCoreCopyAllPagesAbstractWrapper) {
+    const auto& params = GetParam();
+
+    switch (params.dtype) {
+        case DataType::UINT8: test_single_core_copy_abstract_wrapper<uint8_t>(params, mesh_device_.get()); break;
+        case DataType::UINT16: test_single_core_copy_abstract_wrapper<uint16_t>(params, mesh_device_.get()); break;
+        case DataType::BFLOAT16: test_single_core_copy_abstract_wrapper<bfloat16>(params, mesh_device_.get()); break;
         default: TT_THROW("Unsupported data type");
     }
 }

--- a/tt_metal/hw/inc/api/tensor/noc_traits.h
+++ b/tt_metal/hw/inc/api/tensor/noc_traits.h
@@ -25,9 +25,8 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const TensorAccessor<DSpecT>& dst, const Noc& noc, const dst_args_type& args) {
@@ -35,9 +34,8 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
 };
 
@@ -57,9 +55,8 @@ struct noc_traits_t<PageView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const PageView<Accessor>& dst, const Noc& noc, const dst_args_type& args) {
@@ -67,9 +64,8 @@ struct noc_traits_t<PageView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
 };
 
@@ -90,9 +86,8 @@ struct noc_traits_t<ShardView<Accessor>> {
             ASSERT(src.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const ShardView<Accessor>& dst, const Noc& noc, const dst_args_type& args) {
@@ -101,9 +96,8 @@ struct noc_traits_t<ShardView<Accessor>> {
             ASSERT(dst.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
 };
 
@@ -121,9 +115,8 @@ struct noc_traits_t<tensor_accessor::Page> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
     }
     template <Noc::AddressType address_type>
     static auto dst_addr(const tensor_accessor::Page& dst, const Noc& noc, const dst_args_type& args) {
@@ -131,8 +124,39 @@ struct noc_traits_t<tensor_accessor::Page> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
             return static_cast<uint32_t>(noc_addr);
-        } else {
-            return noc_addr;
         }
+        return noc_addr;
+    }
+};
+
+template <>
+struct noc_traits_t<AbstractTensorAccessorWrapper> {
+    struct src_args_type {
+        uint32_t page_id{};
+        uint32_t offset_bytes = 0;
+    };
+    struct dst_args_type {
+        uint32_t page_id{};
+        uint32_t offset_bytes = 0;
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(
+        const AbstractTensorAccessorWrapper& src, const Noc& noc, const src_args_type& args) {
+        uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
+        if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
+            ASSERT(noc.is_local_addr(noc_addr));
+            return static_cast<uint32_t>(noc_addr);
+        }
+        return noc_addr;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(
+        const AbstractTensorAccessorWrapper& dst, const Noc& noc, const dst_args_type& args) {
+        uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
+        if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
+            ASSERT(noc.is_local_addr(noc_addr));
+            return static_cast<uint32_t>(noc_addr);
+        }
+        return noc_addr;
     }
 };


### PR DESCRIPTION
### Summary
Dev 2.0 apis resolve addresses through `noc_traits_t<T>` but `AbstractTensorAccessorWrapper` wasn't supported. Kernels with heterogeneous tensor accessors (different DSpecs, selected at runtime) already use the wrapper for type erasure, but could not migrate to newer APIs. 

Add noc_traits_t<AbstractTensorAccessorWrapper> that forwards to the wrapper’s type-erased get_noc_addr(page_id, offset, noc)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/abstract-ta)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/abstract-ta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/abstract-ta)