### PR TITLE
descriptor framework: re-patch non-Buffer runtime args on cache hit (DynamicRuntimeArg) + in-place fast-path; migrate rand/uniform/bernoulli/dropout/ternary

### DIFF
--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -253,6 +253,20 @@ The correct pattern (static/dynamic split):
 Compile-time values (CB sizes, `#define`s, compile args) can **never** be dynamic — they bake the
 kernel ELF. They must stay hashed (keep them in `attribute_values()`).
 
+> **Precondition for the fast path: the program hash must include everything the per-core runtime
+> args depend on — in particular the shape.** The fast cache-hit path (buffer bindings +
+> `get_dynamic_runtime_args`) only re-patches buffer addresses and your declared dynamic scalars; it
+> does **not** recompute the rest of the runtime args. So it's only correct when "same hash" implies
+> "same program structure" — same shape, same work-split, same per-core tile counts/offsets.
+>
+> Some ops deliberately do the opposite: they **exclude shape from the hash** so one program is
+> reused across shapes, with the per-core args (num_tiles, offsets, num_cores) carrying the shape and
+> the **slow-path rebuild** recomputing them every dispatch (e.g. `binary_ng` hashes `shard_volumes`,
+> not shape). Such shape-agnostic ops **cannot** use buffer bindings — the fast path would leave the
+> shape-dependent args stale and miscompute. Leave them on the slow path (raw addresses, no
+> bindings). Forcing the fast path would require either putting shape back in the hash (losing the
+> cross-shape reuse) or re-deriving every per-core arg (which is just the slow-path rebuild).
+
 ### 1.5 CMakeLists.txt
 
 Create a `CMakeLists.txt` for the `_new` operation and add it to `ttnn/CMakeLists.txt`:

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -200,6 +200,59 @@ While both the old and `_new` operations exist side by side (Phase 1), their pro
 caches won't collide because the default hash includes `type_hash<YourDeviceOperation>`,
 which differs between the two distinct operation types.
 
+**Never write a custom `compute_program_hash` to exclude a per-call value.** A legacy op
+often hand-wrote a hash that dropped a value which varies per call but doesn't change the
+program structure (RNG `seed`, a fused `scalar`, a `from`/`to` range, a semaphore address).
+Under the descriptor framework that is a trap: on a cache **hit** only `Buffer*` address
+slots are re-patched, so a non-`Buffer` value baked into the runtime args is **frozen** at
+the first miss (silent wrong result), unless the op happens to fall to the slow-path rebuild.
+
+The correct pattern (static/dynamic split):
+
+- **Static** (program identity → hashed): exclude the per-call value from the default hash by
+  giving `operation_attributes_t` an `attribute_names` / `attribute_values()` pair that lists
+  only the structural fields and omits the dynamic one. Do **not** add a `compute_program_hash`.
+
+  ```cpp
+  struct operation_attributes_t {
+      Shape shape; DataType dtype; MemoryConfig memory_config;
+      uint32_t seed;  // dynamic — omitted below
+      static constexpr auto attribute_names = std::forward_as_tuple("shape", "dtype", "memory_config");
+      auto attribute_values() const { return std::forward_as_tuple(shape, dtype, memory_config); }
+  };
+  ```
+
+- **Dynamic** (re-patched every dispatch): declare a `get_dynamic_runtime_args` hook returning the
+  current value at the (kernel, core, arg) slot `create_descriptor()` wrote it to. The framework
+  re-applies these on every cache hit (the non-`Buffer` analog of a `BufferBinding`):
+
+  ```cpp
+  static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+      const operation_attributes_t& attrs, const tensor_args_t&, tensor_return_value_t& output,
+      const std::optional<ttnn::MeshCoordinate>& coord = std::nullopt);
+  ```
+
+  Each `DynamicRuntimeArg` is `{kernel_idx, core, arg_idx, value}`. Ops without the hook compile
+  to nothing — only declare it when you excluded a value from the hash.
+
+  > **Gotcha:** `attribute_values()` is also how the framework **discovers the mesh device** (via
+  > `get_first_object_of_type<MeshDevice*>`). For ops with no input tensor (e.g. `rand`) the device
+  > lives in the attrs, so it must appear in `attribute_values()` — and as the **first** element,
+  > because that helper's tuple path only inspects element 0. Put `device` first; otherwise dispatch
+  > throws "No mesh device found". Ops with an input tensor source the device from `tensor_args`, so
+  > this only bites device-in-attrs ops.
+
+- **Do not copy-paste** the work-split / core enumeration between `create_descriptor` and
+  `get_dynamic_runtime_args`. Extract a shared helper both call, so the miss-build and the
+  hit-patch derive the identical core list and value by construction.
+
+- **In-place ops** (output aliases an input) take the fast path fine — register both as `Buffer*`
+  bindings via `emplace_runtime_args`; the framework allows the output==input alias. (A duplicate
+  among two *distinct* inputs, e.g. `matmul(X, X)`, still bails to the slow path.)
+
+Compile-time values (CB sizes, `#define`s, compile args) can **never** be dynamic — they bake the
+kernel ELF. They must stay hashed (keep them in `attribute_values()`).
+
 ### 1.5 CMakeLists.txt
 
 Create a `CMakeLists.txt` for the `_new` operation and add it to `ttnn/CMakeLists.txt`:
@@ -315,6 +368,12 @@ directory. Update:
 
 If the old operation had a custom `compute_program_hash`, delete it. The framework
 handles hashing automatically.
+
+If that custom hash existed to **exclude a per-call value** (seed, scalar, range, semaphore
+address), deleting it would put the value back in the key (recompile per value). Instead apply
+the static/dynamic split from §1.4: omit the value from `attribute_values()` and re-apply it via
+`get_dynamic_runtime_args`. Verify with a regression test: a differing value must NOT add a cache
+entry (it's not in the key) AND must change the output (it's re-patched, not frozen).
 
 ### 3.4 Update CMakeLists.txt
 

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_bernoulli.py
@@ -116,6 +116,38 @@ def test_bernoulli_callback(shape, seed, in_dtype, out_dtype, device):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
+def test_bernoulli_seed_distinguishes_cache_entries(device):
+    """Regression guard for bernoulli's seed static/dynamic contract.
+
+    `seed` is excluded from compute_program_hash (so calls differing only in seed cache-hit) but
+    must be re-applied to the cached program on every dispatch. Pins both halves:
+      * different seed must NOT grow the cache  -> guards against re-adding seed to the hash.
+      * different seed must change the output    -> guards against the frozen-runtime-arg bug on
+        the fast path.
+    """
+    shape = [1, 1, 32, 64]
+    cpu_input = torch.full(shape, 0.5, dtype=torch.float32)
+    npu_input = ttnn.from_torch(cpu_input, device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    out_a = ttnn.to_torch(ttnn.bernoulli(npu_input, 1234, dtype=ttnn.float32)).float()
+    entries_a = device.num_program_cache_entries()
+
+    ttnn.bernoulli(npu_input, 1234, dtype=ttnn.float32)
+    entries_b = device.num_program_cache_entries()
+
+    out_c = ttnn.to_torch(ttnn.bernoulli(npu_input, 5678, dtype=ttnn.float32)).float()
+    entries_c = device.num_program_cache_entries()
+
+    assert entries_b == entries_a, "same seed must reuse the cached program"
+    assert entries_c == entries_a, "a different seed must NOT add a cache entry -- seed is dynamic, not hashed"
+    assert not torch.equal(out_a, out_c), "a different seed must change the output (seed re-patched on the fast path)"
+
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "shape",
     [[512, 512], [5, 8, 70, 40]],

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -170,6 +170,55 @@ def test_rand_different_from_to_values(device):
     device.disable_and_clear_program_cache()
 
 
+def test_rand_different_seed_values(device):
+    """Regression guard for the seed static/dynamic contract (see PR #45350, which hacked this).
+
+    `seed` is a DYNAMIC runtime value: it is deliberately excluded from compute_program_hash
+    (so calls that differ only in seed still cache-hit) BUT must be re-applied to the cached
+    program on every dispatch. This test pins BOTH halves of that contract so neither can
+    regress:
+
+      * `seed` must NOT grow the program cache  -> guards against re-adding seed to the hash
+        (the recompile-per-seed hack). Asserting `== 1` fails the moment seed re-enters the key.
+      * a different seed must change the output  -> guards against the freeze bug, where a
+        cache hit reuses the first call's baked-in seed and silently returns identical data.
+      * the same seed must reproduce the output  -> guards against the dynamic patch wrongly
+        re-randomizing on a deterministic (seed != 0) call.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    dtype = ttnn.float32
+
+    data_seed_a = ttnn.to_torch(ttnn.rand(shape, device=device, dtype=dtype, seed=1234)).float()
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"Expected 1 cache entry after first rand, got {device.num_program_cache_entries()}"
+
+    # Same seed, same shape: must reuse the cached program AND reproduce the exact values.
+    data_seed_a_again = ttnn.to_torch(ttnn.rand(shape, device=device, dtype=dtype, seed=1234)).float()
+    assert device.num_program_cache_entries() == 1, "same seed must reuse the cached program (no new cache entry)"
+    assert torch.equal(
+        data_seed_a, data_seed_a_again
+    ), "same seed must reproduce identical output (deterministic seed path)"
+
+    # Different seed, same shape: seed is excluded from the hash, so it must STILL be a cache
+    # hit (no new entry) and yet produce different values (seed re-patched on the cache hit).
+    data_seed_b = ttnn.to_torch(ttnn.rand(shape, device=device, dtype=dtype, seed=5678)).float()
+    assert device.num_program_cache_entries() == 1, (
+        "a different seed must NOT create a new cache entry -- seed is dynamic, not part of the "
+        "program hash. A new entry here means seed was (re-)added to compute_program_hash (the "
+        "recompile-per-seed hack)."
+    )
+    assert not torch.equal(data_seed_a, data_seed_b), (
+        "a different seed must change the output -- otherwise the cache hit silently reused the "
+        "first call's baked-in seed (the frozen-runtime-arg bug)."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "mesh_device",
     [pytest.param(2, id="1x2_grid"), pytest.param((2, 1), id="2x1_grid")],

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
@@ -137,6 +137,45 @@ def test_uniform_callback(shape, rand_range, dtype, seed, device):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
+def test_uniform_seed_distinguishes_cache_entries(device):
+    """Regression guard for uniform's seed static/dynamic contract.
+
+    uniform writes in-place into its input tensor (output aliases input). `seed` is excluded from
+    compute_program_hash (so calls differing only in seed cache-hit) but must be re-applied to the
+    cached program on every dispatch. Pins both halves:
+      * different seed must NOT grow the cache  -> guards against re-adding seed to the hash.
+      * different seed must change the output    -> guards against the frozen-runtime-arg bug on
+        the in-place fast path (only reachable now that resolve_bindings allows input==output).
+      * same seed must reproduce the output      -> guards against wrongly re-randomizing.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    npu = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.float32), device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT
+    )
+
+    ttnn.uniform(npu, 0.0, 1.0, 1234)
+    out_a = ttnn.to_torch(npu).float().clone()
+    entries_a = device.num_program_cache_entries()
+
+    ttnn.uniform(npu, 0.0, 1.0, 1234)
+    out_a2 = ttnn.to_torch(npu).float().clone()
+    entries_b = device.num_program_cache_entries()
+
+    ttnn.uniform(npu, 0.0, 1.0, 5678)
+    out_c = ttnn.to_torch(npu).float().clone()
+    entries_c = device.num_program_cache_entries()
+
+    assert entries_b == entries_a, "same seed must reuse the cached program"
+    assert entries_c == entries_a, "a different seed must NOT add a cache entry -- seed is dynamic, not hashed"
+    assert torch.equal(out_a, out_a2), "same seed must reproduce identical output"
+    assert not torch.equal(out_a, out_c), "a different seed must change the output (seed re-patched on the fast path)"
+
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "shape",
     [[512, 512], [5, 2, 4, 70, 40]],

--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -57,3 +57,39 @@ def test_dropout_output_tensor(device):
     assert torch.allclose(
         tensor_torch, output_torch
     ), "output_tensor parameter not working: input tensor was not modified in place"
+
+
+@pytest.mark.parametrize("in_place", [False, True])
+def test_dropout_seed_distinguishes_cache_entries(device, in_place):
+    """Regression guard for dropout's seed static/dynamic contract, on both the distinct-output and
+    in-place (output_tensor==input) fast paths.
+
+    `seed` is excluded from compute_program_hash (so calls differing only in seed cache-hit) but
+    must be re-applied to the cached program on every dispatch. Pins both halves:
+      * different seed must NOT grow the cache  -> guards against re-adding seed to the hash.
+      * different seed must change the dropout mask -> guards against the frozen-seed bug on the
+        fast path (the in_place case is only reachable since resolve_bindings allows input==output).
+    """
+    t = torch.ones((1, 1, 32, 64))
+    tensor = ttnn.from_torch(t, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    def run(seed):
+        out_kwargs = {"output_tensor": tensor} if in_place else {}
+        out = ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=seed, **out_kwargs)
+        return ttnn.to_torch(out).float().clone()
+
+    out_a = run(1234)
+    entries_a = device.num_program_cache_entries()
+    run(1234)
+    entries_b = device.num_program_cache_entries()
+    out_c = run(5678)
+    entries_c = device.num_program_cache_entries()
+
+    assert entries_b == entries_a, "same seed must reuse the cached program"
+    assert entries_c == entries_a, "a different seed must NOT add a cache entry -- seed is dynamic, not hashed"
+    assert not torch.equal(out_a, out_c), "a different seed must change the dropout mask (seed re-patched on fast path)"
+
+    device.disable_and_clear_program_cache()

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -377,3 +377,58 @@ def test_addcdiv(device, torch_dtype, ttnn_dtype, value, in_data1_shape, in_data
         )
 
     assert_with_ulp(output_tensor, golden_tensor, ulp_threshold=1, allow_nonfinite=True)
+
+
+def test_ternary_scalar_distinguishes_cache_entries(device):
+    """Regression guard for the ternary scalar static/dynamic contract.
+
+    addcmul(a, b, c, value) packs `value` (scalar_input_a) into the compute-kernel runtime args.
+    The scalar is intentionally EXCLUDED from to_hash()/compute_program_hash (so calls differing
+    only in the scalar cache-hit instead of recompiling) but must be re-applied to the cached
+    program on every dispatch via TernaryDeviceOperation::get_dynamic_runtime_args(). Pins both
+    halves of the contract:
+      * a different scalar must NOT grow the cache  -> guards against re-adding the scalar to the
+        hash (the recompile-per-scalar hack).
+      * a different scalar must change the output   -> guards against the frozen-runtime-arg bug,
+        where the cache hit reuses the first call's baked-in scalar (only correctly re-patched now
+        that the factory registers buffer bindings and declares the scalar dynamic).
+      * the same scalar must reproduce the output   -> guards against wrongly perturbing the scalar
+        on the fast path.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    torch.manual_seed(0)
+    a = ttnn.from_torch(
+        torch.rand(shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+    b = ttnn.from_torch(
+        torch.rand(shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+    c = ttnn.from_torch(
+        torch.rand(shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+
+    out_v1 = ttnn.to_torch(ttnn.addcmul(a, b, c, value=2.0)).float().clone()
+    entries_after_first = device.num_program_cache_entries()
+    assert entries_after_first == 1, f"Expected 1 cache entry after first addcmul, got {entries_after_first}"
+
+    # Same scalar: must reuse the cached program AND reproduce the exact values.
+    out_v1_again = ttnn.to_torch(ttnn.addcmul(a, b, c, value=2.0)).float().clone()
+    assert device.num_program_cache_entries() == 1, "same scalar must reuse the cached program (no new cache entry)"
+    assert torch.equal(out_v1, out_v1_again), "same scalar must reproduce identical output"
+
+    # Different scalar: scalar is excluded from the hash, so it must STILL be a cache hit (no new
+    # entry) and yet produce different values (scalar re-patched on the cache hit).
+    out_v2 = ttnn.to_torch(ttnn.addcmul(a, b, c, value=7.0)).float().clone()
+    assert device.num_program_cache_entries() == 1, (
+        "a different scalar must NOT create a new cache entry -- the scalar is dynamic, not part of "
+        "the program hash. A new entry here means the scalar was (re-)added to compute_program_hash."
+    )
+    assert not torch.equal(out_v1, out_v2), (
+        "a different scalar must change the output (scalar re-patched on the fast path). Identical "
+        "output here means the cache hit reused the first call's frozen scalar runtime arg."
+    )
+
+    device.disable_and_clear_program_cache()

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -90,7 +90,7 @@ struct ResolvedBindings {
 // declares, both runtime-arg bindings and CB `.buffer` bindings.  Deciding
 // whether the resulting `ResolvedBindings` is safe to fast-path on a given
 // cache hit is the caller's job (see DescriptorMeshWorkloadAdapter::apply_descriptor),
-// because the safety check depends on workload contract — specifically whether
+// because the safety check depends on workload variant — specifically whether
 // a slow-path rebuild is available to refresh raw (non-binding) runtime args.
 //
 // tensor_buffers is ordered inputs-first (see collect_tensor_buffers): the first

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -7,9 +7,16 @@
 /**
  * Fast cache-hit patching for descriptor-factory programs.
  *
- * This is a temporary shim. Metal 2.0 solves the same problem at the framework level with
- * native Tensor/Buffer bindings. This shim should be removed once op factories migrate to
- * the Metal 2.0 API.
+ * ⚠️ TEMPORARY SHIM — DO NOT BUILD ON THIS, DO NOT ADD CALLERS. ⚠️
+ *
+ * A stop-gap that lets descriptor-based op factories re-patch Buffer addresses and the handful
+ * of hash-excluded scalar runtime args on a program-cache hit — standing in for the legacy
+ * override_runtime_arguments() path until Metal 2.0 lands. Metal 2.0 solves this at the
+ * framework level with native Tensor/Buffer bindings, at which point THIS ENTIRE FILE AND ITS
+ * IMPLEMENTATION ARE DELETED. Do not extend the API, do not depend on it outside the
+ * mesh-device-operation adapter. New code almost certainly wants the Metal 2.0 binding instead.
+ *
+ * CODE REVIEWERS: if anyone builds on top of this, reject immediately — unless it's Diego.
  *
  * Usage:
  *   // In create_descriptor() — cache miss:

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/program_descriptors.hpp>
 
 #include <cstdint>
+#include <limits>
 #include <span>
 #include <vector>
 
@@ -92,9 +93,24 @@ struct ResolvedBindings {
 // because the safety check depends on workload contract — specifically whether
 // a slow-path rebuild is available to refresh raw (non-binding) runtime args.
 //
+// tensor_buffers is ordered inputs-first (see collect_tensor_buffers): the first
+// num_input_buffers entries come from tensor_args, the rest from the output(s) and any
+// workload buffers.  This split lets the resolver distinguish two kinds of aliasing:
+//   - the SAME buffer appearing twice WITHIN the inputs (e.g. matmul(X, X)) is ambiguous —
+//     a future call with distinct same-shape tensors would miscompute — so we bail to the
+//     slow path.
+//   - an OUTPUT buffer that aliases an INPUT buffer (an in-place op writing back into its
+//     input) is safe: every binding for that buffer resolves to the one shared address,
+//     which is correct on every dispatch — so we keep the fast path.
+// num_input_buffers defaults to SIZE_MAX, which treats every entry as an input (the original
+// conservative behavior: bail on any duplicate).
+//
 // Call immediately after Program{desc} on cache miss; store in shared_variables.
 ResolvedBindings resolve_bindings(
-    Program& program, const ProgramDescriptor& desc, std::span<Buffer* const> tensor_buffers);
+    Program& program,
+    const ProgramDescriptor& desc,
+    std::span<Buffer* const> tensor_buffers,
+    size_t num_input_buffers = std::numeric_limits<size_t>::max());
 
 // Apply resolved bindings to the cached program on a cache hit.
 // current_buffers must be the output of collect_tensor_buffers() for the

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -106,4 +106,30 @@ ResolvedBindings resolve_bindings(
 void apply_resolved_bindings(
     Program& program, const ResolvedBindings& bindings, std::span<Buffer* const> current_buffers);
 
+// ---------------------------------------------------------------------------
+// Dynamic (non-Buffer) runtime args
+// ---------------------------------------------------------------------------
+
+// Declares one runtime-arg slot whose value is DYNAMIC: it is intentionally excluded from the
+// program-cache hash (so two calls that differ only in this value still cache-hit) and therefore
+// MUST be re-applied to the cached program on every dispatch.  This is the non-Buffer analog of
+// BufferBinding: BufferBinding re-patches a buffer address on a cache hit; DynamicRuntimeArg
+// re-patches an arbitrary scalar that a custom compute_program_hash deliberately omitted (e.g. an
+// RNG seed, an [from,to) range, a semaphore L1 address).  The owning device operation produces the
+// current values for each dispatch (see DeviceOperation::get_dynamic_runtime_args); this struct is
+// just the destination (kernel/core/arg) plus the value to write.
+struct DynamicRuntimeArg {
+    uint32_t kernel_idx = 0;  // index into ProgramDescriptor::kernels
+    CoreCoord core{};         // ignored when is_common == true
+    uint32_t arg_idx = 0;     // position within that kernel/core's runtime args
+    uint32_t value = 0;       // current value, derived from the live operation_attributes
+    bool is_common = false;   // true => common (non-per-core) runtime args
+};
+
+// Write each DynamicRuntimeArg's value into the cached program's live runtime args.  Call on every
+// cache hit (after apply_resolved_bindings) for ops that declare dynamic non-Buffer runtime args.
+// Uses GetRuntimeArgs / GetCommonRuntimeArgs for the same pre/post-first-enqueue correctness as
+// apply_resolved_bindings.
+void apply_dynamic_runtime_args(Program& program, std::span<const DynamicRuntimeArg> dynamic_args);
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -26,24 +26,45 @@
 namespace tt::tt_metal {
 
 ResolvedBindings resolve_bindings(
-    Program& program, const ProgramDescriptor& desc, std::span<Buffer* const> tensor_buffers) {
+    Program& program,
+    const ProgramDescriptor& desc,
+    std::span<Buffer* const> tensor_buffers,
+    size_t num_input_buffers) {
     ResolvedBindings result;
 
-    // If the same Buffer* appears in tensor_buffers more than once (e.g. matmul(X, X),
-    // or an output that aliases an input), every binding for that buffer would map to
-    // the first occurrence via std::find below.  At cache hit, all of those bindings
-    // would be patched with current_buffers[first_slot].address(), so the second
-    // tensor's address would never get written.  The result is silent miscompute when
-    // a future call uses distinct tensors at the same shape/dtype.
+    // If the same Buffer* appears more than once, every binding for that buffer maps to the
+    // first occurrence via std::find below; at cache hit all of those bindings get patched with
+    // current_buffers[first_slot].address().  Whether that's safe depends on WHY it aliases:
     //
-    // We can't disambiguate which binding corresponds to which slot from Buffer* alone,
-    // so we fall back to the slow path (rebuild the descriptor) when this happens.
+    //   - Duplicate WITHIN the inputs (e.g. matmul(X, X)): the two slots are distinct logical
+    //     tensors that merely coincide on this call.  A future same-shape call with distinct
+    //     tensors would silently miscompute (the second tensor's address is never written).
+    //     We can't disambiguate from Buffer* alone, so bail to the slow path.
+    //
+    //   - An OUTPUT (or workload) buffer that aliases an INPUT: an in-place op writing back into
+    //     its input.  Both slots are the SAME buffer by construction, on every dispatch, so
+    //     mapping them to the one shared address is always correct.  Keep the fast path.
+    //
+    // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
     {
-        std::unordered_set<Buffer*> seen;
-        seen.reserve(tensor_buffers.size());
-        for (Buffer* buf : tensor_buffers) {
-            if (buf && !seen.insert(buf).second) {
-                return ResolvedBindings{};
+        std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
+        std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
+        for (size_t i = 0; i < tensor_buffers.size(); ++i) {
+            Buffer* buf = tensor_buffers[i];
+            if (!buf) {
+                continue;
+            }
+            if (i < num_input_buffers) {
+                if (!input_buffers.insert(buf).second) {
+                    return ResolvedBindings{};  // duplicate among inputs (e.g. matmul(X, X)) — ambiguous
+                }
+            } else if (input_buffers.count(buf) == 0) {
+                // Output/workload buffer that does NOT alias an input: a duplicate here is still
+                // ambiguous, so preserve the original conservative bail.  (A buffer that DOES
+                // alias an input is the safe in-place case and falls through.)
+                if (!output_buffers.insert(buf).second) {
+                    return ResolvedBindings{};
+                }
             }
         }
     }

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -207,4 +207,25 @@ void apply_resolved_bindings(
     }
 }
 
+void apply_dynamic_runtime_args(Program& program, std::span<const DynamicRuntimeArg> dynamic_args) {
+    // dynamic_args are not sorted (unlike resolved rt_args): the per-op get_dynamic_runtime_args()
+    // typically emits only a handful of slots, so re-deriving the RuntimeArgsData reference per
+    // entry is cheap and avoids imposing an ordering contract on op authors.  The reference is
+    // taken fresh on each call so first-enqueue retargeting of rt_args_data is observed correctly.
+    for (const auto& d : dynamic_args) {
+        auto& data =
+            d.is_common ? GetCommonRuntimeArgs(program, d.kernel_idx) : GetRuntimeArgs(program, d.kernel_idx, d.core);
+        TT_FATAL(
+            d.arg_idx < data.size(),
+            "DynamicRuntimeArg for kernel {} {}arg[{}] is out of range (runtime args size {}). "
+            "The (kernel_idx, core, arg_idx) declared by get_dynamic_runtime_args() must match the "
+            "slot populated in create_descriptor().",
+            d.kernel_idx,
+            d.is_common ? "common " : "",
+            d.arg_idx,
+            data.size());
+        data[d.arg_idx] = d.value;
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -54,17 +54,15 @@ ResolvedBindings resolve_bindings(
             if (!buf) {
                 continue;
             }
-            if (i < num_input_buffers) {
-                if (!input_buffers.insert(buf).second) {
-                    return ResolvedBindings{};  // duplicate among inputs (e.g. matmul(X, X)) — ambiguous
-                }
-            } else if (input_buffers.count(buf) == 0) {
-                // Output/workload buffer that does NOT alias an input: a duplicate here is still
-                // ambiguous, so preserve the original conservative bail.  (A buffer that DOES
-                // alias an input is the safe in-place case and falls through.)
-                if (!output_buffers.insert(buf).second) {
-                    return ResolvedBindings{};
-                }
+            const bool is_input = i < num_input_buffers;
+            // An output/workload buffer that aliases an input is the safe in-place case — skip it.
+            if (!is_input && input_buffers.count(buf) != 0) {
+                continue;
+            }
+            // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.
+            auto& seen = is_input ? input_buffers : output_buffers;
+            if (!seen.insert(buf).second) {
+                return ResolvedBindings{};
             }
         }
     }

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -138,10 +138,10 @@ ResolvedBindings resolve_bindings(
     // mechanism by which input/output addresses can change between dispatches.
     //
     // The CB-resolution gate (whether to use the result on cache hit) lives
-    // in DescriptorMeshWorkloadAdapter::apply_descriptor and is contract-aware:
-    //   - contract 1: fast-path only when rt-arg bindings are present;
+    // in DescriptorMeshWorkloadAdapter::apply_descriptor and is variant-aware:
+    //   - ProgramDescriptor variant: fast-path only when rt-arg bindings are present;
     //     otherwise rebuild the descriptor.
-    //   - contract 2: always fast-path; no rebuild fallback.
+    //   - WorkloadDescriptor variant: always fast-path; no rebuild fallback.
     {
         auto program_cbs = program.circular_buffers();
         for (uint32_t ci = 0; ci < static_cast<uint32_t>(desc.cbs.size()); ++ci) {
@@ -229,7 +229,7 @@ void apply_resolved_bindings(
 void apply_dynamic_runtime_args(Program& program, std::span<const DynamicRuntimeArg> dynamic_args) {
     // dynamic_args are not sorted (unlike resolved rt_args): the per-op get_dynamic_runtime_args()
     // typically emits only a handful of slots, so re-deriving the RuntimeArgsData reference per
-    // entry is cheap and avoids imposing an ordering contract on op authors.  The reference is
+    // entry is cheap and avoids imposing an ordering requirement on op authors.  The reference is
     // taken fresh on each call so first-enqueue retargeting of rt_args_data is observed correctly.
     for (const auto& d : dynamic_args) {
         auto& data =

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -5,8 +5,19 @@
 // Implementation of the fast cache-hit patching helpers declared in
 // tt-metalium/experimental/program_descriptor_patching.hpp.
 //
-// This is a temporary shim. Metal 2.0 solves the same problem at the framework
-// level with native Tensor/Buffer bindings. Remove once op factories migrate.
+// ⚠️ TEMPORARY SHIM — DO NOT BUILD ON THIS, DO NOT ADD CALLERS. ⚠️
+//
+// These helpers (resolve_bindings / apply_resolved_bindings / apply_dynamic_runtime_args)
+// are a stop-gap that lets descriptor-based op factories re-patch Buffer addresses and the
+// handful of hash-excluded scalar runtime args on a program-cache hit — standing in for the
+// legacy override_runtime_arguments() path until Metal 2.0 lands.
+//
+// Metal 2.0 solves this at the framework level with native Tensor/Buffer bindings, at which
+// point THIS ENTIRE FILE AND ITS HEADER ARE DELETED. Do not extend the API, do not depend on
+// it outside the mesh-device-operation adapter. New code almost certainly wants the Metal 2.0
+// binding instead.
+//
+// CODE REVIEWERS: if anyone builds on top of this, reject immediately — unless it's Diego.
 
 #include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include <tt-metalium/program_descriptors.hpp>

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -56,7 +56,7 @@ ResolvedBindings resolve_bindings(
             }
             const bool is_input = i < num_input_buffers;
             // An output/workload buffer that aliases an input is the safe in-place case — skip it.
-            if (!is_input && input_buffers.count(buf) != 0) {
+            if (!is_input && input_buffers.contains(buf)) {
                 continue;
             }
             // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -307,7 +307,7 @@ public:
     //
     // Adapts a ProgramDescriptorFactoryConcept factory for mesh dispatch.
     //
-    // Supports two contracts:
+    // Supports two factory variants:
     //
     //   1) Simple ops (no workload-scoped state):
     //        static ProgramDescriptor T::create_descriptor(attrs, args, ret, [coord]);
@@ -326,19 +326,19 @@ public:
     //      and outlive the cached workload via the program cache.
     //
     // On cache hits the framework either patches buffer addresses through the
-    // BufferBinding fast path (contract 2 always; contract 1 when the factory
-    // used emplace_runtime_args()) or, for contract (1) factories that bind
+    // BufferBinding fast path (the WorkloadDescriptor variant always; the ProgramDescriptor variant when the factory
+    // used emplace_runtime_args()) or, for ProgramDescriptor-variant factories that bind
     // raw addresses, rebuilds the descriptor and bulk-copies runtime args.
     // -----------------------------------------------------------------------
     template <ProgramDescriptorFactoryConcept DescriptorFactory>
     struct DescriptorMeshWorkloadAdapter {
-        // --- Contract detection ---
+        // --- Variant detection ---
 
-        // Contract (2): does the factory define a static create_workload_descriptor
+        // WorkloadDescriptor variant: does the factory define a static create_workload_descriptor
         // that takes the tensor coord range set AND returns a
         // tt::tt_metal::WorkloadDescriptor?  The return-type check pins
         // the contract so an accidental wrong signature surfaces as a clean
-        // concept failure rather than silent fallback to contract (1).
+        // concept failure rather than silent fallback to the ProgramDescriptor variant.
         static constexpr bool has_workload_descriptor = requires(
             const operation_attributes_t& a,
             const tensor_args_t& t,
@@ -351,7 +351,7 @@ public:
 
         // Signature-mismatch guard: a factory that defines a
         // `create_workload_descriptor` with a wrong signature/return type would
-        // silently fall through to the contract-1 path (which then tries
+        // silently fall through to the ProgramDescriptor-variant path (which then tries
         // `create_descriptor` and produces a deep template error).  Surface
         // the problem clearly at concept-check time.
         static_assert(
@@ -373,11 +373,11 @@ public:
             // miss) by create_workload_descriptor() and held here so its resource
             // members (semaphores, buffers) outlive the cached workload via
             // the program cache.  Default-constructed (empty vectors) for
-            // contract (1) factories.
+            // ProgramDescriptor-variant factories.
             tt::tt_metal::WorkloadDescriptor workload_descriptor;
             // Resolved buffer bindings for the fast cache-hit path.
             // Non-empty when the factory used emplace_runtime_args() with
-            // Buffer* args (or, for contract 2, declared any CB buffer binding).
+            // Buffer* args (or, for the WorkloadDescriptor variant, declared any CB buffer binding).
             tt::tt_metal::ResolvedBindings resolved_bindings;
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
@@ -414,7 +414,7 @@ public:
             return buffers;
         }
 
-        // Whether create_descriptor (contract 1) wants the per-coord MeshCoordinate.
+        // Whether create_descriptor (the ProgramDescriptor variant) wants the per-coord MeshCoordinate.
         // DirectDescriptorFactory accepts the 4-arg form unconditionally but only forwards
         // when the underlying DeviceOperation defines it. Custom factories opt in explicitly.
         static consteval bool create_descriptor_uses_mesh_dispatch_coordinate() {
@@ -439,8 +439,8 @@ public:
             }
         }
 
-        // Build a ProgramDescriptor for one mesh coordinate (contract 1).
-        // The declarative WorkloadDescriptor path (contract 2) does NOT go through
+        // Build a ProgramDescriptor for one mesh coordinate (the ProgramDescriptor variant).
+        // The declarative WorkloadDescriptor path (the WorkloadDescriptor variant) does NOT go through
         // this — it iterates `workload_descriptor.programs` directly.
         static tt::tt_metal::ProgramDescriptor invoke_per_coord(
             const operation_attributes_t& attrs,
@@ -468,7 +468,7 @@ public:
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
             if constexpr (has_workload_descriptor) {
-                // Contract (2) — declarative: the factory builds the entire
+                // WorkloadDescriptor variant — declarative: the factory builds the entire
                 // WorkloadDescriptor (resources + per-coord programs) in
                 // one call.  Resources (GlobalSemaphores, MeshBuffers) are
                 // allocated and any Synchronize barrier is run as part of
@@ -494,7 +494,7 @@ public:
                 }
                 return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
             } else {
-                // Contract (1) — simple per-coord create_descriptor.
+                // ProgramDescriptor variant — simple per-coord create_descriptor.
                 tt::tt_metal::WorkloadDescriptor empty_descriptor;
 
                 const auto build_and_add_program =
@@ -557,7 +557,7 @@ public:
                 auto& sv = cached_workload.shared_variables.at(coordinate_range);
 
                 if constexpr (has_workload_descriptor) {
-                    // Contract (2) — declarative: there is no slow-path rebuild
+                    // WorkloadDescriptor variant — declarative: there is no slow-path rebuild
                     // because re-running create_workload_descriptor would re-allocate
                     // workload-scoped resources (GlobalSemaphores, MeshBuffers).
                     // CB bindings are always populated by resolve_bindings, so the
@@ -568,12 +568,12 @@ public:
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
                     }
-                    // Contract (2) never rebuilds, so any value a custom hash excluded would stay
-                    // frozen at first miss — re-apply declared dynamic non-Buffer runtime args.
+                    // The WorkloadDescriptor variant never rebuilds, so a value a custom hash
+                    // excluded would stay frozen at first miss — re-apply declared dynamic args.
                     apply_dynamic_runtime_args_if_declared(
                         program, attrs, tensor_args, tensor_return_value, coordinate_range);
                 } else {
-                    // Contract (1) — simple per-coord factory.  Fast-path only
+                    // ProgramDescriptor variant — simple per-coord factory.  Fast-path only
                     // when the factory declared rt-arg buffer bindings via
                     // emplace_runtime_args().  Without those, the factory may be
                     // mixing `.buffer = ...` CBs with OLD-style raw uint32 rt-args

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -337,7 +337,7 @@ public:
         // WorkloadDescriptor variant: does the factory define a static create_workload_descriptor
         // that takes the tensor coord range set AND returns a
         // tt::tt_metal::WorkloadDescriptor?  The return-type check pins
-        // the contract so an accidental wrong signature surfaces as a clean
+        // the requirement so an accidental wrong signature surfaces as a clean
         // concept failure rather than silent fallback to the ProgramDescriptor variant.
         static constexpr bool has_workload_descriptor = requires(
             const operation_attributes_t& a,

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -397,9 +397,16 @@ public:
         static ttsl::SmallVector<tt::tt_metal::Buffer*, 16> collect_tensor_buffers(
             const tensor_args_t& tensor_args,
             const tensor_return_value_t& tensor_return_value,
-            const tt::tt_metal::WorkloadDescriptor& workload_descriptor) {
+            const tt::tt_metal::WorkloadDescriptor& workload_descriptor,
+            size_t* num_input_buffers = nullptr) {
             ttsl::SmallVector<tt::tt_metal::Buffer*, 16> buffers;
             extract_tensor_buffers_into(tensor_args, buffers);
+            // Boundary between input buffers and output/workload buffers, used by resolve_bindings
+            // to allow safe in-place aliasing (output buffer == input buffer) while still bailing
+            // on ambiguous duplicates within the inputs (e.g. matmul(X, X)).
+            if (num_input_buffers != nullptr) {
+                *num_input_buffers = buffers.size();
+            }
             extract_tensor_buffers_into(tensor_return_value, buffers);
             for (const auto& wb : workload_descriptor.buffers) {
                 buffers.push_back(wb.buffer);
@@ -477,8 +484,10 @@ public:
                 auto programs = std::move(workload_descriptor.programs);
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
-                    auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
-                    auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
+                    size_t num_input_buffers = 0;
+                    auto tensor_buffers = collect_tensor_buffers(
+                        tensor_args, tensor_return_value, workload_descriptor, &num_input_buffers);
+                    auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers, num_input_buffers);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
                         .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(resolved)};
@@ -493,9 +502,11 @@ public:
                         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
                         auto desc = invoke_per_coord(attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
                         tt::tt_metal::Program program{desc};
-                        auto tensor_buffers =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
-                        auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
+                        size_t num_input_buffers = 0;
+                        auto tensor_buffers = collect_tensor_buffers(
+                            tensor_args, tensor_return_value, empty_descriptor, &num_input_buffers);
+                        auto resolved =
+                            tt::tt_metal::resolve_bindings(program, desc, tensor_buffers, num_input_buffers);
                         mesh_workload.add_program(device_range, std::move(program));
                         shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(resolved)};
                     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -394,24 +394,28 @@ public:
         //
         // Returns a stack-allocated SmallVector (16 inline slots) so the
         // cache-hit fast path avoids the heap allocation tax.
-        static ttsl::SmallVector<tt::tt_metal::Buffer*, 16> collect_tensor_buffers(
+        // Result of collect_tensor_buffers. `num_input_buffers` is the boundary between input
+        // buffers and output/workload buffers, used by resolve_bindings to allow safe in-place
+        // aliasing (output buffer == input buffer) while still bailing on ambiguous duplicates
+        // within the inputs (e.g. matmul(X, X)).
+        struct CollectedTensorBuffers {
+            ttsl::SmallVector<tt::tt_metal::Buffer*, 16> buffers;
+            size_t num_input_buffers = 0;
+        };
+
+        static CollectedTensorBuffers collect_tensor_buffers(
             const tensor_args_t& tensor_args,
             const tensor_return_value_t& tensor_return_value,
-            const tt::tt_metal::WorkloadDescriptor& workload_descriptor,
-            size_t* num_input_buffers = nullptr) {
-            ttsl::SmallVector<tt::tt_metal::Buffer*, 16> buffers;
+            const tt::tt_metal::WorkloadDescriptor& workload_descriptor) {
+            CollectedTensorBuffers collected;
+            auto& buffers = collected.buffers;
             extract_tensor_buffers_into(tensor_args, buffers);
-            // Boundary between input buffers and output/workload buffers, used by resolve_bindings
-            // to allow safe in-place aliasing (output buffer == input buffer) while still bailing
-            // on ambiguous duplicates within the inputs (e.g. matmul(X, X)).
-            if (num_input_buffers != nullptr) {
-                *num_input_buffers = buffers.size();
-            }
+            collected.num_input_buffers = buffers.size();
             extract_tensor_buffers_into(tensor_return_value, buffers);
             for (const auto& wb : workload_descriptor.buffers) {
                 buffers.push_back(wb.buffer);
             }
-            return buffers;
+            return collected;
         }
 
         // Whether create_descriptor (the ProgramDescriptor variant) wants the per-coord MeshCoordinate.
@@ -484,13 +488,12 @@ public:
                 auto programs = std::move(workload_descriptor.programs);
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
-                    size_t num_input_buffers = 0;
-                    auto tensor_buffers = collect_tensor_buffers(
-                        tensor_args, tensor_return_value, workload_descriptor, &num_input_buffers);
-                    auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers, num_input_buffers);
+                    auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
+                    auto bindings =
+                        tt::tt_metal::resolve_bindings(program, desc, collected.buffers, collected.num_input_buffers);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
-                        .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(resolved)};
+                        .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(bindings)};
                 }
                 return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
             } else {
@@ -502,13 +505,11 @@ public:
                         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
                         auto desc = invoke_per_coord(attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
                         tt::tt_metal::Program program{desc};
-                        size_t num_input_buffers = 0;
-                        auto tensor_buffers = collect_tensor_buffers(
-                            tensor_args, tensor_return_value, empty_descriptor, &num_input_buffers);
-                        auto resolved =
-                            tt::tt_metal::resolve_bindings(program, desc, tensor_buffers, num_input_buffers);
+                        auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
+                        auto bindings = tt::tt_metal::resolve_bindings(
+                            program, desc, collected.buffers, collected.num_input_buffers);
                         mesh_workload.add_program(device_range, std::move(program));
-                        shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(resolved)};
+                        shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(bindings)};
                     };
 
                 if constexpr (create_descriptor_uses_mesh_dispatch_coordinate()) {
@@ -564,9 +565,9 @@ public:
                     // fast path covers cache hits even when the factory only sets
                     // `desc.cbs[i].buffer` and declares no rt-arg buffer bindings.
                     if (!sv.resolved_bindings.empty()) {
-                        auto current_buffers =
+                        auto collected =
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
-                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
+                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                     }
                     // The WorkloadDescriptor variant never rebuilds, so a value a custom hash
                     // excluded would stay frozen at first miss — re-apply declared dynamic args.
@@ -581,9 +582,9 @@ public:
                     // would leave those rt-args pointing at stale addresses.  Fall
                     // through to the slow-path rebuild instead.
                     if (!sv.resolved_bindings.rt_args.empty()) {
-                        auto current_buffers =
+                        auto collected =
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
-                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
+                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                         // Fast path doesn't rebuild the descriptor, so re-apply any declared dynamic
                         // non-Buffer runtime args (the slow-path else-branch below rebuilds
                         // create_descriptor() and so already re-derives them).

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -514,6 +514,29 @@ public:
             }
         }
 
+        // If the device operation declares dynamic (non-Buffer) runtime args via
+        // get_dynamic_runtime_args(), re-apply them to the cached program for this coordinate.
+        // These are values a custom compute_program_hash deliberately excluded from the cache key
+        // (e.g. an RNG seed, an [from,to) range, a semaphore address) and so must be patched on
+        // every fast-path cache hit — the non-Buffer analog of apply_resolved_bindings.  Ops that
+        // don't define the method compile this away (if constexpr) and pay nothing.
+        static void apply_dynamic_runtime_args_if_declared(
+            tt::tt_metal::Program& program,
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value,
+            const ttnn::MeshCoordinateRange& coordinate_range) {
+            if constexpr (requires {
+                              DeviceOperation::get_dynamic_runtime_args(
+                                  attrs, tensor_args, tensor_return_value, std::optional<ttnn::MeshCoordinate>{});
+                          }) {
+                const std::optional<ttnn::MeshCoordinate> coord(coordinate_range.start_coord());
+                const auto dynamic_args =
+                    DeviceOperation::get_dynamic_runtime_args(attrs, tensor_args, tensor_return_value, coord);
+                tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
+            }
+        }
+
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& attrs,
@@ -534,6 +557,10 @@ public:
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
                     }
+                    // Contract (2) never rebuilds, so any value a custom hash excluded would stay
+                    // frozen at first miss — re-apply declared dynamic non-Buffer runtime args.
+                    apply_dynamic_runtime_args_if_declared(
+                        program, attrs, tensor_args, tensor_return_value, coordinate_range);
                 } else {
                     // Contract (1) — simple per-coord factory.  Fast-path only
                     // when the factory declared rt-arg buffer bindings via
@@ -546,6 +573,11 @@ public:
                         auto current_buffers =
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, current_buffers);
+                        // Fast path doesn't rebuild the descriptor, so re-apply any declared dynamic
+                        // non-Buffer runtime args (the slow-path else-branch below rebuilds
+                        // create_descriptor() and so already re-derives them).
+                        apply_dynamic_runtime_args_if_declared(
+                            program, attrs, tensor_args, tensor_return_value, coordinate_range);
                     } else {
                         const ttnn::MeshCoordinate mesh_coord = coordinate_range.start_coord();
                         const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(mesh_coord);

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -62,16 +62,6 @@ BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    return ttsl::hash::hash_objects_with_default_seed(
-        ttsl::hash::type_hash<BernoulliDeviceOperation>,
-        attrs.dtype,
-        attrs.memory_config,
-        attrs.compute_kernel_config,
-        tensor_args);
-}
-
 }  // namespace ttnn::operations::bernoulli
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <optional>
+#include <vector>
+
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/types.hpp"
+#include "ttnn/distributed/types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::bernoulli {
 
@@ -38,6 +43,15 @@ struct BernoulliDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // seed is excluded from compute_program_hash (so calls differing only in seed cache-hit); it is
+    // DYNAMIC and re-applied to the cached program on every dispatch. Must mirror the compute-kernel
+    // seed runtime arg built in create_descriptor().
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -22,6 +22,11 @@ struct BernoulliDeviceOperation {
         const DataType dtype;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
+
+        // seed is re-applied via get_dynamic_runtime_args, so it's excluded from the hash.
+        // Shape/device come from the input tensor (tensor_args).
+        static constexpr auto attribute_names = std::forward_as_tuple("dtype", "memory_config", "compute_kernel_config");
+        auto attribute_values() const { return std::forward_as_tuple(dtype, memory_config, compute_kernel_config); }
     };
 
     struct tensor_args_t {
@@ -42,9 +47,7 @@ struct BernoulliDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed is excluded from compute_program_hash (so calls differing only in seed cache-hit); it is
+    // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch. Must mirror the compute-kernel
     // seed runtime arg built in create_descriptor().
     static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -50,7 +50,7 @@ struct BernoulliDeviceOperation {
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch. Must mirror the compute-kernel
     // seed runtime arg built in create_descriptor().
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -50,7 +50,7 @@ struct BernoulliDeviceOperation {
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch. Must mirror the compute-kernel
     // seed runtime arg built in create_descriptor().
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -25,12 +25,12 @@ uint32_t get_random_seed() { return dist(rng); }
 
 // Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit).
 struct BernoulliWorkSplit {
-    uint32_t num_cores;
+    uint32_t num_cores = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
-    uint32_t units_per_core_group_1;
-    uint32_t units_per_core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
     std::vector<CoreCoord> cores;
 };
 
@@ -200,7 +200,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -210,7 +210,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynam
     constexpr uint32_t kComputeKernelIdx = 2;
     auto cores = bernoulli_work_split(output).cores;
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(cores.size());
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -200,7 +200,7 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     return desc;
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -210,7 +210,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get
     constexpr uint32_t kComputeKernelIdx = 2;
     auto cores = bernoulli_work_split(output).cores;
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(cores.size());
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -158,15 +158,17 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
             TT_THROW("Core not in specified core ranges");
         }
 
-        reader_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{input.buffer()->address(), tile_offset, units_per_core});
+        // Register input/output addresses as Buffer* bindings so bernoulli takes the fast
+        // cache-hit path (the framework patches their addresses each dispatch).
+        reader_desc.emplace_runtime_args(core, {input.buffer(), tile_offset, units_per_core});
 
+        // seed is DYNAMIC (excluded from compute_program_hash): baked here for the cache-miss
+        // build, re-applied on every cache hit via get_dynamic_runtime_args().
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, tile_offset, units_per_core});
 
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{output.buffer()->address(), tile_offset, units_per_core});
+        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
@@ -176,6 +178,34 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     desc.kernels.push_back(std::move(compute_desc));
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // MUST mirror create_descriptor(): kernels are pushed reader(0), writer(1), compute(2); the
+    // compute runtime args are {seed, tile_offset, units_per_core}.  Only the per-call seed is
+    // re-applied.  The work-split is recomputed (cheap host-side integer math, no rebuild) so the
+    // per-core seed offsets match create_descriptor() exactly.
+    constexpr uint32_t kComputeKernelIdx = 2;
+
+    IDevice* device = output.device();
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    [[maybe_unused]] auto
+        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+            split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size());
+    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
+        const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+        dynamic_args.push_back({kComputeKernelIdx, cores[i], 0, seed});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -22,6 +22,33 @@ namespace {
 std::mt19937 rng(std::time(nullptr));
 std::uniform_int_distribution<uint32_t> dist(1, 1 << 20);
 uint32_t get_random_seed() { return dist(rng); }
+
+// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit).
+struct BernoulliWorkSplit {
+    uint32_t num_cores;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1;
+    uint32_t units_per_core_group_2;
+    std::vector<CoreCoord> cores;
+};
+
+BernoulliWorkSplit bernoulli_work_split(const Tensor& output) {
+    auto grid = output.device()->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    return {
+        num_cores,
+        all_cores,
+        core_group_1,
+        core_group_2,
+        units_per_core_group_1,
+        units_per_core_group_2,
+        std::move(cores)};
+}
 }  // namespace
 
 ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
@@ -31,15 +58,8 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     const Tensor& input = tensor_args.input;
 
     IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-        split_work_to_cores(grid, units_to_divide);
-
-    uint32_t num_cores_x = grid.x;
-    uint32_t num_cores_y = grid.y;
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y);
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2, cores] =
+        bernoulli_work_split(output);
 
     // ---- Circular buffers ----
 
@@ -185,19 +205,10 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynam
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // MUST mirror create_descriptor(): kernels are pushed reader(0), writer(1), compute(2); the
-    // compute runtime args are {seed, tile_offset, units_per_core}.  Only the per-call seed is
-    // re-applied.  The work-split is recomputed (cheap host-side integer math, no rebuild) so the
-    // per-core seed offsets match create_descriptor() exactly.
+    // compute is kernel 2 (reader 0, writer 1); its args are {seed, tile_offset, units_per_core}.
+    // Only the per-call seed is re-applied.
     constexpr uint32_t kComputeKernelIdx = 2;
-
-    IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    [[maybe_unused]] auto
-        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-            split_work_to_cores(grid, units_to_divide);
-    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    auto cores = bernoulli_work_split(output).cores;
 
     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(cores.size());

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -548,6 +548,10 @@ Tensor TernaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor_a.device());
 }
 
+// Kept (not attribute_names): coarsens the input to its VOLUME (ternary is elementwise — program
+// depends on tile count, not shape). attribute_names can't express that — it only controls the attrs
+// struct, while the input shape is hashed from tensor_args. scalar_input_a/b are excluded here and
+// re-applied via get_dynamic_runtime_args.
 ttsl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_a = tensor_args.input_tensor_a;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <optional>
+#include <vector>
+
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::ternary {
 
@@ -54,6 +59,13 @@ struct TernaryDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
+    // scalar_input_a/b are excluded from the hash; re-applied each dispatch. Mirrors the factory.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -61,7 +61,7 @@ struct TernaryDeviceOperation {
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // scalar_input_a/b are excluded from the hash; re-applied each dispatch. Mirrors the factory.
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -61,7 +61,7 @@ struct TernaryDeviceOperation {
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // scalar_input_a/b are excluded from the hash; re-applied each dispatch. Mirrors the factory.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -525,7 +525,7 @@ struct TernaryCorePartition {
     uint32_t num_cores_total = 0;
     bool has_sharding = false;
     bool zero_start_grid = false;
-    CoreCoord compute_with_storage_grid{};
+    CoreCoord compute_with_storage_grid;
     uint32_t num_tiles_per_core_group_1 = 0;
     uint32_t num_tiles_per_core_group_2 = 0;
     bool row_major = true;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1382,7 +1382,7 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
@@ -1406,7 +1406,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic
 
     auto partition = CMAKE_UNIQUE_NAMESPACE::compute_core_partition(operation_attributes, tensor_args, output);
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(partition.cores.size());
     for (uint32_t i = 0; i < partition.num_cores_total; ++i) {
         const auto& core = partition.cores[i];

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -517,6 +517,116 @@ void setup_ts_reader_args_and_dims(
     }
 }
 
+// Shared work-split so create_descriptor() and get_dynamic_runtime_args() patch the same cores.
+struct TernaryCorePartition {
+    std::vector<CoreCoord> cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t num_cores_total = 0;
+    bool has_sharding = false;
+    bool zero_start_grid = false;
+    CoreCoord compute_with_storage_grid{};
+    uint32_t num_tiles_per_core_group_1 = 0;
+    uint32_t num_tiles_per_core_group_2 = 0;
+    bool row_major = true;
+};
+
+TernaryCorePartition compute_core_partition(
+    const TernaryDeviceOperation::operation_attributes_t& operation_attributes,
+    const TernaryDeviceOperation::tensor_args_t& tensor_args,
+    TernaryDeviceOperation::tensor_return_value_t& output) {
+    const auto& [predicate_tensor, value_true_tensor, value_false_tensor, optional_output_tensor] = tensor_args;
+    uint32_t num_output_tiles = output.physical_volume() / output.tensor_spec().tile().get_tile_hw();
+
+    TernaryCorePartition p;
+
+    // Get shard specs early
+    const auto shard_specs = get_shard_specs(
+        predicate_tensor.tensor_spec(),
+        value_true_tensor.has_value() ? value_true_tensor->tensor_spec() : std::optional<TensorSpec>{},
+        value_false_tensor.has_value() ? value_false_tensor->tensor_spec() : std::optional<TensorSpec>{},
+        output.tensor_spec());
+    p.has_sharding = shard_specs.has_value();
+    auto grid = p.has_sharding ? shard_specs->predicate_shard_spec.grid : CoreRangeSet{};
+
+    p.row_major = p.has_sharding ? shard_specs->predicate_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
+
+    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
+    // as well as having the sharded tensors (if any) start at (0, 0)
+    const auto& all_device_cores = operation_attributes.worker_grid;
+    if (grid.size() == 1) {
+        const auto& cr = *all_device_cores.ranges().begin();
+        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
+            if (p.has_sharding) {
+                const auto& shard_start_coord = grid.ranges()[0].start_coord;
+                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
+                    p.zero_start_grid = true;
+                    p.compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+                }
+            } else {
+                p.zero_start_grid = true;
+                p.compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
+            }
+        }
+    }
+    p.num_cores_total = p.zero_start_grid ? p.compute_with_storage_grid.x * p.compute_with_storage_grid.y
+                                          : all_device_cores.num_cores();
+
+    uint32_t num_cores;
+    CoreRangeSet all_cores;
+    if (p.has_sharding) {
+        p.core_group_1 = grid;
+        if (p.zero_start_grid) {
+            auto bbox = p.core_group_1.bounding_box();
+            p.cores = grid_to_cores_with_noop(
+                bbox.end_coord.x,
+                bbox.end_coord.y,
+                p.compute_with_storage_grid.x,
+                p.compute_with_storage_grid.y,
+                p.row_major);
+        } else {
+            p.cores = grid_to_cores_with_noop(p.core_group_1, all_device_cores, p.row_major);
+        }
+    } else if (p.zero_start_grid) {
+        std::tie(
+            num_cores,
+            all_cores,
+            p.core_group_1,
+            p.core_group_2,
+            p.num_tiles_per_core_group_1,
+            p.num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(p.compute_with_storage_grid, num_output_tiles, p.row_major);
+        p.cores =
+            grid_to_cores(p.num_cores_total, p.compute_with_storage_grid.x, p.compute_with_storage_grid.y, p.row_major);
+    } else {
+        std::tie(
+            num_cores,
+            all_cores,
+            p.core_group_1,
+            p.core_group_2,
+            p.num_tiles_per_core_group_1,
+            p.num_tiles_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(all_device_cores, num_output_tiles, p.row_major);
+        p.cores = corerange_to_cores(all_device_cores, {}, p.row_major);
+    }
+    return p;
+}
+
+// Single source of truth for packing the (hash-excluded, dynamic) compute-kernel scalar arg.
+uint32_t pack_compute_scalar_arg(
+    const TernaryDeviceOperation::operation_attributes_t& operation_attributes, DataType output_dtype) {
+    TernaryVariant variant = operation_attributes.ternary_variant;
+    if (variant == TernaryVariant::TTS) {
+        return pack_scalar_runtime_arg(operation_attributes.scalar_input_b.value(), output_dtype);
+    }
+    if (variant == TernaryVariant::TST || ((operation_attributes.ternary_op_type == TernaryOpType::ADDCMUL ||
+                                            operation_attributes.ternary_op_type == TernaryOpType::ADDCDIV) &&
+                                           operation_attributes.scalar_input_a.has_value())) {
+        return pack_scalar_runtime_arg(operation_attributes.scalar_input_a.value(), output_dtype);
+    }
+    return 0u;
+}
+
 void populate_runtime_arguments(
     KernelDescriptor& reader_desc,
     KernelDescriptor& writer_desc,
@@ -527,47 +637,15 @@ void populate_runtime_arguments(
     ttnn::operations::ternary::TernaryBroadcastType broadcast_type) {
     const auto& [predicate_tensor, value_true_tensor, value_false_tensor, optional_output_tensor] = tensor_args;
     TernaryVariant variant = operation_attributes.ternary_variant;
-    uint32_t num_output_tiles = output.physical_volume() / output.tensor_spec().tile().get_tile_hw();
 
-    // Get shard specs early
-    const auto shard_specs = get_shard_specs(
-        predicate_tensor.tensor_spec(),
-        value_true_tensor.has_value() ? value_true_tensor->tensor_spec() : std::optional<TensorSpec>{},
-        value_false_tensor.has_value() ? value_false_tensor->tensor_spec() : std::optional<TensorSpec>{},
-        output.tensor_spec());
-    const bool has_sharding = shard_specs.has_value();
-    auto grid = has_sharding ? shard_specs->predicate_shard_spec.grid : CoreRangeSet{};
-
-    const auto row_major =
-        has_sharding ? shard_specs->predicate_shard_spec.orientation == ShardOrientation::ROW_MAJOR : true;
-
-    // zero_start_grid is a flag to indicate that we are using a single rectangular grid that starts at (0, 0)
-    // as well as having the sharded tensors (if any) start at (0, 0)
-    bool zero_start_grid = false;
-    CoreCoord compute_with_storage_grid;
-    const auto& all_device_cores = operation_attributes.worker_grid;
-    if (grid.size() == 1) {
-        const auto& cr = *all_device_cores.ranges().begin();
-        if (cr.start_coord.x == 0 && cr.start_coord.y == 0) {
-            if (has_sharding) {
-                const auto& shard_start_coord = grid.ranges()[0].start_coord;
-                if (shard_start_coord.x == 0 && shard_start_coord.y == 0) {
-                    zero_start_grid = true;
-                    compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-                }
-            } else {
-                zero_start_grid = true;
-                compute_with_storage_grid = CoreCoord(cr.end_coord.x + 1, cr.end_coord.y + 1);
-            }
-        }
-    }
-    const uint32_t num_cores_total =
-        zero_start_grid ? compute_with_storage_grid.x * compute_with_storage_grid.y : all_device_cores.num_cores();
-
-    uint32_t num_tiles_per_core_group_1{}, num_tiles_per_core_group_2{};
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-    uint32_t num_cores;
-    std::vector<CoreCoord> cores;
+    auto partition = compute_core_partition(operation_attributes, tensor_args, output);
+    const auto& cores = partition.cores;
+    const auto& core_group_1 = partition.core_group_1;
+    const auto& core_group_2 = partition.core_group_2;
+    const uint32_t num_cores_total = partition.num_cores_total;
+    const bool has_sharding = partition.has_sharding;
+    const uint32_t num_tiles_per_core_group_1 = partition.num_tiles_per_core_group_1;
+    const uint32_t num_tiles_per_core_group_2 = partition.num_tiles_per_core_group_2;
 
     const uint32_t tile_height = output.tensor_spec().tile().get_height();
     const uint32_t tile_width = output.tensor_spec().tile().get_width();
@@ -579,7 +657,13 @@ void populate_runtime_arguments(
     ShardShapeGenerator output_shard_shape_generator;
 
     if (has_sharding) {
-        core_group_1 = grid;
+        // Re-derive the shard specs only for the per-core shard-shape generators (the core list /
+        // work-split partition was already produced by compute_core_partition above).
+        const auto shard_specs = get_shard_specs(
+            predicate_tensor.tensor_spec(),
+            value_true_tensor.has_value() ? value_true_tensor->tensor_spec() : std::optional<TensorSpec>{},
+            value_false_tensor.has_value() ? value_false_tensor->tensor_spec() : std::optional<TensorSpec>{},
+            output.tensor_spec());
         predicate_shard_shape_generator = ShardShapeGenerator(shard_specs->predicate_shard_spec, predicate_tensor);
         if (value_true_tensor.has_value()) {
             true_shard_shape_generator = ShardShapeGenerator(shard_specs->true_shard_spec, *value_true_tensor);
@@ -593,28 +677,6 @@ void populate_runtime_arguments(
         num_shards_per_width = get_shards_per_width(
             shard_specs->output_shard_spec,
             get_memory_layout(predicate_tensor, value_true_tensor, value_false_tensor, output));
-
-        if (zero_start_grid) {
-            auto bbox = core_group_1.bounding_box();
-            cores = grid_to_cores_with_noop(
-                bbox.end_coord.x,
-                bbox.end_coord.y,
-                compute_with_storage_grid.x,
-                compute_with_storage_grid.y,
-                row_major);
-        } else {
-            cores = grid_to_cores_with_noop(core_group_1, all_device_cores, row_major);
-        }
-    } else if (zero_start_grid) {
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid, num_output_tiles, row_major);
-        cores = grid_to_cores(num_cores_total, compute_with_storage_grid.x, compute_with_storage_grid.y, row_major);
-    } else {
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(all_device_cores, num_output_tiles, row_major);
-        cores = corerange_to_cores(all_device_cores, {}, row_major);
     }
     constexpr size_t num_reader_args = 27;
     constexpr size_t num_writer_args = 11;
@@ -690,7 +752,17 @@ void populate_runtime_arguments(
                 out_rank,
                 tile_h,
                 tile_w);
-            reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+            // Register the buffer base addresses (slots 0 and 1) as Buffer* bindings so the
+            // descriptor takes the fast cache-hit path (real program caching) with the addresses
+            // re-patched each dispatch.  Slot 2 (scalar operand) stays a plain 0 for TTS/TST.
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.reserve(num_reader_args);
+            reader_args.push_back(predicate_tensor.buffer());  // 0: src0_addr (predicate)
+            reader_args.push_back(tensor_operand.buffer());    // 1: src1_addr (tensor operand)
+            for (size_t k = 2; k < num_reader_args; ++k) {
+                reader_args.push_back(reader_runtime_args[k]);
+            }
+            reader_desc.emplace_runtime_args(core, reader_args);
         } else if (variant == TernaryVariant::TTT) {
             auto pred_dims = extract_tensor_dimensions(predicate_tensor, out_rank, tile_h, tile_w);
             auto true_dims = extract_tensor_dimensions(value_true_tensor.value(), out_rank, tile_h, tile_w);
@@ -729,37 +801,43 @@ void populate_runtime_arguments(
             reader_runtime_args[25] = c_current_shard_width;    // 25: dst_shard_width
             reader_runtime_args[26] = a_num_tiles;              // 26: src_num_tiles (predicate)
 
-            reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+            // Register the three buffer base addresses (slots 0,1,2) as Buffer* bindings so the
+            // descriptor takes the fast cache-hit path with the addresses re-patched each dispatch.
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.reserve(num_reader_args);
+            reader_args.push_back(predicate_tensor.buffer());            // 0: src0_addr (predicate)
+            reader_args.push_back(value_true_tensor.value().buffer());   // 1: src1_addr (true tensor)
+            reader_args.push_back(value_false_tensor.value().buffer());  // 2: src2_addr (false tensor)
+            for (size_t k = 3; k < num_reader_args; ++k) {
+                reader_args.push_back(reader_runtime_args[k]);
+            }
+            reader_desc.emplace_runtime_args(core, reader_args);
         } else {
             TT_FATAL(false, "Unsupported Where variant in TernaryDeviceOperation. Supported: TTS, TST, TTT");
         }
 
-        // Writer runtime args
-        std::array writer_runtime_args = {
-            output.buffer()->address(),  // 0: dst_addr
-            num_tiles_per_core,          // 1: num_tiles
-            c_start_id,                  // 2: start_id
-            c_current_shard_width,       // 3: dst_shard_width
-            output_dims.D,               // 4: D
-            output_dims.N,               // 5: N
-            output_dims.C,               // 6: C
-            output_dims.Ht,              // 7: Ht
-            output_dims.Wt,              // 8: Wt
-            output_dims.ND,              // 9: cND
-            0u                           // 10: padding
-        };
-        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+        // Writer runtime args.  Register the output base address (slot 0) as a Buffer* binding so
+        // the descriptor takes the fast cache-hit path with the address re-patched each dispatch.
+        // The framework allows the output buffer to alias an input (in-place ops).
+        KernelDescriptor::RTArgList writer_args;
+        writer_args.reserve(num_writer_args);
+        writer_args.push_back(output.buffer());        // 0: dst_addr
+        writer_args.push_back(num_tiles_per_core);     // 1: num_tiles
+        writer_args.push_back(c_start_id);             // 2: start_id
+        writer_args.push_back(c_current_shard_width);  // 3: dst_shard_width
+        writer_args.push_back(output_dims.D);          // 4: D
+        writer_args.push_back(output_dims.N);          // 5: N
+        writer_args.push_back(output_dims.C);          // 6: C
+        writer_args.push_back(output_dims.Ht);         // 7: Ht
+        writer_args.push_back(output_dims.Wt);         // 8: Wt
+        writer_args.push_back(output_dims.ND);         // 9: cND
+        writer_args.push_back(0u);                     // 10: padding
+        writer_desc.emplace_runtime_args(core, writer_args);
 
-        // Compute runtime args
-        uint32_t scalar_arg = 0u;
-        if (variant == TernaryVariant::TTS) {
-            scalar_arg = pack_scalar_runtime_arg(operation_attributes.scalar_input_b.value(), output.dtype());
-        } else if (
-            variant == TernaryVariant::TST || ((operation_attributes.ternary_op_type == TernaryOpType::ADDCMUL ||
-                                                operation_attributes.ternary_op_type == TernaryOpType::ADDCDIV) &&
-                                               operation_attributes.scalar_input_a.has_value())) {
-            scalar_arg = pack_scalar_runtime_arg(operation_attributes.scalar_input_a.value(), output.dtype());
-        }
+        // Compute runtime args.  scalar_arg is the packed scalar_input_a/scalar_input_b; it is
+        // EXCLUDED from compute_program_hash and therefore DYNAMIC -- re-applied on every cache hit
+        // via get_dynamic_runtime_args().  Packed here via the shared single-source-of-truth helper.
+        const uint32_t scalar_arg = pack_compute_scalar_arg(operation_attributes, output.dtype());
         auto [freq, counter] = [&] {
             switch (broadcast_type) {
                 case TernaryBroadcastType::ROW_COL_BCAST:
@@ -1302,6 +1380,43 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc));
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // scalar_input_a / scalar_input_b are EXCLUDED from compute_program_hash (so calls differing
+    // only in a scalar cache-hit instead of recompiling).  On a cache hit the descriptor is never
+    // rebuilt, so the scalar baked at first miss would otherwise stay frozen.  Re-apply it here.
+    //
+    // MUST mirror create_descriptor()/populate_runtime_arguments() exactly:
+    //   - kernels are pushed reader(0), writer(1), compute(2)  -> scalar lives in kernel 2.
+    //   - compute per-core runtime args are {num_tiles_per_core, freq, counter, scalar_arg}
+    //     -> scalar is arg_idx 3.
+    //   - the scalar is written only to WORK cores (core_group_1/core_group_2); noop cores get
+    //     all-zero compute args and do no work, so they are left untouched.
+    // The packed value and the (cores, work-group) partition both come from the same helpers used
+    // by populate_runtime_arguments(), so this stays a by-construction exact mirror.
+    constexpr uint32_t kComputeKernelIdx = 2;
+    constexpr uint32_t kScalarArgIdx = 3;
+
+    const uint32_t scalar_arg = CMAKE_UNIQUE_NAMESPACE::pack_compute_scalar_arg(operation_attributes, output.dtype());
+
+    auto partition = CMAKE_UNIQUE_NAMESPACE::compute_core_partition(operation_attributes, tensor_args, output);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(partition.cores.size());
+    for (uint32_t i = 0; i < partition.num_cores_total; ++i) {
+        const auto& core = partition.cores[i];
+        const bool is_work_core = partition.core_group_1.contains(core) || partition.core_group_2.contains(core);
+        if (!is_work_core) {
+            continue;  // noop core: compute arg[3] stays 0, mirrors create_descriptor()
+        }
+        dynamic_args.push_back({kComputeKernelIdx, core, kScalarArgIdx, scalar_arg});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1382,7 +1382,7 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     return desc;
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
@@ -1406,7 +1406,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_d
 
     auto partition = CMAKE_UNIQUE_NAMESPACE::compute_core_partition(operation_attributes, tensor_args, output);
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(partition.cores.size());
     for (uint32_t i = 0; i < partition.num_cores_total; ++i) {
         const auto& core = partition.cores[i];

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -33,9 +33,13 @@ struct DropoutDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
+    // Kept (not attribute_names): the hash coarsens the input to its VOLUME, since dropout is
+    // elementwise (program depends on tile count, not shape). attribute_names can't express that —
+    // it only controls the attrs struct, while the input shape is hashed from tensor_args. The seed
+    // it excludes is re-applied via get_dynamic_runtime_args below.
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // seed is excluded from compute_program_hash (so calls differing only in seed cache-hit); it is
+    // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
     // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.
     static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -42,7 +42,7 @@ struct DropoutDeviceOperation {
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
     // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -42,7 +42,7 @@ struct DropoutDeviceOperation {
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
     // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& args,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -6,12 +6,14 @@
 
 #include <optional>
 #include <variant>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "dropout_program_factory.hpp"
 
 #include "dropout_device_operation_types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn::experimental::prim {
@@ -32,6 +34,15 @@ struct DropoutDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // seed is excluded from compute_program_hash (so calls differing only in seed cache-hit); it is
+    // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
+    // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& args,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -344,7 +344,7 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& /*output*/,
@@ -369,7 +369,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_d
     constexpr uint32_t kComputeGroup1Idx = 2;
     constexpr uint32_t kComputeGroup2Idx = 3;
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -145,13 +145,13 @@ inline tt::tt_metal::KernelDescriptor create_compute_kernel(
  */
 // Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit).
 struct DropoutCoreSplit {
-    uint32_t num_cores;
-    uint32_t num_cores_y;
+    uint32_t num_cores = 0;
+    uint32_t num_cores_y = 0;
     tt::tt_metal::CoreRangeSet all_cores;
     tt::tt_metal::CoreRangeSet core_group_1;
     tt::tt_metal::CoreRangeSet core_group_2;
-    uint32_t num_tiles_per_core_group_1;
-    uint32_t num_tiles_per_core_group_2;
+    uint32_t num_tiles_per_core_group_1 = 0;
+    uint32_t num_tiles_per_core_group_2 = 0;
 };
 
 DropoutCoreSplit dropout_core_split(const Tensor& input) {
@@ -344,7 +344,7 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& /*output*/,
@@ -369,7 +369,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic
     constexpr uint32_t kComputeGroup1Idx = 2;
     constexpr uint32_t kComputeGroup2Idx = 3;
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(num_cores);
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -145,8 +145,8 @@ inline tt::tt_metal::KernelDescriptor create_compute_kernel(
  */
 inline void assign_per_core_runtime_args(
     DropoutKernels& kernels,
-    const tt::tt_metal::Buffer* src_buffer,
-    const tt::tt_metal::Buffer* dst_buffer,
+    tt::tt_metal::Buffer* src_buffer,
+    tt::tt_metal::Buffer* dst_buffer,
     uint32_t num_cores,
     uint32_t num_cores_y,
     uint32_t num_tiles_per_core_group_1,
@@ -184,13 +184,13 @@ inline void assign_per_core_runtime_args(
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
-        // Reader kernel: (src_addr, number_of_tiles, offset_in_tiles)
-        kernels.reader.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{src_buffer->address(), num_tiles_per_core, num_tiles_written});
+        // Reader kernel: (src_addr, number_of_tiles, offset_in_tiles).  src/dst go in as Buffer*
+        // bindings so the framework patches their addresses on the fast cache-hit path (the
+        // input==output in-place case is allowed by resolve_bindings).
+        kernels.reader.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, num_tiles_written});
 
         // Writer kernel: (dst_addr, number_of_tiles, offset_in_tiles)
-        kernels.writer.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        kernels.writer.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
 
         num_tiles_written += num_tiles_per_core;
     }
@@ -316,6 +316,44 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
     const auto effective_args = override_per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input);
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*output*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    using namespace tt::tt_metal;
+
+    // seed is the only dynamic arg (prob/scale are compile-time); per-device path offsets by device id.
+    const uint32_t seed = args.use_per_device_seed
+                              ? override_per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input).seed
+                              : args.seed;
+
+    const auto& input = tensor_args.input;
+    auto* device = input.device();
+    uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t num_cores_y = grid.y;
+    [[maybe_unused]] auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+            split_work_to_cores(grid, num_tiles);
+
+    // kernels are pushed reader(0), writer(1), compute_group_1(2), compute_group_2(3 if present).
+    constexpr uint32_t kComputeGroup1Idx = 2;
+    constexpr uint32_t kComputeGroup2Idx = 3;
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(num_cores);
+    for (uint32_t i = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        if (core_group_1.contains(core)) {
+            dynamic_args.push_back({kComputeGroup1Idx, core, 0, seed});
+        } else if (core_group_2.contains(core)) {
+            dynamic_args.push_back({kComputeGroup2Idx, core, 0, seed});
+        }
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -143,6 +143,32 @@ inline tt::tt_metal::KernelDescriptor create_compute_kernel(
  * Set up the runtime arguments for the relevant kernels (reader, writer, compute G1, compute G2)
  *        for each core in the grid.
  */
+// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit).
+struct DropoutCoreSplit {
+    uint32_t num_cores;
+    uint32_t num_cores_y;
+    tt::tt_metal::CoreRangeSet all_cores;
+    tt::tt_metal::CoreRangeSet core_group_1;
+    tt::tt_metal::CoreRangeSet core_group_2;
+    uint32_t num_tiles_per_core_group_1;
+    uint32_t num_tiles_per_core_group_2;
+};
+
+DropoutCoreSplit dropout_core_split(const Tensor& input) {
+    auto grid = input.device()->compute_with_storage_grid_size();
+    uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(grid, num_tiles);
+    return {
+        num_cores,
+        grid.y,
+        all_cores,
+        core_group_1,
+        core_group_2,
+        num_tiles_per_core_group_1,
+        num_tiles_per_core_group_2};
+}
+
 inline void assign_per_core_runtime_args(
     DropoutKernels& kernels,
     tt::tt_metal::Buffer* src_buffer,
@@ -205,7 +231,6 @@ tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     // 1) Setup device, data formats, tile sizes, and compute split
     // -------------------------------------------------------------------------
     const auto& input = tensor_args.input;
-    auto* device = input.device();
 
     ProgramDescriptor descriptor{};
 
@@ -215,13 +240,14 @@ tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     uint32_t single_tile_size_in = tt::tile_size(data_fmt_in);
     uint32_t single_tile_size_out = tt::tile_size(data_fmt_out);
 
-    uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+    auto
+        [num_cores,
+         num_cores_y,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_tiles_per_core_group_1,
+         num_tiles_per_core_group_2] = dropout_core_split(input);
 
     // -------------------------------------------------------------------------
     // 2) Create and configure circular buffers
@@ -330,14 +356,14 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic
                               ? override_per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input).seed
                               : args.seed;
 
-    const auto& input = tensor_args.input;
-    auto* device = input.device();
-    uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
-    auto grid = device->compute_with_storage_grid_size();
-    uint32_t num_cores_y = grid.y;
     [[maybe_unused]] auto
-        [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-            split_work_to_cores(grid, num_tiles);
+        [num_cores,
+         num_cores_y,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_tiles_per_core_group_1,
+         num_tiles_per_core_group_2] = dropout_core_split(tensor_args.input);
 
     // kernels are pushed reader(0), writer(1), compute_group_1(2), compute_group_2(3 if present).
     constexpr uint32_t kComputeGroup1Idx = 2;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -158,7 +158,7 @@ DropoutCoreSplit dropout_core_split(const Tensor& input) {
     auto grid = input.device()->compute_with_storage_grid_size();
     uint32_t num_tiles = input.physical_volume() / tt::constants::TILE_HW;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(grid, num_tiles);
+        tt::tt_metal::split_work_to_cores(grid, num_tiles);
     return {
         num_cores,
         grid.y,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.cpp
@@ -130,14 +130,6 @@ MorehAdamWDeviceOperation::tensor_return_value_t MorehAdamWDeviceOperation::crea
 
     return result;
 }
-
-ttsl::hash::hash_t MorehAdamWDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto operation_attributes_without_step_and_lr = operation_attributes;
-    operation_attributes_without_step_and_lr.step = 0;
-    operation_attributes_without_step_and_lr.lr = 0.0f;
-    return ttsl::hash::hash_objects_with_default_seed(operation_attributes_without_step_and_lr, tensor_args);
-}
 }  // namespace ttnn::operations::moreh::moreh_adamw
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -5,12 +5,14 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::moreh::moreh_adamw {
 
@@ -25,6 +27,17 @@ struct MorehAdamWDeviceOperation {
         bool amsgrad = false;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
+
+        // lr and step are excluded from the program hash (they vary every optimizer step, so
+        // hashing them would recompile every call); they are re-applied on each cache hit via
+        // get_dynamic_runtime_args(). beta1/beta2/eps/weight_decay are rarely-varying
+        // hyperparameters and stay in the hash.
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "beta1", "beta2", "eps", "weight_decay", "amsgrad", "memory_config", "compute_kernel_config");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                beta1, beta2, eps, weight_decay, amsgrad, memory_config, compute_kernel_config);
+        }
     };
 
     struct tensor_args_t {
@@ -58,7 +71,15 @@ struct MorehAdamWDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    // lr/step (and the step-derived beta1/beta2 exponents) are excluded from the hash, so they
+    // must be re-applied to the cached program on every fast-path cache hit. Mirrors the reader and
+    // compute runtime args built in create_descriptor() — test_moreh_adamw_cache enforces it (it
+    // fails outright if step/lr stay frozen across the cache-hit steps).
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 }  // namespace ttnn::operations::moreh::moreh_adamw
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -75,7 +75,7 @@ struct MorehAdamWDeviceOperation {
     // must be re-applied to the cached program on every fast-path cache hit. Mirrors the reader and
     // compute runtime args built in create_descriptor() — test_moreh_adamw_cache enforces it (it
     // fails outright if step/lr stay frozen across the cache-hit steps).
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -75,7 +75,7 @@ struct MorehAdamWDeviceOperation {
     // must be re-applied to the cached program on every fast-path cache hit. Mirrors the reader and
     // compute runtime args built in create_descriptor() — test_moreh_adamw_cache enforces it (it
     // fails outright if step/lr stay frozen across the cache-hit steps).
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -27,13 +27,13 @@ namespace {
 // Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
 // both derive the identical core list and group membership.
 struct AdamwWorkSplit {
-    uint32_t num_cores;
-    uint32_t num_cores_y;
+    uint32_t num_cores = 0;
+    uint32_t num_cores_y = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
-    uint32_t num_units_per_core_group_1;
-    uint32_t num_units_per_core_group_2;
+    uint32_t num_units_per_core_group_1 = 0;
+    uint32_t num_units_per_core_group_2 = 0;
 };
 
 AdamwWorkSplit compute_adamw_work_split(const Tensor& param_in) {
@@ -348,7 +348,7 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& /*tensor_return_value*/,
@@ -370,7 +370,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dyna
 
     const auto ws = compute_adamw_work_split(tensor_args.param_in);
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(static_cast<size_t>(ws.num_cores) * 5);
     for (uint32_t i = 0; i < ws.num_cores; ++i) {
         const CoreCoord core = {i / ws.num_cores_y, i % ws.num_cores_y};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -348,7 +348,7 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     return desc;
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& /*tensor_return_value*/,
@@ -370,7 +370,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::ge
 
     const auto ws = compute_adamw_work_split(tensor_args.param_in);
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(static_cast<size_t>(ws.num_cores) * 5);
     for (uint32_t i = 0; i < ws.num_cores; ++i) {
         const CoreCoord core = {i / ws.num_cores_y, i % ws.num_cores_y};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -22,6 +22,37 @@ static constexpr const char* WRITER_KERNEL_PATH =
 static constexpr const char* COMPUTE_KERNEL_PATH =
     "ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/kernels/moreh_adamw.cpp";
 
+namespace {
+
+// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
+// both derive the identical core list and group membership.
+struct AdamwWorkSplit {
+    uint32_t num_cores;
+    uint32_t num_cores_y;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t num_units_per_core_group_1;
+    uint32_t num_units_per_core_group_2;
+};
+
+AdamwWorkSplit compute_adamw_work_split(const Tensor& param_in) {
+    auto grid = param_in.device()->compute_with_storage_grid_size();
+    uint32_t num_units = param_in.physical_volume() / tt::constants::TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+        split_work_to_cores(grid, num_units);
+    return {
+        num_cores,
+        grid.y,
+        all_cores,
+        core_group_1,
+        core_group_2,
+        num_units_per_core_group_1,
+        num_units_per_core_group_2};
+}
+
+}  // namespace
+
 ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -39,8 +70,6 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     uint32_t step = operation_attributes.step;
     bool amsgrad = operation_attributes.amsgrad;
 
-    uint32_t num_units = param_in.physical_volume() / tt::constants::TILE_HW;
-
     const std::optional<Tensor>& max_exp_avg_sq_in = tensor_args.max_exp_avg_sq_in;
 
     // It's guarantee that param_out, exp_avg_out, exp_avg_sq_out are created.
@@ -54,12 +83,14 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    IDevice* device = param_in.device();
-    auto grid = device->compute_with_storage_grid_size();
-    const auto num_cores_y = grid.y;
-
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
-        split_work_to_cores(grid, num_units);
+    const auto
+        [num_cores,
+         num_cores_y,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_units_per_core_group_1,
+         num_units_per_core_group_2] = compute_adamw_work_split(param_in);
 
     auto arch = param_in.device()->arch();
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
@@ -315,6 +346,42 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     }
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Kernel layout from create_descriptor: reader=0, writer=1, compute(group_1)=2, compute(group_2)=3.
+    // The reader bakes lr (arg 5) and the step-derived beta1/beta2 exponents (args 10/11) and step
+    // (arg 12); each compute kernel bakes step (arg 0). lr/step are excluded from the hash, so these
+    // must be re-applied on every cache hit. beta1/beta2/eps/weight_decay are hashed (static).
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kComputeGroup1KernelIdx = 2;
+    constexpr uint32_t kComputeGroup2KernelIdx = 3;
+
+    const uint32_t step = operation_attributes.step;
+    const float beta1_exponent = std::pow(operation_attributes.beta1, step);
+    const float beta2_exponent = std::pow(operation_attributes.beta2, step);
+    const uint32_t f2u_lr = std::bit_cast<uint32_t>(operation_attributes.lr);
+    const uint32_t f2u_beta1_exponent = std::bit_cast<uint32_t>(beta1_exponent);
+    const uint32_t f2u_beta2_exponent = std::bit_cast<uint32_t>(beta2_exponent);
+
+    const auto ws = compute_adamw_work_split(tensor_args.param_in);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(static_cast<size_t>(ws.num_cores) * 5);
+    for (uint32_t i = 0; i < ws.num_cores; ++i) {
+        const CoreCoord core = {i / ws.num_cores_y, i % ws.num_cores_y};
+        dynamic_args.push_back({kReaderKernelIdx, core, 5, f2u_lr});
+        dynamic_args.push_back({kReaderKernelIdx, core, 10, f2u_beta1_exponent});
+        dynamic_args.push_back({kReaderKernelIdx, core, 11, f2u_beta2_exponent});
+        dynamic_args.push_back({kReaderKernelIdx, core, 12, step});
+        const uint32_t compute_idx = ws.core_group_1.contains(core) ? kComputeGroup1KernelIdx : kComputeGroup2KernelIdx;
+        dynamic_args.push_back({compute_idx, core, 0, step});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_adamw

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -41,15 +41,6 @@ RandDeviceOperation::tensor_return_value_t RandDeviceOperation::create_output_te
         operation_attributes.device);
 }
 
-ttsl::hash::hash_t RandDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
-    return tt::tt_metal::operation::hash_operation<RandDeviceOperation>(
-        operation_attributes.shape,
-        operation_attributes.dtype,
-        operation_attributes.layout,
-        operation_attributes.memory_config);
-}
-
 }  // namespace ttnn::operations::rand
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -57,7 +57,7 @@ struct RandDeviceOperation {
     // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
     // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
     // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -57,7 +57,7 @@ struct RandDeviceOperation {
     // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
     // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
     // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -26,6 +26,14 @@ struct RandDeviceOperation {
         const float to;
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
+
+        // Program identity. seed/from/to are re-applied via get_dynamic_runtime_args (excluded
+        // here). `device` must be FIRST: rand has no input tensor, so the framework discovers the
+        // mesh device via get_first_object_of_type over attribute_values(), and its tuple path only
+        // inspects element 0.
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
+        auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
     };
 
     struct tensor_args_t {};
@@ -43,9 +51,8 @@ struct RandDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // seed/from/to are intentionally excluded from compute_program_hash (so calls differing only in
+    // seed/from/to are excluded from the program hash (so calls differing only in
     // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
     // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
     // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -6,9 +6,12 @@
 
 #include <optional>
 
+#include <vector>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::rand {
 
@@ -41,6 +44,17 @@ struct RandDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // seed/from/to are intentionally excluded from compute_program_hash (so calls differing only in
+    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
+    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
+    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
+    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -134,7 +134,6 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-    const uint32_t output_addr = output.buffer()->address();
 
     uint32_t tile_offset = 0;
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
@@ -151,11 +150,14 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
         uint32_t seed =
             operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset : get_random_seed();
 
+        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
+        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
 
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
+        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
+        // (real program caching) with the address correctly re-patched each dispatch.
+        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
@@ -164,6 +166,69 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     desc.kernels.push_back(std::move(compute_desc));
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    // MUST mirror the seed/from/to runtime args produced in create_descriptor() above:
+    //   - writer is pushed as kernel index 0, compute as kernel index 1
+    //   - compute runtime args layout is {seed, from_bits, to_bits, tile_offset, units_per_core}
+    // Only the per-call values (seed, from, to) are re-applied here; the structural args
+    // (tile_offset, units_per_core) are part of the program identity and never change for a given
+    // cache entry.  The work-split is recomputed (cheap host-side integer math, no kernel rebuild)
+    // so the per-core seed offsets match create_descriptor() exactly.  The
+    // test_rand_different_seed_values regression test enforces this mirror.
+    constexpr uint32_t kComputeKernelIdx = 1;
+    constexpr uint32_t kSeedArgIdx = 0;
+    constexpr uint32_t kFromArgIdx = 1;
+    constexpr uint32_t kToArgIdx = 2;
+
+    IDevice* device = output.device();
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    // Only the core count/list matter here (per-core seed offsets); the work-split groups and
+    // per-group tile counts are part of the static program identity and are not re-applied.
+    [[maybe_unused]] auto
+        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+            split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+
+    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value_or(
+        ttnn::MeshCoordinate::zero_coordinate(operation_attributes.device->shape().dims()));
+
+    uint32_t device_seed_offset = 0;
+    const auto& shard_mask = operation_attributes.mesh_dim_is_sharded;
+    if (!shard_mask.empty()) {
+        const auto& mesh_shape = operation_attributes.device->shape();
+        size_t shard_linear_idx = 0;
+        size_t shard_stride = 1;
+        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
+            if (shard_mask[i]) {
+                shard_linear_idx += mesh_coordinate[i] * shard_stride;
+                shard_stride *= mesh_shape[i];
+            }
+        }
+        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
+    }
+
+    const float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * 3);
+    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
+        const auto& core = cores[i];
+        const uint32_t seed =
+            operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset : get_random_seed();
+        dynamic_args.push_back({kComputeKernelIdx, core, kSeedArgIdx, seed});
+        dynamic_args.push_back({kComputeKernelIdx, core, kFromArgIdx, from_bits});
+        dynamic_args.push_back({kComputeKernelIdx, core, kToArgIdx, to_bits});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -206,7 +206,7 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     return desc;
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -220,7 +220,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dyna
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(ws.cores.size() * 3);
     for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -30,14 +30,14 @@ constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/devic
 // Work split + per-device seed offset, shared by create_descriptor (cache miss) and
 // get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
 struct RandWorkSplit {
-    uint32_t num_cores;
+    uint32_t num_cores = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
-    uint32_t units_per_core_group_1;
-    uint32_t units_per_core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
     std::vector<CoreCoord> cores;
-    uint32_t device_seed_offset;
+    uint32_t device_seed_offset = 0;
 };
 
 RandWorkSplit compute_rand_work_split(
@@ -206,7 +206,7 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -220,7 +220,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_ru
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(ws.cores.size() * 3);
     for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -27,6 +27,62 @@ auto get_random_seed() -> uint32_t { return distribution(rng); }
 constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
+// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
+// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+struct RandWorkSplit {
+    uint32_t num_cores;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1;
+    uint32_t units_per_core_group_2;
+    std::vector<CoreCoord> cores;
+    uint32_t device_seed_offset;
+};
+
+RandWorkSplit compute_rand_work_split(
+    const RandDeviceOperation::operation_attributes_t& attrs,
+    RandDeviceOperation::tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    auto grid = output.device()->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+
+    const ttnn::MeshCoordinate mesh_coordinate =
+        mesh_dispatch_coordinate.value_or(ttnn::MeshCoordinate::zero_coordinate(attrs.device->shape().dims()));
+    uint32_t device_seed_offset = 0;
+    const auto& shard_mask = attrs.mesh_dim_is_sharded;
+    if (!shard_mask.empty()) {
+        const auto& mesh_shape = attrs.device->shape();
+        size_t shard_linear_idx = 0;
+        size_t shard_stride = 1;
+        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
+            if (shard_mask[i]) {
+                shard_linear_idx += mesh_coordinate[i] * shard_stride;
+                shard_stride *= mesh_shape[i];
+            }
+        }
+        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
+    }
+    return {
+        num_cores,
+        all_cores,
+        core_group_1,
+        core_group_2,
+        units_per_core_group_1,
+        units_per_core_group_2,
+        std::move(cores),
+        device_seed_offset};
+}
+
+// Per-core seed; shared so the miss-build and the hit-patch produce identical values.
+uint32_t rand_seed_for_core(
+    const RandDeviceOperation::operation_attributes_t& attrs, int i, uint32_t device_seed_offset) {
+    return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
+}
+
 }  // namespace
 
 ProgramDescriptor RandDeviceOperation::create_descriptor(
@@ -34,14 +90,15 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-        split_work_to_cores(grid, units_to_divide);
-
-    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         units_per_core_group_1,
+         units_per_core_group_2,
+         cores,
+         device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
     const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
@@ -54,24 +111,6 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
 
     constexpr uint32_t intermed_cb_id = CBIndex::c_24;
     constexpr uint32_t dst_cb_id = CBIndex::c_0;
-
-    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value_or(
-        ttnn::MeshCoordinate::zero_coordinate(operation_attributes.device->shape().dims()));
-
-    uint32_t device_seed_offset = 0;
-    const auto& shard_mask = operation_attributes.mesh_dim_is_sharded;
-    if (!shard_mask.empty()) {
-        const auto& mesh_shape = operation_attributes.device->shape();
-        size_t shard_linear_idx = 0;
-        size_t shard_stride = 1;
-        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
-            if (shard_mask[i]) {
-                shard_linear_idx += mesh_coordinate[i] * shard_stride;
-                shard_stride *= mesh_shape[i];
-            }
-        }
-        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
-    }
 
     ProgramDescriptor desc;
 
@@ -147,8 +186,7 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
             TT_THROW("Core not in specified core ranges");
         }
 
-        uint32_t seed =
-            operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset : get_random_seed();
+        uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
 
         // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
         // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
@@ -173,60 +211,22 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_ru
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // MUST mirror the seed/from/to runtime args produced in create_descriptor() above:
-    //   - writer is pushed as kernel index 0, compute as kernel index 1
-    //   - compute runtime args layout is {seed, from_bits, to_bits, tile_offset, units_per_core}
-    // Only the per-call values (seed, from, to) are re-applied here; the structural args
-    // (tile_offset, units_per_core) are part of the program identity and never change for a given
-    // cache entry.  The work-split is recomputed (cheap host-side integer math, no kernel rebuild)
-    // so the per-core seed offsets match create_descriptor() exactly.  The
-    // test_rand_different_seed_values regression test enforces this mirror.
+    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
+    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
     constexpr uint32_t kComputeKernelIdx = 1;
-    constexpr uint32_t kSeedArgIdx = 0;
-    constexpr uint32_t kFromArgIdx = 1;
-    constexpr uint32_t kToArgIdx = 2;
-
-    IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    // Only the core count/list matter here (per-core seed offsets); the work-split groups and
-    // per-group tile counts are part of the static program identity and are not re-applied.
-    [[maybe_unused]] auto
-        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-            split_work_to_cores(grid, units_to_divide);
-    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
-
-    const ttnn::MeshCoordinate mesh_coordinate = mesh_dispatch_coordinate.value_or(
-        ttnn::MeshCoordinate::zero_coordinate(operation_attributes.device->shape().dims()));
-
-    uint32_t device_seed_offset = 0;
-    const auto& shard_mask = operation_attributes.mesh_dim_is_sharded;
-    if (!shard_mask.empty()) {
-        const auto& mesh_shape = operation_attributes.device->shape();
-        size_t shard_linear_idx = 0;
-        size_t shard_stride = 1;
-        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
-            if (shard_mask[i]) {
-                shard_linear_idx += mesh_coordinate[i] * shard_stride;
-                shard_stride *= mesh_shape[i];
-            }
-        }
-        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
-    }
+    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
 
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
-        const uint32_t seed =
-            operation_attributes.seed != 0 ? operation_attributes.seed + i + device_seed_offset : get_random_seed();
-        dynamic_args.push_back({kComputeKernelIdx, core, kSeedArgIdx, seed});
-        dynamic_args.push_back({kComputeKernelIdx, core, kFromArgIdx, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, core, kToArgIdx, to_bits});
+    dynamic_args.reserve(ws.cores.size() * 3);
+    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
+        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
+        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
+        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
     }
     return dynamic_args;
 }

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -34,12 +34,6 @@ UniformDeviceOperation::tensor_return_value_t UniformDeviceOperation::create_out
     return tensor_args.input;
 }
 
-ttsl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
-    return ttsl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
-}
-
 }  // namespace ttnn::operations::uniform
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <optional>
+#include <vector>
+
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::uniform {
 
@@ -38,6 +43,15 @@ struct UniformDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // seed/from/to are excluded from compute_program_hash (so calls differing only in those values
+    // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
+    // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::uniform

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -50,7 +50,7 @@ struct UniformDeviceOperation {
     // seed/from/to are excluded from the program hash (so calls differing only in those values
     // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
     // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
-    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -23,6 +23,11 @@ struct UniformDeviceOperation {
         uint32_t seed;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
+
+        // from/to/seed are re-applied via get_dynamic_runtime_args, so they're excluded from the
+        // hash. Shape/dtype/device come from the input tensor (tensor_args).
+        static constexpr auto attribute_names = std::forward_as_tuple("memory_config", "compute_kernel_config");
+        auto attribute_values() const { return std::forward_as_tuple(memory_config, compute_kernel_config); }
     };
 
     struct tensor_args_t {
@@ -42,9 +47,7 @@ struct UniformDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from compute_program_hash (so calls differing only in those values
+    // seed/from/to are excluded from the program hash (so calls differing only in those values
     // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
     // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
     static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -50,7 +50,7 @@ struct UniformDeviceOperation {
     // seed/from/to are excluded from the program hash (so calls differing only in those values
     // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
     // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    static ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -179,7 +179,7 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     return desc;
 }
 
-ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
+std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -193,7 +193,7 @@ ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_d
     const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(cores.size() * 3);
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -24,6 +24,34 @@ std::mt19937 rng(std::time(nullptr));
 std::uniform_int_distribution<int32_t> distribution(1, std::numeric_limits<int32_t>::max());
 
 uint32_t get_random_seed() { return distribution(rng); }
+
+// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
+// both derive the identical core list.
+struct UniformWorkSplit {
+    uint32_t num_cores;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1;
+    uint32_t units_per_core_group_2;
+    std::vector<CoreCoord> cores;
+};
+
+UniformWorkSplit uniform_work_split(Tensor& output) {
+    auto grid = output.device()->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    return {
+        num_cores,
+        all_cores,
+        core_group_1,
+        core_group_2,
+        units_per_core_group_1,
+        units_per_core_group_2,
+        std::move(cores)};
+}
 }  // namespace
 
 static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
@@ -35,13 +63,8 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output) {
     IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-        split_work_to_cores(grid, units_to_divide);
-
-    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2, cores] =
+        uniform_work_split(output);
     const auto num_cores_total = cores.size();
 
     DataType output_dtype = output.dtype();
@@ -161,20 +184,10 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // MUST mirror create_descriptor(): writer is kernel 0, compute is kernel 1; the compute
-    // runtime args are {seed, f2u_from, f2u_to, tile_offset, units_per_core}.  Only the per-call
-    // values (seed, from, to) are re-applied; tile_offset/units_per_core are part of the static
-    // program identity.  The work-split is recomputed (cheap host-side integer math, no rebuild)
-    // so the per-core seed offsets match create_descriptor() exactly.
+    // compute is kernel 1; its runtime args are {seed, f2u_from, f2u_to, tile_offset, units_per_core}.
+    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
     constexpr uint32_t kComputeKernelIdx = 1;
-
-    IDevice* device = output.device();
-    auto grid = device->compute_with_storage_grid_size();
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
-    [[maybe_unused]] auto
-        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
-            split_work_to_cores(grid, units_to_divide);
-    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+    auto cores = uniform_work_split(output).cores;
 
     const float eps = 1e-6f;
     const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -28,12 +28,12 @@ uint32_t get_random_seed() { return distribution(rng); }
 // Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
 // both derive the identical core list.
 struct UniformWorkSplit {
-    uint32_t num_cores;
+    uint32_t num_cores = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
-    uint32_t units_per_core_group_1;
-    uint32_t units_per_core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
     std::vector<CoreCoord> cores;
 };
 
@@ -179,7 +179,7 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
+ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -193,7 +193,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic
     const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    ttsl::SmallVector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
     dynamic_args.reserve(cores.size() * 3);
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -123,7 +123,6 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     // -eps make sure that generated number is < operation_attributes.to
     const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    const uint32_t output_addr = output.buffer()->address();
     uint32_t tile_offset = 0;
     for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
         const auto& core = cores[i];
@@ -139,11 +138,14 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
         // Each core has its own seed to increase the number of generated random numbers
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
 
+        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
+        // cache-miss build, re-applied on every cache hit via get_dynamic_runtime_args().
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from, f2u_to, tile_offset, units_per_core});
 
-        writer_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{output_addr, tile_offset, units_per_core});
+        // Register the (in-place) output address as a Buffer* binding so uniform takes the fast
+        // cache-hit path; the framework allows the input==output alias (see resolve_bindings).
+        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
@@ -152,6 +154,41 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     desc.kernels.push_back(std::move(compute_desc));
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // MUST mirror create_descriptor(): writer is kernel 0, compute is kernel 1; the compute
+    // runtime args are {seed, f2u_from, f2u_to, tile_offset, units_per_core}.  Only the per-call
+    // values (seed, from, to) are re-applied; tile_offset/units_per_core are part of the static
+    // program identity.  The work-split is recomputed (cheap host-side integer math, no rebuild)
+    // so the per-core seed offsets match create_descriptor() exactly.
+    constexpr uint32_t kComputeKernelIdx = 1;
+
+    IDevice* device = output.device();
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+    [[maybe_unused]] auto
+        [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+            split_work_to_cores(grid, units_to_divide);
+    auto cores = grid_to_cores(num_cores, grid.x, grid.y);
+
+    const float eps = 1e-6f;
+    const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
+    const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * 3);
+    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
+        const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+        dynamic_args.push_back({kComputeKernelIdx, cores[i], 0, seed});
+        dynamic_args.push_back({kComputeKernelIdx, cores[i], 1, f2u_from});
+        dynamic_args.push_back({kComputeKernelIdx, cores[i], 2, f2u_to});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::uniform


### PR DESCRIPTION
## Problem

On a program-cache **hit**, the descriptor framework only re-patches `Buffer*` address slots (`apply_resolved_bindings`). An op that gives itself a custom `compute_program_hash` to exclude a per-call value (RNG `seed`, `from`/`to`, dropout `seed`, optimizer `lr`/`step`, …) then has two bad options:

- if it registers `Buffer*` runtime-arg bindings → it takes the **fast path** and the excluded scalar is **frozen** at the first cache miss (silent wrong result), or
- if it bakes addresses as raw runtime args → it falls to the **slow path**, which rebuilds the whole `ProgramDescriptor` on *every* dispatch (correct, but the program cache buys it nothing).

Separately, `resolve_bindings` bailed to the slow path on *any* duplicate `Buffer*` (added in #43920 for `matmul(X, X)`), which also caught **in-place ops** (output aliases input) — so they could never take the fast path at all.

## Change

- **`DynamicRuntimeArg`** + `apply_dynamic_runtime_args` (`program_descriptor_patching`): the non-`Buffer` analog of `BufferBinding`. An op opts in with `get_dynamic_runtime_args(attrs, tensor_args, output, coord)`; the mesh adapter re-applies the returned values on the fast cache-hit path. Ops that don't define it compile to nothing (`if constexpr`).
- **In-place carve-out** (`resolve_bindings`): `collect_tensor_buffers` now reports the input/output boundary, so a duplicate *within the inputs* (`matmul(X, X)`) still bails, but an output that aliases an input (in-place) keeps the fast path.

Net: an op can be **cached and correct** — the per-call scalar is excluded from the key and re-patched every dispatch.

## Migrated (each: fast path + correct, with a regression test)

`rand`, `uniform`, `bernoulli`, `dropout` (per-device seed, in-place), `ternary` (`scalar_input_a/b`), and `moreh_adamw` (`lr`/`step` + step-derived β1/β2 exponents). The custom `compute_program_hash` was removed from `rand`/`uniform`/`bernoulli`/`moreh_adamw` (replaced by `attribute_names` that omit the dynamic fields); kept on `dropout`/`ternary` where it coarsens by volume.

Each regression test pins both halves: a differing scalar must **not** add a cache entry (guards re-hashing the value) **and** must change the output (guards the frozen-arg bug). For `moreh_adamw` the pre-existing `test_moreh_adamw_cache` already fails on the un-fixed binary.

## Validation

- Build (Wormhole) green; clang-tidy clean on changed files.
- Per-op seed/scalar cache+correctness tests pass locally; `moreh_adamw` confirmed green on CI hardware.
- `matmul(Y,Y)` after `matmul(X,X)` returns `Y@Y` (the #43920 guard still bails correctly).

## Audit of main

All 36 descriptor-framework ops carrying a custom hash were classified. The set above is the actionable single-device fix; everything else is either clean, correctly slow-path, or not affected. Two callouts:

- **binary_ng** — *not a bug*: its hash is intentionally shape-agnostic (one program serves many shapes via runtime args), so fast-path bindings can't apply. Correctly stays slow-path; documented in the migration recipe.
- **CCL semaphore freeze** — re-checked per op. `all_broadcast` and `all_to_all_combine` park their semaphores on `WorkloadDescriptor::semaphores` (workload-scoped, stay valid across cache hits) → **not affected**. `ring_attention_all_gather_async` is a genuine attrs-owned-semaphore freeze, but the addresses are interleaved with fabric routing args and it's multi-device — **follow-up** (needs a CI-paired session). The correct fix there is workload-scoping, not `get_dynamic_runtime_args`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/descriptor-static-dynamic-partition)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/descriptor-static-dynamic-partition)
