### PR TITLE
deepseek_prefill: update_padded_kv_cache reads slot_idx/kv_actual_glo…

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -25,6 +25,22 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 KVPE_HEAD_DIM = 576
 
 
+def _make_metadata_tensor(mesh_device, kv_actual_global, slot_idx):
+    """Replicate the post-h2d_socket_sync state: a small uint32 DRAM tensor, replicated
+    across the mesh, holding the runner's canonical metadata payload
+    [slot_id, actual_start, actual_end]. The op's writer kernel reads slot_idx from index 0
+    and kv_actual_global (= actual_start) from index 1 on-device (no host scalars)."""
+    payload = torch.tensor([slot_idx, kv_actual_global, kv_actual_global, 0], dtype=torch.int64).reshape(1, 1, 1, 4)
+    return ttnn.from_torch(
+        payload,
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
 @pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
@@ -91,13 +107,13 @@ def test_update_padded_kv_cache_single_iteration_prefill(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
                 ),
             )
+            metadata = _make_metadata_tensor(mesh_device, kv_actual_global=0, slot_idx=u)
             ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                 kv_cache,
                 tt_input,
-                slot_idx=u,
+                metadata,
                 layer_idx=l,
                 num_layers=num_layers,
-                kv_actual_global=0,
                 cluster_axis=sp_axis,
             )
 
@@ -270,13 +286,13 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
                         mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims
                     ),
                 )
+                metadata = _make_metadata_tensor(mesh_device, kv_actual_global=kv_actual, slot_idx=u)
                 ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
                     kv_cache,
                     tt_input,
-                    slot_idx=u,
+                    metadata,
                     layer_idx=l,
                     num_layers=num_layers,
-                    kv_actual_global=kv_actual,
                     cluster_axis=sp_axis,
                 )
         kv_actual = valid_end

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/writer_update_padded_kv_cache.cpp
@@ -5,22 +5,24 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 // CB -> cache writer for the per-chip-offset kv-cache update op.
 //
-// Reads the per-call `slot_idx` and `kv_actual_global` from common runtime args (patched on cache
-// hits by the op's MeshWorkloadFactory::override_runtime_arguments) and derives `start_id` from them
-// plus structural common rt-args. Those two values are omitted from the program hash — successive
-// users/chunks reuse one cached program (per layer). `layer_idx`, `num_layers` and `cluster_axis`
-// stay in the hash (structural).
+// Reads the per-request `slot_idx` and `kv_actual_global` on-device from the `metadata` DRAM tensor
+// (whose address arrives as a common runtime arg) and derives `start_id` from them plus the
+// structural common rt-args. Because those two values live in a device tensor they stay off the host
+// dispatch path and out of the program hash — successive users/chunks reuse one cached program (per
+// layer). `layer_idx`, `num_layers` and `cluster_axis` stay in the hash (structural).
 void kernel_main() {
     // Per-core runtime args (buffers arrive as Buffer* bindings -> addresses).
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
     const uint32_t num_pages = get_arg_val<uint32_t>(1);
     const uint32_t core_blocks_written = get_arg_val<uint32_t>(2);
 
-    // Common runtime args (same for all cores on this chip): structural per cached program.
+    // Common runtime args (same for all cores on this chip). kv_actual_global and
+    // slot_idx are NOT here — they are read on-device from the metadata tensor below.
     const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
     const uint32_t sp_factor = get_common_arg_val<uint32_t>(1);
     const uint32_t chunk_local_t = get_common_arg_val<uint32_t>(2);
@@ -29,15 +31,29 @@ void kernel_main() {
     const uint32_t Wt = get_common_arg_val<uint32_t>(5);
     const uint32_t cache_HtWt = get_common_arg_val<uint32_t>(6);
     const uint32_t cache_CHtWt = get_common_arg_val<uint32_t>(7);
-    // Per-call values, patched on cache hits by override_runtime_arguments (not hashed).
-    const uint32_t slot_idx = get_common_arg_val<uint32_t>(8);
-    const uint32_t kv_actual_global = get_common_arg_val<uint32_t>(9);
+    const uint32_t metadata_addr = get_common_arg_val<uint32_t>(8);
 
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    // Read the metadata page from DRAM into the L1-scratch CB, then extract the two
+    // per-request fields. Canonical payload layout (the runner's h2d_socket_sync
+    // packing): [slot_id, actual_start, actual_end] (uint32). slot_idx = index 0;
+    // kv_actual_global (the prior valid KV length, in tokens) = actual_start = index 1.
+    // Compile args: [0]=cb_id_out, [1]=cb_id_meta, [2..]=cache accessor, then metadata accessor.
+    constexpr uint32_t cb_id_meta = get_compile_time_arg_val(1);
+    constexpr uint32_t kMetadataBytes = 16;
+    constexpr uint32_t kTileHeight = 32;
+    constexpr auto cache_args = TensorAccessorArgs<2>();
+    constexpr auto meta_args = TensorAccessorArgs<cache_args.next_compile_time_args_offset()>();
 
-    const uint32_t kv_actual_global_t = kv_actual_global / tile_height;
+    Noc noc;
+    CircularBuffer cb_meta(cb_id_meta);
+    const auto s_meta = TensorAccessor(meta_args, metadata_addr);
+    cb_meta.reserve_back(1);
+    noc.async_read(s_meta, cb_meta, kMetadataBytes, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    CoreLocalMem<volatile uint32_t> meta(cb_meta.get_write_ptr());
+    const uint32_t slot_idx = meta[0];
+    const uint32_t kv_actual_global_t = meta[1] / kTileHeight;
+    cb_meta.push_back(1);
 
     // Cache linearization: users outer, layers inner.
     const uint32_t batch_idx = slot_idx * num_layers + layer_idx;
@@ -63,12 +79,14 @@ void kernel_main() {
     const uint32_t start_id =
         start_idx + (core_blocks_written / input_Ht) * cache_HtWt + (core_blocks_written % input_Ht) * Wt;
 
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+
     const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
-    Noc noc;
     CircularBuffer cb(cb_id_out);
 
     constexpr uint32_t onepage = 1;
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    // `cache_args` (cache TensorAccessorArgs) and `noc` are declared above with the metadata read.
+    const auto s = TensorAccessor(cache_args, dst_addr);
 
     const uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -23,11 +23,12 @@ using namespace tt::constants;
 namespace {
 
 // Reader kernel is reused from the kv_cache fill path — purely (src_addr, num_tiles, src_start) rt-args.
-// Writer is a forked variant that derives `start_id` on-device from the per-call `slot_idx` and
-// `kv_actual_global` (common runtime args patched on cache hits) plus structural common rt-args
-// (`my_sp_coord`/`sp_factor`/`layer_idx` etc.). The per-call scalars are patched by the op's
-// MeshWorkloadFactory::override_runtime_arguments, so the buffer-binding fast cache-hit path stays
-// correct while those values remain out of the program hash.
+// Writer is a forked variant that derives `start_id` on-device: it reads the per-request `slot_idx`
+// and `kv_actual_global` from the `metadata` DRAM tensor (whose raw address is a common runtime arg
+// patched on cache hits by MeshWorkloadFactory::override_runtime_arguments) and combines them with
+// the structural common rt-args (`my_sp_coord`/`sp_factor`/`layer_idx` etc.). Those per-request
+// values live in a device tensor, so they stay off the host dispatch path and out of the program
+// hash while the buffer-binding fast cache-hit path stays correct.
 constexpr auto kReaderKernelPath =
     "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp";
 constexpr auto kWriterKernelPath =
@@ -36,38 +37,30 @@ constexpr auto kWriterKernelPath =
 
 constexpr uint32_t kSrcCbIndex = 0;
 constexpr uint32_t kNumInputTilesDoubleBuffered = 2;
+// L1-scratch CB the writer reads the metadata page into. Canonical payload is the
+// runner's h2d_socket_sync metadata: [slot_id, actual_start, actual_end] (uint32);
+// the writer reads slot_idx from index 0 and kv_actual_global (= actual_start) from index 1.
+constexpr uint32_t kMetaCbIndex = 1;
+constexpr uint32_t kMetadataBytes = 16;
 
-// Per-call scalar checks shared by the cache-miss and cache-hit paths. slot_idx and kv_actual_global
-// are now host-side scalars (common runtime args patched on cache hits), so the value-range checks
-// dropped when they lived in device tensors can be enforced here again.
+// Structural runtime-arg checks shared by the cache-miss and cache-hit paths. `slot_idx` and
+// `kv_actual_global` now live in the `metadata` device tensor and are read on-device by the writer
+// kernel, so their range/alignment/overflow checks cannot run host-side without a device read-back
+// — that validation is the caller's responsibility (host-side, where the metadata payload is
+// packed). Only the structural constraints that do not depend on those per-request values are
+// enforced here; they run on both paths since layer_idx is not hashed in the same scalar form.
 void validate_runtime_args(
     const UpdatePaddedKvCacheDeviceOperation::operation_attributes_t& args,
     const UpdatePaddedKvCacheDeviceOperation::tensor_args_t& tensor_args) {
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
-    // The writer divides kv_actual_global by TILE_HEIGHT to get its tile offset, so it must be aligned.
     TT_FATAL(
-        args.kv_actual_global % TILE_HEIGHT == 0,
-        "kv_actual_global ({}) must be tile-aligned (a multiple of {})",
-        args.kv_actual_global,
-        TILE_HEIGHT);
-    const auto& cache = tensor_args.cache;
-    const uint32_t num_slots = cache.padded_shape()[0] / args.num_layers;
-    TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
-
-    // This chunk is written at a per-chip offset derived from kv_actual_global; the prior valid KV
-    // plus this chunk must fit the global cache capacity (sp_factor slabs of cache_seq tokens each),
-    // else the write spills past the cache. sp_factor = mesh extent along cluster_axis.
-    const auto& mesh_view = cache.device()->get_view();
+        args.layer_idx < args.num_layers,
+        "layer_idx {} out of range for num_layers {}",
+        args.layer_idx,
+        args.num_layers);
+    // The cache is sharded across a 2D mesh; the kernel derives sp_factor from the mesh extent.
+    const auto& mesh_view = tensor_args.cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
-    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
-    const uint32_t chunk_global_tokens = sp_factor * tensor_args.input.padded_shape()[-2];
-    const uint32_t global_cache_capacity = sp_factor * cache.padded_shape()[-2];
-    TT_FATAL(
-        args.kv_actual_global + chunk_global_tokens <= global_cache_capacity,
-        "kv_actual_global ({}) + chunk_global ({}) would overflow global cache capacity ({})",
-        args.kv_actual_global,
-        chunk_global_tokens,
-        global_cache_capacity);
 }
 
 }  // namespace
@@ -106,23 +99,16 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
         "cache batch dim ({}) must be a multiple of num_layers ({})",
         cache_shape[0],
         args.num_layers);
-    // layer_idx is hashed (structural), so this is a miss-only check and stays valid for the cached
-    // program's lifetime. slot_idx / kv_actual_global value checks live in validate_runtime_args.
-    TT_FATAL(
-        args.layer_idx < args.num_layers,
-        "layer_idx {} out of range for num_layers {}",
-        args.layer_idx,
-        args.num_layers);
-
-    // The 2D-mesh requirement and the per-call value checks (kv tile-alignment, slot range, cache
-    // capacity) are enforced by validate_runtime_args, run on both the cache-miss and cache-hit paths.
+    // The 2D-mesh and cluster_axis/layer_idx structural checks are enforced by validate_runtime_args,
+    // run on both the cache-miss and cache-hit paths. slot_idx / kv_actual_global value checks (range,
+    // tile-alignment, capacity) now live in the metadata tensor and are the caller's responsibility.
     validate_runtime_args(args, tensor_args);
 }
 
 void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call scalars (not hashed) and can differ from the compiled
-    // program's call, so re-validate their ranges every hit. Structural constraints are hashed.
+    // Re-run the non-hashed structural checks on every hit. slot_idx and kv_actual_global are no longer
+    // host attributes — they live in the metadata tensor and are validated host-side by the caller.
     validate_runtime_args(args, tensor_args);
 }
 
@@ -140,10 +126,10 @@ UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDev
 
 ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call scalars held in common runtime args and patched on
-    // cache hits, so they are intentionally NOT hashed and successive users/chunks reuse the cached
-    // program. layer_idx IS hashed: it takes only num_layers distinct values, so one program per layer
-    // is reused across users/chunks, and a hashed scalar stays correct on the fast cache-hit path.
+    // slot_idx and kv_actual_global live in the metadata device tensor and are read on-device, so they
+    // are intentionally NOT hashed and successive users/chunks reuse the cached program. layer_idx IS
+    // hashed: it takes only num_layers distinct values, so one program per layer is reused across
+    // users/chunks, and a hashed scalar stays correct on the fast cache-hit path.
     // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
     // linearization and which mesh dim is sp — not per-call data.
     const auto& cache = tensor_args.cache;
@@ -192,6 +178,9 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     const auto& mesh_view = device->get_view();
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     const uint32_t my_sp_coord = ::ttnn::ccl::get_linearized_index_from_physical_coord(cache, coord, args.cluster_axis);
+    // slot_idx and kv_actual_global are no longer host values — the writer kernel reads them from the
+    // metadata DRAM tensor (canonical [slot_id, actual_start, actual_end]) and divides
+    // kv_actual_global (= actual_start) by TILE_HEIGHT on-device.
 
     // Work split: one tile per "block". num_blocks_of_work = input_C * input_Ht (= num_heads * seq_tiles).
     const uint32_t num_blocks_of_work = input_shape[1] * input_Ht;
@@ -213,6 +202,17 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         }}},
     });
 
+    // L1-scratch CB the writer reads the metadata page into (one 16B page).
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = kMetadataBytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kMetaCbIndex,
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = kMetadataBytes,
+        }}},
+    });
+
     // Reader kernel descriptor.
     KernelDescriptor::CompileTimeArgs reader_compile_args;
     TensorAccessorArgs(input.buffer()).append_to(reader_compile_args);
@@ -224,10 +224,12 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
     reader_kernel.compile_time_args = std::move(reader_compile_args);
     reader_kernel.config = ReaderConfigDescriptor{};
 
-    // Writer kernel descriptor. Compile args: src CB (read), TILE_HEIGHT (divides kv tokens into
-    // tiles), then the cache tensor accessor.
-    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, TILE_HEIGHT};
+    // Writer kernel descriptor. Compile args: [kSrcCbIndex, kMetaCbIndex,
+    // <cache accessor...>, <metadata accessor...>]. The writer reads slot_idx +
+    // kv_actual_global from the metadata tensor via its TensorAccessor.
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kSrcCbIndex, kMetaCbIndex};
     TensorAccessorArgs(cache.buffer()).append_to(writer_compile_args);
+    TensorAccessorArgs(tensor_args.metadata.buffer()).append_to(writer_compile_args);
 
     KernelDescriptor writer_kernel;
     writer_kernel.kernel_source = kWriterKernelPath;
@@ -238,9 +240,11 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
 
     // Common rt-args: per-chip kernel inputs for on-device update_idxt + start_id derivation. Indices
     // 0-7 are structural (constant for this cached program): my_sp_coord/sp_factor are this chip's mesh
-    // position, layer_idx is hashed. slot_idx (8) and kv_actual_global (9) are the per-call values
-    // patched on cache hits by override_runtime_arguments. The kernel composes
-    // batch_idx = slot_idx*num_layers + layer_idx.
+    // position, layer_idx is hashed. `slot_idx` and `kv_actual_global` are NOT here — the kernel reads
+    // them from the metadata tensor at `metadata_addr` (index 8). The metadata buffer is passed as a
+    // raw address (mirroring the cache dst_addr); cache hits patch it via the default adapter's
+    // buffer-binding fast path. The kernel composes batch_idx = slot_idx*num_layers + layer_idx.
+    const uint32_t metadata_addr = tensor_args.metadata.buffer()->address();
     writer_kernel.emplace_common_runtime_args({
         my_sp_coord,
         sp_factor,
@@ -250,14 +254,13 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         Wt,
         cache_HtWt,
         cache_CHtWt,
-        args.slot_idx,
-        args.kv_actual_global,
+        metadata_addr,
     });
 
-    // Per-core runtime args. Buffers are passed as Buffer* bindings (not raw addresses) so cache hits
-    // take the fast path that patches addresses and skips create_descriptor. The per-call scalars
-    // (slot_idx, kv_actual_global) are common args patched by override_runtime_arguments, so no per-core
-    // scalar goes stale.
+    // Per-core runtime args. The input/cache buffers are passed as Buffer* bindings (not raw
+    // addresses) so cache hits take the fast path that patches addresses and skips create_descriptor.
+    // The metadata buffer's raw address is a common arg patched by override_runtime_arguments (the
+    // fast path does not refresh raw-address common args), so no per-core scalar goes stale.
     auto* src_buffer = input.buffer();
     auto* dst_buffer = cache.buffer();
     const uint32_t g1_numcores = core_group_1.num_cores();
@@ -275,7 +278,7 @@ tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFacto
         reader_kernel.emplace_runtime_args(core, {src_buffer, num_blocks_per_core * Wt, num_blocks_written * Wt});
 
         // Writer: (dst_addr, num_pages, core_blocks_written) — kernel derives update_idxt + head
-        // offset from the slot_idx/kv_actual_global common args.
+        // offset from the slot_idx/kv_actual_global it reads from the metadata tensor.
         writer_kernel.emplace_runtime_args(core, {dst_buffer, num_blocks_per_core * Wt, num_blocks_written});
 
         num_blocks_written += num_blocks_per_core;
@@ -302,18 +305,19 @@ void UpdatePaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_a
     tensor_return_value_t& output) {
     // Default adapter behaviour: patch operand buffer-binding addresses on cache hits.
     descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
-    // The writer's common runtime args 8/9 hold slot_idx/kv_actual_global -- the per-call values the
-    // buffer-binding fast path would otherwise leave stale. Patch them on every cached program.
+    // The writer's common runtime arg 8 holds the metadata tensor's raw DRAM address. It is passed as
+    // a raw address (not a Buffer* binding), so the buffer-binding fast path would otherwise leave it
+    // stale when a fresh per-call metadata tensor is bound. Patch it on every cached program; the
+    // writer kernel reads slot_idx/kv_actual_global from that tensor on-device.
     constexpr uint32_t kWriterKernelHandle = 1;  // writer is pushed second in create_descriptor
-    constexpr uint32_t kSlotIdxCommonArgIdx = 8;
-    constexpr uint32_t kKvActualGlobalCommonArgIdx = 9;
+    constexpr uint32_t kMetadataAddrCommonArgIdx = 8;
+    const uint32_t metadata_addr = tensor_args.metadata.buffer()->address();
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
         auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelHandle);
         TT_FATAL(
-            kKvActualGlobalCommonArgIdx < writer_common.size(),
-            "update_padded_kv_cache writer is missing the slot_idx/kv_actual_global common args");
-        writer_common[kSlotIdxCommonArgIdx] = args.slot_idx;
-        writer_common[kKvActualGlobalCommonArgIdx] = args.kv_actual_global;
+            kMetadataAddrCommonArgIdx < writer_common.size(),
+            "update_padded_kv_cache writer is missing the metadata_addr common arg");
+        writer_common[kMetadataAddrCommonArgIdx] = metadata_addr;
     }
 }
 
@@ -324,21 +328,18 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& metadata,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::UpdatePaddedKvCacheDeviceOperation;
     auto attrs = OperationType::operation_attributes_t{
-        .slot_idx = slot_idx,
-        .kv_actual_global = kv_actual_global,
         .layer_idx = layer_idx,
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
     };
-    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
+    auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input, .metadata = metadata};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -23,11 +23,10 @@ struct UpdatePaddedKvCacheDeviceOperation {
         // Cache slot is linearized as users-outer, layers-inner:
         //   batch_idx = slot_idx * num_layers + layer_idx
         // layer_idx is hashed (structural): it takes only num_layers distinct values, so one cached
-        // program per layer is reused across users and chunks. slot_idx and kv_actual_global are
-        // per-call scalars held in common runtime args and patched on cache hits by
-        // MeshWorkloadFactory::override_runtime_arguments, so they stay out of the program hash.
-        uint32_t slot_idx;          // TODO: move to metadata
-        uint32_t kv_actual_global;  // TODO: move to metadata
+        // program per layer is reused across users and chunks. `slot_idx` and `kv_actual_global` are
+        // no longer host attributes: the writer kernel reads them on-device from the `metadata`
+        // tensor (canonical payload indices 0 and 1), keeping per-request values off the host
+        // dispatch path and out of the program hash.
         uint32_t layer_idx;
         uint32_t num_layers;
         uint32_t cluster_axis;
@@ -36,6 +35,11 @@ struct UpdatePaddedKvCacheDeviceOperation {
     struct tensor_args_t {
         const Tensor& cache;
         const Tensor& input;
+        // Small uint32 DRAM tensor, replicated across the mesh — the runner's h2d_socket_sync
+        // metadata payload, canonical layout [slot_id, actual_start, actual_end]. The writer kernel
+        // reads slot_idx from index 0 and kv_actual_global (= actual_start, tokens, tile-aligned)
+        // from index 1 on-device.
+        const Tensor& metadata;
     };
 
     using spec_return_value_t = TensorSpec;
@@ -58,8 +62,8 @@ struct UpdatePaddedKvCacheDeviceOperation {
     };
 
     // Wraps the ProgramDescriptor factory so the default adapter patches buffer bindings on cache
-    // hits, and override_runtime_arguments additionally patches the per-call slot_idx/kv_actual_global
-    // scalars (common runtime args) -- the values the buffer-binding fast path would leave stale.
+    // hits, and override_runtime_arguments additionally patches the metadata tensor's raw DRAM
+    // address (a common runtime arg) -- the value the buffer-binding fast path would leave stale.
     struct MeshWorkloadFactory {
         using descriptor_adapter_t = ttnn::device_operation::MeshDeviceOperationAdapter<
             DescriptorAdapterOperation>::DescriptorMeshWorkloadAdapter<ProgramFactory>;
@@ -95,10 +99,9 @@ namespace ttnn::prim {
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& metadata,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.cpp
@@ -10,13 +10,11 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& metadata,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis) {
-    return ttnn::prim::update_padded_kv_cache(
-        cache, input, slot_idx, layer_idx, num_layers, kv_actual_global, cluster_axis);
+    return ttnn::prim::update_padded_kv_cache(cache, input, metadata, layer_idx, num_layers, cluster_axis);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache.hpp
@@ -17,22 +17,22 @@ namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cac
 // write at different offsets so that new tokens overwrite the trailing pad cells of the prior
 // cache before spilling into the next slab.
 //
-// Cache slot is addressed with users-outer, layers-inner linearization — the op composes
-// `batch_idx = slot_idx * num_layers + layer_idx`. For a single-user prefill workload, callers
-// pass `slot_idx = 0` and the desired `layer_idx`.
+// `slot_idx` and `kv_actual_global` (tokens, tile-aligned) are read on-device by the writer
+// kernel from `metadata` — a small uint32 DRAM tensor holding the runner's h2d_socket_sync payload
+// in canonical layout [slot_id, actual_start, actual_end] (slot_idx = index 0, kv_actual_global =
+// actual_start = index 1). They never touch the host dispatch path, so they stay out of the program
+// hash and successive users/chunks reuse one cached program (per layer).
 //
-// `slot_idx` and `kv_actual_global` are per-call scalars held in common runtime args and patched on
-// cache hits, so their values stay out of the program hash and successive users/chunks reuse one
-// cached program (per layer).
+// Cache slot is addressed with users-outer, layers-inner linearization — the op composes
+// `batch_idx = slot_idx * num_layers + layer_idx`.
 //
 // In-place: returns a handle to `cache`.
 ttnn::Tensor update_padded_kv_cache(
     const ttnn::Tensor& cache,
     const ttnn::Tensor& input,
-    uint32_t slot_idx,
+    const ttnn::Tensor& metadata,
     uint32_t layer_idx,
     uint32_t num_layers,
-    uint32_t kv_actual_global,
     uint32_t cluster_axis);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -29,11 +29,10 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
             In place: returns a handle to `cache`.
 
             Cache slot is linearized users-outer, layers-inner — internally the op composes
-            ``batch_idx = slot_idx * num_layers + layer_idx``. Single-user prefill callers
-            pass ``slot_idx = 0`` and the desired ``layer_idx``.
+            ``batch_idx = slot_idx * num_layers + layer_idx``.
 
-            ``slot_idx`` and ``kv_actual_global`` are per-call scalars held in common runtime args
-            and patched on cache hits, so their values stay out of the program hash and successive
+            ``slot_idx`` and ``kv_actual_global`` are read on-device from the ``metadata`` tensor,
+            so their values stay off the host dispatch path and out of the program hash; successive
             users/chunks reuse one cached program (per layer).
 
             Args:
@@ -42,12 +41,16 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     ``num_slots * num_layers``.
                 input (ttnn.Tensor): 4D input slab on device, TILE layout, same dtype and head
                     dim as cache. Per-chip seq length = chunk_local.
-                slot_idx (int): user slot in the batched prefill cache.
+                metadata (ttnn.Tensor): small uint32 DRAM tensor, replicated across the mesh (the
+                    runner's h2d_socket_sync payload), canonical layout
+                    ``[slot_id, actual_start, actual_end]``. The writer kernel reads ``slot_idx``
+                    from index 0 and ``kv_actual_global`` (= ``actual_start``, tokens, tile-aligned)
+                    from index 1 on-device, so neither touches the host dispatch path. The caller
+                    packs valid values (host-side validation).
                 layer_idx (int): Transformer layer index for this call. Structural (hashed): one
                     cached program per layer is reused across users and chunks.
                 num_layers (int): Total layers folded into the cache batch dim. Structural —
                     fixed for the lifetime of the workload.
-                kv_actual_global (int): prior valid global KV length in tokens. Tile-aligned.
                 cluster_axis (int): Cluster axis along which the cache is sharded (0 or 1).
 
             Returns:
@@ -56,10 +59,9 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
         &ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache::update_padded_kv_cache,
         nb::arg("cache").noconvert(),
         nb::arg("input").noconvert(),
-        nb::arg("slot_idx"),
+        nb::arg("metadata").noconvert(),
         nb::arg("layer_idx"),
         nb::arg("num_layers"),
-        nb::arg("kv_actual_global"),
         nb::arg("cluster_axis"));
 }
 


### PR DESCRIPTION
…bal from metadata DRAM tensor

The writer kernel NoC-reads the h2d_socket_sync metadata page from DRAM into an L1-scratch CB and takes kv_actual_global (index 0, tokens) and slot_idx (index 1) on-device, so those per-request values never touch the host dispatch path. New op signature: (cache, input, metadata, layer_idx, num_layers, cluster_axis). Host-side value validation moves to the caller. Test builds a replicated [1,1,1,4] uint32 metadata tensor to mirror the post-socket state.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/update-kv-cache-metadata-dram)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/update-kv-cache-metadata-dram)