### PR TITLE
[skip ci] Disable MeshWatcherDumpAllFixture.TestWatcherTileCounterLog* in runtime-unit-tests runtime_sd_debug_tools_device_dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -201,6 +201,7 @@ public:
 class MeshWatcherDumpAllFixture : public MeshWatcherFixture {
 protected:
     void SetUp() override {
+        GTEST_SKIP() << "Disabled: see #45675";
         MeshWatcherFixture::SetUp();
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_dump_all(true);
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -193,6 +193,7 @@ void RunTest(
 
 // Test bypass mode (strided consumer access pattern)
 TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogBypass) {
+    GTEST_SKIP() << "Disabled: see #45675";
     const auto& hal = MetalContext::instance().hal();
     if (!hal.has_tile_counter_registers()) {
         GTEST_SKIP() << "Tile counters are only used on Quasar";
@@ -208,6 +209,7 @@ TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogBypass) {
 
 // Test remapper mode (blocked consumer access pattern)
 TEST_F(MeshWatcherDumpAllFixture, TestWatcherTileCounterLogRemapper) {
+    GTEST_SKIP() << "Disabled: see #45675";
     const auto& hal = MetalContext::instance().hal();
     if (!hal.has_tile_counter_registers()) {
         GTEST_SKIP() << "Tile counters are only used on Quasar";


### PR DESCRIPTION
Disable `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogBypass` and `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogRemapper` in `runtime-unit-tests` `runtime_sd_debug_tools_device_dispatch` on `wh_n150_civ2` and `wh_n300_civ2`. Tracked in issue #45675.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogBypass` [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372142 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:45 UTC |
| `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogBypass` [wh_n300_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372144 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:45 UTC |
| `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogRemapper` [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372142 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:45 UTC |
| `MeshWatcherDumpAllFixture.TestWatcherTileCounterLogRemapper` [wh_n300_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372144 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:45 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-unit-tests-mesh-watcher-tile-counter-20260601)