### PR TITLE
ds_prefill :: LB hang fix avoid typecast

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -84,8 +84,13 @@ def run_dispatch_op(mesh_device, use_l1_small):
     tt_weights = ttnn.from_torch(
         weights, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
     )
+    # #44928: dispatch consumes UINT16 indices directly from moe_grouped_topk.
     tt_indices = ttnn.from_torch(
-        indices, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.int32
+        indices.to(torch.int16),
+        mesh_mapper=mesh_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.uint16,
     )
 
     expert_dispatch_table = ExpertMapping.create_dispatch_table(

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -86,7 +86,7 @@ def run_dispatch_op(mesh_device, use_l1_small):
     )
     # #44928: dispatch consumes UINT16 indices directly from moe_grouped_topk.
     tt_indices = ttnn.from_torch(
-        indices.to(torch.int16),
+        indices,
         mesh_mapper=mesh_mapper,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -224,7 +224,7 @@ def test_ttnn_dispatch(
     )
 
     tt_indices = ttnn.from_torch(
-        indices.to(torch.int16),
+        indices,
         mesh_mapper=mesh_mapper_replicated,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_prefill_dispatch.py
@@ -224,7 +224,11 @@ def test_ttnn_dispatch(
     )
 
     tt_indices = ttnn.from_torch(
-        indices, mesh_mapper=mesh_mapper_replicated, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.int32
+        indices.to(torch.int16),
+        mesh_mapper=mesh_mapper_replicated,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.uint16,
     )
 
     # Create expert dispatch table

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
@@ -159,7 +159,7 @@ def test_ttnn_reduce(
         dims=(0, None),
     )
     tt_indices = ttnn.from_torch(
-        torch_indices.to(torch.int16),
+        torch_indices,
         mesh_mapper=indices_mapper,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_reduce.py
@@ -159,11 +159,11 @@ def test_ttnn_reduce(
         dims=(0, None),
     )
     tt_indices = ttnn.from_torch(
-        torch_indices,
+        torch_indices.to(torch.int16),
         mesh_mapper=indices_mapper,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,
-        dtype=ttnn.int32,
+        dtype=ttnn.uint16,
     )
     tt_expert_dispatch_table = ttnn.from_torch(
         expert_dispatch_table,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -314,7 +314,7 @@ def test_ttnn_dispatch_combine(
         dtype=ttnn.bfloat16,
     )
     tt_indices = ttnn.from_torch(
-        indices.to(torch.int16),
+        indices,
         mesh_mapper=mesh_mapper_dispatch_inputs,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,
@@ -668,7 +668,7 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
         dtype=ttnn.bfloat16,
     )
     tt_indices = ttnn.from_torch(
-        indices.to(torch.int16),
+        indices,
         mesh_mapper=mesh_mapper_dispatch_inputs,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_dispatch_combine.py
@@ -314,11 +314,11 @@ def test_ttnn_dispatch_combine(
         dtype=ttnn.bfloat16,
     )
     tt_indices = ttnn.from_torch(
-        indices,
+        indices.to(torch.int16),
         mesh_mapper=mesh_mapper_dispatch_inputs,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,
-        dtype=ttnn.int32,
+        dtype=ttnn.uint16,
     )
 
     # Initialize TTNN dispatch module
@@ -668,11 +668,11 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
         dtype=ttnn.bfloat16,
     )
     tt_indices = ttnn.from_torch(
-        indices,
+        indices.to(torch.int16),
         mesh_mapper=mesh_mapper_dispatch_inputs,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=mesh_device,
-        dtype=ttnn.int32,
+        dtype=ttnn.uint16,
     )
 
     expert_dispatch_table = ExpertMapping.create_dispatch_table(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -453,17 +453,8 @@ class TtMoe(LightweightModule):
             _offsets_host = ttnn.to_torch(_offsets_4d, mesh_composer=_ep_composer).squeeze(2)
             logger.info(f"[TtMoe.forward] expert_region_offsets: {_offsets_host.flatten().tolist()}")
 
-        # Gate outputs uint16 indices; dispatch requires int32.
-        # this should be aligned in the further PR.
-        # Typecast in TILE_LAYOUT to avoid alignment issues, then convert to ROW_MAJOR.
-        if indices.dtype != ttnn.int32:
-            indices = ttnn.to_layout(indices, ttnn.TILE_LAYOUT)
-            indices = ttnn.typecast(indices, ttnn.int32)
-            indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)
-        else:
-            indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)
-        #
         # Ensure ROW_MAJOR layout for dispatch compatibility
+        indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)
         scores = ttnn.to_layout(scores, ttnn.ROW_MAJOR_LAYOUT)
 
         # Reshape back to 3D: (batch*seq, topk) -> (batch, seq, topk)
@@ -510,6 +501,7 @@ class TtMoe(LightweightModule):
         # ========================================
         # Dispatch expects full emb_dim on each device (x already has this)
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
+
         dispatched_buffer, metadata = self.dispatch_module(
             x,
             scores,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -501,7 +501,6 @@ class TtMoe(LightweightModule):
         # ========================================
         # Dispatch expects full emb_dim on each device (x already has this)
         logger.debug(f"[TtMoe.forward] {x.shape=} {x.memory_config()=}")
-
         dispatched_buffer, metadata = self.dispatch_module(
             x,
             scores,

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -339,14 +339,8 @@ def _forward_prefill_deepseek_chunk(
     ttnn.deallocate(idx_for_routing)
 
     # Step 3: Format indices/scores for dispatch
-    if topk_expert_indices.dtype != ttnn.int32:
-        indices_tile = ttnn.to_layout(topk_expert_indices, ttnn.TILE_LAYOUT)
-        indices_i32 = ttnn.typecast(indices_tile, ttnn.int32)
-        ttnn.deallocate(indices_tile)
-        indices_rm = ttnn.to_layout(indices_i32, ttnn.ROW_MAJOR_LAYOUT)
-        ttnn.deallocate(indices_i32)
-    else:
-        indices_rm = ttnn.to_layout(topk_expert_indices, ttnn.ROW_MAJOR_LAYOUT)
+    # Indices stay as uint16 from the gate - dispatch reads them natively.
+    indices_rm = ttnn.to_layout(topk_expert_indices, ttnn.ROW_MAJOR_LAYOUT)
     scores_rm = ttnn.to_layout(topk_expert_weights, ttnn.ROW_MAJOR_LAYOUT)
     scores_for_reduce = ttnn.clone(scores_rm, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -37,8 +37,8 @@ void DispatchDeviceOperation::validate_on_program_cache_miss(
         "Weights tensor must be BFLOAT16, got {}",
         tensor_args.weights_tensor.dtype());
     TT_FATAL(
-        tensor_args.indices_tensor.dtype() == DataType::INT32 || tensor_args.indices_tensor.dtype() == DataType::UINT32,
-        "Indices tensor must be INT32 or UINT32, got {}",
+        tensor_args.indices_tensor.dtype() == DataType::UINT16,
+        "Indices tensor must be UINT16 (matching moe_grouped_topk output), got {}",
         tensor_args.indices_tensor.dtype());
     TT_FATAL(
         tensor_args.expert_offsets_tensor.dtype() == DataType::INT32 ||

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -348,8 +348,8 @@ void kernel_main() {
                 tt_l1_ptr uint16_t* weights_t =
                     reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
                 for (uint32_t k = 0; k < num_experts_per_tok; k++) {
-                    auto routed_expert = (int32_t)indices_t[k];
-                    if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
+                    uint32_t routed_expert = (uint32_t)indices_t[k];
+                    if ((routed_expert & core_mask) != dispatch_core_idx) {
                         continue;
                     }
                     auto expert_chip_og = expert_dispatch_table[routed_expert];
@@ -453,7 +453,7 @@ void kernel_main() {
                 reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
 
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
-                auto routed_expert = (int32_t)indices[k];
+                uint32_t routed_expert = (uint32_t)indices[k];
 
                 if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
                     continue;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_dispatch.cpp
@@ -343,12 +343,12 @@ void kernel_main() {
             bool has_non_local = false;
 
             for (uint32_t t = 0; t < batch_count; t++) {
-                tt_l1_ptr int32_t* indices_t =
-                    reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
+                tt_l1_ptr uint16_t* indices_t =
+                    reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
                 tt_l1_ptr uint16_t* weights_t =
                     reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
                 for (uint32_t k = 0; k < num_experts_per_tok; k++) {
-                    auto routed_expert = indices_t[k];
+                    auto routed_expert = (int32_t)indices_t[k];
                     if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
                         continue;
                     }
@@ -447,13 +447,13 @@ void kernel_main() {
 #else
             uint32_t token_input_addr = input_base + t * aligned_input_page_size;
 #endif
-            tt_l1_ptr int32_t* indices =
-                reinterpret_cast<tt_l1_ptr int32_t*>(indices_base + t * aligned_indices_page_size);
+            tt_l1_ptr uint16_t* indices =
+                reinterpret_cast<tt_l1_ptr uint16_t*>(indices_base + t * aligned_indices_page_size);
             tt_l1_ptr uint16_t* weights =
                 reinterpret_cast<tt_l1_ptr uint16_t*>(weights_base + t * aligned_weights_page_size);
 
             for (uint32_t k = 0; k < num_experts_per_tok; ++k) {
-                auto routed_expert = indices[k];
+                auto routed_expert = (int32_t)indices[k];
 
                 if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
                     continue;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -23,6 +23,31 @@ constexpr uint32_t emb_dim_cb_tiles = get_compile_time_arg_val(1);
 constexpr uint32_t dispatch_table_num_pages = get_compile_time_arg_val(2);
 constexpr bool use_dispatch_table_skip = get_compile_time_arg_val(3) != 0;
 
+// Like read_tile_value but reads a uint16 element (zero-extended to uint32_t).
+// Indices arrive from DRAM as uint16 and stay uint16 in the CB; this avoids
+// an in-place uint16→int32 expansion in the writer kernel and removes an
+// architecture-dependent slot-size constraint on max top-k.
+ALWI uint32_t read_tile_value_uint16(uint32_t cb_id, uint32_t tile_index, uint32_t element_offset) {
+#ifndef ARCH_QUASAR
+    uint32_t value = 0;
+    UNPACK({
+        uint32_t operand_id = get_operand_id(cb_id);
+        uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr;
+        uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
+        uint32_t byte_address = (base_address + offset_address) << 4;
+        value = (uint32_t)reinterpret_cast<volatile uint16_t*>(byte_address)[element_offset];
+        mailbox_write(ckernel::ThreadId::MathThreadId, value);
+        mailbox_write(ckernel::ThreadId::PackThreadId, value);
+    })
+    MATH(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    PACK(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    return value;
+#else
+    ASSERT(false && "read_tile_value_uint16 is not implemented for ARCH_QUASAR");
+    return 0;
+#endif
+}
+
 void kernel_main() {
     constexpr uint32_t TOKENS_PER_CHUNK = 32;
     uint32_t token_start_idx = get_arg_val<uint32_t>(0);
@@ -62,7 +87,7 @@ void kernel_main() {
                 bool skip_expert = false;
                 bool must_zero_init = false;
                 if constexpr (use_dispatch_table_skip) {
-                    uint32_t expert_id = read_tile_value(cb_indices, i, expert_idx);
+                    uint32_t expert_id = read_tile_value_uint16(cb_indices, i, expert_idx);
                     // Check dispatch table: -1 (0xFFFFFFFF) means non-local
                     uint32_t chip_id = read_tile_value(cb_dispatch_table, 0, expert_id);
                     bool is_local = (chip_id != 0xFFFFFFFF);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -96,6 +96,30 @@ void kernel_main() {
                     token_start_idx + i, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
             }
             noc_async_read_barrier();
+            // #44928: source indices are UINT16 (gate emits uint16 and we pass it
+            // straight through). The compute kernel reads cb_indices via
+            // read_tile_value which treats elements as 4-byte uint32, so we
+            // expand uint16→int32 in place right-to-left (so we don't overwrite
+            // source bytes before reading them). After this loop the buffer is
+            // fully int32 and downstream code can treat cb_indices as int32.
+            //
+            // The in-place expansion is only safe if the expanded int32 form of
+            // one token fits inside that token's page slot. If num_experts grows
+            // past indices_aligned_page_size / 4, the last writes for token i
+            // would spill into token i+1's slot and corrupt its uint16 source
+            // before the outer loop reads it.
+            static_assert(
+                indices_aligned_page_size >= num_experts * sizeof(int32_t),
+                "per-page slot must hold the expanded int32 indices");
+            for (uint32_t i = 0; i < TOKENS_PER_CHUNK; i++) {
+                uint32_t page_addr = indices_write_addr + i * indices_aligned_page_size;
+                volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_addr);
+                volatile tt_l1_ptr int32_t* dst = reinterpret_cast<volatile tt_l1_ptr int32_t*>(page_addr);
+                for (int k = (int)num_experts - 1; k >= 0; k--) {
+                    uint16_t v = src[k];
+                    dst[k] = (int32_t)v;
+                }
+            }
             cb_push_back(cb_indices, TOKENS_PER_CHUNK);
         }
 
@@ -106,6 +130,8 @@ void kernel_main() {
             bool has_local = true;
             if constexpr (use_dispatch_table_skip) {
                 tt_l1_ptr int32_t* dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_write_addr);
+                // After the in-place uint16→int32 expansion above, cb_indices always
+                // holds int32 elements. Read as int32 regardless of source dtype.
                 tt_l1_ptr int32_t* token_indices =
                     reinterpret_cast<tt_l1_ptr int32_t*>(indices_write_addr + token_idx * indices_aligned_page_size);
                 has_local = false;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -96,30 +96,8 @@ void kernel_main() {
                     token_start_idx + i, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
             }
             noc_async_read_barrier();
-            // #44928: source indices are UINT16 (gate emits uint16 and we pass it
-            // straight through). The compute kernel reads cb_indices via
-            // read_tile_value which treats elements as 4-byte uint32, so we
-            // expand uint16→int32 in place right-to-left (so we don't overwrite
-            // source bytes before reading them). After this loop the buffer is
-            // fully int32 and downstream code can treat cb_indices as int32.
-            //
-            // The in-place expansion is only safe if the expanded int32 form of
-            // one token fits inside that token's page slot. If num_experts grows
-            // past indices_aligned_page_size / 4, the last writes for token i
-            // would spill into token i+1's slot and corrupt its uint16 source
-            // before the outer loop reads it.
-            static_assert(
-                indices_aligned_page_size >= num_experts * sizeof(int32_t),
-                "per-page slot must hold the expanded int32 indices");
-            for (uint32_t i = 0; i < TOKENS_PER_CHUNK; i++) {
-                uint32_t page_addr = indices_write_addr + i * indices_aligned_page_size;
-                volatile tt_l1_ptr uint16_t* src = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(page_addr);
-                volatile tt_l1_ptr int32_t* dst = reinterpret_cast<volatile tt_l1_ptr int32_t*>(page_addr);
-                for (int k = (int)num_experts - 1; k >= 0; k--) {
-                    uint16_t v = src[k];
-                    dst[k] = (int32_t)v;
-                }
-            }
+            // Indices stay as uint16 in the CB — the compute kernel reads them
+            // directly via read_tile_value_uint16.
             cb_push_back(cb_indices, TOKENS_PER_CHUNK);
         }
 
@@ -130,10 +108,9 @@ void kernel_main() {
             bool has_local = true;
             if constexpr (use_dispatch_table_skip) {
                 tt_l1_ptr int32_t* dispatch_table = reinterpret_cast<tt_l1_ptr int32_t*>(dispatch_table_write_addr);
-                // After the in-place uint16→int32 expansion above, cb_indices always
-                // holds int32 elements. Read as int32 regardless of source dtype.
-                tt_l1_ptr int32_t* token_indices =
-                    reinterpret_cast<tt_l1_ptr int32_t*>(indices_write_addr + token_idx * indices_aligned_page_size);
+                // Indices stay as uint16 in the CB — no in-place expansion.
+                tt_l1_ptr uint16_t* token_indices =
+                    reinterpret_cast<tt_l1_ptr uint16_t*>(indices_write_addr + token_idx * indices_aligned_page_size);
                 has_local = false;
                 for (uint32_t k = 0; k < num_experts; ++k) {
                     if (dispatch_table[token_indices[k]] != -1) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/post_combine_reduce_device_operation.cpp
@@ -89,7 +89,12 @@ void PostCombineReduceDeviceOperation::validate_on_program_cache_miss(
 
     if (indices.has_value()) {
         TT_FATAL(indices->layout() == ttnn::Layout::ROW_MAJOR, "indices must be ROW_MAJOR");
-        TT_FATAL(indices->dtype() == DataType::INT32, "indices must be int32");
+        // #44928: indices come straight from moe_grouped_topk as UINT16. The
+        // writer expands them to int32 in L1 before the compute kernel reads.
+        TT_FATAL(
+            indices->dtype() == DataType::UINT16,
+            "indices must be uint16 (matching moe_grouped_topk output), got {}",
+            indices->dtype());
         TT_FATAL(expert_dispatch_table->layout() == ttnn::Layout::ROW_MAJOR, "expert_dispatch_table must be ROW_MAJOR");
         TT_FATAL(expert_dispatch_table->dtype() == DataType::INT32, "expert_dispatch_table must be int32");
     }


### PR DESCRIPTION
Addresses https://github.com/tenstorrent/tt-metal/issues/44928
Related to https://github.com/tenstorrent/tt-metal/issues/45714 and https://github.com/tenstorrent/tt-metal/issues/41163
                                                                
  - Remove ttnn.typecast(uint16 → int32) from the MoE path, which caused data corruption under Tracy profiler                                                                                                                               
  - MoE ops (dispatch, post_combine_reduce) now consume uint16 indices natively from the gate, eliminating the buggy typecast       
  - Add `read_tile_value_uint16` compute kernel helper for reading uint16 elements from cb since the `read_tile_value` by default reads int32

Tested locally 200 iterations of layer3 block loop test ISL=3840, no hang. ISL=3840 used to always hang on the 1st iteration.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nmilicevic/deepseek-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nmilicevic/deepseek-hang-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nmilicevic/deepseek-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nmilicevic/deepseek-hang-fix) [Perf tests no hang](https://github.com/tenstorrent/tt-metal/actions/runs/26749717258/job/78953362078)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nmilicevic/deepseek-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nmilicevic/deepseek-hang-fix) [Perf tests no hang](https://github.com/tenstorrent/tt-metal/actions/runs/26812841467/job/79051030131)

GPT OSS
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-e2e-tests.yaml/badge.svg?branch=nmilicevic/deepseek-hang-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-e2e-tests.yaml?query=branch:nmilicevic/deepseek-hang-fix)

