### PR TITLE
[skip ci] Disable test_reduce_scatter_async_sharded_to_interleaved Composite RS in t3000-e2e-tests t3k_ccl_tests (TT_FATAL trace buffer > trace_region_size)

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -1065,7 +1065,7 @@ def test_reduce_scatter_async_interleaved_to_sharded(
             1,  # check
         ),
         # Composite RS
-        (
+        pytest.param(
             [1, 1, 384, 240],
             3,
             [64, 256],
@@ -1075,6 +1075,7 @@ def test_reduce_scatter_async_interleaved_to_sharded(
             False,
             True,
             10,  # perf
+            marks=pytest.mark.skip(reason="Disabled: see #45687"),
         ),
     ],
 )


### PR DESCRIPTION
Disable Composite RS parametrization of `test_reduce_scatter_async_sharded_to_interleaved` in `t3k_ccl_tests [wh_llmbox]`. links https://github.com/tenstorrent/tt-metal/issues/45687

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py::test_reduce_scatter_async_sharded_to_interleaved[wormhole_b0-fabric_ring-rs_input_shape2-3-input_shard_shape2-input_shard_grid2-TensorMemoryLayout.HEIGHT_SHARDED-BufferType.L1-False-True-10-Layout.TILE-DataType.BFLOAT16-1link-mesh_device0]` | https://github.com/tenstorrent/tt-metal/actions/runs/26706571044/job/78709264101 | [b24ad48d](https://github.com/tenstorrent/tt-metal/commit/b24ad48df9ce8e1b1e083a73d5539c3ceb2886d4) | 2026-05-31 09:07 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-async-20260601)