### PR TITLE
[skip ci] Disable test_reduce_scatter_async_training_shapes tt_training_test_six-perf in t3000-e2e-tests t3k_ccl_tests

### DIFF
--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -663,7 +663,16 @@ def test_reduce_scatter_async(
         # Scatter on dim 1
         ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, True, 10),  # perf
         ([16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, False, 1),  # check
-        pytest.param([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, True, 10, marks=pytest.mark.skip(reason="Disabled: see #45699")),  # perf
+        pytest.param(
+            [16, 8, 8, 8],
+            1,
+            ttnn.TILE_LAYOUT,
+            ttnn.bfloat16,
+            True,
+            True,
+            10,
+            marks=pytest.mark.skip(reason="Disabled: see #45699"),
+        ),  # perf
         # Scatter on dim 2
         ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, False, 1),  # check
         ([16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, True, 10),  # perf

--- a/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
+++ b/tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py
@@ -663,7 +663,7 @@ def test_reduce_scatter_async(
         # Scatter on dim 1
         ([1, 16, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, True, 10),  # perf
         ([16, 16, 128, 128], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, False, 1),  # check
-        ([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, True, 10),  # perf
+        pytest.param([16, 8, 8, 8], 1, ttnn.TILE_LAYOUT, ttnn.bfloat16, True, True, 10, marks=pytest.mark.skip(reason="Disabled: see #45699")),  # perf
         # Scatter on dim 2
         ([1, 16, 512, 8], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, False, 1),  # check
         ([16, 1, 512, 128], 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, False, True, 10),  # perf


### PR DESCRIPTION
## CI Test Disable PR

Disables `test_reduce_scatter_async_training_shapes[wormhole_b0-fabric_ring-random-mem_config_input0-mem_config_rs0-tt_training_test_six-perf-mesh_device0-1link]` in `t3000-e2e-tests.yaml` `t3k_ccl_tests [wh_llmbox]`.

Tracking issue: #45699

## Failure evidence

Test `test_reduce_scatter_async_training_shapes` with parametrization `tt_training_test_six-perf` (`[16, 8, 8, 8]` shape, dim=1, `use_new=True`, `enable_trace=True`, `num_iters=10`, `fabric_ring` topology) has failed in 3+ consecutive main branch runs:

| Run | SHA | Completed | Error |
|-----|-----|-----------|-------|
| [26677770587](https://github.com/tenstorrent/tt-metal/actions/runs/26677770587/job/78633103770) | d7a34140 | 2026-05-30 09:05 UTC | `Failed: Timeout >300s` |
| [26706571044](https://github.com/tenstorrent/tt-metal/actions/runs/26706571044/job/78709264101) | b24ad48d | 2026-05-31 08:24 UTC | `TT_THROW @ system_memory_manager.cpp:738` |
| [26742897792](https://github.com/tenstorrent/tt-metal/actions/runs/26742897792/job/78812418447) | 97ca6204 | 2026-06-01 09:09 UTC | `TT_THROW @ system_memory_manager.cpp:738` |

**Note**: This is a separate test from `test_reduce_scatter_async_sharded_to_interleaved[...-rs_input_shape2-...]` (tracked in #45687, PR #45688). Both fail in `t3k_ccl_tests [wh_llmbox]` but are different test functions.

## Change

`pytest.param(..., marks=pytest.mark.skip(reason="Disabled: see #45699"))` added to `tt_training_test_six-perf` entry in `tests/nightly/t3000/ccl/test_minimal_reduce_scatter_async.py`.

## Verification

Pending — automation will dispatch fresh-build verification on `t3000-e2e-tests.yaml`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-e2e-tests-reduce-scatter-training-shapes-20260601)