### PR TITLE
Reduce WH LLK pack code size

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -33,6 +33,27 @@ inline void finalize_multitile_pack_tail()
     // normal single-tile state for the next caller.
     TTI_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, 0xf, 0, 1, 0, 1);
 }
+
+static __attribute__((noinline, noclone)) void pack_multitile(const std::uint32_t tile_index, const std::uint32_t address)
+{
+    set_dst_write_addr(tile_index);
+    LLK_ASSERT(is_valid_L1_address(address), "L1 address must be in valid L1 memory region");
+    std::uint32_t new_l1_addr = (1 << 31) | address;
+    TT_SETDMAREG(0, LOWER_HALFWORD(address), 0, LO_16(p_gpr_pack::OUTPUT_ADDR));
+    TT_SETDMAREG(0, UPPER_HALFWORD(new_l1_addr), 0, HI_16(p_gpr_pack::OUTPUT_ADDR));
+    TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::OUTPUT_ADDR);
+    // The programmed MOP performs the blocked sequence for this whole call;
+    // the explicit tail below is only the final close/reset step.
+    mop_run(1, 1);
+    if (llk_pack_internal::configured_zero_output == p_pacr::P_ZERO_OUTPUT_ENABLED)
+    {
+        finalize_multitile_pack_tail<true>();
+    }
+    else
+    {
+        finalize_multitile_pack_tail<false>();
+    }
+}
 } // namespace llk_pack_internal
 
 inline std::uint32_t _llk_pack_output_size_bytes_(const std::uint32_t pack_dst_format, const std::uint32_t datum_count)
@@ -274,24 +295,7 @@ inline void _llk_pack_(const std::uint32_t tile_index, const std::uint32_t addre
     {
         if (llk_pack_internal::configured_num_tiles > 1)
         {
-            set_dst_write_addr(tile_index);
-            LLK_ASSERT(is_valid_L1_address(address), "L1 address must be in valid L1 memory region");
-            std::uint32_t new_l1_addr = (1 << 31) | address;
-            TT_SETDMAREG(0, LOWER_HALFWORD(address), 0, LO_16(p_gpr_pack::OUTPUT_ADDR));
-            TT_SETDMAREG(0, UPPER_HALFWORD(new_l1_addr), 0, HI_16(p_gpr_pack::OUTPUT_ADDR));
-            TTI_REG2FLOP(1, 0, 0, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32 - THCON_CFGREG_BASE_ADDR32, p_gpr_pack::OUTPUT_ADDR);
-            // The programmed MOP performs the blocked sequence for this whole
-            // call; the explicit tail below is only the final close/reset step,
-            // not a second multi-tile MOP.
-            mop_run(1, 1);
-            if (llk_pack_internal::configured_zero_output == p_pacr::P_ZERO_OUTPUT_ENABLED)
-            {
-                llk_pack_internal::finalize_multitile_pack_tail<true>();
-            }
-            else
-            {
-                llk_pack_internal::finalize_multitile_pack_tail<false>();
-            }
+            llk_pack_internal::pack_multitile(tile_index, address);
             return;
         }
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -34,6 +34,8 @@ inline void finalize_multitile_pack_tail()
     TTI_PACR(ADDR_MOD_1, ZERO_OUTPUT_FLAG, 0xf, 0, 1, 0, 1);
 }
 
+// Keep the multi-tile path out of line to share this pack sequence across call
+// sites and reduce TRISC code size. The single-tile hot path stays inline.
 static __attribute__((noinline, noclone)) void pack_multitile(const std::uint32_t tile_index, const std::uint32_t address)
 {
     set_dst_write_addr(tile_index);


### PR DESCRIPTION
## Summary

Move the runtime multi-tile branch of the Wormhole `_llk_pack_` implementation into a shared out-of-line helper. The common single-tile path remains inline.

## Motivation

WH kernels with many `pack_tile` call sites currently clone both the single-tile path and the runtime multi-tile path from `_llk_pack_` into each call site. In the MLA prefill SDPA specialization, that packer LLK expansion made TRISC2 the dominant code-size contributor and caused the watcher build to exceed the 70,656 byte aggregate TENSIX kernel-code limit.

## Implementation

- Add `llk_pack_internal::pack_multitile(...)` marked `noinline,noclone`.
- Move only the `configured_num_tiles > 1` body into that helper.
- Keep the single-tile path inline: `set_dst_write_addr`, `program_packer_destination`, and `mop_run`.
- Preserve existing zero-output tail handling through `finalize_multitile_pack_tail<true/false>()`.

This keeps the expected hot single-tile pack sequence inline while sharing the less common multi-tile sequence across many pack call sites.

## Impact

Measured on:

`tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py::test_flash_mla_prefill[q_dtype=DataType.BFLOAT16-dtype=DataType.BFLOAT8_B-use_paged_attention=True-block_size=128-batch=2-seq_len=1024-nh=128-nkv=1-kv_lora_rank=512-d_rope=64]`

With only this LLK change applied, after reverting the SDPA-local helper experiment:

| mode | ncrisc | brisc | trisc0 | trisc1 | trisc2 | total `.text` |
|---|---:|---:|---:|---:|---:|---:|
| no watcher | 4,140 | 2,360 | 13,808 | 9,080 | 21,480 | 50,868 |
| watcher | 7,036 | 5,320 | 14,536 | 9,772 | 21,920 | 58,584 |

For the watcher build, the previous total was 71,032 bytes and TRISC2 was 34,368 bytes. This change brings the watcher total to 58,584 bytes, leaving 12,072 bytes of headroom under the 70,656 byte limit.

## Testing

- `git diff --check`
- `pytest -q tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py::test_flash_mla_prefill[q_dtype=DataType.BFLOAT16-dtype=DataType.BFLOAT8_B-use_paged_attention=True-block_size=128-batch=2-seq_len=1024-nh=128-nkv=1-kv_lora_rank=512-d_rope=64] -s`
- `TT_METAL_WATCHER=120 TT_METAL_WATCHER_APPEND=1 pytest -q tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py::test_flash_mla_prefill[q_dtype=DataType.BFLOAT16-dtype=DataType.BFLOAT8_B-use_paged_attention=True-block_size=128-batch=2-seq_len=1024-nh=128-nkv=1-kv_lora_rank=512-d_rope=64] -s`

Watcher run reached `PASSED` with PCC `0.9996839160387764` and no code-size fatal, then hung during existing watcher teardown behavior. Device was reset with `tt-smi -r --no_reinit`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/wh-llk-pack-multitile-outline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/wh-llk-pack-multitile-outline)