### PR TITLE
Support MeshTensor-backed CBs in fusion dispatch op infrastructure

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -18,6 +18,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_convert_to_hwc_gather.cpp
     test_gelu_bw_ulp.cpp
     test_gelu_bw_main_ulp.cpp
+    test_fusion_dispatch_op_helpers.cpp
     test_generic_op.cpp
     test_graph_add.cpp
     test_graph_basic.cpp

--- a/tests/ttnn/unit_tests/gtests/test_fusion_dispatch_op_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_fusion_dispatch_op_helpers.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn_test_fixtures.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp"
+
+namespace ttnn::operations::experimental::fusion::test {
+
+using ::tt::tt_metal::CBDescriptor;
+using ::tt::tt_metal::ProgramDescriptor;
+
+namespace {
+
+Tensor make_device_tensor(tt::tt_metal::distributed::MeshDevice* device) {
+    ttnn::Shape shape{1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+    return ttnn::random::random(shape, DataType::BFLOAT16).to_device(device);
+}
+
+const CBSlot* find_cb_slot(const AddressSlots& slots, std::uint32_t cb_idx) {
+    for (const auto& s : slots.cb_slots) {
+        if (s.cb_idx == cb_idx) {
+            return &s;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+// The fusion op caches a ProgramDescriptor and refreshes IO-tensor-derived CB backings in place
+// on every dispatch.  A CB may be backed by either a raw ``Buffer*`` (.buffer) or a ``MeshTensor*``
+// (.tensor).  This verifies that compute_address_slots discovers BOTH kinds and that
+// patch_stale_descriptor refreshes each to the live tensor while preserving the backing kind and
+// the buffer-xor-tensor invariant.
+TEST_F(TTNNFixtureWithDevice, FusionHelpersRefreshBufferAndTensorBackedCBs) {
+    Tensor a = make_device_tensor(device_);  // CB 0 will be .buffer-backed by this tensor
+    Tensor b = make_device_tensor(device_);  // CB 1 will be .tensor-backed by this tensor
+
+    ProgramDescriptor desc;
+    {
+        CBDescriptor cb_buffer;
+        cb_buffer.buffer = a.buffer();
+        desc.cbs.push_back(cb_buffer);
+
+        CBDescriptor cb_tensor;
+        cb_tensor.tensor = &b.mesh_tensor();
+        desc.cbs.push_back(cb_tensor);
+    }
+
+    const std::vector<Tensor> io_tensors = {a, b};
+    const AddressSlots slots = compute_address_slots(desc, io_tensors);
+
+    // Both CBs are discovered and matched to the right IO tensor, with the backing kind recorded.
+    ASSERT_EQ(slots.cb_slots.size(), 2u);
+
+    const CBSlot* buffer_slot = find_cb_slot(slots, /*cb_idx=*/0);
+    const CBSlot* tensor_slot = find_cb_slot(slots, /*cb_idx=*/1);
+    ASSERT_NE(buffer_slot, nullptr);
+    ASSERT_NE(tensor_slot, nullptr);
+
+    EXPECT_EQ(buffer_slot->io_tensor_index, 0u);
+    EXPECT_FALSE(buffer_slot->tensor_backed);
+    EXPECT_EQ(tensor_slot->io_tensor_index, 1u);
+    EXPECT_TRUE(tensor_slot->tensor_backed);
+
+    // Fresh tensors (distinct allocations, since a/b are still alive) stand in for a cache hit.
+    Tensor a2 = make_device_tensor(device_);
+    Tensor b2 = make_device_tensor(device_);
+    ASSERT_NE(a2.buffer()->address(), a.buffer()->address());
+    ASSERT_NE(b2.buffer()->address(), b.buffer()->address());
+
+    const std::vector<Tensor> io_tensors_refreshed = {a2, b2};
+    patch_stale_descriptor(desc, io_tensors_refreshed, slots);
+
+    // Buffer-backed CB now points at the new tensor's buffer; tensor stays cleared.
+    EXPECT_EQ(desc.cbs[0].buffer, a2.buffer());
+    EXPECT_EQ(desc.cbs[0].tensor, nullptr);
+
+    // Tensor-backed CB now points at the new tensor's MeshTensor; buffer stays cleared.
+    EXPECT_EQ(desc.cbs[1].tensor, &b2.mesh_tensor());
+    EXPECT_EQ(desc.cbs[1].buffer, nullptr);
+
+    // The tensor-backed CB resolves to the new tensor's L1 address (the value the dynamic-CB
+    // consumer reads via cb.tensor->mesh_buffer().get_reference_buffer()).
+    EXPECT_EQ(desc.cbs[1].tensor->mesh_buffer().get_reference_buffer()->address(), b2.buffer()->address());
+}
+
+}  // namespace ttnn::operations::experimental::fusion::test

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -403,15 +403,15 @@ void py_module_types(nb::module_& mod) {
             "Byte offset from buffer base address for CB placement (default 0)")
         .def(
             "has_buffer",
-            [](const tt::tt_metal::CBDescriptor& self) { return self.buffer != nullptr; },
+            [](const tt::tt_metal::CBDescriptor& self) { return self.buffer != nullptr || self.tensor != nullptr; },
             R"pbdoc(
-                Check if this CB has a pinned L1 buffer.
+                Check if this CB has a pinned L1 buffer/ tensor.
 
                 When True, the CB is bound to a specific L1 address (e.g., a sharded tensor's memory).
                 Writes to this CB go directly to that tensor's L1 space.
 
                 Returns:
-                    True if a buffer pointer is set, False otherwise.
+                    True if a buffer or tensor pointer is set, False otherwise.
             )pbdoc")
         .def(
             "has_global_circular_buffer",
@@ -456,6 +456,7 @@ void py_module_types(nb::module_& mod) {
             "set_buffer_from_cb",
             [](tt::tt_metal::CBDescriptor& self, const tt::tt_metal::CBDescriptor& other) {
                 self.buffer = other.buffer;
+                self.tensor = other.tensor;
             },
             nb::arg("other"),
             R"pbdoc(
@@ -469,6 +470,9 @@ void py_module_types(nb::module_& mod) {
             [](const tt::tt_metal::CBDescriptor& self) -> std::optional<uint32_t> {
                 if (self.buffer != nullptr) {
                     return self.buffer->address();
+                }
+                if (self.tensor != nullptr) {
+                    return static_cast<uint32_t>(self.tensor->address());
                 }
                 return std::nullopt;
             },

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
@@ -40,12 +41,18 @@ inline std::optional<std::uint32_t> find_io_tensor_index(std::uint32_t value, co
     return std::nullopt;
 }
 
-/// For each CBDescriptor with a buffer, match its address against *tensor_addrs*.
+/// For each CBDescriptor backed by a buffer or tensor, match its address against *tensor_addrs*.
 inline std::vector<std::pair<uint32_t, uint32_t>> compute_cb_io_tensor_map(
     const tt::tt_metal::ProgramDescriptor& desc, const std::vector<OptionalAddr>& tensor_addrs) {
     std::vector<std::pair<uint32_t, uint32_t>> result;
     for (size_t ci = 0; ci < desc.cbs.size(); ++ci) {
-        const auto* buf = desc.cbs[ci].buffer;
+        const auto& cb = desc.cbs[ci];
+        // A CB may be backed by either a raw Buffer* or a MeshTensor* (mutually exclusive); resolve
+        // both to the reference Buffer so either kind matches against the IO-tensor addresses.
+        const tt::tt_metal::Buffer* buf = cb.buffer;
+        if (buf == nullptr && cb.tensor != nullptr) {
+            buf = cb.tensor->mesh_buffer().get_reference_buffer();
+        }
         if (buf != nullptr) {
             if (auto ti = find_io_tensor_index(buf->address(), tensor_addrs)) {
                 result.emplace_back(static_cast<uint32_t>(ci), *ti);
@@ -72,10 +79,11 @@ struct CommonRTArgSlot {
     std::uint32_t io_tensor_index;
 };
 
-/// Slot: a CB whose buffer comes from an IO tensor.
+/// Slot: a CB whose backing (buffer or tensor) comes from an IO tensor.
 struct CBSlot {
     std::uint32_t cb_idx;
     std::uint32_t io_tensor_index;
+    bool tensor_backed = false;  // true if the CB is backed by .tensor (MeshTensor*) rather than .buffer
 };
 
 /// Slot: a per-core runtime arg that holds a barrier semaphore L1 address.
@@ -142,7 +150,7 @@ inline AddressSlots compute_address_slots(
     }
 
     for (const auto& [cb_idx, io_idx] : compute_cb_io_tensor_map(desc, tensor_addrs)) {
-        slots.cb_slots.push_back({cb_idx, io_idx});
+        slots.cb_slots.push_back({cb_idx, io_idx, desc.cbs[cb_idx].tensor != nullptr});
     }
 
     return slots;
@@ -175,7 +183,19 @@ inline void patch_stale_descriptor(
         }
     }
     for (const auto& slot : slots.cb_slots) {
-        desc.cbs[slot.cb_idx].buffer = io_tensors[slot.io_tensor_index].buffer();
+        const auto& tensor = io_tensors[slot.io_tensor_index];
+        auto& cb = desc.cbs[slot.cb_idx];
+        if (slot.tensor_backed) {
+            // Repoint at the live tensor's MeshTensor.  ``mesh_tensor()`` returns a reference owned
+            // by the Tensor's shared storage, so the pointer is valid for the duration of this
+            // dispatch — the same lifetime guarantee as the ``buffer()`` pointer in the else-branch.
+            // Clear ``buffer`` to uphold the CBDescriptor buffer-xor-tensor invariant.
+            cb.tensor = &tensor.mesh_tensor();
+            cb.buffer = nullptr;
+        } else {
+            cb.buffer = tensor.buffer();
+            cb.tensor = nullptr;
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
@@ -186,10 +186,6 @@ inline void patch_stale_descriptor(
         const auto& tensor = io_tensors[slot.io_tensor_index];
         auto& cb = desc.cbs[slot.cb_idx];
         if (slot.tensor_backed) {
-            // Repoint at the live tensor's MeshTensor.  ``mesh_tensor()`` returns a reference owned
-            // by the Tensor's shared storage, so the pointer is valid for the duration of this
-            // dispatch — the same lifetime guarantee as the ``buffer()`` pointer in the else-branch.
-            // Clear ``buffer`` to uphold the CBDescriptor buffer-xor-tensor invariant.
             cb.tensor = &tensor.mesh_tensor();
             cb.buffer = nullptr;
         } else {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug Fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Metal Tensor is a new core runtime data structure that has been introduced recently.
It is meant to replace usage of single device buffer (`Buffer`) whenever possible.
In #44327 it has been integrated into the program descriptor framework (specifically Circular buffer specifier) in parallel to the `.buffer` field.
However, fusion op infra is not aware of this field, which trips on mesh tensor migration, specifically layernorm.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Because tensor is reducible to Buffer, this PR updates the C++ side of the fusion op infra to transparently handle the new `tensor` field on top of existing `buffer` field.

### Test ran manually:

- tests/ttnn/unit_tests/operations/fused/test_parallel_sequential_*.py all passes
- tests/ttnn/unit_tests/operations/fused/demo/test_fused_demo.py all passes except
  -  `tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py::TestPerfDemos::test_parallel_chains_ln_mm_rms_mm_fused[perf_mode=none]` this also fails on main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fusion-dispatch-tensor-int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fusion-dispatch-tensor-int)