### PR TITLE
[Bug Fix]: Fix debug_tools inter-test ETH heartbeat failure

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -49,11 +49,24 @@ protected:
         }
 
         this->DetectDispatchMode();
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        this->arch_ = tt::tt_metal::MetalContext::instance().get_cluster().arch();
         init_max_cbs();
     }
 
     void TearDown() override {
+        // Reset idle eth cores that tests intentionally tripped into watcher sanitize hang loop.
+        // UMD topology discovery probes heartbeats on any eth core whose reset bit is deasserted,
+        // and a hung core will fail that check. Tensix/DRAM cores don't need this.
+        auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        for (auto& [device_id, device] : id_to_device_) {
+            for (const auto& logical_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
+                CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+                    device->get_devices()[0]->id(), logical_core, CoreType::ETH);
+                cluster.assert_risc_reset_at_core(
+                    tt_cxy_pair(device->get_devices()[0]->id(), virtual_core), tt::umd::RiscType::ALL);
+            }
+        }
+
         for (auto& [device_id, device] : id_to_device_) {
             device->close();
             device.reset();
@@ -124,7 +137,7 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(true);
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
 
-        const auto detected_arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        const auto detected_arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noc_sanitize_linked_transaction(
             detected_arch == tt::ARCH::BLACKHOLE || detected_arch == tt::ARCH::QUASAR);
 


### PR DESCRIPTION
### PR Category
Bug Fix. Fixes https://github.com/tenstorrent/tt-metal/issues/45675

### Summary
Tests that intentionally trip watcher sanitize on idle ETH cores (e.g. `IdleEthTestWatcherSanitizeIEth`) leave those cores hanging. Subsequent tests called `get_umd_arch_name()` which triggers a UMD topology re-discovery - probing heartbeats on all eth cores. The hung core fails the heartbeat check, timing out in UMD in the init in next test.

Two fixes:
1. Replace `get_umd_arch_name()` with `MetalContext::instance().get_cluster().arch()` since it already has arch instead of re-running topology discovery.
2. Assert reset on idle eth cores in fixture teardown for any future code path that may trigger UMD discovery.

### Notes for reviewers
1. `get_umd_arch_name()` calls `Cluster::create_cluster_descriptor()` which probes ETH heartbeats etc. We can replace this with `MetalContext.get_cluster().arch()` which already did this once at MetalContext process init.
2. Tensix/DRAM cores don't need the reset at teardown because UMD doesn't heartbeat-check them during discovery and they are reset anyway before launching kernels.


Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/26787486067

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_debug_unit_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_debug_unit_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_debug_unit_tests)