### PR TITLE
[Bug fix] discover and link MPI CXX for distributed tests

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -36,7 +36,12 @@ target_link_libraries(
         test_common_libs
 )
 if(ENABLE_DISTRIBUTED)
-    target_link_libraries(distributed_unit_tests PRIVATE OpenMPI::MPI)
+    target_link_libraries(
+        distributed_unit_tests
+        PRIVATE
+            OpenMPI::MPI
+            $<$<TARGET_EXISTS:MPI::MPI_CXX>:MPI::MPI_CXX>
+    )
 endif()
 
 target_include_directories(

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -43,7 +43,13 @@ if(ENABLE_DISTRIBUTED AND EXISTS ${ULFM_PREFIX}/lib/libmpi.so.40)
     )
 elseif(ENABLE_DISTRIBUTED)
     # Try to find system MPI if distributed is enabled
-    find_package(MPI QUIET COMPONENTS C)
+    find_package(
+        MPI
+        QUIET
+        COMPONENTS
+            C
+            CXX
+    )
     if(MPI_FOUND)
         message(STATUS "ULFM MPI not found, using system MPI")
         add_library(OpenMPI::MPI ALIAS MPI::MPI_C)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #45708.

1. Discover system MPI with both `C` and `CXX` components in the distributed fallback path.
2. Link `distributed_unit_tests` against `MPI::MPI_CXX` when that target exists.
3. Keep the existing ULFM path and the `MPI::MPI_C` alias unchanged.

### Notes for reviewers

1. The failure shows up in `tests/tt_metal/distributed/test_mpi_subcontext.cpp`, which pulls in OpenMPI C++ wrapper symbols from the system headers.
2. Before this change, the failing link only got `libmpi.so`, which left symbols like `ompi_mpi_cxx_op_intercept` and `MPI::Comm::Comm()` unresolved.
3. Local validation was a targeted rebuild of `distributed_unit_tests` with `ENABLE_DISTRIBUTED=ON` and `TT_METAL_BUILD_TESTS=ON`.
