### PR TITLE
Get `moe_compute` to be functional and tested across multiple models on BH LB

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -65,14 +65,14 @@ MOE_DEVICE_PARAMS = {
     "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
     "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-    "trace_region_size": 750000,
+    "trace_region_size": 500000,
 }
 
 MOE_DEVICE_PARAMS_LINEAR = {
     "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
     "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-    "trace_region_size": 500000,
+    "trace_region_size": 750000,
 }
 
 

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -24,6 +24,7 @@ from ttnn.operations.ccl import MoEActivationFunction
 from ttnn.experimental.moe_compute_utils import (
     auto_output_width_shard_dim,
     get_tilize_drain_core,
+    effective_matmul_ring_size,
     _shard_tiles,
     _w2_shard_tiles,
 )
@@ -315,7 +316,10 @@ def _run_model_test(
         N=model_cfg.N,
         hidden_size=model_cfg.hidden_size,
         output_height_shard_dim=model_cfg.output_height_shard_dim,
-        output_width_shard_dim=auto_output_width_shard_dim(model_cfg.hidden_size),
+        output_width_shard_dim=auto_output_width_shard_dim(
+            model_cfg.hidden_size,
+            matmul_ring_size=effective_matmul_ring_size(mesh_device, bh_ring_size),
+        ),
         dtype=ttnn.bfloat16,
         enable_trace=enable_trace,
         activation_type=activation_type,
@@ -2214,6 +2218,10 @@ def test_auto_output_width_shard_dim():
     assert auto_output_width_shard_dim(5120) == 4  # GLM-4.7: Ht=160
     assert auto_output_width_shard_dim(4096) == 4  # DS V4 Flash: Ht=128
     assert auto_output_width_shard_dim(7168) == 4  # Kimi K2.5: same as DS
+    # Ring-aware: GPT-OSS width=3 at N=12, falls back to 2 at N=8/16
+    assert auto_output_width_shard_dim(2880, matmul_ring_size=12) == 3
+    assert auto_output_width_shard_dim(2880, matmul_ring_size=8) == 2
+    assert auto_output_width_shard_dim(2880, matmul_ring_size=16) == 2
 
 
 def test_shard_tiles_total_always_correct():

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -188,7 +188,7 @@ def _expand_model_configs(
                                         id=f"{cfg.name}-{test_mode}-{bias_tag}-{epd}experts_per_device-{act_tag}-{trace_tag}-{ring_tag}",
                                         marks=cfg.marks,
                                     )
-                            )
+                                )
     return expanded
 
 

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -64,7 +64,7 @@ MOE_DEVICE_PARAMS = {
     "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
     "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
     "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-    "trace_region_size": 500000,
+    "trace_region_size": 750000,
 }
 
 MOE_DEVICE_PARAMS_LINEAR = {
@@ -104,6 +104,7 @@ class MoEModelConfig:
     num_iterations: int = 3
     tokens_per_device: int = 32
     output_height_shard_dim: int = 4
+    bh_ring_size_values: tuple = (12,)
     marks: tuple = ()
 
 
@@ -161,7 +162,7 @@ def _expand_model_configs(
     test_modes_fn=_test_modes_for_model,
     trace_values_fn=_trace_values_for_case,
 ):
-    """Expand model configs into pytest.param entries (test_mode, has_bias, epd, act, enable_trace)."""
+    """Expand model configs into pytest.param entries (test_mode, has_bias, epd, act, enable_trace, bh_ring_size)."""
     expanded = []
     for cfg in configs:
         for test_mode in test_modes_fn(cfg):
@@ -169,20 +170,23 @@ def _expand_model_configs(
                 for epd in cfg.experts_per_device_values:
                     for act in cfg.activation_types:
                         for enable_trace in trace_values_fn(cfg, test_mode):
-                            bias_tag = "bias" if has_bias else "no_bias"
-                            act_tag = act.name.lower()
-                            trace_tag = "enable_trace" if enable_trace else "disable_trace"
-                            expanded.append(
-                                pytest.param(
-                                    cfg,
-                                    test_mode,
-                                    has_bias,
-                                    epd,
-                                    act,
-                                    enable_trace,
-                                    id=f"{cfg.name}-{test_mode}-{bias_tag}-{epd}experts_per_device-{act_tag}-{trace_tag}",
-                                    marks=cfg.marks,
-                                )
+                            for bh_ring_size in cfg.bh_ring_size_values:
+                                bias_tag = "bias" if has_bias else "no_bias"
+                                act_tag = act.name.lower()
+                                trace_tag = "enable_trace" if enable_trace else "disable_trace"
+                                ring_tag = f"bh_ring_size{bh_ring_size}"
+                                expanded.append(
+                                    pytest.param(
+                                        cfg,
+                                        test_mode,
+                                        has_bias,
+                                        epd,
+                                        act,
+                                        enable_trace,
+                                        bh_ring_size,
+                                        id=f"{cfg.name}-{test_mode}-{bias_tag}-{epd}experts_per_device-{act_tag}-{trace_tag}-{ring_tag}",
+                                        marks=cfg.marks,
+                                    )
                             )
     return expanded
 
@@ -251,8 +255,18 @@ _MODELS_1x8 = [
 ]
 
 _MODELS_BH_LB_1x8 = [
-    MoEModelConfig("gpt_oss",     N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), activation_types=(MoEActivationFunction.SWIGLU,)),
-    MoEModelConfig("deepseek_v3", N=2048, hidden_size=7168, selected_experts_k=8, has_bias_values=(False, True), tokens_per_device=8),
+    MoEModelConfig("deepseek_ocr",       N=896,  hidden_size=1280, selected_experts_k=6),
+    MoEModelConfig("qwen3_omni_talker",  N=384,  hidden_size=1024, selected_experts_k=6),
+    MoEModelConfig("qwen3_omni_thinker", N=768,  hidden_size=2048, selected_experts_k=8),
+    MoEModelConfig("qwen35_35b",         N=512,  hidden_size=2048, selected_experts_k=8),
+    MoEModelConfig("gemma_4_26b",        N=704,  hidden_size=2816, selected_experts_k=8, activation_types=(MoEActivationFunction.GELU,)),
+    MoEModelConfig("gpt_oss",            N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), test_modes=("perf", "correctness"), activation_types=(MoEActivationFunction.SWIGLU,), bh_ring_size_values=(8, 12, 16)),
+    MoEModelConfig("qwen3_235b",         N=1536, hidden_size=4096, selected_experts_k=8),
+    MoEModelConfig("qwen35_397b",        N=1024, hidden_size=4096, selected_experts_k=10),
+    MoEModelConfig("glm_47",             N=1536, hidden_size=5120, selected_experts_k=8),
+    MoEModelConfig("glm5",               N=2048, hidden_size=6144, selected_experts_k=8),
+    MoEModelConfig("kimi_k25",           N=2048, hidden_size=7168, selected_experts_k=8, experts_per_device_values=(6,), tokens_per_device=8),
+    MoEModelConfig("deepseek_v3",        N=2048, hidden_size=7168, selected_experts_k=8, has_bias_values=(False, True), tokens_per_device=8, test_modes=("perf", "correctness"),),
 ]
 
 _MOE_MESH_CONFIGS = [
@@ -278,6 +292,7 @@ def _run_model_test(
     activation_type,
     num_links,
     topology=None,
+    bh_ring_size=12,
 ):
     if test_mode == "perf":
         selected_experts_k = 1
@@ -307,6 +322,7 @@ def _run_model_test(
         has_bias=has_bias,
         topology=topology,
         num_links=num_links,
+        bh_ring_size=bh_ring_size,
     )
 
 
@@ -1460,6 +1476,7 @@ def _run_moe_compute_impl(
     has_bias,
     num_links,
     topology=None,
+    bh_ring_size=12,
 ):
     """Run MoE compute E2E validation. Called from test_moe_compute via _run_model_test."""
     torch.manual_seed(2003)
@@ -1876,6 +1893,7 @@ def _run_moe_compute_impl(
             optional_output_tensor=tt_combine_output_tensors[layer_id],
             optional_cross_device_semaphore=combine_barrier_semaphore,
             activation_type=activation_type,
+            bh_ring_size=bh_ring_size,
         )
 
     #########################################
@@ -1950,7 +1968,7 @@ def _run_moe_compute_impl(
         mesh_device, output_height_shard_dim, output_width_shard_dim
     )
     worker_mcast_bbox = ttnn.experimental.get_moe_worker_mcast_bounding_box(
-        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size
+        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size, bh_ring_size
     )
     per_expert_tokens_all_passed = True
     activation_all_passed = True
@@ -2057,7 +2075,7 @@ def _run_moe_compute_impl(
 #   MOE_COMPUTE_FULL=1             — all models x all meshes (1x8/1x16 x torus/linear); tier rules unchanged.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "device_params, mesh_cfg, mesh_shape, mesh_device, model_cfg, test_mode, has_bias, experts_per_device, activation_type, enable_trace",
+    "device_params, mesh_cfg, mesh_shape, mesh_device, model_cfg, test_mode, has_bias, experts_per_device, activation_type, enable_trace, bh_ring_size",
     MOE_COMPUTE_MODEL_TEST_CASES,
     indirect=["device_params", "mesh_device"],
 )
@@ -2071,6 +2089,7 @@ def test_moe_compute(
     has_bias,
     experts_per_device,
     activation_type,
+    bh_ring_size,
 ):
     from ttnn.operations.ccl import Topology
 
@@ -2086,6 +2105,7 @@ def test_moe_compute(
         activation_type,
         topology=topology,
         num_links=mesh_cfg.num_links,
+        bh_ring_size=bh_ring_size,
     )
 
 

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -251,8 +251,8 @@ _MODELS_1x8 = [
 ]
 
 _MODELS_BH_LB_1x8 = [
-    MoEModelConfig("gpt_oss",     N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), tokens_per_device=8, num_layers=1, num_iterations=2, activation_types=(MoEActivationFunction.SWIGLU,)),
-    MoEModelConfig("deepseek_v3", N=2048, hidden_size=7168, selected_experts_k=8, has_bias_values=(False, True), tokens_per_device=8, num_layers=1, num_iterations=2),
+    MoEModelConfig("gpt_oss",     N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), activation_types=(MoEActivationFunction.SWIGLU,)),
+    MoEModelConfig("deepseek_v3", N=2048, hidden_size=7168, selected_experts_k=8, has_bias_values=(False, True), tokens_per_device=8),
 ]
 
 _MOE_MESH_CONFIGS = [

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -1725,6 +1725,7 @@ def _run_moe_compute_impl(
         hidden_size=hidden_size,
         intermediate_size=N,
         has_bias=has_bias,
+        bh_ring_size=bh_ring_size,
     )
     w0_w1_mem_config = weight_mem_configs.w0_w1
     w2_mem_config = weight_mem_configs.w2
@@ -1762,6 +1763,7 @@ def _run_moe_compute_impl(
             E=experts_per_device,
             K=hidden_size,
             N=N,
+            bh_ring_size=bh_ring_size,
         )
         ttnn.deallocate(tt_b0_raw)
         ttnn.deallocate(tt_b1_raw)
@@ -1773,6 +1775,7 @@ def _run_moe_compute_impl(
             E=experts_per_device,
             K=hidden_size,
             N=N,
+            bh_ring_size=bh_ring_size,
         )
     ttnn.deallocate(tt_w0_raw)
     ttnn.deallocate(tt_w1_raw)
@@ -1792,6 +1795,7 @@ def _run_moe_compute_impl(
             E=experts_per_device,
             N=N,
             K=hidden_size,
+            bh_ring_size=bh_ring_size,
         )
         ttnn.deallocate(tt_b2_raw)
     else:
@@ -1801,6 +1805,7 @@ def _run_moe_compute_impl(
             E=experts_per_device,
             N=N,
             K=hidden_size,
+            bh_ring_size=bh_ring_size,
         )
     ttnn.deallocate(tt_w2_raw)
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -43,6 +43,7 @@ from ttnn.experimental.moe_compute_utils import (
     get_weight_mem_configs,
     auto_output_width_shard_dim,
     get_tilize_drain_core,
+    effective_matmul_ring_size,
 )
 
 # Reuse 6U test helpers verbatim. The intent is that this single-card test
@@ -87,9 +88,9 @@ def _run_moe_compute_single_card_test(
     Single-card MoE compute test body. cluster_axis is fixed to None
     (no dispatch axis on 1x1 mesh) and compute_only is fixed to True.
 
-    `bh_ring_size`: pinned BH matmul ring size. None defaults to 12. Tests that require
-    a specific N (e.g., GPT-OSS needs N=12 because output_width_shard_dim=3 only divides
-    12) should pass it explicitly to lock the layout.
+    `bh_ring_size`: pinned BH matmul ring size. None defaults to 12. Pass the same value to
+    ``auto_output_width_shard_dim(..., matmul_ring_size=effective_matmul_ring_size(...))`` so
+    host tensor layout matches the op's ring-aware width-parallel auto-derivation.
     """
     # The MoE op uses tilize cores keyed off the per-arch layout table in the program
     # factory's `get_layout()` (see #41827) and matmul cores from
@@ -531,22 +532,12 @@ def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias, bh_
 
 
 # GPT-OSS canonical config from the GPT-OSS entry in `_MODELS_1x8` (test_moe_compute_6U.py):
-#   experts_per_device=4, has_bias=True, activation=SWIGLU, output_width_shard_dim=3.
-# This single test exercises FOUR distinct BH-specific gaps the baseline DS-v3 test misses:
-#   1. The w2_shard_tiles COMPLEMENTARY branch — for Ht=Nt=90, n_big_ht + n_big_nt == n_cores
-#      when n_cores=12 (90%12 + 90%12 = 6+6 = 12). DS-v3 (balanced 64/8) never enters this branch.
-#   2. The bank-run loop on a NON-BALANCED shard map — shard_tiles(90, c, 12) is [8,7,8,7,8,...],
-#      while DS-v3 at N=8 is [8]*8 (perfectly balanced).
-#   3. The bias path on a non-DS shape (b0/b1 K-padding, b2 N-append, has_bias=True kernel
-#      branch with the cb_c2c_ones_tile + bias-row matmul).
-#   4. SWIGLU activation, which PR #43932 was the first to actually exercise (commit 3918012f6e1).
-#
-# GPT-OSS requires N=12 on BH because hidden_size=2880 → output_width_shard_dim =
-# auto_output_width_shard_dim(2880) = 3 (Ht=90 has no divisor ≤4 except 3). The op
-# validates matmul_num_cores % output_width_shard_dim == 0; on BH only N=12 satisfies
-# this (8%3≠0, 12%3==0, 16%3≠0). The test pins bh_ring_size=12 explicitly via the op
-# kwarg to lock the layout. WH always has 12 DRAM banks (1:1 with ring), so the same
-# N=12 works there too.
+#   experts_per_device=4, has_bias=True, activation=SWIGLU.
+# Ring-aware width dim: N=12 → width=3; N=8/16 → width=2 (90%3==0 but 8%3≠0).
+_GPT_BH_RING_SIZES = [12]
+_GPT_BH_RING_SIZES += [8, 16]  # comment this line to skip N=8 and N=16 sweep
+
+
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -557,12 +548,16 @@ def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias, bh_
     ],
     indirect=True,
 )
+@pytest.mark.parametrize("bh_ring_size", _GPT_BH_RING_SIZES)
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
-def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape):
-    """compute_only=True on a 1x1 WH mesh, GPT-OSS-shaped workload (hidden=N=2880, SWIGLU+bias).
+def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, bh_ring_size):
+    """compute_only=True on a 1x1 mesh, GPT-OSS-shaped workload (hidden=N=2880, SWIGLU+bias).
 
-    bh_ring_size=12 is pinned via the op kwarg to lock the layout for the GPT-OSS shape.
+    Parametrized over bh_ring_size. WH always uses N=12; N=8/16 only run on BH.
     """
+    if bh_ring_size != 12 and mesh_device.arch() != ttnn.device.Arch.BLACKHOLE:
+        pytest.skip(f"bh_ring_size={bh_ring_size} is BH-only; WH always uses N=12")
+    ring_n = effective_matmul_ring_size(mesh_device, bh_ring_size)
     _run_moe_compute_single_card_test(
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,
@@ -572,11 +567,11 @@ def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape):
         N=2880,
         hidden_size=2880,
         output_height_shard_dim=4,
-        output_width_shard_dim=auto_output_width_shard_dim(2880),  # = 3 (Ht=90; 90%3==0)
+        output_width_shard_dim=auto_output_width_shard_dim(2880, matmul_ring_size=ring_n),
         dtype=ttnn.bfloat16,
         activation_type=MoEActivationFunction.SWIGLU,
         has_bias=True,
-        bh_ring_size=12,
+        bh_ring_size=bh_ring_size,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -534,8 +534,7 @@ def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias, bh_
 # GPT-OSS canonical config from the GPT-OSS entry in `_MODELS_1x8` (test_moe_compute_6U.py):
 #   experts_per_device=4, has_bias=True, activation=SWIGLU.
 # Ring-aware width dim: N=12 → width=3; N=8/16 → width=2 (90%3==0 but 8%3≠0).
-_GPT_BH_RING_SIZES = [12]
-_GPT_BH_RING_SIZES += [8, 16]  # comment this line to skip N=8 and N=16 sweep
+_GPT_BH_RING_SIZES = [12, 8, 16]  # remove 8, 16 to limit sweep to ring_n=12
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
@@ -113,6 +113,7 @@ void kernel_main() {
     constexpr uint32_t packet_header_cb_id = get_named_compile_time_arg_val("packet_header_cb_id");
     constexpr uint32_t num_token_parallel_cores = get_named_compile_time_arg_val("num_token_parallel_cores");
     constexpr uint32_t num_data_parallel_cores = get_named_compile_time_arg_val("num_data_parallel_cores");
+    constexpr uint32_t num_workers_per_link = get_named_compile_time_arg_val("num_workers_per_link");
     constexpr bool use_init_semaphore = get_named_compile_time_arg_val("use_init_semaphore") == 1;
     constexpr uint32_t noc_x_start = get_named_compile_time_arg_val("noc_x_start");
     constexpr uint32_t noc_y_start = get_named_compile_time_arg_val("noc_y_start");
@@ -326,7 +327,12 @@ void kernel_main() {
         auto termination_sync_semaphore_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_args.termination_sync_address);
 
-        noc_semaphore_wait(termination_sync_semaphore_ptr, num_data_parallel_cores - 1);
+        // Wait for every other worker on this link to signal termination. The count is
+        // (num_workers_per_link - 1): a link's termination master is incremented by all the other
+        // workers sharing its link, which can exceed num_data_parallel_cores - 1 when a link spans
+        // multiple token-parallel groups (e.g. BH num_links=2). The previous (num_data_parallel_cores
+        // - 1) target was overshot by the extra increments, so the exact-match wait never observed it.
+        noc_semaphore_wait(termination_sync_semaphore_ptr, num_workers_per_link - 1);
         noc_semaphore_set(termination_sync_semaphore_ptr, 0);
 
         const uint64_t global_noc_semaphore_addr = get_noc_addr(global_semaphore_addr, /*noc=*/1);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
@@ -327,11 +327,6 @@ void kernel_main() {
         auto termination_sync_semaphore_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_args.termination_sync_address);
 
-        // Wait for every other worker on this link to signal termination. The count is
-        // (num_workers_per_link - 1): a link's termination master is incremented by all the other
-        // workers sharing its link, which can exceed num_data_parallel_cores - 1 when a link spans
-        // multiple token-parallel groups (e.g. BH num_links=2). The previous (num_data_parallel_cores
-        // - 1) target was overshot by the extra increments, so the exact-match wait never observed it.
         noc_semaphore_wait(termination_sync_semaphore_ptr, num_workers_per_link - 1);
         noc_semaphore_set(termination_sync_semaphore_ptr, 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -7,7 +7,9 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "selective_reduce_combine_device_operation.hpp"
+#include "selective_reduce_combine_program_factory.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_align.hpp>
@@ -17,12 +19,27 @@ namespace ttnn::experimental::prim {
 
 void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.dense_input_tensor;
     const auto& token_activations_tensor = tensor_args.dense_activations_tensor;
 
     TT_FATAL(
         tensor_args.dense_token_maps_tensor.logical_shape().rank() == 2,
         "dense_token_maps_tensor must be rank 2 ([experts, per-token-stride]); got rank {}",
         tensor_args.dense_token_maps_tensor.logical_shape().rank());
+
+    const auto num_links = operation_attributes.num_links;
+    TT_FATAL(num_links > 0, "num_links must be > 0, got {}", num_links);
+
+    const auto num_worker_cores = detail::compute_num_worker_cores(
+        input_tensor,
+        operation_attributes.hidden_size,
+        operation_attributes.num_token_parallel_cores,
+        operation_attributes.num_data_parallel_cores);
+    TT_FATAL(
+        num_worker_cores % num_links == 0,
+        "num_worker_cores ({}) must be divisible by num_links ({})",
+        num_worker_cores,
+        num_links);
 
     const auto batch_size = operation_attributes.batch_size;
     const auto seq_size = operation_attributes.seq_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -9,7 +9,6 @@
 #include "selective_reduce_combine_device_operation.hpp"
 #include "selective_reduce_combine_program_factory.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "cpp/ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_align.hpp>
@@ -30,11 +29,12 @@ void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     const auto num_links = operation_attributes.num_links;
     TT_FATAL(num_links > 0, "num_links must be > 0, got {}", num_links);
 
-    const auto num_worker_cores = detail::compute_num_worker_cores(
+    const auto worker_layout = detail::compute_worker_layout(
         input_tensor,
         operation_attributes.hidden_size,
         operation_attributes.num_token_parallel_cores,
         operation_attributes.num_data_parallel_cores);
+    const auto num_worker_cores = worker_layout.num_worker_cores;
     TT_FATAL(
         num_worker_cores % num_links == 0,
         "num_worker_cores ({}) must be divisible by num_links ({})",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -43,19 +43,25 @@ std::vector<uint32_t> data_parallel_split(
     return data_parallel_sizes_bytes;
 }
 
-uint32_t compute_num_worker_cores(
+SelectiveReduceCombineWorkerLayout compute_worker_layout(
     const Tensor& input_tensor,
     const uint32_t hidden_size,
     const uint32_t num_token_parallel_cores,
-    const uint32_t num_data_parallel_cores) {
-    const auto fabric_max_packet_size_bytes = get_tt_fabric_channel_buffer_size_bytes();
+    const uint32_t num_data_parallel_cores_attr) {
+    const auto fabric_max_packet_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     const auto input_dtype = input_tensor.dtype();
-    const uint32_t max_packet_size_bytes =
-        input_dtype == DataType::BFLOAT16 ? std::bit_floor(fabric_max_packet_size_bytes) : fabric_max_packet_size_bytes;
+    const uint32_t max_packet_size_bytes = input_dtype == tt::tt_metal::DataType::BFLOAT16
+                                               ? std::bit_floor(fabric_max_packet_size_bytes)
+                                               : fabric_max_packet_size_bytes;
     const uint32_t token_size_bytes = hidden_size * input_tensor.element_size();
-    const auto data_parallel_sizes_bytes =
-        data_parallel_split(token_size_bytes, max_packet_size_bytes, num_data_parallel_cores);
-    return num_token_parallel_cores * static_cast<uint32_t>(data_parallel_sizes_bytes.size());
+    auto data_parallel_sizes_bytes =
+        data_parallel_split(token_size_bytes, max_packet_size_bytes, num_data_parallel_cores_attr);
+    const uint32_t num_data_parallel_cores = static_cast<uint32_t>(data_parallel_sizes_bytes.size());
+    return {
+        .data_parallel_sizes_bytes = std::move(data_parallel_sizes_bytes),
+        .num_data_parallel_cores = num_data_parallel_cores,
+        .num_worker_cores = num_token_parallel_cores * num_data_parallel_cores,
+    };
 }
 
 auto launch_mux_workers(
@@ -328,11 +334,11 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // in validate mux_core_range_set.size() == 2(directions) * num_links
     const auto& mux_core_range_set = operation_attributes.mux_core_range_set;
 
-    const auto data_parallel_sizes_bytes =
-        detail::data_parallel_split(token_size_bytes, max_packet_size_bytes, num_data_parallel_cores);
-
-    num_data_parallel_cores = data_parallel_sizes_bytes.size();
-    const auto num_worker_cores = num_token_parallel_cores * num_data_parallel_cores;
+    const auto worker_layout =
+        detail::compute_worker_layout(input_tensor, hidden_size, num_token_parallel_cores, num_data_parallel_cores);
+    const auto& data_parallel_sizes_bytes = worker_layout.data_parallel_sizes_bytes;
+    num_data_parallel_cores = worker_layout.num_data_parallel_cores;
+    const auto num_worker_cores = worker_layout.num_worker_cores;
     const std::vector<CoreCoord> sender_cores(worker_cores.begin(), worker_cores.begin() + num_worker_cores);
     const ttnn::CoreRangeSet needed_worker_core_range_set(sender_cores);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -478,6 +478,11 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // here is only correct when num_workers_per_link == num_data_parallel_cores (e.g. WH layouts);
     // on layouts where a link spans multiple token-parallel groups (e.g. BH num_links=2) the
     // semaphore overshoots that smaller target and an exact-match wait deadlocks.
+    TT_FATAL(
+        num_worker_cores % num_links == 0,
+        "num_worker_cores ({}) must be divisible by num_links ({})",
+        num_worker_cores,
+        num_links);
     const uint32_t num_workers_per_link = num_worker_cores / num_links;
 
     std::unordered_map<std::string, uint32_t> writer_named_ct_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -43,6 +43,21 @@ std::vector<uint32_t> data_parallel_split(
     return data_parallel_sizes_bytes;
 }
 
+uint32_t compute_num_worker_cores(
+    const Tensor& input_tensor,
+    const uint32_t hidden_size,
+    const uint32_t num_token_parallel_cores,
+    const uint32_t num_data_parallel_cores) {
+    const auto fabric_max_packet_size_bytes = get_tt_fabric_channel_buffer_size_bytes();
+    const auto input_dtype = input_tensor.dtype();
+    const uint32_t max_packet_size_bytes =
+        input_dtype == DataType::BFLOAT16 ? std::bit_floor(fabric_max_packet_size_bytes) : fabric_max_packet_size_bytes;
+    const uint32_t token_size_bytes = hidden_size * input_tensor.element_size();
+    const auto data_parallel_sizes_bytes =
+        data_parallel_split(token_size_bytes, max_packet_size_bytes, num_data_parallel_cores);
+    return num_token_parallel_cores * static_cast<uint32_t>(data_parallel_sizes_bytes.size());
+}
+
 auto launch_mux_workers(
     const MeshDevice& mesh_device,
     const CoreRangeSet& mux_core_range_set,
@@ -473,16 +488,6 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // Writer compute sync: when used from MoE, use matmul's data-ready semaphore; else create local (standalone).
     const uint32_t writer_compute_sync_semaphore_id = compute_sync_semaphore_id;
 
-    // Each link's termination master is incremented by every other worker on that link, so the
-    // local-termination wait count must be (workers per link - 1). Using num_data_parallel_cores - 1
-    // here is only correct when num_workers_per_link == num_data_parallel_cores (e.g. WH layouts);
-    // on layouts where a link spans multiple token-parallel groups (e.g. BH num_links=2) the
-    // semaphore overshoots that smaller target and an exact-match wait deadlocks.
-    TT_FATAL(
-        num_worker_cores % num_links == 0,
-        "num_worker_cores ({}) must be divisible by num_links ({})",
-        num_worker_cores,
-        num_links);
     const uint32_t num_workers_per_link = num_worker_cores / num_links;
 
     std::unordered_map<std::string, uint32_t> writer_named_ct_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -473,6 +473,13 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     // Writer compute sync: when used from MoE, use matmul's data-ready semaphore; else create local (standalone).
     const uint32_t writer_compute_sync_semaphore_id = compute_sync_semaphore_id;
 
+    // Each link's termination master is incremented by every other worker on that link, so the
+    // local-termination wait count must be (workers per link - 1). Using num_data_parallel_cores - 1
+    // here is only correct when num_workers_per_link == num_data_parallel_cores (e.g. WH layouts);
+    // on layouts where a link spans multiple token-parallel groups (e.g. BH num_links=2) the
+    // semaphore overshoots that smaller target and an exact-match wait deadlocks.
+    const uint32_t num_workers_per_link = num_worker_cores / num_links;
+
     std::unordered_map<std::string, uint32_t> writer_named_ct_args = {
         {"dense_token_maps_cb_id", dense_token_maps_cb_id},
         {"data_cb_id", data_cb_id},
@@ -482,6 +489,7 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
         {"packet_header_cb_id", client_interface_cb_id},
         {"num_token_parallel_cores", num_token_parallel_cores},
         {"num_data_parallel_cores", num_data_parallel_cores},
+        {"num_workers_per_link", num_workers_per_link},
         {"use_init_semaphore", use_init_semaphore},
         {"noc_x_start", start_coord.x},
         {"noc_y_start", start_coord.y},
@@ -538,7 +546,6 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
         writer_config);
 
     const auto termination_master_semaphore_id = CreateSemaphore(program, {needed_worker_core_range_set}, 0);
-    const uint32_t num_workers_per_link = num_worker_cores / num_links;
 
     const auto idx = std::views::iota(std::size_t{0}, sender_cores.size());
     auto termination_master_cores = idx |

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
@@ -10,6 +10,16 @@
 
 namespace ttnn::experimental::prim {
 
+namespace detail {
+
+uint32_t compute_num_worker_cores(
+    const Tensor& input_tensor,
+    uint32_t hidden_size,
+    uint32_t num_token_parallel_cores,
+    uint32_t num_data_parallel_cores);
+
+}  // namespace detail
+
 struct SelectiveReduceCombineProgramArtifacts {
     tt::tt_metal::KernelHandle reader_kernel_id{};
     tt::tt_metal::KernelHandle writer_kernel_id{};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "selective_reduce_combine_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
@@ -12,7 +15,13 @@ namespace ttnn::experimental::prim {
 
 namespace detail {
 
-uint32_t compute_num_worker_cores(
+struct SelectiveReduceCombineWorkerLayout {
+    std::vector<uint32_t> data_parallel_sizes_bytes;
+    uint32_t num_data_parallel_cores = 0;
+    uint32_t num_worker_cores = 0;
+};
+
+SelectiveReduceCombineWorkerLayout compute_worker_layout(
     const Tensor& input_tensor,
     uint32_t hidden_size,
     uint32_t num_token_parallel_cores,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -408,28 +408,28 @@ std::vector<ttnn::Tensor> moe_compute(
 
     auto* mesh_device = tilize_input_tensor.device();
 
-    // Auto-compute num_data_parallel_cores: largest divisor of hidden_tiles <= 4.
-    // This replaces the prior hand-rolled per-config (DeepSeek/GPT) lookup. Works for both
-    // WH (N=12) and BH (N in {8, 12, 16}) -- the formula does not depend on ring N.
+    // BH ring size: default 12; supported {8, 12, 16}. WH always uses 12 (12 DRAM banks).
+    // Validate before num_data_parallel_cores derivation so ring-aware width dim can use ring_n.
+    const uint32_t ring_n = (mesh_device->arch() == tt::ARCH::BLACKHOLE) ? bh_ring_size.value_or(12u) : 12u;
+    TT_FATAL(
+        ring_n == 8 || ring_n == 12 || ring_n == 16,
+        "moe_compute: bh_ring_size={} is not supported (must be 8, 12, or 16)",
+        ring_n);
+
+    // Auto-compute num_data_parallel_cores: largest divisor d of hidden_tiles with d <= 4
+    // AND ring_n % d == 0. dm1 maps ring cores to combine columns via
+    // RING_CORES_PER_COMBINE_COL = num_cores / width_shard_dim, so both must divide evenly.
+    // E.g. GPT-OSS (Ht=90) picks d=3 at N=12 but falls back to d=2 at N=8 or N=16.
     const uint32_t hidden_tiles = hidden_size / 32;
     uint32_t num_data_parallel_cores = 1;
     for (uint32_t d = 4; d >= 1; --d) {
-        if (hidden_tiles % d == 0) {
+        if (hidden_tiles % d == 0 && ring_n % d == 0) {
             num_data_parallel_cores = d;
             break;
         }
     }
 
     const auto& combine_cores = get_moe_combine_cores(mesh_device, num_token_parallel_cores, num_data_parallel_cores);
-
-    // BH ring size: default 12; supported {8, 12, 16}. WH always uses 12 (12 DRAM banks).
-    // Validate at the API boundary for a clear "moe_compute:" error; get_cores() re-validates
-    // before kernel build as a structural invariant.
-    const uint32_t ring_n = (mesh_device->arch() == tt::ARCH::BLACKHOLE) ? bh_ring_size.value_or(12u) : 12u;
-    TT_FATAL(
-        ring_n == 8 || ring_n == 12 || ring_n == 16,
-        "moe_compute: bh_ring_size={} is not supported (must be 8, 12, or 16)",
-        ring_n);
 
     TT_FATAL(
         !(compute_only && cluster_axis.has_value()),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -39,8 +39,8 @@ struct MoEComputeParams {
     MoEComputePath path = MoEComputePath::Full;
 
     // Ring size in matmul cores. On WH this is always 12 (DRAM banks). On BH it is 8, 12,
-    // or 16 (resolved from the bh_ring_size op kwarg, default 12 — the smallest BH ring
-    // that satisfies every shipped model's output_width_shard_dim divisibility check).
+    // or 16 (resolved from the bh_ring_size op kwarg, default 12). num_data_parallel_cores
+    // is auto-derived ring-aware (largest d | hidden_tiles with d<=4 and ring_n % d == 0).
     // Stored in attributes() so the program cache distinguishes different ring sizes
     // within the same session.
     uint32_t bh_ring_size = 12;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -66,8 +66,11 @@ void bind_moe_compute(nb::module_& mod) {
 
         - ``output_height_shard_dim``: Number of token-parallel (height) cores used
           for the combine output. The width (data-parallel) core count is auto-derived
-          from ``hidden_size``. Use ``auto_output_width_shard_dim(hidden_size)`` from
-          ``moe_compute_utils`` to compute the recommended value.
+          from ``hidden_size`` and the matmul ring size (``bh_ring_size`` on BH, 12 on WH):
+          largest divisor d of ``hidden_tiles`` with d <= 4 and ``ring_n % d == 0``.
+          Use ``auto_output_width_shard_dim(hidden_size, matmul_ring_size=...)`` from
+          ``moe_compute_utils`` (with ``effective_matmul_ring_size``) so test tensors
+          match the device op.
 
         **Bias support (optional)**
 
@@ -96,7 +99,7 @@ void bind_moe_compute(nb::module_& mod) {
           ``prepare_w2_tensor_with_bias``
         - Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size)``
         - Memory configs: ``get_weight_mem_configs(...)``
-        - Output shard dim: ``auto_output_width_shard_dim(hidden_size)``
+        - Output shard dim: ``auto_output_width_shard_dim(hidden_size, matmul_ring_size=...)``
 
         These functions are kept in sync with the test suite and can be used as
         "executable documentation" for the layout contract; they are not a required

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -226,6 +226,12 @@ WeightCoreShardMaps get_weight_core_shard_maps(
     const uint32_t n_dram_banks = static_cast<uint32_t>(in0_core_coords.size());
 
     const bool is_blackhole = mesh_device->arch() == tt::ARCH::BLACKHOLE;
+    if (is_blackhole) {
+        TT_FATAL(
+            bh_ring_size == 8 || bh_ring_size == 12 || bh_ring_size == 16,
+            "bh_ring_size ({}) must be 8, 12, or 16 on BLACKHOLE",
+            bh_ring_size);
+    }
     const uint32_t target_ring_size = is_blackhole ? bh_ring_size : n_dram_banks;
 
     // Ring ordering: sort the DRAM-bank logical core coords by (y, x) descending.
@@ -253,6 +259,8 @@ WeightCoreShardMaps get_weight_core_shard_maps(
     dram_core_ranges.reserve(n_dram_banks);
 
     for (uint32_t ring_pos = 0; ring_pos < target_ring_size; ++ring_pos) {
+        // First n_dram_banks ring positions map to real DRAM-bank-adjacent cores;
+        // positions beyond that are synthetic (HEIGHT_SHARDED regroups onto n_dram_banks physical shards).
         if (ring_pos < n_dram_banks) {
             const uint32_t dram_bank_id = ring_to_dram_bank[ring_pos];
             const ttnn::CoreCoord dram_core(dram_bank_id, 0);

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -64,7 +64,8 @@ memory configs, or see ``test_moe_compute_6U.py`` for the full flow.
 
 **Available functions**
 
-- Shard formulas: ``_shard_tiles``, ``_w2_shard_tiles``, ``auto_output_width_shard_dim``
+- Shard formulas: ``_shard_tiles``, ``_w2_shard_tiles``, ``auto_output_width_shard_dim``,
+  ``effective_matmul_ring_size``
 - Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size)``
 - Memory configs: ``get_weight_mem_configs(...)``
 - Non-bias: ``prepare_w0_w1_tensor_for_moe_compute``, ``prepare_w2_tensor_for_moe_compute``
@@ -82,12 +83,11 @@ from typing import Sequence
 import ttnn
 
 
-# Supported BH matmul ring sizes. Default is 12 (= LCM(3, 4)), the smallest BH ring
-# that satisfies every shipped model's output_width_shard_dim ∈ {3, 4} divisibility
-# check (DS-family width=4 → 12%4==0; GPT-OSS width=3 → 12%3==0). N=8 maps 1:1 to
-# BH's 8 DRAM banks; N=12/16 cross banks via the bank-run loop in dm0.cpp. WH always
-# uses N=12 (12 DRAM banks, 1:1 with ring). Must stay in sync with C++ supported set
-# enforced in get_cores() (moe_compute_program_factory.cpp).
+# Supported BH matmul ring sizes. Default is 12. With ring-aware auto width dim, N=8/16
+# also work for GPT-OSS (width falls back from 3 to 2). N=8 maps 1:1 to BH's 8 DRAM
+# banks; N=12/16 cross banks via the bank-run loop in dm0.cpp. WH always uses N=12
+# (12 DRAM banks, 1:1 with ring). Must stay in sync with C++ supported set enforced
+# in get_cores() (moe_compute_program_factory.cpp).
 _BH_SUPPORTED_RING_SIZES = (8, 12, 16)
 
 
@@ -385,11 +385,31 @@ def _w2_shard_tiles(Ht: int, core_id: int, Nt: int, n_cores: int) -> int:
     return _shard_tiles(Ht, core_id, n_cores)
 
 
-def auto_output_width_shard_dim(hidden_size: int, tile_size: int = 32, max_dim: int = 4) -> int:
-    """Largest divisor of (hidden_size // tile_size) that is <= max_dim."""
+def effective_matmul_ring_size(mesh_device, bh_ring_size: int = 12) -> int:
+    """Matmul ring N used by ``moe_compute`` on this device (12 on WH; ``bh_ring_size`` on BH)."""
+    if mesh_device.arch() == ttnn.Arch.BLACKHOLE:
+        return bh_ring_size
+    return 12
+
+
+def auto_output_width_shard_dim(
+    hidden_size: int,
+    tile_size: int = 32,
+    max_dim: int = 4,
+    matmul_ring_size: int | None = None,
+) -> int:
+    """Largest divisor d of (hidden_size // tile_size) with d <= max_dim.
+
+    When ``matmul_ring_size`` is set, also require ``matmul_ring_size % d == 0`` so the
+    chosen width parallelism divides the matmul ring evenly. This matches the op's
+    ring-aware auto-derivation in ``moe_compute_device_operation.cpp::invoke()``.
+
+    Use ``effective_matmul_ring_size(mesh_device, bh_ring_size)`` for ``matmul_ring_size``
+    when preparing test tensors so host layout matches the device op.
+    """
     hidden_tiles = hidden_size // tile_size
     for d in range(max_dim, 0, -1):
-        if hidden_tiles % d == 0:
+        if hidden_tiles % d == 0 and (matmul_ring_size is None or matmul_ring_size % d == 0):
             return d
     return 1
 

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -388,6 +388,9 @@ def _w2_shard_tiles(Ht: int, core_id: int, Nt: int, n_cores: int) -> int:
 def effective_matmul_ring_size(mesh_device, bh_ring_size: int = 12) -> int:
     """Matmul ring N used by ``moe_compute`` on this device (12 on WH; ``bh_ring_size`` on BH)."""
     if mesh_device.arch() == ttnn.Arch.BLACKHOLE:
+        assert (
+            bh_ring_size in _BH_SUPPORTED_RING_SIZES
+        ), f"bh_ring_size={bh_ring_size} not in supported set {_BH_SUPPORTED_RING_SIZES}"
         return bh_ring_size
     return 12
 

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -66,7 +66,7 @@ memory configs, or see ``test_moe_compute_6U.py`` for the full flow.
 
 - Shard formulas: ``_shard_tiles``, ``_w2_shard_tiles``, ``auto_output_width_shard_dim``,
   ``effective_matmul_ring_size``
-- Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size)``
+- Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size, bh_ring_size=12)``
 - Memory configs: ``get_weight_mem_configs(...)``
 - Non-bias: ``prepare_w0_w1_tensor_for_moe_compute``, ``prepare_w2_tensor_for_moe_compute``
 - With bias: ``prepare_w0_w1_tensor_with_bias``, ``prepare_w2_tensor_with_bias``
@@ -388,9 +388,10 @@ def _w2_shard_tiles(Ht: int, core_id: int, Nt: int, n_cores: int) -> int:
 def effective_matmul_ring_size(mesh_device, bh_ring_size: int = 12) -> int:
     """Matmul ring N used by ``moe_compute`` on this device (12 on WH; ``bh_ring_size`` on BH)."""
     if mesh_device.arch() == ttnn.Arch.BLACKHOLE:
-        assert (
-            bh_ring_size in _BH_SUPPORTED_RING_SIZES
-        ), f"bh_ring_size={bh_ring_size} not in supported set {_BH_SUPPORTED_RING_SIZES}"
+        if bh_ring_size not in _BH_SUPPORTED_RING_SIZES:
+            raise ValueError(
+                f"bh_ring_size={bh_ring_size} is not supported (must be one of {_BH_SUPPORTED_RING_SIZES})"
+            )
         return bh_ring_size
     return 12
 


### PR DESCRIPTION
#45294 added combine fusion in MoE for Blackhole, but had it working only for DS and GPT-oss. This PR fixes a bug that allows other models to also run on BH LB.

### Changes
* Fixes `moe_compute` combine kernel noc semaphore wait to get it working on Blackhole for multiple models
* Adds testing for `bh_ring_size = {8, 12, 16}` in `test_moe_compute_6U.py` BH LB tests
* Updates `auto_output_width_shard_dim()` function to be `bh_ring_size`-aware so that GPT-oss works with `bh_ring_size`s 8 and 16 (with output_shard_width auto-calculated to 2 `= GCD(8 or 16, 90)`) in addition to 12 (with output_shard_width auto-calculated to 3 `= GCD(12, 90)`)
* Tests run fine locally and pass without perf regressions.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/fixes-for-moe_fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/fixes-for-moe_fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/fixes-for-moe_fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/fixes-for-moe_fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/fixes-for-moe_fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/fixes-for-moe_fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/fixes-for-moe_fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/fixes-for-moe_fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/fixes-for-moe_fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/fixes-for-moe_fused)