### PR TITLE
Fix unsafe construction of SFPLOADI opcodes

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -22,7 +22,7 @@ inline void _sfpu_load_imm32_(const std::uint32_t dest, const std::uint32_t val)
 
 inline void _sfpu_load_imm16_(const std::uint32_t dest, const std::uint32_t val)
 {
-    TT_SFPLOADI(dest, 2, val); // insmod == 2 will write imm16 value treated as unsigned integer, right justified and padded with zeroes on the MSBs
+    TT_SFPLOADI(dest, 2, val & 0xFFFF); // insmod == 2 will write imm16 value treated as unsigned integer, right justified and padded with zeroes on the MSBs
 }
 
 inline void _sfpu_load_config32_(const std::uint32_t dest, const std::uint32_t upper16, const std::uint32_t lower16)

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_load_config.h
@@ -22,7 +22,7 @@ inline void _sfpu_load_imm32_(const std::uint32_t dest, const std::uint32_t val)
 
 inline void _sfpu_load_imm16_(const std::uint32_t dest, const std::uint32_t val)
 {
-    TT_SFPLOADI(dest, 2, val); // insmod == 2 will write imm16 value treated as unsigned integer, right justified and padded with zeroes on the MSBs
+    TT_SFPLOADI(dest, 2, val & 0xFFFF); // insmod == 2 will write imm16 value treated as unsigned integer, right justified and padded with zeroes on the MSBs
 }
 
 inline void _sfpu_load_config32_(const std::uint32_t dest, const std::uint32_t upper16, const std::uint32_t lower16)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
uint16 fill kernels used by tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py were constructing invalid opcodes, which were flagged by ttsim. In the limit, the invalid opcodes could have started setting bits in the high 8 bits and even changing the SFPLOADI into a completely different instruction.

### Notes for reviewers
Could in theory make the API take a uint16_t, but this was clearly the lowest-risk fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/sfploadi-bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/sfploadi-bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/sfploadi-bug)