### PR TITLE
[Test Only] Re-enable TestSimpleL1Read without timing gate

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -95,10 +95,9 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
 
     double bytes_per_cycle = (double)total_bytes / (double)cycles_elapsed;
     double bytes_per_cycle_legacy_api = (double)total_bytes / (double)cycles_elapsed_legacy_api;
-
-    double speedup = bytes_per_cycle_legacy_api / bytes_per_cycle;
-    // Ensure no differences greater than 0.5% (relaxed from 0.05% due to runner timing jitter)
-    ASSERT_LT(std::abs(speedup - 1.0), 0.005);
+    // Keep the throughput comparison in logs, but do not gate correctness on a
+    // timing ratio that is unstable on shared CI runners.
+    [[maybe_unused]] double speedup = bytes_per_cycle_legacy_api / bytes_per_cycle;
 
     log_info(
         tt::LogTest,
@@ -126,10 +125,7 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
 
 namespace tt::tt_metal {
 
-// DISABLED: timing assertion flaky on N300-viommu runners — tolerance relaxed to 0.5% in
-// PR #45624 (2026-05-29) but still failing (0.545%). Pending codeowner fix; see
-// https://github.com/tenstorrent/tt-metal/actions/runs/26685226265/job/78652589121
-TEST_F(UnitMeshCQSingleCardSharedFixture, DISABLED_TestSimpleL1Read) {
+TEST_F(UnitMeshCQSingleCardSharedFixture, TestSimpleL1Read) {
     for (auto& mesh_device : devices_) {
         RunTest(mesh_device.get());
     }


### PR DESCRIPTION
### PR Category

Test Only

### Summary

Fixes #45649.

1. Re-enable `UnitMeshCQSingleCardSharedFixture.TestSimpleL1Read`.
2. Remove the timing-based speedup assertion that was repeatedly flaking on shared CI runners.
3. Keep the data-pattern correctness checks and throughput logging unchanged.

### Notes for reviewers

1. The only behavior change is that this test no longer fails the suite on small throughput variance between the new and legacy L1 read APIs.
2. The correctness checks are still intact:
   - local core data must match the expected pattern
   - neighbor core data must match the expected pattern
3. This follows up on the sequence from `#45624` to `#45647`:
   - `#45624` widened the tolerance from `0.05%` to `0.5%`
   - `#45647` still had to disable the test after a `0.545%` failure
