### PR TITLE
[skip ci] Disable test_ttnn_combine[fp8_out] in blackhole-e2e-tests bh_qb_DeepSeek_PREFILL (TT_FATAL untilize_combine Fp8 fp32_dest_acc_en)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py
@@ -61,7 +61,14 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     ids=["tile", "row_major"],
 )
-@pytest.mark.parametrize("use_fp8_output", [False, True], ids=["bf16_out", "fp8_out"])
+@pytest.mark.parametrize(
+    "use_fp8_output",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.skip(reason="Disabled: see #45703")),
+    ],
+    ids=["bf16_out", "fp8_out"],
+)
 def test_ttnn_combine(
     mesh_device,
     seq_len_per_chip,


### PR DESCRIPTION
Disable `test_prefill_combine.py::test_ttnn_combine[fp8_out]` parametrizations in `blackhole-e2e-tests` `bh_qb_DeepSeek_PREFILL [bh_llmbox]`. Tracked in issue #45703.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_combine.py::test_ttnn_combine[blackhole-fp8_out-tile-random-linear-4-1link-pcc]` [bh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/26717955997/job/78749252088 | [0513b90e](https://github.com/tenstorrent/tt-metal/commit/0513b90ee068771fef548885a6b6bb223165d3fe) | 2026-05-31 17:36 UTC |