### PR TITLE
[Feature] Usability improvements to Metal 2.0 `DataMovementHardwareConfig`

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -109,7 +109,7 @@ inline KernelSpec MakeMinimalGen1DMKernel(
 // Helper to create a minimal valid KernelSpec for data movement that relies on a
 // Gen1 role hint (READER/WRITER) to fill in the hardware config, rather than
 // supplying an explicit Gen1Config (Gen1/WH/BH).
-inline KernelSpec MakeMinimalRoleDMKernel(const std::string& name, DataMovementHardwareConfig::RoleHint role) {
+inline KernelSpec MakeMinimalRoleDMKernel(const std::string& name, DataMovementRoleHint role) {
     return KernelSpec{
         .unique_id = name,
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -106,6 +106,21 @@ inline KernelSpec MakeMinimalGen1DMKernel(
     };
 }
 
+// Helper to create a minimal valid KernelSpec for data movement that relies on a
+// Gen1 role hint (READER/WRITER) to fill in the hardware config, rather than
+// supplying an explicit Gen1Config (Gen1/WH/BH).
+inline KernelSpec MakeMinimalRoleDMKernel(const std::string& name, DataMovementHardwareConfig::RoleHint role) {
+    return KernelSpec{
+        .unique_id = name,
+        .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
+        .num_threads = 1,
+        .hw_config =
+            DataMovementHardwareConfig{
+                .role = role,
+            },
+    };
+}
+
 // Helper to create a minimal valid KernelSpec for compute
 inline KernelSpec MakeMinimalComputeKernel(const std::string& name, uint32_t num_threads = 1) {
     return KernelSpec{

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -741,7 +741,7 @@ TEST_F(ProgramSpecTestQuasar, RoleHintIgnoredOnGen2Succeeds) {
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto kernel = MakeMinimalRoleDMKernel("kernel", DataMovementHardwareConfig::RoleHint::READER);
+    auto kernel = MakeMinimalRoleDMKernel("kernel", DataMovementRoleHint::READER);
 
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
@@ -2654,8 +2654,8 @@ TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto reader = MakeMinimalRoleDMKernel("reader", DataMovementHardwareConfig::RoleHint::READER);
-    auto writer = MakeMinimalRoleDMKernel("writer", DataMovementHardwareConfig::RoleHint::WRITER);
+    auto reader = MakeMinimalRoleDMKernel("reader", DataMovementRoleHint::READER);
+    auto writer = MakeMinimalRoleDMKernel("writer", DataMovementRoleHint::WRITER);
 
     spec.kernels = {reader, writer};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"reader", "writer"})};
@@ -2672,8 +2672,8 @@ TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto r0 = MakeMinimalRoleDMKernel("r0", DataMovementHardwareConfig::RoleHint::READER);
-    auto r1 = MakeMinimalRoleDMKernel("r1", DataMovementHardwareConfig::RoleHint::READER);
+    auto r0 = MakeMinimalRoleDMKernel("r0", DataMovementRoleHint::READER);
+    auto r1 = MakeMinimalRoleDMKernel("r1", DataMovementRoleHint::READER);
 
     spec.kernels = {r0, r1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"r0", "r1"})};
@@ -2691,7 +2691,7 @@ TEST_F(ProgramSpecTestGen1, RoleHintWithExplicitGen1ConfigFails) {
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementHardwareConfig::RoleHint::READER);
+    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementRoleHint::READER);
     auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
     dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -57,6 +57,7 @@ using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalDMKernel;
 using test_helpers::MakeMinimalGen1DMKernel;
 using test_helpers::MakeMinimalGen1ValidProgramSpec;
+using test_helpers::MakeMinimalRoleDMKernel;
 using test_helpers::MakeMinimalTensorParameter;
 using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
@@ -712,14 +713,16 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithoutGen2ConfigSucceeds) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
+TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllSucceeds) {
+    // On Gen2 a DM kernel needs no config at all: the role hint is moot (Gen2 has a unified
+    // NOC and fully automated DM placement), and gen2_config is optional (absence = defaults).
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
     auto kernel = MakeMinimalDMKernel("kernel");
-    // Remove both Gen1 and Gen2 configs
+    // Remove both Gen1 and Gen2 configs, leaving a default (UNSPECIFIED role) config.
     auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
     dm_config.gen1_config = std::nullopt;
     dm_config.gen2_config = std::nullopt;
@@ -727,10 +730,23 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithNoConfigAtAllFails) {
     spec.kernels = {kernel};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("KernelSpec 'kernel' must specify a DM config for Gen1, Gen2, or both")));
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestQuasar, RoleHintIgnoredOnGen2Succeeds) {
+    // A READER/WRITER role hint is a Gen1 concept; on Gen2 it is informational and imposes no
+    // requirement (no explicit Gen1Config needed, gen2_config still optional).
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto kernel = MakeMinimalRoleDMKernel("kernel", DataMovementHardwareConfig::RoleHint::READER);
+
+    spec.kernels = {kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 // Remote DFBs are part of the API surface but not yet supported by the runtime.
@@ -2594,13 +2610,14 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
 }
 
 TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
-    // On gen1, a DM kernel that only has Gen2Config must be rejected
+    // On Gen1, a DM kernel that declares neither a role hint nor an explicit Gen1Config must be
+    // rejected: it has no way to resolve its processor/NOC placement.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    // MakeMinimalDMKernel produces a gen2 (Quasar) DM config
+    // MakeMinimalDMKernel produces a gen2 (Quasar) DM config (UNSPECIFIED role, no Gen1Config).
     auto kernel = MakeMinimalDMKernel("dm_kernel");
 
     spec.kernels = {kernel};
@@ -2608,7 +2625,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must specify a Gen1 DM config")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("specifies neither a role hint")));
 }
 
 TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
@@ -2627,6 +2644,64 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
+}
+
+TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {
+    // A READER and a WRITER role resolve to distinct processors (RISCV_1 and RISCV_0
+    // respectively), so two role-driven DM kernels coexist on one node without conflict.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto reader = MakeMinimalRoleDMKernel("reader", DataMovementHardwareConfig::RoleHint::READER);
+    auto writer = MakeMinimalRoleDMKernel("writer", DataMovementHardwareConfig::RoleHint::WRITER);
+
+    spec.kernels = {reader, writer};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"reader", "writer"})};
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
+    // Both READER kernels resolve to the same processor (RISCV_1), so placing them on the
+    // same node is a conflict — confirming the role hint resolves to a fixed, deterministic
+    // processor (the same uniqueness rule as explicit configs).
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto r0 = MakeMinimalRoleDMKernel("r0", DataMovementHardwareConfig::RoleHint::READER);
+    auto r1 = MakeMinimalRoleDMKernel("r1", DataMovementHardwareConfig::RoleHint::READER);
+
+    spec.kernels = {r0, r1};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"r0", "r1"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
+}
+
+TEST_F(ProgramSpecTestGen1, RoleHintWithExplicitGen1ConfigFails) {
+    // A role hint and an explicit Gen1Config are mutually exclusive: the hint already fills
+    // in the config, so supplying both is contradictory and must be rejected.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementHardwareConfig::RoleHint::READER);
+    auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
+    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1};
+
+    spec.kernels = {kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("sets both a READER/WRITER role hint and an explicit Gen1 config")));
 }
 
 // WH N150 mock grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2683,28 +2683,25 @@ TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
-TEST_F(ProgramSpecTestGen1, ExplicitGen1ConfigOverridesRoleHint) {
-    // When both are set, the explicit Gen1Config wins and the role hint is informational. Here a
-    // READER (which would resolve to RISCV_1) carries an explicit RISCV_0 config; pairing it with
-    // another RISCV_0 kernel on the same node must conflict — proving the config, not the role,
-    // determined the processor.
+TEST_F(ProgramSpecTestGen1, RoleHintWithExplicitGen1ConfigFails) {
+    // A role hint and an explicit Gen1Config are mutually exclusive: the hint already fills
+    // in the config, so supplying both is contradictory and must be rejected.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto overridden = MakeMinimalRoleDMKernel("overridden", DataMovementRoleHint::READER);
-    auto& dm_config = std::get<DataMovementHardwareConfig>(overridden.hw_config);
-    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_0};
+    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementRoleHint::READER);
+    auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
+    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1};
 
-    auto other = MakeMinimalGen1DMKernel("other", DataMovementProcessor::RISCV_0);
-
-    spec.kernels = {overridden, other};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"overridden", "other"})};
+    spec.kernels = {kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("sets both a READER/WRITER role hint and an explicit Gen1 config")));
 }
 
 // WH N150 mock grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2683,25 +2683,28 @@ TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
-TEST_F(ProgramSpecTestGen1, RoleHintWithExplicitGen1ConfigFails) {
-    // A role hint and an explicit Gen1Config are mutually exclusive: the hint already fills
-    // in the config, so supplying both is contradictory and must be rejected.
+TEST_F(ProgramSpecTestGen1, ExplicitGen1ConfigOverridesRoleHint) {
+    // When both are set, the explicit Gen1Config wins and the role hint is informational. Here a
+    // READER (which would resolve to RISCV_1) carries an explicit RISCV_0 config; pairing it with
+    // another RISCV_0 kernel on the same node must conflict — proving the config, not the role,
+    // determined the processor.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
     spec.name = "test_program";
 
-    auto kernel = MakeMinimalRoleDMKernel("dm_kernel", DataMovementRoleHint::READER);
-    auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1};
+    auto overridden = MakeMinimalRoleDMKernel("overridden", DataMovementRoleHint::READER);
+    auto& dm_config = std::get<DataMovementHardwareConfig>(overridden.hw_config);
+    dm_config.gen1_config = DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_0};
 
-    spec.kernels = {kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+    auto other = MakeMinimalGen1DMKernel("other", DataMovementProcessor::RISCV_0);
+
+    spec.kernels = {overridden, other};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"overridden", "other"})};
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("sets both a READER/WRITER role hint and an explicit Gen1 config")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
 // WH N150 mock grid reference (wormhole_N150.yaml, harvest_mask=0x40 = 1 row harvested):

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -469,6 +469,9 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     // `sem::<accessor_name>` constants in `kernel_bindings_generated.h` for the kernel to
     // consume. The producer and consumer below choose different accessor names for the same
     // semaphore.
+    // These two DM kernels only need to land on distinct DM processors. The READER/WRITER role
+    // hints are the idiomatic way to get that — the producer writes the semaphore signal, the
+    // consumer reads it — with no need to hand-pick a processor/NOC via an explicit Gen1Config.
     KernelSpec producer{
         .unique_id = "producer",
         .source =
@@ -478,10 +481,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .gen1_config =
-                    DataMovementHardwareConfig::Gen1Config{
-                        .processor = DataMovementProcessor::RISCV_0,
-                    },
+                .role = DataMovementHardwareConfig::RoleHint::WRITER,
             },
     };
     KernelSpec consumer{
@@ -493,10 +493,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .gen1_config =
-                    DataMovementHardwareConfig::Gen1Config{
-                        .processor = DataMovementProcessor::RISCV_1,
-                    },
+                .role = DataMovementHardwareConfig::RoleHint::READER,
             },
     };
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -481,7 +481,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "signal"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementHardwareConfig::RoleHint::WRITER,
+                .role = DataMovementRoleHint::WRITER,
             },
     };
     KernelSpec consumer{
@@ -493,7 +493,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
         .semaphore_bindings = {{.semaphore_spec_name = "only_sem", .accessor_name = "waiter"}},
         .hw_config =
             DataMovementHardwareConfig{
-                .role = DataMovementHardwareConfig::RoleHint::READER,
+                .role = DataMovementRoleHint::READER,
             },
     };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -21,12 +21,13 @@ namespace tt::tt_metal::experimental {
 // The DM hardware differs between Gen1 architectures (Wormhole, Blackhole) and
 // Gen2 architectures (Quasar and derivatives), so this config carries a separate
 // Gen1Config and Gen2Config. The runtime selects the one matching the target
-// architecture. Architecture-agnostic host code may populate both.
+// architecture, so architecture-agnostic host code may populate both.
 //
 // Gen1 DM config (i.e., which RISC and NOC a kernel uses) is performance-critical,
 // but the common case is handled for you: set the `role` hint to READER or WRITER
 // and the runtime fills in the conventional processor/NOC/NOC-mode. Power users
-// who need to override that convention can provide an explicit Gen1Config.
+// who want to override that convention can provide an explicit Gen1Config
+// (alongside RoleHint::UNSPECIFIED).
 //
 // Gen2 has a unified NOC and its DM kernel core selection is fully automated.
 // The gen2_config controls only whether the ISR-based DFB implicit sync is enabled.
@@ -38,8 +39,8 @@ struct DataMovementHardwareConfig {
     // Declares what the DM kernel does.
     //  - If specified, the runtime will automatically fill in an omitted Gen1Config
     //    with the standard optimal Gen1 DM config for a READER or WRITER kernel.
-    //  - The role hint is ignored (informational) if a Gen1Config is provided.
-    //  - For Gen2, the role hint is informational.
+    //  - If an explicit Gen1Config is provided, set the role hint to UNSPECIFIED.
+    //  - For Gen2, the role hint is ignored / informational.
     enum class RoleHint { READER, WRITER, UNSPECIFIED };
     RoleHint role = RoleHint::UNSPECIFIED;
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -21,27 +21,25 @@ namespace tt::tt_metal::experimental {
 // The DM hardware differs between Gen1 architectures (Wormhole, Blackhole) and
 // Gen2 architectures (Quasar and derivatives), so this config carries a separate
 // Gen1Config and Gen2Config. The runtime selects the one matching the target
-// architecture, so architecture-agnostic host code may populate both.
+// architecture. Architecture-agnostic host code may populate both.
 //
-// Gen1 placement (which RISC and NOC a kernel uses) is performance-critical, but
-// the common case is handled for you: set the `role` hint to READER or WRITER and
-// the runtime fills in the conventional processor/NOC/NOC-mode. Power users who
-// need to override that convention instead set an explicit Gen1Config (alongside
-// RoleHint::UNSPECIFIED). On Gen1, exactly one of these two paths is required.
+// Gen1 DM config (i.e., which RISC and NOC a kernel uses) is performance-critical,
+// but the common case is handled for you: set the `role` hint to READER or WRITER
+// and the runtime fills in the conventional processor/NOC/NOC-mode. Power users
+// who need to override that convention can provide an explicit Gen1Config.
 //
-// Gen2 has a unified NOC, and DM kernel placement is fully automated. The
-// gen2_config controls only whether the ISR-based DFB implicit sync is enabled.
+// Gen2 has a unified NOC and its DM kernel core selection is fully automated.
+// The gen2_config controls only whether the ISR-based DFB implicit sync is enabled.
 // This config is optional: when absent, the runtime uses default settings.
 //
 // ============================================================================
 
 struct DataMovementHardwareConfig {
-    // Declares what the DM kernel does, so the runtime can fill in the Gen1 hardware
-    // knobs (processor, NOC) for you using the standard reader/writer convention.
-    //   - READER / WRITER: the runtime fills in the Gen1 config; leave gen1_config unset.
-    //   - UNSPECIFIED:     you supply an explicit gen1_config yourself (power-user path).
-    // Only has teeth on Gen1 (WH/BH), where RISC/NOC choice is performance-critical;
-    // on Gen2 it is informational (the hardware is indifferent to DM core / NOC).
+    // Declares what the DM kernel does.
+    //  - If specified, the runtime will automatically fill in an omitted Gen1Config
+    //    with the standard optimal Gen1 DM config for a READER or WRITER kernel.
+    //  - The role hint is ignored (informational) if a Gen1Config is provided.
+    //  - For Gen2, the role hint is informational.
     enum class RoleHint { READER, WRITER, UNSPECIFIED };
     RoleHint role = RoleHint::UNSPECIFIED;
 
@@ -50,9 +48,9 @@ struct DataMovementHardwareConfig {
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
     };
-    // Explicit Gen1 placement override. Leave unset when using a READER/WRITER role
-    // (the runtime fills it in); set it together with RoleHint::UNSPECIFIED to take
-    // manual control. On Gen1, one of {role hint, explicit gen1_config} is required.
+    // For a Gen1 DM kernel, specifying the Gen1Config is optional.
+    // If unspecified, the runtime infers the settings from the role hint (READER/WRITER).
+    // (A Gen1 DM kernel must provide either a role hint or an explicit Gen1Config.)
     std::optional<Gen1Config> gen1_config = std::nullopt;
 
     struct Gen2Config {
@@ -63,11 +61,11 @@ struct DataMovementHardwareConfig {
         // Any bound DFB not listed here will use implicit sync by default.
         std::vector<DFBSpecName> disable_implicit_sync_for;
     };
+    // For a Gen2 DM kernel, providing the Gen2Config is optional.
     std::optional<Gen2Config> gen2_config = std::nullopt;
 };
 
-// Flat alias for the nested role enum, so common-path call sites stay readable:
-//   DataMovementHardwareConfig{.role = DataMovementRoleHint::READER}
+// Convenience alias for the nested role enum
 using DataMovementRoleHint = DataMovementHardwareConfig::RoleHint;
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -66,4 +66,8 @@ struct DataMovementHardwareConfig {
     std::optional<Gen2Config> gen2_config = std::nullopt;
 };
 
+// Flat alias for the nested role enum, so common-path call sites stay readable:
+//   DataMovementHardwareConfig{.role = DataMovementRoleHint::READER}
+using DataMovementRoleHint = DataMovementHardwareConfig::RoleHint;
+
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -16,30 +16,43 @@ namespace tt::tt_metal::experimental {
 //  DataMovementHardwareConfig
 // ============================================================================
 //
-// The DataMovementHardwareConfig describes the configuration of the hardware resources
-// controlled by a data movement kernel. ("DM" is the abbreviation for Data
-// Movement, used throughout the API).
+// Describes the hardware resources controlled by a data movement ("DM") kernel.
 //
-// The DM configuration differs between Gen1 architectures (Wormhole, Blackhole)
-// and Gen2 architectures (Quasar and derivatives).
+// The DM hardware differs between Gen1 architectures (Wormhole, Blackhole) and
+// Gen2 architectures (Quasar and derivatives), so this config carries a separate
+// Gen1Config and Gen2Config. The runtime selects the one matching the target
+// architecture, so architecture-agnostic host code may populate both.
 //
-// The DataMovementHardwareConfig struct exposes both a Gen1Config and a Gen2Config variant.
-// The runtime will dynamically select the appropriate variant based on the
-// target architecture. For architecture-agnostic host code, you may specify
-// both variants in the same DataMovementHardwareConfig.
+// Gen1 placement (which RISC and NOC a kernel uses) is performance-critical, but
+// the common case is handled for you: set the `role` hint to READER or WRITER and
+// the runtime fills in the conventional processor/NOC/NOC-mode. Power users who
+// need to override that convention instead set an explicit Gen1Config (alongside
+// RoleHint::UNSPECIFIED). On Gen1, exactly one of these two paths is required.
 //
-// If the variant for the target architecture is not supplied:
-//  - Gen 1 will trigger an error (config is mandatory for now)
-//  - Gen 2 will use default settings
+// Gen2 has a unified NOC, and DM kernel placement is fully automated. The
+// gen2_config controls only whether the ISR-based DFB implicit sync is enabled.
+// This config is optional: when absent, the runtime uses default settings.
 //
 // ============================================================================
 
 struct DataMovementHardwareConfig {
+    // Declares what the DM kernel does, so the runtime can fill in the Gen1 hardware
+    // knobs (processor, NOC) for you using the standard reader/writer convention.
+    //   - READER / WRITER: the runtime fills in the Gen1 config; leave gen1_config unset.
+    //   - UNSPECIFIED:     you supply an explicit gen1_config yourself (power-user path).
+    // Only has teeth on Gen1 (WH/BH), where RISC/NOC choice is performance-critical;
+    // on Gen2 it is informational (the hardware is indifferent to DM core / NOC).
+    enum class RoleHint { READER, WRITER, UNSPECIFIED };
+    RoleHint role = RoleHint::UNSPECIFIED;
+
     struct Gen1Config {
         tt::tt_metal::DataMovementProcessor processor = tt::tt_metal::DataMovementProcessor::RISCV_0;
         tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default;
         tt::tt_metal::NOC_MODE noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC;
     };
+    // Explicit Gen1 placement override. Leave unset when using a READER/WRITER role
+    // (the runtime fills it in); set it together with RoleHint::UNSPECIFIED to take
+    // manual control. On Gen1, one of {role hint, explicit gen1_config} is required.
     std::optional<Gen1Config> gen1_config = std::nullopt;
 
     struct Gen2Config {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -154,18 +154,22 @@ inline bool is_gen1_arch() {
 }
 
 // Resolve the effective Gen1 hardware knobs (processor, NOC, NOC mode) for a DM kernel.
-// When the user supplies a READER/WRITER role hint, the runtime fills in the conventional
-// triple, mirroring the legacy ReaderDataMovementConfig / WriterDataMovementConfig
-// convention (see kernel_types.cpp):
+// An explicit gen1_config takes precedence; the role hint is informational when one is set.
+// Otherwise, a READER/WRITER role fills in the conventional triple, mirroring the legacy
+// ReaderDataMovementConfig / WriterDataMovementConfig convention (see kernel_types.cpp):
 //   READER -> NCRISC (RISCV_1) on NOC_0
 //   WRITER -> BRISC  (RISCV_0) on NOC_1
-// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached only
-// via RoleHint::UNSPECIFIED + an explicit gen1_config, which is returned verbatim.
+// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached via an
+// explicit gen1_config.
 //
-// Precondition (guaranteed by validation on Gen1): exactly one of {a READER/WRITER role,
+// Precondition (guaranteed by validation on Gen1): at least one of {a READER/WRITER role,
 // an explicit gen1_config} is present.
 DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardwareConfig& dm_config) {
     using Gen1Config = DataMovementHardwareConfig::Gen1Config;
+    // Explicit config wins; the role hint is informational when a gen1_config is supplied.
+    if (dm_config.gen1_config.has_value()) {
+        return dm_config.gen1_config.value();
+    }
     switch (dm_config.role) {
         case DataMovementRoleHint::READER:
             return Gen1Config{
@@ -173,9 +177,10 @@ DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardw
         case DataMovementRoleHint::WRITER:
             return Gen1Config{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_1, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementRoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
+        case DataMovementRoleHint::UNSPECIFIED:
+            break;  // no gen1_config and no role hint — validation rejects this on Gen1
     }
-    TT_THROW("Unhandled RoleHint in ResolveGen1Config");
+    TT_THROW("ResolveGen1Config: Gen1 DM kernel has neither an explicit gen1_config nor a role hint");
 }
 
 NodeRangeSet to_node_range_set(const Nodes& nodes) {
@@ -696,20 +701,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_data_movement_kernel()) {
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
 
-            // A role hint and an explicit Gen1 config are mutually exclusive: a READER/WRITER
-            // hint already fills in the Gen1 config, so also supplying one is contradictory.
-            TT_FATAL(
-                data_movement_config.role == DataMovementRoleHint::UNSPECIFIED ||
-                    !data_movement_config.gen1_config.has_value(),
-                "KernelSpec '{}' sets both a READER/WRITER role hint and an explicit Gen1 config. "
-                "A role hint fills the Gen1 config for you; either drop the explicit config, or use "
-                "RoleHint::UNSPECIFIED to take manual control.",
-                kernel.unique_id);
-
             // On Gen1 (WH/BH), the kernel must declare its placement: either a READER/WRITER role
-            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config. There
-            // is no safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional:
-            // absence is treated as "use defaults" (empty disable_implicit_sync_for).
+            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config (which
+            // takes precedence — the role hint is then informational). There is no safe default for
+            // reader-vs-writer — it is op-specific. Gen2 is fully optional: absence is treated as
+            // "use defaults" (empty disable_implicit_sync_for).
             if (is_gen1_arch()) {
                 TT_FATAL(
                     data_movement_config.role != DataMovementRoleHint::UNSPECIFIED ||

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -153,6 +153,31 @@ inline bool is_gen1_arch() {
     return arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE;
 }
 
+// Resolve the effective Gen1 hardware knobs (processor, NOC, NOC mode) for a DM kernel.
+// When the user supplies a READER/WRITER role hint, the runtime fills in the conventional
+// triple, mirroring the legacy ReaderDataMovementConfig / WriterDataMovementConfig
+// convention (see kernel_types.cpp):
+//   READER -> NCRISC (RISCV_1) on NOC_0
+//   WRITER -> BRISC  (RISCV_0) on NOC_1
+// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached only
+// via RoleHint::UNSPECIFIED + an explicit gen1_config, which is returned verbatim.
+//
+// Precondition (guaranteed by validation on Gen1): exactly one of {a READER/WRITER role,
+// an explicit gen1_config} is present.
+DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardwareConfig& dm_config) {
+    using Gen1Config = DataMovementHardwareConfig::Gen1Config;
+    switch (dm_config.role) {
+        case DataMovementHardwareConfig::RoleHint::READER:
+            return Gen1Config{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_0, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
+        case DataMovementHardwareConfig::RoleHint::WRITER:
+            return Gen1Config{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_1, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
+        case DataMovementHardwareConfig::RoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
+    }
+    TT_THROW("Unhandled RoleHint in ResolveGen1Config");
+}
+
 NodeRangeSet to_node_range_set(const Nodes& nodes) {
     return std::visit(
         [](const auto& n) -> NodeRangeSet {
@@ -671,20 +696,26 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_data_movement_kernel()) {
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
 
-            // Both Gen1 and Gen2 configs are optional. But at least one must be specified.
+            // A role hint and an explicit Gen1 config are mutually exclusive: a READER/WRITER
+            // hint already fills in the Gen1 config, so also supplying one is contradictory.
             TT_FATAL(
-                data_movement_config.gen1_config.has_value() ||
-                    data_movement_config.gen2_config.has_value(),
-                "KernelSpec '{}' must specify a DM config for Gen1, Gen2, or both.",
+                data_movement_config.role == DataMovementHardwareConfig::RoleHint::UNSPECIFIED ||
+                    !data_movement_config.gen1_config.has_value(),
+                "KernelSpec '{}' sets both a READER/WRITER role hint and an explicit Gen1 config. "
+                "A role hint fills the Gen1 config for you; either drop the explicit config, or use "
+                "RoleHint::UNSPECIFIED to take manual control.",
                 kernel.unique_id);
 
-            // Gen1 builds still require an explicit Gen1 config (its fields — processor, NOC,
-            // NOC mode — have no universally-safe defaults). Gen2 is fully optional even on
-            // Gen2 builds: absence is treated as "use defaults" (empty disable_implicit_sync_for).
+            // On Gen1 (WH/BH), the kernel must declare its placement: either a READER/WRITER role
+            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config. There
+            // is no safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional:
+            // absence is treated as "use defaults" (empty disable_implicit_sync_for).
             if (is_gen1_arch()) {
                 TT_FATAL(
-                    data_movement_config.gen1_config.has_value(),
-                    "KernelSpec '{}' must specify a Gen1 DM config when targeting WH or BH.",
+                    data_movement_config.role != DataMovementHardwareConfig::RoleHint::UNSPECIFIED ||
+                        data_movement_config.gen1_config.has_value(),
+                    "KernelSpec '{}' targets Gen1 (WH/BH) but specifies neither a role hint "
+                    "(READER/WRITER) nor an explicit Gen1 config. One is required.",
                     kernel.unique_id);
             }
         }
@@ -700,7 +731,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 continue;
             }
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            const auto& gen1 = dm_config.gen1_config.value();
+            const auto gen1 = ResolveGen1Config(dm_config);
             const NodeRangeSet& nodes = collected.kernel_node_set.at(kernel.unique_id);
             for (const auto& range : nodes.ranges()) {
                 for (const auto& node : range) {
@@ -1730,8 +1761,9 @@ KernelRiscMaskMap SolveGen2KernelRiscMasks(const ProgramSpec& spec, const Collec
     return result;
 }
 
-// Gen1 (WH/BH) processor assignment: just read the explicit processor from Gen1Config
-// and returns a KernelRiscMaskMap using the Gen1 bit encoding (RISCV_0: bit 0, RISCV_1: bit 1, compute: bit 2).
+// Gen1 (WH/BH) processor assignment: read the effective processor (explicit, or derived
+// from the role hint via ResolveGen1Config) and return a KernelRiscMaskMap using the Gen1
+// bit encoding (RISCV_0: bit 0, RISCV_1: bit 1, compute: bit 2).
 KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     static constexpr uint8_t GEN1_COMPUTE_RISC_BIT = 2;
 
@@ -1739,7 +1771,7 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
     for (const KernelSpec& kernel : spec.kernels) {
         if (kernel.is_data_movement_kernel()) {
             const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
-            const auto& gen1 = dm_config.gen1_config.value();
+            const auto gen1 = ResolveGen1Config(dm_config);
             result[&kernel] = static_cast<uint16_t>(1u << static_cast<uint8_t>(gen1.processor));
         } else {
             result[&kernel] = static_cast<uint16_t>(1u << GEN1_COMPUTE_RISC_BIT);
@@ -2135,7 +2167,7 @@ std::map<std::string, std::string> to_defines_map(const KernelSpec::CompilerOpti
 DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
     TT_FATAL(kernel_spec.is_data_movement_kernel(), "Expected a DM kernel");
     const auto& dm_config = std::get<DataMovementHardwareConfig>(kernel_spec.hw_config);
-    const auto& gen1 = dm_config.gen1_config.value();
+    const auto gen1 = ResolveGen1Config(dm_config);
 
     return DataMovementConfig{
         .processor = gen1.processor,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -167,13 +167,13 @@ inline bool is_gen1_arch() {
 DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardwareConfig& dm_config) {
     using Gen1Config = DataMovementHardwareConfig::Gen1Config;
     switch (dm_config.role) {
-        case DataMovementHardwareConfig::RoleHint::READER:
+        case DataMovementRoleHint::READER:
             return Gen1Config{
                 .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_0, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementHardwareConfig::RoleHint::WRITER:
+        case DataMovementRoleHint::WRITER:
             return Gen1Config{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_1, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementHardwareConfig::RoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
+        case DataMovementRoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
     }
     TT_THROW("Unhandled RoleHint in ResolveGen1Config");
 }
@@ -699,7 +699,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // A role hint and an explicit Gen1 config are mutually exclusive: a READER/WRITER
             // hint already fills in the Gen1 config, so also supplying one is contradictory.
             TT_FATAL(
-                data_movement_config.role == DataMovementHardwareConfig::RoleHint::UNSPECIFIED ||
+                data_movement_config.role == DataMovementRoleHint::UNSPECIFIED ||
                     !data_movement_config.gen1_config.has_value(),
                 "KernelSpec '{}' sets both a READER/WRITER role hint and an explicit Gen1 config. "
                 "A role hint fills the Gen1 config for you; either drop the explicit config, or use "
@@ -712,7 +712,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             // absence is treated as "use defaults" (empty disable_implicit_sync_for).
             if (is_gen1_arch()) {
                 TT_FATAL(
-                    data_movement_config.role != DataMovementHardwareConfig::RoleHint::UNSPECIFIED ||
+                    data_movement_config.role != DataMovementRoleHint::UNSPECIFIED ||
                         data_movement_config.gen1_config.has_value(),
                     "KernelSpec '{}' targets Gen1 (WH/BH) but specifies neither a role hint "
                     "(READER/WRITER) nor an explicit Gen1 config. One is required.",

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -154,22 +154,18 @@ inline bool is_gen1_arch() {
 }
 
 // Resolve the effective Gen1 hardware knobs (processor, NOC, NOC mode) for a DM kernel.
-// An explicit gen1_config takes precedence; the role hint is informational when one is set.
-// Otherwise, a READER/WRITER role fills in the conventional triple, mirroring the legacy
-// ReaderDataMovementConfig / WriterDataMovementConfig convention (see kernel_types.cpp):
+// When the user supplies a READER/WRITER role hint, the runtime fills in the conventional
+// triple, mirroring the legacy ReaderDataMovementConfig / WriterDataMovementConfig
+// convention (see kernel_types.cpp):
 //   READER -> NCRISC (RISCV_1) on NOC_0
 //   WRITER -> BRISC  (RISCV_0) on NOC_1
-// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached via an
-// explicit gen1_config.
+// NOC mode is always DM_DEDICATED_NOC; DM_DYNAMIC_NOC is a power-user knob reached only
+// via RoleHint::UNSPECIFIED + an explicit gen1_config, which is returned verbatim.
 //
-// Precondition (guaranteed by validation on Gen1): at least one of {a READER/WRITER role,
+// Precondition (guaranteed by validation on Gen1): exactly one of {a READER/WRITER role,
 // an explicit gen1_config} is present.
 DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardwareConfig& dm_config) {
     using Gen1Config = DataMovementHardwareConfig::Gen1Config;
-    // Explicit config wins; the role hint is informational when a gen1_config is supplied.
-    if (dm_config.gen1_config.has_value()) {
-        return dm_config.gen1_config.value();
-    }
     switch (dm_config.role) {
         case DataMovementRoleHint::READER:
             return Gen1Config{
@@ -177,10 +173,9 @@ DataMovementHardwareConfig::Gen1Config ResolveGen1Config(const DataMovementHardw
         case DataMovementRoleHint::WRITER:
             return Gen1Config{
                 .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_1, .noc_mode = NOC_MODE::DM_DEDICATED_NOC};
-        case DataMovementRoleHint::UNSPECIFIED:
-            break;  // no gen1_config and no role hint — validation rejects this on Gen1
+        case DataMovementRoleHint::UNSPECIFIED: return dm_config.gen1_config.value();
     }
-    TT_THROW("ResolveGen1Config: Gen1 DM kernel has neither an explicit gen1_config nor a role hint");
+    TT_THROW("Unhandled RoleHint in ResolveGen1Config");
 }
 
 NodeRangeSet to_node_range_set(const Nodes& nodes) {
@@ -701,11 +696,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         if (kernel.is_data_movement_kernel()) {
             const auto& data_movement_config = std::get<DataMovementHardwareConfig>(kernel.hw_config);
 
+            // A role hint and an explicit Gen1 config are mutually exclusive: a READER/WRITER
+            // hint already fills in the Gen1 config, so also supplying one is contradictory.
+            TT_FATAL(
+                data_movement_config.role == DataMovementRoleHint::UNSPECIFIED ||
+                    !data_movement_config.gen1_config.has_value(),
+                "KernelSpec '{}' sets both a READER/WRITER role hint and an explicit Gen1 config. "
+                "A role hint fills the Gen1 config for you; either drop the explicit config, or use "
+                "RoleHint::UNSPECIFIED to take manual control.",
+                kernel.unique_id);
+
             // On Gen1 (WH/BH), the kernel must declare its placement: either a READER/WRITER role
-            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config (which
-            // takes precedence — the role hint is then informational). There is no safe default for
-            // reader-vs-writer — it is op-specific. Gen2 is fully optional: absence is treated as
-            // "use defaults" (empty disable_implicit_sync_for).
+            // hint (the runtime fills in processor/NOC/NOC-mode), or an explicit Gen1 config. There
+            // is no safe default for reader-vs-writer — it is op-specific. Gen2 is fully optional:
+            // absence is treated as "use defaults" (empty disable_implicit_sync_for).
             if (is_gen1_arch()) {
                 TT_FATAL(
                     data_movement_config.role != DataMovementRoleHint::UNSPECIFIED ||


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR significantly improves the usability of the `DataMovementHardwareConfig` in Metal 2.0. 

### Usability shortfalls

1. **No intent-level knob.** For Gen1 configuration, the API required an explicit `processor`, `noc`, and `noc_mode`. The default settings were not particularly useful, because half of any Program's DM kernels can't use the "default" processor! Worse, you need to "just know" the right processor-noc pair. Get it wrong, and you'll be punished with poor (and hard to debug) performance.
2. **Over-zealous validation.** The validator required a DM kernel to supply at least one of `gen1_config` / `gen2_config`. That's silly; a Gen2-only kernel that just wants defaults should be allowed a default-constructed struct.

### PR Changes

The `DataMovementHardwareConfig` now looks like this:
```cpp
struct DataMovementHardwareConfig {
    // RoleHint is new in this PR
    enum class RoleHint { READER, WRITER, UNSPECIFIED };
    RoleHint role = RoleHint::UNSPECIFIED;

    struct Gen1Config { ... };
    std::optional<Gen1Config> gen1_config = std::nullopt;

    struct Gen2Config { ... };
    std::optional<Gen2Config> gen2_config = std::nullopt;
};
```

**`RoleHint` Behavior:**

If the `RoleHint` is provided (`READER` or `WRITER`), the Gen1 config is automatically inferred.
If the `RoleHint` is `UNSPECIFIED`, the user must provide the Gen1 config (power user manual override).
(The automatic resolution "solver" is intentionally dumb. There is no partial config resolution. If the `std::optional` gen1_config is specified, it is honored as written.)

The Gen2 config is always optional. For Gen2, the `RoleHint` field is ignored (but can provide intent documentation).

(**Note**: Runtime host code is always device-agnostic at compilation; device-specific code paths are resolved at runtime, not compile time. )

The examples below assume that the config is used in a `KernelSpec`.
```cpp
// Role unspecified (default = UNSPECIFIED); neither config provided.
// On a Gen1 target (WH/BH) this is a runtime error.
// On Gen2 it's legal — the kernel uses the default Gen2 DM config.
auto ex1 = DataMovementHardwareConfig{};

// Role specified; neither config provided.
// The Gen1 config is inferred from the role hint; the Gen2 config defaults (as ex1).
auto ex2 = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};

// Role unspecified; gen1_config provided explicitly.
// Power-user override of the default Gen1 settings (rare in practice).
// Also legal on Gen2 (uses the default Gen2 DM config).
auto ex3 = DataMovementHardwareConfig{
    .gen1_config = DataMovementHardwareConfig::Gen1Config{...}};

// Gen2 config is optional (currently a single power-user knob).
// Both Gen1 and Gen2 configs may be set together in arch-agnostic host code.
auto ex4 = DataMovementHardwareConfig{
    .gen1_config = DataMovementHardwareConfig::Gen1Config{...},
    .gen2_config = DataMovementHardwareConfig::Gen2Config{...}};
```

**Other changes:**
The overzealous validation check is fixed, and the header comments have been reworked for clarity.


## Notes for reviewers
I didn't propagate this change to the Metal tests that use Metal 2.0, because almost all of them use a `processor` + `noc` combo that is performance suboptimal (and therefore not inferable from `RoleHint`). So, the tests continue to use the verbose "power-user "path... though probably not for good reason. We might want to clean this up at some point, but changing the test configs is outside the scope of this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/improve-dm-config-usability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/improve-dm-config-usability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/improve-dm-config-usability)