### PR TITLE
Update fabric tests script for subtorus validation

### DIFF
--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -122,7 +122,7 @@ def visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray_mapping, 
 #   m0(tr1)  m1(tr3)
 #   m3(tr2)  m2(tr4)
 # Intra-host Z: 0-1, 1-2, 2-3, 0-3 (bh_galaxy_split_4x2_multi_mesh).
-# NOTE: 2x4x4z / 16x4x4z now use the 2x4 slice discovery instead (see
+# NOTE: 2x4x4z / 8x4x4z now use the 2x4 slice discovery instead (see
 # FABRIC_TEST_SLICE_MAPPINGS / resolve_fabric_test_visible_devices_slices below).
 FABRIC_TEST_TRAY_MAPPINGS = {
     # 4 Z-connected 4x2 meshes: one tray per mesh (same as BH_GLX_QUAD_RANK_TO_TRAY_MAPPING).
@@ -163,7 +163,7 @@ def resolve_fabric_test_visible_devices(
     return [visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray, rank) for rank in sorted(rank_to_tray)]
 
 
-# --- Slice-based device resolution (2x4x4z / 16x4x4z) -----------------------
+# --- Slice-based device resolution (2x4x4z / 8x4x4z) -----------------------
 # Uses the 2x4 "slice" discovery (Generate2x4SliceToPCIeDeviceMapping) instead
 # of per-tray discovery. A slice is a host-local 2x4 (8-chip) block spanning two
 # trays; the gtest already accounts for the Rev C tray swap, so slice ids 0..3
@@ -177,7 +177,7 @@ def resolve_fabric_test_visible_devices(
 # Both lists are ordered top-tray-pair slice first, bottom-tray-pair slice
 # second (1 before 2, 0 before 3) so the two meshes share a consistent
 # device ordering. The discovery runs across all hosts in one mpirun and writes
-# a per-host keyed mapping, so the quad layout (16x4x4z) no longer needs a
+# a per-host keyed mapping, so the quad layout (8x4x4z) no longer needs a
 # per-host SSH discovery loop.
 SLICE_MAPPING_GTEST_FILTER = "*Generate2x4SliceToPCIeDeviceMapping*"
 SLICE_MAPPING_FILE = "slice_to_pcie_device_mapping.yaml"
@@ -185,14 +185,14 @@ DEVICES_PER_SLICE = 8
 
 # Single-host (2x4x4z) local mesh -> slice ids. With no adjacent host both 4x4
 # meshes are self-contained: mesh 0 = inner pair {1,2}, mesh 1 = outer pair {0,3}.
-# The quad layout (16x4x4z) instead splits the outer slices across adjacent ring
+# The quad layout (8x4x4z) instead splits the outer slices across adjacent ring
 # hosts -- see build_quad_split_rank_table / resolve_quad_split_rank_table.
 FABRIC_TEST_SLICE_MAPPINGS = {
     "2x4x4z": {0: [1, 2], 1: [0, 3]},
 }
 
 # CLI choices for --slice-config: single-host plus the quad split layout.
-SLICE_CONFIG_CHOICES = ["2x4x4z", "16x4x4z"]
+SLICE_CONFIG_CHOICES = ["2x4x4z", "8x4x4z"]
 
 
 def generate_slice_to_pcie_device_mapping(hosts, mpi_if=None, work_dir=None, mapping_file=SLICE_MAPPING_FILE):
@@ -306,7 +306,7 @@ def resolve_fabric_test_visible_devices_slices(
 
 
 def build_quad_split_rank_table(hosts):
-    """Canonical 12-rank table for the quad split 4x4 layout (16x4x4z).
+    """Canonical 12-rank table for the quad split 4x4 layout (8x4x4z).
 
     8 meshes across 4 ring-ordered hosts:
       even mesh 2i  -> single-host 4x4 on hosts[i], slices {1,2}, host_rank 0
@@ -319,7 +319,7 @@ def build_quad_split_rank_table(hosts):
     (mesh_id, host_rank, host, slice_ids).
     """
     if len(hosts) != 4:
-        logger.error(f"16x4x4z requires exactly 4 hosts in ring order, got {len(hosts)}: {hosts}")
+        logger.error(f"8x4x4z requires exactly 4 hosts in ring order, got {len(hosts)}: {hosts}")
         sys.exit(1)
 
     table = []
@@ -386,17 +386,17 @@ def parse_args():
     parser.add_argument(
         "--fabric-config",
         choices=sorted(FABRIC_TEST_TRAY_MAPPINGS.keys()),
-        help="Single-host fabric test layout (used by run_fabric_tests.sh 4x8z/2x4x4z and per-host on 16x4x4z)",
+        help="Single-host fabric test layout (used by run_fabric_tests.sh 4x8z/2x4x4z and per-host on 8x4x4z)",
     )
     parser.add_argument(
         "--slice-config",
         choices=SLICE_CONFIG_CHOICES,
-        help="Slice-based fabric test layout (used by run_fabric_tests.sh 2x4x4z/16x4x4z)",
+        help="Slice-based fabric test layout (used by run_fabric_tests.sh 2x4x4z/8x4x4z)",
     )
     parser.add_argument(
         "--hosts",
         default="",
-        help="With --slice-config: comma-separated hosts (in rank/mesh order; ring order for 16x4x4z)",
+        help="With --slice-config: comma-separated hosts (in rank/mesh order; ring order for 8x4x4z)",
     )
     parser.add_argument(
         "--mpi-if",
@@ -411,7 +411,7 @@ def parse_args():
     parser.add_argument(
         "--print-rank-table",
         action="store_true",
-        help="With --slice-config 16x4x4z: print one FABRIC_RANK:<mesh_id>;<host_rank>;<host>;<devices> line per rank",
+        help="With --slice-config 8x4x4z: print one FABRIC_RANK:<mesh_id>;<host_rank>;<host>;<devices> line per rank",
     )
     parser.add_argument(
         "--no-discovery",
@@ -731,7 +731,7 @@ def generate_supported_rank_bindings():
 
 if __name__ == "__main__":
     args = parse_args()
-    if args.slice_config == "16x4x4z":
+    if args.slice_config == "8x4x4z":
         hosts = [h for h in args.hosts.split(",") if h]
         rank_table = resolve_quad_split_rank_table(
             hosts,

--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import copy
 import os
 import subprocess
@@ -11,31 +12,49 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
+# Machine-readable stdout prefix for run_fabric_tests.sh (--print-devices).
+FABRIC_VISIBLE_DEVICES_PREFIX = "FABRIC_VISIBLE_DEVICES:"
 
-def generate_tray_to_pcie_device_mapping(mapping_file):
-    # Use absolute path to the test executable
-    test_executable = Path("build/test/tt_metal/tt_fabric/test_physical_discovery")
+
+def generate_tray_to_pcie_device_mapping(mapping_file="tray_to_pcie_device_mapping.yaml", work_dir=None):
+    cwd = Path(work_dir) if work_dir else Path.cwd()
+    test_executable = cwd / "build/test/tt_metal/tt_fabric/test_physical_discovery"
 
     if not test_executable.exists():
         logger.error(f"Test executable not found at {test_executable}")
         logger.info("Please build with: ./build_metal.sh --build-tests")
         sys.exit(1)
 
+    mapping_path = Path(mapping_file)
+    if not mapping_path.is_absolute():
+        mapping_path = cwd / mapping_path
+
     MAPPING_GENERATION_CMD = [str(test_executable), "--gtest_filter=*GenerateTrayToPCIeDeviceMapping*"]
 
-    logger.info(f"Running: {' '.join(MAPPING_GENERATION_CMD)}")
+    logger.info(f"Running in {cwd}: {' '.join(MAPPING_GENERATION_CMD)}")
 
+    original_cwd = os.getcwd()
     try:
-        result = subprocess.run(MAPPING_GENERATION_CMD)
+        os.chdir(cwd)
+        result = subprocess.run(
+            MAPPING_GENERATION_CMD,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         if result.returncode != 0:
+            if result.stderr:
+                logger.error(result.stderr.rstrip())
             logger.error(f"{MAPPING_GENERATION_CMD} Failed to generate tray to pcie device mapping")
             sys.exit(result.returncode)
     except KeyboardInterrupt:
         logger.error(f"{MAPPING_GENERATION_CMD} Interrupted")
         sys.exit(1)
+    finally:
+        os.chdir(original_cwd)
 
-    if not os.path.exists(mapping_file):
-        logger.error(f"{mapping_file} not found")
+    if not mapping_path.exists():
+        logger.error(f"{mapping_path} not found")
         sys.exit(1)
 
 
@@ -79,6 +98,98 @@ def generate_rank_binding_yaml(
 
     logger.info(f"Generated rank configuration file: {output_file}")
     return rank_config
+
+
+def visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray_mapping, rank):
+    """Return comma-separated TT_VISIBLE_DEVICES for one rank from tray discovery."""
+    tray_ids = rank_to_tray_mapping[rank]
+    device_ids = []
+    device_mapping = tray_to_pcie_device_mapping["device_mapping"]
+    for tray_id in tray_ids:
+        if tray_id not in device_mapping:
+            logger.error(f"Tray {tray_id} not found in mapping for rank {rank}")
+            sys.exit(1)
+        device_ids.extend(sorted(device_mapping[tray_id]))
+    return ",".join(map(str, device_ids))
+
+
+# Rev C Blackhole Galaxy single-host layouts used by run_fabric_tests.sh (4x8z / 2x4x4z).
+# Quad configs (16x4x4z) reuse these per-host layouts via SSH discovery on
+# each galaxy host; mesh_id is assigned globally in rankfile order (host0 meshes first).
+# Tray ids come from test_physical_discovery (tray_to_pcie_device_mapping.yaml).
+# 4x8z must follow BH_GLX_QUAD rank->tray order. Physical 2x2 tray grid per host:
+#   m0(tr1)  m1(tr3)
+#   m3(tr2)  m2(tr4)
+# Intra-host Z: 0-1, 1-2, 2-3, 0-3 (bh_galaxy_split_4x2_multi_mesh).
+# Quad inter-host: same local mesh index across chassis stack (see quad_bh_galaxy_16x4x2_z MGD; 4x4x8z TBD).
+FABRIC_TEST_TRAY_MAPPINGS = {
+    # 2 Z-connected 4x4 meshes: trays 1+2 (top) and 3+4 (bottom) on Rev C.
+    "2x4x4z": {
+        0: [1, 2],
+        1: [3, 4],
+    },
+    # 4 Z-connected 4x2 meshes: one tray per mesh (same as BH_GLX_QUAD_RANK_TO_TRAY_MAPPING).
+    "4x8z": {
+        0: [1],
+        1: [3],
+        2: [4],
+        3: [2],
+    },
+}
+
+
+def resolve_fabric_test_visible_devices(
+    fabric_config,
+    mapping_file="tray_to_pcie_device_mapping.yaml",
+    run_discovery=True,
+    work_dir=None,
+):
+    """Discover trays and return TT_VISIBLE_DEVICES strings (one per MPI rank)."""
+    if fabric_config not in FABRIC_TEST_TRAY_MAPPINGS:
+        logger.error(f"Unknown fabric config {fabric_config!r}. Supported: {sorted(FABRIC_TEST_TRAY_MAPPINGS)}")
+        sys.exit(1)
+
+    rank_to_tray = FABRIC_TEST_TRAY_MAPPINGS[fabric_config]
+    cwd = Path(work_dir) if work_dir else Path.cwd()
+    mapping_path = cwd / mapping_file
+
+    if run_discovery:
+        generate_tray_to_pcie_device_mapping(mapping_file, work_dir=cwd)
+    elif not mapping_path.exists():
+        logger.error(f"{mapping_path} not found (use discovery or pass --no-discovery after generating it)")
+        sys.exit(1)
+
+    with open(mapping_path, "r") as f:
+        tray_to_pcie_device_mapping = yaml.safe_load(f)
+    validate_device_mapping(tray_to_pcie_device_mapping)
+
+    return [visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray, rank) for rank in sorted(rank_to_tray)]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate rank bindings from tray discovery")
+    parser.add_argument(
+        "--fabric-config",
+        choices=sorted(FABRIC_TEST_TRAY_MAPPINGS.keys()),
+        help="Single-host fabric test layout (used by run_fabric_tests.sh 4x8z/2x4x4z and per-host on 16x4x4z)",
+    )
+    parser.add_argument(
+        "--print-devices",
+        action="store_true",
+        help="With --fabric-config: print one TT_VISIBLE_DEVICES line per rank (stdout)",
+    )
+    parser.add_argument(
+        "--no-discovery",
+        action="store_true",
+        help="With --fabric-config: use existing tray_to_pcie_device_mapping.yaml in cwd",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Directory for discovery output and test binary (default: cwd)",
+    )
+    return parser.parse_args()
 
 
 def validate_device_mapping(tray_to_pcie_device_mapping):
@@ -384,4 +495,18 @@ def generate_supported_rank_bindings():
 
 
 if __name__ == "__main__":
-    generate_supported_rank_bindings()
+    args = parse_args()
+    if args.fabric_config:
+        devices = resolve_fabric_test_visible_devices(
+            args.fabric_config,
+            run_discovery=not args.no_discovery,
+            work_dir=args.work_dir,
+        )
+        if args.print_devices:
+            for line in devices:
+                print(f"{FABRIC_VISIBLE_DEVICES_PREFIX}{line}")
+        else:
+            for rank, visible in enumerate(devices):
+                print(f"rank {rank}: TT_VISIBLE_DEVICES={visible}")
+    else:
+        generate_supported_rank_bindings()

--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -14,6 +14,9 @@ from loguru import logger
 
 # Machine-readable stdout prefix for run_fabric_tests.sh (--print-devices).
 FABRIC_VISIBLE_DEVICES_PREFIX = "FABRIC_VISIBLE_DEVICES:"
+# Machine-readable stdout prefix for run_fabric_tests.sh (--print-rank-table).
+# Format: FABRIC_RANK:<mesh_id>;<host_rank>;<host>;<devices_csv>
+FABRIC_RANK_PREFIX = "FABRIC_RANK:"
 
 
 def generate_tray_to_pcie_device_mapping(mapping_file="tray_to_pcie_device_mapping.yaml", work_dir=None):
@@ -113,21 +116,15 @@ def visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray_mapping, 
     return ",".join(map(str, device_ids))
 
 
-# Rev C Blackhole Galaxy single-host layouts used by run_fabric_tests.sh (4x8z / 2x4x4z).
-# Quad configs (16x4x4z) reuse these per-host layouts via SSH discovery on
-# each galaxy host; mesh_id is assigned globally in rankfile order (host0 meshes first).
+# Rev C Blackhole Galaxy single-host tray layout used by run_fabric_tests.sh (4x8z).
 # Tray ids come from test_physical_discovery (tray_to_pcie_device_mapping.yaml).
 # 4x8z must follow BH_GLX_QUAD rank->tray order. Physical 2x2 tray grid per host:
 #   m0(tr1)  m1(tr3)
 #   m3(tr2)  m2(tr4)
 # Intra-host Z: 0-1, 1-2, 2-3, 0-3 (bh_galaxy_split_4x2_multi_mesh).
-# Quad inter-host: same local mesh index across chassis stack (see quad_bh_galaxy_16x4x2_z MGD; 4x4x8z TBD).
+# NOTE: 2x4x4z / 16x4x4z now use the 2x4 slice discovery instead (see
+# FABRIC_TEST_SLICE_MAPPINGS / resolve_fabric_test_visible_devices_slices below).
 FABRIC_TEST_TRAY_MAPPINGS = {
-    # 2 Z-connected 4x4 meshes: trays 1+2 (top) and 3+4 (bottom) on Rev C.
-    "2x4x4z": {
-        0: [1, 2],
-        1: [3, 4],
-    },
     # 4 Z-connected 4x2 meshes: one tray per mesh (same as BH_GLX_QUAD_RANK_TO_TRAY_MAPPING).
     "4x8z": {
         0: [1],
@@ -166,6 +163,224 @@ def resolve_fabric_test_visible_devices(
     return [visible_devices_for_rank(tray_to_pcie_device_mapping, rank_to_tray, rank) for rank in sorted(rank_to_tray)]
 
 
+# --- Slice-based device resolution (2x4x4z / 16x4x4z) -----------------------
+# Uses the 2x4 "slice" discovery (Generate2x4SliceToPCIeDeviceMapping) instead
+# of per-tray discovery. A slice is a host-local 2x4 (8-chip) block spanning two
+# trays; the gtest already accounts for the Rev C tray swap, so slice ids 0..3
+# are logical. Each 4x4 mesh is composed from two slices.
+#
+# Slice -> 4x4 composition follows the canonical slice layout used by the blitz
+# decode pipeline (blitz_pipeline_config_quad_galaxy_4x4.yaml): the two 4x4
+# meshes are *interleaved* across all four trays, not split into tray-pairs.
+#   inner pair  -> slices {1, 2}  (single-host 4x4 in the blitz config)
+#   outer pair  -> slices {0, 3}  (the wrap/split 4x4 in the blitz config)
+# Both lists are ordered top-tray-pair slice first, bottom-tray-pair slice
+# second (1 before 2, 0 before 3) so the two meshes share a consistent
+# device ordering. The discovery runs across all hosts in one mpirun and writes
+# a per-host keyed mapping, so the quad layout (16x4x4z) no longer needs a
+# per-host SSH discovery loop.
+SLICE_MAPPING_GTEST_FILTER = "*Generate2x4SliceToPCIeDeviceMapping*"
+SLICE_MAPPING_FILE = "slice_to_pcie_device_mapping.yaml"
+DEVICES_PER_SLICE = 8
+
+# Single-host (2x4x4z) local mesh -> slice ids. With no adjacent host both 4x4
+# meshes are self-contained: mesh 0 = inner pair {1,2}, mesh 1 = outer pair {0,3}.
+# The quad layout (16x4x4z) instead splits the outer slices across adjacent ring
+# hosts -- see build_quad_split_rank_table / resolve_quad_split_rank_table.
+FABRIC_TEST_SLICE_MAPPINGS = {
+    "2x4x4z": {0: [1, 2], 1: [0, 3]},
+}
+
+# CLI choices for --slice-config: single-host plus the quad split layout.
+SLICE_CONFIG_CHOICES = ["2x4x4z", "16x4x4z"]
+
+
+def generate_slice_to_pcie_device_mapping(hosts, mpi_if=None, work_dir=None, mapping_file=SLICE_MAPPING_FILE):
+    """Run the multi-host 2x4 slice discovery; writes slice_to_pcie_device_mapping.yaml."""
+    cwd = Path(work_dir) if work_dir else Path.cwd()
+    test_executable = cwd / "build/test/tt_metal/tt_fabric/test_physical_discovery"
+    if not test_executable.exists():
+        logger.error(f"Test executable not found at {test_executable}")
+        logger.info("Please build with: ./build_metal.sh --build-tests")
+        sys.exit(1)
+
+    cmd = [
+        "mpirun",
+        "--np",
+        str(len(hosts)),
+        "--host",
+        ",".join(hosts),
+        "--mca",
+        "btl",
+        "self,tcp",
+    ]
+    if mpi_if:
+        cmd.extend(["--mca", "btl_tcp_if_include", mpi_if])
+    cmd.extend(["--bind-to", "none", "--tag-output", "--wdir", str(cwd)])
+    cmd.extend([str(test_executable), f"--gtest_filter={SLICE_MAPPING_GTEST_FILTER}"])
+
+    logger.info(f"Running: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+        if result.returncode != 0:
+            if result.stderr:
+                logger.error(result.stderr.rstrip())
+            logger.error(f"{cmd} Failed to generate slice to pcie device mapping")
+            sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        logger.error(f"{cmd} Interrupted")
+        sys.exit(1)
+
+    mapping_path = cwd / mapping_file
+    if not mapping_path.exists():
+        logger.error(f"{mapping_path} not found")
+        sys.exit(1)
+    return mapping_path
+
+
+def _match_slice_host_key(device_mapping, host):
+    """Map a requested host to its key in the slice mapping (exact or short-name match)."""
+    if host in device_mapping:
+        return host
+    host_short = host.split(".")[0]
+    for key in device_mapping:
+        if key == host_short or key.split(".")[0] == host_short:
+            return key
+    logger.error(f"Host {host!r} not found in slice mapping (keys: {sorted(device_mapping)})")
+    sys.exit(1)
+
+
+def resolve_fabric_test_visible_devices_slices(
+    fabric_config,
+    hosts,
+    mpi_if=None,
+    run_discovery=True,
+    work_dir=None,
+):
+    """Discover 2x4 slices across hosts; return one TT_VISIBLE_DEVICES per rank.
+
+    Ranks are ordered host-major: host0 local mesh 0, host0 local mesh 1,
+    host1 local mesh 0, ... matching the rankfile slot order in run_fabric_tests.sh.
+    """
+    if fabric_config not in FABRIC_TEST_SLICE_MAPPINGS:
+        logger.error(f"Unknown slice config {fabric_config!r}. Supported: {sorted(FABRIC_TEST_SLICE_MAPPINGS)}")
+        sys.exit(1)
+    if not hosts:
+        logger.error("Slice-based resolution requires at least one host (--hosts)")
+        sys.exit(1)
+
+    local_mesh_to_slices = FABRIC_TEST_SLICE_MAPPINGS[fabric_config]
+    cwd = Path(work_dir) if work_dir else Path.cwd()
+    mapping_path = cwd / SLICE_MAPPING_FILE
+
+    if run_discovery:
+        generate_slice_to_pcie_device_mapping(hosts, mpi_if=mpi_if, work_dir=cwd)
+    elif not mapping_path.exists():
+        logger.error(f"{mapping_path} not found (run discovery or generate it first)")
+        sys.exit(1)
+
+    with open(mapping_path, "r") as f:
+        slice_mapping = yaml.safe_load(f)
+    device_mapping = slice_mapping.get("device_mapping", {})
+
+    visible = []
+    for host in hosts:
+        host_key = _match_slice_host_key(device_mapping, host)
+        host_slices = device_mapping[host_key]
+        for local_mesh in sorted(local_mesh_to_slices):
+            devices = []
+            for slice_id in local_mesh_to_slices[local_mesh]:
+                if slice_id not in host_slices:
+                    logger.error(f"Slice {slice_id} not found for host {host_key} in {mapping_path}")
+                    sys.exit(1)
+                slice_devices = sorted(host_slices[slice_id])
+                if len(slice_devices) != DEVICES_PER_SLICE:
+                    logger.error(
+                        f"Slice {slice_id} on {host_key} resolved to {len(slice_devices)} devices, "
+                        f"expected {DEVICES_PER_SLICE}"
+                    )
+                    sys.exit(1)
+                devices.extend(slice_devices)
+            visible.append(",".join(map(str, devices)))
+    return visible
+
+
+def build_quad_split_rank_table(hosts):
+    """Canonical 12-rank table for the quad split 4x4 layout (16x4x4z).
+
+    8 meshes across 4 ring-ordered hosts:
+      even mesh 2i  -> single-host 4x4 on hosts[i], slices {1,2}, host_rank 0
+      odd  mesh 2i+1 -> split 4x4: host_rank 0 = hosts[i]   slice {3}
+                                    host_rank 1 = hosts[i+1] slice {0}  (ring wrap)
+
+    Entries are ordered mesh-major then host-rank-minor, matching control_plane's
+    (mesh_id, host_rank) -> mpi_rank assignment, so the launcher must emit MPMD
+    segments / rankfile slots in exactly this order. Each entry is a tuple
+    (mesh_id, host_rank, host, slice_ids).
+    """
+    if len(hosts) != 4:
+        logger.error(f"16x4x4z requires exactly 4 hosts in ring order, got {len(hosts)}: {hosts}")
+        sys.exit(1)
+
+    table = []
+    for mesh_id in range(8):
+        host_idx = mesh_id // 2
+        if mesh_id % 2 == 0:
+            table.append((mesh_id, 0, hosts[host_idx], [1, 2]))
+        else:
+            table.append((mesh_id, 0, hosts[host_idx], [3]))
+            table.append((mesh_id, 1, hosts[(host_idx + 1) % 4], [0]))
+    return table
+
+
+def resolve_quad_split_rank_table(hosts, mpi_if=None, run_discovery=True, work_dir=None):
+    """Discover 2x4 slices across the 4 quad hosts; return the 12-rank table.
+
+    Returns a list (in canonical rank order) of dicts:
+      {"mesh_id": int, "host_rank": int, "host": str, "devices": "d0,d1,..."}.
+    """
+    table = build_quad_split_rank_table(hosts)
+    cwd = Path(work_dir) if work_dir else Path.cwd()
+    mapping_path = cwd / SLICE_MAPPING_FILE
+
+    if run_discovery:
+        generate_slice_to_pcie_device_mapping(hosts, mpi_if=mpi_if, work_dir=cwd)
+    elif not mapping_path.exists():
+        logger.error(f"{mapping_path} not found (run discovery or generate it first)")
+        sys.exit(1)
+
+    with open(mapping_path, "r") as f:
+        slice_mapping = yaml.safe_load(f)
+    device_mapping = slice_mapping.get("device_mapping", {})
+
+    rank_table = []
+    for mesh_id, host_rank, host, slice_ids in table:
+        host_key = _match_slice_host_key(device_mapping, host)
+        host_slices = device_mapping[host_key]
+        devices = []
+        for slice_id in slice_ids:
+            if slice_id not in host_slices:
+                logger.error(f"Slice {slice_id} not found for host {host_key} in {mapping_path}")
+                sys.exit(1)
+            slice_devices = sorted(host_slices[slice_id])
+            if len(slice_devices) != DEVICES_PER_SLICE:
+                logger.error(
+                    f"Slice {slice_id} on {host_key} resolved to {len(slice_devices)} devices, "
+                    f"expected {DEVICES_PER_SLICE}"
+                )
+                sys.exit(1)
+            devices.extend(slice_devices)
+        rank_table.append(
+            {
+                "mesh_id": mesh_id,
+                "host_rank": host_rank,
+                "host": host,
+                "devices": ",".join(map(str, devices)),
+            }
+        )
+    return rank_table
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate rank bindings from tray discovery")
     parser.add_argument(
@@ -174,9 +389,29 @@ def parse_args():
         help="Single-host fabric test layout (used by run_fabric_tests.sh 4x8z/2x4x4z and per-host on 16x4x4z)",
     )
     parser.add_argument(
+        "--slice-config",
+        choices=SLICE_CONFIG_CHOICES,
+        help="Slice-based fabric test layout (used by run_fabric_tests.sh 2x4x4z/16x4x4z)",
+    )
+    parser.add_argument(
+        "--hosts",
+        default="",
+        help="With --slice-config: comma-separated hosts (in rank/mesh order; ring order for 16x4x4z)",
+    )
+    parser.add_argument(
+        "--mpi-if",
+        default=None,
+        help="With --slice-config: network interface for the discovery mpirun (btl_tcp_if_include)",
+    )
+    parser.add_argument(
         "--print-devices",
         action="store_true",
-        help="With --fabric-config: print one TT_VISIBLE_DEVICES line per rank (stdout)",
+        help="With --fabric-config/--slice-config 2x4x4z: print one TT_VISIBLE_DEVICES line per rank (stdout)",
+    )
+    parser.add_argument(
+        "--print-rank-table",
+        action="store_true",
+        help="With --slice-config 16x4x4z: print one FABRIC_RANK:<mesh_id>;<host_rank>;<host>;<devices> line per rank",
     )
     parser.add_argument(
         "--no-discovery",
@@ -496,7 +731,42 @@ def generate_supported_rank_bindings():
 
 if __name__ == "__main__":
     args = parse_args()
-    if args.fabric_config:
+    if args.slice_config == "16x4x4z":
+        hosts = [h for h in args.hosts.split(",") if h]
+        rank_table = resolve_quad_split_rank_table(
+            hosts,
+            mpi_if=args.mpi_if,
+            run_discovery=not args.no_discovery,
+            work_dir=args.work_dir,
+        )
+        if args.print_rank_table:
+            for entry in rank_table:
+                print(
+                    f"{FABRIC_RANK_PREFIX}{entry['mesh_id']};{entry['host_rank']};"
+                    f"{entry['host']};{entry['devices']}"
+                )
+        else:
+            for rank, entry in enumerate(rank_table):
+                print(
+                    f"rank {rank}: mesh_id={entry['mesh_id']} host_rank={entry['host_rank']} "
+                    f"host={entry['host']} TT_VISIBLE_DEVICES={entry['devices']}"
+                )
+    elif args.slice_config:
+        hosts = [h for h in args.hosts.split(",") if h]
+        devices = resolve_fabric_test_visible_devices_slices(
+            args.slice_config,
+            hosts,
+            mpi_if=args.mpi_if,
+            run_discovery=not args.no_discovery,
+            work_dir=args.work_dir,
+        )
+        if args.print_devices:
+            for line in devices:
+                print(f"{FABRIC_VISIBLE_DEVICES_PREFIX}{line}")
+        else:
+            for rank, visible in enumerate(devices):
+                print(f"rank {rank}: TT_VISIBLE_DEVICES={visible}")
+    elif args.fabric_config:
         devices = resolve_fabric_test_visible_devices(
             args.fabric_config,
             run_discovery=not args.no_discovery,

--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -192,6 +192,7 @@ FABRIC_TEST_SLICE_MAPPINGS = {
 }
 
 # CLI choices for --slice-config: single-host plus the quad split layout.
+
 SLICE_CONFIG_CHOICES = ["2x4x4z", "8x4x4z"]
 
 

--- a/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+++ b/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
@@ -190,7 +190,6 @@ DEVICES_PER_SLICE = 8
 FABRIC_TEST_SLICE_MAPPINGS = {
     "2x4x4z": {0: [1, 2], 1: [0, 3]},
 }
-
 # CLI choices for --slice-config: single-host plus the quad split layout.
 
 SLICE_CONFIG_CHOICES = ["2x4x4z", "8x4x4z"]

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -18,7 +18,9 @@ Optional:
                                         They launch one MPI rank per mesh, each with its own TT_MESH_ID.
                                         4x8z    = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
                                         2x4x4z  = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
-                                        16x4x4z = full quad: 4 hosts x 2 Z-connected 4x4 meshes each (8 ranks).
+                                        16x4x4z = full quad: 8 Z-connected 4x4 meshes across 4 hosts (12 ranks);
+                                                  even mesh ids are single-host (slices {1,2}), odd mesh ids are
+                                                  split across two adjacent ring hosts ({3} + next-host {0}).
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
                                         4x8 default:   tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
@@ -31,7 +33,7 @@ Optional:
                                         4x32z default:  tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
                                                        (4 galaxies as 4 Z-connected 8x4 torus meshes)
                                         16x4x4z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
-                                                       (4 galaxies x 2 Z-connected 4x4 meshes each)
+                                                       (8 Z-connected 4x4 meshes across 4 galaxies; even single-host, odd split 2x1)
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
@@ -287,45 +289,6 @@ run_fabric_discovery_local() {
     fi
 }
 
-is_local_fabric_host() {
-    local host="$1"
-    local short_name fqdn host_short
-    short_name="$(hostname -s 2>/dev/null || hostname)"
-    fqdn="$(hostname -f 2>/dev/null || true)"
-    host_short="${host%%.*}"
-    [[ "$host" == "localhost" || "$host" == "127.0.0.1" || "$host" == "$short_name" || "$host" == "$fqdn" || "$host_short" == "$short_name" ]]
-}
-
-run_fabric_discovery_on_host() {
-    local host="$1"
-    local fabric_config="$2"
-    local tt_home="${TT_METAL_HOME:-$(pwd)}"
-    local ssh_opts=(-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
-
-    if is_local_fabric_host "$host"; then
-        run_fabric_discovery_local "$fabric_config"
-        return
-    fi
-
-    if [[ "$DOCKER_IMAGE" == "none" ]]; then
-        local gen_rb="${tt_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
-        ssh "${ssh_opts[@]}" "$host" \
-            "cd '${tt_home}' && LD_LIBRARY_PATH='${tt_home}/build/lib:'\${LD_LIBRARY_PATH:-} TT_METAL_HOME='${tt_home}' python3 '${gen_rb}' --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_home}'"
-    else
-        ssh "${ssh_opts[@]}" "$host" \
-            "docker run --rm --net=host --privileged \
-                -v /tmp:/tmp \
-                -v /dev/hugepages-1G:/dev/hugepages-1G \
-                -v '${HOME}:${HOME}' \
-                --user '$(id -u):$(id -g)' \
-                -v /etc/passwd:/etc/passwd:ro \
-                -v /etc/group:/etc/group:ro \
-                --entrypoint='' \
-                '${DOCKER_IMAGE}' \
-                bash -c 'cd \"\$TT_METAL_HOME\" && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config ${fabric_config} --print-devices --work-dir \"\$TT_METAL_HOME\"'"
-    fi
-}
-
 resolve_single_host_z_visible_devices() {
     local fabric_config="$1"
     local expected_ranks="$2"
@@ -355,63 +318,113 @@ resolve_single_host_z_visible_devices() {
     done
 }
 
-resolve_quad_host_z_visible_devices() {
-    local per_host_fabric_config="$1"
-    local num_hosts="$2"
-    local ranks_per_host="$3"
-    local expected_total=$((num_hosts * ranks_per_host))
+# Resolve TT_VISIBLE_DEVICES for 2x4x4z from the multi-host 2x4 slice discovery
+# (generate_rank_bindings.py --slice-config). One mpirun across all hosts
+# produces a per-host slice mapping (Rev C tray swap handled in the gtest), so no
+# per-host SSH loop is needed. Prints one TT_VISIBLE_DEVICES line per rank in
+# host-major order (host0 local mesh 0, host0 local mesh 1, host1 ...).
+#
+# Discovery ALWAYS runs natively on the launch host, even in docker mode: it only
+# reads the hardware topology and emits logical device ids (identical whether run
+# natively or inside a container), and the multi-host discovery gtest cannot be
+# launched across per-rank containers. In docker mode the resolved
+# TT_VISIBLE_DEVICES are forwarded into the containers via -x at launch time.
+# Requires a local host build of test_physical_discovery + python3 (loguru/yaml).
+resolve_slice_z_visible_devices() {
+    local slice_config="$1"
+    local hosts_csv="$2"
+    local expected_ranks="$3"
+    local tt_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
 
-    if [[ "$DOCKER_IMAGE" == "none" ]]; then
-        local gen_rb="${TT_METAL_HOME:-$(pwd)}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
-        if [[ ! -f "$gen_rb" ]]; then
-            echo "Error: rank binding helper not found: $gen_rb" >&2
-            exit 1
-        fi
-    fi
-
-    IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
-    if [[ "${#Z_RANK_HOSTS[@]}" -ne "$num_hosts" ]]; then
-        echo "Error: --config requires exactly $num_hosts hosts in --hosts (got ${#Z_RANK_HOSTS[@]})" >&2
+    if [[ ! -f "$gen_rb" ]]; then
+        echo "Error: rank binding helper not found: $gen_rb" >&2
         exit 1
     fi
 
-    echo "Resolving TT_VISIBLE_DEVICES via tray discovery on ${num_hosts} hosts (--fabric-config ${per_host_fabric_config})..."
+    echo "Resolving TT_VISIBLE_DEVICES via 2x4 slice discovery (--slice-config ${slice_config}, hosts ${hosts_csv})..."
     Z_VISIBLE_DEVICES=()
+    mapfile -t Z_VISIBLE_DEVICES < <(
+        cd "$tt_home" && \
+        LD_LIBRARY_PATH="${tt_home}/build/lib:${LD_LIBRARY_PATH:-}" \
+        TT_METAL_HOME="$tt_home" \
+        python3 "$gen_rb" --slice-config "$slice_config" --hosts "$hosts_csv" --mpi-if "$MPI_IF" \
+            --print-devices --work-dir "$tt_home" \
+            | grep '^FABRIC_VISIBLE_DEVICES:' | sed 's/^FABRIC_VISIBLE_DEVICES://'
+    )
 
-    local host_idx=0
-    for host in "${Z_RANK_HOSTS[@]}"; do
-        local host_devices=()
-        mapfile -t host_devices < <(
-            run_fabric_discovery_on_host "$host" "$per_host_fabric_config" \
-                | grep '^FABRIC_VISIBLE_DEVICES:' | sed 's/^FABRIC_VISIBLE_DEVICES://'
-        )
-        if [[ "${#host_devices[@]}" -ne "$ranks_per_host" ]]; then
-            echo "Error: expected ${ranks_per_host} TT_VISIBLE_DEVICES entries from ${host}, got ${#host_devices[@]}" >&2
-            exit 1
-        fi
-        for ((local_rank = 0; local_rank < ranks_per_host; local_rank++)); do
-            local global_rank=$((host_idx * ranks_per_host + local_rank))
-            Z_VISIBLE_DEVICES+=("${host_devices[$local_rank]}")
-            echo "  rank $global_rank (host ${host}, local mesh ${local_rank}) -> TT_VISIBLE_DEVICES=${host_devices[$local_rank]}"
-        done
-        ((host_idx++))
-    done
-
-    if [[ "${#Z_VISIBLE_DEVICES[@]}" -ne "$expected_total" ]]; then
-        echo "Error: expected ${expected_total} TT_VISIBLE_DEVICES entries, got ${#Z_VISIBLE_DEVICES[@]}" >&2
+    if [[ "${#Z_VISIBLE_DEVICES[@]}" -ne "$expected_ranks" ]]; then
+        echo "Error: expected ${expected_ranks} TT_VISIBLE_DEVICES entries for ${slice_config}, got ${#Z_VISIBLE_DEVICES[@]}" >&2
         exit 1
     fi
+    for ((i = 0; i < expected_ranks; i++)); do
+        echo "  rank $i -> TT_VISIBLE_DEVICES=${Z_VISIBLE_DEVICES[$i]}"
+    done
 }
 
-write_quad_z_rankfile() {
-    local ranks_per_host="$1"
+# Resolve the 16x4x4z quad split layout: 8 Z-connected 4x4 meshes across 4 ring
+# hosts as a 12-rank table (even meshes single-host {1,2}; odd meshes split
+# {3}+next-host {0}). Populates parallel per-rank arrays in canonical
+# (mesh_id, host_rank) -> mpi_rank order:
+#   Z_RANK_MESH_ID, Z_RANK_HOST_RANK, Z_RANK_PIN_HOSTS, Z_VISIBLE_DEVICES.
+#
+# Like resolve_slice_z_visible_devices, the slice discovery always runs natively
+# on the launch host (even in docker mode); only the test launch is containerized.
+resolve_quad_split_rank_table() {
+    local hosts_csv="$1"
+    local expected_ranks="$2"
+    local tt_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+
+    if [[ ! -f "$gen_rb" ]]; then
+        echo "Error: rank binding helper not found: $gen_rb" >&2
+        exit 1
+    fi
+
+    echo "Resolving quad split rank table via 2x4 slice discovery (--slice-config 16x4x4z, hosts ${hosts_csv})..."
+    local rank_lines=()
+    mapfile -t rank_lines < <(
+        cd "$tt_home" && \
+        LD_LIBRARY_PATH="${tt_home}/build/lib:${LD_LIBRARY_PATH:-}" \
+        TT_METAL_HOME="$tt_home" \
+        python3 "$gen_rb" --slice-config 16x4x4z --hosts "$hosts_csv" --mpi-if "$MPI_IF" \
+            --print-rank-table --work-dir "$tt_home" \
+            | grep '^FABRIC_RANK:' | sed 's/^FABRIC_RANK://'
+    )
+
+    if [[ "${#rank_lines[@]}" -ne "$expected_ranks" ]]; then
+        echo "Error: expected ${expected_ranks} FABRIC_RANK entries for 16x4x4z, got ${#rank_lines[@]}" >&2
+        exit 1
+    fi
+
+    Z_RANK_MESH_ID=()
+    Z_RANK_HOST_RANK=()
+    Z_RANK_PIN_HOSTS=()
+    Z_VISIBLE_DEVICES=()
+    local idx=0
+    local mesh_id host_rank host devices
+    for line in "${rank_lines[@]}"; do
+        IFS=';' read -r mesh_id host_rank host devices <<< "$line"
+        Z_RANK_MESH_ID[$idx]="$mesh_id"
+        Z_RANK_HOST_RANK[$idx]="$host_rank"
+        Z_RANK_PIN_HOSTS[$idx]="$host"
+        Z_VISIBLE_DEVICES[$idx]="$devices"
+        echo "  rank $idx -> mesh_id ${mesh_id} host_rank ${host_rank} host ${host} TT_VISIBLE_DEVICES=${devices}"
+        ((idx++))
+    done
+}
+
+# Build an OpenMPI rankfile that pins each rank to its host (from
+# Z_RANK_PIN_HOSTS), assigning per-host slots in increasing order.
+write_quad_split_rankfile() {
     Z_RANKFILE="$(mktemp)"
-    local global_rank=0
-    for ((h = 0; h < ${#Z_RANK_HOSTS[@]}; h++)); do
-        for ((slot = 0; slot < ranks_per_host; slot++)); do
-            echo "rank $global_rank=${Z_RANK_HOSTS[$h]} slot=$slot" >> "$Z_RANKFILE"
-            ((global_rank++))
-        done
+    declare -A host_slot
+    local i h slot
+    for ((i = 0; i < NUM_RANKS; i++)); do
+        h="${Z_RANK_PIN_HOSTS[$i]}"
+        slot="${host_slot[$h]:-0}"
+        echo "rank $i=${h} slot=$slot" >> "$Z_RANKFILE"
+        host_slot[$h]=$((slot + 1))
     done
     Z_GLOBAL_HOST=(--hostfile "$Z_RANKFILE" --map-by "rankfile:file=$Z_RANKFILE")
 }
@@ -425,6 +438,110 @@ cleanup_run_artifacts() {
 }
 trap cleanup_run_artifacts EXIT
 
+# ---------------------------------------------------------------------------
+# Success highlighting helpers (used live during test output and at end).
+# Defined here, before the launch logic, so the pipelines below can call them.
+# ---------------------------------------------------------------------------
+
+FABRIC_SUCCESS_MARKER="Test | All tests completed successfully"
+
+# Print an unmissable banner when a rank reports success.
+_print_fabric_success_banner() {
+    local plain_line="$1"
+    local success_count="$2"
+    local rank_label=""
+
+    if [[ "$plain_line" =~ \[1,([0-9]+)\] ]]; then
+        rank_label=" (MPI rank ${BASH_REMATCH[1]})"
+    fi
+
+    echo ""
+    echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+    echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+    echo -e "\033[42m\033[1;30m   >>>>>  FABRIC TESTS PASSED${rank_label}  <<<<<                              \033[0m"
+    echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+    echo -e "\033[42m\033[1;30m   Detected: ${FABRIC_SUCCESS_MARKER}                                       \033[0m"
+    echo -e "\033[42m\033[1;30m   Success signals so far: ${success_count}                                   \033[0m"
+    echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+    echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+    echo ""
+}
+
+# Tee filter: pass output through unchanged, but shout when success is detected.
+# The success phrase is never split by ANSI codes mid-string, so we substring-match
+# the raw line directly instead of spawning a sed per line (keeps the live pipe fast).
+highlight_fabric_test_success() {
+    local line success_count=0
+
+    while IFS= read -r line; do
+        printf '%s\n' "$line"
+        if [[ "$line" == *"All tests completed successfully"* ]]; then
+            success_count=$((success_count + 1))
+            _print_fabric_success_banner "$line" "$success_count"
+        fi
+    done
+}
+
+# After the run, summarize pass/fail from the log (one success line per MPI rank).
+print_fabric_final_summary() {
+    local log_file="$1"
+    local success_count=0
+    local expected_hosts=0
+    local all_passed=false
+
+    if [[ ! -f "$log_file" ]]; then
+        echo ""
+        echo -e "\033[1;31mNo log file found; cannot verify fabric test results.\033[0m"
+        return 1
+    fi
+
+    # Single awk pass over the log: strip ANSI inline, count success markers and
+    # distinct MPI rank tags ([1,N] from --tag-output). This replaces a bash
+    # while-loop that spawned printf|sed per line (two processes per log line),
+    # which was very slow on large multi-rank logs.
+    read -r success_count expected_hosts < <(
+        awk '
+        {
+            line = $0
+            gsub(/\033\[[0-9;]*m/, "", line)
+            if (line ~ /All tests completed successfully/) success++
+            if (match(line, /^\[1,[0-9]+\]/)) ranks[substr(line, RSTART, RLENGTH)] = 1
+        }
+        END { n = 0; for (k in ranks) n++; print success + 0, n + 0 }
+        ' "$log_file"
+    )
+
+    if [[ "$expected_hosts" -eq 0 ]]; then
+        expected_hosts=1
+    fi
+
+    if [[ "$success_count" -eq "$expected_hosts" && "$success_count" -gt 0 ]]; then
+        all_passed=true
+    fi
+
+    echo ""
+    if [[ "$all_passed" == true ]]; then
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m   ##########################  ALL FABRIC TESTS PASSED  ######################## \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m   Every MPI rank (${success_count}/${expected_hosts}) reported: ${FABRIC_SUCCESS_MARKER} \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo -e "\033[42m\033[1;30m                                                                                \033[0m"
+        echo ""
+    else
+        echo -e "\033[1;31m================================================================================\033[0m"
+        echo -e "\033[1;31m FABRIC TESTS DID NOT FULLY PASS \033[0m"
+        echo -e "\033[1;31m Success signals: ${success_count}/${expected_hosts} MPI rank(s)\033[0m"
+        echo -e "\033[1;31m Expected '${FABRIC_SUCCESS_MARKER}' once per rank.\033[0m"
+        echo -e "\033[1;31m See log: ${log_file}\033[0m"
+        echo -e "\033[1;31m================================================================================\033[0m"
+        echo ""
+    fi
+}
+
 if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "16x4x4z" ]]; then
     # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
     # TT_MESH_ID, so the descriptor's inter-mesh (Z) connections are exercised
@@ -432,7 +549,10 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
     Z_VISIBLE_DEVICES=()
     Z_RANK_HOSTS=()
     Z_GLOBAL_HOST=()
-    Z_RANKS_PER_HOST=1
+    Z_RANK_MESH_ID=()
+    Z_RANK_HOST_RANK=()
+    Z_RANK_PIN_HOSTS=()
+    NUM_RANKS=""
 
     if [[ "$CONFIG" == "4x8z" ]]; then
         NUM_MESHES=4
@@ -444,24 +564,24 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
         NUM_MESHES=2
         SINGLE_HOST="${HOSTS%%,*}"
         Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
-        resolve_single_host_z_visible_devices "2x4x4z" "$NUM_MESHES"
-        echo "Running multi-mesh 2x4x4z (2 Z-connected 4x4 meshes) on single host: $SINGLE_HOST"
+        resolve_slice_z_visible_devices "2x4x4z" "$SINGLE_HOST" "$NUM_MESHES"
+        echo "Running multi-mesh 2x4x4z (2 Z-connected 4x4 meshes, slice-based) on single host: $SINGLE_HOST"
     elif [[ "$CONFIG" == "16x4x4z" ]]; then
+        # 8 Z-connected 4x4 meshes across 4 ring hosts, composed from 2x4 slices:
+        # even meshes are single-host 4x4 {1,2}; odd meshes are split across two
+        # adjacent hosts ({3} on host H + {0} on host H+1). That yields 12 ranks
+        # (3 per host) ordered mesh-major then host-rank-minor, matching
+        # control_plane's (mesh_id, host_rank) -> mpi_rank assignment.
         NUM_MESHES=8
-        Z_RANKS_PER_HOST=2
+        NUM_RANKS=12
         IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
         if [[ "${#Z_RANK_HOSTS[@]}" -ne 4 ]]; then
             echo "Error: --config 16x4x4z requires exactly 4 hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
             exit 1
         fi
-        resolve_quad_host_z_visible_devices "2x4x4z" 4 "$Z_RANKS_PER_HOST"
-        write_quad_z_rankfile "$Z_RANKS_PER_HOST"
-        echo "Running multi-mesh 16x4x4z (4 hosts x 2 Z-connected 4x4 meshes, 8 ranks total); rank i pinned via rankfile:"
-        for ((i = 0; i < NUM_MESHES; i++)); do
-            local_host_idx=$((i / Z_RANKS_PER_HOST))
-            local_mesh=$((i % Z_RANKS_PER_HOST))
-            echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$local_host_idx]} (local mesh ${local_mesh})"
-        done
+        resolve_quad_split_rank_table "$HOSTS" "$NUM_RANKS"
+        write_quad_split_rankfile
+        echo "Running multi-mesh 16x4x4z (8 Z-connected 4x4 meshes across 4 hosts, slice-based split; 12 ranks, even=single-host {1,2}, odd=split {3}+next-host {0}); ranks pinned via rankfile."
     else
         NUM_MESHES=4
         # 4x32z: one full galaxy per host. The Z ring (mesh 0->1->2->3->0) only
@@ -486,17 +606,33 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
     fi
     echo ""
 
+    # Configs other than 16x4x4z launch one rank per mesh (mesh_id == rank, no
+    # explicit host rank). Fill the per-rank arrays so the segment builder below
+    # is shared by all Z configs.
+    if [[ -z "$NUM_RANKS" ]]; then
+        NUM_RANKS="$NUM_MESHES"
+        for ((i = 0; i < NUM_RANKS; i++)); do
+            Z_RANK_MESH_ID[$i]="$i"
+            Z_RANK_HOST_RANK[$i]=""
+        done
+    fi
+
     # Assemble the per-rank ":"-separated MPMD segments shared by the docker
     # and no-docker launch paths. Each segment carries its own TT_MESH_ID (and,
-    # for 4x8z/2x4x4z, TT_VISIBLE_DEVICES). Host placement for 4x32z is handled
-    # by the OpenMPI rankfile in Z_GLOBAL_HOST, not per-segment --host.
+    # where resolved, TT_VISIBLE_DEVICES). 16x4x4z additionally sets
+    # TT_MESH_HOST_RANK (required on multi-host systems, and distinguishes the
+    # two ranks of a split mesh). Host placement for 4x32z/16x4x4z is handled by
+    # the OpenMPI rankfile in Z_GLOBAL_HOST, not per-segment --host.
     # TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS matches full_rank_binding.yaml so the
     # slowest ethernet handshakes don't trip the Fabric Router Sync timeout.
     Z_SEGMENTS=()
-    for ((i = 0; i < NUM_MESHES; i++)); do
+    for ((i = 0; i < NUM_RANKS; i++)); do
         [[ $i -gt 0 ]] && Z_SEGMENTS+=(":")
         Z_SEGMENTS+=(-np 1)
-        Z_SEGMENTS+=(-x TT_MESH_ID="$i")
+        Z_SEGMENTS+=(-x TT_MESH_ID="${Z_RANK_MESH_ID[$i]}")
+        if [[ -n "${Z_RANK_HOST_RANK[$i]:-}" ]]; then
+            Z_SEGMENTS+=(-x TT_MESH_HOST_RANK="${Z_RANK_HOST_RANK[$i]}")
+        fi
         if [[ "${#Z_VISIBLE_DEVICES[@]}" -gt 0 ]]; then
             Z_SEGMENTS+=(-x TT_VISIBLE_DEVICES="${Z_VISIBLE_DEVICES[$i]}")
         fi
@@ -521,7 +657,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
             "${MPI_EXTRA_ARGS[@]}" \
             --bind-to none \
             "${Z_GLOBAL_HOST[@]}" \
-            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE"
+            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE" | highlight_fabric_test_success
     else
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
@@ -530,7 +666,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
             "${MPI_EXTRA_ARGS[@]}" \
             --bind-to none \
             "${Z_GLOBAL_HOST[@]}" \
-            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE"
+            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE" | highlight_fabric_test_success
     fi
 elif [[ "$DOCKER_IMAGE" == "none" ]]; then
     # No-docker path: invoke mpirun-ulfm directly against the local build.
@@ -550,7 +686,7 @@ elif [[ "$DOCKER_IMAGE" == "none" ]]; then
             -x TT_MESH_ID=0 \
             -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
             "$TEST_BINARY" \
-            --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+            --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE" | highlight_fabric_test_success
     else
         mpirun-ulfm \
             --tag-output \
@@ -578,7 +714,7 @@ elif [[ "$DOCKER_IMAGE" == "none" ]]; then
             -x TT_MESH_ID=0 \
             -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
             "$TEST_BINARY" \
-            --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+            --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE" | highlight_fabric_test_success
     fi
 elif [[ "$CONFIG" == "4x8" ]]; then
     SINGLE_HOST="${HOSTS%%,*}"
@@ -595,7 +731,7 @@ elif [[ "$CONFIG" == "4x8" ]]; then
         -x TT_MESH_ID=0 \
         -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
         "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE" | highlight_fabric_test_success
 else
     ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
         --empty-entrypoint \
@@ -622,7 +758,7 @@ else
         -x TT_MESH_ID=0 \
         -x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH" \
         "$TEST_BINARY" \
-        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE"
+        --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS |& tee "$LOG_FILE" | highlight_fabric_test_success
 fi
 
 echo ""
@@ -642,4 +778,6 @@ for report in pairwise_validation_summary.log pairwise_validation_detailed.log; 
         echo "Copied report: $OUTPUT_DIR/$report"
     fi
 done
+
+print_fabric_final_summary "$LOG_FILE"
 echo "=========================================="

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -12,12 +12,12 @@ Required Options:
     --image <docker-image>              Docker image to use ("none" to use local build)
 
 Optional:
-    --config <4x8|4x32|8x16|4x8z|4x4x2z|4x32z>  Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16|4x8z|2x4x4z|4x32z>  Mesh configuration (default: 4x32)
                                         The *z configs are multi-mesh layouts that exercise Z links
                                         (inter-mesh) in addition to the intra-mesh N/S/E/W links.
                                         They launch one MPI rank per mesh, each with its own TT_MESH_ID.
                                         4x8z   = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
-                                        4x4x2z = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
+                                        2x4x4z = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
                                         4x8 default:   tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
@@ -25,7 +25,7 @@ Optional:
                                         8x16 default:  tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
                                         4x8z default:  tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto
                                                        (single galaxy split into 4 Z-connected 4x2 meshes)
-                                        4x4x2z default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto
+                                        2x4x4z default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
                                                        (single galaxy split into 2 Z-connected 4x4 meshes)
                                         4x32z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
                                                        (4 galaxies as 4 Z-connected 8x4 torus meshes)
@@ -33,7 +33,7 @@ Optional:
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
-                                        (4x8z/4x32z default: test_fabric_multi_mesh_sanity_common.yaml, whose
+                                        (4x8z/2x4x4z/4x32z default: test_fabric_multi_mesh_sanity_common.yaml, whose
                                          neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
@@ -55,8 +55,8 @@ MESH_GRAPH_DESC_PATH_4x8="tt_metal/fabric/mesh_graph_descriptors/single_bh_galax
 MESH_GRAPH_DESC_PATH_4x32="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_8x16="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x8z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto"
-# 4x4x2z: single galaxy split into 2 Z-connected 4x4 meshes (dual_4x4 layout).
-MESH_GRAPH_DESC_PATH_4x4x2z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto"
+# 2x4x4z: single galaxy split into 2 Z-connected 4x4 meshes (dual_4x4 layout).
+MESH_GRAPH_DESC_PATH_2x4x4z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto"
 CONFIG="4x32"
 MESH_GRAPH_DESC_PATH=""
@@ -98,8 +98,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "4x4x2z" && "$CONFIG" != "4x32z" ]]; then
-                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '4x4x2z', or '4x32z'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "2x4x4z" && "$CONFIG" != "4x32z" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '2x4x4z', or '4x32z'"
                 echo ""
                 show_help
                 exit 1
@@ -203,8 +203,8 @@ if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x16"
     elif [[ "$CONFIG" == "4x8z" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x8z"
-    elif [[ "$CONFIG" == "4x4x2z" ]]; then
-        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x4x2z"
+    elif [[ "$CONFIG" == "2x4x4z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_2x4x4z"
     elif [[ "$CONFIG" == "4x32z" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32z"
     fi
@@ -212,7 +212,7 @@ fi
 
 # Multi-mesh (Z) configs need a multi-mesh-aware test config; fall back to the
 # multi-mesh sanity config unless the user explicitly passed --test-config.
-if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ) ]]; then
+if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ) ]]; then
     TEST_CONFIG="$TEST_CONFIG_Z"
 fi
 
@@ -254,11 +254,11 @@ fi
 RUN_START_MARKER="$(mktemp)"
 trap 'rm -f "$RUN_START_MARKER"' EXIT
 
-if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ]]; then
+if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; then
     # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
     # TT_MESH_ID, so the descriptor's inter-mesh (Z) connections are exercised
     # alongside the intra-mesh N/S/E/W links during neighbor exchange.
-    # NUM_MESHES is set per-config below (4x4x2z has only 2 meshes).
+    # NUM_MESHES is set per-config below (2x4x4z has only 2 meshes).
     Z_VISIBLE_DEVICES=()
     Z_RANK_HOSTS=()      # per-rank host pinning (rank i -> Z_RANK_HOSTS[i]); empty => use Z_GLOBAL_HOST
     Z_GLOBAL_HOST=()     # global --host args (single-host packing case)
@@ -278,7 +278,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ]]; t
             "24,25,26,27,28,29,30,31"
         )
         echo "Running multi-mesh 4x8z (4 Z-connected 4x2 meshes) on single host: $SINGLE_HOST"
-    elif [[ "$CONFIG" == "4x4x2z" ]]; then
+    elif [[ "$CONFIG" == "2x4x4z" ]]; then
         # Single galaxy host carved into 2 Z-connected 4x4 meshes (16 chips each)
         # -- the dual_4x4 layout. Split the 32 chips into 2 groups of 16 via
         # TT_VISIBLE_DEVICES (mirrors dual_4x4_rank_binding.yaml). Placement order
@@ -290,7 +290,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ]]; t
             "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"
             "16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
         )
-        echo "Running multi-mesh 4x4x2z (2 Z-connected 4x4 meshes) on single host: $SINGLE_HOST"
+        echo "Running multi-mesh 2x4x4z (2 Z-connected 4x4 meshes) on single host: $SINGLE_HOST"
     else
         NUM_MESHES=4
         # 4x32z: one full galaxy per host. The Z ring (mesh 0->1->2->3->0) only

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -219,7 +219,9 @@ fi
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
-LOG_FILE="$OUTPUT_DIR/fabric_tests_$(date +%Y%m%d_%H%M%S).log"
+RUN_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+LOG_FILE="$OUTPUT_DIR/fabric_tests_${RUN_TIMESTAMP}.log"
+Z_RANKFILE=""   # 4x32z OpenMPI rankfile; set below when CONFIG=4x32z
 
 echo "=========================================="
 echo "Running fabric tests..."
@@ -252,7 +254,8 @@ fi
 # Marker used to detect reports written during this run (vs. stale ones from a
 # previous run). We compare report mtimes against this file with bash's `-nt`.
 RUN_START_MARKER="$(mktemp)"
-trap 'rm -f "$RUN_START_MARKER"' EXIT
+cleanup_run_artifacts() { rm -f "$RUN_START_MARKER"; }
+trap cleanup_run_artifacts EXIT
 
 if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; then
     # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
@@ -260,7 +263,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
     # alongside the intra-mesh N/S/E/W links during neighbor exchange.
     # NUM_MESHES is set per-config below (2x4x4z has only 2 meshes).
     Z_VISIBLE_DEVICES=()
-    Z_RANK_HOSTS=()      # per-rank host pinning (rank i -> Z_RANK_HOSTS[i]); empty => use Z_GLOBAL_HOST
+    Z_RANK_HOSTS=()      # 4x32z host list (for rankfile + logging); empty for single-host Z configs
     Z_GLOBAL_HOST=()     # global --host args (single-host packing case)
 
     if [[ "$CONFIG" == "4x8z" ]]; then
@@ -304,9 +307,19 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
             exit 1
         fi
         # mpi-docker requires --host/--hostfile in global MPI args (before the first
-        # -np). Per-rank --host below still pins rank i -> mesh i deterministically.
-        Z_GLOBAL_HOST=(--host "$HOSTS")
+        # -np). MPMD with per-segment --host or global host:1 slot syntax does NOT
+        # reliably pin ranks when each segment is a separate -np 1 (rank 0 can still
+        # land on the launch node). Use an OpenMPI rankfile + --map-by rankfile,
+        # matching scaleout_configs/full_rankfile and tt-run's production pattern.
+        Z_RANKFILE="$OUTPUT_DIR/fabric_rankfile_${RUN_TIMESTAMP}.txt"
+        : > "$Z_RANKFILE"
+        for ((i = 0; i < NUM_MESHES; i++)); do
+            echo "rank $i=${Z_RANK_HOSTS[$i]} slot=0" >> "$Z_RANKFILE"
+        done
+        Z_GLOBAL_HOST=(--hostfile "$Z_RANKFILE" --map-by "rankfile:file=$Z_RANKFILE")
         echo "Running multi-mesh 4x32z (4 Z-connected 8x4 torus galaxies); rank i pinned to host i:"
+        echo "Rankfile: $Z_RANKFILE"
+        cat "$Z_RANKFILE"
         for ((i = 0; i < NUM_MESHES; i++)); do
             echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$i]}"
         done
@@ -315,16 +328,14 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
 
     # Assemble the per-rank ":"-separated MPMD segments shared by the docker
     # and no-docker launch paths. Each segment carries its own TT_MESH_ID (and,
-    # for 4x8z, TT_VISIBLE_DEVICES; for 4x32z, an explicit --host pin).
+    # for 4x8z/2x4x4z, TT_VISIBLE_DEVICES). Host placement for 4x32z is handled
+    # by the OpenMPI rankfile in Z_GLOBAL_HOST, not per-segment --host.
     # TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS matches full_rank_binding.yaml so the
     # slowest ethernet handshakes don't trip the Fabric Router Sync timeout.
     Z_SEGMENTS=()
     for ((i = 0; i < NUM_MESHES; i++)); do
         [[ $i -gt 0 ]] && Z_SEGMENTS+=(":")
         Z_SEGMENTS+=(-np 1)
-        if [[ "${#Z_RANK_HOSTS[@]}" -gt 0 ]]; then
-            Z_SEGMENTS+=(--host "${Z_RANK_HOSTS[$i]}")
-        fi
         Z_SEGMENTS+=(-x TT_MESH_ID="$i")
         if [[ "${#Z_VISIBLE_DEVICES[@]}" -gt 0 ]]; then
             Z_SEGMENTS+=(-x TT_VISIBLE_DEVICES="${Z_VISIBLE_DEVICES[$i]}")

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -12,12 +12,13 @@ Required Options:
     --image <docker-image>              Docker image to use ("none" to use local build)
 
 Optional:
-    --config <4x8|4x32|8x16|4x8z|2x4x4z|4x32z>  Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16|4x8z|2x4x4z|4x32z|16x4x4z>  Mesh configuration (default: 4x32)
                                         The *z configs are multi-mesh layouts that exercise Z links
                                         (inter-mesh) in addition to the intra-mesh N/S/E/W links.
                                         They launch one MPI rank per mesh, each with its own TT_MESH_ID.
-                                        4x8z   = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
-                                        2x4x4z = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
+                                        4x8z    = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
+                                        2x4x4z  = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
+                                        16x4x4z = full quad: 4 hosts x 2 Z-connected 4x4 meshes each (8 ranks).
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
                                         4x8 default:   tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
@@ -27,13 +28,15 @@ Optional:
                                                        (single galaxy split into 4 Z-connected 4x2 meshes)
                                         2x4x4z default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
                                                        (single galaxy split into 2 Z-connected 4x4 meshes)
-                                        4x32z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
+                                        4x32z default:  tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
                                                        (4 galaxies as 4 Z-connected 8x4 torus meshes)
+                                        16x4x4z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
+                                                       (4 galaxies x 2 Z-connected 4x4 meshes each)
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
-                                        (4x8z/2x4x4z/4x32z default: test_fabric_multi_mesh_sanity_common.yaml, whose
+                                        (4x8z/2x4x4z/4x32z/16x4x4z default: test_fabric_multi_mesh_sanity_common.yaml, whose
                                          neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
@@ -58,6 +61,7 @@ MESH_GRAPH_DESC_PATH_4x8z="tt_metal/fabric/mesh_graph_descriptors/single_bh_gala
 # 2x4x4z: single galaxy split into 2 Z-connected 4x4 meshes (dual_4x4 layout).
 MESH_GRAPH_DESC_PATH_2x4x4z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto"
+MESH_GRAPH_DESC_PATH_16x4x4z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto"
 CONFIG="4x32"
 MESH_GRAPH_DESC_PATH=""
 MESH_GRAPH_DESC_PATH_EXPLICIT=false
@@ -98,8 +102,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "2x4x4z" && "$CONFIG" != "4x32z" ]]; then
-                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '2x4x4z', or '4x32z'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "2x4x4z" && "$CONFIG" != "4x32z" && "$CONFIG" != "16x4x4z" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '2x4x4z', '4x32z', or '16x4x4z'"
                 echo ""
                 show_help
                 exit 1
@@ -207,12 +211,14 @@ if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_2x4x4z"
     elif [[ "$CONFIG" == "4x32z" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32z"
+    elif [[ "$CONFIG" == "16x4x4z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_16x4x4z"
     fi
 fi
 
 # Multi-mesh (Z) configs need a multi-mesh-aware test config; fall back to the
 # multi-mesh sanity config unless the user explicitly passed --test-config.
-if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ) ]]; then
+if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "16x4x4z" ) ]]; then
     TEST_CONFIG="$TEST_CONFIG_Z"
 fi
 
@@ -251,49 +257,221 @@ if [[ -n "$FILTER" ]]; then
     EXTRA_BINARY_ARGS="$EXTRA_BINARY_ARGS --filter $FILTER"
 fi
 
+# Resolve TT_VISIBLE_DEVICES for single-host multi-mesh Z configs from tray discovery
+# (tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config).
+resolve_fabric_python() {
+    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
+    local py="${tt_metal_home}/python_env/bin/python"
+    if [[ -x "$py" ]]; then
+        echo "$py"
+    elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+        echo "${VIRTUAL_ENV}/bin/python"
+    else
+        echo python3
+    fi
+}
+
+FABRIC_PYTHON="$(resolve_fabric_python)"
+
+run_fabric_discovery_local() {
+    local fabric_config="$1"
+    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+
+    if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        cd "$tt_metal_home" && \
+        LD_LIBRARY_PATH="${tt_metal_home}/build/lib:${LD_LIBRARY_PATH:-}" \
+        "$FABRIC_PYTHON" "$gen_rb" --fabric-config "$fabric_config" --print-devices --work-dir "$tt_metal_home"
+    else
+        docker run --rm --net=host --privileged \
+            -v /tmp:/tmp \
+            -v /dev/hugepages-1G:/dev/hugepages-1G \
+            -v "$HOME:$HOME" \
+            --user "$(id -u):$(id -g)" \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/group:/etc/group:ro \
+            --entrypoint="" \
+            -e "LD_LIBRARY_PATH=${tt_metal_home}/build/lib" \
+            "$DOCKER_IMAGE" \
+            bash -c "cd '${tt_metal_home}' && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'"
+    fi
+}
+
+is_local_fabric_host() {
+    local host="$1"
+    local short_name fqdn host_short
+    short_name="$(hostname -s 2>/dev/null || hostname)"
+    fqdn="$(hostname -f 2>/dev/null || true)"
+    host_short="${host%%.*}"
+    [[ "$host" == "localhost" || "$host" == "127.0.0.1" || "$host" == "$short_name" || "$host" == "$fqdn" || "$host_short" == "$short_name" ]]
+}
+
+run_fabric_discovery_on_host() {
+    local host="$1"
+    local fabric_config="$2"
+    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+    local ssh_opts=(-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+    local remote_py="${tt_metal_home}/python_env/bin/python"
+
+    if is_local_fabric_host "$host"; then
+        run_fabric_discovery_local "$fabric_config"
+        return
+    fi
+
+    if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        ssh "${ssh_opts[@]}" "$host" \
+            "PY='${remote_py}'; [[ -x \"\$PY\" ]] || PY=python3; cd '${tt_metal_home}' && LD_LIBRARY_PATH='${tt_metal_home}/build/lib:'\${LD_LIBRARY_PATH:-} \"\$PY\" '${gen_rb}' --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'"
+    else
+        ssh "${ssh_opts[@]}" "$host" \
+            "docker run --rm --net=host --privileged \
+                -v /tmp:/tmp \
+                -v /dev/hugepages-1G:/dev/hugepages-1G \
+                -v '${HOME}:${HOME}' \
+                --user '$(id -u):$(id -g)' \
+                -v /etc/passwd:/etc/passwd:ro \
+                -v /etc/group:/etc/group:ro \
+                --entrypoint='' \
+                -e 'LD_LIBRARY_PATH=${tt_metal_home}/build/lib' \
+                '${DOCKER_IMAGE}' \
+                bash -c \"cd '${tt_metal_home}' && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'\""
+    fi
+}
+
+resolve_single_host_z_visible_devices() {
+    local fabric_config="$1"
+    local expected_ranks="$2"
+    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+
+    if [[ ! -f "$gen_rb" ]]; then
+        echo "Error: rank binding helper not found: $gen_rb" >&2
+        exit 1
+    fi
+
+    echo "Resolving TT_VISIBLE_DEVICES via tray discovery (--fabric-config ${fabric_config})..."
+    Z_VISIBLE_DEVICES=()
+
+    mapfile -t Z_VISIBLE_DEVICES < <(
+        run_fabric_discovery_local "$fabric_config" \
+            | grep '^FABRIC_VISIBLE_DEVICES:' | sed 's/^FABRIC_VISIBLE_DEVICES://'
+    )
+
+    if [[ "${#Z_VISIBLE_DEVICES[@]}" -ne "$expected_ranks" ]]; then
+        echo "Error: expected ${expected_ranks} TT_VISIBLE_DEVICES entries for ${fabric_config}, got ${#Z_VISIBLE_DEVICES[@]}" >&2
+        exit 1
+    fi
+    for ((i = 0; i < expected_ranks; i++)); do
+        echo "  rank $i -> TT_VISIBLE_DEVICES=${Z_VISIBLE_DEVICES[$i]}"
+    done
+}
+
+resolve_quad_host_z_visible_devices() {
+    local per_host_fabric_config="$1"
+    local num_hosts="$2"
+    local ranks_per_host="$3"
+    local expected_total=$((num_hosts * ranks_per_host))
+    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
+    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+
+    if [[ ! -f "$gen_rb" ]]; then
+        echo "Error: rank binding helper not found: $gen_rb" >&2
+        exit 1
+    fi
+
+    IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
+    if [[ "${#Z_RANK_HOSTS[@]}" -ne "$num_hosts" ]]; then
+        echo "Error: --config requires exactly $num_hosts hosts in --hosts (got ${#Z_RANK_HOSTS[@]})" >&2
+        exit 1
+    fi
+
+    echo "Resolving TT_VISIBLE_DEVICES via tray discovery on ${num_hosts} hosts (--fabric-config ${per_host_fabric_config})..."
+    Z_VISIBLE_DEVICES=()
+
+    local host_idx=0
+    for host in "${Z_RANK_HOSTS[@]}"; do
+        local host_devices=()
+        mapfile -t host_devices < <(
+            run_fabric_discovery_on_host "$host" "$per_host_fabric_config" \
+                | grep '^FABRIC_VISIBLE_DEVICES:' | sed 's/^FABRIC_VISIBLE_DEVICES://'
+        )
+        if [[ "${#host_devices[@]}" -ne "$ranks_per_host" ]]; then
+            echo "Error: expected ${ranks_per_host} TT_VISIBLE_DEVICES entries from ${host}, got ${#host_devices[@]}" >&2
+            exit 1
+        fi
+        for ((local_rank = 0; local_rank < ranks_per_host; local_rank++)); do
+            local global_rank=$((host_idx * ranks_per_host + local_rank))
+            Z_VISIBLE_DEVICES+=("${host_devices[$local_rank]}")
+            echo "  rank $global_rank (host ${host}, local mesh ${local_rank}) -> TT_VISIBLE_DEVICES=${host_devices[$local_rank]}"
+        done
+        ((host_idx++))
+    done
+
+    if [[ "${#Z_VISIBLE_DEVICES[@]}" -ne "$expected_total" ]]; then
+        echo "Error: expected ${expected_total} TT_VISIBLE_DEVICES entries, got ${#Z_VISIBLE_DEVICES[@]}" >&2
+        exit 1
+    fi
+}
+
+write_quad_z_rankfile() {
+    local ranks_per_host="$1"
+    Z_RANKFILE="$(mktemp)"
+    local global_rank=0
+    for ((h = 0; h < ${#Z_RANK_HOSTS[@]}; h++)); do
+        for ((slot = 0; slot < ranks_per_host; slot++)); do
+            echo "rank $global_rank=${Z_RANK_HOSTS[$h]} slot=$slot" >> "$Z_RANKFILE"
+            ((global_rank++))
+        done
+    done
+    Z_GLOBAL_HOST=(--hostfile "$Z_RANKFILE" --map-by "rankfile:file=$Z_RANKFILE")
+}
+
 # Marker used to detect reports written during this run (vs. stale ones from a
 # previous run). We compare report mtimes against this file with bash's `-nt`.
 RUN_START_MARKER="$(mktemp)"
-cleanup_run_artifacts() { rm -f "$RUN_START_MARKER"; }
+cleanup_run_artifacts() {
+    rm -f "$RUN_START_MARKER"
+    [[ -n "$Z_RANKFILE" ]] && rm -f "$Z_RANKFILE"
+}
 trap cleanup_run_artifacts EXIT
 
-if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; then
+if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "16x4x4z" ]]; then
     # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
     # TT_MESH_ID, so the descriptor's inter-mesh (Z) connections are exercised
     # alongside the intra-mesh N/S/E/W links during neighbor exchange.
-    # NUM_MESHES is set per-config below (2x4x4z has only 2 meshes).
     Z_VISIBLE_DEVICES=()
-    Z_RANK_HOSTS=()      # 4x32z host list (for rankfile + logging); empty for single-host Z configs
-    Z_GLOBAL_HOST=()     # global --host args (single-host packing case)
+    Z_RANK_HOSTS=()
+    Z_GLOBAL_HOST=()
+    Z_RANKS_PER_HOST=1
 
     if [[ "$CONFIG" == "4x8z" ]]; then
-        # Single galaxy host carved into 4 Z-connected 4x2 meshes (8 chips each).
-        # Split the 32 chips into 4 groups of 8 via TT_VISIBLE_DEVICES
-        # (rank i -> mesh i -> tray (i+1)). Placement order is irrelevant on one
-        # host, so use a global host spec.
         NUM_MESHES=4
         SINGLE_HOST="${HOSTS%%,*}"
         Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
-        Z_VISIBLE_DEVICES=(
-            "0,1,2,3,4,5,6,7"
-            "8,9,10,11,12,13,14,15"
-            "16,17,18,19,20,21,22,23"
-            "24,25,26,27,28,29,30,31"
-        )
+        resolve_single_host_z_visible_devices "4x8z" "$NUM_MESHES"
         echo "Running multi-mesh 4x8z (4 Z-connected 4x2 meshes) on single host: $SINGLE_HOST"
     elif [[ "$CONFIG" == "2x4x4z" ]]; then
-        # Single galaxy host carved into 2 Z-connected 4x4 meshes (16 chips each)
-        # -- the dual_4x4 layout. Split the 32 chips into 2 groups of 16 via
-        # TT_VISIBLE_DEVICES. Placement order
-        # is irrelevant on one host, so use a global host spec.
         NUM_MESHES=2
         SINGLE_HOST="${HOSTS%%,*}"
         Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
-        Z_VISIBLE_DEVICES=(
-            "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"
-            "16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
-        )
+        resolve_single_host_z_visible_devices "2x4x4z" "$NUM_MESHES"
         echo "Running multi-mesh 2x4x4z (2 Z-connected 4x4 meshes) on single host: $SINGLE_HOST"
+    elif [[ "$CONFIG" == "16x4x4z" ]]; then
+        NUM_MESHES=8
+        Z_RANKS_PER_HOST=2
+        IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
+        if [[ "${#Z_RANK_HOSTS[@]}" -ne 4 ]]; then
+            echo "Error: --config 16x4x4z requires exactly 4 hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
+            exit 1
+        fi
+        resolve_quad_host_z_visible_devices "2x4x4z" 4 "$Z_RANKS_PER_HOST"
+        write_quad_z_rankfile "$Z_RANKS_PER_HOST"
+        echo "Running multi-mesh 16x4x4z (4 hosts x 2 Z-connected 4x4 meshes, 8 ranks total); rank i pinned via rankfile:"
+        for ((i = 0; i < NUM_MESHES; i++)); do
+            local_host_idx=$((i / Z_RANKS_PER_HOST))
+            local_mesh=$((i % Z_RANKS_PER_HOST))
+            echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$local_host_idx]} (local mesh ${local_mesh})"
+        done
     else
         NUM_MESHES=4
         # 4x32z: one full galaxy per host. The Z ring (mesh 0->1->2->3->0) only
@@ -306,20 +484,12 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
             echo "Error: --config 4x32z requires exactly $NUM_MESHES hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
             exit 1
         fi
-        # mpi-docker requires --host/--hostfile in global MPI args (before the first
-        # -np). MPMD with per-segment --host or global host:1 slot syntax does NOT
-        # reliably pin ranks when each segment is a separate -np 1 (rank 0 can still
-        # land on the launch node). Use an OpenMPI rankfile + --map-by rankfile,
-        # matching scaleout_configs/full_rankfile and tt-run's production pattern.
-        Z_RANKFILE="$OUTPUT_DIR/fabric_rankfile_${RUN_TIMESTAMP}.txt"
-        : > "$Z_RANKFILE"
+        Z_RANKFILE="$(mktemp)"
         for ((i = 0; i < NUM_MESHES; i++)); do
             echo "rank $i=${Z_RANK_HOSTS[$i]} slot=0" >> "$Z_RANKFILE"
         done
         Z_GLOBAL_HOST=(--hostfile "$Z_RANKFILE" --map-by "rankfile:file=$Z_RANKFILE")
         echo "Running multi-mesh 4x32z (4 Z-connected 8x4 torus galaxies); rank i pinned to host i:"
-        echo "Rankfile: $Z_RANKFILE"
-        cat "$Z_RANKFILE"
         for ((i = 0; i < NUM_MESHES; i++)); do
             echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$i]}"
         done
@@ -345,6 +515,14 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
         Z_SEGMENTS+=("$TEST_BINARY" --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS)
     done
 
+    # Single-host and multi-rank-per-host Z configs via mpi-docker: one container
+    # per MPMD segment. OpenMPI's default sm BTL needs a shared IPC namespace
+    # across containers on the same host; force TCP instead (same as tt-run).
+    Z_DOCKER_MPI_ARGS=()
+    if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "16x4x4z" ]]; then
+        Z_DOCKER_MPI_ARGS=(--mca btl self,tcp)
+    fi
+
     if [[ "$DOCKER_IMAGE" == "none" ]]; then
         mpirun-ulfm \
             --tag-output \
@@ -358,6 +536,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
             --mpi-interface "$MPI_IF" \
+            "${Z_DOCKER_MPI_ARGS[@]}" \
             "${MPI_EXTRA_ARGS[@]}" \
             --bind-to none \
             "${Z_GLOBAL_HOST[@]}" \

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -12,13 +12,13 @@ Required Options:
     --image <docker-image>              Docker image to use ("none" to use local build)
 
 Optional:
-    --config <4x8|4x32|8x16|4x8z|2x4x4z|4x32z|16x4x4z>  Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16|4x8z|2x4x4z|4x32z|8x4x4z>  Mesh configuration (default: 4x32)
                                         The *z configs are multi-mesh layouts that exercise Z links
                                         (inter-mesh) in addition to the intra-mesh N/S/E/W links.
                                         They launch one MPI rank per mesh, each with its own TT_MESH_ID.
                                         4x8z    = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
                                         2x4x4z  = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
-                                        16x4x4z = full quad: 8 Z-connected 4x4 meshes across 4 hosts (12 ranks);
+                                        8x4x4z = full quad: 8 Z-connected 4x4 meshes across 4 hosts (12 ranks);
                                                   even mesh ids are single-host (slices {1,2}), odd mesh ids are
                                                   split across two adjacent ring hosts ({3} + next-host {0}).
     --output <directory>                Output directory for log files (default: fabric_test_logs)
@@ -32,13 +32,13 @@ Optional:
                                                        (single galaxy split into 2 Z-connected 4x4 meshes)
                                         4x32z default:  tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
                                                        (4 galaxies as 4 Z-connected 8x4 torus meshes)
-                                        16x4x4z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
+                                        8x4x4z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
                                                        (8 Z-connected 4x4 meshes across 4 galaxies; even single-host, odd split 2x1)
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
-                                        (4x8z/2x4x4z/4x32z/16x4x4z default: test_fabric_multi_mesh_sanity_common.yaml, whose
+                                        (4x8z/2x4x4z/4x32z/8x4x4z default: test_fabric_multi_mesh_sanity_common.yaml, whose
                                          neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
@@ -63,7 +63,7 @@ MESH_GRAPH_DESC_PATH_4x8z="tt_metal/fabric/mesh_graph_descriptors/single_bh_gala
 # 2x4x4z: single galaxy split into 2 Z-connected 4x4 meshes (dual_4x4 layout).
 MESH_GRAPH_DESC_PATH_2x4x4z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto"
-MESH_GRAPH_DESC_PATH_16x4x4z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto"
+MESH_GRAPH_DESC_PATH_8x4x4z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto"
 CONFIG="4x32"
 MESH_GRAPH_DESC_PATH=""
 MESH_GRAPH_DESC_PATH_EXPLICIT=false
@@ -104,8 +104,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "2x4x4z" && "$CONFIG" != "4x32z" && "$CONFIG" != "16x4x4z" ]]; then
-                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '2x4x4z', '4x32z', or '16x4x4z'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "2x4x4z" && "$CONFIG" != "4x32z" && "$CONFIG" != "8x4x4z" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '2x4x4z', '4x32z', or '8x4x4z'"
                 echo ""
                 show_help
                 exit 1
@@ -213,14 +213,14 @@ if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_2x4x4z"
     elif [[ "$CONFIG" == "4x32z" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32z"
-    elif [[ "$CONFIG" == "16x4x4z" ]]; then
-        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_16x4x4z"
+    elif [[ "$CONFIG" == "8x4x4z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x4x4z"
     fi
 fi
 
 # Multi-mesh (Z) configs need a multi-mesh-aware test config; fall back to the
 # multi-mesh sanity config unless the user explicitly passed --test-config.
-if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "16x4x4z" ) ]]; then
+if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "8x4x4z" ) ]]; then
     TEST_CONFIG="$TEST_CONFIG_Z"
 fi
 
@@ -362,7 +362,7 @@ resolve_slice_z_visible_devices() {
     done
 }
 
-# Resolve the 16x4x4z quad split layout: 8 Z-connected 4x4 meshes across 4 ring
+# Resolve the 8x4x4z quad split layout: 8 Z-connected 4x4 meshes across 4 ring
 # hosts as a 12-rank table (even meshes single-host {1,2}; odd meshes split
 # {3}+next-host {0}). Populates parallel per-rank arrays in canonical
 # (mesh_id, host_rank) -> mpi_rank order:
@@ -381,19 +381,19 @@ resolve_quad_split_rank_table() {
         exit 1
     fi
 
-    echo "Resolving quad split rank table via 2x4 slice discovery (--slice-config 16x4x4z, hosts ${hosts_csv})..."
+    echo "Resolving quad split rank table via 2x4 slice discovery (--slice-config 8x4x4z, hosts ${hosts_csv})..."
     local rank_lines=()
     mapfile -t rank_lines < <(
         cd "$tt_home" && \
         LD_LIBRARY_PATH="${tt_home}/build/lib:${LD_LIBRARY_PATH:-}" \
         TT_METAL_HOME="$tt_home" \
-        python3 "$gen_rb" --slice-config 16x4x4z --hosts "$hosts_csv" --mpi-if "$MPI_IF" \
+        python3 "$gen_rb" --slice-config 8x4x4z --hosts "$hosts_csv" --mpi-if "$MPI_IF" \
             --print-rank-table --work-dir "$tt_home" \
             | grep '^FABRIC_RANK:' | sed 's/^FABRIC_RANK://'
     )
 
     if [[ "${#rank_lines[@]}" -ne "$expected_ranks" ]]; then
-        echo "Error: expected ${expected_ranks} FABRIC_RANK entries for 16x4x4z, got ${#rank_lines[@]}" >&2
+        echo "Error: expected ${expected_ranks} FABRIC_RANK entries for 8x4x4z, got ${#rank_lines[@]}" >&2
         exit 1
     fi
 
@@ -542,7 +542,7 @@ print_fabric_final_summary() {
     fi
 }
 
-if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "16x4x4z" ]]; then
+if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$CONFIG" == "8x4x4z" ]]; then
     # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
     # TT_MESH_ID, so the descriptor's inter-mesh (Z) connections are exercised
     # alongside the intra-mesh N/S/E/W links during neighbor exchange.
@@ -566,7 +566,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
         Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
         resolve_slice_z_visible_devices "2x4x4z" "$SINGLE_HOST" "$NUM_MESHES"
         echo "Running multi-mesh 2x4x4z (2 Z-connected 4x4 meshes, slice-based) on single host: $SINGLE_HOST"
-    elif [[ "$CONFIG" == "16x4x4z" ]]; then
+    elif [[ "$CONFIG" == "8x4x4z" ]]; then
         # 8 Z-connected 4x4 meshes across 4 ring hosts, composed from 2x4 slices:
         # even meshes are single-host 4x4 {1,2}; odd meshes are split across two
         # adjacent hosts ({3} on host H + {0} on host H+1). That yields 12 ranks
@@ -576,12 +576,12 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
         NUM_RANKS=12
         IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
         if [[ "${#Z_RANK_HOSTS[@]}" -ne 4 ]]; then
-            echo "Error: --config 16x4x4z requires exactly 4 hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
+            echo "Error: --config 8x4x4z requires exactly 4 hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
             exit 1
         fi
         resolve_quad_split_rank_table "$HOSTS" "$NUM_RANKS"
         write_quad_split_rankfile
-        echo "Running multi-mesh 16x4x4z (8 Z-connected 4x4 meshes across 4 hosts, slice-based split; 12 ranks, even=single-host {1,2}, odd=split {3}+next-host {0}); ranks pinned via rankfile."
+        echo "Running multi-mesh 8x4x4z (8 Z-connected 4x4 meshes across 4 hosts, slice-based split; 12 ranks, even=single-host {1,2}, odd=split {3}+next-host {0}); ranks pinned via rankfile."
     else
         NUM_MESHES=4
         # 4x32z: one full galaxy per host. The Z ring (mesh 0->1->2->3->0) only
@@ -606,7 +606,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
     fi
     echo ""
 
-    # Configs other than 16x4x4z launch one rank per mesh (mesh_id == rank, no
+    # Configs other than 8x4x4z launch one rank per mesh (mesh_id == rank, no
     # explicit host rank). Fill the per-rank arrays so the segment builder below
     # is shared by all Z configs.
     if [[ -z "$NUM_RANKS" ]]; then
@@ -619,9 +619,9 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
 
     # Assemble the per-rank ":"-separated MPMD segments shared by the docker
     # and no-docker launch paths. Each segment carries its own TT_MESH_ID (and,
-    # where resolved, TT_VISIBLE_DEVICES). 16x4x4z additionally sets
+    # where resolved, TT_VISIBLE_DEVICES). 8x4x4z additionally sets
     # TT_MESH_HOST_RANK (required on multi-host systems, and distinguishes the
-    # two ranks of a split mesh). Host placement for 4x32z/16x4x4z is handled by
+    # two ranks of a split mesh). Host placement for 4x32z/8x4x4z is handled by
     # the OpenMPI rankfile in Z_GLOBAL_HOST, not per-segment --host.
     # TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS matches full_rank_binding.yaml so the
     # slowest ethernet handshakes don't trip the Fabric Router Sync timeout.
@@ -645,7 +645,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" || "$
     # per MPMD segment. OpenMPI's default sm BTL needs a shared IPC namespace
     # across containers on the same host; force TCP instead (same as tt-run).
     Z_DOCKER_MPI_ARGS=()
-    if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "16x4x4z" ]]; then
+    if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "8x4x4z" ]]; then
         Z_DOCKER_MPI_ARGS=(--mca btl self,tcp)
     fi
 

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -12,16 +12,29 @@ Required Options:
     --image <docker-image>              Docker image to use ("none" to use local build)
 
 Optional:
-    --config <4x8|4x32|8x16>           Mesh configuration (default: 4x32)
+    --config <4x8|4x32|8x16|4x8z|4x4x2z|4x32z>  Mesh configuration (default: 4x32)
+                                        The *z configs are multi-mesh layouts that exercise Z links
+                                        (inter-mesh) in addition to the intra-mesh N/S/E/W links.
+                                        They launch one MPI rank per mesh, each with its own TT_MESH_ID.
+                                        4x8z   = single galaxy as 4 Z-connected 4x2 meshes (4 ranks).
+                                        4x4x2z = single galaxy as 2 Z-connected 4x4 meshes (2 ranks, dual_4x4 layout).
     --output <directory>                Output directory for log files (default: fabric_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file (overrides --config)
-                                        4x8 default:  tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
-                                        4x32 default: tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
-                                        8x16 default: tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+                                        4x8 default:   tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
+                                        4x32 default:  tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+                                        8x16 default:  tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto
+                                        4x8z default:  tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto
+                                                       (single galaxy split into 4 Z-connected 4x2 meshes)
+                                        4x4x2z default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto
+                                                       (single galaxy split into 2 Z-connected 4x4 meshes)
+                                        4x32z default: tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto
+                                                       (4 galaxies as 4 Z-connected 8x4 torus meshes)
     --test-binary <path>                Path to test binary
                                         (default: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric)
     --test-config <path>                Path to test configuration file
                                         (default: tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml)
+                                        (4x8z/4x32z default: test_fabric_multi_mesh_sanity_common.yaml, whose
+                                         neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
     --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
     --mpi-args <args>                   Extra arguments passed directly to mpirun (quoted string)
@@ -41,11 +54,22 @@ OUTPUT_DIR="fabric_test_logs"
 MESH_GRAPH_DESC_PATH_4x8="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_4x32="tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
 MESH_GRAPH_DESC_PATH_8x16="tt_metal/fabric/mesh_graph_descriptors/16x8_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"
+MESH_GRAPH_DESC_PATH_4x8z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto"
+# 4x4x2z: single galaxy split into 2 Z-connected 4x4 meshes (dual_4x4 layout).
+MESH_GRAPH_DESC_PATH_4x4x2z="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto"
+MESH_GRAPH_DESC_PATH_4x32z="tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_4x4x8_z_torus_graph_descriptor.textproto"
 CONFIG="4x32"
 MESH_GRAPH_DESC_PATH=""
 MESH_GRAPH_DESC_PATH_EXPLICIT=false
 TEST_BINARY="./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric"
 TEST_CONFIG="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml"
+TEST_CONFIG_EXPLICIT=false
+# Multi-mesh (Z) configs default to the multi-mesh sanity config, whose
+# neighbor_exchange/all_to_all patterns route across mesh boundaries (Z links).
+# The single-mesh test_fabric_sanity_neighbor_exchange.yaml is NOT compatible
+# with an inter-mesh Z fabric (its Linear/Ring/Torus setups trip the tensix
+# datamover buffer-index assert), so it must not be the default here.
+TEST_CONFIG_Z="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml"
 FILTER=""
 MPI_IF="ens5f0np0"
 MPI_EXTRA_ARGS=()
@@ -74,8 +98,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             CONFIG="$2"
-            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" ]]; then
-                echo "Error: --config must be one of '4x8', '4x32', or '8x16'"
+            if [[ "$CONFIG" != "4x8" && "$CONFIG" != "4x32" && "$CONFIG" != "8x16" && "$CONFIG" != "4x8z" && "$CONFIG" != "4x4x2z" && "$CONFIG" != "4x32z" ]]; then
+                echo "Error: --config must be one of '4x8', '4x32', '8x16', '4x8z', '4x4x2z', or '4x32z'"
                 echo ""
                 show_help
                 exit 1
@@ -113,6 +137,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             TEST_CONFIG="$2"
+            TEST_CONFIG_EXPLICIT=true
             shift 2
             ;;
         --filter)
@@ -176,7 +201,19 @@ if [[ "$MESH_GRAPH_DESC_PATH_EXPLICIT" == false ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32"
     elif [[ "$CONFIG" == "8x16" ]]; then
         MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_8x16"
+    elif [[ "$CONFIG" == "4x8z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x8z"
+    elif [[ "$CONFIG" == "4x4x2z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x4x2z"
+    elif [[ "$CONFIG" == "4x32z" ]]; then
+        MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH_4x32z"
     fi
+fi
+
+# Multi-mesh (Z) configs need a multi-mesh-aware test config; fall back to the
+# multi-mesh sanity config unless the user explicitly passed --test-config.
+if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ) ]]; then
+    TEST_CONFIG="$TEST_CONFIG_Z"
 fi
 
 # Create output directory if it doesn't exist
@@ -217,7 +254,102 @@ fi
 RUN_START_MARKER="$(mktemp)"
 trap 'rm -f "$RUN_START_MARKER"' EXIT
 
-if [[ "$DOCKER_IMAGE" == "none" ]]; then
+if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "4x4x2z" || "$CONFIG" == "4x32z" ]]; then
+    # Multi-mesh Z configs: launch one MPI rank per mesh, each with its own
+    # TT_MESH_ID, so the descriptor's inter-mesh (Z) connections are exercised
+    # alongside the intra-mesh N/S/E/W links during neighbor exchange.
+    # NUM_MESHES is set per-config below (4x4x2z has only 2 meshes).
+    Z_VISIBLE_DEVICES=()
+    Z_RANK_HOSTS=()      # per-rank host pinning (rank i -> Z_RANK_HOSTS[i]); empty => use Z_GLOBAL_HOST
+    Z_GLOBAL_HOST=()     # global --host args (single-host packing case)
+
+    if [[ "$CONFIG" == "4x8z" ]]; then
+        # Single galaxy host carved into 4 Z-connected 4x2 meshes (8 chips each).
+        # Split the 32 chips into 4 groups of 8 via TT_VISIBLE_DEVICES
+        # (rank i -> mesh i -> tray (i+1)). Placement order is irrelevant on one
+        # host, so use a global host spec.
+        NUM_MESHES=4
+        SINGLE_HOST="${HOSTS%%,*}"
+        Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
+        Z_VISIBLE_DEVICES=(
+            "0,1,2,3,4,5,6,7"
+            "8,9,10,11,12,13,14,15"
+            "16,17,18,19,20,21,22,23"
+            "24,25,26,27,28,29,30,31"
+        )
+        echo "Running multi-mesh 4x8z (4 Z-connected 4x2 meshes) on single host: $SINGLE_HOST"
+    elif [[ "$CONFIG" == "4x4x2z" ]]; then
+        # Single galaxy host carved into 2 Z-connected 4x4 meshes (16 chips each)
+        # -- the dual_4x4 layout. Split the 32 chips into 2 groups of 16 via
+        # TT_VISIBLE_DEVICES (mirrors dual_4x4_rank_binding.yaml). Placement order
+        # is irrelevant on one host, so use a global host spec.
+        NUM_MESHES=2
+        SINGLE_HOST="${HOSTS%%,*}"
+        Z_GLOBAL_HOST=(--host "${SINGLE_HOST}:${NUM_MESHES}")
+        Z_VISIBLE_DEVICES=(
+            "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"
+            "16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+        )
+        echo "Running multi-mesh 4x4x2z (2 Z-connected 4x4 meshes) on single host: $SINGLE_HOST"
+    else
+        NUM_MESHES=4
+        # 4x32z: one full galaxy per host. The Z ring (mesh 0->1->2->3->0) only
+        # exists between specific physically-adjacent galaxies, so rank i (==
+        # mesh i) MUST land on a deterministic host. We therefore pin rank i to
+        # the i-th --hosts entry (do NOT rely on MPI round-robin). Provide hosts
+        # in the same order as scaleout_configs/full_rankfile.
+        IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"
+        if [[ "${#Z_RANK_HOSTS[@]}" -ne "$NUM_MESHES" ]]; then
+            echo "Error: --config 4x32z requires exactly $NUM_MESHES hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
+            exit 1
+        fi
+        echo "Running multi-mesh 4x32z (4 Z-connected 8x4 torus galaxies); rank i pinned to host i:"
+        for ((i = 0; i < NUM_MESHES; i++)); do
+            echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$i]}"
+        done
+    fi
+    echo ""
+
+    # Assemble the per-rank ":"-separated MPMD segments shared by the docker
+    # and no-docker launch paths. Each segment carries its own TT_MESH_ID (and,
+    # for 4x8z, TT_VISIBLE_DEVICES; for 4x32z, an explicit --host pin).
+    # TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS matches full_rank_binding.yaml so the
+    # slowest ethernet handshakes don't trip the Fabric Router Sync timeout.
+    Z_SEGMENTS=()
+    for ((i = 0; i < NUM_MESHES; i++)); do
+        [[ $i -gt 0 ]] && Z_SEGMENTS+=(":")
+        Z_SEGMENTS+=(-np 1)
+        if [[ "${#Z_RANK_HOSTS[@]}" -gt 0 ]]; then
+            Z_SEGMENTS+=(--host "${Z_RANK_HOSTS[$i]}")
+        fi
+        Z_SEGMENTS+=(-x TT_MESH_ID="$i")
+        if [[ "${#Z_VISIBLE_DEVICES[@]}" -gt 0 ]]; then
+            Z_SEGMENTS+=(-x TT_VISIBLE_DEVICES="${Z_VISIBLE_DEVICES[$i]}")
+        fi
+        Z_SEGMENTS+=(-x TT_MESH_GRAPH_DESC_PATH="$MESH_GRAPH_DESC_PATH")
+        Z_SEGMENTS+=(-x TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=1000000)
+        Z_SEGMENTS+=("$TEST_BINARY" --test_config "$TEST_CONFIG" $EXTRA_BINARY_ARGS)
+    done
+
+    if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        mpirun-ulfm \
+            --tag-output \
+            --mca plm_ssh_args "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
+            --bind-to none \
+            "${Z_GLOBAL_HOST[@]}" \
+            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE"
+    else
+        ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+            --empty-entrypoint \
+            --mpi-interface "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
+            --bind-to none \
+            "${Z_GLOBAL_HOST[@]}" \
+            "${Z_SEGMENTS[@]}" |& tee "$LOG_FILE"
+    fi
+elif [[ "$DOCKER_IMAGE" == "none" ]]; then
     # No-docker path: invoke mpirun-ulfm directly against the local build.
     if [[ "$CONFIG" == "4x8" ]]; then
         SINGLE_HOST="${HOSTS%%,*}"

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -259,29 +259,20 @@ fi
 
 # Resolve TT_VISIBLE_DEVICES for single-host multi-mesh Z configs from tray discovery
 # (tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config).
-resolve_fabric_python() {
-    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
-    local py="${tt_metal_home}/python_env/bin/python"
-    if [[ -x "$py" ]]; then
-        echo "$py"
-    elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
-        echo "${VIRTUAL_ENV}/bin/python"
-    else
-        echo python3
-    fi
-}
-
-FABRIC_PYTHON="$(resolve_fabric_python)"
-
+#
+# No-docker runs use TT_METAL_HOME (or pwd) on the host, like bootstrap_pipeline_dir.sh.
+# Docker runs use the image's TT_METAL_HOME and python3, like run_dispatch_tests.sh /
+# run_validation.sh (upstream test images set both in dockerfile/upstream_test_images/).
 run_fabric_discovery_local() {
     local fabric_config="$1"
-    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
-    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
 
     if [[ "$DOCKER_IMAGE" == "none" ]]; then
-        cd "$tt_metal_home" && \
-        LD_LIBRARY_PATH="${tt_metal_home}/build/lib:${LD_LIBRARY_PATH:-}" \
-        "$FABRIC_PYTHON" "$gen_rb" --fabric-config "$fabric_config" --print-devices --work-dir "$tt_metal_home"
+        local tt_home="${TT_METAL_HOME:-$(pwd)}"
+        local gen_rb="${tt_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+        cd "$tt_home" && \
+        LD_LIBRARY_PATH="${tt_home}/build/lib:${LD_LIBRARY_PATH:-}" \
+        TT_METAL_HOME="$tt_home" \
+        python3 "$gen_rb" --fabric-config "$fabric_config" --print-devices --work-dir "$tt_home"
     else
         docker run --rm --net=host --privileged \
             -v /tmp:/tmp \
@@ -291,9 +282,8 @@ run_fabric_discovery_local() {
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/group:/etc/group:ro \
             --entrypoint="" \
-            -e "LD_LIBRARY_PATH=${tt_metal_home}/build/lib" \
             "$DOCKER_IMAGE" \
-            bash -c "cd '${tt_metal_home}' && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'"
+            bash -c 'cd "$TT_METAL_HOME" && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config '"$fabric_config"' --print-devices --work-dir "$TT_METAL_HOME"'
     fi
 }
 
@@ -309,10 +299,8 @@ is_local_fabric_host() {
 run_fabric_discovery_on_host() {
     local host="$1"
     local fabric_config="$2"
-    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
-    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+    local tt_home="${TT_METAL_HOME:-$(pwd)}"
     local ssh_opts=(-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
-    local remote_py="${tt_metal_home}/python_env/bin/python"
 
     if is_local_fabric_host "$host"; then
         run_fabric_discovery_local "$fabric_config"
@@ -320,8 +308,9 @@ run_fabric_discovery_on_host() {
     fi
 
     if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        local gen_rb="${tt_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
         ssh "${ssh_opts[@]}" "$host" \
-            "PY='${remote_py}'; [[ -x \"\$PY\" ]] || PY=python3; cd '${tt_metal_home}' && LD_LIBRARY_PATH='${tt_metal_home}/build/lib:'\${LD_LIBRARY_PATH:-} \"\$PY\" '${gen_rb}' --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'"
+            "cd '${tt_home}' && LD_LIBRARY_PATH='${tt_home}/build/lib:'\${LD_LIBRARY_PATH:-} TT_METAL_HOME='${tt_home}' python3 '${gen_rb}' --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_home}'"
     else
         ssh "${ssh_opts[@]}" "$host" \
             "docker run --rm --net=host --privileged \
@@ -332,21 +321,21 @@ run_fabric_discovery_on_host() {
                 -v /etc/passwd:/etc/passwd:ro \
                 -v /etc/group:/etc/group:ro \
                 --entrypoint='' \
-                -e 'LD_LIBRARY_PATH=${tt_metal_home}/build/lib' \
                 '${DOCKER_IMAGE}' \
-                bash -c \"cd '${tt_metal_home}' && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config '${fabric_config}' --print-devices --work-dir '${tt_metal_home}'\""
+                bash -c 'cd \"\$TT_METAL_HOME\" && python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py --fabric-config ${fabric_config} --print-devices --work-dir \"\$TT_METAL_HOME\"'"
     fi
 }
 
 resolve_single_host_z_visible_devices() {
     local fabric_config="$1"
     local expected_ranks="$2"
-    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
-    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
 
-    if [[ ! -f "$gen_rb" ]]; then
-        echo "Error: rank binding helper not found: $gen_rb" >&2
-        exit 1
+    if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        local gen_rb="${TT_METAL_HOME:-$(pwd)}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+        if [[ ! -f "$gen_rb" ]]; then
+            echo "Error: rank binding helper not found: $gen_rb" >&2
+            exit 1
+        fi
     fi
 
     echo "Resolving TT_VISIBLE_DEVICES via tray discovery (--fabric-config ${fabric_config})..."
@@ -371,12 +360,13 @@ resolve_quad_host_z_visible_devices() {
     local num_hosts="$2"
     local ranks_per_host="$3"
     local expected_total=$((num_hosts * ranks_per_host))
-    local tt_metal_home="${TT_METAL_HOME:-$(pwd)}"
-    local gen_rb="${tt_metal_home}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
 
-    if [[ ! -f "$gen_rb" ]]; then
-        echo "Error: rank binding helper not found: $gen_rb" >&2
-        exit 1
+    if [[ "$DOCKER_IMAGE" == "none" ]]; then
+        local gen_rb="${TT_METAL_HOME:-$(pwd)}/tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py"
+        if [[ ! -f "$gen_rb" ]]; then
+            echo "Error: rank binding helper not found: $gen_rb" >&2
+            exit 1
+        fi
     fi
 
     IFS=',' read -ra Z_RANK_HOSTS <<< "$HOSTS"

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -281,7 +281,7 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
     elif [[ "$CONFIG" == "2x4x4z" ]]; then
         # Single galaxy host carved into 2 Z-connected 4x4 meshes (16 chips each)
         # -- the dual_4x4 layout. Split the 32 chips into 2 groups of 16 via
-        # TT_VISIBLE_DEVICES (mirrors dual_4x4_rank_binding.yaml). Placement order
+        # TT_VISIBLE_DEVICES. Placement order
         # is irrelevant on one host, so use a global host spec.
         NUM_MESHES=2
         SINGLE_HOST="${HOSTS%%,*}"
@@ -303,6 +303,9 @@ if [[ "$CONFIG" == "4x8z" || "$CONFIG" == "2x4x4z" || "$CONFIG" == "4x32z" ]]; t
             echo "Error: --config 4x32z requires exactly $NUM_MESHES hosts in --hosts (got ${#Z_RANK_HOSTS[@]})"
             exit 1
         fi
+        # mpi-docker requires --host/--hostfile in global MPI args (before the first
+        # -np). Per-rank --host below still pins rank i -> mesh i deterministically.
+        Z_GLOBAL_HOST=(--host "$HOSTS")
         echo "Running multi-mesh 4x32z (4 Z-connected 8x4 torus galaxies); rank i pinned to host i:"
         for ((i = 0; i < NUM_MESHES; i++)); do
             echo "  rank $i -> mesh_id $i -> ${Z_RANK_HOSTS[$i]}"

--- a/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_16x4x2_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_16x4x2_z_graph_descriptor.textproto
@@ -1,0 +1,262 @@
+# --- Meshes ---------------------------------------------------------------
+# Quad BH galaxy (4 hosts, 128 chips) as 16 Z-connected meshes ("16x4x2"):
+#   One tray (4x2 / 8 ASICs) per mesh. Matches Galaxy cabling diagram: 4 chassis
+#   stacked vertically, 4 UBB trays per chassis.
+#
+#   Per-host mesh layout (BH_GLX_QUAD / FABRIC_TEST 4x8z tray order):
+#         m0(tr1)  m1(tr3)     <- top row of trays
+#         m3(tr2)  m2(tr4)     <- bottom row of trays
+#
+#   Intra-host Z (purple + green horizontal within chassis):
+#         0-1  (tr1 <-> tr3, top horizontal)
+#         3-2  (tr2 <-> tr4, bottom horizontal)
+#         0-3  (tr1 <-> tr2, vertical with swapped ASIC pairing)
+#         1-2  (tr3 <-> tr4, vertical with swapped ASIC pairing)
+#     Same graph as bh_galaxy_split_4x2_multi_mesh.textproto.
+#
+#   Inter-host Z (green vertical torus between chassis):
+#     Same tray/mesh index on adjacent hosts in the stack (NOT row-bridge pairs).
+#     Host ring order matches full_rankfile / 4x32z:
+#       host0(c07u08): meshes 0..3
+#       host1(c07u02): meshes 4..7
+#       host2(c08u02): meshes 8..11
+#       host3(c08u08): meshes 12..15
+#     Connections: (H*4+i) <-> ((H+1)*4+i) for i in 0..3, H in 0..2, plus wrap
+#       0/4, 1/5, 2/6, 3/7
+#       4/8, 5/9, 6/10, 7/11
+#       8/12, 9/13, 10/14, 11/15
+#       12/0, 13/1, 14/2, 15/3
+#
+# Launch: 16 MPI ranks (4 per host), TT_MESH_ID 0..15, TT_VISIBLE_DEVICES per tray.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+
+  # --- Intra-host Z (2x2 tray grid per chassis) -----------------------------
+  # Host 0
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  # Host 1
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  # Host 2
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  # Host 3
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+
+  # --- Inter-host Z (same tray index, vertical chassis stack) ----------------
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
@@ -1,0 +1,87 @@
+# --- Meshes ---------------------------------------------------------------
+# Quad BH galaxy (4 hosts, 128 chips) as 8 Z-connected meshes ("8x4x4"):
+#   - Each host runs the same 2x4x4 split as single_bh_galaxy_2x4x4_z: 2 meshes
+#     per galaxy (mesh_id pairs 0+1, 2+3, 4+5, 6+7), each a 4x4 grid (16 chips).
+#   - Z dimension = 8 meshes wired in a ring (0->1->...->7->0), exercising both
+#     intra-host Z links (even/odd pairs on the same host) and inter-host Z links
+#     (odd mesh on host H to even mesh on host H+1).
+# Neighbor-exchange therefore exercises BOTH:
+#   - non-Z links: intra-mesh 4x4 adjacency (N/S/E/W)
+#   - Z links:     inter-mesh ring connections (assign_z_direction)
+#
+# Launch: 8 MPI ranks across 4 galaxy hosts (2 ranks per host), one per mesh
+# (TT_MESH_ID 0..7); each rank pinned to 16 chips via TT_VISIBLE_DEVICES.
+# Host order must match models/demos/deepseek_v3_b1/scaleout_configs/full_rankfile.
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 4 ] dim_types: [ RING, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
@@ -24,7 +24,7 @@
 # with the 4 split meshes contributing 2 ranks each. Ranks are ordered
 # mesh-major then host-rank-minor to match control_plane's
 # (mesh_id, host_rank) -> mpi_rank assignment. See run_fabric_tests.sh
-# (--config 16x4x4z) and generate_rank_bindings.py (--slice-config 16x4x4z).
+# (--config 8x4x4z) and generate_rank_bindings.py (--slice-config 8x4x4z).
 # Host order matches scaleout_configs/full_rankfile (c07u08, c07u02, c08u02, c08u08).
 
 mesh_descriptors {

--- a/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/quad_bh_galaxy_8x4x4_z_graph_descriptor.textproto
@@ -1,23 +1,45 @@
 # --- Meshes ---------------------------------------------------------------
-# Quad BH galaxy (4 hosts, 128 chips) as 8 Z-connected meshes ("8x4x4"):
-#   - Each host runs the same 2x4x4 split as single_bh_galaxy_2x4x4_z: 2 meshes
-#     per galaxy (mesh_id pairs 0+1, 2+3, 4+5, 6+7), each a 4x4 grid (16 chips).
-#   - Z dimension = 8 meshes wired in a ring (0->1->...->7->0), exercising both
-#     intra-host Z links (even/odd pairs on the same host) and inter-host Z links
-#     (odd mesh on host H to even mesh on host H+1).
+# Quad BH galaxy (4 hosts, 128 chips) as 8 Z-connected 4x4 meshes ("8x4x4"),
+# using the 2x4 slice composition validated by the blitz decode pipeline
+# (models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config_quad_galaxy_4x4.yaml):
+#
+#   Per host the four 2x4 slices (0..3) split as:
+#     slices {1,2} -> one self-contained single-host 4x4  (even mesh ids)
+#     slice  {3}   -> upstream half of the next split 4x4 (this host)
+#     slice  {0}   -> downstream half of a split 4x4       (from the prev ring host)
+#
+#   So even mesh ids are single-host 4x4 toruses (host_topology 1x1) and odd
+#   mesh ids are 4x4 toruses split across 2 adjacent ring hosts (host_topology
+#   2x1): host H slice{3} (host_rank 0) + host H+1 slice{0} (host_rank 1).
+#
+#   Z dimension = 8 meshes wired in a ring (0->1->...->7->0):
+#     even->odd  : intra-host Z (single-host 4x4 to the split 4x4 it feeds)
+#     odd->even  : inter-host Z (split 4x4 to the next host's single-host 4x4)
+#
 # Neighbor-exchange therefore exercises BOTH:
 #   - non-Z links: intra-mesh 4x4 adjacency (N/S/E/W)
 #   - Z links:     inter-mesh ring connections (assign_z_direction)
 #
-# Launch: 8 MPI ranks across 4 galaxy hosts (2 ranks per host), one per mesh
-# (TT_MESH_ID 0..7); each rank pinned to 16 chips via TT_VISIBLE_DEVICES.
-# Host order must match models/demos/deepseek_v3_b1/scaleout_configs/full_rankfile.
+# Launch: 12 MPI ranks across 4 galaxy hosts (3 ranks per host) -- 8 meshes,
+# with the 4 split meshes contributing 2 ranks each. Ranks are ordered
+# mesh-major then host-rank-minor to match control_plane's
+# (mesh_id, host_rank) -> mpi_rank assignment. See run_fabric_tests.sh
+# (--config 16x4x4z) and generate_rank_bindings.py (--slice-config 16x4x4z).
+# Host order matches scaleout_configs/full_rankfile (c07u08, c07u02, c08u02, c08u08).
 
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 4, 4 ] dim_types: [ RING, LINE ] }
+  device_topology { dims: [ 4, 4 ] dim_types: [ RING, RING ] }
   host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+mesh_descriptors {
+  name: "M1"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 4 ] dim_types: [ RING, RING ] }
+  host_topology   { dims: [ 2, 1 ] }
   channels { count: 2 policy: STRICT }
 }
 
@@ -25,58 +47,58 @@ graph_descriptors {
   name: "G0"
   type: "FABRIC"
   instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
-  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
-  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 3 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
-  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 5 } }
   instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
-  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M1" mesh_id: 7 } }
 
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 1 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 3 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 3 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 5 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 5 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 7 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }
   connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M1" mesh_id: 7 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
@@ -15,7 +15,7 @@
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 4, 4 ] dim_types: [ RING, LINE ] }
+  device_topology { dims: [ 4, 4 ] dim_types: [ RING, RING ] }
   host_topology   { dims: [ 1, 1 ] }
   channels { count: 2 policy: STRICT }
 }

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
@@ -7,7 +7,6 @@
 #   - non-Z links: intra-mesh 4x4 adjacency (N/S/E/W)
 #   - Z links:     inter-mesh connection (assign_z_direction)
 #
-# Mirrors models/demos/deepseek_v3_b1/scaleout_configs/dual_4x4.textproto.
 #
 # Launch: 2 MPI ranks on a single host, one per mesh (TT_MESH_ID 0..1), each
 # rank pinned to 16 chips via TT_VISIBLE_DEVICES (trays 1+2 -> mesh 0,

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
@@ -1,5 +1,5 @@
 # --- Meshes ---------------------------------------------------------------
-# Single BH galaxy (32 chips) carved into 2 Z-connected meshes ("4x4x2"):
+# Single BH galaxy (32 chips) carved into 2 Z-connected meshes ("2x4x4"):
 #   - Z dimension = 2 meshes (mesh_id 0..1), wired with a single Z link.
 #   - Each mesh is a 4x4 grid (16 chips) -> intra-mesh neighbor hops use the
 #     non-Z N/S/E/W routing directions (X RING, Y LINE).

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_graph_descriptor.textproto
@@ -1,6 +1,9 @@
 # --- Meshes ---------------------------------------------------------------
 # Single BH galaxy (32 chips) carved into 4 Z-connected meshes ("4x4x2"):
-#   - Z dimension = 4 meshes (mesh_id 0..3), wired in a ring with Z links.
+#   - Z dimension = 4 meshes (mesh_id 0..3), cyclic 2x2 layout (BH_GLX_QUAD trays):
+#         [0, 1]   row 0 (trays 1, 3)
+#         [2, 3]   row 1 (trays 4, 2)
+#     Z links follow bh_galaxy_split_4x2_multi_mesh: 0-1, 1-2, 2-3, 0-3
 #   - Each mesh is a 4x2 grid (8 chips) -> intra-mesh neighbor hops use the
 #     non-Z N/S/E/W routing directions.
 # Neighbor-exchange therefore exercises BOTH:
@@ -45,8 +48,8 @@ graph_descriptors {
     assign_z_direction: true
   }
   connections {
-    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
     nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
     channels { count: 8 policy: RELAXED }
     assign_z_direction: true
   }

--- a/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto
+++ b/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2z_graph_descriptor.textproto
@@ -1,0 +1,38 @@
+# --- Meshes ---------------------------------------------------------------
+# Single BH galaxy (32 chips) carved into 2 Z-connected meshes ("4x4x2"):
+#   - Z dimension = 2 meshes (mesh_id 0..1), wired with a single Z link.
+#   - Each mesh is a 4x4 grid (16 chips) -> intra-mesh neighbor hops use the
+#     non-Z N/S/E/W routing directions (X RING, Y LINE).
+# Neighbor-exchange therefore exercises BOTH:
+#   - non-Z links: intra-mesh 4x4 adjacency (N/S/E/W)
+#   - Z links:     inter-mesh connection (assign_z_direction)
+#
+# Mirrors models/demos/deepseek_v3_b1/scaleout_configs/dual_4x4.textproto.
+#
+# Launch: 2 MPI ranks on a single host, one per mesh (TT_MESH_ID 0..1), each
+# rank pinned to 16 chips via TT_VISIBLE_DEVICES (trays 1+2 -> mesh 0,
+# trays 3+4 -> mesh 1 on Rev C).
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 4 ] dim_types: [ RING, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: STRICT }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+    assign_z_direction: true
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
We need to run multiple configurations on top of what already exists in run_fabric_tests.sh in order to properly validate the subtorus topology on single and quad cabled bh glx machines.
adds 4x8z, 2x4x4z, and 4x32z configurations
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/update-fabric-test-script-for-subtorus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/update-fabric-test-script-for-subtorus)