### PR TITLE
[skip ci] Disable SlowDispatch/SDPrefetch* in runtime-unit-tests runtime_fd2 (DISPATCH_TELEMETRY_DISABLED compile error)

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1041,6 +1041,7 @@ template <typename FDFixture>
 class SDDispatchTestBase : public FDFixture {
 public:
     void SetUp() override {
+        GTEST_SKIP() << "Disabled: see #45689";
         if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2570,6 +2570,7 @@ template <typename FDFixture>
 class SDPrefetchTestBase : public FDFixture {
 public:
     void SetUp() override {
+        GTEST_SKIP() << "Disabled: see #45689";
         if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }


### PR DESCRIPTION
Disable 23 `SlowDispatch/SDPrefetch*` tests in `runtime-unit-tests` `runtime_fd2` that are deterministically failing due to a JIT kernel compile error.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `SlowDispatch/SDPrefetchDRAMToL1TestFixture.DRAMToL1PagedRead` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchDRAMToL1TestFixture.TestTerminate` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchPackedReadTestFixture.PackedReadTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchPackedReadTestFixture.SmokeTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchRandomTestFixture.RandomTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchLinearPackedReadTestFixture.LinearPackedReadTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchRingbufferReadTestFixture.RingbufferReadTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchPagedReadWriteTestFixture.PagedReadWriteTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchHostTextFixture.HostTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| `SlowDispatch/SDPrefetchHostTextFixture.HostSmokeTest` (all parametrizations) [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372129 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |
| Same 10 test groups [bh_p150b_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26737509560/job/78794372149 | [97ca6204](https://github.com/tenstorrent/tt-metal/commit/97ca6204f5aa5d6dbee6fe39da6bd468e4ef42d7) | 2026-06-01 05:59 UTC |

Tracking issue: #45689

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-unit-tests-sd-prefetch-telemetry-20260601)