### PR TITLE
Fix Welford pre-allgather reciprocal width for padded tensors

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -705,14 +705,7 @@ def test_residual_logical_shape_mismatch_rejected(device, op_name, inp_shape, re
     [
         (1, 1, 32, 128),
         (1, 1, 32, 1024),
-        pytest.param(
-            (1, 1, 37, 72),
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="Welford pre-all-gather overflows to inf on non-tile-aligned H shapes; "
-                "torch comparison fails on mean and var. Issue #43935",
-            ),
-        ),
+        (1, 1, 37, 72),
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -30,13 +30,15 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
     const bool is_rmsnorm = operation_attributes.norm_type == LayerNormDistributedType::RMSNORM;
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
     const uint32_t tile_width = a.tensor_spec().tile().get_width();
-    const auto& shape = a.padded_shape();
-    const uint32_t W = shape[-1], H = shape[-2];
-    const uint32_t HW = H * W;
-    const uint32_t NC = a.physical_volume() / HW;
+    const auto& logical_shape = a.logical_shape();
+    const auto& padded_shape = a.padded_shape();
+    const uint32_t W = logical_shape[-1];
+    const uint32_t padded_W = padded_shape[-1], padded_H = padded_shape[-2];
+    const uint32_t padded_HW = padded_H * padded_W;
+    const uint32_t NC = a.physical_volume() / padded_HW;
 
-    const uint32_t Wt = W / tile_width;
-    const uint32_t Ht = H / tile_height;
+    const uint32_t Wt = padded_W / tile_width;
+    const uint32_t Ht = padded_H / tile_height;
 
     IDevice* device = a.device();
     auto grid_size = device->compute_with_storage_grid_size();
@@ -47,7 +49,8 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGatherWelfordProgramFactory::crea
 
     log_debug(tt::LogOp, "is_rmsnorm: {}", is_rmsnorm);
     log_debug(tt::LogOp, "W: {}", W);
-    log_debug(tt::LogOp, "H: {}", H);
+    log_debug(tt::LogOp, "padded_W: {}", padded_W);
+    log_debug(tt::LogOp, "padded_H: {}", padded_H);
     log_debug(tt::LogOp, "num_tile_rows: {}", num_tile_rows);
     log_debug(tt::LogOp, "Wt: {}", Wt);
     log_debug(tt::LogOp, "Ht: {}", Ht);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Welford `layer_norm_pre_all_gather` failed on non-tile-aligned shapes such as `(1, 1, 37, 72)` because the program factory used the padded tensor width as the Welford recurrence and reciprocal-LUT width while callers create the reciprocal tensor for the logical width. On WH this made the kernel read past the 72-entry L1 reciprocal shard at `0x16e000`, and it also made the old strict xfail still expect the corrected case to fail. The change keeps padded dimensions for tile traversal and work splitting, passes logical width to the compute kernel for Welford math and reciprocal indexing, and removes the stale strict xfail now that the shape passes against torch.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/welford-reciprocal-width)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/welford-reciprocal-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/welford-reciprocal-width)