### PR TITLE
ttnn: add experimental deepseek_prefill.update_padded_kv_cache op

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -40,7 +40,7 @@ def _index_tensor(value, mesh_device):
     )
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4), (8, 4)], ids=["2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
     [

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -25,21 +25,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 KVPE_HEAD_DIM = 576
 
 
-def _index_tensor(value, mesh_device):
-    """Single-element ROW_MAJOR uint32 device tensor (mesh-replicated), read on-device by the op.
-    slot_idx and kv_actual_global are passed this way so their values stay out of the program hash
-    and the buffer-binding fast cache-hit path can patch their addresses across calls. A fresh tensor
-    per call (different buffer address, same shape/dtype) exercises that path."""
-    return ttnn.from_torch(
-        torch.tensor([value], dtype=torch.int32).reshape(1, 1, 1, 1),
-        device=mesh_device,
-        dtype=ttnn.uint32,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-    )
-
-
 @pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
@@ -109,10 +94,10 @@ def test_update_padded_kv_cache_single_iteration_prefill(
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                 kv_cache,
                 tt_input,
-                slot_idx=_index_tensor(u, mesh_device),
+                slot_idx=u,
                 layer_idx=l,
                 num_layers=num_layers,
-                kv_actual_global=_index_tensor(0, mesh_device),
+                kv_actual_global=0,
                 cluster_axis=sp_axis,
             )
 
@@ -177,7 +162,7 @@ def _rotated_chip_positions(kv_actual, sp, chunk_local):
     return positions
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4), (8, 4)], ids=["2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
     [
@@ -288,10 +273,10 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
                 ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                     kv_cache,
                     tt_input,
-                    slot_idx=_index_tensor(u, mesh_device),
+                    slot_idx=u,
                     layer_idx=l,
                     num_layers=num_layers,
-                    kv_actual_global=_index_tensor(kv_actual, mesh_device),
+                    kv_actual_global=kv_actual,
                     cluster_axis=sp_axis,
                 )
         kv_actual = valid_end

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
@@ -16,7 +16,6 @@ import torch
 from loguru import logger
 
 import ttnn
-
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -37,7 +36,14 @@ KVPE_HEAD_DIM = 576
 )
 @pytest.mark.timeout(0)
 def test_update_padded_kv_cache_single_iteration_prefill(
-    mesh_device, config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev, is_ci_env, is_ci_v2_env
+    mesh_device,
+    config_name,
+    num_users,
+    num_layers,
+    new_isl_tiles_per_dev,
+    cache_tokens_per_dev,
+    is_ci_env,
+    is_ci_v2_env,
 ):
     """Single-iteration (non-padded) prefill: write one chunk-aligned slab per (user, layer)
     at offset 0, gather the whole cache, and PCC each slot's valid data against what was sent."""
@@ -124,7 +130,10 @@ def test_update_padded_kv_cache_single_iteration_prefill(
             # Each chip's slab-0 prefix [0:chunk_local] holds its share of the chunk;
             # concat across chips to rebuild natural global order.
             written = torch.cat(
-                [cache_host[batch_idx, 0, c * cache_tokens_per_dev : c * cache_tokens_per_dev + chunk_local, :] for c in range(sp)],
+                [
+                    cache_host[batch_idx, 0, c * cache_tokens_per_dev : c * cache_tokens_per_dev + chunk_local, :]
+                    for c in range(sp)
+                ],
                 dim=0,
             )
             _, msg = assert_with_pcc(sent[(u, l)], written, 0.99)
@@ -169,7 +178,15 @@ def _rotated_chip_positions(kv_actual, sp, chunk_local):
 @pytest.mark.parametrize("scenario", ["non_padded", "padded_partial"], ids=["non_padded", "padded_partial"])
 @pytest.mark.timeout(0)
 def test_update_padded_kv_cache_multi_iteration_prefill(
-    mesh_device, config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev, scenario, is_ci_env, is_ci_v2_env
+    mesh_device,
+    config_name,
+    num_users,
+    num_layers,
+    new_isl_tiles_per_dev,
+    cache_tokens_per_dev,
+    scenario,
+    is_ci_env,
+    is_ci_v2_env,
 ):
     """Multi-iteration prefill, multi-user / multi-layer.
 
@@ -280,7 +297,9 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     cache_host = ttnn.to_torch(
         kv_cache,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape),
-    ).to(torch.bfloat16)[:, :1, :, :]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
+    ).to(torch.bfloat16)[
+        :, :1, :, :
+    ]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
 
     # cache cell (chip c, local row lr) holds global position (lr//C)*chunk_global + c*C + (lr%C);
     # invert for every valid position to rebuild natural order from the chip-concatenated gather.

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
@@ -25,6 +25,21 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 KVPE_HEAD_DIM = 576
 
 
+def _index_tensor(value, mesh_device):
+    """Single-element ROW_MAJOR uint32 device tensor (mesh-replicated), read on-device by the op.
+    slot_idx and kv_actual_global are passed this way so their values stay out of the program hash
+    and the buffer-binding fast cache-hit path can patch their addresses across calls. A fresh tensor
+    per call (different buffer address, same shape/dtype) exercises that path."""
+    return ttnn.from_torch(
+        torch.tensor([value], dtype=torch.int32).reshape(1, 1, 1, 1),
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
 @pytest.mark.parametrize("mesh_device", [(2, 4), (8, 4)], ids=["2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
@@ -78,7 +93,6 @@ def test_update_padded_kv_cache_single_iteration_prefill(
     input_shard_dims[sp_axis] = 2  # split the chunk across sp devices
 
     mesh_device.enable_program_cache()
-    entries_after_first = None
 
     for u in range(num_users):
         for l in range(num_layers):
@@ -95,23 +109,20 @@ def test_update_padded_kv_cache_single_iteration_prefill(
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                 kv_cache,
                 tt_input,
-                slot_idx=u,
+                slot_idx=_index_tensor(u, mesh_device),
                 layer_idx=l,
                 num_layers=num_layers,
-                kv_actual_global=0,
+                kv_actual_global=_index_tensor(0, mesh_device),
                 cluster_axis=sp_axis,
             )
-            if entries_after_first is None:
-                ttnn.synchronize_device(mesh_device)
-                entries_after_first = mesh_device.num_program_cache_entries()
 
     ttnn.synchronize_device(mesh_device)
 
-    # slot_idx / layer_idx / kv_actual_global are runtime args (not in the program hash), so
-    # every subsequent (user, layer) call must reuse the program compiled on the first call.
-    assert mesh_device.num_program_cache_entries() == entries_after_first, (
-        f"op must reuse one cached program across users/layers; entries grew from "
-        f"{entries_after_first} to {mesh_device.num_program_cache_entries()}"
+    # slot_idx and kv_actual_global are device tensors (not in the program hash) and layer_idx is
+    # hashed, so exactly one cached program per layer is reused across all users — entries == num_layers.
+    assert mesh_device.num_program_cache_entries() == num_layers, (
+        f"op must reuse one cached program per layer across users; expected {num_layers} entries, "
+        f"got {mesh_device.num_program_cache_entries()}"
     )
 
     # Gather: concat sp shards on the seq dim, drop the tp-replicated head copies.
@@ -212,6 +223,13 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
         new_actual_isls = [chunk_global, chunk_global]
     else:  # padded_partial: whole-tile boundary_offset != 0; boundary chip writes straddle slabs
         new_actual_isls = [(sp - 1) * C + tile, 2 * C, sp * C]
+    # Each iteration writes exactly one chunk_global-token chunk, so the valid frontier can advance by
+    # at most chunk_global per iteration. A larger advance would claim tokens valid that were never
+    # written, leaving an unwritten hole -- e.g. a scenario tuned for sp>=2 (2*C) run at sp=1, where
+    # chunk_global == C is smallest.
+    assert all(
+        isl <= chunk_global for isl in new_actual_isls
+    ), f"each new_isl must be <= chunk_global ({chunk_global}); got {new_actual_isls}"
     cum_total = sum(new_actual_isls)
     cache_global = cache_tokens_per_dev * sp
     assert cum_total <= cache_global, f"valid tokens ({cum_total}) must fit the cache ({cache_global})"
@@ -241,7 +259,6 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     input_shard_dims[sp_axis] = 2
 
     mesh_device.enable_program_cache()
-    entries_after_first = None
 
     kv_actual = 0
     for it, new_actual_isl in enumerate(new_actual_isls):
@@ -271,24 +288,22 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
                 ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                     kv_cache,
                     tt_input,
-                    slot_idx=u,
+                    slot_idx=_index_tensor(u, mesh_device),
                     layer_idx=l,
                     num_layers=num_layers,
-                    kv_actual_global=kv_actual,
+                    kv_actual_global=_index_tensor(kv_actual, mesh_device),
                     cluster_axis=sp_axis,
                 )
-                if entries_after_first is None:
-                    ttnn.synchronize_device(mesh_device)
-                    entries_after_first = mesh_device.num_program_cache_entries()
         kv_actual = valid_end
 
     ttnn.synchronize_device(mesh_device)
 
-    # kv_actual_global / slot_idx / layer_idx are runtime args (not in the program hash), so every
-    # iteration and (user, layer) must reuse the program compiled on the first call.
-    assert mesh_device.num_program_cache_entries() == entries_after_first, (
-        f"op must reuse one cached program across iterations/users/layers; entries grew from "
-        f"{entries_after_first} to {mesh_device.num_program_cache_entries()}"
+    # kv_actual_global and slot_idx are device tensors (not in the program hash) and layer_idx is
+    # hashed, so exactly one cached program per layer is reused across all iterations and users —
+    # entries == num_layers.
+    assert mesh_device.num_program_cache_entries() == num_layers, (
+        f"op must reuse one cached program per layer across iterations/users; expected {num_layers} "
+        f"entries, got {mesh_device.num_program_cache_entries()}"
     )
 
     concat_dims = [None, None]

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device test for ttnn.experimental.deepseek_prefill.update_padded_kv_cache.
+
+The op writes a per-chip input slab into a KV cache at a per-device start offset
+derived from a single global token count `kv_actual_global`. When that count is
+chunk-aligned every device writes at the same local offset; otherwise devices
+around the boundary write at different offsets so new tokens overwrite the prior
+cache's trailing pad cells before spilling into the next slab.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# MLA KVPE head dim (kv_lora_rank=512 + qk_rope_head_dim=64). The op is a pure tile
+# copy, so a gathered cache slot should match the data we sent (PCC, allowing for the
+# bfloat8_b cache round-trip).
+KVPE_HEAD_DIM = 576
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4), (8, 4)], ids=["2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize(
+    "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
+    [
+        ("small", 2, 3, 4, 512),  # small: 2 users x 3 layers, 4-tile chunk/dev, ~1k cache
+        ("repr", 2, 3, 20, 6400),  # representative: 5k new isl + 50k cache on 8x4 (per-dev scaled)
+    ],
+    ids=["small", "repr"],
+)
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_single_iteration_prefill(
+    mesh_device, config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev, is_ci_env, is_ci_v2_env
+):
+    """Single-iteration (non-padded) prefill: write one chunk-aligned slab per (user, layer)
+    at offset 0, gather the whole cache, and PCC each slot's valid data against what was sent."""
+    if is_ci_env or is_ci_v2_env:
+        pytest.skip("CI runs only the small padded_partial case (multi-iteration); this is a subset of it")
+    sp_axis, tp_axis = 0, 1
+    sp = mesh_device.shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+
+    chunk_local = new_isl_tiles_per_dev * tile  # per-device new tokens
+    new_isl_global = chunk_local * sp  # one global chunk = slab 0
+    cache_global = cache_tokens_per_dev * sp
+
+    torch.manual_seed(0)
+    # Reference new tokens per (user, layer), in natural global order.
+    sent = {
+        (u, l): torch.randn(new_isl_global, KVPE_HEAD_DIM, dtype=torch.bfloat16)
+        for u in range(num_users)
+        for l in range(num_layers)
+    }
+
+    kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=KVPE_HEAD_DIM,
+        mesh_device=mesh_device,
+        seq_len=cache_global,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_users * num_layers,
+    )
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2  # split the chunk across sp devices
+
+    mesh_device.enable_program_cache()
+    entries_after_first = None
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            tt_input = ttnn.from_torch(
+                sent[(u, l)].reshape(1, 1, new_isl_global, KVPE_HEAD_DIM),
+                device=mesh_device,
+                dtype=ttnn.bfloat8_b,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
+                ),
+            )
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                kv_cache,
+                tt_input,
+                slot_idx=u,
+                layer_idx=l,
+                num_layers=num_layers,
+                kv_actual_global=0,
+                cluster_axis=sp_axis,
+            )
+            if entries_after_first is None:
+                ttnn.synchronize_device(mesh_device)
+                entries_after_first = mesh_device.num_program_cache_entries()
+
+    ttnn.synchronize_device(mesh_device)
+
+    # slot_idx / layer_idx / kv_actual_global are runtime args (not in the program hash), so
+    # every subsequent (user, layer) call must reuse the program compiled on the first call.
+    assert mesh_device.num_program_cache_entries() == entries_after_first, (
+        f"op must reuse one cached program across users/layers; entries grew from "
+        f"{entries_after_first} to {mesh_device.num_program_cache_entries()}"
+    )
+
+    # Gather: concat sp shards on the seq dim, drop the tp-replicated head copies.
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    cache_host = ttnn.to_torch(
+        kv_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)
+    cache_host = cache_host[:, :1, :, :]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            batch_idx = u * num_layers + l
+            # Each chip's slab-0 prefix [0:chunk_local] holds its share of the chunk;
+            # concat across chips to rebuild natural global order.
+            written = torch.cat(
+                [cache_host[batch_idx, 0, c * cache_tokens_per_dev : c * cache_tokens_per_dev + chunk_local, :] for c in range(sp)],
+                dim=0,
+            )
+            _, msg = assert_with_pcc(sent[(u, l)], written, 0.99)
+            logger.info(f"  user {u} layer {l}: valid-data PCC {msg}")
+
+    logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")
+
+
+def _rotated_chip_positions(kv_actual, sp, chunk_local):
+    """Global token position carried by each chip-local input row after the op's KV-pad-aware
+    rotation, mirroring the writer kernel's update_idxt math. positions[c][r] is the global
+    position chip c's r-th input row will land at; rows whose position is >= the valid frontier
+    are server pad. Slab-aware (handles kv_actual spanning multiple slabs)."""
+    C = chunk_local
+    chunk_global = sp * C
+    boundary_slab = kv_actual // chunk_global
+    boundary_chip = (kv_actual // C) % sp
+    boundary_offset = kv_actual % C
+    positions = [[0] * C for _ in range(sp)]
+    for c in range(sp):
+        if c < boundary_chip:
+            update_idxt = (boundary_slab + 1) * C
+        elif c == boundary_chip:
+            update_idxt = boundary_slab * C + boundary_offset
+        else:
+            update_idxt = boundary_slab * C
+        for r in range(C):
+            lr = update_idxt + r  # local cache row this input row lands in
+            positions[c][r] = (lr // C) * chunk_global + c * C + (lr % C)
+    return positions
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4), (8, 4)], ids=["2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize(
+    "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
+    [
+        ("small", 2, 3, 4, 512),  # small
+        ("repr", 2, 3, 20, 6400),  # representative
+    ],
+    ids=["small", "repr"],
+)
+@pytest.mark.parametrize("scenario", ["non_padded", "padded_partial"], ids=["non_padded", "padded_partial"])
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_multi_iteration_prefill(
+    mesh_device, config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev, scenario, is_ci_env, is_ci_v2_env
+):
+    """Multi-iteration prefill, multi-user / multi-layer.
+
+    - non_padded: two full-chunk iterations (chunk-aligned, no rotation).
+    - padded_partial: three iterations exercising whole-tile, non-zero pad offsets (the general
+      case -- a whole-device pad boundary is just the offset == 0 special case). iter 0 fills the
+      last device by one tile; iter 1 completes the last device (its write straddles a slab),
+      fills the next device, and leaves device 1 partially filled by one tile; iter 2 is a full
+      chunk that enters at device 1's tile offset (a second straddle).
+
+    Each iteration sends server-rotated input; afterwards the cache is gathered, natural order is
+    rebuilt, and every (user, layer) slot's valid prefix is PCC'd against the data sent.
+    """
+    if (is_ci_env or is_ci_v2_env) and not (config_name == "small" and scenario == "padded_partial"):
+        pytest.skip("CI runs only the small padded_partial case; the others are subsets of it")
+    sp_axis, tp_axis = 0, 1
+    sp = mesh_device.shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+    C = new_isl_tiles_per_dev * tile  # per-device chunk (physical, fixed every iter)
+    chunk_global = C * sp
+
+    if scenario == "non_padded":
+        new_actual_isls = [chunk_global, chunk_global]
+    else:  # padded_partial: whole-tile boundary_offset != 0; boundary chip writes straddle slabs
+        new_actual_isls = [(sp - 1) * C + tile, 2 * C, sp * C]
+    cum_total = sum(new_actual_isls)
+    cache_global = cache_tokens_per_dev * sp
+    assert cum_total <= cache_global, f"valid tokens ({cum_total}) must fit the cache ({cache_global})"
+
+    logger.info(
+        f"sp={sp} chunk_local={C} chunk_global={chunk_global} cache_global={cache_global}; "
+        f"new_isl per iter={new_actual_isls} (cum_total={cum_total})"
+    )
+
+    torch.manual_seed(0)
+    sent = {
+        (u, l): torch.randn(cum_total, KVPE_HEAD_DIM, dtype=torch.bfloat16)
+        for u in range(num_users)
+        for l in range(num_layers)
+    }
+
+    kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=KVPE_HEAD_DIM,
+        mesh_device=mesh_device,
+        seq_len=cache_global,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_users * num_layers,
+    )
+
+    input_shard_dims = [None, None]
+    input_shard_dims[sp_axis] = 2
+
+    mesh_device.enable_program_cache()
+    entries_after_first = None
+
+    kv_actual = 0
+    for it, new_actual_isl in enumerate(new_actual_isls):
+        positions = _rotated_chip_positions(kv_actual, sp, C)
+        flat = [positions[c][r] for c in range(sp) for r in range(C)]  # chip-concat order
+        valid_end = kv_actual + new_actual_isl
+        logger.info(
+            f"  iter {it}: kv_actual={kv_actual} new_isl={new_actual_isl} valid_end={valid_end} "
+            f"pad_boundary_chip={(valid_end // C) % sp}"
+        )
+        gather_idx = torch.tensor([min(g, cum_total - 1) for g in flat], dtype=torch.long)
+        pad_mask = torch.tensor([g >= valid_end for g in flat])
+        for u in range(num_users):
+            for l in range(num_layers):
+                chunk = sent[(u, l)][gather_idx].clone()  # [chunk_global, KVPE_HEAD_DIM]
+                chunk[pad_mask] = 0.0  # server pad rows
+                tt_input = ttnn.from_torch(
+                    chunk.reshape(1, 1, chunk_global, KVPE_HEAD_DIM),
+                    device=mesh_device,
+                    dtype=ttnn.bfloat8_b,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
+                    ),
+                )
+                ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                    kv_cache,
+                    tt_input,
+                    slot_idx=u,
+                    layer_idx=l,
+                    num_layers=num_layers,
+                    kv_actual_global=kv_actual,
+                    cluster_axis=sp_axis,
+                )
+                if entries_after_first is None:
+                    ttnn.synchronize_device(mesh_device)
+                    entries_after_first = mesh_device.num_program_cache_entries()
+        kv_actual = valid_end
+
+    ttnn.synchronize_device(mesh_device)
+
+    # kv_actual_global / slot_idx / layer_idx are runtime args (not in the program hash), so every
+    # iteration and (user, layer) must reuse the program compiled on the first call.
+    assert mesh_device.num_program_cache_entries() == entries_after_first, (
+        f"op must reuse one cached program across iterations/users/layers; entries grew from "
+        f"{entries_after_first} to {mesh_device.num_program_cache_entries()}"
+    )
+
+    concat_dims = [None, None]
+    concat_dims[sp_axis] = 2
+    concat_dims[tp_axis] = 1
+    cache_host = ttnn.to_torch(
+        kv_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=tuple(concat_dims), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:, :1, :, :]  # [users*layers, 1, cache_global, KVPE_HEAD_DIM]
+
+    # cache cell (chip c, local row lr) holds global position (lr//C)*chunk_global + c*C + (lr%C);
+    # invert for every valid position to rebuild natural order from the chip-concatenated gather.
+    p = torch.arange(cum_total)
+    chip = (p % chunk_global) // C
+    local_row = (p // chunk_global) * C + (p % C)
+    dim2_idx = chip * cache_tokens_per_dev + local_row
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            batch_idx = u * num_layers + l
+            recon = cache_host[batch_idx, 0, dim2_idx, :]  # [cum_total, KVPE_HEAD_DIM]
+            _, msg = assert_with_pcc(sent[(u, l)], recon, 0.99)
+            logger.info(f"  user {u} layer {l}: valid-prefix PCC {msg}")
+
+    logger.info(f"program cache entries: {mesh_device.num_program_cache_entries()}")

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -272,7 +272,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check)) and (not test_rope_prefill or 4x2)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4)" || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -136,7 +136,7 @@
 - name: t3k_DeepSeek_PREFILL_OP_TESTS
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check)) and not test_dispatch_combine_l1_small_semaphores" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4))) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check)) and (not update_padded_kv_cache or 2x4) and not test_dispatch_combine_l1_small_semaphores" || exit_code=$?
     exit $exit_code
   skus:
     wh_llmbox:

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -266,6 +266,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::Extract
         TTNN::Ops::Experimental::DeepSeekPrefill::Insert
         TTNN::Ops::Experimental::DeepSeekPrefill::MoeGroupedTopk
+        TTNN::Ops::Experimental::DeepSeekPrefill::UpdatePaddedKvCache
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::PlusOne
         TTNN::Ops::Experimental::Reduction
@@ -522,6 +523,7 @@ add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/extract)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/insert)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk)
+add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache)
 add_subdirectory(cpp/ttnn/operations/experimental/padded_slice)
 add_subdirectory(cpp/ttnn/operations/experimental/paged_cache)
 add_subdirectory(cpp/ttnn/operations/experimental/plusone)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/CMakeLists.txt
@@ -1,0 +1,41 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache ${LIB_TYPE})
+add_library(
+    TTNN::Ops::Experimental::DeepSeekPrefill::UpdatePaddedKvCache
+    ALIAS ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache
+)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_UPDATE_PADDED_KV_CACHE_API_HEADERS}
+    PRIVATE
+        device/update_padded_kv_cache_device_operation.cpp
+        update_padded_kv_cache.cpp
+)
+
+target_link_libraries(
+    ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache
+    PRIVATE
+        TT::Metalium
+    PUBLIC
+        TTNN::Core
+)
+
+install(TARGETS ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache LIBRARY COMPONENT tar)
+
+install(TARGETS ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache FILE_SET api COMPONENT ttnn-dev)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+// CB -> cache writer for the per-chip-offset kv-cache update op.
+//
+// Derives `start_id` on-device from per-call common rt-args so that
+// `kv_actual_global`, `slot_idx`, `layer_idx` can be omitted from the program
+// hash — successive chunks with different values reuse the same cached program;
+// only rt-args are refreshed via apply_descriptor_runtime_args on the cache-hit
+// slow path. `num_layers` and `cluster_axis` stay in the hash (structural).
+void kernel_main() {
+    // Per-core runtime args.
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+    const uint32_t core_blocks_written = get_arg_val<uint32_t>(2);
+
+    // Common runtime args (same for all cores on this chip).
+    const uint32_t kv_actual_global_t = get_common_arg_val<uint32_t>(0);
+    const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(1);
+    const uint32_t sp_factor = get_common_arg_val<uint32_t>(2);
+    const uint32_t chunk_local_t = get_common_arg_val<uint32_t>(3);
+    const uint32_t slot_idx = get_common_arg_val<uint32_t>(4);
+    const uint32_t layer_idx = get_common_arg_val<uint32_t>(5);
+    const uint32_t num_layers = get_common_arg_val<uint32_t>(6);
+    const uint32_t Wt = get_common_arg_val<uint32_t>(7);
+    const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(8);
+    const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(9);
+
+    // Cache linearization: users outer, layers inner.
+    const uint32_t batch_idx = slot_idx * num_layers + layer_idx;
+
+    // Derive this chip's tile-row write offset (update_idxt) into its local cache slab from the
+    // global valid length kv_actual_global_t. The boundary chip is the one holding the first pad
+    // cell; chips before it have already had their pad consumed, so they write into the next slab;
+    // the boundary chip writes mid-slab at boundary_offset_t; chips after it write at the current
+    // slab base.
+    const uint32_t chunk_global_t = sp_factor * chunk_local_t;
+    const uint32_t boundary_slab_idx = kv_actual_global_t / chunk_global_t;
+    const uint32_t boundary_chip = (kv_actual_global_t / chunk_local_t) % sp_factor;
+    const uint32_t boundary_offset_t = kv_actual_global_t % chunk_local_t;
+
+    uint32_t update_idxt;
+    if (my_sp_coord < boundary_chip) {
+        update_idxt = (boundary_slab_idx + 1) * chunk_local_t;
+    } else if (my_sp_coord == boundary_chip) {
+        update_idxt = boundary_slab_idx * chunk_local_t + boundary_offset_t;
+    } else {
+        update_idxt = boundary_slab_idx * chunk_local_t;
+    }
+
+    const uint32_t input_Ht = chunk_local_t;
+    const uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;
+    const uint32_t start_id =
+        start_idx + (core_blocks_written / input_Ht) * cache_HtWt + (core_blocks_written % input_Ht) * Wt;
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
+
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
+    Noc noc;
+    CircularBuffer cb(cb_id_out);
+
+    constexpr uint32_t onepage = 1;
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    const uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb.wait_front(onepage);
+        noc.async_write(cb, s, page_bytes, {}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -45,14 +45,11 @@ void kernel_main() {
     const uint32_t boundary_chip = (kv_actual_global_t / chunk_local_t) % sp_factor;
     const uint32_t boundary_offset_t = kv_actual_global_t % chunk_local_t;
 
-    uint32_t update_idxt;
-    if (my_sp_coord < boundary_chip) {
-        update_idxt = (boundary_slab_idx + 1) * chunk_local_t;
-    } else if (my_sp_coord == boundary_chip) {
-        update_idxt = boundary_slab_idx * chunk_local_t + boundary_offset_t;
-    } else {
-        update_idxt = boundary_slab_idx * chunk_local_t;
-    }
+    // From the current slab base, chips before the boundary advance a full slab, the boundary chip
+    // advances by its pad offset, and chips after it stay at the base.
+    const uint32_t update_idxt =
+        boundary_slab_idx * chunk_local_t +
+        (my_sp_coord < boundary_chip ? chunk_local_t : (my_sp_coord == boundary_chip ? boundary_offset_t : 0));
 
     const uint32_t input_Ht = chunk_local_t;
     const uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -9,18 +9,16 @@
 
 // CB -> cache writer for the per-chip-offset kv-cache update op.
 //
-// Reads the per-call `slot_idx` and `kv_actual_global` from single-element ROW_MAJOR uint32 device
-// tensors (on-device, below) and derives `start_id` from them plus structural common rt-args. Those
-// two values are therefore omitted from the program hash — successive users/chunks reuse one cached
-// program (per layer), and their buffer addresses are patched on the buffer-binding fast cache-hit
-// path. `layer_idx`, `num_layers` and `cluster_axis` stay in the hash (structural).
+// Reads the per-call `slot_idx` and `kv_actual_global` from common runtime args (patched on cache
+// hits by the op's MeshWorkloadFactory::override_runtime_arguments) and derives `start_id` from them
+// plus structural common rt-args. Those two values are omitted from the program hash — successive
+// users/chunks reuse one cached program (per layer). `layer_idx`, `num_layers` and `cluster_axis`
+// stay in the hash (structural).
 void kernel_main() {
     // Per-core runtime args (buffers arrive as Buffer* bindings -> addresses).
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t slot_addr = get_arg_val<uint32_t>(1);
-    const uint32_t kv_addr = get_arg_val<uint32_t>(2);
-    const uint32_t num_pages = get_arg_val<uint32_t>(3);
-    const uint32_t core_blocks_written = get_arg_val<uint32_t>(4);
+    const uint32_t num_pages = get_arg_val<uint32_t>(1);
+    const uint32_t core_blocks_written = get_arg_val<uint32_t>(2);
 
     // Common runtime args (same for all cores on this chip): structural per cached program.
     const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
@@ -31,34 +29,15 @@ void kernel_main() {
     const uint32_t Wt = get_common_arg_val<uint32_t>(5);
     const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(6);
     const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(7);
+    // Per-call values, patched on cache hits by override_runtime_arguments (not hashed).
+    const uint32_t slot_idx = get_common_arg_val<uint32_t>(8);
+    const uint32_t kv_actual_global = get_common_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t slot_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t kv_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(3);
-    constexpr auto dst_args = TensorAccessorArgs<4>();
-    constexpr auto slot_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
-    constexpr auto kv_args = TensorAccessorArgs<slot_args.next_compile_time_args_offset()>();
+    constexpr uint32_t tile_height = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
 
-    // Read the single on-device slot_idx datum into a CB. Its address is patched on cache hits; its
-    // value is not hashed.
-    const auto s_slot = TensorAccessor(slot_args, slot_addr);
-    cb_reserve_back(slot_cb_id, 1);
-    const uint32_t slot_l1 = get_write_ptr(slot_cb_id);
-    noc_async_read_page(0, s_slot, slot_l1);
-    noc_async_read_barrier();
-    cb_push_back(slot_cb_id, 1);
-    const uint32_t slot_idx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_l1)[0];
-
-    // Read the single on-device kv_actual_global datum (prior valid global KV length in tokens) and
-    // convert to tiles.
-    const auto s_kv = TensorAccessor(kv_args, kv_addr);
-    cb_reserve_back(kv_cb_id, 1);
-    const uint32_t kv_l1 = get_write_ptr(kv_cb_id);
-    noc_async_read_page(0, s_kv, kv_l1);
-    noc_async_read_barrier();
-    cb_push_back(kv_cb_id, 1);
-    const uint32_t kv_actual_global_t = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kv_l1)[0] / tile_height;
+    const uint32_t kv_actual_global_t = kv_actual_global / tile_height;
 
     // Cache linearization: users outer, layers inner.
     const uint32_t batch_idx = slot_idx * num_layers + layer_idx;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -9,28 +9,56 @@
 
 // CB -> cache writer for the per-chip-offset kv-cache update op.
 //
-// Derives `start_id` on-device from per-call common rt-args so that
-// `kv_actual_global`, `slot_idx`, `layer_idx` can be omitted from the program
-// hash — successive chunks with different values reuse the same cached program;
-// only rt-args are refreshed via apply_descriptor_runtime_args on the cache-hit
-// slow path. `num_layers` and `cluster_axis` stay in the hash (structural).
+// Reads the per-call `slot_idx` and `kv_actual_global` from single-element ROW_MAJOR uint32 device
+// tensors (on-device, below) and derives `start_id` from them plus structural common rt-args. Those
+// two values are therefore omitted from the program hash — successive users/chunks reuse one cached
+// program (per layer), and their buffer addresses are patched on the buffer-binding fast cache-hit
+// path. `layer_idx`, `num_layers` and `cluster_axis` stay in the hash (structural).
 void kernel_main() {
-    // Per-core runtime args.
+    // Per-core runtime args (buffers arrive as Buffer* bindings -> addresses).
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_pages = get_arg_val<uint32_t>(1);
-    const uint32_t core_blocks_written = get_arg_val<uint32_t>(2);
+    const uint32_t slot_addr = get_arg_val<uint32_t>(1);
+    const uint32_t kv_addr = get_arg_val<uint32_t>(2);
+    const uint32_t num_pages = get_arg_val<uint32_t>(3);
+    const uint32_t core_blocks_written = get_arg_val<uint32_t>(4);
 
-    // Common runtime args (same for all cores on this chip).
-    const uint32_t kv_actual_global_t = get_common_arg_val<uint32_t>(0);
-    const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(1);
-    const uint32_t sp_factor = get_common_arg_val<uint32_t>(2);
-    const uint32_t chunk_local_t = get_common_arg_val<uint32_t>(3);
-    const uint32_t slot_idx = get_common_arg_val<uint32_t>(4);
-    const uint32_t layer_idx = get_common_arg_val<uint32_t>(5);
-    const uint32_t num_layers = get_common_arg_val<uint32_t>(6);
-    const uint32_t Wt = get_common_arg_val<uint32_t>(7);
-    const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(8);
-    const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(9);
+    // Common runtime args (same for all cores on this chip): structural per cached program.
+    const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
+    const uint32_t sp_factor = get_common_arg_val<uint32_t>(1);
+    const uint32_t chunk_local_t = get_common_arg_val<uint32_t>(2);
+    const uint32_t layer_idx = get_common_arg_val<uint32_t>(3);
+    const uint32_t num_layers = get_common_arg_val<uint32_t>(4);
+    const uint32_t Wt = get_common_arg_val<uint32_t>(5);
+    const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(6);
+    const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(7);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t slot_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t kv_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t tile_height = get_compile_time_arg_val(3);
+    constexpr auto dst_args = TensorAccessorArgs<4>();
+    constexpr auto slot_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
+    constexpr auto kv_args = TensorAccessorArgs<slot_args.next_compile_time_args_offset()>();
+
+    // Read the single on-device slot_idx datum into a CB. Its address is patched on cache hits; its
+    // value is not hashed.
+    const auto s_slot = TensorAccessor(slot_args, slot_addr);
+    cb_reserve_back(slot_cb_id, 1);
+    const uint32_t slot_l1 = get_write_ptr(slot_cb_id);
+    noc_async_read_page(0, s_slot, slot_l1);
+    noc_async_read_barrier();
+    cb_push_back(slot_cb_id, 1);
+    const uint32_t slot_idx = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_l1)[0];
+
+    // Read the single on-device kv_actual_global datum (prior valid global KV length in tokens) and
+    // convert to tiles.
+    const auto s_kv = TensorAccessor(kv_args, kv_addr);
+    cb_reserve_back(kv_cb_id, 1);
+    const uint32_t kv_l1 = get_write_ptr(kv_cb_id);
+    noc_async_read_page(0, s_kv, kv_l1);
+    noc_async_read_barrier();
+    cb_push_back(kv_cb_id, 1);
+    const uint32_t kv_actual_global_t = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kv_l1)[0] / tile_height;
 
     // Cache linearization: users outer, layers inner.
     const uint32_t batch_idx = slot_idx * num_layers + layer_idx;
@@ -55,9 +83,6 @@ void kernel_main() {
     const uint32_t start_idx = batch_idx * cache_CHtWt + update_idxt * Wt;
     const uint32_t start_id =
         start_idx + (core_blocks_written / input_Ht) * cache_HtWt + (core_blocks_written % input_Ht) * Wt;
-
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "update_padded_kv_cache_device_operation.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace {
+
+// Reader kernel is reused from the kv_cache fill path — purely (src_addr, num_tiles, src_start) rt-args.
+// Writer is a forked variant that derives `start_id` on-device from common rt-args so that
+// `batch_idx`, `kv_actual_global` and `cluster_axis` can stay out of the program hash.
+constexpr auto kReaderKernelPath =
+    "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp";
+constexpr auto kWriterKernelPath =
+    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/"
+    "writer_update_padded_kv_cache.cpp";
+
+constexpr uint32_t kSrcCbIndex = 0;
+constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
+
+// Count distinct values along the cluster axis among the participating devices to determine
+// sp_factor without round-tripping to the mesh view.
+uint32_t sp_factor_for_tensor(const Tensor& tensor, uint32_t cluster_axis) {
+    const auto device_coords = tensor.device_storage().get_coords();
+    TT_FATAL(!device_coords.empty(), "device_coords is empty when computing sp_factor");
+    uint32_t min_v = std::numeric_limits<uint32_t>::max();
+    uint32_t max_v = 0;
+    for (const auto& c : device_coords) {
+        TT_FATAL(c.dims() > cluster_axis, "cluster_axis {} out of range for coord rank {}", cluster_axis, c.dims());
+        const uint32_t v = c[cluster_axis];
+        min_v = std::min(min_v, v);
+        max_v = std::max(max_v, v);
+    }
+    return max_v - min_v + 1;
+}
+
+// Validation of the runtime-arg-dependent constraints (slot_idx, layer_idx, kv_actual_global).
+// These args are intentionally kept out of the program hash so successive chunks reuse the cached
+// program, so they bypass validate_on_program_cache_miss on the 2nd+ call — this helper is invoked
+// from BOTH the miss and hit paths to keep them checked every call. Purely structural constraints
+// (shapes, dtypes, num_layers divisibility) are hashed and so stay miss-only.
+void validate_runtime_args(
+    const UpdatePaddedKvCacheDeviceOperation::operation_attributes_t& args,
+    const UpdatePaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& cache = tensor_args.cache;
+    const auto& input = tensor_args.input;
+    const auto& cache_shape = cache.padded_shape();
+    const auto& input_shape = input.padded_shape();
+
+    TT_FATAL(
+        args.kv_actual_global % TILE_HEIGHT == 0, "kv_actual_global ({}) must be tile-aligned", args.kv_actual_global);
+
+    TT_FATAL(
+        args.layer_idx < args.num_layers,
+        "layer_idx {} out of range for num_layers {}",
+        args.layer_idx,
+        args.num_layers);
+    const uint32_t num_slots = cache_shape[0] / args.num_layers;
+    TT_FATAL(
+        args.slot_idx < num_slots,
+        "slot_idx {} out of range for num_slots {} (cache_batch={}, num_layers={})",
+        args.slot_idx,
+        num_slots,
+        cache_shape[0],
+        args.num_layers);
+
+    // Verify cluster-axis sizing: the cache holds `sp_factor` copies of the per-chip slot globally.
+    const uint32_t sp_factor = sp_factor_for_tensor(cache, args.cluster_axis);
+    const uint32_t chunk_local_tokens = input_shape[-2];
+    const uint32_t global_cache_capacity = sp_factor * cache_shape[-2];
+    TT_FATAL(
+        args.kv_actual_global + sp_factor * chunk_local_tokens <= global_cache_capacity,
+        "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
+        args.kv_actual_global,
+        sp_factor * chunk_local_tokens,
+        global_cache_capacity);
+}
+
+}  // namespace
+
+UpdatePaddedKvCacheDeviceOperation::program_factory_t UpdatePaddedKvCacheDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return ProgramFactory{};
+}
+
+void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& cache = tensor_args.cache;
+    const auto& input = tensor_args.input;
+
+    TT_FATAL(cache.storage_type() == StorageType::DEVICE, "cache must be on device");
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "input must be on device");
+    TT_FATAL(cache.layout() == Layout::TILE, "cache must be TILE layout");
+    TT_FATAL(input.layout() == Layout::TILE, "input must be TILE layout");
+    TT_FATAL(cache.dtype() == input.dtype(), "cache and input dtype must match");
+
+    const auto& cache_shape = cache.padded_shape();
+    const auto& input_shape = input.padded_shape();
+    TT_FATAL(cache_shape.rank() == 4, "cache must be 4D (got rank {})", cache_shape.rank());
+    TT_FATAL(input_shape.rank() == 4, "input must be 4D (got rank {})", input_shape.rank());
+    TT_FATAL(cache_shape[-1] == input_shape[-1], "cache and input head dim must match");
+    TT_FATAL(cache_shape[1] == input_shape[1], "cache and input num-heads dim must match");
+
+    const uint32_t cache_seq = cache_shape[-2];
+    const uint32_t input_seq = input_shape[-2];
+    TT_FATAL(input_seq % TILE_HEIGHT == 0, "input seq dim ({}) must be tile-aligned", input_seq);
+    TT_FATAL(cache_seq % input_seq == 0, "cache seq ({}) must be a multiple of input seq ({})", cache_seq, input_seq);
+
+    TT_FATAL(args.num_layers > 0, "num_layers must be positive");
+    TT_FATAL(
+        cache_shape[0] % args.num_layers == 0,
+        "cache batch dim ({}) must be a multiple of num_layers ({})",
+        cache_shape[0],
+        args.num_layers);
+
+    // Runtime-arg-dependent constraints (slot_idx, layer_idx, kv_actual_global). Also re-checked
+    // on the program-cache-hit path since those args are not hashed.
+    validate_runtime_args(args, tensor_args);
+}
+
+void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // slot_idx, layer_idx and kv_actual_global are runtime args (not in the program hash) and can
+    // differ from the call that compiled the cached program, so re-validate them every hit. The
+    // structural constraints are hashed and therefore guaranteed unchanged here.
+    validate_runtime_args(args, tensor_args);
+}
+
+UpdatePaddedKvCacheDeviceOperation::spec_return_value_t UpdatePaddedKvCacheDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    // In-place: output spec = cache spec.
+    return tensor_args.cache.tensor_spec();
+}
+
+UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDeviceOperation::create_output_tensors(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    // In-place: return a handle to the cache.
+    return tensor_args.cache;
+}
+
+ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Per-call data values (slot_idx, layer_idx, kv_actual_global) are runtime args read by
+    // the writer kernel and intentionally NOT in the hash, so successive chunks reuse the
+    // cached program; rt-args refresh on cache hits via apply_descriptor_runtime_args.
+    // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
+    // linearization (num_layers) and which mesh dim is sp (cluster_axis) — not per-call data.
+    const auto& cache = tensor_args.cache;
+    const auto& input = tensor_args.input;
+    return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
+        args.num_layers,
+        args.cluster_axis,
+        input.dtype(),
+        input.memory_config(),
+        input.padded_shape().volume(),
+        cache.memory_config(),
+        cache.padded_shape().volume());
+}
+
+tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*output*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    TT_FATAL(
+        mesh_dispatch_coordinate.has_value(),
+        "UpdatePaddedKvCache::create_descriptor requires a mesh dispatch coordinate");
+    const auto& coord = mesh_dispatch_coordinate.value();
+
+    const auto& cache = tensor_args.cache;
+    const auto& input = tensor_args.input;
+    auto* device = input.device();
+
+    const auto& cache_shape = cache.padded_shape();
+    const auto& input_shape = input.padded_shape();
+
+    const tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
+    const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    const uint32_t Wt = cache_shape[-1] / TILE_WIDTH;
+    const uint32_t input_Ht = input_shape[-2] / TILE_HEIGHT;
+    const uint32_t cache_HtWt = cache_shape[-2] * Wt / TILE_HEIGHT;
+    const uint32_t cache_CHtWt = cache_shape[1] * cache_HtWt;
+
+    // Per-chip kernel inputs: kernel does the update_idxt + start_id math itself from these.
+    const uint32_t sp_factor = sp_factor_for_tensor(cache, args.cluster_axis);
+    const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cache, coord, args.cluster_axis);
+    const uint32_t kv_actual_global_t = args.kv_actual_global / TILE_HEIGHT;
+
+    // Work split: one tile per "block". num_blocks_of_work = input_C * input_Ht (= num_heads * seq_tiles).
+    const uint32_t num_blocks_of_work = input_shape[1] * input_Ht;
+
+    const auto compute_grid = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_g1, num_blocks_per_core_g2] =
+        tt::tt_metal::split_work_to_cores(compute_grid, num_blocks_of_work, /*row_major=*/true);
+
+    tt::tt_metal::ProgramDescriptor desc;
+
+    // CB for the input tiles.
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = kNumInputTilesDoubleBuffered * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kSrcCbIndex,
+            .data_format = data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    // Reader kernel descriptor.
+    KernelDescriptor::CompileTimeArgs reader_compile_args;
+    TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
+
+    KernelDescriptor reader_kernel;
+    reader_kernel.kernel_source = kReaderKernelPath;
+    reader_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel.core_ranges = all_cores;
+    reader_kernel.compile_time_args = std::move(reader_compile_args);
+    reader_kernel.config = ReaderConfigDescriptor{};
+
+    // Writer kernel descriptor.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex};
+    TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
+
+    KernelDescriptor writer_kernel;
+    writer_kernel.kernel_source = kWriterKernelPath;
+    writer_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel.core_ranges = all_cores;
+    writer_kernel.compile_time_args = std::move(writer_compile_args);
+    writer_kernel.config = WriterConfigDescriptor{};
+
+    // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation.
+    // Slot+layer kept separate (kernel composes batch_idx = slot_idx * num_layers + layer_idx).
+    writer_kernel.emplace_common_runtime_args({
+        kv_actual_global_t,
+        my_sp_coord,
+        sp_factor,
+        input_Ht,
+        args.slot_idx,
+        args.layer_idx,
+        args.num_layers,
+        Wt,
+        cache_HtWt,
+        cache_CHtWt,
+    });
+
+    // Per-core runtime args.
+    auto* src_buffer = input.buffer();
+    auto* dst_buffer = cache.buffer();
+    const uint32_t g1_numcores = core_group_1.num_cores();
+
+    const auto cores = corerange_to_cores(all_cores, num_cores, /*row_major=*/true);
+    reader_kernel.runtime_args.reserve(num_cores);
+    writer_kernel.runtime_args.reserve(num_cores);
+
+    uint32_t num_blocks_written = 0;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const CoreCoord& core = cores.at(i);
+        const uint32_t num_blocks_per_core = (i < g1_numcores) ? num_blocks_per_core_g1 : num_blocks_per_core_g2;
+
+        // Reader: (src_addr, num_tiles, src_start_tile_id)
+        reader_kernel.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                src_buffer->address(),
+                num_blocks_per_core * Wt,
+                num_blocks_written * Wt,
+            });
+
+        // Writer: (dst_addr, num_pages, core_blocks_written) — kernel adds update_idxt+head offset itself.
+        writer_kernel.runtime_args.emplace_back(
+            core,
+            KernelDescriptor::CoreRuntimeArgs{
+                dst_buffer->address(),
+                num_blocks_per_core * Wt,
+                num_blocks_written,
+            });
+
+        num_blocks_written += num_blocks_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_kernel));
+    desc.kernels.push_back(std::move(writer_kernel));
+    return desc;
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache
+
+namespace ttnn::prim {
+
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    uint32_t slot_idx,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t kv_actual_global,
+    uint32_t cluster_axis) {
+    using OperationType =
+        ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
+    auto attrs = OperationType::operation_attributes_t{
+        .slot_idx = slot_idx,
+        .layer_idx = layer_idx,
+        .num_layers = num_layers,
+        .kv_actual_global = kv_actual_global,
+        .cluster_axis = cluster_axis,
+    };
+    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -23,8 +23,10 @@ using namespace tt::constants;
 namespace {
 
 // Reader kernel is reused from the kv_cache fill path — purely (src_addr, num_tiles, src_start) rt-args.
-// Writer is a forked variant that derives `start_id` on-device from common rt-args so that
-// `batch_idx`, `kv_actual_global` and `cluster_axis` can stay out of the program hash.
+// Writer is a forked variant that derives `start_id` on-device: it reads the per-call `slot_idx` and
+// `kv_actual_global` from single-element device tensors and takes `my_sp_coord`/`sp_factor`/`layer_idx`
+// etc. as common rt-args, so no per-call scalar lives in the runtime args. That keeps the
+// buffer-binding fast cache-hit path correct (it patches addresses but skips create_descriptor).
 constexpr auto kReaderKernelPath =
     "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp";
 constexpr auto kWriterKernelPath =
@@ -32,52 +34,21 @@ constexpr auto kWriterKernelPath =
     "writer_update_padded_kv_cache.cpp";
 
 constexpr uint32_t kSrcCbIndex = 0;
+constexpr uint32_t kSlotCbIndex = 1;
+constexpr uint32_t kKvCbIndex = 2;
 constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
 
-// Validation of the runtime-arg-dependent constraints (slot_idx, layer_idx, kv_actual_global).
-// These args are intentionally kept out of the program hash so successive chunks reuse the cached
-// program, so they bypass validate_on_program_cache_miss on the 2nd+ call — this helper is invoked
-// from BOTH the miss and hit paths to keep them checked every call. Purely structural constraints
-// (shapes, dtypes, num_layers divisibility) are hashed and so stay miss-only.
-void validate_runtime_args(
-    const UpdatePaddedKvCacheDeviceOperation::operation_attributes_t& args,
-    const UpdatePaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
-    const auto& cache = tensor_args.cache;
-    const auto& input = tensor_args.input;
-    const auto& cache_shape = cache.padded_shape();
-    const auto& input_shape = input.padded_shape();
-
-    TT_FATAL(
-        args.kv_actual_global % TILE_HEIGHT == 0, "kv_actual_global ({}) must be tile-aligned", args.kv_actual_global);
-
-    TT_FATAL(
-        args.layer_idx < args.num_layers,
-        "layer_idx {} out of range for num_layers {}",
-        args.layer_idx,
-        args.num_layers);
-    const uint32_t num_slots = cache_shape[0] / args.num_layers;
-    TT_FATAL(
-        args.slot_idx < num_slots,
-        "slot_idx {} out of range for num_slots {} (cache_batch={}, num_layers={})",
-        args.slot_idx,
-        num_slots,
-        cache_shape[0],
-        args.num_layers);
-
-    // Verify cluster-axis sizing: the cache holds `sp_factor` copies of the per-chip slot globally.
-    // sp_factor is just the mesh extent along the cluster axis (mirrors how ring-joint SDPA derives
-    // num_devices from cluster_axis).
-    const auto& mesh_view = cache.device()->get_view();
-    TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
-    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    const uint32_t chunk_local_tokens = input_shape[-2];
-    const uint32_t global_cache_capacity = sp_factor * cache_shape[-2];
-    TT_FATAL(
-        args.kv_actual_global + sp_factor * chunk_local_tokens <= global_cache_capacity,
-        "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
-        args.kv_actual_global,
-        sp_factor * chunk_local_tokens,
-        global_cache_capacity);
+// Structural validation of an index tensor (slot_idx / kv_actual_global): a single-element ROW_MAJOR
+// uint32 datum on the same device as the cache, read on-device by the writer. Its value is unknown
+// host-side (it is intentionally out of the program hash), so value-range checks that the old scalar
+// path did (kv_actual tile-alignment, slot_idx < num_slots, global capacity overflow) are dropped --
+// the same trade-off as the indexed-RoPE op; only structure is checked, and only on the cache miss.
+void validate_index_tensor(const Tensor& t, const Tensor& input, const char* name) {
+    TT_FATAL(t.storage_type() == StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(t.buffer() != nullptr, "{} must be allocated in a buffer on device", name);
+    TT_FATAL(t.device() == input.device(), "{} must be on the same device as input", name);
+    TT_FATAL(t.layout() == Layout::ROW_MAJOR, "{} must be ROW_MAJOR layout", name);
+    TT_FATAL(t.dtype() == DataType::UINT32, "{} must be uint32 (got {})", name, t.dtype());
 }
 
 }  // namespace
@@ -116,18 +87,28 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
         "cache batch dim ({}) must be a multiple of num_layers ({})",
         cache_shape[0],
         args.num_layers);
+    // layer_idx is hashed (structural), so this is a miss-only check and stays valid for the cached
+    // program's lifetime; slot_idx's value-range check is dropped (its value is on-device only).
+    TT_FATAL(
+        args.layer_idx < args.num_layers,
+        "layer_idx {} out of range for num_layers {}",
+        args.layer_idx,
+        args.num_layers);
 
-    // Runtime-arg-dependent constraints (slot_idx, layer_idx, kv_actual_global). Also re-checked
-    // on the program-cache-hit path since those args are not hashed.
-    validate_runtime_args(args, tensor_args);
+    // 2D mesh is required for the per-chip sp offset derivation (sp_factor = mesh extent on cluster_axis).
+    const auto& mesh_view = cache.device()->get_view();
+    TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
+
+    // slot_idx and kv_actual_global are single-element device tensors read on-device; check structure.
+    validate_index_tensor(tensor_args.slot_idx, input, "slot_idx");
+    validate_index_tensor(tensor_args.kv_actual_global, input, "kv_actual_global");
 }
 
 void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx, layer_idx and kv_actual_global are runtime args (not in the program hash) and can
-    // differ from the call that compiled the cached program, so re-validate them every hit. The
-    // structural constraints are hashed and therefore guaranteed unchanged here.
-    validate_runtime_args(args, tensor_args);
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    // Nothing to re-validate per hit: slot_idx and kv_actual_global are device tensors whose values
+    // are unknown host-side (and out of the hash), and layer_idx is hashed (so structural and
+    // guaranteed unchanged for this cached program). All structural constraints were checked on miss.
 }
 
 UpdatePaddedKvCacheDeviceOperation::spec_return_value_t UpdatePaddedKvCacheDeviceOperation::compute_output_specs(
@@ -144,24 +125,33 @@ UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDev
 
 ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Per-call data values (slot_idx, layer_idx, kv_actual_global) are runtime args read by
-    // the writer kernel and intentionally NOT in the hash, so successive chunks reuse the
-    // cached program; rt-args refresh on cache hits via apply_descriptor_runtime_args.
-    // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
-    // linearization (num_layers) and which mesh dim is sp (cluster_axis) — not per-call data.
+    // slot_idx and kv_actual_global are per-call device tensors read on-device and intentionally
+    // NOT hashed by value, so successive users/chunks reuse the cached program (their addresses are
+    // patched on cache hits via the buffer-binding fast path). Only their structure (dtype/mem_config)
+    // is hashed. layer_idx IS hashed: it takes only num_layers distinct values, so one program per
+    // layer is reused across users/chunks, and a hashed scalar (unlike a non-hashed common rt-arg)
+    // stays correct on the fast cache-hit path. num_layers and cluster_axis stay IN: both are
+    // structural — they govern the cache slot linearization and which mesh dim is sp — not per-call data.
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
+    const auto& slot_idx = tensor_args.slot_idx;
+    const auto& kv_actual_global = tensor_args.kv_actual_global;
     // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
     // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
     // tensors that happen to share a volume must NOT collide onto the same cached program.
     return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
+        args.layer_idx,
         args.num_layers,
         args.cluster_axis,
         input.dtype(),
         input.memory_config(),
         input.padded_shape(),
         cache.memory_config(),
-        cache.padded_shape());
+        cache.padded_shape(),
+        slot_idx.dtype(),
+        slot_idx.memory_config(),
+        kv_actual_global.dtype(),
+        kv_actual_global.memory_config());
 }
 
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
@@ -176,6 +166,8 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
+    const auto& slot_idx = tensor_args.slot_idx;
+    const auto& kv_actual_global = tensor_args.kv_actual_global;
     auto* device = input.device();
 
     const auto& cache_shape = cache.padded_shape();
@@ -183,6 +175,13 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     const tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t single_tile_size = tt::tile_size(data_format);
+
+    // slot_idx and kv_actual_global are single ROW_MAJOR uint32 data, each read as one page into a
+    // small CB. Their values are read on-device by the writer, so they never enter the program hash.
+    const tt::DataFormat slot_cb_data_format = datatype_to_dataformat_converter(slot_idx.dtype());
+    const uint32_t slot_page_size = slot_idx.buffer()->aligned_page_size();
+    const tt::DataFormat kv_cb_data_format = datatype_to_dataformat_converter(kv_actual_global.dtype());
+    const uint32_t kv_page_size = kv_actual_global.buffer()->aligned_page_size();
 
     const uint32_t Wt = cache_shape[-1] / TILE_WIDTH;
     const uint32_t input_Ht = input_shape[-2] / TILE_HEIGHT;
@@ -194,7 +193,6 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& mesh_view = device->get_view();
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cache, coord, args.cluster_axis);
-    const uint32_t kv_actual_global_t = args.kv_actual_global / TILE_HEIGHT;
 
     // Work split: one tile per "block". num_blocks_of_work = input_C * input_Ht (= num_heads * seq_tiles).
     const uint32_t num_blocks_of_work = input_shape[1] * input_Ht;
@@ -216,6 +214,26 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         }}},
     });
 
+    // Small CBs the writer reads slot_idx and kv_actual_global into (one uint32 page each).
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = slot_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kSlotCbIndex,
+            .data_format = slot_cb_data_format,
+            .page_size = slot_page_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = kv_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kKvCbIndex,
+            .data_format = kv_cb_data_format,
+            .page_size = kv_page_size,
+        }}},
+    });
+
     // Reader kernel descriptor.
     KernelDescriptor::CompileTimeArgs reader_compile_args;
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
@@ -227,9 +245,12 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     reader_kernel.compile_time_args = std::move(reader_compile_args);
     reader_kernel.config = ReaderConfigDescriptor{};
 
-    // Writer kernel descriptor.
-    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex};
+    // Writer kernel descriptor. Compile args: src CB (read), slot/kv CBs (on-device index reads),
+    // TILE_HEIGHT (divides kv tokens into tiles), then the cache/slot/kv tensor accessors.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, kSlotCbIndex, kKvCbIndex, TILE_HEIGHT};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
+    TensorAccessorArgs(slot_idx.buffer()).append_to(writer_compile_args);
+    TensorAccessorArgs(kv_actual_global.buffer()).append_to(writer_compile_args);
 
     KernelDescriptor writer_kernel;
     writer_kernel.kernel_source = kWriterKernelPath;
@@ -238,14 +259,15 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     writer_kernel.compile_time_args = std::move(writer_compile_args);
     writer_kernel.config = WriterConfigDescriptor{};
 
-    // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation.
-    // Slot+layer kept separate (kernel composes batch_idx = slot_idx * num_layers + layer_idx).
+    // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation. These
+    // are structural (constant across calls for this cached program): my_sp_coord/sp_factor are this
+    // chip's mesh position, and layer_idx is hashed. slot_idx and kv_actual_global are NOT here --
+    // they arrive via device tensors read on-device, so no per-call scalar is left to go stale on the
+    // buffer-binding fast cache-hit path. The kernel composes batch_idx = slot_idx*num_layers+layer_idx.
     writer_kernel.emplace_common_runtime_args({
-        kv_actual_global_t,
         my_sp_coord,
         sp_factor,
         input_Ht,
-        args.slot_idx,
         args.layer_idx,
         args.num_layers,
         Wt,
@@ -253,9 +275,13 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         cache_CHtWt,
     });
 
-    // Per-core runtime args.
+    // Per-core runtime args. Buffers are passed as Buffer* bindings (not raw addresses) so cache hits
+    // take the fast path that patches addresses and skips create_descriptor — correct now that the
+    // per-call values (slot_idx, kv_actual_global) live in device tensors, leaving no stale scalar.
     auto* src_buffer = input.buffer();
     auto* dst_buffer = cache.buffer();
+    auto* slot_buffer = slot_idx.buffer();
+    auto* kv_buffer = kv_actual_global.buffer();
     const uint32_t g1_numcores = core_group_1.num_cores();
 
     const auto cores = corerange_to_cores(all_cores, num_cores, /*row_wise=*/true);
@@ -268,22 +294,12 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         const uint32_t num_blocks_per_core = (i < g1_numcores) ? num_blocks_per_core_g1 : num_blocks_per_core_g2;
 
         // Reader: (src_addr, num_tiles, src_start_tile_id)
-        reader_kernel.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                src_buffer->address(),
-                num_blocks_per_core * Wt,
-                num_blocks_written * Wt,
-            });
+        reader_kernel.emplace_runtime_args(core, {src_buffer, num_blocks_per_core * Wt, num_blocks_written * Wt});
 
-        // Writer: (dst_addr, num_pages, core_blocks_written) — kernel adds update_idxt+head offset itself.
-        writer_kernel.runtime_args.emplace_back(
-            core,
-            KernelDescriptor::CoreRuntimeArgs{
-                dst_buffer->address(),
-                num_blocks_per_core * Wt,
-                num_blocks_written,
-            });
+        // Writer: (dst_addr, slot_addr, kv_addr, num_pages, core_blocks_written) — kernel reads
+        // slot/kv on-device and adds update_idxt + head offset itself.
+        writer_kernel.emplace_runtime_args(
+            core, {dst_buffer, slot_buffer, kv_buffer, num_blocks_per_core * Wt, num_blocks_written});
 
         num_blocks_written += num_blocks_per_core;
     }
@@ -300,21 +316,20 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
+    const ttnn::Tensor& kv_actual_global,
     uint32_t cluster_axis) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
     auto attrs = OperationType::operation_attributes_t{
-        .slot_idx = slot_idx,
         .layer_idx = layer_idx,
         .num_layers = num_layers,
-        .kv_actual_global = kv_actual_global,
         .cluster_axis = cluster_axis,
     };
-    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
+    auto tensor_args = OperationType::tensor_args_t{
+        .cache = cache, .input = input, .slot_idx = slot_idx, .kv_actual_global = kv_actual_global};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -34,22 +34,6 @@ constexpr auto kWriterKernelPath =
 constexpr uint32_t kSrcCbIndex = 0;
 constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
 
-// Count distinct values along the cluster axis among the participating devices to determine
-// sp_factor without round-tripping to the mesh view.
-uint32_t sp_factor_for_tensor(const Tensor& tensor, uint32_t cluster_axis) {
-    const auto device_coords = tensor.device_storage().get_coords();
-    TT_FATAL(!device_coords.empty(), "device_coords is empty when computing sp_factor");
-    uint32_t min_v = std::numeric_limits<uint32_t>::max();
-    uint32_t max_v = 0;
-    for (const auto& c : device_coords) {
-        TT_FATAL(c.dims() > cluster_axis, "cluster_axis {} out of range for coord rank {}", cluster_axis, c.dims());
-        const uint32_t v = c[cluster_axis];
-        min_v = std::min(min_v, v);
-        max_v = std::max(max_v, v);
-    }
-    return max_v - min_v + 1;
-}
-
 // Validation of the runtime-arg-dependent constraints (slot_idx, layer_idx, kv_actual_global).
 // These args are intentionally kept out of the program hash so successive chunks reuse the cached
 // program, so they bypass validate_on_program_cache_miss on the 2nd+ call — this helper is invoked
@@ -81,7 +65,11 @@ void validate_runtime_args(
         args.num_layers);
 
     // Verify cluster-axis sizing: the cache holds `sp_factor` copies of the per-chip slot globally.
-    const uint32_t sp_factor = sp_factor_for_tensor(cache, args.cluster_axis);
+    // sp_factor is just the mesh extent along the cluster axis (mirrors how ring-joint SDPA derives
+    // num_devices from cluster_axis).
+    const auto& mesh_view = cache.device()->get_view();
+    TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
+    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t chunk_local_tokens = input_shape[-2];
     const uint32_t global_cache_capacity = sp_factor * cache_shape[-2];
     TT_FATAL(
@@ -163,14 +151,17 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     // linearization (num_layers) and which mesh dim is sp (cluster_axis) — not per-call data.
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
+    // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
+    // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
+    // tensors that happen to share a volume must NOT collide onto the same cached program.
     return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
         args.num_layers,
         args.cluster_axis,
         input.dtype(),
         input.memory_config(),
-        input.padded_shape().volume(),
+        input.padded_shape(),
         cache.memory_config(),
-        cache.padded_shape().volume());
+        cache.padded_shape());
 }
 
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
@@ -199,7 +190,9 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const uint32_t cache_CHtWt = cache_shape[1] * cache_HtWt;
 
     // Per-chip kernel inputs: kernel does the update_idxt + start_id math itself from these.
-    const uint32_t sp_factor = sp_factor_for_tensor(cache, args.cluster_axis);
+    // sp_factor is the mesh extent along the cluster axis (validated 2D in validate_runtime_args).
+    const auto& mesh_view = device->get_view();
+    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cache, coord, args.cluster_axis);
     const uint32_t kv_actual_global_t = args.kv_actual_global / TILE_HEIGHT;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -208,7 +208,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     const auto compute_grid = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_g1, num_blocks_per_core_g2] =
-        tt::tt_metal::split_work_to_cores(compute_grid, num_blocks_of_work, /*row_major=*/true);
+        tt::tt_metal::split_work_to_cores(compute_grid, num_blocks_of_work, /*row_wise=*/true);
 
     tt::tt_metal::ProgramDescriptor desc;
 
@@ -265,7 +265,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     auto* dst_buffer = cache.buffer();
     const uint32_t g1_numcores = core_group_1.num_cores();
 
-    const auto cores = corerange_to_cores(all_cores, num_cores, /*row_major=*/true);
+    const auto cores = corerange_to_cores(all_cores, num_cores, /*row_wise=*/true);
     reader_kernel.runtime_args.reserve(num_cores);
     writer_kernel.runtime_args.reserve(num_cores);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -23,10 +23,11 @@ using namespace tt::constants;
 namespace {
 
 // Reader kernel is reused from the kv_cache fill path — purely (src_addr, num_tiles, src_start) rt-args.
-// Writer is a forked variant that derives `start_id` on-device: it reads the per-call `slot_idx` and
-// `kv_actual_global` from single-element device tensors and takes `my_sp_coord`/`sp_factor`/`layer_idx`
-// etc. as common rt-args, so no per-call scalar lives in the runtime args. That keeps the
-// buffer-binding fast cache-hit path correct (it patches addresses but skips create_descriptor).
+// Writer is a forked variant that derives `start_id` on-device from the per-call `slot_idx` and
+// `kv_actual_global` (common runtime args patched on cache hits) plus structural common rt-args
+// (`my_sp_coord`/`sp_factor`/`layer_idx` etc.). The per-call scalars are patched by the op's
+// MeshWorkloadFactory::override_runtime_arguments, so the buffer-binding fast cache-hit path stays
+// correct while those values remain out of the program hash.
 constexpr auto kReaderKernelPath =
     "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp";
 constexpr auto kWriterKernelPath =
@@ -34,28 +35,46 @@ constexpr auto kWriterKernelPath =
     "writer_update_padded_kv_cache.cpp";
 
 constexpr uint32_t kSrcCbIndex = 0;
-constexpr uint32_t kSlotCbIndex = 1;
-constexpr uint32_t kKvCbIndex = 2;
 constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
 
-// Structural validation of an index tensor (slot_idx / kv_actual_global): a single-element ROW_MAJOR
-// uint32 datum on the same device as the cache, read on-device by the writer. Its value is unknown
-// host-side (it is intentionally out of the program hash), so value-range checks that the old scalar
-// path did (kv_actual tile-alignment, slot_idx < num_slots, global capacity overflow) are dropped --
-// the same trade-off as the indexed-RoPE op; only structure is checked, and only on the cache miss.
-void validate_index_tensor(const Tensor& t, const Tensor& input, const char* name) {
-    TT_FATAL(t.storage_type() == StorageType::DEVICE, "{} must be on device", name);
-    TT_FATAL(t.buffer() != nullptr, "{} must be allocated in a buffer on device", name);
-    TT_FATAL(t.device() == input.device(), "{} must be on the same device as input", name);
-    TT_FATAL(t.layout() == Layout::ROW_MAJOR, "{} must be ROW_MAJOR layout", name);
-    TT_FATAL(t.dtype() == DataType::UINT32, "{} must be uint32 (got {})", name, t.dtype());
+// Per-call scalar checks shared by the cache-miss and cache-hit paths. slot_idx and kv_actual_global
+// are now host-side scalars (common runtime args patched on cache hits), so the value-range checks
+// dropped when they lived in device tensors can be enforced here again.
+void validate_runtime_args(
+    const UpdatePaddedKvCacheDeviceOperation::operation_attributes_t& args,
+    const UpdatePaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
+    TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
+    // The writer divides kv_actual_global by TILE_HEIGHT to get its tile offset, so it must be aligned.
+    TT_FATAL(
+        args.kv_actual_global % TILE_HEIGHT == 0,
+        "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
+        args.kv_actual_global,
+        TILE_HEIGHT);
+    const auto& cache = tensor_args.cache;
+    const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
+    TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
+
+    // This chunk is written at a per-chip offset derived from kv_actual_global; the prior valid KV
+    // plus this chunk must fit the global cache capacity (sp_factor slabs of cache_seq tokens each),
+    // else the write spills past the cache. sp_factor = mesh extent along cluster_axis.
+    const auto& mesh_view = cache.device()->get_view();
+    TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
+    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    const uint32_t chunk_global_tokens = sp_factor * tensor_args.input.padded_shape()[-2];
+    const uint32_t global_cache_capacity = sp_factor * cache.padded_shape()[-2];
+    TT_FATAL(
+        args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
+        "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
+        args.kv_actual_global,
+        chunk_global_tokens,
+        global_cache_capacity);
 }
 
 }  // namespace
 
 UpdatePaddedKvCacheDeviceOperation::program_factory_t UpdatePaddedKvCacheDeviceOperation::select_program_factory(
     const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
-    return ProgramFactory{};
+    return MeshWorkloadFactory{};
 }
 
 void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
@@ -88,27 +107,23 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
         cache_shape[0],
         args.num_layers);
     // layer_idx is hashed (structural), so this is a miss-only check and stays valid for the cached
-    // program's lifetime; slot_idx's value-range check is dropped (its value is on-device only).
+    // program's lifetime. slot_idx / kv_actual_global value checks live in validate_runtime_args.
     TT_FATAL(
         args.layer_idx < args.num_layers,
         "layer_idx {} out of range for num_layers {}",
         args.layer_idx,
         args.num_layers);
 
-    // 2D mesh is required for the per-chip sp offset derivation (sp_factor = mesh extent on cluster_axis).
-    const auto& mesh_view = cache.device()->get_view();
-    TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
-
-    // slot_idx and kv_actual_global are single-element device tensors read on-device; check structure.
-    validate_index_tensor(tensor_args.slot_idx, input, "slot_idx");
-    validate_index_tensor(tensor_args.kv_actual_global, input, "kv_actual_global");
+    // The 2D-mesh requirement and the per-call value checks (kv tile-alignment, slot range, cache
+    // capacity) are enforced by validate_runtime_args, run on both the cache-miss and cache-hit paths.
+    validate_runtime_args(args, tensor_args);
 }
 
 void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
-    // Nothing to re-validate per hit: slot_idx and kv_actual_global are device tensors whose values
-    // are unknown host-side (and out of the hash), and layer_idx is hashed (so structural and
-    // guaranteed unchanged for this cached program). All structural constraints were checked on miss.
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // slot_idx and kv_actual_global are per-call scalars (not hashed) and can differ from the compiled
+    // program's call, so re-validate their ranges every hit. Structural constraints are hashed.
+    validate_runtime_args(args, tensor_args);
 }
 
 UpdatePaddedKvCacheDeviceOperation::spec_return_value_t UpdatePaddedKvCacheDeviceOperation::compute_output_specs(
@@ -125,17 +140,14 @@ UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDev
 
 ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call device tensors read on-device and intentionally
-    // NOT hashed by value, so successive users/chunks reuse the cached program (their addresses are
-    // patched on cache hits via the buffer-binding fast path). Only their structure (dtype/mem_config)
-    // is hashed. layer_idx IS hashed: it takes only num_layers distinct values, so one program per
-    // layer is reused across users/chunks, and a hashed scalar (unlike a non-hashed common rt-arg)
-    // stays correct on the fast cache-hit path. num_layers and cluster_axis stay IN: both are
-    // structural — they govern the cache slot linearization and which mesh dim is sp — not per-call data.
+    // slot_idx and kv_actual_global are per-call scalars held in common runtime args and patched on
+    // cache hits, so they are intentionally NOT hashed and successive users/chunks reuse the cached
+    // program. layer_idx IS hashed: it takes only num_layers distinct values, so one program per layer
+    // is reused across users/chunks, and a hashed scalar stays correct on the fast cache-hit path.
+    // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
+    // linearization and which mesh dim is sp — not per-call data.
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
-    const auto& slot_idx = tensor_args.slot_idx;
-    const auto& kv_actual_global = tensor_args.kv_actual_global;
     // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
     // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
     // tensors that happen to share a volume must NOT collide onto the same cached program.
@@ -147,11 +159,7 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
         input.memory_config(),
         input.padded_shape(),
         cache.memory_config(),
-        cache.padded_shape(),
-        slot_idx.dtype(),
-        slot_idx.memory_config(),
-        kv_actual_global.dtype(),
-        kv_actual_global.memory_config());
+        cache.padded_shape());
 }
 
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
@@ -166,8 +174,6 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
-    const auto& slot_idx = tensor_args.slot_idx;
-    const auto& kv_actual_global = tensor_args.kv_actual_global;
     auto* device = input.device();
 
     const auto& cache_shape = cache.padded_shape();
@@ -175,13 +181,6 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     const tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
     const uint32_t single_tile_size = tt::tile_size(data_format);
-
-    // slot_idx and kv_actual_global are single ROW_MAJOR uint32 data, each read as one page into a
-    // small CB. Their values are read on-device by the writer, so they never enter the program hash.
-    const tt::DataFormat slot_cb_data_format = datatype_to_dataformat_converter(slot_idx.dtype());
-    const uint32_t slot_page_size = slot_idx.buffer()->aligned_page_size();
-    const tt::DataFormat kv_cb_data_format = datatype_to_dataformat_converter(kv_actual_global.dtype());
-    const uint32_t kv_page_size = kv_actual_global.buffer()->aligned_page_size();
 
     const uint32_t Wt = cache_shape[-1] / TILE_WIDTH;
     const uint32_t input_Ht = input_shape[-2] / TILE_HEIGHT;
@@ -214,26 +213,6 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         }}},
     });
 
-    // Small CBs the writer reads slot_idx and kv_actual_global into (one uint32 page each).
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = slot_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = kSlotCbIndex,
-            .data_format = slot_cb_data_format,
-            .page_size = slot_page_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = kv_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = kKvCbIndex,
-            .data_format = kv_cb_data_format,
-            .page_size = kv_page_size,
-        }}},
-    });
-
     // Reader kernel descriptor.
     KernelDescriptor::CompileTimeArgs reader_compile_args;
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
@@ -245,12 +224,10 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     reader_kernel.compile_time_args = std::move(reader_compile_args);
     reader_kernel.config = ReaderConfigDescriptor{};
 
-    // Writer kernel descriptor. Compile args: src CB (read), slot/kv CBs (on-device index reads),
-    // TILE_HEIGHT (divides kv tokens into tiles), then the cache/slot/kv tensor accessors.
-    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, kSlotCbIndex, kKvCbIndex, TILE_HEIGHT};
+    // Writer kernel descriptor. Compile args: src CB (read), TILE_HEIGHT (divides kv tokens into
+    // tiles), then the cache tensor accessor.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, TILE_HEIGHT};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
-    TensorAccessorArgs(slot_idx.buffer()).append_to(writer_compile_args);
-    TensorAccessorArgs(kv_actual_global.buffer()).append_to(writer_compile_args);
 
     KernelDescriptor writer_kernel;
     writer_kernel.kernel_source = kWriterKernelPath;
@@ -259,11 +236,11 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     writer_kernel.compile_time_args = std::move(writer_compile_args);
     writer_kernel.config = WriterConfigDescriptor{};
 
-    // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation. These
-    // are structural (constant across calls for this cached program): my_sp_coord/sp_factor are this
-    // chip's mesh position, and layer_idx is hashed. slot_idx and kv_actual_global are NOT here --
-    // they arrive via device tensors read on-device, so no per-call scalar is left to go stale on the
-    // buffer-binding fast cache-hit path. The kernel composes batch_idx = slot_idx*num_layers+layer_idx.
+    // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation. Indices
+    // 0-7 are structural (constant for this cached program): my_sp_coord/sp_factor are this chip's mesh
+    // position, layer_idx is hashed. slot_idx (8) and kv_actual_global (9) are the per-call values
+    // patched on cache hits by override_runtime_arguments. The kernel composes
+    // batch_idx = slot_idx*num_layers + layer_idx.
     writer_kernel.emplace_common_runtime_args({
         my_sp_coord,
         sp_factor,
@@ -273,15 +250,16 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         Wt,
         cache_HtWt,
         cache_CHtWt,
+        args.slot_idx,
+        args.kv_actual_global,
     });
 
     // Per-core runtime args. Buffers are passed as Buffer* bindings (not raw addresses) so cache hits
-    // take the fast path that patches addresses and skips create_descriptor — correct now that the
-    // per-call values (slot_idx, kv_actual_global) live in device tensors, leaving no stale scalar.
+    // take the fast path that patches addresses and skips create_descriptor. The per-call scalars
+    // (slot_idx, kv_actual_global) are common args patched by override_runtime_arguments, so no per-core
+    // scalar goes stale.
     auto* src_buffer = input.buffer();
     auto* dst_buffer = cache.buffer();
-    auto* slot_buffer = slot_idx.buffer();
-    auto* kv_buffer = kv_actual_global.buffer();
     const uint32_t g1_numcores = core_group_1.num_cores();
 
     const auto cores = corerange_to_cores(all_cores, num_cores, /*row_wise=*/true);
@@ -296,10 +274,9 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         // Reader: (src_addr, num_tiles, src_start_tile_id)
         reader_kernel.emplace_runtime_args(core, {src_buffer, num_blocks_per_core * Wt, num_blocks_written * Wt});
 
-        // Writer: (dst_addr, slot_addr, kv_addr, num_pages, core_blocks_written) — kernel reads
-        // slot/kv on-device and adds update_idxt + head offset itself.
-        writer_kernel.emplace_runtime_args(
-            core, {dst_buffer, slot_buffer, kv_buffer, num_blocks_per_core * Wt, num_blocks_written});
+        // Writer: (dst_addr, num_pages, core_blocks_written) — kernel derives update_idxt + head
+        // offset from the slot_idx/kv_actual_global common args.
+        writer_kernel.emplace_runtime_args(core, {dst_buffer, num_blocks_per_core * Wt, num_blocks_written});
 
         num_blocks_written += num_blocks_per_core;
     }
@@ -309,6 +286,37 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     return desc;
 }
 
+UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::cached_mesh_workload_t
+UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::create_mesh_workload(
+    const operation_attributes_t& args,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    return descriptor_adapter_t::create_mesh_workload(args, tensor_coords, tensor_args, output);
+}
+
+void UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    // Default adapter behaviour: patch operand buffer-binding addresses on cache hits.
+    descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
+    // The writer's common runtime args 8/9 hold slot_idx/kv_actual_global -- the per-call values the
+    // buffer-binding fast path would otherwise leave stale. Patch them on every cached program.
+    constexpr uint32_t kWriterKernelHandle = 1;  // writer is pushed second in create_descriptor
+    constexpr uint32_t kSlotIdxCommonArgIdx = 8;
+    constexpr uint32_t kKvActualGlobalCommonArgIdx = 9;
+    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+        auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelHandle);
+        TT_FATAL(
+            kKvActualGlobalCommonArgIdx < writer_common.size(),
+            "update_padded_kv_cache writer is missing the slot_idx/kv_actual_global common args");
+        writer_common[kSlotIdxCommonArgIdx] = args.slot_idx;
+        writer_common[kKvActualGlobalCommonArgIdx] = args.kv_actual_global;
+    }
+}
+
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache
 
 namespace ttnn::prim {
@@ -316,20 +324,21 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    const ttnn::Tensor& slot_idx,
+    uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    const ttnn::Tensor& kv_actual_global,
+    uint32_t kv_actual_global,
     uint32_t cluster_axis) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
     auto attrs = OperationType::operation_attributes_t{
+        .slot_idx = slot_idx,
+        .kv_actual_global = kv_actual_global,
         .layer_idx = layer_idx,
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
     };
-    auto tensor_args = OperationType::tensor_args_t{
-        .cache = cache, .input = input, .slot_idx = slot_idx, .kv_actual_global = kv_actual_global};
+    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
+
+struct UpdatePaddedKvCacheDeviceOperation {
+    struct operation_attributes_t {
+        // Cache slot is linearized as users-outer, layers-inner:
+        //   batch_idx = slot_idx * num_layers + layer_idx
+        uint32_t slot_idx;  // TODO: should be moved to metadata
+        uint32_t layer_idx;
+        uint32_t num_layers;
+        uint32_t kv_actual_global;  // in tokens; tile-aligned. TODO: should be moved to metadata
+        uint32_t cluster_axis;
+    };
+
+    struct tensor_args_t {
+        const Tensor& cache;
+        const Tensor& input;
+    };
+
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct ProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& args,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache
+
+namespace ttnn::prim {
+
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    uint32_t slot_idx,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t kv_actual_global,
+    uint32_t cluster_axis);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -8,10 +8,12 @@
 #include <optional>
 #include <variant>
 
+#include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
@@ -20,11 +22,12 @@ struct UpdatePaddedKvCacheDeviceOperation {
     struct operation_attributes_t {
         // Cache slot is linearized as users-outer, layers-inner:
         //   batch_idx = slot_idx * num_layers + layer_idx
-        // slot_idx is a per-call device tensor (see tensor_args_t); layer_idx is hashed (structural):
-        // it takes only num_layers distinct values, so one cached program per layer is reused across
-        // users and chunks -- and a hashed scalar stays correct on the buffer-binding fast cache-hit
-        // path (each program bakes its own layer_idx), unlike a non-hashed common rt-arg which would
-        // go stale there.
+        // layer_idx is hashed (structural): it takes only num_layers distinct values, so one cached
+        // program per layer is reused across users and chunks. slot_idx and kv_actual_global are
+        // per-call scalars held in common runtime args and patched on cache hits by
+        // MeshWorkloadFactory::override_runtime_arguments, so they stay out of the program hash.
+        uint32_t slot_idx;          // TODO: move to metadata
+        uint32_t kv_actual_global;  // TODO: move to metadata
         uint32_t layer_idx;
         uint32_t num_layers;
         uint32_t cluster_axis;
@@ -33,12 +36,6 @@ struct UpdatePaddedKvCacheDeviceOperation {
     struct tensor_args_t {
         const Tensor& cache;
         const Tensor& input;
-        // Single-element ROW_MAJOR uint32 device tensors, read on-device by the writer kernel.
-        // Tensors (not scalar attrs) so their values stay out of the program hash and the
-        // buffer-binding fast cache-hit path can patch their addresses -- one cached program (per
-        // layer) is reused across users and chunks. NOT hashed by value.
-        const Tensor& slot_idx;          // user slot in the batched prefill cache
-        const Tensor& kv_actual_global;  // prior valid global KV length in tokens; tile-aligned
     };
 
     using spec_return_value_t = TensorSpec;
@@ -52,7 +49,36 @@ struct UpdatePaddedKvCacheDeviceOperation {
             const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    // Minimal operation-shaped helper so the descriptor factory can be adapted into a mesh workload.
+    struct DescriptorAdapterOperation {
+        using operation_attributes_t = UpdatePaddedKvCacheDeviceOperation::operation_attributes_t;
+        using tensor_args_t = UpdatePaddedKvCacheDeviceOperation::tensor_args_t;
+        using spec_return_value_t = UpdatePaddedKvCacheDeviceOperation::spec_return_value_t;
+        using tensor_return_value_t = UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t;
+    };
+
+    // Wraps the ProgramDescriptor factory so the default adapter patches buffer bindings on cache
+    // hits, and override_runtime_arguments additionally patches the per-call slot_idx/kv_actual_global
+    // scalars (common runtime args) -- the values the buffer-binding fast path would leave stale.
+    struct MeshWorkloadFactory {
+        using descriptor_adapter_t = ttnn::device_operation::MeshDeviceOperationAdapter<
+            DescriptorAdapterOperation>::DescriptorMeshWorkloadAdapter<ProgramFactory>;
+        using cached_mesh_workload_t = typename descriptor_adapter_t::cached_mesh_workload_t;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& args,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& args,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<MeshWorkloadFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
@@ -69,10 +95,10 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    const ttnn::Tensor& slot_idx,
+    uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    const ttnn::Tensor& kv_actual_global,
+    uint32_t kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -20,16 +20,25 @@ struct UpdatePaddedKvCacheDeviceOperation {
     struct operation_attributes_t {
         // Cache slot is linearized as users-outer, layers-inner:
         //   batch_idx = slot_idx * num_layers + layer_idx
-        uint32_t slot_idx;  // TODO: should be moved to metadata
+        // slot_idx is a per-call device tensor (see tensor_args_t); layer_idx is hashed (structural):
+        // it takes only num_layers distinct values, so one cached program per layer is reused across
+        // users and chunks -- and a hashed scalar stays correct on the buffer-binding fast cache-hit
+        // path (each program bakes its own layer_idx), unlike a non-hashed common rt-arg which would
+        // go stale there.
         uint32_t layer_idx;
         uint32_t num_layers;
-        uint32_t kv_actual_global;  // in tokens; tile-aligned. TODO: should be moved to metadata
         uint32_t cluster_axis;
     };
 
     struct tensor_args_t {
         const Tensor& cache;
         const Tensor& input;
+        // Single-element ROW_MAJOR uint32 device tensors, read on-device by the writer kernel.
+        // Tensors (not scalar attrs) so their values stay out of the program hash and the
+        // buffer-binding fast cache-hit path can patch their addresses -- one cached program (per
+        // layer) is reused across users and chunks. NOT hashed by value.
+        const Tensor& slot_idx;          // user slot in the batched prefill cache
+        const Tensor& kv_actual_global;  // prior valid global KV length in tokens; tile-aligned
     };
 
     using spec_return_value_t = TensorSpec;
@@ -60,10 +69,10 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
+    const ttnn::Tensor& kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/sources.cmake
@@ -1,0 +1,4 @@
+# Source files for ttnn_op_experimental_deepseek_prefill_update_padded_kv_cache.
+# Module owners should update this file when adding/removing/renaming source files.
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_UPDATE_PADDED_KV_CACHE_API_HEADERS update_padded_kv_cache.hpp)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "update_padded_kv_cache.hpp"
+#include "device/update_padded_kv_cache_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
+
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    uint32_t slot_idx,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t kv_actual_global,
+    uint32_t cluster_axis) {
+    return ttnn::prim::update_padded_kv_cache(
+        cache, input, slot_idx, layer_idx, num_layers, kv_actual_global, cluster_axis);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -10,10 +10,10 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    const ttnn::Tensor& slot_idx,
+    uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    const ttnn::Tensor& kv_actual_global,
+    uint32_t kv_actual_global,
     uint32_t cluster_axis) {
     return ttnn::prim::update_padded_kv_cache(
         cache, input, slot_idx, layer_idx, num_layers, kv_actual_global, cluster_axis);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -10,10 +10,10 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
+    const ttnn::Tensor& kv_actual_global,
     uint32_t cluster_axis) {
     return ttnn::prim::update_padded_kv_cache(
         cache, input, slot_idx, layer_idx, num_layers, kv_actual_global, cluster_axis);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache {
+
+// Writes a `chunk_local`-row input slab into a KV cache at a per-device start offset, derived
+// from a single global token count `kv_actual_global` and the device's coordinate along
+// `cluster_axis`. When `kv_actual_global` aligns to a chunk boundary every device writes at the
+// same local offset (the chunked-natural case); when it does not, devices around the boundary
+// write at different offsets so that new tokens overwrite the trailing pad cells of the prior
+// cache before spilling into the next slab.
+//
+// Cache slot is addressed with users-outer, layers-inner linearization — the op composes
+// `batch_idx = slot_idx * num_layers + layer_idx`. For a single-user prefill workload, callers
+// pass `slot_idx=0` and the desired `layer_idx`.
+//
+// In-place: returns a handle to `cache`.
+ttnn::Tensor update_padded_kv_cache(
+    const ttnn::Tensor& cache,
+    const ttnn::Tensor& input,
+    uint32_t slot_idx,
+    uint32_t layer_idx,
+    uint32_t num_layers,
+    uint32_t kv_actual_global,
+    uint32_t cluster_axis);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache
+
+namespace ttnn {
+using operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache;
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -19,20 +19,20 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 //
 // Cache slot is addressed with users-outer, layers-inner linearization — the op composes
 // `batch_idx = slot_idx * num_layers + layer_idx`. For a single-user prefill workload, callers
-// pass a `slot_idx` tensor holding 0 and the desired `layer_idx`.
+// pass `slot_idx = 0` and the desired `layer_idx`.
 //
-// `slot_idx` and `kv_actual_global` are single-element ROW_MAJOR uint32 device tensors (read
-// on-device), not scalars, so their values stay out of the program hash and successive users/chunks
-// reuse one cached program (per layer) via the buffer-binding fast cache-hit path.
+// `slot_idx` and `kv_actual_global` are per-call scalars held in common runtime args and patched on
+// cache hits, so their values stay out of the program hash and successive users/chunks reuse one
+// cached program (per layer).
 //
 // In-place: returns a handle to `cache`.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    const ttnn::Tensor& slot_idx,
+    uint32_t slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    const ttnn::Tensor& kv_actual_global,
+    uint32_t kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -19,16 +19,20 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 //
 // Cache slot is addressed with users-outer, layers-inner linearization — the op composes
 // `batch_idx = slot_idx * num_layers + layer_idx`. For a single-user prefill workload, callers
-// pass `slot_idx=0` and the desired `layer_idx`.
+// pass a `slot_idx` tensor holding 0 and the desired `layer_idx`.
+//
+// `slot_idx` and `kv_actual_global` are single-element ROW_MAJOR uint32 device tensors (read
+// on-device), not scalars, so their values stay out of the program hash and successive users/chunks
+// reuse one cached program (per layer) via the buffer-binding fast cache-hit path.
 //
 // In-place: returns a handle to `cache`.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& slot_idx,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
+    const ttnn::Tensor& kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "update_padded_kv_cache_nanobind.hpp"
+
+#include <cstdint>
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "update_padded_kv_cache.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail {
+
+void bind_update_padded_kv_cache(nb::module_& mod) {
+    ttnn::bind_function<"update_padded_kv_cache", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(
+            Write a chunk_local-row input slab into a KV cache at a per-device start offset
+            derived from a single global token count.
+
+            Each device participating in the mesh derives its own write offset from
+            `kv_actual_global` and its coordinate along `cluster_axis`, so that new tokens
+            overwrite the trailing pad cells of the prior cache before spilling into the
+            next slab. When `kv_actual_global` aligns to a chunk-global boundary the math
+            degenerates to a uniform per-device offset (the chunked-natural case).
+
+            In place: returns a handle to `cache`.
+
+            Cache slot is linearized users-outer, layers-inner — internally the op composes
+            ``batch_idx = slot_idx * num_layers + layer_idx``. Single-user prefill callers
+            pass ``slot_idx=0`` and the desired ``layer_idx``.
+
+            Args:
+                cache (ttnn.Tensor): 4D KV cache tensor on device, TILE layout. Sharded across
+                    `cluster_axis` with `sp_factor` slots per chip. Outermost dim equals
+                    ``num_slots * num_layers``.
+                input (ttnn.Tensor): 4D input slab on device, TILE layout, same dtype and head
+                    dim as cache. Per-chip seq length = chunk_local.
+                slot_idx (int): User slot in the batched prefill cache.
+                layer_idx (int): Transformer layer index for this call.
+                num_layers (int): Total layers folded into the cache batch dim. Structural —
+                    fixed for the lifetime of the workload.
+                kv_actual_global (int): Prior valid global KV length in tokens. Tile-aligned.
+                cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
+
+            Returns:
+                ttnn.Tensor: handle to `cache` with the new slab written in place.
+        )doc",
+        &ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache,
+        nb::arg("cache").noconvert(),
+        nb::arg("input").noconvert(),
+        nb::arg("slot_idx"),
+        nb::arg("layer_idx"),
+        nb::arg("num_layers"),
+        nb::arg("kv_actual_global"),
+        nb::arg("cluster_axis"));
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+
+void bind_update_padded_kv_cache(::nanobind::module_& mod) {
+    update_padded_kv_cache::detail::bind_update_padded_kv_cache(mod);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -30,7 +30,11 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
 
             Cache slot is linearized users-outer, layers-inner — internally the op composes
             ``batch_idx = slot_idx * num_layers + layer_idx``. Single-user prefill callers
-            pass ``slot_idx=0`` and the desired ``layer_idx``.
+            pass a ``slot_idx`` tensor holding 0 and the desired ``layer_idx``.
+
+            ``slot_idx`` and ``kv_actual_global`` are single-element ROW_MAJOR uint32 device
+            tensors read on-device, so their values stay out of the program hash and successive
+            users/chunks reuse one cached program (per layer).
 
             Args:
                 cache (ttnn.Tensor): 4D KV cache tensor on device, TILE layout. Sharded across
@@ -38,11 +42,14 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     ``num_slots * num_layers``.
                 input (ttnn.Tensor): 4D input slab on device, TILE layout, same dtype and head
                     dim as cache. Per-chip seq length = chunk_local.
-                slot_idx (int): User slot in the batched prefill cache.
-                layer_idx (int): Transformer layer index for this call.
+                slot_idx (ttnn.Tensor): single-element ROW_MAJOR uint32 device tensor — user slot
+                    in the batched prefill cache.
+                layer_idx (int): Transformer layer index for this call. Structural (hashed): one
+                    cached program per layer is reused across users and chunks.
                 num_layers (int): Total layers folded into the cache batch dim. Structural —
                     fixed for the lifetime of the workload.
-                kv_actual_global (int): Prior valid global KV length in tokens. Tile-aligned.
+                kv_actual_global (ttnn.Tensor): single-element ROW_MAJOR uint32 device tensor —
+                    prior valid global KV length in tokens. Tile-aligned.
                 cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
 
             Returns:
@@ -51,10 +58,10 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
         &ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache,
         nb::arg("cache").noconvert(),
         nb::arg("input").noconvert(),
-        nb::arg("slot_idx"),
+        nb::arg("slot_idx").noconvert(),
         nb::arg("layer_idx"),
         nb::arg("num_layers"),
-        nb::arg("kv_actual_global"),
+        nb::arg("kv_actual_global").noconvert(),
         nb::arg("cluster_axis"));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -30,10 +30,10 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
 
             Cache slot is linearized users-outer, layers-inner — internally the op composes
             ``batch_idx = slot_idx * num_layers + layer_idx``. Single-user prefill callers
-            pass a ``slot_idx`` tensor holding 0 and the desired ``layer_idx``.
+            pass ``slot_idx = 0`` and the desired ``layer_idx``.
 
-            ``slot_idx`` and ``kv_actual_global`` are single-element ROW_MAJOR uint32 device
-            tensors read on-device, so their values stay out of the program hash and successive
+            ``slot_idx`` and ``kv_actual_global`` are per-call scalars held in common runtime args
+            and patched on cache hits, so their values stay out of the program hash and successive
             users/chunks reuse one cached program (per layer).
 
             Args:
@@ -42,14 +42,12 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     ``num_slots * num_layers``.
                 input (ttnn.Tensor): 4D input slab on device, TILE layout, same dtype and head
                     dim as cache. Per-chip seq length = chunk_local.
-                slot_idx (ttnn.Tensor): single-element ROW_MAJOR uint32 device tensor — user slot
-                    in the batched prefill cache.
+                slot_idx (int): user slot in the batched prefill cache.
                 layer_idx (int): Transformer layer index for this call. Structural (hashed): one
                     cached program per layer is reused across users and chunks.
                 num_layers (int): Total layers folded into the cache batch dim. Structural —
                     fixed for the lifetime of the workload.
-                kv_actual_global (ttnn.Tensor): single-element ROW_MAJOR uint32 device tensor —
-                    prior valid global KV length in tokens. Tile-aligned.
+                kv_actual_global (int): prior valid global KV length in tokens. Tile-aligned.
                 cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
 
             Returns:
@@ -58,10 +56,10 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
         &ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache,
         nb::arg("cache").noconvert(),
         nb::arg("input").noconvert(),
-        nb::arg("slot_idx").noconvert(),
+        nb::arg("slot_idx"),
         nb::arg("layer_idx"),
         nb::arg("num_layers"),
-        nb::arg("kv_actual_global").noconvert(),
+        nb::arg("kv_actual_global"),
         nb::arg("cluster_axis"));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail {
+namespace nb = nanobind;
+void bind_update_padded_kv_cache(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::detail
+
+namespace ttnn::operations::experimental::deepseek_prefill::detail {
+void bind_update_padded_kv_cache(::nanobind::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek_prefill::detail

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -77,6 +77,7 @@
 #include "ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/moe_grouped_topk_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/deepseek_moe_gate_nanobind.hpp"
 
 namespace ttnn::operations::experimental {
@@ -174,6 +175,7 @@ void py_module(nb::module_& mod) {
     deepseek_prefill::detail::bind_unified_routed_expert_ffn(mod);
     deepseek_prefill::detail::bind_extract(mod);
     deepseek_prefill::detail::bind_insert(mod);
+    deepseek_prefill::detail::bind_update_padded_kv_cache(mod);
 
     deepseek_moe_post_combine_tilize::detail::bind_deepseek_moe_post_combine_tilize(mod);
     fusion::detail::bind_fusion_dispatch_op(mod);

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -189,6 +189,7 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/insert/insert_nanobind.cpp
+    cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
     cpp/ttnn/operations/experimental/plusone/plusone_nanobind.cpp
     cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp
     cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_nanobind.cpp


### PR DESCRIPTION
## What
Resolves #45542

Adds `ttnn.experimental.deepseek_prefill.update_padded_kv_cache`, a KV-cache fill op for **KV-pad-aware rotated chunked prefill** (DeepSeek V3 MLA).

It writes a per-chip input slab into a 4D KV cache at a **per-device start offset** derived on-device from a single global valid-token count (`kv_actual_global`) and the device's coordinate along `cluster_axis`:

- chunk-aligned counts → every device writes at a uniform offset (the chunked-natural case);
- otherwise devices around the boundary write at **staggered offsets**, so new tokens overwrite the prior cache's trailing pad cells before spilling into the next slab.

Cache slots are linearized users-outer, layers-inner (`batch_idx = slot_idx*num_layers + layer_idx`). `slot_idx`, `layer_idx`, and `kv_actual_global` are **runtime args kept out of the program hash**, so successive prefill chunks reuse one cached program; `num_layers` and `cluster_axis` stay structural.

## Implementation

- Device operation + forked writer kernel (`writer_update_padded_kv_cache.cpp`) that derives `update_idxt` on-device.
- Public ttnn op + nanobind binding + CMake wiring.
- The interleaved reader is reused from the existing `kv_cache` fill path.

## Tests

`models/demos/deepseek_v3_d_p/tests/pcc/test_deepseek_prefill_update_padded_kv_cache.py` — accuracy device tests that fill the cache, gather it back to host, and PCC each (user, layer) slot's valid data against what was sent:

- `test_update_padded_kv_cache_single_iteration_prefill` — multi-user × multi-layer chunk-aligned fill + a program-cache-reuse assertion.
- `test_update_padded_kv_cache_multi_iteration_prefill` — multi-user/-layer, scenarios:
  - `non_padded` — two full chunks (chunk-aligned, no rotation);
  - `padded_partial` — three iterations with whole-tile, non-zero pad offsets so the boundary chip's write straddles a slab boundary; last iteration is a full chunk.

Both parametrized over `small` and `repr` shapes on `2x4` / `8x4` meshes. In CI only the **small `padded_partial`** case runs (everything else is a subset), gated via `is_ci_env` / `is_ci_v2_env`. Picked up by the `bh-lb-deepseek-prefill` lane through the existing `pytest models/demos/deepseek_v3_d_p/tests/pcc/` run.

All `2x4`and `8x4` variants validated on hardware (PCC ≈ 0.99997, bf8 round-trip floor)

- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset) -> kv cache op tests passed (failure like on main)
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset) -> op tests passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/kv_cache_per_chip_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/kv_cache_per_chip_offset)
