### PR TITLE
Cleanup: Fix runtime CI tests disabled by pipeline reorg (#43579)

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -137,9 +137,9 @@ runtime:
     bh_quietbox: 5
     bh_loudbox: 5
   unit:
-    wh_n150_civ2: 217
+    wh_n150_civ2: 222
     wh_n300_civ2: 74
-    bh_p150b_civ2: 205
+    bh_p150b_civ2: 210
     bh_p150b_civ2_viommu: 5
     bh_p100a_civ2_viommu: 74
     bh_quietbox: 20

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -59,8 +59,7 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# --- Context, Device, Misc, JIT Build ---
-# NOTE: unit_tests_noc dropped.
+# --- Context, Device, Misc, JIT Build, NOC ---
 - name: runtime_core
   # MetalContextIntegrationTest.Legacy disabled by #44767.
   cmd: |
@@ -68,6 +67,7 @@
     ./build/test/tt_metal/unit_tests_device
     ./build/test/tt_metal/unit_tests_misc
     ./build/test/tt_metal/unit_tests_jit_build
+    ./build/test/tt_metal/unit_tests_noc
   skus:
     wh_n150_civ2:
       timeout: 12

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -77,16 +77,15 @@
   team: runtime
 
 # --- Integration Tests ---
-# NOTE: unit_tests_integration disabled (matmul JIT + SFPU device hang). Re-add when fixed.
-# - name: runtime_integration
-#   cmd: ./build/test/tt_metal/unit_tests_integration
-#   skus:
-#     wh_n150_civ2:
-#       timeout: 8
-#     bh_p150b_civ2:
-#       timeout: 8
-#   owner_id: U099A7FMKL2 # Manish Sudumbrekar
-#   team: runtime
+- name: runtime_integration
+  cmd: ./build/test/tt_metal/unit_tests_integration
+  skus:
+    wh_n150_civ2:
+      timeout: 8
+    bh_p150b_civ2:
+      timeout: 8
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
 
 # --- LLK + SFPI Tests ---
 - name: runtime_llk
@@ -103,8 +102,7 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# --- Debug Tools (DPrint, Watcher, Inspector, Clean Init) ---
-# NOTE: unit_tests_noc_debugging disabled (NOC debug detection broken); re-enable once owner fixes.
+# --- Debug Tools (DPrint, Watcher, Inspector, Clean Init, NOC Debugging) ---
 - name: runtime_debug_tools
   # 60 tests disabled by #44767.
   disabled_debug_tools_filter: &disabled_debug_tools 'MeshWatcherDelayFixture.TensixTestWatcherSanitizeInsertDelays:MeshWatcherFixture.ActiveEthTestWatcherDetectLinkUp:MeshWatcherFixture.ActiveEthTestWatcherEthLinkCheck:MeshWatcherFixture.ActiveEthTestWatcherSanitizeEthDestL1Overflow:MeshWatcherFixture.ActiveEthTestWatcherSanitizeEthSrcL1Overflow:MeshWatcherFixture.ActiveEthTestWatcherSanitizeL1Overflow:MeshWatcherFixture.HostMcastWrapAroundXY_DownRight:MeshWatcherFixture.HostMcastWrapAroundXY_UpLeft:MeshWatcherFixture.HostMcastWrapAroundX_Left:MeshWatcherFixture.HostMcastWrapAroundX_Right:MeshWatcherFixture.HostMcastWrapAroundY_Down:MeshWatcherFixture.HostMcastWrapAroundY_Up:MeshWatcherFixture.IdleEthTestWatcherSanitizeNOCInlineWriteDram:MeshWatcherFixture.QuasarTestWatcherSanitizeMultiDMRace:MeshWatcherFixture.TensixDramTestWatcherRingBufferDrisc:MeshWatcherFixture.TensixTestWatcherPause:MeshWatcherFixture.TensixTestWatcherSanitizeL1Overflow:MeshWatcherFixture.TensixTestWatcherSanitizeMulticastSemaphoreInc:MeshWatcherFixture.TestWatcherRingBufferBrisc:MeshWatcherFixture.TestWatcherRingBufferErisc:MeshWatcherFixture.TestWatcherRingBufferIErisc:MeshWatcherFixture.TestWatcherRingBufferNCrisc:MeshWatcherFixture.TestWatcherRingBufferTrisc0:MeshWatcherFixture.TestWatcherRingBufferTrisc1:MeshWatcherFixture.TestWatcherRingBufferTrisc2:MeshWatcherFixture.TestWatcherWaypoints:RTATestFixture.CorrectArgDispatchAndPayloadValidation:RTATestFixture.QuasarMultiDMOutOfBoundsArgDetection:RTATestFixture.SentinelPatternHandlingAndMissingRTADetection:WatcherAssertTests/WatcherAssertTest.TestWatcherAssert/Drisc:WatcherAssertTests/WatcherAssertTest.TestWatcherAssert/IErisc:WatcherArgAsserts/RTAAssertTest.OutOfBoundsArgAccessDetection/RTA_DM0:WatcherArgAsserts/RTAAssertTest.OutOfBoundsArgAccessDetection/RTA_TRISC0:WatcherArgAsserts/RTAAssertTest.OutOfBoundsArgAccessDetection/CRTA_DM0:WatcherArgAsserts/RTAAssertTest.OutOfBoundsArgAccessDetection/CRTA_TRISC0:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Brisc:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM2:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM3:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM4:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM5:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM6:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/DM7:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Drisc:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Erisc:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/HWFault2:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/HWFault4:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/HWFault5:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/HWFault6:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/HWFault7:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/IErisc:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/NCrisc:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/NCriscPacketTag:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Trisc0:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Trisc1:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Trisc2:WatcherNonDefaultAssertTests/WatcherAssertTest.TestWatcherAssert/Trisc3:WatcherStackUsageTests/StackUsageTest.TestWatcherStackUsage/StackUsage0:WatcherStackUsageTests/StackUsageTest.TestWatcherStackUsage/StackUsage0_QuasarMultiKernel:WatcherStackUsageTests/StackUsageTest.TestWatcherStackUsage/StackUsage16:WatcherStackUsageTests/StackUsageTest.TestWatcherStackUsage/StackUsage16_QuasarMultiKernel'
@@ -117,6 +115,16 @@
       timeout: 12
     bh_p150b_civ2:
       timeout: 12
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+- name: runtime_noc_debugging
+  cmd: ./build/test/tt_metal/unit_tests_noc_debugging
+  skus:
+    wh_n150_civ2:
+      timeout: 5
+    bh_p150b_civ2:
+      timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -197,44 +197,41 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
             tt_metal::CircularBufferConfig(byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
                 .set_page_size(tt::CBIndex::c_16, test_config.tile_byte_size);
         tt_metal::CreateCircularBuffer(program, core_range, l1_output_cb_config);
+    }
 
-        auto reader_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/kernels/dataflow/reader_unary.cpp",
-            test_config.cores,
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+    auto reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/reader_unary.cpp",
+        test_config.cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
-        // Enqueue apis only supported on gs so far
-        auto writer_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/kernels/dataflow/writer_unary.cpp",
-            test_config.cores,
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+    auto writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        test_config.cores,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-        std::map<std::string, std::string> sfpu_defines = sfpu_util::sfpu_op_to_op_name.at(test_config.sfpu_op);
+    std::map<std::string, std::string> sfpu_defines = sfpu_util::sfpu_op_to_op_name.at(test_config.sfpu_op);
+    sfpu_defines["SFPU_OP_EXP_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_GELU_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_RECIP_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_SQRT_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_ELU_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_NEG_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
 
-        sfpu_defines["SFPU_OP_EXP_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_GELU_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_RECIP_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_SQRT_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_ELU_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_NEG_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
-        sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
+    tt_metal::CreateKernel(
+        program,
+        "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+        test_config.cores,
+        tt_metal::ComputeConfig{
+            .math_approx_mode = test_config.approx_mode, .compile_args = compute_kernel_args, .defines = sfpu_defines});
 
-        tt_metal::CreateKernel(
-            program,
-            "tt_metal/kernels/compute/eltwise_sfpu.cpp",
-            test_config.cores,
-            tt_metal::ComputeConfig{
-                .math_approx_mode = test_config.approx_mode,
-                .compile_args = compute_kernel_args,
-                .defines = sfpu_defines});
-
-        // TODO(agrebenisan): Clean this up to only use the first path once Enqueue apis supported on WH
+    for (const CoreRange& core_range : test_config.cores.ranges()) {
         for (const CoreCoord& core_coord : core_range) {
             SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
             SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -145,6 +145,8 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
     auto mesh_workload = distributed::MeshWorkload();
 
     const distributed::DeviceLocalBufferConfig device_local_config{
+        // One DRAM page holding all tiles: reader_unary walks the buffer linearly by
+        // tile size, which matches this layout (see test_EnqueueTrace.cpp for 1-tile case).
         .page_size = byte_size,
         .buffer_type = tt_metal::BufferType::DRAM,
     };
@@ -152,14 +154,22 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
     const distributed::ReplicatedBufferConfig replicated_buffer_config{.size = byte_size};
     auto input_dram_buffer =
         distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, cq.device());
-    uint32_t input_dram_byte_address = input_dram_buffer->address();
     auto output_dram_buffer =
         distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, cq.device());
-    uint32_t output_dram_byte_address = output_dram_buffer->address();
 
+    const distributed::MeshCoordinate local_coord = distributed::MeshCoordinate(0, 0);
+    auto* input_dev_buffer = input_dram_buffer->get_device_buffer(local_coord);
+    auto* output_dev_buffer = output_dram_buffer->get_device_buffer(local_coord);
+    TT_FATAL(input_dev_buffer != nullptr && output_dev_buffer != nullptr, "Missing device buffer for local mesh coord");
+    const uint32_t input_dram_byte_address = input_dev_buffer->address();
+    const uint32_t output_dram_byte_address = output_dev_buffer->address();
+    const uint32_t num_pages = input_dev_buffer->num_pages();
+    TT_FATAL(num_pages == 1, "Expected a single contiguous DRAM page, got {}", num_pages);
+
+    // With single-tile CBs, use one block per tile so reserve_back(1) matches CB capacity.
     vector<uint32_t> compute_kernel_args = {
         uint32_t(test_config.num_tiles),  // per_core_block_cnt
-        1                                 // per_core_block_cnt
+        1,                                // per_core_block_dim
     };
 
     // Input
@@ -174,27 +184,28 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
     });
     std::vector<uint32_t> packed_golden = pack_vector<uint32_t, bfloat16>(golden);
 
-    // Same runtime args for every core
+    // Same runtime args for every core. Third arg is tile count (reader walks linearly).
     vector<uint32_t> reader_rt_args = {
-        (uint32_t)input_dram_byte_address,
+        input_dram_byte_address,
         0,
-        (uint32_t)test_config.num_tiles,
+        static_cast<uint32_t>(test_config.num_tiles),
     };
 
     vector<uint32_t> writer_rt_args = {
-        (uint32_t)output_dram_byte_address,
+        output_dram_byte_address,
         0,
-        (uint32_t)test_config.num_tiles,
+        static_cast<uint32_t>(test_config.num_tiles),
     };
 
     for (const CoreRange& core_range : test_config.cores.ranges()) {
         tt_metal::CircularBufferConfig l1_input_cb_config =
-            tt_metal::CircularBufferConfig(byte_size, {{tt::CBIndex::c_0, test_config.l1_input_data_format}})
+            tt_metal::CircularBufferConfig(test_config.tile_byte_size, {{tt::CBIndex::c_0, test_config.l1_input_data_format}})
                 .set_page_size(tt::CBIndex::c_0, test_config.tile_byte_size);
         tt_metal::CreateCircularBuffer(program, core_range, l1_input_cb_config);
 
         tt_metal::CircularBufferConfig l1_output_cb_config =
-            tt_metal::CircularBufferConfig(byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
+            tt_metal::CircularBufferConfig(
+                test_config.tile_byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
                 .set_page_size(tt::CBIndex::c_16, test_config.tile_byte_size);
         tt_metal::CreateCircularBuffer(program, core_range, l1_output_cb_config);
     }
@@ -244,8 +255,9 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
     distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, false);
 
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    distributed::Finish(cq);
 
-    distributed::ReadShard(cq, dest_buffer_data, output_dram_buffer, distributed::MeshCoordinate(0, 0));
+    distributed::ReadShard(cq, dest_buffer_data, output_dram_buffer, local_coord);
 
     return sfpu_util::is_close_packed_sfpu_output(dest_buffer_data, packed_golden, test_config.sfpu_op);
 }

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -134,49 +135,47 @@ struct SfpuConfig {
     bool approx_mode = true;
 };
 
-/// @brief Does Dram --> Reader --> CB --> Sfpu Compute --> CB --> Writer --> Dram. So far, enqueue APIs only added to
-/// grayskull
-/// @param device
-/// @param test_config - Configuration of the test -- see struct
-/// @return
+// Build SFPU defines for eltwise_sfpu.cpp.
+std::map<std::string, std::string> build_sfpu_defines(const SfpuConfig& test_config) {
+    std::map<std::string, std::string> sfpu_defines = sfpu_util::sfpu_op_to_op_name.at(test_config.sfpu_op);
+    sfpu_defines["SFPU_OP_EXP_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_GELU_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_RECIP_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_SQRT_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_ELU_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_NEG_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
+    return sfpu_defines;
+}
+
+/// @brief Does Dram --> Reader --> CB --> Sfpu Compute --> CB --> Writer --> Dram.
 bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfig& test_config) {
+    auto* mesh_device = cq.device();
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
-    tt_metal::Program program = tt_metal::CreateProgram();
-    auto mesh_workload = distributed::MeshWorkload();
+    const size_t tile_byte_size = test_config.tile_byte_size;
+
+    const distributed::MeshCoordinate local_coord = distributed::MeshCoordinate(0, 0);
+    const distributed::MeshCoordinateRange device_range(local_coord, local_coord);
 
     const distributed::DeviceLocalBufferConfig device_local_config{
-        // One DRAM page holding all tiles: reader_unary walks the buffer linearly by
-        // tile size, which matches this layout (see test_EnqueueTrace.cpp for 1-tile case).
         .page_size = byte_size,
         .buffer_type = tt_metal::BufferType::DRAM,
     };
-
     const distributed::ReplicatedBufferConfig replicated_buffer_config{.size = byte_size};
     auto input_dram_buffer =
-        distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, cq.device());
+        distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, mesh_device);
     auto output_dram_buffer =
-        distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, cq.device());
+        distributed::MeshBuffer::create(replicated_buffer_config, device_local_config, mesh_device);
 
-    const distributed::MeshCoordinate local_coord = distributed::MeshCoordinate(0, 0);
-    auto* input_dev_buffer = input_dram_buffer->get_device_buffer(local_coord);
-    auto* output_dev_buffer = output_dram_buffer->get_device_buffer(local_coord);
+    Buffer* input_dev_buffer = input_dram_buffer->get_device_buffer(local_coord);
+    Buffer* output_dev_buffer = output_dram_buffer->get_device_buffer(local_coord);
     TT_FATAL(input_dev_buffer != nullptr && output_dev_buffer != nullptr, "Missing device buffer for local mesh coord");
-    const uint32_t input_dram_byte_address = input_dev_buffer->address();
-    const uint32_t output_dram_byte_address = output_dev_buffer->address();
-    const uint32_t num_pages = input_dev_buffer->num_pages();
-    TT_FATAL(num_pages == 1, "Expected a single contiguous DRAM page, got {}", num_pages);
 
-    // With single-tile CBs, use one block per tile so reserve_back(1) matches CB capacity.
-    vector<uint32_t> compute_kernel_args = {
-        uint32_t(test_config.num_tiles),  // per_core_block_cnt
-        1,                                // per_core_block_dim
-    };
-
-    // Input
     std::vector<uint32_t> packed_input = sfpu_util::generate_packed_sfpu_input(
         byte_size / sizeof(bfloat16), test_config.sfpu_op, std::chrono::system_clock::now().time_since_epoch().count());
 
-    // Golden output
     auto input = unpack_vector<bfloat16, uint32_t>(packed_input);
     std::vector<bfloat16> golden(input.size());
     std::transform(input.begin(), input.end(), golden.begin(), [&](const bfloat16& val) {
@@ -184,29 +183,25 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
     });
     std::vector<uint32_t> packed_golden = pack_vector<uint32_t, bfloat16>(golden);
 
-    // Same runtime args for every core. Third arg is tile count (reader walks linearly).
-    vector<uint32_t> reader_rt_args = {
-        input_dram_byte_address,
-        0,
+    tt_metal::Program program = tt_metal::CreateProgram();
+    distributed::MeshWorkload mesh_workload;
+
+    const std::map<std::string, std::string> sfpu_defines = build_sfpu_defines(test_config);
+    const vector<uint32_t> compute_kernel_args = {
         static_cast<uint32_t>(test_config.num_tiles),
+        1u,
     };
 
-    vector<uint32_t> writer_rt_args = {
-        output_dram_byte_address,
-        0,
-        static_cast<uint32_t>(test_config.num_tiles),
-    };
-
+    // Single-tile streaming CBs: one page per reserve/push, matching reader_unary/writer_unary.
     for (const CoreRange& core_range : test_config.cores.ranges()) {
         tt_metal::CircularBufferConfig l1_input_cb_config =
-            tt_metal::CircularBufferConfig(test_config.tile_byte_size, {{tt::CBIndex::c_0, test_config.l1_input_data_format}})
-                .set_page_size(tt::CBIndex::c_0, test_config.tile_byte_size);
+            tt_metal::CircularBufferConfig(tile_byte_size, {{tt::CBIndex::c_0, test_config.l1_input_data_format}})
+                .set_page_size(tt::CBIndex::c_0, tile_byte_size);
         tt_metal::CreateCircularBuffer(program, core_range, l1_input_cb_config);
 
         tt_metal::CircularBufferConfig l1_output_cb_config =
-            tt_metal::CircularBufferConfig(
-                test_config.tile_byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
-                .set_page_size(tt::CBIndex::c_16, test_config.tile_byte_size);
+            tt_metal::CircularBufferConfig(tile_byte_size, {{tt::CBIndex::c_16, test_config.l1_output_data_format}})
+                .set_page_size(tt::CBIndex::c_16, tile_byte_size);
         tt_metal::CreateCircularBuffer(program, core_range, l1_output_cb_config);
     }
 
@@ -224,39 +219,40 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-    std::map<std::string, std::string> sfpu_defines = sfpu_util::sfpu_op_to_op_name.at(test_config.sfpu_op);
-    sfpu_defines["SFPU_OP_EXP_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_GELU_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_RECIP_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_SQRT_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_ELU_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_NEG_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
-    sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
-
     tt_metal::CreateKernel(
         program,
         "tt_metal/kernels/compute/eltwise_sfpu.cpp",
         test_config.cores,
         tt_metal::ComputeConfig{
-            .math_approx_mode = test_config.approx_mode, .compile_args = compute_kernel_args, .defines = sfpu_defines});
+            .math_approx_mode = test_config.approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = sfpu_defines});
+
+    const vector<uint32_t> reader_rt_args = {
+        input_dev_buffer->address(),
+        0u,
+        static_cast<uint32_t>(test_config.num_tiles),
+    };
+    const vector<uint32_t> writer_rt_args = {
+        output_dev_buffer->address(),
+        0u,
+        static_cast<uint32_t>(test_config.num_tiles),
+    };
 
     for (const CoreRange& core_range : test_config.cores.ranges()) {
         for (const CoreCoord& core_coord : core_range) {
-            SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
             SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);
+            SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
         }
     }
 
-    mesh_workload.add_program(distributed::MeshCoordinateRange(cq.device()->shape()), std::move(program));
+    mesh_workload.add_program(device_range, std::move(program));
 
-    std::vector<uint32_t> dest_buffer_data;
-    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, false);
-
+    distributed::WriteShard(cq, input_dram_buffer, packed_input, local_coord);
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);
 
+    std::vector<uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, output_dram_buffer, local_coord);
 
     return sfpu_util::is_close_packed_sfpu_output(dest_buffer_data, packed_golden, test_config.sfpu_op);

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -23,7 +23,6 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "mesh_dispatch_fixture.hpp"
 #include "impl/context/metal_context.hpp"
@@ -70,7 +69,8 @@ void build_and_run_program(
     uint32_t program2_semaphore1 = CreateSemaphore(program2, cr_set, 0);
 
     vector<uint32_t> compile_args = {MAX_LOOP, page_size, 2};
-    tt_metal::TensorAccessorArgs::create_l1_interleaved().append_to(compile_args);
+    compile_args.push_back(0);          // TensorAccessorArgs: args_config = None (L1 interleaved)
+    compile_args.push_back(page_size);  // TensorAccessorArgs: aligned_page_size
 
     auto brisc_kernel1 = CreateKernel(
         program1,
@@ -221,7 +221,8 @@ void build_and_run_program_ethernet(
     uint32_t program2_semaphore1 = CreateSemaphore(program2, eth_cr_set, 0, CoreType::ETH);
 
     vector<uint32_t> compile_args = {MAX_LOOP, page_size, 2};
-    tt_metal::TensorAccessorArgs::create_l1_interleaved().append_to(compile_args);
+    compile_args.push_back(0);          // TensorAccessorArgs: args_config = None (L1 interleaved)
+    compile_args.push_back(page_size);  // TensorAccessorArgs: aligned_page_size
 
     // Create ERISC0 kernel for program1 (Dynamic NOC)
     auto eth_erisc0_kernel1 = CreateKernel(

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -19,6 +19,9 @@ namespace tt::tt_metal {
 class NOCDebuggingFixture : public MeshDispatchFixture {
 public:
     static void SetUpTestSuite() {
+#if !defined(TRACY_ENABLE)
+        return;
+#endif
         // NOC debugging requires profiler + NOC event infrastructure, which is
         // created during MetalContext::initialize_impl() only when profiler_enabled
         // is true at that time.  Setting the env var before create_shared_devices()
@@ -34,6 +37,9 @@ public:
     }
 
     static void TearDownTestSuite() {
+#if !defined(TRACY_ENABLE)
+        return;
+#endif
         MeshDispatchFixture::destroy_shared_devices();
         if (had_prev_env_) {
             setenv("TT_METAL_NOC_DEBUG_DUMP", prev_env_value_.c_str(), 1);
@@ -129,6 +135,9 @@ protected:
     static inline std::string prev_env_value_{};
 
     void SetUp() override {
+#if !defined(TRACY_ENABLE)
+        GTEST_SKIP() << "NOC debugging tests require a Tracy-enabled build (build with ENABLE_TRACY=ON)";
+#endif
         MeshDispatchFixture::SetUp();
 
         if (this->IsSlowDispatch()) {
@@ -147,6 +156,9 @@ protected:
     }
 
     void TearDown() override {
+#if !defined(TRACY_ENABLE)
+        return;
+#endif
         if (auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state()) {
             noc_debug_state->reset_state();
         }

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <string>
 #include <gtest/gtest.h>
 #include "profiler_state_manager.hpp"
 #include "tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp"
@@ -23,14 +24,20 @@ public:
         // is true at that time.  Setting the env var before create_shared_devices()
         // ensures profiler_state_manager_ is allocated and firmware is configured
         // for NOC event collection.
-        suite_owned_env_ = (getenv("TT_METAL_NOC_DEBUG_DUMP") == nullptr);
-        setenv("TT_METAL_NOC_DEBUG_DUMP", "1", /*overwrite=*/0);
+        const char* prev = getenv("TT_METAL_NOC_DEBUG_DUMP");
+        had_prev_env_ = (prev != nullptr);
+        if (had_prev_env_) {
+            prev_env_value_ = prev;
+        }
+        setenv("TT_METAL_NOC_DEBUG_DUMP", "1", /*overwrite=*/1);
         MeshDispatchFixture::create_shared_devices();
     }
 
     static void TearDownTestSuite() {
         MeshDispatchFixture::destroy_shared_devices();
-        if (suite_owned_env_) {
+        if (had_prev_env_) {
+            setenv("TT_METAL_NOC_DEBUG_DUMP", prev_env_value_.c_str(), 1);
+        } else {
             unsetenv("TT_METAL_NOC_DEBUG_DUMP");
         }
     }
@@ -118,7 +125,8 @@ public:
     }
 
 protected:
-    static inline bool suite_owned_env_{false};
+    static inline bool had_prev_env_{false};
+    static inline std::string prev_env_value_{};
 
     void SetUp() override {
         MeshDispatchFixture::SetUp();

--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include "profiler_state_manager.hpp"
 #include "tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp"
@@ -16,6 +17,24 @@ namespace tt::tt_metal {
 
 class NOCDebuggingFixture : public MeshDispatchFixture {
 public:
+    static void SetUpTestSuite() {
+        // NOC debugging requires profiler + NOC event infrastructure, which is
+        // created during MetalContext::initialize_impl() only when profiler_enabled
+        // is true at that time.  Setting the env var before create_shared_devices()
+        // ensures profiler_state_manager_ is allocated and firmware is configured
+        // for NOC event collection.
+        suite_owned_env_ = (getenv("TT_METAL_NOC_DEBUG_DUMP") == nullptr);
+        setenv("TT_METAL_NOC_DEBUG_DUMP", "1", /*overwrite=*/0);
+        MeshDispatchFixture::create_shared_devices();
+    }
+
+    static void TearDownTestSuite() {
+        MeshDispatchFixture::destroy_shared_devices();
+        if (suite_owned_env_) {
+            unsetenv("TT_METAL_NOC_DEBUG_DUMP");
+        }
+    }
+
     bool has_write_barrier_issue(ChipId chip_id, CoreCoord virtual_core, int processor_id) const {
         auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state();
         if (!noc_debug_state) {
@@ -99,26 +118,20 @@ public:
     }
 
 protected:
-    bool previous_debug_dump_enabled_{};
+    static inline bool suite_owned_env_{false};
 
     void SetUp() override {
+        MeshDispatchFixture::SetUp();
+
         if (this->IsSlowDispatch()) {
             GTEST_SKIP() << "NOC debugging tests require fast dispatch mode";
         }
 
-        // This is a simple test with simple kernels
-        // Don't run this test if Watcher or DPrint is enabled
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() ||
             tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(
                 tt::llrt::RunTimeDebugFeatureDprint)) {
             GTEST_SKIP() << "NOC debugging tests require Watcher and DPRINT to be disabled";
         }
-
-        previous_debug_dump_enabled_ =
-            tt::tt_metal::MetalContext::instance().rtoptions().get_experimental_noc_debug_dump_enabled();
-        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_noc_debug_dump_enabled(true);
-
-        MeshDispatchFixture::SetUp();
 
         if (auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state()) {
             noc_debug_state->reset_state();
@@ -126,14 +139,10 @@ protected:
     }
 
     void TearDown() override {
-        MeshDispatchFixture::TearDown();
-
         if (auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state()) {
             noc_debug_state->reset_state();
         }
-
-        tt::tt_metal::MetalContext::instance().rtoptions().set_experimental_noc_debug_dump_enabled(
-            previous_debug_dump_enabled_);
+        MeshDispatchFixture::TearDown();
     }
 };
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dedicated_noc_writer.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
     }
 
     // Test gen_fast
-    constexpr auto s_args = TensorAccessorArgs<2>();
+    constexpr auto s_args = TensorAccessorArgs<3>();
     const auto s0 = TensorAccessor(s_args, l1_read_addr);
 
     for (uint32_t i = 0; i < iteration; i++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dynamic_noc_writer.cpp
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 
-#include "internal/tt-1xx/blackhole/noc/noc_parameters.h"
+#include "noc_parameters.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 
@@ -76,7 +76,7 @@ void kernel_main() {
     }
 
     // Test gen_fast
-    constexpr auto s_args = TensorAccessorArgs<2>();
+    constexpr auto s_args = TensorAccessorArgs<3>();
     const auto s0 = TensorAccessor(s_args, l1_read_addr);
 
     for (uint32_t i = 0; i < iteration; i ++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout.cpp
@@ -53,10 +53,10 @@ void kernel_main() {
     uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
     uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
 
-    constexpr auto in0_args = TensorAccessorArgs<0>();
-    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s0 = TensorAccessor(
+        tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), in0_tensor_addr, single_tile_size_bytes);
+    const auto s1 = TensorAccessor(
+        tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), in1_tensor_addr, single_tile_size_bytes);
 
     for (uint32_t b = 0; b < num_blocks; b++) {
         cb_reserve_back(cb_id_in0, in0_block_num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
@@ -35,8 +35,8 @@ void kernel_main() {
     // single-tile
     uint32_t single_tile_size_bytes = cb_out0.get_tile_size();
 
-    constexpr auto out_args = TensorAccessorArgs<0>();
-    const auto s = TensorAccessor(out_args, out_tensor_addr);
+    const auto s = TensorAccessor(
+        tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), out_tensor_addr, single_tile_size_bytes);
 
     bool one_time_profile = true;
     uint32_t out_tensor_sbh_start_tile_id = out_tensor_start_tile_id;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_matmul_tile_layout.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     // out tensor args

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2798,7 +2798,8 @@ void DeviceProfiler::pollDebugDumpResults(
             auto& active_risc_map = this->active_dram_buffer_per_core_risc_map[virtual_core];
 
             for (tracy::RiscType risc_type : enchantum::values_generator<tracy::RiscType>) {
-                if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || (is_eth && risc_type != tracy::RiscType::ERISC) ||
+                if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || risc_type == tracy::RiscType::NONE ||
+                    (is_eth && risc_type != tracy::RiscType::ERISC) ||
                     (!is_eth && risc_type == tracy::RiscType::ERISC)) {
                     continue;
                 }
@@ -2919,7 +2920,8 @@ void DeviceProfiler::pollDebugDumpResults(
             bool core_has_l1_data = false;
 
             for (tracy::RiscType risc_type : enchantum::values_generator<tracy::RiscType>) {
-                if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || (is_eth && risc_type != tracy::RiscType::ERISC) ||
+                if (risc_type == tracy::RiscType::TENSIX_RISC_AGG || risc_type == tracy::RiscType::NONE ||
+                    (is_eth && risc_type != tracy::RiscType::ERISC) ||
                     (!is_eth && risc_type == tracy::RiscType::ERISC)) {
                     continue;
                 }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -984,9 +984,18 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // the profiler infrastructure will be used to continuously dump NOC debug packets to a file. Default: false
         // (debug dump mode disabled) Usage: export TT_METAL_NOC_DEBUG_DUMP=1
         case EnvVarID::TT_METAL_NOC_DEBUG_DUMP: {
+#if !defined(TRACY_ENABLE)
+            if (is_env_enabled(value)) {
+                log_warning(
+                    tt::LogMetal,
+                    "TT_METAL_NOC_DEBUG_DUMP=1 requires a Tracy-enabled build (build with ENABLE_TRACY=ON). "
+                    "Ignoring; NOC debug events will not be collected.");
+            }
+#else
             if (is_env_enabled(value)) {
                 this->set_experimental_noc_debug_dump_enabled(true);
             }
+#endif
             break;
         }
 


### PR DESCRIPTION
Addresses some issues of (#43579).
Re-enable three test jobs that were disabled during the pipeline reorg:

**unit_tests_integration** — matmul JIT and SFPU hangs resolved on main.

**unit_tests_noc** — PR #41902 changed TensorAccessor to derive page_size from TensorAccessorArgs, exposing two pre-existing bugs in the dynamic NOC test kernels:
  - CTA_OFFSET mismatch: TensorAccessorArgs<2>() should be <3>() because the host pushes 3 user args before the accessor data.
  - Zero aligned_page_size: create_l1_interleaved() appended page_size=0, causing 0-byte NOC transfers that hang hardware.
  - Hardcoded BH noc_parameters.h include replaced with arch-agnostic path.

**unit_tests_noc_debugging** — the fixture enabled profiler flags after MetalContext creation, so profiler_state_manager_ was never allocated:
  - Segfault: ReadMeshDeviceProfilerResults dereferenced null profiler_state_manager_ during device-close recovery path.
  - False negatives: signal_debug_dump_read() was skipped, so NOC events were never read from hardware.
  - Fix: override SetUpTestSuite to set TT_METAL_NOC_DEBUG_DUMP=1 before create_shared_devices(), ensuring profiler infrastructure is created during MetalContext init.
  - Also filter RiscType::NONE in profiler pollDebugDumpResults loops (pre-existing bug exposed by enabling the profiler).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-runtime-ci-reorg-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-runtime-ci-reorg-tests)