### PR TITLE
Declare device sampling capability on model side.

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -294,7 +294,7 @@ jobs:
               "runner-label": "config-t3000",
               "arch": "arch-wormhole_b0",
               "mesh-device": "(1, 2)",
-              "tt-config": "{\"register_test_models\": true, \"sample_on_device_mode\": \"all\", \"input_queue_batching_delay\": 0}",
+              "tt-config": "{\"register_test_models\": true, \"input_queue_batching_delay\": 0}",
               "additional-server-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --async-scheduling",
               "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --temperature 0.0",
               "multimodal": false,

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -22,18 +22,18 @@ class WarmupForwardMixin:
     - self.decode_forward(): method to perform decode forward pass
     """
 
-    def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, batch_size):
+    def _create_sampling_params(self, can_sample_on_device, batch_size, greedy_only: bool = False):
         """
-        non_greedy_decoding_on_device: when True, device supports non-greedy sampling (temperature,
-        top_k, top_p, presence/frequency/repetition penalties, log_probs); warmup then includes
-        those configs. When False, only greedy decoding is warmed up (temperature=0.0, top_k=1, top_p=1.0).
+        greedy_only: when True, warmup only covers greedy decoding on device (temperature=0.0,
+        top_k=1, top_p=1.0). When False (the default), warmup also exercises non-greedy variants
+        — temperature/top_k/top_p, presence/frequency/repetition penalties, and log_probs.
         """
         if not can_sample_on_device:
             return [None]
 
         sampling_configs = []
 
-        if non_greedy_decoding_on_device:
+        if not greedy_only:
             for penalties, log_probs in product([True, False], repeat=2):
                 presence_penalty, frequency_penalty, repetition_penalty = None, None, None
 
@@ -85,15 +85,13 @@ class WarmupForwardMixin:
         max_batch_size,
         num_blocks,
         can_sample_on_device,
-        non_greedy_decoding_on_device,
         read_from_device=True,
+        greedy_only: bool = False,
     ):
         """
         This function is called by vLLM
         """
-        sampling_params = self._create_sampling_params(
-            can_sample_on_device, non_greedy_decoding_on_device, max_batch_size
-        )
+        sampling_params = self._create_sampling_params(can_sample_on_device, max_batch_size, greedy_only=greedy_only)
 
         tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_blocks)
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -343,7 +343,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 kv_cache=None,
                 enable_trace=False,
                 can_sample_on_device=False,
-                non_greedy_decoding_on_device=False,
                 min_token_len=min_token_len,
                 max_token_len=max_token_len,
                 sample_on_device=self.sample_on_device,
@@ -3185,10 +3184,10 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         kv_cache,
         enable_trace,
         can_sample_on_device,
-        non_greedy_decoding_on_device,
         min_token_len: int = 0,
         max_token_len: int = 0,
         sample_on_device: bool | None = None,
+        greedy_only: bool = False,
     ) -> None:
         if enable_trace:
             logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator; skipping warmup.")

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -42,6 +42,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
+        "supports_sample_on_device": True,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -248,7 +248,6 @@ class Generator(WarmupForwardMixin):
                 if not sampling_parameters_sweeped:
                     sampling_params_list = self._create_sampling_params(
                         can_sample_on_device=sampling_on_device_enabled,
-                        non_greedy_decoding_on_device=sampling_on_device_enabled,
                         batch_size=batch,
                     )
                 else:
@@ -1448,7 +1447,7 @@ class Generator(WarmupForwardMixin):
 
         return padded_page_table
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False) -> None:
         # page_table gets padded properly in prefill_forward_text
         # be sure to pad correctly for non traced sequences in future warmup calls
         page_table = torch.zeros(1, 1, dtype=torch.int32)

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -165,6 +165,7 @@ class LlamaForCausalLM(Generator):
     model_capabilities = {
         "supports_async_decode": True,
         "supports_prefix_caching": True,
+        "supports_sample_on_device": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -212,6 +213,11 @@ class LlamaForCausalLM(Generator):
 
 # @INPUT_REGISTRY.register_input_processor(input_processor_for_qwen_text)
 class QwenForCausalLM(Generator):
+    # Class-level capabilities
+    model_capabilities = {
+        "supports_sample_on_device": True,
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -955,10 +955,8 @@ def test_demo_text(
     can_sample_on_device = model_supports_device_sampling and not token_accuracy
     if model_supports_device_sampling and token_accuracy:
         logger.info("token_accuracy=True: using host logits / host sampling (device sampling disabled)")
-    non_greedy_decoding_on_device = can_sample_on_device and sampling_params.get("temperature", 0) > 0
-    logger.info(
-        f"Gemma3 decode sampling: device={can_sample_on_device}, non_greedy_warmup={non_greedy_decoding_on_device}"
-    )
+    greedy_only = sampling_params.get("temperature", 0) <= 0
+    logger.info(f"Gemma3 decode sampling: device={can_sample_on_device}, greedy_only_warmup={greedy_only}")
 
     logger.info("Warming up model...")
     # Must match paged_attention: non-paged KV uses a single logical block; decode warmup cannot use a 1024-wide page table.
@@ -971,7 +969,7 @@ def test_demo_text(
         kv_cache=tt_kv_cache,
         enable_trace=enable_trace,
         can_sample_on_device=can_sample_on_device,
-        non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+        greedy_only=greedy_only,
     )
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
@@ -979,7 +977,7 @@ def test_demo_text(
         max_batch_size=global_batch_size,
         num_blocks=num_blocks,
         can_sample_on_device=can_sample_on_device,
-        non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+        greedy_only=greedy_only,
     )
     logger.info("Warmup complete")
 

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -276,7 +276,7 @@ def test_multimodal_demo_text(
     generator = GemmaMultimodalGenerator(model, model_args, mesh_device)
 
     can_sample_on_device = getattr(model[0], "_supports_on_device_sampling", False) and model[0].sampling is not None
-    non_greedy_decoding_on_device = can_sample_on_device and temperature > 0
+    greedy_only = temperature <= 0
     if can_sample_on_device:
         if temperature <= 0:
             device_sampling_params = SamplingParams(temperature=0.0, top_k=1, top_p=1.0)
@@ -290,7 +290,7 @@ def test_multimodal_demo_text(
         kv_cache=None,
         enable_trace=enable_trace,
         can_sample_on_device=can_sample_on_device,
-        non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+        greedy_only=greedy_only,
     )
     logger.info("Warmup complete")
 

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -148,7 +148,6 @@ class GemmaMultimodalGenerator(Generator):
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
                 can_sample_on_device=sampling_on_device_enabled,
-                non_greedy_decoding_on_device=sampling_on_device_enabled,
             )
 
         batch_size, batch_seq_len = tokens.shape
@@ -569,7 +568,7 @@ class GemmaMultimodalGenerator(Generator):
         else:
             return output_tensor
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True
@@ -617,8 +616,8 @@ class GemmaMultimodalGenerator(Generator):
                     if not sampling_parameters_sweeped:
                         sampling_params = self._create_sampling_params(
                             can_sample_on_device=can_sample_on_device,
-                            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
                             batch_size=batch_size,
+                            greedy_only=greedy_only,
                         )
                     else:
                         sampling_params = [None]

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -218,7 +218,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
     def process_decode_output_host(self, tt_out, is_tokens=False):
         return self._ttt_generator.process_decode_output_host(tt_out, is_tokens=is_tokens)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen2_5_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen2_5_VL")
 

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -240,7 +240,7 @@ class Generator(WarmupForwardMixin):
 
             return logits
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen3_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen3_VL")
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -137,7 +137,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         return ret
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True
@@ -185,8 +185,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     if not sampling_parameters_sweeped:
                         sampling_params = self._create_sampling_params(
                             can_sample_on_device=can_sample_on_device,
-                            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
                             batch_size=batch_size,
+                            greedy_only=greedy_only,
                         )
                     else:
                         sampling_params = [None]
@@ -563,7 +563,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 kv_cache=kv_cache,
                 enable_trace=enable_trace,
                 can_sample_on_device=sampling_on_device_enabled,
-                non_greedy_decoding_on_device=sampling_on_device_enabled,
             )
 
         batch_size, batch_seq_len = tokens.shape

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -406,6 +406,7 @@ class CustomNamespace(SimpleNamespace):
 class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
     model_capabilities = {
         "supports_prefix_caching": False,
+        "supports_sample_on_device": True,
     }
 
     def __init__(self, *args, **kwargs):
@@ -496,9 +497,13 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
 class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     # Class-level capabilities
     # Note: Mllama doesn't support prefix caching (it's V0 only)
+    # decode_forward calls decode_forward_llama_vision and discards anything
+    # but logits, so sampling_params never reach a sampler — explicitly
+    # declare on-device sampling unsupported.
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": True,
+        "supports_sample_on_device": False,
     }
 
     @classmethod
@@ -618,6 +623,7 @@ class LlamaForCausalLM(Generator):
     model_capabilities = {
         "supports_prefix_caching": True,
         "supports_async_decode": True,
+        "supports_sample_on_device": True,
     }
 
     @classmethod
@@ -702,6 +708,7 @@ class QwenForCausalLM(Generator):
     model_capabilities = {
         "supports_prefix_caching": True,
         "supports_async_decode": True,
+        "supports_sample_on_device": True,
     }
 
     @classmethod
@@ -780,6 +787,7 @@ class MistralForCausalLM(Generator):
     model_capabilities = {
         "supports_prefix_caching": True,
         "supports_async_decode": True,
+        "supports_sample_on_device": True,
     }
 
     @classmethod
@@ -877,6 +885,7 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": True,
+        "supports_sample_on_device": True,
     }
 
     @classmethod
@@ -1015,6 +1024,7 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     model_capabilities = {
         "supports_prefix_caching": False,  # Sliding window => no prefix caching
         "supports_async_decode": True,
+        "supports_sample_on_device": True,
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Require full sampling support if declared (greedy-only can have fast-path but full support required)

### PR Category
Feature/cleanup

### Summary
Device sampling capability is now declared in model, not hardcoded in vllm
Declared capability matches earlier behavior (Mllama would have crashed previously, now explicitly declared unsupported)
Clean up sampling-related args in warmup param generation


### Notes for reviewers
Companion vllm PR https://github.com/tenstorrent/vllm/pull/409

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/sample-on-device-capability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/sample-on-device-capability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/sample-on-device-capability)