### PR TITLE
[Bugfix] Fix issues with DFB endpoint invariant relaxation in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -551,7 +551,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingMixingComputeAndDMOnSameRoleFails) 
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     // Producer side mixes a DM and a compute kernel on disjoint zones. Each individually
     // would form a valid binding, but the DFB's hardware config carries a single producer
@@ -564,9 +564,9 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingMixingComputeAndDMOnSameRoleFails) 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(dm_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(compute_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    dm_producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    compute_producer.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
 
     spec.kernels = {dm_producer, compute_producer, consumer};
     spec.dataflow_buffers = {dfb};
@@ -2261,7 +2261,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingForcesUniformRiscMaskAcrossProducer
     NodeCoord node1{1, 0};
 
     ProgramSpec spec;
-    spec.program_id = "test_program";
+    spec.name = "test_program";
 
     auto producer_a = MakeMinimalDMKernel("producer_a", /*num_threads=*/1);
     auto producer_b = MakeMinimalDMKernel("producer_b", /*num_threads=*/1);
@@ -2271,9 +2271,9 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingForcesUniformRiscMaskAcrossProducer
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    BindDFBToKernel(producer_a, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(producer_b, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
-    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    producer_a.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    producer_b.dfb_bindings.push_back(ProducerOf("dfb", "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf("dfb", "in"));
     // unrelated_dm intentionally has no DFB bindings — it just consumes DM lanes on node0.
 
     spec.kernels = {producer_a, producer_b, unrelated_dm, consumer};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2012,7 +2012,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
 // ============================================================================
 // SECTION 6: Processor Assignment Edge Cases
 // ============================================================================
-// Here, we test two edge cases:
+// Here, we test several edge cases:
 //
 // A) ALGORITHM FAILURE
 //    The original naive greedy algorithm could either pass or fail on logically
@@ -2025,8 +2025,17 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
 //    Some strictly legal ProgramSpecs are unsolvable if we assume that a kernel
 //    must uses the same processor indices on all nodes it runs on.
 //
-// Our plan is to keep the simplifying assumption for now.
-// We issue a clear message if the assumption is ever violated in the real world.
+//    NOTE: Our plan is to keep the simplifying assumption for now.
+//    We issue a clear message if the assumption is ever violated in the real world.
+//
+// C) KERNELS COUPLED THROUGH MULTI-DFB BINDINGS
+//    Until LLK APIs adopt DFBAccessor, we cannot specialize DFBs (multiple DFBs
+//    for a single DataflowBufferSpec). This induces additional DM solver constraints
+//    when a DFB endpoint is bound by more than one KernelSpec.
+//
+//    NOTE: The plan is to lift this artificial constraint once LLK support is in
+//    place. DFB IDs will then be passed as implicit RTAs rather than implicit CTAs
+//    on Quasar only.
 
 // Category A: Order-Independence Test
 // This test verifies that the backtracking solver finds valid assignments,
@@ -2191,6 +2200,51 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("Failed to find valid processor assignments for DM kernels")));
+}
+
+// Category C: Coupling-group constraint exercised
+// Multi-bound same-role DM kernels must end up with identical DM RISC masks (the DFB's
+// hardware config carries one producer_risc_mask / consumer_risc_mask per side). The
+// solver implements this by treating each coupling-group equivalence class as a single
+// "super-kernel" with merged node coverage. Without that constraint, an unrelated DM
+// kernel competing for lanes on one zone could push the producers to different lanes on
+// their respective nodes — passing the greedy assignment but failing per-role mask
+// uniformity.
+TEST_F(ProgramSpecTestQuasar, DFBMultiBindingForcesUniformRiscMaskAcrossProducers) {
+    // Scenario: zone-specialized DM producers (producer_a on node0, producer_b on node1)
+    // both bound as PRODUCER of the same DFB. An unrelated 2-thread DM kernel on node0
+    // consumes lanes DM2-DM3 (the lanes the un-constrained solver would greedily hand to
+    // producer_a). If the producers weren't coupled, producer_a would get bumped to DM4
+    // on node0 while producer_b kept DM2 on node1 — different masks. The coupling-group
+    // solver instead picks a lane available on BOTH producer nodes first, then lets the
+    // unrelated kernel work around it.
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    auto producer_a = MakeMinimalDMKernel("producer_a", /*num_threads=*/1);
+    auto producer_b = MakeMinimalDMKernel("producer_b", /*num_threads=*/1);
+    auto unrelated_dm = MakeMinimalDMKernel("unrelated_dm", /*num_threads=*/2);
+    auto consumer = MakeMinimalComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(producer_a, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(producer_b, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+    // unrelated_dm intentionally has no DFB bindings — it just consumes DM lanes on node0.
+
+    spec.kernels = {producer_a, producer_b, unrelated_dm, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"producer_a", "unrelated_dm", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"producer_b", "consumer"}),
+    };
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -375,7 +375,9 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
     spec.name = "test_program";
 
     auto producer = MakeMinimalDMKernel("producer");
-    auto consumer1 = MakeMinimalComputeKernel("consumer1");
+    // Both consumers DM (same kind) so the per-role kind-uniformity check passes and the
+    // WU-disjointness check is what fires.
+    auto consumer1 = MakeMinimalDMKernel("consumer1");
     auto consumer2 = MakeMinimalDMKernel("consumer2");
 
     auto dfb = MakeMinimalDFB("dfb");
@@ -544,6 +546,40 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
             ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs with mismatched num_threads")));
 }
 
+TEST_F(ProgramSpecTestQuasar, DFBMultiBindingMixingComputeAndDMOnSameRoleFails) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+
+    ProgramSpec spec;
+    spec.program_id = "test_program";
+
+    // Producer side mixes a DM and a compute kernel on disjoint zones. Each individually
+    // would form a valid binding, but the DFB's hardware config carries a single producer
+    // processor mask per role; the two kinds occupy disjoint mask bit ranges and cannot
+    // share a mask. The validator must reject upfront.
+    auto dm_producer = MakeMinimalDMKernel("dm_producer");
+    auto compute_producer = MakeMinimalComputeKernel("compute_producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    BindDFBToKernel(dm_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(compute_producer, "dfb", "out", KernelSpec::DFBEndpointType::PRODUCER);
+    BindDFBToKernel(consumer, "dfb", "in", KernelSpec::DFBEndpointType::CONSUMER);
+
+    spec.kernels = {dm_producer, compute_producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("wu_g1", node0, {"dm_producer", "consumer"}),
+        MakeMinimalWorkUnit("wu_g2", node1, {"compute_producer", "consumer"}),
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("mixing compute and data-movement kinds")));
+}
+
 TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
@@ -588,9 +624,12 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
     // an unrelated producer-only kernel is bound, while extra_consumer covers the consume side.
     // Producer set = {self_loop_1, extra_producer}; consumer set = {self_loop_1, extra_consumer}.
     // The sets are not equal — the self-loop multi-binding rule rejects this mix.
-    auto self_loop_1 = MakeMinimalComputeKernel("self_loop_1");
+    //
+    // All three kernels are DM (an unusual self-loop pattern but mechanically valid) so the
+    // per-role kind-uniformity check passes and the self-loop refinement check is reached.
+    auto self_loop_1 = MakeMinimalDMKernel("self_loop_1");
     auto extra_producer = MakeMinimalDMKernel("extra_producer");
-    auto extra_consumer = MakeMinimalComputeKernel("extra_consumer");
+    auto extra_consumer = MakeMinimalDMKernel("extra_consumer");
 
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -40,6 +40,7 @@
 //   It is legal to bind more than one KernelSpec producer (or consumer) to a
 //   DFB endpoint, provided that they have:
 //     - non-overlapping node coverage, AND
+//     - the same kernel kind (compute or data movement), AND
 //     - identical binding-site parameters (access_pattern, num_threads)
 //
 // INSTANCING: Like KernelSpec, a DataflowBufferSpec is a *per-node template*.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -6,6 +6,7 @@
 #include <bit>
 #include <functional>
 #include <limits>
+#include <numeric>
 #include <set>
 #include <string_view>
 #include <unordered_set>
@@ -127,8 +128,9 @@ struct ProcessorMask {
 using DMProcessorMask = ProcessorMask<QUASAR_DM_CORES_PER_NODE>;
 using ComputeEngineMask = ProcessorMask<QUASAR_TENSIX_ENGINES_PER_NODE>;
 
-// Kernel -> ProcessorMask maps (Gen2/Quasar only)
-using DMProcessorMaskMap = std::unordered_map<const KernelSpec*, DMProcessorMask>;
+// Kernel -> ProcessorMask map (Gen2/Quasar only).
+// DM masks flow through KernelCouplingGroup (equivalence class) rather than per-KernelSpec, so the DM
+// counterpart of this map is defined in the dm_solver namespace and keyed by KernelCouplingGroup*.
 using ComputeEngineMaskMap = std::unordered_map<const KernelSpec*, ComputeEngineMask>;
 
 // Kernel -> DFB risc mask (passed to MakeDataflowBufferConfig)
@@ -1564,6 +1566,25 @@ namespace dm_solver {
 // WorkUnitSpec target_nodes). Used by the solver to read each kernel's placement.
 using KernelNodeSetMap = std::unordered_map<KernelSpecName, NodeRangeSet>;
 
+// Equivalence class of DM kernels coupled by shared DFB endpoint roles.
+//
+// All DM kernels bound to the same DFB on the same role (PRODUCER/CONSUMER) must end up
+// with identical DM RISC masks — the DFB's hardware config carries a single mask per role.
+// Membership is computed by union-find over DM kernels: two kernels are merged if they share
+// any DFB endpoint role; the transitive closure yields KernelCouplingGroups.
+//
+// num_threads is uniform within a group (the per-DFB-side num_threads validator + transitive
+// equality guarantees this for any chain of shared endpoints).
+//
+// The DM solver operates on KernelCouplingGroups instead of individual KernelSpecs: each group is
+// assigned one DMProcessorMask, which then applies to every member. A non-multi-bound DM
+// kernel ends up in a singleton group.
+struct KernelCouplingGroup {
+    std::vector<const KernelSpec*> members;  // ≥ 1; canonical member is members.front()
+    NodeRangeSet merged_node_set;            // union of members' node sets
+    uint8_t num_threads = 0;                 // shared across members
+};
+
 // State for tracking per-node processor usage
 class NodeUsageTracker {
 public:
@@ -1609,109 +1630,212 @@ private:
     std::map<NodeCoord, DMProcessorMask> node_used_masks_;
 };
 
-// Constraint score for sorting: higher = more constrained (RISC cores should be assigned earlier)
-int ConstraintScore(const KernelSpec* k, const NodeRangeSet& kernel_nodes) {
-    int node_count = static_cast<int>(kernel_nodes.num_cores());
-    int thread_count = static_cast<int>(k->num_threads);
+// Result map: one DMProcessorMask per KernelCouplingGroup (which expands to its member kernels).
+using KernelCouplingGroupMaskMap = std::unordered_map<const KernelCouplingGroup*, DMProcessorMask>;
+
+// Constraint score for sorting: higher = more constrained (assigned earlier)
+int ConstraintScore(const KernelCouplingGroup* g) {
+    int node_count = static_cast<int>(g->merged_node_set.num_cores());
+    int thread_count = static_cast<int>(g->num_threads);
     return (node_count * 100) + thread_count;  // nodes dominate, threads break ties
 }
 
-void SortByConstraint(std::vector<const KernelSpec*>& kernels, const KernelNodeSetMap& kernel_node_set) {
-    std::sort(kernels.begin(), kernels.end(), [&kernel_node_set](const KernelSpec* a, const KernelSpec* b) {
-        int score_a = ConstraintScore(a, kernel_node_set.at(a->unique_id));
-        int score_b = ConstraintScore(b, kernel_node_set.at(b->unique_id));
+// Deterministic tiebreaker: sort by the lexicographically-smallest member unique_id.
+// Group::members is canonicalized at construction time so members.front() is the sort key.
+const std::string& group_sort_key(const KernelCouplingGroup* g) { return g->members.front()->unique_id; }
+
+void SortByConstraint(std::vector<const KernelCouplingGroup*>& groups) {
+    std::sort(groups.begin(), groups.end(), [](const KernelCouplingGroup* a, const KernelCouplingGroup* b) {
+        int score_a = ConstraintScore(a);
+        int score_b = ConstraintScore(b);
         if (score_a != score_b) {
             return score_a > score_b;  // Higher score first
         }
-        // In the case of a tie, use unique_id as (deterministic) tiebreaker
-        return a->unique_id < b->unique_id;
+        return group_sort_key(a) < group_sort_key(b);
     });
 }
 
-// Try to assign all kernels in the given order using greedy selection
-// Returns true if successful, populates result map
+// Try to assign all groups in the given order using greedy selection.
+// Returns true if successful, populates result map.
 bool TryGreedyAssignment(
-    const std::vector<const KernelSpec*>& kernel_order,
-    const KernelNodeSetMap& kernel_node_set,
+    const std::vector<const KernelCouplingGroup*>& group_order,
     NodeUsageTracker& tracker,
-    DMProcessorMaskMap& result) {
-    for (const KernelSpec* kernel : kernel_order) {
-        const NodeRangeSet& target_nodes = kernel_node_set.at(kernel->unique_id);
-        DMProcessorMask combined_used = tracker.get_combined_used_mask(target_nodes);
+    KernelCouplingGroupMaskMap& result) {
+    for (const KernelCouplingGroup* group : group_order) {
+        DMProcessorMask combined_used = tracker.get_combined_used_mask(group->merged_node_set);
 
-        auto selected = ReserveProcessors(kernel->num_threads, combined_used);
+        auto selected = ReserveProcessors(group->num_threads, combined_used);
         if (!selected.has_value()) {
-            return false;  // Can't assign this kernel
+            return false;  // Can't assign this group
         }
 
-        result[kernel] = selected.value();
-        tracker.mark_used(target_nodes, selected.value());
+        result[group] = selected.value();
+        tracker.mark_used(group->merged_node_set, selected.value());
     }
     return true;
 }
 
-// Backtracking solver over kernel orderings
-// Note: In the worst case, this is O(N!) in the number of kernels.
+// Backtracking solver over kernel coupling group orderings.
+// Note: In the worst case, this is O(N!) in the number of groups.
 //       In practice, I expect this will almost always solve in the first greedy attempt (if sorted).
 //       The backtracking is just here for pathological cases.
-//       Even then, it shouldn't be horrendous. We won't have a a huge number of kernels in a ProgramSpec.
+//       Even then, it shouldn't be horrendous. We won't have a huge number of kernels in a ProgramSpec.
 //       And in the common case (traced), Program creation isn't on the critical path.
 //       We can revisit if this ever becomes a problem.
 bool SolveWithOrderingBacktrack(
-    std::vector<const KernelSpec*> kernels,  // by value - we'll permute it
-    const KernelNodeSetMap& kernel_node_set,
+    std::vector<const KernelCouplingGroup*> groups,  // by value - we'll permute it
     NodeUsageTracker& tracker,
-    DMProcessorMaskMap& result) {
+    KernelCouplingGroupMaskMap& result) {
     // Try current ordering
-    if (TryGreedyAssignment(kernels, kernel_node_set, tracker, result)) {
+    if (TryGreedyAssignment(groups, tracker, result)) {
         return true;
     }
 
-    // Backtrack: try all permutations
-    // (std::next_permutation requires sorted input)
-    // Sort by unique_id for deterministic permutation order
-    auto by_name = [](const KernelSpec* a, const KernelSpec* b) { return a->unique_id < b->unique_id; };
-    std::sort(kernels.begin(), kernels.end(), by_name);
+    // Backtrack: try all permutations.
+    // (std::next_permutation requires sorted input.)
+    auto by_name = [](const KernelCouplingGroup* a, const KernelCouplingGroup* b) {
+        return group_sort_key(a) < group_sort_key(b);
+    };
+    std::sort(groups.begin(), groups.end(), by_name);
     do {
         tracker.reset();
         result.clear();
-        if (TryGreedyAssignment(kernels, kernel_node_set, tracker, result)) {
+        if (TryGreedyAssignment(groups, tracker, result)) {
             return true;
         }
-    } while (std::next_permutation(kernels.begin(), kernels.end(), by_name));
+    } while (std::next_permutation(groups.begin(), groups.end(), by_name));
 
     return false;
+}
+
+// Build DM kernel groups via union-find over shared DFB endpoint roles.
+//
+// Two DM kernels are merged if they share a DFB endpoint role (both PRODUCER of the same DFB,
+// or both CONSUMER of the same DFB). The transitive closure yields equivalence classes.
+//
+// Compute kernels are not eligible — they don't participate in the DM solver. (Compute kernels
+// bound to the same DFB role share num_threads, which makes AssignComputeProcessors deterministic
+// across them, so no equivalence-class machinery is needed for compute.)
+std::vector<KernelCouplingGroup> BuildDMKernelCouplingGroups(
+    const std::vector<const KernelSpec*>& dm_kernels,
+    const CollectedSpecData& collected,
+    const KernelNodeSetMap& kernel_node_set) {
+    // Small N — flat union-find indexed by position in dm_kernels.
+    std::unordered_map<const KernelSpec*, size_t> idx_of;
+    idx_of.reserve(dm_kernels.size());
+    for (size_t i = 0; i < dm_kernels.size(); ++i) {
+        idx_of[dm_kernels[i]] = i;
+    }
+
+    std::vector<size_t> parent(dm_kernels.size());
+    std::iota(parent.begin(), parent.end(), size_t{0});
+    auto find = [&parent](size_t x) {
+        while (parent[x] != x) {
+            parent[x] = parent[parent[x]];  // path compression
+            x = parent[x];
+        }
+        return x;
+    };
+    auto unite = [&](size_t a, size_t b) {
+        size_t ra = find(a), rb = find(b);
+        if (ra != rb) {
+            parent[ra] = rb;
+        }
+    };
+
+    // For each DFB, union all DM kernels on each side (PRODUCER, CONSUMER) independently.
+    auto union_same_side = [&](const auto& endpoints) {
+        std::optional<size_t> anchor;
+        for (const auto& rec : endpoints) {
+            if (!rec.kernel->is_dm_kernel()) {
+                continue;
+            }
+            const size_t k = idx_of.at(rec.kernel);
+            if (!anchor.has_value()) {
+                anchor = k;
+            } else {
+                unite(anchor.value(), k);
+            }
+        }
+    };
+    for (const auto& [dfb_name, endpoint_info] : collected.dfb_endpoints) {
+        union_same_side(endpoint_info.producers);
+        union_same_side(endpoint_info.consumers);
+    }
+
+    // Collect classes: root index → group.
+    // Iterate dm_kernels in given order to preserve a deterministic per-class member order.
+    std::unordered_map<size_t, size_t> root_to_group_idx;
+    std::vector<KernelCouplingGroup> groups;
+    for (size_t i = 0; i < dm_kernels.size(); ++i) {
+        const size_t r = find(i);
+        auto [it, inserted] = root_to_group_idx.try_emplace(r, groups.size());
+        if (inserted) {
+            groups.emplace_back();
+        }
+        groups[it->second].members.push_back(dm_kernels[i]);
+    }
+
+    // Finalize each group: merged_node_set + num_threads + canonical member sort.
+    for (auto& g : groups) {
+        std::sort(g.members.begin(), g.members.end(), [](const KernelSpec* a, const KernelSpec* b) {
+            return a->unique_id < b->unique_id;
+        });
+        for (const KernelSpec* k : g.members) {
+            g.merged_node_set = g.merged_node_set.merge(kernel_node_set.at(k->unique_id));
+        }
+        g.num_threads = g.members.front()->num_threads;
+    }
+    return groups;
 }
 
 }  // namespace dm_solver
 
 // Gen2 (Quasar) processor assignment: runs the backtracking DM solver and returns
 // a KernelRiscMaskMap using the Gen2 bit encoding (DM: bits 0-7, compute: bits 8-15).
+//
+// The DM solver operates on KernelCouplingGroups (equivalence classes of DM kernels coupled by shared
+// DFB endpoint roles), not individual kernels. Each group is assigned one DMProcessorMask
+// which then applies to every member kernel. This ensures multi-bound same-role kernels end
+// up with identical masks, matching the per-side single-mask shape of DataflowBufferConfig.
 KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const CollectedSpecData& collected) {
-    DMProcessorMaskMap dm_assignments;
     ComputeEngineMaskMap compute_assignments;
 
-    // Collect DM kernels and compute kernels separately
+    // Collect DM kernels and compute kernels separately.
+    // Compute kernels get a deterministic per-kernel mask (one compute kernel per node assumption;
+    // num_threads uniformity is enforced upstream, so same-role compute kernels get identical masks
+    // without any coupling-group machinery).
     std::vector<const KernelSpec*> dm_kernels;
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             dm_kernels.push_back(&kernel);
         } else {
-            // Compute kernels: trivial assignment (one compute kernel per node assumption)
             compute_assignments[&kernel] = AssignComputeProcessors(&kernel, kernel.unique_id);
         }
+    }
+
+    // Build DM kernel groups (equivalence classes via shared DFB endpoint roles).
+    // Each group's merged_node_set is the union of its members' node sets — the solver
+    // will pick a mask that's free on every node in that union.
+    std::vector<dm_solver::KernelCouplingGroup> groups =
+        dm_solver::BuildDMKernelCouplingGroups(dm_kernels, collected, collected.kernel_node_set);
+
+    std::vector<const dm_solver::KernelCouplingGroup*> group_ptrs;
+    group_ptrs.reserve(groups.size());
+    for (const auto& g : groups) {
+        group_ptrs.push_back(&g);
     }
 
     // Sort by constraint score (most constrained first)
     constexpr bool kSortByConstraint = true;  // Toggle to disable upfront sorting
     if constexpr (kSortByConstraint) {
-        dm_solver::SortByConstraint(dm_kernels, collected.kernel_node_set);
+        dm_solver::SortByConstraint(group_ptrs);
     }
 
-    // Solve DM assignments
+    // Solve DM assignments at the group level
     dm_solver::NodeUsageTracker tracker;
-    bool success =
-        dm_solver::SolveWithOrderingBacktrack(dm_kernels, collected.kernel_node_set, tracker, dm_assignments);
+    dm_solver::KernelCouplingGroupMaskMap group_assignments;
+    bool success = dm_solver::SolveWithOrderingBacktrack(group_ptrs, tracker, group_assignments);
 
     TT_FATAL(
         success,
@@ -1719,10 +1843,12 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
         "Either the ProgramSpec is invalid, or that the \"same DM cores on every node\" "
         "simplifying assumption has been violated.");
 
-    // Convert to KernelRiscMaskMap using Gen2 bit encoding
+    // Convert to KernelRiscMaskMap using Gen2 bit encoding: expand each group's mask to all members.
     KernelRiscMaskMap result;
-    for (const auto& [kernel, mask] : dm_assignments) {
-        result[kernel] = mask.bits;  // DM processors in bits 0-7
+    for (const auto& [group, mask] : group_assignments) {
+        for (const KernelSpec* member : group->members) {
+            result[member] = mask.bits;  // DM processors in bits 0-7
+        }
     }
     for (const auto& [kernel, mask] : compute_assignments) {
         result[kernel] = static_cast<uint16_t>(mask.bits) << 8;  // Compute engines in bits 8-15
@@ -2325,26 +2451,19 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     KernelRiscMaskMap kernel_to_risc_mask =
         is_gen2_arch() ? SolveGen2KernelRiscMasks(spec, collected) : BuildGen1KernelRiscMasks(spec);
 
-    // Step 2a-bis: For multi-binding DFBs, all KernelSpecs on the same role must end up with
+    // Step 2b: For multi-binding DFBs, all KernelSpecs on the same role must end up with
     // identical risc_masks. The DFB has a single producer_risc_mask / consumer_risc_mask in
     // its hardware config; per-node mask variation would require splitting the DFB at lowering
-    // time (deliberately not done here).
+    // time (deliberately not done yet -- awaiting LLK DFBAccessor API support before we can do
+    // 1:N DFBs, as doing so requires passing DFB IDs as implicit RTAs rather than implicit CTAs).
     //
-    // Gen1: the mask is a deterministic function of the user's KernelSpec config (compute
+    // Gen1: the mask is a deterministic function of the user's KernelSpec hw_config (compute
     //   placement is fixed; DM processor is user-specified via Gen1Config). A
-    //   mismatch is therefore a user error — the user supplied multi-binding KernelSpecs with
-    //   incompatible processor placement.
-    // Gen2 (Quasar): the mask is solver-assigned. The solver currently doesn't know about
-    //   multi-binding equivalence classes, so even when the user's intent is compatible the
-    //   solver may produce a mismatch. The proper fix is to extend the DM/compute solver to
-    //   constrain same-role multi-binding kernels to identical placements; this is intentionally
-    //   deferred. For now, on Gen2 we surface the mismatch as an internal error so a real
-    //   workload exercising the case can find us; the user can't act on it directly.
-    //
-    // TODO(quasar-multi-binding-solver): extend SolveGen2KernelRiscMasks to take the
-    // multi-binding equivalence classes (derived from collected.dfb_endpoints) and constrain
-    // same-class kernels to the same risc_mask. Then this check downgrades to a defensive
-    // assertion on both arches.
+    //   mismatch is a user error — incompatible processor placement across multi-bound kernels.
+    // Gen2 (Quasar): the mask is solver-assigned, with the solver constrained to give every
+    //   member of a DM coupling-group equivalence class the same DM mask. Compute kernel masks
+    //   are deterministic from num_threads, which is uniform per role. So on Gen2 the uniformity
+    //   property is guaranteed by construction; the check is retained as a defensive assertion.
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
         auto check_uniform_mask = [&](const auto& records, std::string_view role) {
@@ -2359,21 +2478,15 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                     continue;
                 }
                 if (is_gen2_arch()) {
-                    TT_FATAL(
-                        false,
-                        "Internal error: Inconsistent RISC mask solution failure. DFB '{}' has "
-                        "multiple {} KernelSpecs ('{}', '{}') that the Gen2 (Quasar) solver "
-                        "placed on different processor lanes (mask 0x{:x} vs 0x{:x}). The DFB's "
-                        "hardware config carries a single mask per role; multi-binding requires "
-                        "all same-role kernels to share a mask. The Quasar solver does not yet "
-                        "enforce this constraint; this is a known framework limitation. "
-                        "TODO(quasar-multi-binding-solver): extend the solver to constrain "
-                        "multi-binding equivalence classes.",
+                    TT_THROW(
+                        "Internal error: Gen2 solver produced disagreeing risc_masks for DFB '{}' "
+                        "{} bindings ('{}' = 0x{:x} vs '{}' = 0x{:x}). The coupling-group solver "
+                        "extension should guarantee per-role mask uniformity by construction.",
                         dfb.unique_id,
                         role,
                         first_kernel->unique_id,
-                        records[i].kernel->unique_id,
                         first_mask,
+                        records[i].kernel->unique_id,
                         mask);
                 } else {
                     TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2137,7 +2137,7 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     // With multi-binding, all same-role KernelSpecs share kind (DM/compute), access_pattern,
     // num_threads, and risc_mask. The first three are enforced in ValidateProgramSpec; the
     // fourth is solver-guaranteed on Gen2 (the coupling-group equivalence-class constraint)
-    // and user-validated on Gen1 (see Step 2a-bis in MakeProgramFromSpec). So any
+    // and user-validated on Gen1 (see Step 2b in MakeProgramFromSpec). So any
     // representative producer/consumer gives the correct DFB config — we take the first.
     const KernelSpec* producer = dfb_endpoint_info.producers.front().kernel;
     const KernelSpec* consumer = dfb_endpoint_info.consumers.front().kernel;
@@ -2526,7 +2526,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         check_uniform_mask(endpoints.consumers, "CONSUMER");
     }
 
-    // Step 2b: Resolve TensorParameters against the MeshDevice into static CTA payloads.
+    // Step 2c: Resolve TensorParameters against the MeshDevice into static CTA payloads.
     //
     // TensorBindings ride two existing kernel-arg channels:
     //   - Static layout (rank, shape, bank coords, ...) flows through the kernel's positional

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -996,13 +996,18 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
 
-        // (3) and (4): per-role uniformity of binding-site parameters.
+        // (3) and (4): per-role uniformity of binding-site parameters, plus kernel kind.
+        // Kind (compute vs DM) must agree because the DFB's hardware config carries a single
+        // processor mask per role, and compute / DM masks live in disjoint bit ranges (bits
+        // 0-7 vs 8-15 on Gen2; orthogonal RISC encodings on Gen1) — mismatched kinds cannot
+        // share a mask.
         auto check_role_uniformity = [&](const auto& records, std::string_view role) {
             if (records.size() < 2) {
                 return;
             }
             const auto first_pattern = records[0].binding->access_pattern;
             const auto first_threads = records[0].kernel->num_threads;
+            const bool first_is_compute = records[0].kernel->is_compute_kernel();
             const auto& first_kernel = records[0].kernel->unique_id;
             for (size_t i = 1; i < records.size(); ++i) {
                 TT_FATAL(
@@ -1022,6 +1027,18 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     first_threads,
                     records[i].kernel->unique_id,
                     records[i].kernel->num_threads);
+                TT_FATAL(
+                    records[i].kernel->is_compute_kernel() == first_is_compute,
+                    "DFB '{}' has multiple {} KernelSpecs mixing compute and data-movement kinds "
+                    "('{}' is a {} kernel; '{}' is a {} kernel). All KernelSpecs bound to the same "
+                    "DFB role must be of the same kind — the DFB's hardware config carries a single "
+                    "processor mask per role.",
+                    dfb.unique_id,
+                    role,
+                    first_kernel,
+                    first_is_compute ? "compute" : "data-movement",
+                    records[i].kernel->unique_id,
+                    first_is_compute ? "data-movement" : "compute");
             }
         };
         check_role_uniformity(endpoints.producers, "PRODUCER");
@@ -2117,11 +2134,11 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     const DataflowBufferSpec* dfb_spec,
     const CollectedSpecData::DFBEndpointInfo& dfb_endpoint_info,
     const KernelRiscMaskMap& kernel_to_risc_mask) {
-    // With multi-binding, all producer KernelSpecs share the same access_pattern, num_threads,
-    // AND risc_mask: the first two are enforced in ValidateProgramSpec; the third is checked
-    // in MakeProgramFromSpec right after the risc-mask solver runs (see the
-    // "check_uniform_mask" loop). So any representative producer/consumer gives the correct
-    // DFB config — we take the first.
+    // With multi-binding, all same-role KernelSpecs share kind (DM/compute), access_pattern,
+    // num_threads, and risc_mask. The first three are enforced in ValidateProgramSpec; the
+    // fourth is solver-guaranteed on Gen2 (the coupling-group equivalence-class constraint)
+    // and user-validated on Gen1 (see Step 2a-bis in MakeProgramFromSpec). So any
+    // representative producer/consumer gives the correct DFB config — we take the first.
     const KernelSpec* producer = dfb_endpoint_info.producers.front().kernel;
     const KernelSpec* consumer = dfb_endpoint_info.consumers.front().kernel;
     const DFBBinding* producer_binding = dfb_endpoint_info.producers.front().binding;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1764,7 +1764,7 @@ std::vector<KernelCouplingGroup> BuildDMKernelCouplingGroups(
     auto union_same_side = [&](const auto& endpoints) {
         std::optional<size_t> anchor;
         for (const auto& rec : endpoints) {
-            if (!rec.kernel->is_dm_kernel()) {
+            if (!rec.kernel->is_data_movement_kernel()) {
                 continue;
             }
             const size_t k = idx_of.at(rec.kernel);


### PR DESCRIPTION
## PR Category
Bugfix

## Summary
A previous PR (https://github.com/tenstorrent/tt-metal/pull/44586) relaxed the invariant that a `DFBSpec` must have exactly one producer `KernelSpec` binding and exactly one consumer binding. The revised invariant is now:

```cpp
// INVARIANT: At the node level, a DFB instance has exactly one producer kernel
//   instance and exactly one consumer kernel instance. You must respect this
//   invariant across the DataflowBufferSpec's endpoint bindings.
//   It is legal to bind more than one KernelSpec producer (or consumer) to a
//   DFB endpoint, provided that they have:
//     - non-overlapping node coverage, AND
//     - the same kernel kind (compute or data movement), AND
//     - identical binding-site parameters (access_pattern, num_threads)
```

The previous quick fix for WH/BH op ports left some corner-case bugs in its wake:
 - The DM kernel core placement solver for Quasar was not updated to account for DFB multi-bindings. Two DM `KernelSpec`s that bind the same DFB endpoint must (in the current Quasar backend implementation) be assigned the same DM cores. (This was a known shortcoming, documented as a TODO.)
 - (minor) The DFB header comments were not updated to reflect the new invariant! This confused the op porting AIs.
 - (minor) The validator wasn't catching the case where both a compute and DM kernel attempt to bind to the same DFB endpoint. (This would produce a downstream internal error.)

This PR fixes the Quasar DM solver issue, and addresses the minor problems also.

## Notes for reviewers
The "what" of this change is pretty straightforward. (Let me know if the new header comment is clear.)
The "why" of this change is more interesting... it's documented in https://github.com/tenstorrent/tt-metal/issues/45754.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-dfb-invariant-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-dfb-invariant-relaxation)