### PR TITLE
[Bug fix] Fixed perf microbenchmark kernel configs to define and disable dispatch telemetry

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1298,6 +1298,8 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
         {"FD_CORE_TYPE", "0"},
         {"IS_D_VARIANT", "1"},
         {"IS_H_VARIANT", "1"},
+        {"DISPATCH_TELEMETRY_ADDR", "0"},
+        {"DISPATCH_TELEMETRY_DISABLED", "1"},
     };
 }
 
@@ -1395,6 +1397,8 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"OFFSETOF_ROUTER_DIRECTION", "2"},
         {"FD_CORE_TYPE", "0"},
         {"PREFETCH_Q_ENTRY_BITS", std::to_string(entry_size * 8)},
+        {"DISPATCH_TELEMETRY_ADDR", "0"},
+        {"DISPATCH_TELEMETRY_DISABLED", "1"},
         // FABRIC_RELAY intentionally omitted - must be undefined for #if defined(FABRIC_RELAY) to be false
     };
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #45689 

Perf microbenchmark unit tests define their own fast dispatch configs. This patch adds in the new telemetry options and disables telemetry for these tests.

### Notes for reviewers
`test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher` and `test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher` can be re-enabled in the CI after this fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/45689-fix-sd-utest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/45689-fix-sd-utest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/45689-fix-sd-utest)