### PR TITLE
[skip ci] Fix: Add inter-node fwbundle consistency check to cluster validation

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -207,6 +207,9 @@ public:
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
     const tt::umd::semver_t& get_ethernet_firmware_version() const { return ethernet_firmware_version_; }
+    const std::optional<tt::umd::FirmwareBundleVersion>& get_firmware_bundle_version() const {
+        return firmware_bundle_version_;
+    }
     const std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>>&
     get_pcie_devices_per_tray() const {
         return pcie_devices_per_tray_;
@@ -227,6 +230,7 @@ public:
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
     tt::umd::semver_t& get_ethernet_firmware_version() { return ethernet_firmware_version_; }
+    std::optional<tt::umd::FirmwareBundleVersion>& get_firmware_bundle_version() { return firmware_bundle_version_; }
     std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>>&
     get_pcie_devices_per_tray() {
         return pcie_devices_per_tray_;
@@ -249,6 +253,7 @@ private:
     ExitNodeConnectionTable exit_node_connection_table_;
     bool all_hostnames_unique_ = true;
     tt::umd::semver_t ethernet_firmware_version_;
+    std::optional<tt::umd::FirmwareBundleVersion> firmware_bundle_version_;
     std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>> pcie_devices_per_tray_;
     std::unordered_map<std::string, std::unordered_map<uint32_t, ASICLocation>> pcie_id_to_asic_location_;
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -226,15 +226,19 @@ void validate_fw_bundle_versions(
     const std::optional<tt::umd::FirmwareBundleVersion>& peer_firmware_bundle_version,
     const std::string& my_host_name,
     const std::string& peer_host_name) {
-    // In multi-host cluster validation, firmware bundle version must be available on all nodes
-    TT_FATAL(
-        psd.get_firmware_bundle_version().has_value() && peer_firmware_bundle_version.has_value(),
-        "Cannot validate firmware bundle versions: missing data. Host {} has version: {}, Host {} has version: {}. "
-        "This may indicate an older UMD version that doesn't report firmware bundle versions.",
-        my_host_name,
-        psd.get_firmware_bundle_version().has_value() ? "yes" : "no",
-        peer_host_name,
-        peer_firmware_bundle_version.has_value() ? "yes" : "no");
+    // Skip validation if firmware bundle versions are not available (e.g., CPU-only tests, older UMD)
+    if (!psd.get_firmware_bundle_version().has_value() || !peer_firmware_bundle_version.has_value()) {
+        log_warning(
+            tt::LogMetal,
+            "Skipping firmware bundle version validation between {} and {}: firmware bundle versions not available "
+            "(local: {}, peer: {}). This may occur in CPU-only mode or with older UMD versions.",
+            my_host_name,
+            peer_host_name,
+            psd.get_firmware_bundle_version().has_value() ? "available" : "unavailable",
+            peer_firmware_bundle_version.has_value() ? "available" : "unavailable");
+        return;
+    }
+
     log_debug(
         tt::LogMetal,
         "Validating firmware bundle versions: {} has {} vs {} has {}",

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -221,6 +221,38 @@ void validate_eth_fw_versions(
         peer_ethernet_firmware_version.to_string());
 }
 
+void validate_fw_bundle_versions(
+    PhysicalSystemDescriptor& psd,
+    const std::optional<tt::umd::FirmwareBundleVersion>& peer_firmware_bundle_version,
+    const std::string& my_host_name,
+    const std::string& peer_host_name) {
+    // In multi-host cluster validation, firmware bundle version must be available on all nodes
+    TT_FATAL(
+        psd.get_firmware_bundle_version().has_value() && peer_firmware_bundle_version.has_value(),
+        "Cannot validate firmware bundle versions: missing data. Host {} has version: {}, Host {} has version: {}. "
+        "This may indicate an older UMD version that doesn't report firmware bundle versions.",
+        my_host_name,
+        psd.get_firmware_bundle_version().has_value() ? "yes" : "no",
+        peer_host_name,
+        peer_firmware_bundle_version.has_value() ? "yes" : "no");
+    log_debug(
+        tt::LogMetal,
+        "Validating firmware bundle versions: {} has {} vs {} has {}",
+        my_host_name,
+        psd.get_firmware_bundle_version()->to_string(),
+        peer_host_name,
+        peer_firmware_bundle_version->to_string());
+
+    TT_FATAL(
+        peer_firmware_bundle_version.value() == psd.get_firmware_bundle_version().value(),
+        "Firmware Bundle Versions are expected to be consistent across all nodes in the cluster. The following "
+        "hosts have different Firmware Bundle Versions: {} ({}) and {} ({})",
+        my_host_name,
+        psd.get_firmware_bundle_version()->to_string(),
+        peer_host_name,
+        peer_firmware_bundle_version->to_string());
+}
+
 void remove_unresolved_nodes(PhysicalSystemDescriptor& psd) {
     auto& asic_descriptors = psd.get_asic_descriptors();
     auto& system_graph = psd.get_system_graph();
@@ -465,10 +497,12 @@ void exchange_metadata(
     bool issue_gather) {
     using namespace tt::tt_metal::distributed::multihost;
     constexpr uint32_t controller_rank = 0;
-    if (*(distributed_context->size()) == 1) {
+    auto my_rank = *(distributed_context->rank());
+    auto total_size = *(distributed_context->size());
+
+    if (total_size == 1) {
         return;
     }
-    auto my_rank = *(distributed_context->rank());
     std::set<uint32_t> sender_ranks;
     std::set<uint32_t> receiver_ranks;
 
@@ -487,7 +521,6 @@ void exchange_metadata(
             }
         }
     }
-
     if (sender_ranks.contains(my_rank)) {
         auto serialized_desc = serialize_physical_system_descriptor_to_bytes(psd);
         std::size_t desc_size = serialized_desc.size();
@@ -527,6 +560,11 @@ void exchange_metadata(
             validate_eth_fw_versions(
                 psd,
                 peer_desc.get_ethernet_firmware_version(),
+                psd.get_asic_descriptors().begin()->second.host_name,
+                peer_desc.get_asic_descriptors().begin()->second.host_name);
+            validate_fw_bundle_versions(
+                psd,
+                peer_desc.get_firmware_bundle_version(),
                 psd.get_asic_descriptors().begin()->second.host_name,
                 peer_desc.get_asic_descriptors().begin()->second.host_name);
             psd.merge(std::move(peer_desc));
@@ -649,8 +687,9 @@ PhysicalSystemDescriptor run_local_discovery(
 
     psd.get_system_graph().host_connectivity_graph[hostname_key] = {};
     // Get Ethernet Firmware Version from the driver - Initialize to 0 if not available
-    psd.get_ethernet_firmware_version() =
-        cluster_desc.get_cluster_eth_fw_version().value_or(tt::umd::semver_t(0, 0, 0));
+    psd.get_ethernet_firmware_version() = cluster_desc.get_cluster_eth_fw_version().value_or(tt::umd::semver_t(0, 0, 0));
+    // Get Firmware Bundle Version from the driver
+    psd.get_firmware_bundle_version() = cluster_desc.get_cluster_firmware_bundle_version();
 
     return psd;
 }

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -97,6 +97,12 @@ message EthernetFirmwareVersion {
     uint32 patch = 3;
 }
 
+message FirmwareBundleVersion {
+    uint32 major = 1;
+    uint32 minor = 2;
+    uint32 patch = 3;
+}
+
 // PCIe devices per tray for a specific host
 message PcieDevicesPerTray {
     uint32 tray_id = 1;
@@ -130,6 +136,7 @@ message PhysicalSystemDescriptor {
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
     uint32 target_device_type = 6;
     EthernetFirmwareVersion ethernet_firmware_version = 7;
+    optional FirmwareBundleVersion firmware_bundle_version = 10;
     repeated HostPcieDevicesMap pcie_devices_per_tray = 8;
     repeated HostPcieIdToAsicLocationMap pcie_id_to_asic_location = 9;
 }

--- a/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
+++ b/tt_metal/fabric/serialization/physical_system_descriptor_serialization.cpp
@@ -201,6 +201,13 @@ void physical_system_descriptor_to_proto(
     proto_desc->mutable_ethernet_firmware_version()->set_minor(descriptor.get_ethernet_firmware_version().minor);
     proto_desc->mutable_ethernet_firmware_version()->set_patch(descriptor.get_ethernet_firmware_version().patch);
 
+    // Set firmware bundle version (optional)
+    if (descriptor.get_firmware_bundle_version().has_value()) {
+        proto_desc->mutable_firmware_bundle_version()->set_major(descriptor.get_firmware_bundle_version()->major);
+        proto_desc->mutable_firmware_bundle_version()->set_minor(descriptor.get_firmware_bundle_version()->minor);
+        proto_desc->mutable_firmware_bundle_version()->set_patch(descriptor.get_firmware_bundle_version()->patch);
+    }
+
     // Convert pcie_devices_per_tray map
     for (const auto& [host_name, tray_map] : descriptor.get_pcie_devices_per_tray()) {
         auto* proto_host_pcie_map = proto_desc->add_pcie_devices_per_tray();
@@ -299,6 +306,14 @@ std::unique_ptr<PhysicalSystemDescriptor> proto_to_physical_system_descriptor(
     descriptor->get_ethernet_firmware_version().major = proto_desc.ethernet_firmware_version().major();
     descriptor->get_ethernet_firmware_version().minor = proto_desc.ethernet_firmware_version().minor();
     descriptor->get_ethernet_firmware_version().patch = proto_desc.ethernet_firmware_version().patch();
+
+    // Set firmware bundle version (optional)
+    if (proto_desc.has_firmware_bundle_version()) {
+        descriptor->get_firmware_bundle_version() = tt::umd::FirmwareBundleVersion(
+            proto_desc.firmware_bundle_version().major(),
+            proto_desc.firmware_bundle_version().minor(),
+            proto_desc.firmware_bundle_version().patch());
+    }
 
     // Convert pcie_devices_per_tray map
     auto& pcie_devices_per_tray = descriptor->get_pcie_devices_per_tray();


### PR DESCRIPTION
### Issue
Ticket: [DCAMP-255: Improve FW consistency check on physical validation test](https://tenstorrent.atlassian.net/browse/DCAMP-255)

### Summary
Cluster validation was only checking Ethernet firmware version consistency across hosts, but not firmware bundle version consistency. This meant nodes could run with mismatched firmware bundles (e.g., 19.8.1 vs 19.8.0), leading to potential compatibility issues and undefined behavior in multi-node deployments that required error debugging and wasted time and resources to investigate a simple and avoidable issue.


### What's changed
- Uses updated UMD from [PR #2740](https://github.com/tenstorrent/tt-umd/pull/2740) that exposes the fwbundle version in `ClusterDescriptor`
- Added explicit cross-host fwbundle validation with clear error message and version report that fails before tests are started

Example - error message from test runs: 
```
| critical |          Always | TT_FATAL: Firmware Bundle Versions are expected to be consistent across all nodes in the cluster.
The following hosts have different Firmware Bundle Versions: bh-glx-110-d09u02 (19.8.1) and bh-glx-110-d09u08 (19.8.0) (assert.hpp:104)
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gsarabando-fw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gsarabando-fw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gsarabando-fw_check)