### PR TITLE
[LLK] Make unpacker/packer x-start/x-end transient and fix unpack-to-dest unpacker selection (tt-llk#1036)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -105,5 +105,5 @@ inline void llk_unpack_AB_reduce_block_max_row(
  */
 template <bool respect_trigger = false>
 inline void llk_unpack_AB_reduce_block_max_row_uninit() {
-    _llk_unpack_AB_reduce_block_max_row_uninit_<respect_trigger>(FACE_R_DIM, FACE_R_DIM);
+    _llk_unpack_AB_reduce_block_max_row_uninit_<respect_trigger>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -109,5 +109,5 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
  * Use standard LLK cleanup procedures for general-purpose operations.
  */
 inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(FACE_R_DIM, FACE_R_DIM, respect_trigger);
+    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -95,9 +95,6 @@ inline void llk_unpack_A_block(
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_A_uninit(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-
-    _llk_unpack_A_uninit_<BType>(face_r_dim);
+inline void llk_unpack_A_uninit() {
+    _llk_unpack_A_uninit_<BType>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -30,13 +30,12 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
- * @param operand    Input circular buffer / operand index.
- * @param face_r_dim Face row dimension to restore (defaults to FACE_R_DIM).
+ * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const uint num_faces = get_operand_num_faces(operand);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces);
 }
 
 /**
@@ -392,6 +391,5 @@ llk_unpack_tilizeA_B_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -157,4 +157,4 @@ inline void llk_unpack_A_block(
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_A_uninit(const std::uint32_t operand) {}
+inline void llk_unpack_A_uninit() {}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_api.h
@@ -102,5 +102,5 @@ inline void llk_unpack_AB_reduce_block_max_row(
  */
 template <bool respect_trigger = false>
 inline void llk_unpack_AB_reduce_block_max_row_uninit() {
-    _llk_unpack_AB_reduce_block_max_row_uninit_<respect_trigger>(FACE_R_DIM, FACE_R_DIM);
+    _llk_unpack_AB_reduce_block_max_row_uninit_<respect_trigger>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_reduce_custom_runtime_api.h
@@ -104,5 +104,5 @@ inline void llk_unpack_AB_reduce_block_max_row_runtime(
  * Use standard LLK cleanup procedures for general-purpose operations.
  */
 inline void llk_unpack_AB_reduce_block_max_row_uninit_runtime(bool respect_trigger = false) {
-    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(FACE_R_DIM, FACE_R_DIM, respect_trigger);
+    _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(respect_trigger);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -91,9 +91,6 @@ inline void llk_unpack_A_block(
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
-inline void llk_unpack_A_uninit(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-
-    _llk_unpack_A_uninit_<BType>(face_r_dim);
+inline void llk_unpack_A_uninit() {
+    _llk_unpack_A_uninit_<BType>();
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -31,13 +31,12 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
- * @param operand    Input circular buffer / operand index.
- * @param face_r_dim Face row dimension to restore (defaults to FACE_R_DIM).
+ * @param operand Input circular buffer / operand index.
  */
-inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
+inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces);
 }
 
 /**
@@ -458,6 +457,5 @@ inline void llk_unpack_fast_tilize_block(
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id], face_r_dim);
+    _llk_unpack_tilizeA_B_uninit_((uint)unpack_dst_format[operand_id]);
 }

--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -112,7 +112,7 @@ ALWI void unary_bcast_uninit(uint32_t icb) {
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
 
-    UNPACK((llk_unpack_A_uninit<bcast_type>(icb)));
+    UNPACK((llk_unpack_A_uninit<bcast_type>()));
 
     if (enable_unpack_to_dest) {
         MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, true>()));
@@ -121,7 +121,7 @@ ALWI void unary_bcast_uninit(uint32_t icb) {
     }
 #endif
 #else
-    UNPACK((llk_unpack_A_uninit<bcast_type>(icb)));
+    UNPACK((llk_unpack_A_uninit<bcast_type>()));
     // Quasar's llk_math_eltwise_unary_datacopy_uninit is a no-op for both unpack_to_dest values,
     // so no runtime dispatch on dst format is needed here.
     MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type>()));

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -145,9 +145,10 @@ inline void _llk_pack_untilize_wrapper_(
         address, pack_dst_format, face_r_dim, tile_dst_rt_offset);
 }
 
-inline void _llk_pack_untilize_uninit_wrapper_([[maybe_unused]] const std::uint32_t pack_src_format, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_pack_untilize_uninit_wrapper_(
+    [[maybe_unused]] const std::uint32_t pack_src_format, [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM)
 {
-    _llk_pack_untilize_uninit_(face_r_dim);
+    _llk_pack_untilize_uninit_();
 }
 
 #elif defined(ARCH_BLACKHOLE)

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -56,10 +56,9 @@ inline void _llk_unpack_tilize_wrapper_(
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, block_ct_dim, face_r_dim, num_faces, narrow_tile);
 }
 
-inline void _llk_unpack_tilize_uninit_wrapper_(
-    const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_tilize_uninit_wrapper_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4)
 {
-    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces);
 }
 
 #elif defined(ARCH_BLACKHOLE)
@@ -106,10 +105,9 @@ inline void _llk_unpack_tilize_wrapper_(
     _llk_unpack_tilize_(base_address, tile_index, unpack_src_format, unpack_dst_format, face_r_dim, num_faces, narrow_tile);
 }
 
-inline void _llk_unpack_tilize_uninit_wrapper_(
-    const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4, const std::uint32_t face_r_dim = ckernel::FACE_R_DIM)
+inline void _llk_unpack_tilize_uninit_wrapper_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces = 4)
 {
-    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces, face_r_dim);
+    _llk_unpack_tilize_uninit_(unpack_dst_format, num_faces);
 }
 
 #else

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
@@ -143,4 +143,4 @@ class MatmulUnpacker(Unpacker):
     ) -> str:
         face_r_dim_a = compute_unit.src_a.tile_shape.face_r_dim
         face_r_dim_b = compute_unit.src_b.tile_shape.face_r_dim
-        return f"_llk_unpack_AB_matmul_uninit_({face_r_dim_a}, {face_r_dim_b});\n"
+        return f"_llk_unpack_AB_matmul_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
@@ -141,6 +141,4 @@ class MatmulUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim_a = compute_unit.src_a.tile_shape.face_r_dim
-        face_r_dim_b = compute_unit.src_b.tile_shape.face_r_dim
         return f"_llk_unpack_AB_matmul_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
@@ -53,7 +53,7 @@ class ReduceBlockMaxUnpacker(Unpacker):
         block: BlockData,
     ) -> str:
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        return f"_llk_unpack_AB_reduce_block_max_row_uninit_({face_r_dim}, {face_r_dim});\n"
+        return f"_llk_unpack_AB_reduce_block_max_row_uninit_();\n"
 
     def perf_set_valid(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
@@ -52,7 +52,6 @@ class ReduceBlockMaxUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         return f"_llk_unpack_AB_reduce_block_max_row_uninit_();\n"
 
     def perf_set_valid(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
@@ -100,4 +100,4 @@ class UnpackerTilizeA(Unpacker):
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         num_faces = compute_unit.src_a.tile_shape.total_num_faces()
 
-        return f"    _llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces}, {face_r_dim});\n"
+        return f"    _llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/tilize_a.py
@@ -97,7 +97,6 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         num_faces = compute_unit.src_a.tile_shape.total_num_faces()
 
         return f"    _llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
@@ -179,4 +179,4 @@ class UnpackerA(Unpacker):
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
 
-        return f"_llk_unpack_A_uninit_<{broadcast_type}>({face_r_dim});\n"
+        return f"_llk_unpack_A_uninit_<{broadcast_type}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
@@ -177,6 +177,4 @@ class UnpackerA(Unpacker):
         block: BlockData,
     ) -> str:
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-
         return f"_llk_unpack_A_uninit_<{broadcast_type}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
@@ -173,5 +173,4 @@ class UnpackerAB(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return f"_llk_unpack_AB_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
@@ -174,4 +174,4 @@ class UnpackerAB(Unpacker):
         block: BlockData,
     ) -> str:
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
-        return f"_llk_unpack_AB_uninit_({shape_var}, {shape_var});\n"
+        return f"_llk_unpack_AB_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
@@ -142,4 +142,4 @@ class MatmulUnpacker(Unpacker):
         block: BlockData,
     ) -> str:
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        return f"_llk_unpack_AB_matmul_uninit_({face_r_dim});\n"
+        return f"_llk_unpack_AB_matmul_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
@@ -141,5 +141,4 @@ class MatmulUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         return f"_llk_unpack_AB_matmul_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
@@ -46,7 +46,7 @@ class ReduceBlockMaxUnpacker(Unpacker):
         block: "BlockData",
     ) -> str:
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        return f"_llk_unpack_AB_reduce_block_max_row_uninit_({face_r_dim}, {face_r_dim});\n"
+        return f"_llk_unpack_AB_reduce_block_max_row_uninit_();\n"
 
     def perf_set_valid(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
@@ -45,7 +45,6 @@ class ReduceBlockMaxUnpacker(Unpacker):
         compute_unit: "ComputeNode",
         block: "BlockData",
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         return f"_llk_unpack_AB_reduce_block_max_row_uninit_();\n"
 
     def perf_set_valid(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
@@ -85,4 +85,4 @@ class ReduceBlockMaxRuntimeUnpacker(Unpacker):
         block: BlockData,
     ) -> str:
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        return f"_llk_unpack_AB_reduce_block_max_row_uninit_runtime_({face_r_dim}, {face_r_dim});\n"
+        return f"_llk_unpack_AB_reduce_block_max_row_uninit_runtime_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
@@ -84,5 +84,4 @@ class ReduceBlockMaxRuntimeUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         return f"_llk_unpack_AB_reduce_block_max_row_uninit_runtime_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -107,4 +107,4 @@ class UnpackerTilizeA(Unpacker):
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         num_faces = compute_unit.src_a.tile_shape.total_num_faces()
 
-        return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces}, {face_r_dim});\n\n"
+        return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces});\n\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -104,7 +104,6 @@ class UnpackerTilizeA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
         num_faces = compute_unit.src_a.tile_shape.total_num_faces()
 
         return f"_llk_unpack_tilize_uninit_({config.sentinel.unpack_a_dst_format}, {num_faces});\n\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
@@ -179,4 +179,4 @@ class UnpackerA(Unpacker):
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
 
-        return f"_llk_unpack_A_uninit_<{broadcast_type}>({face_r_dim});\n"
+        return f"_llk_unpack_A_uninit_<{broadcast_type}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
@@ -177,6 +177,4 @@ class UnpackerA(Unpacker):
         block: BlockData,
     ) -> str:
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-
         return f"_llk_unpack_A_uninit_<{broadcast_type}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
@@ -173,5 +173,4 @@ class UnpackerAB(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        shape_var = f"tensor_shape_stage_{operation.stage_id}"
         return f"_llk_unpack_AB_uninit_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
@@ -174,4 +174,4 @@ class UnpackerAB(Unpacker):
         block: BlockData,
     ) -> str:
         shape_var = f"tensor_shape_stage_{operation.stage_id}"
-        return f"_llk_unpack_AB_uninit_({shape_var}, {shape_var});\n"
+        return f"_llk_unpack_AB_uninit_();\n"

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
@@ -130,7 +130,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         {
             ZONE_SCOPED("UNINIT")
-            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, 4, FACE_R_DIM);
+            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, 4);
         }
         return;
     }

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
@@ -114,8 +114,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             ZONE_SCOPED("INIT")
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
-            _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false);
+                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+            _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
@@ -124,13 +124,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
                 {
                     _llk_unpack_tilize_dispatch_(
-                        _llk_unpack_tilize_, L1_ADDRESS(buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4, false);
+                        _llk_unpack_tilize_, L1_ADDRESS(buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4 /* num_faces */, false /* narrow_tile */);
                 }
             }
         }
         {
             ZONE_SCOPED("UNINIT")
-            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, 4);
+            _llk_unpack_tilize_uninit_(formats.unpack_A_dst, 4 /* num_faces */);
         }
         return;
     }
@@ -144,13 +144,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             const std::uint32_t compat_dst = ckernel::to_underlying(DataFormat::Float16_b);
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, compat_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
+                formats.unpack_A_src, formats.unpack_B_src, compat_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(compat_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         else
         {
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
+                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(formats.unpack_A_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         // Base address is programmed per-call inside _llk_unpack_fast_tilize_block_
@@ -183,7 +183,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     const std::uint32_t col_datum_offset = col_offset * TILE_C_DIM;
                     const std::uint32_t chunk_base       = L1_ADDRESS(buffer_A[0]) + (SCALE_DATUM_SIZE(formats.unpack_A_src, col_datum_offset) >> 4);
-                    _llk_unpack_fast_tilize_block_(chunk_base, 0, formats.unpack_A_src, chunk, 4);
+                    _llk_unpack_fast_tilize_block_(chunk_base, 0 /* tile_index */, formats.unpack_A_src, chunk, 4 /* num_faces */);
                     col_offset += chunk;
                 }
             }
@@ -224,14 +224,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             ZONE_SCOPED("INIT")
             _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(4, formats.math);
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(4 /* num_faces */, formats.math);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(0, formats.math, formats.math, 4);
+                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* dst_index */, formats.math, formats.math, 4 /* num_faces */);
                 _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
@@ -358,7 +358,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
-            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(0, formats.pack_dst, unit_dims[0], 4, formats.pack_src);
+            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
@@ -395,7 +395,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         }
 
                         _llk_packer_wait_for_math_done_();
-                        _llk_pack_fast_tilize_row_chunk_(0, udim, 4);
+                        _llk_pack_fast_tilize_row_chunk_(0 /* tile_index */, udim, 4 /* num_faces */);
                         _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
                     }
 
@@ -405,7 +405,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         {
             ZONE_SCOPED("UNINIT")
-            _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, FACE_R_DIM, 4, formats.pack_src);
+            _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, formats.pack_src);
         }
 
     } // end else (fast tilize path)

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -84,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tile_size); // have to reconfigure unpack kernel data formats_array if they change in this run
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
-    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, 4 /* num_faces */, FACE_R_DIM);
+    _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, 4 /* num_faces */);
     _llk_unpack_AB_matmul_init_<>();
     _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized), 0, 0, tile_size, tile_size);
 }
@@ -162,7 +162,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t res_dst_index       = 0;
     static constexpr bool UNTILIZE          = false;
 
-    int run           = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
+    int run                      = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     static constexpr bool TILIZE = true;
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
         formats_array[run].pack_src, formats_array[run].pack_dst, 16 * 16 * 4 /* tile_size */);

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -67,7 +67,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(buffer_A1[batch * 1 + 0]), L1_ADDRESS(buffer_B1[batch * 1 + 0]));
         }
-        _llk_unpack_AB_reduce_block_max_row_uninit_(16, 16);
+        _llk_unpack_AB_reduce_block_max_row_uninit_();
     }
     // Operation 2: Fused Unpack
     UNUSED const Operand buffer_A2(0x1a000, 2048);

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -33,7 +33,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_A_<BROADCAST_TYPE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
             L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
     }
-    _llk_unpack_A_uninit_<BROADCAST_TYPE>(FACE_R_DIM);
+    _llk_unpack_A_uninit_<BROADCAST_TYPE>();
 }
 
 #endif
@@ -51,7 +51,7 @@ using namespace ckernel::sfpu;
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    const bool is_int_fpu_en = false;
+    const bool is_int_fpu_en         = false;
     constexpr DataCopyType copy_type = (BROADCAST_TYPE == BroadcastType::NONE || unpack_to_dest) ? DataCopyType::A2D : DataCopyType::B2D;
 
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -54,7 +54,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_A_<BROADCAST_TYPE, ACC_TO_DEST, REUSE_DEST_TYPE, unpack_to_dest>(
             L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
     }
-    _llk_unpack_A_uninit_<BROADCAST_TYPE>(params.TEST_FACE_R_DIM);
+    _llk_unpack_A_uninit_<BROADCAST_TYPE>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -641,8 +641,8 @@ inline void configure_pack(
     regfile[p_gpr_pack::TILE_HEADER + 3] = 0;
     sync_regfile_write(p_gpr_pack::TILE_HEADER + 3);
 
-    // In Blackhole, x_start/x_end must be within 1 row size (i.e. from 0 to 15)
-    TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
+    // x-start/x-end (packer ADC X counter) is a transient state set by each operation's init LLK
+    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 }
 
 inline std::uint8_t get_packer_dest_offset_index()

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -640,9 +640,6 @@ inline void configure_pack(
     regfile[p_gpr_pack::TILE_HEADER + 2] = 0;
     regfile[p_gpr_pack::TILE_HEADER + 3] = 0;
     sync_regfile_write(p_gpr_pack::TILE_HEADER + 3);
-
-    // x-start/x-end (packer ADC X counter) is a transient state set by each operation's init LLK
-    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 }
 
 inline std::uint8_t get_packer_dest_offset_index()

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -863,9 +863,6 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC1_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    // x-start/x-end (unpacker ADC X counter) is a transient state set by each operation's init LLK
-    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
-
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0
     const std::uint32_t Dest_cntx0_address         = unpA_face_r_dim == 0 ? 22 * 16 : 4 * 16;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -863,9 +863,8 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC1_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    std::uint32_t unpA_x_end = (unpA_face_r_dim == 0) ? 1 : (unpA_face_r_dim << 4) - 1;
-    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
+    // x-start/x-end (unpacker ADC X counter) is a transient state set by each operation's init LLK
+    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -220,6 +220,21 @@ inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, cons
     return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
 }
 
+/*
+ * Single source of truth for whether _llk_unpack_A_ takes the "unpack to dest" (SrcA -> DEST) path.
+ * It is only taken for genuinely 32-bit input; otherwise the MOP falls through to the normal/broadcast
+ * path. Both _llk_unpack_A_init_ (which programs the X counter) and _llk_unpack_A_mop_config_ (which
+ * programs the MOP) gate on this, so they cannot diverge if the policy ever changes.
+ *
+ * \param unpack_to_dest    Whether the caller requested unpack-to-dest.
+ * \param unpack_src_format Unpacker input (L1) data format.
+ * \param unpack_dst_format Unpacker output (register) data format.
+ */
+inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
+}
+
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
@@ -283,7 +283,6 @@ inline void _llk_pack_fast_tilize_uninit_(
     // BH-specific: restore strides modified by fast-tilize init (WH doesn't modify them).
     // Note: set_packer_strides's first param is semantically pack_src_format.
     set_packer_strides<PackMode::Default>(pack_src_format, TILE_C_DIM);
-    // Restore X counter, addr_mods, and MOP via _llk_pack_init_ (aligned with WH approach)
-    TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
+    // Restore X counter (transient x-start/x-end, see tt-llk#1036), addr_mods, and MOP via _llk_pack_init_ (aligned with WH approach)
     _llk_pack_init_<PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */>(FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
@@ -283,6 +283,6 @@ inline void _llk_pack_fast_tilize_uninit_(
     // BH-specific: restore strides modified by fast-tilize init (WH doesn't modify them).
     // Note: set_packer_strides's first param is semantically pack_src_format.
     set_packer_strides<PackMode::Default>(pack_src_format, TILE_C_DIM);
-    // Restore X counter (transient x-start/x-end, see tt-llk#1036), addr_mods, and MOP via _llk_pack_init_ (aligned with WH approach)
+    // Restore X counter, addr_mods, and MOP via _llk_pack_init_ (aligned with WH approach)
     _llk_pack_init_<PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */>(FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
@@ -384,7 +384,6 @@ inline void _llk_pack_fast_untilize_uninit_(const std::uint32_t pack_src_format)
         _llk_pack_fast_untilize_clear_output_row_stride_();
     }
     set_packer_strides<PackMode::Default>(pack_src_format, TILE_C_DIM);
-    // X counter (transient x-start/x-end, see tt-llk#1036) is restored by _llk_pack_init_ below.
     _llk_pack_init_<PackMode::Default, false, false>(FACE_R_DIM, TILE_C_DIM, FAST_UNTILIZE_NUM_FACES, 1);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_untilize.h
@@ -384,7 +384,7 @@ inline void _llk_pack_fast_untilize_uninit_(const std::uint32_t pack_src_format)
         _llk_pack_fast_untilize_clear_output_row_stride_();
     }
     set_packer_strides<PackMode::Default>(pack_src_format, TILE_C_DIM);
-    TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
+    // X counter (transient x-start/x-end, see tt-llk#1036) is restored by _llk_pack_init_ below.
     _llk_pack_init_<PackMode::Default, false, false>(FACE_R_DIM, TILE_C_DIM, FAST_UNTILIZE_NUM_FACES, 1);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -165,14 +165,12 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_(const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if constexpr (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -165,12 +165,12 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_(
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if constexpr (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -165,8 +165,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_(
-    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_()
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -166,7 +166,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -160,8 +160,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * This function should NOT be used as a substitute for native reduce unpacking cleanup.
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
-    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -161,14 +161,12 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
-    const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_0, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -67,5 +67,5 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -67,5 +67,4 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -151,7 +151,9 @@ inline void _llk_unpack_fast_untilize_bfp_block_(const std::uint32_t address, co
 
 inline void _llk_unpack_fast_untilize_uninit_()
 {
-    _llk_unpack_A_uninit_<BroadcastType::NONE>(FACE_R_DIM);
+    // Fast untilize reprograms the unpacker X counter during the block loop; restore the default
+    // full-tile x-start/x-end so the next operation starts from a clean transient state.
+    TTI_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }
 
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -151,9 +151,6 @@ inline void _llk_unpack_fast_untilize_bfp_block_(const std::uint32_t address, co
 
 inline void _llk_unpack_fast_untilize_uninit_()
 {
-    // Fast untilize reprograms the unpacker X counter during the block loop; restore the default
-    // full-tile x-start/x-end so the next operation starts from a clean transient state.
-    TTI_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
 }
 
 } // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -369,8 +369,6 @@ inline void pack_init_apply(
         set_packer_strides<pack_mode>(pack_src_format, tile_c_dim);
     }
 
-    // x-start/x-end is a transient state: every pack init programs the packer ADC X counter
-    // to the operand's row width (see tt-llk#1036). FACE_C_DIM - 1 is the default tile row width.
     TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
 }
 } // namespace llk_pack_internal_bh

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -345,14 +345,13 @@ namespace llk_pack_internal_bh
  * @tparam zero_output: When true, the packer emits zeros instead of dest data.
  * @tparam skip_addrmod_config: When true, leave the ADDR_MOD slots untouched.
  * @tparam skip_packer_strides: When true, do not re-program the packer strides.
- * @tparam skip_final_adcxx: When true, skip the closing SETADCXX of the packer X counter.
  * @param pack_src_format: Source (dest register) data format; only used when programming strides.
  * @param face_r_dim: Number of rows per face.
  * @param tile_c_dim: Tile column dimension (datums).
  * @param num_faces: Faces per tile, valid values = <1, 2, 4>
  * @param num_tiles: Number of tiles processed per MOP run.
  */
-template <PackMode pack_mode, bool zero_output, bool skip_addrmod_config, bool skip_packer_strides, bool skip_final_adcxx>
+template <PackMode pack_mode, bool zero_output, bool skip_addrmod_config, bool skip_packer_strides>
 inline void pack_init_apply(
     const std::uint32_t pack_src_format,
     const std::uint32_t face_r_dim,
@@ -370,10 +369,9 @@ inline void pack_init_apply(
         set_packer_strides<pack_mode>(pack_src_format, tile_c_dim);
     }
 
-    if constexpr (!skip_final_adcxx)
-    {
-        TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
-    }
+    // x-start/x-end is a transient state: every pack init programs the packer ADC X counter
+    // to the operand's row width (see tt-llk#1036). FACE_C_DIM - 1 is the default tile row width.
+    TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0);
 }
 } // namespace llk_pack_internal_bh
 
@@ -473,7 +471,7 @@ inline void _llk_pack_init_(
     const std::uint32_t num_tiles  = 1)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, true /* skip_packer_strides */, true /* skip_final_adcxx */>(
+    llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, true /* skip_packer_strides */>(
         0 /* pack_src_format unused */, face_r_dim, tile_c_dim, num_faces, num_tiles);
 }
 
@@ -520,12 +518,12 @@ inline void _llk_pack_init_(
     // so we can skip the workaround which involves unswizzling rows in the tile.
     if (skip_bh_tilize_workaround && pack_mode == PackMode::Tilize)
     {
-        llk_pack_internal_bh::pack_init_apply<PackMode::Default, zero_output, skip_addrmod_config, skip_packer_strides, false /* skip_final_adcxx */>(
+        llk_pack_internal_bh::pack_init_apply<PackMode::Default, zero_output, skip_addrmod_config, skip_packer_strides>(
             pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles);
     }
     else
     {
-        llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides, false /* skip_final_adcxx */>(
+        llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
             pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles);
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
@@ -163,6 +163,4 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_rows.h
@@ -163,6 +163,6 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
-    // Restore X counter to default
-    TTI_SETADCXX(p_setadc::PAC, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -280,12 +280,10 @@ inline void _llk_unpack_A_init_(
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_A_uninit_(const std::uint32_t face_r_dim)
+inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // Unpack A is used for all single unpacker operations, except bcast, since bcast HW feature is only available on unpacker B
-    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_B;
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(UNP_SEL, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -282,8 +282,6 @@ inline void _llk_unpack_A_init_(
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -303,7 +303,6 @@ inline void _llk_unpack_A_init_(
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK; nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -251,7 +251,18 @@ inline void _llk_unpack_A_init_(
     // bool disable_src_zero_flag_val = disable_src_zero_flag || (static_cast<uint>(unpack_dst_format) == static_cast<uint>(DataFormat::UInt16));
     // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable_src_zero_flag_val ? 1 : 0);
 
-    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE || unpack_to_dest) ? p_setadc::UNP_A : p_setadc::UNP_B;
+    // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
+    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused:
+    //   plain datacopy            -> SrcA           (unpacker A)
+    //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
+    //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
+    //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
+    //   broadcast                  -> SrcB;  unpack-to-dest -> SrcA
+    constexpr bool reads_srca =
+        unpack_to_dest || (BType == BroadcastType::NONE && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA));
+    constexpr bool reads_srcb =
+        !unpack_to_dest && (BType != BroadcastType::NONE || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB));
+    constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
     if constexpr ((BType == BroadcastType::ROW || BType == BroadcastType::SCALAR) && unpack_to_dest) // ROW and SCALAR bcast will only unpack a single row
     {
         config_unpacker_x_end<UNP_SEL>(1);
@@ -282,6 +293,7 @@ inline void _llk_unpack_A_init_(
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()
 {
+    // x-start/x-end is transient and programmed by each operation's init LLK; nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -67,7 +67,7 @@ inline void _llk_unpack_A_mop_config_(
     static constexpr std::uint32_t srcb_set_z_2           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 2, 0b0001); // set srcB ch0_z = 2
     static constexpr std::uint32_t srcb_clear_z           = TT_OP_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0001); // set srcB ch0_z = 0
 
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    if (should_unpack_to_dest(unpack_to_dest, unpack_src_format, unpack_dst_format))
     {
         if (transpose_of_faces && num_faces == 4)
         {
@@ -254,8 +254,9 @@ inline void _llk_unpack_A_init_(
     // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
     // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused.
     // The unpack-to-dest (SrcA) path is only taken when the input is actually 32-bit; otherwise the MOP
-    // falls through to the normal/broadcast path, so gate on is_32bit_input here exactly like it does.
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    // falls through to the normal/broadcast path, so gate on the shared should_unpack_to_dest() predicate
+    // the MOP uses, so the two cannot diverge.
+    if (should_unpack_to_dest(unpack_to_dest, unpack_src_format, unpack_dst_format))
     {
         // SrcA -> dest. ROW and SCALAR broadcast only unpack a single row; everything else a full face.
         if constexpr (BType == BroadcastType::ROW || BType == BroadcastType::SCALAR)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -252,23 +252,33 @@ inline void _llk_unpack_A_init_(
     // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable_src_zero_flag_val ? 1 : 0);
 
     // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
-    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused:
-    //   plain datacopy            -> SrcA           (unpacker A)
-    //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
-    //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
-    //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
-    //   broadcast                  -> SrcB;  unpack-to-dest -> SrcA
-    constexpr bool reads_srca =
-        unpack_to_dest || (BType == BroadcastType::NONE && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA));
-    constexpr bool reads_srcb =
-        !unpack_to_dest && (BType != BroadcastType::NONE || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB));
-    constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
-    if constexpr ((BType == BroadcastType::ROW || BType == BroadcastType::SCALAR) && unpack_to_dest) // ROW and SCALAR bcast will only unpack a single row
+    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused.
+    // The unpack-to-dest (SrcA) path is only taken when the input is actually 32-bit; otherwise the MOP
+    // falls through to the normal/broadcast path, so gate on is_32bit_input here exactly like it does.
+    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        config_unpacker_x_end<UNP_SEL>(1);
+        // SrcA -> dest. ROW and SCALAR broadcast only unpack a single row; everything else a full face.
+        if constexpr (BType == BroadcastType::ROW || BType == BroadcastType::SCALAR)
+        {
+            config_unpacker_x_end<p_setadc::UNP_A>(1);
+        }
+        else
+        {
+            config_unpacker_x_end<p_setadc::UNP_A>(face_r_dim);
+        }
     }
-    else // base case is to upk the entire face
+    else
     {
+        //   plain datacopy            -> SrcA           (unpacker A)
+        //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
+        //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
+        //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
+        //   broadcast                  -> SrcB
+        constexpr bool reads_srca =
+            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb =
+            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -280,7 +280,7 @@ inline void _llk_unpack_A_init_(
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_A_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -214,7 +214,7 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
-inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
+inline void _llk_unpack_AB_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -214,11 +214,10 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
-inline void _llk_unpack_AB_uninit_(const ckernel::TensorShape unpA_tensor_shape, const ckernel::TensorShape unpB_tensor_shape)
+inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
 {
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, unpA_tensor_shape.face_r_dim * unpA_tensor_shape.face_c_dim - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_tensor_shape.face_r_dim * unpB_tensor_shape.face_c_dim - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -216,8 +216,6 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  */
 inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -279,20 +279,19 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 }
 
 /**
- * @brief Restore unpacker datum-count state after a matmul operation.
+ * @brief No-op after a matmul operation.
  *
- * Resets the X-dimension address counters for both SrcA and SrcB back to a single face worth of
- * datums.
+ * x-start/x-end is transient and reprogrammed by the next operation's init (see tt-llk#1036), so
+ * there is nothing to restore here.
  *
- * @param unpA_face_r_dim: Rows per face for operand A, used to compute the restored datum count.
- * @param unpB_face_r_dim: Rows per face for operand B, used to compute the restored datum count.
+ * @param unpA_face_r_dim: Unused; retained for API compatibility.
+ * @param unpB_face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_AB_matmul_init_ before this function.
  */
-inline void _llk_unpack_AB_matmul_uninit_(const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -290,8 +290,6 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
  */
 inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -284,11 +284,9 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
  * x-start/x-end is transient and reprogrammed by the next operation's init (see tt-llk#1036), so
  * there is nothing to restore here.
  *
- * @param unpA_face_r_dim: Unused; retained for API compatibility.
- * @param unpB_face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_AB_matmul_init_ before this function.
  */
-inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_matmul_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -172,7 +172,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
 
-        TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
+        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 
@@ -235,7 +235,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
 
-        TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
+        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -171,8 +171,6 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 
@@ -234,8 +232,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -293,7 +293,6 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // Revert Z dim value back to default.
     const std::uint32_t Tile_z_dim = num_faces;
@@ -535,7 +534,6 @@ inline void _llk_unpack_tilizeA_B_(
 inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // _llk_unpack_tilizeA_B uses y-stride and updates y counter
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -280,22 +280,20 @@ inline void _llk_unpack_tilize_(
 /**
  * @brief Restore unpacker state after a tilize operation.
  *
- * Reverts the X-dimension datum counts and the tile descriptor Z-dimension to defaults and
- * rewrites the unpack config (clearing tileize mode) so subsequent ops see a normal tile layout.
+ * Reverts the tile descriptor Z-dimension to default and rewrites the unpack config (clearing
+ * tilize mode) so subsequent ops see a normal tile layout. x-start/x-end is transient and
+ * reprogrammed by the next operation's init (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @param num_faces: Number of faces, used to restore the Z dimension, valid values = <1, 2, 4>.
- * @param face_r_dim: Rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    // Revert X dim value to default.
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // Revert Z dim value back to default.
     const std::uint32_t Tile_z_dim = num_faces;
@@ -526,20 +524,18 @@ inline void _llk_unpack_tilizeA_B_(
 /**
  * @brief Restore unpacker state after a tilize-A-with-unpack-B operation.
  *
- * Reverts the SrcA/SrcB X-dimension datum counts and the SrcA Y counter, and rewrites the unpack
- * config and tile X-dim back to the default 16x16 face layout.
+ * Reverts the SrcA Y counter and rewrites the unpack config and tile X-dim back to the default
+ * 16x16 face layout. x-start/x-end is transient and reprogrammed by the next operation's init
+ * (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @param face_r_dim: Rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // Revert X dim value to default.
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // _llk_unpack_tilizeA_B uses y-stride and updates y counter
     TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -286,10 +286,9 @@ inline void _llk_unpack_tilize_(
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @param num_faces: Number of faces, used to restore the Z dimension, valid values = <1, 2, 4>.
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, [[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
@@ -528,10 +527,9 @@ inline void _llk_unpack_tilizeA_B_(
  * (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -143,7 +143,6 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     // Wait for cfg to be free to edit
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
 
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_untilize.h
@@ -143,8 +143,7 @@ inline void _llk_unpack_untilize_uninit_(const std::uint32_t unpack_dst_format, 
     // Wait for cfg to be free to edit
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
 
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::FACE_DIM_16x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xFFFF>(1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -680,7 +680,7 @@ inline void configure_pack(
     const std::uint32_t face_r_dim  = FACE_R_DIM,
     const std::uint32_t num_faces   = 4,
     const bool partial_face         = false,
-    const bool narrow_tile          = false,
+    [[maybe_unused]] const bool narrow_tile = false,
     const std::uint32_t relu_config = 0)
 {
     static_assert(

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -676,12 +676,12 @@ template <bool is_fp32_dest_acc_en, PackMode pack_mode>
 inline void configure_pack(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t tile_size   = 0,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t num_faces   = 4,
-    const bool partial_face         = false,
+    const std::uint32_t tile_size           = 0,
+    const std::uint32_t face_r_dim          = FACE_R_DIM,
+    const std::uint32_t num_faces           = 4,
+    const bool partial_face                 = false,
     [[maybe_unused]] const bool narrow_tile = false,
-    const std::uint32_t relu_config = 0)
+    const std::uint32_t relu_config         = 0)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize,
@@ -746,9 +746,6 @@ inline void configure_pack(
     regfile[p_gpr_pack::TILE_HEADER + 2] = 0;
     regfile[p_gpr_pack::TILE_HEADER + 3] = 0;
     sync_regfile_write(p_gpr_pack::TILE_HEADER + 3);
-
-    // x-start/x-end (packer ADC X counter) is a transient state set by each operation's init LLK
-    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 }
 
 inline std::uint8_t get_packer_dest_offset_index()

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -747,13 +747,8 @@ inline void configure_pack(
     regfile[p_gpr_pack::TILE_HEADER + 3] = 0;
     sync_regfile_write(p_gpr_pack::TILE_HEADER + 3);
 
-    const std::uint32_t face_dim = face_r_dim * FACE_C_DIM;
-
-    // To untilize narrow tile (32x16) we just pack 2 faces back to back
-    // Number of datums to pack per row
-    const std::uint32_t pack_x_dim = (narrow_tile || pack_mode != PackMode::Untilize) ? face_dim : FACE_R_DIM;
-
-    TT_SETADCXX(p_setadc::PAC, pack_x_dim - 1, 0x0);
+    // x-start/x-end (packer ADC X counter) is a transient state set by each operation's init LLK
+    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 }
 
 inline std::uint8_t get_packer_dest_offset_index()

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -221,6 +221,21 @@ inline constexpr bool is_32bit_input(const std::uint32_t unpack_src_format, cons
     return (input_df == DataFormat::Int32 || input_df == DataFormat::Float32) && (output_df == DataFormat::Int32 || output_df == DataFormat::Float32);
 }
 
+/*
+ * Single source of truth for whether _llk_unpack_A_ takes the "unpack to dest" (SrcA -> DEST) path.
+ * It is only taken for genuinely 32-bit input; otherwise the MOP falls through to the normal/broadcast
+ * path. Both _llk_unpack_A_init_ (which programs the X counter) and _llk_unpack_A_mop_config_ (which
+ * programs the MOP) gate on this, so they cannot diverge if the policy ever changes.
+ *
+ * \param unpack_to_dest    Whether the caller requested unpack-to-dest.
+ * \param unpack_src_format Unpacker input (L1) data format.
+ * \param unpack_dst_format Unpacker output (register) data format.
+ */
+inline constexpr bool should_unpack_to_dest(const bool unpack_to_dest, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format)
+{
+    return unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format);
+}
+
 /**
  * \brief Checks if the unpacker conversion is supported w.r.t. the FP32 dest accumulation mode.
  *

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -851,9 +851,8 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC1_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    std::uint32_t unpA_x_end = (unpA_face_r_dim == 0) ? 1 : (unpA_face_r_dim << 4) - 1;
-    TT_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, (unpB_face_r_dim << 4) - 1, 0x0);
+    // x-start/x-end (unpacker ADC X counter) is a transient state set by each operation's init LLK
+    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
 
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -851,9 +851,6 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC1_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    // x-start/x-end (unpacker ADC X counter) is a transient state set by each operation's init LLK
-    // (see tt-llk#1036), so it is intentionally not programmed here in the HW config.
-
     // Program base address for all 2 sections (each section address is loaded to corresponding context)
     // Load dummy data to unused location if face height is 0
     const std::uint32_t Dest_cntx0_address         = unpA_face_r_dim == 0 ? 22 * 16 : 4 * 16;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -160,8 +160,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_(
-    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_()
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -160,12 +160,11 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_(const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if constexpr (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -160,11 +160,11 @@ inline void _llk_unpack_AB_reduce_block_max_row_(const std::uint32_t address_a, 
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 template <bool respect_trigger = false>
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_([[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_(
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if constexpr (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -155,8 +155,7 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * This function should NOT be used as a substitute for native reduce unpacking cleanup.
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
-inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
-    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
+inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(bool respect_trigger = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -156,12 +156,11 @@ inline void _llk_unpack_AB_reduce_block_max_row_runtime_(const std::uint32_t add
  * Standard _llk_unpack_AB_reduce_init_ operations typically don't require explicit cleanup.
  */
 inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
-    const std::uint32_t unpA_face_r_dim, const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
+    [[maybe_unused]] const std::uint32_t unpA_face_r_dim, [[maybe_unused]] const std::uint32_t unpB_face_r_dim, bool respect_trigger = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    TT_SETADCXX(p_setadc::UNP_A, unpA_face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -160,7 +160,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK);
     TTI_WRCFG(p_gpr_unpack::SR_UNPACK_UNTILIZER_STATE_1, p_cfg::WRCFG_32b, THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     if (respect_trigger)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -64,7 +64,5 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    // Restore the default full-face unpack X span used by the generic unpack
-    // helpers. The custom blocked path forces both unpackers to full 32x32.
-    TTI_SETADCXX(p_setadc::UNP_AB, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -64,5 +64,4 @@ inline void _llk_unpack_AB_sub_bcast_col_custom_(const std::uint32_t address_a, 
 
 inline void _llk_unpack_AB_sub_bcast_col_uninit_custom_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -415,8 +415,6 @@ inline void _llk_pack_init_(
  */
 inline void _llk_pack_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -405,17 +405,18 @@ inline void _llk_pack_init_(
 }
 
 /**
- * @brief Tear down the packer after a pack op by restoring the PAC X counter.
+ * @brief No-op teardown after a pack op.
  *
- * Resets the packer X counter to the full-face value for the given face geometry, undoing the X
- * counter set in @ref _llk_pack_init_.
+ * The packer x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036),
+ * so there is nothing to restore here.
  *
- * @param face_r_dim: Number of rows per face used to size the restored X counter.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_pack_init_ before this function.
  */
-inline void _llk_pack_uninit_(const std::uint32_t face_r_dim)
+inline void _llk_pack_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    TT_SETADCXX(p_setadc::PAC, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -410,10 +410,9 @@ inline void _llk_pack_init_(
  * The packer x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036),
  * so there is nothing to restore here.
  *
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_pack_init_ before this function.
  */
-inline void _llk_pack_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_pack_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
@@ -239,8 +239,7 @@ inline void _llk_pack_fast_tilize_uninit_(
     // restore default packer dest offsets
     _llk_init_packer_dest_offset_registers_<Dst>();
 
-    // packers pack a whole face by default, restore it
-    TTI_SETADCXX(p_setadc::PAC, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient (see tt-llk#1036) and is restored by _llk_pack_init_ below.
     // reset counters
     TTI_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
@@ -239,7 +239,6 @@ inline void _llk_pack_fast_tilize_uninit_(
     // restore default packer dest offsets
     _llk_init_packer_dest_offset_registers_<Dst>();
 
-    // x-start/x-end is transient (see tt-llk#1036) and is restored by _llk_pack_init_ below.
     // reset counters
     TTI_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
@@ -136,6 +136,4 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_rows.h
@@ -136,5 +136,6 @@ inline void _llk_pack_rows_(const std::uint32_t tile_index, const std::uint32_t 
  */
 inline void _llk_pack_rows_uninit_()
 {
-    TTI_SETADCXX(p_setadc::PAC, FACE_R_DIM * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -214,8 +214,6 @@ inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const 
  */
 inline void _llk_pack_untilize_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -209,10 +209,9 @@ inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const 
  * The packer x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036),
  * so there is nothing to restore here.
  *
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_pack_untilize_init_ before this function.
  */
-inline void _llk_pack_untilize_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_pack_untilize_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_untilize.h
@@ -204,17 +204,18 @@ inline void _llk_pack_untilize_init_(const std::uint32_t pack_dst_format, const 
 }
 
 /**
- * @brief Restore the packer X counter after an untilize pack op.
+ * @brief No-op teardown after an untilize pack op.
  *
- * Resets the packer X counter to the full-face value for the given face geometry, undoing the X
- * counter set in @ref _llk_pack_untilize_init_.
+ * The packer x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036),
+ * so there is nothing to restore here.
  *
- * @param face_r_dim: Number of rows per face used to size the restored X counter.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_pack_untilize_init_ before this function.
  */
-inline void _llk_pack_untilize_uninit_(const std::uint32_t face_r_dim)
+inline void _llk_pack_untilize_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    TT_SETADCXX(p_setadc::PAC, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -357,6 +357,6 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_A_uninit_()
 {
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -253,23 +253,33 @@ inline void _llk_unpack_A_init_(
     // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable_src_zero_flag_val ? 1 : 0);
 
     // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
-    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused:
-    //   plain datacopy            -> SrcA           (unpacker A)
-    //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
-    //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
-    //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
-    //   broadcast                  -> SrcB;  unpack-to-dest -> SrcA
-    constexpr bool reads_srca =
-        unpack_to_dest || (BType == BroadcastType::NONE && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA));
-    constexpr bool reads_srcb =
-        !unpack_to_dest && (BType != BroadcastType::NONE || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB));
-    constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
-    if constexpr ((BType == BroadcastType::ROW || BType == BroadcastType::SCALAR) && unpack_to_dest) // ROW and SCALAR bcast will only unpack a single row
+    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused.
+    // The unpack-to-dest (SrcA) path is only taken when the input is actually 32-bit; otherwise the MOP
+    // falls through to the normal/broadcast path, so gate on is_32bit_input here exactly like it does.
+    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
     {
-        config_unpacker_x_end<UNP_SEL>(1);
+        // SrcA -> dest. ROW and SCALAR broadcast only unpack a single row; everything else a full face.
+        if constexpr (BType == BroadcastType::ROW || BType == BroadcastType::SCALAR)
+        {
+            config_unpacker_x_end<p_setadc::UNP_A>(1);
+        }
+        else
+        {
+            config_unpacker_x_end<p_setadc::UNP_A>(face_r_dim);
+        }
     }
-    else // base case is to upk the entire face
+    else
     {
+        //   plain datacopy            -> SrcA           (unpacker A)
+        //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
+        //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
+        //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
+        //   broadcast                  -> SrcB
+        constexpr bool reads_srca =
+            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb =
+            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -359,6 +359,4 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -78,7 +78,7 @@ inline void _llk_unpack_A_mop_config_(
     static constexpr std::uint32_t unpack_srca_zerosrc_set_dvalid = lltt::replay_insn(0, 2);
     static constexpr std::uint32_t unpack_srcb_unpack_srcb        = lltt::replay_insn(2, 2);
 
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    if (should_unpack_to_dest(unpack_to_dest, unpack_src_format, unpack_dst_format))
     {
         if (transpose_of_faces && num_faces == 4)
         {
@@ -255,8 +255,9 @@ inline void _llk_unpack_A_init_(
     // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
     // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused.
     // The unpack-to-dest (SrcA) path is only taken when the input is actually 32-bit; otherwise the MOP
-    // falls through to the normal/broadcast path, so gate on is_32bit_input here exactly like it does.
-    if (unpack_to_dest && is_32bit_input(unpack_src_format, unpack_dst_format))
+    // falls through to the normal/broadcast path, so gate on the shared should_unpack_to_dest() predicate
+    // the MOP uses, so the two cannot diverge.
+    if (should_unpack_to_dest(unpack_to_dest, unpack_src_format, unpack_dst_format))
     {
         // SrcA -> dest. ROW and SCALAR broadcast only unpack a single row; everything else a full face.
         if constexpr (BType == BroadcastType::ROW || BType == BroadcastType::SCALAR)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -380,5 +380,4 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK; nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -252,7 +252,18 @@ inline void _llk_unpack_A_init_(
     // bool disable_src_zero_flag_val = disable_src_zero_flag || (static_cast<uint>(unpack_dst_format) == static_cast<uint>(DataFormat::UInt16));
     // cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable_src_zero_flag_val ? 1 : 0);
 
-    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE || unpack_to_dest) ? p_setadc::UNP_A : p_setadc::UNP_B;
+    // x-start/x-end is per-unpacker state, so program it on exactly the unpacker(s) the MOP issues a
+    // real (non-ZEROSRC) UNPACR against; a zeroed source does not read L1, so its X counter is unused:
+    //   plain datacopy            -> SrcA           (unpacker A)
+    //   acc_to_dest, no reuse      -> SrcA and SrcB  (both)
+    //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
+    //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
+    //   broadcast                  -> SrcB;  unpack-to-dest -> SrcA
+    constexpr bool reads_srca =
+        unpack_to_dest || (BType == BroadcastType::NONE && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA));
+    constexpr bool reads_srcb =
+        !unpack_to_dest && (BType != BroadcastType::NONE || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB));
+    constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
     if constexpr ((BType == BroadcastType::ROW || BType == BroadcastType::SCALAR) && unpack_to_dest) // ROW and SCALAR bcast will only unpack a single row
     {
         config_unpacker_x_end<UNP_SEL>(1);
@@ -359,4 +370,5 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_A_uninit_()
 {
+    // x-start/x-end is transient and programmed by each operation's init LLK; nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -357,8 +357,8 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
-inline void _llk_unpack_A_uninit_(const std::uint32_t face_r_dim)
+inline void _llk_unpack_A_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    constexpr std::uint32_t UNP_SEL = (BType == BroadcastType::NONE) ? p_setadc::UNP_A : p_setadc::UNP_AB;
-    TT_SETADCXX(UNP_SEL, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -205,8 +205,6 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  */
 inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**
@@ -410,7 +408,6 @@ inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_D
 {
     // Revisit default stride value in tt-llk#1015
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(y_stride);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -203,7 +203,7 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
-inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
+inline void _llk_unpack_AB_uninit_()
 {
 }
 
@@ -401,10 +401,9 @@ inline void _llk_unpack_bcastA_B_init_()
  * (see tt-llk#1036), so it is not restored here.
  *
  * @param y_stride: SrcA Y stride to restore.
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_bcastA_B_init_ before this function.
  */
-inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2, [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2)
 {
     // Revisit default stride value in tt-llk#1015
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(y_stride);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -203,11 +203,10 @@ inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const 
  * @param unpB_tensor_shape: Tensor shape for source B operand
  * @note Call @ref _llk_unpack_AB_init_ before this function.
  */
-inline void _llk_unpack_AB_uninit_(const ckernel::TensorShape unpA_tensor_shape, const ckernel::TensorShape unpB_tensor_shape)
+inline void _llk_unpack_AB_uninit_([[maybe_unused]] const ckernel::TensorShape unpA_tensor_shape, [[maybe_unused]] const ckernel::TensorShape unpB_tensor_shape)
 {
-    // TODO NC: Issue tt-llk#1036 will make this transient
-    TT_SETADCXX(p_setadc::UNP_A, unpA_tensor_shape.face_r_dim * unpA_tensor_shape.face_c_dim - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, unpB_tensor_shape.face_r_dim * unpB_tensor_shape.face_c_dim - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**
@@ -400,17 +399,18 @@ inline void _llk_unpack_bcastA_B_init_()
 /**
  * @brief Uninitialize the unpacker after the SDPA sub_bcast_row variant.
  *
- * Restores the SrcA Y stride and resets the SrcA/SrcB datum counters to a full face worth of datums.
+ * Restores the SrcA Y stride. x-start/x-end is transient and reprogrammed by each operation's init
+ * (see tt-llk#1036), so it is not restored here.
  *
  * @param y_stride: SrcA Y stride to restore.
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_bcastA_B_init_ before this function.
  */
-inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2, const std::uint32_t face_r_dim = FACE_R_DIM)
+inline void _llk_unpack_bcastA_B_uninit_(const std::uint32_t y_stride = FACE_R_DIM * 2, [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM)
 {
     // Revisit default stride value in tt-llk#1015
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_RMW>(y_stride);
-    TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -247,17 +247,18 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
 }
 
 /**
- * @brief Restore unpacker datum-count state after a matmul operation.
+ * @brief No-op after a matmul operation.
  *
- * Resets the X-dimension address counters for both SrcA and SrcB back to a single face worth of
- * datums.
+ * x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036), so there
+ * is nothing to restore here.
  *
- * @param face_r_dim: Rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_AB_matmul_init_ before this function.
  */
-inline void _llk_unpack_AB_matmul_uninit_(const std::uint32_t face_r_dim)
+inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    TT_SETADCXX(p_setadc::UNP_AB, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
+    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -257,8 +257,6 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
  */
 inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
 {
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036);
-    // nothing to restore here.
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -252,10 +252,9 @@ __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
  * x-start/x-end is transient and reprogrammed by each operation's init (see tt-llk#1036), so there
  * is nothing to restore here.
  *
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_AB_matmul_init_ before this function.
  */
-inline void _llk_unpack_AB_matmul_uninit_([[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_AB_matmul_uninit_()
 {
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -172,8 +172,6 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 
@@ -232,8 +230,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
-
-        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -173,7 +173,7 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
 
-        TT_SETADCXX(p_setadc::UNP_A, (unpack_face_r_dim << 4) - 1, 0x0);
+        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 
@@ -233,7 +233,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
         // Set Z-dim to number of faces
         cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32 + 1, 0, 0xffff0000>(0 | (unpack_num_faces << 16));
 
-        TT_SETADCXX(p_setadc::UNP_B, (unpack_face_r_dim << 4) - 1, 0x0);
+        // x-start/x-end is transient (set by each operation's init LLK, see tt-llk#1036); not touched on reconfig.
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -532,21 +532,21 @@ inline void _llk_unpack_tilizeA_B_(
 /**
  * @brief Restore unpacker state after a tilize operation.
  *
- * Reverts the X-dimension datum counts and the tile descriptor Z-dimension to defaults and
- * rewrites the unpack config (clearing tileize mode) so subsequent ops see a normal tile layout.
+ * Reverts the tile descriptor Z-dimension to default and rewrites the unpack config (clearing
+ * tilize mode) so subsequent ops see a normal tile layout. x-start/x-end is transient and
+ * reprogrammed by each operation's init (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @param num_faces: Number of faces in the tile (1, 2, or 4); restored into the tile descriptor Z-dim.
- * @param face_r_dim: Rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // Restore Z dim to the default operand state set by _llk_unpack_init_:
     // THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1 - word 1 of the same-named register
@@ -573,18 +573,18 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 /**
  * @brief Restore unpacker state after a tilize-A-with-unpack-B operation.
  *
- * Reverts the SrcA/SrcB X-dimension datum counts and the SrcA Y counter, and rewrites the unpack
- * config and tile X-dim back to the default 16x16 face layout.
+ * Resets the SrcA/SrcB Z/W counters and rewrites the unpack config and tile X-dim back to the
+ * default 16x16 face layout. x-start/x-end is transient and reprogrammed by each operation's init
+ * (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @param face_r_dim: Rows per face, used to compute the restored datum count.
+ * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
-    TT_SETADCXX(p_setadc::UNP_B, face_r_dim * FACE_C_DIM - 1, 0x0);
+    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // reset z/w counters
     TTI_SETADCZW(p_setadc::UNP_AB, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -538,10 +538,9 @@ inline void _llk_unpack_tilizeA_B_(
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
  * @param num_faces: Number of faces in the tile (1, 2, or 4); restored into the tile descriptor Z-dim.
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilize_init_ before this function.
  */
-inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces, [[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, const std::uint32_t num_faces)
 {
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Stalling SETDMAREG done by THCON until UNPACK finishes
@@ -577,10 +576,9 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
  * (see tt-llk#1036), so it is not restored here.
  *
  * @param unpack_dst_format: Destination data format to restore in the unpack config.
- * @param face_r_dim: Unused; retained for API compatibility.
  * @note Call @ref _llk_unpack_tilizeA_B_init_ before this function.
  */
-inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
+inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -546,7 +546,6 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // Restore Z dim to the default operand state set by _llk_unpack_init_:
     // THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1 - word 1 of the same-named register
@@ -584,7 +583,6 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
 inline void _llk_unpack_tilizeA_B_uninit_(const std::uint32_t unpack_dst_format, [[maybe_unused]] const std::uint32_t face_r_dim)
 {
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
-    // x-start/x-end is transient and programmed by each operation's init LLK (see tt-llk#1036); nothing to restore here.
 
     // reset z/w counters
     TTI_SETADCZW(p_setadc::UNP_AB, 0, 0, 0, 0, SETADC_CH01(p_setadc::ZW));


### PR DESCRIPTION
### PR Category
Bug fix, Cleanup

### Summary
This PR makes unpacker/packer `x-start` and `x-end` (`SETADCXX`) transient LLK state: each op programs what it needs in init, while hw-config/reconfig/startup/uninit paths no longer restore or own that state.

It also includes a tightly related unpacker-selection fix: in broadcast + unpack-to-dest flows with non-32-bit source input, init now programs the unpacker actually used by the MOP.

### Notes for reviewers
Primary behavioral changes:
- `configure_unpack_AB` / `configure_pack` no longer program `SETADCXX`.
- Unpack reconfig no longer programs `SETADCXX` (tile descriptor X updates remain).
- `*_uninit_` paths are no-op for x-counter restore (including fast-untilize uninit).
- Init paths now consistently own x-counter programming.
- Wormhole `unpack_A` init now gates unpack-to-dest unpacker selection on `is_32bit_input`, fixing the non-32-bit broadcast edge case.

Non-behavioral cleanup:
- Removed redundant explanatory comment in `unpack_A` uninit as requested in review.

Validation:
- Hardware re-validation on WH sanity, BH post-commit, runtime sanity, nightly L2 subgroups, and device perf matches expectations; observed failures are consistent with main/infra baselines.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/llk-1036-transient-x-start-end)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/llk-1036-transient-x-start-end)