### PR TITLE
[Bug fix] enforce Gemma4 vLLM KV cache ownership

### DIFF
--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -2110,3 +2110,32 @@ def test_bridge_alias_handles_distinct_source_page_tables():
     # Source layers themselves stay self-pointing.
     assert out[13] is page_tables[13]
     assert out[14] is page_tables[14]
+
+
+def test_bridge_rejects_swapped_runtime_kv_cache_allocation():
+    """The Gemma4 vLLM bridge should pin the first runtime KV allocation.
+
+    The issue is not that callers pass ``kv_cache`` at all; the shared Generator
+    API still threads it through. The issue is that after trace capture the
+    bridge should treat the first harness-owned cache allocation as sticky
+    runtime state and reject a later call that swaps in different cache leaves.
+
+    Re-wrapping the same leaves in fresh Python lists must stay allowed, since
+    the Generator / bridge stack does that naturally. Swapping the leaves
+    themselves must fail loudly.
+    """
+    from models.demos.gemma4.tt.generator_vllm import Gemma4ForCausalLM
+
+    bridge = Gemma4ForCausalLM.__new__(Gemma4ForCausalLM)
+    bridge._runtime_kv_cache_identity = None
+
+    leaf_a0 = object()
+    leaf_a1 = object()
+    first_handle = [[leaf_a0, leaf_a1]]
+    bridge._remember_runtime_kv_cache_identity(first_handle)
+
+    # Same leaves, freshly wrapped: valid compatibility path.
+    bridge._remember_runtime_kv_cache_identity([[leaf_a0, leaf_a1]])
+
+    with pytest.raises(ValueError, match="different kv_cache allocation after initialization"):
+        bridge._remember_runtime_kv_cache_identity([[object(), leaf_a1]])

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1641,12 +1641,18 @@ def test_full_model_parity_decode_trace(layer_set, decode_steps, pli, mesh_devic
         # vLLM path: refresh persistent per-layer page tables + stash
         # the per-submesh routing list, then go through the same
         # Generator.decode_forward. Exactly mirrors what
-        # ``Gemma4ForCausalLM.decode_forward`` does in the bridge.
+        # ``Gemma4ForCausalLM.decode_forward`` does in the bridge. The
+        # externally threaded ``kv_cache`` is just the compatibility handle
+        # into the harness-owned cache allocation; the actual per-step routing
+        # authority comes from the page-table refresh above.
         pool.reserve_decode_token(req)
         pts_step_torch = pool.per_layer_page_tables(req)
         tt_model_vllm.update_persistent_per_layer_page_tables(pts_step_torch)
         tt_model_vllm._active_page_tables_per_layer = pts_step_torch
         try:
+            # Reuse the same harness-owned cache handle across decode steps.
+            # The thing that changes step to step is the refreshed page-table
+            # routing above, not the identity of ``kv_cache`` itself.
             v_out = gen_vllm.decode_forward(
                 tokens=tokens_step,
                 start_pos=pos_step,
@@ -1838,7 +1844,11 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
     # captured trace lands on the per-layer routing path. Without this
     # the warmup trace would bind against the legacy page_table only,
     # and at inference our update_persistent_per_layer_page_tables
-    # writes wouldn't reach anything the trace actually reads.
+    # writes wouldn't reach anything the trace actually reads. This is
+    # the ownership boundary the issue calls out: after trace capture,
+    # the authoritative decode state lives in the model's persistent
+    # buffers plus the harness-owned cache allocation, not in a caller
+    # swapping ``kv_cache`` references between steps.
     tt_model_vllm.update_persistent_per_layer_page_tables(warmup_page_table_per_layer)
     tt_model_vllm._active_page_tables_per_layer = warmup_page_table_per_layer
     try:

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -58,6 +58,33 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         # on every step. Defaults to on; flip ``GEMMA4_BOUNDED_SLIDING_KV_CACHE=0``
         # to fall back to the legacy unbounded path through the paged ops.
         self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", "1") != "0"
+        self._runtime_kv_cache_identity = None
+
+    def _kv_cache_identity_tree(self, kv_cache):
+        if isinstance(kv_cache, (list, tuple)):
+            return tuple(self._kv_cache_identity_tree(entry) for entry in kv_cache)
+        return id(kv_cache)
+
+    def _remember_runtime_kv_cache_identity(self, kv_cache):
+        """Treat the first explicit vLLM cache allocation as sticky runtime state.
+
+        Gemma4's traced vLLM path may re-wrap the same cache leaves in fresh
+        Python lists as calls move through Generator / bridge helpers, but it
+        must not silently swap in a different cache allocation later. The
+        authoritative per-step mutation is the page-table refresh into the
+        model-owned persistent buffers, not a new ``kv_cache`` object graph.
+        """
+        if kv_cache is None:
+            return
+        identity_tree = self._kv_cache_identity_tree(kv_cache)
+        if self._runtime_kv_cache_identity is None:
+            self._runtime_kv_cache_identity = identity_tree
+            return
+        if identity_tree != self._runtime_kv_cache_identity:
+            raise ValueError(
+                "Gemma4 vLLM bridge saw a different kv_cache allocation after initialization. "
+                "Reuse the same harness-owned cache and refresh page tables instead of swapping kv_cache handles."
+            )
 
     def _get_prefill_user_page_table(
         self,
@@ -383,6 +410,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         return self.model_args[0].weight_cache_path(ttnn.bfloat16)
 
     def prefill_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        self._remember_runtime_kv_cache_identity(kwargs.get("kv_cache"))
         page_tables_per_layer = self._build_per_layer_page_tables(page_tables_per_layer, kwargs.get("page_table"))
         page_tables_per_layer = self._pad_sliding_page_tables_for_bounded(page_tables_per_layer, kwargs.get("kv_cache"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
@@ -405,6 +433,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
             return super().prefill_forward_text(**kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
+        self._remember_runtime_kv_cache_identity(kwargs.get("kv_cache"))
         page_tables_per_layer = self._build_per_layer_page_tables(page_tables_per_layer, kwargs.get("page_table"))
         page_tables_per_layer = self._pad_sliding_page_tables_for_bounded(page_tables_per_layer, kwargs.get("kv_cache"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -396,6 +396,12 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):
+            # The vLLM bridge owns the authoritative runtime state here: the
+            # harness-allocated per-layer cache plus the persistent per-layer
+            # page-table buffers on the model. ``kv_cache`` remains a
+            # compatibility kwarg because Generator threads it through, but
+            # callers must treat it as an initialization handle, not a
+            # freely swappable decode-time input after trace capture.
             return super().prefill_forward_text(**kwargs)
 
     def decode_forward(self, *args, page_tables_per_layer=None, **kwargs):
@@ -406,6 +412,12 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):
+            # The bridge refreshes per-layer page tables and persistent device
+            # buffers before entering Generator.decode_forward. After trace
+            # capture, those model-owned buffers are the authoritative routing
+            # state; ``kv_cache`` is kept only for compatibility with the shared
+            # Generator API and should not be treated as a caller-owned handle
+            # that can be swapped independently step to step.
             # Skip ``HybridAttentionForCausalLM.decode_forward``, which is a
             # NotImplementedError placeholder; route to ``Generator``'s
             # actual decode implementation. ``decode_forward_text`` was

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -906,13 +906,12 @@ class Gemma4Model:
 
         ``page_tables_per_layer`` likewise comes via a stash
         (``_active_page_tables_per_layer``) when running under the vLLM
-        hybrid bridge. In that path, the bridge-managed cache + persistent
-        page-table buffers are the authoritative runtime state; the threaded
-        ``kv_cache`` kwarg remains for Generator compatibility only.
-        hybrid bridge — Generator's prefill internals don't thread the
-        kwarg, so the bridge attaches it to the model object before
-        invoking us. When None, falls back to legacy single-page-table
-        behavior.
+        hybrid bridge, because Generator's prefill internals don't thread
+        that kwarg directly. In that path, the bridge-managed cache plus
+        the persistent page-table buffers are the authoritative runtime
+        state; the threaded ``kv_cache`` kwarg remains for Generator
+        compatibility only. When the stash is absent, this falls back to
+        legacy single-page-table behavior.
 
         ``get_last_token`` is passed down so the last-token slice happens
         *before* lm_head — slicing after would still allocate full-seq

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -906,6 +906,9 @@ class Gemma4Model:
 
         ``page_tables_per_layer`` likewise comes via a stash
         (``_active_page_tables_per_layer``) when running under the vLLM
+        hybrid bridge. In that path, the bridge-managed cache + persistent
+        page-table buffers are the authoritative runtime state; the threaded
+        ``kv_cache`` kwarg remains for Generator compatibility only.
         hybrid bridge — Generator's prefill internals don't thread the
         kwarg, so the bridge attaches it to the model object before
         invoking us. When None, falls back to legacy single-page-table
@@ -1064,7 +1067,10 @@ class Gemma4Model:
             current_pos: [1,32] uint32 position tensor for RoPE embedding lookup.
             rot_mat_idxs: Unused (RoPE computed internally from current_pos).
             page_table: Optional paged attention table.
-            kv_cache: Optional KV cache override.
+            kv_cache: Optional KV cache override. ``None`` uses the model-owned
+                ``self.tt_kv_cache``. In the Gemma4 vLLM bridge, callers should
+                treat explicit ``kv_cache`` inputs as setup-time compatibility
+                plumbing rather than a freely swappable runtime ownership handle.
             sampling_on_device: If True and self.sampling exists, sample on device.
             capture_sampling_trace: If True, return logits for split-trace sampling.
             pli_combined: Optional [1,1,n_layers,pli_size] device tensor of host-precomputed


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Fixes #45763.
2. Enforce the Gemma4 vLLM `kv_cache` ownership contract in the bridge and model decode/prefill entrypoints.
3. Add a Gemma4-local runtime guard that pins the first harness-owned KV cache allocation and rejects later calls that swap in different cache leaves after initialization.
4. Add a pure-Python negative test so a future refactor cannot silently treat `kv_cache` as a freely swappable decode-time handle again.

### Notes for reviewers
1. This does not remove `kv_cache` from the shared Generator API.
2. The change stays local to the Gemma4 vLLM bridge:
   - the bridge still accepts the compatibility kwarg,
   - it records the first runtime cache-leaf identity it sees,
   - and it raises if a later call swaps in a different allocation.
3. The traced path already depends on bridge-managed state before this patch:
   - `Gemma4ForCausalLM` refreshes per-layer page tables before entering `Generator.decode_forward`,
   - `Gemma4Model.ttnn_prefill_forward` and `ttnn_decode_forward` already consume bridge-stashed page-table state,
   - parity tests already reuse the same vLLM cache handle while updating page-table routing step to step.
4. Re-wrapping the same cache leaves in fresh Python lists is still allowed. The guard only rejects a different underlying allocation.

### Test plan
1. `python3 -m compileall models/demos/gemma4/tt/generator_vllm.py models/demos/gemma4/tt/model.py models/demos/gemma4/tests/unit/test_vllm_parity.py`
2. Added a pure-Python regression test for the new guard in `test_vllm_parity.py`.
3. Full Gemma4 parity tests were not run in this worktree because the local Python environment did not have the repo test dependencies installed (`pytest`, `torch`).
