### PR TITLE
fix precission regresion after #44412

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -188,7 +188,6 @@ def test_var_fp32_translation_invariance(device, dim, offset, scalar):
 #                                       hw_configure flip between cb_in's Default mode and
 #                                       cb_scaled's UnpackToDestFp32 mode across many
 #                                       iterations rather than just one boundary crossing)
-@pytest.mark.skip(reason="Skipped due to bit 11 precision regression introduced in PR #44412")
 @pytest.mark.parametrize("scalar", [2.0, -2.0, 0.5, 4.0])
 @pytest.mark.parametrize("N", [33, 129], ids=["Wt2", "Wt5"])
 def test_var_fp32_doscale_wt_gt_1(device, scalar, N):

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -149,13 +149,11 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
     if (enable_unpack_to_dest) {
-        MATH((_llk_math_dbg_feature_disable_()));
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(idst, icb)));
         MATH((llk_math_transpose_dest<false, true>(idst)));
-        MATH((_llk_math_dbg_feature_enable_()));
     } else {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false>(icb, itile)));
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst, icb)));

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -149,11 +149,13 @@ ALWI void transpose_wh_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
     if (enable_unpack_to_dest) {
+        MATH((_llk_math_dbg_feature_disable_()));
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(idst, icb)));
         MATH((llk_math_transpose_dest<false, true>(idst)));
+        MATH((_llk_math_dbg_feature_enable_()));
     } else {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false>(icb, itile)));
         MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(idst, icb)));

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
@@ -144,18 +144,7 @@ void kernel_main() {
                 cb_in_obj.wait_front(onetile);
                 tile_regs_acquire();
                 reconfig_data_format_srca(cb_in);
-                if constexpr (welford_fp32_input) {
-                    // Full init_bcast each iter: programs UNPACK hw_configure for cb_in
-                    // (Default mode), resetting any UnpackToDest mode left by either the previous
-                    // wt's cb_scaled transpose or the previous NCHt's cb_var final transpose.
-                    // On FP32 input, the _init_short variants are not sufficient because they
-                    // skip llk_unpack_hw_configure, which is the only call that reprograms the
-                    // unpack-to-DEST mode bit; reconfig_data_format_srca reprograms only
-                    // SrcA's src/dst data format and tile geometry, not the unpack-to-DEST bit.
-                    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::SCALAR>(cb_in, cb_scalar, cb_scaled);
-                } else {
-                    mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar);
-                }
+                mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar);
                 mul_tiles_bcast_scalar(cb_in, cb_scalar, 0, 0, input_dst);
                 tile_regs_commit();
                 cb_in_obj.pop_front(1);
@@ -170,15 +159,7 @@ void kernel_main() {
                 cb_scaled_obj.wait_front(onetile);
                 tile_regs_acquire();
                 reconfig_data_format_srca(cb_scaled);
-                if constexpr (welford_fp32_input) {
-                    // Full transpose_wh_init each iter: programs UNPACK hw_configure for
-                    // cb_scaled (UnpackToDestFp32 mode), preserving the FPU mul output's
-                    // mantissa bits past TF32. The next wt iter's init_bcast resets UNPACK
-                    // back to cb_in's Default mode before the FPU mul reads SrcA again.
-                    transpose_wh_init(cb_scaled, cb_var);
-                } else {
-                    transpose_wh_init_short(cb_scaled);
-                }
+                transpose_wh_init_short(cb_scaled);
                 transpose_wh_tile(cb_scaled, 0, input_dst);
                 cb_scaled_obj.pop_front(onetile);
             } else {
@@ -234,13 +215,7 @@ void kernel_main() {
 
         cb_var_obj.wait_front(onetile);
         reconfig_data_format_srca(cb_var);
-        if constexpr (welford_fp32_input) {
-            // cb_var is UnpackToDestFp32 for FP32 input; needs full hw_configure to activate
-            // the unpack-to-DEST mode.
-            transpose_wh_init(cb_var, cb_out);
-        } else {
-            transpose_wh_init_short(cb_var);
-        }
+        transpose_wh_init_short(cb_var);
         tile_regs_acquire();
         transpose_wh_tile(cb_var, 0, var_dst);
         if constexpr (is_std) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
After PR #44412 which removed bit 11 from the unpack thread, `test_var_fp32_doscale_wt_gt_1` started failing with precision loss. The do_scale FP32 Welford W-reduce path called `init_bcast` and `transpose_wh_init` (full) every Wt iteration, which invoked `_llk_unpack_hw_configure_` repeatedly. Each call reset internal unpacker state (z-stride, address counters, tile descriptor) that the `unpack-to-dest` 32-bit DEST addressing relies on being stable from kernel startup. Previously this was masked by bit 11 leaked from the unpacker. Fixed by replacing the full init variants with their `_short` counterparts (`mul_tiles_bcast_scalar_init_short`, `transpose_wh_init_short`), which only reprogram the MOP and address mods without touching the unpacker hardware configuration.


### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/bit11_fix_sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/bit11_fix_sanity)