### PR TITLE
[skip ci] Disable deepseek test_generator_vllm.py tests in t3000-integration-tests t3k_deepseek_module_tests

### DIFF
--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -14,6 +14,7 @@ from models.demos.deepseek_v3.tt import generator_vllm as generator_vllm_module
 pytestmark = pytest.mark.t3k_compat
 
 
+@pytest.mark.skip(reason="Disabled: see #45677")
 def test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
@@ -43,6 +44,7 @@ def test_deepseek_generator_exposes_max_tokens_all_users_capability() -> None:
     assert generator_vllm_module.DeepseekGenerator.get_max_tokens_all_users() == FALLBACK_MAX_TOKENS_ALL_USERS
 
 
+@pytest.mark.skip(reason="Disabled: see #45677")
 def test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: True)
 
@@ -56,6 +58,7 @@ def test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole(monkeypatch:
     )
 
 
+@pytest.mark.skip(reason="Disabled: see #45677")
 def test_get_max_tokens_all_users_uses_fallback_for_other_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: False)
 


### PR DESCRIPTION
Disable 3 deterministically failing tests in `models/demos/deepseek_v3/tests/test_generator_vllm.py` in `t3000-integration-tests` `t3k_deepseek_module_tests [wh_llmbox]`. Tracked in issue #45677.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/deepseek_v3/tests/test_generator_vllm.py::test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache` [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26728843280/job/78769290307 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 01:16 UTC |
| `models/demos/deepseek_v3/tests/test_generator_vllm.py::test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole` [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26728843280/job/78769290307 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 01:16 UTC |
| `models/demos/deepseek_v3/tests/test_generator_vllm.py::test_get_max_tokens_all_users_uses_fallback_for_other_configs` [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26728843280/job/78769290307 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 01:16 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-integration-tests-deepseek-vllm-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-integration-tests-deepseek-vllm-20260601)