### PR TITLE
[Bug fix] expose custom DRAM prefetcher mappings

### DIFF
--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -262,14 +262,28 @@ class Prefetcher(LightweightModule):
             num_receiver_cores is None or num_receiver_cores in self.legal_receiver_cores
         ), "num_receiver_cores must be in legal_receiver_cores"
         if self.receiver_mapping_override is not None:
+            assert (
+                len(self.receiver_mapping_override) == self.num_senders
+            ), f"receiver_mapping_override must define exactly {self.num_senders} senders"
+            inferred_receiver_counts = {len(v) for v in self.receiver_mapping_override.values()}
+            assert len(inferred_receiver_counts) == 1, (
+                "receiver_mapping_override must assign the same number of receivers to every sender"
+            )
+            inferred_receiver_count = inferred_receiver_counts.pop()
+            assert inferred_receiver_count > 0, "receiver_mapping_override must define at least one receiver per sender"
             if num_receiver_cores is None:
-                inferred_receiver_counts = {len(v) for v in self.receiver_mapping_override.values()}
-                assert len(inferred_receiver_counts) == 1, "receiver_mapping_override must assign the same number of receivers to every sender"
-                self.num_receiver_cores = inferred_receiver_counts.pop()
+                self.num_receiver_cores = inferred_receiver_count
             else:
+                assert inferred_receiver_count == num_receiver_cores, (
+                    "receiver_mapping_override receiver counts must match num_receiver_cores"
+                )
                 self.num_receiver_cores = num_receiver_cores
-            assert self.num_receiver_cores > 0, "receiver_mapping_override must define at least one receiver per sender"
-            assert len(self.receiver_mapping_override) > 0, "receiver_mapping_override must define at least one sender"
+            assert (
+                self.num_receiver_cores in self.legal_receiver_cores
+            ), "receiver_mapping_override must use a supported number of receivers per sender"
+            assert is_prefetcher_supported(
+                self.model_name, self.mesh_device.get_num_devices(), self.num_receiver_cores * self.num_senders
+            ), "receiver_mapping_override is not supported"
         elif num_receiver_cores is not None:
             assert is_prefetcher_supported(
                 self.model_name, self.mesh_device.get_num_devices(), num_receiver_cores * self.num_senders

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -232,6 +232,7 @@ class Prefetcher(LightweightModule):
         num_tensors: int,
         num_layers: int,
         num_receiver_cores: int = None,
+        receiver_mapping_override: Optional[dict] = None,
     ):
         """
         Prefetcher class that prefetches tensors from DRAM to L1.
@@ -239,6 +240,8 @@ class Prefetcher(LightweightModule):
         Args:
             receiver_mapping_override: If provided, keys become sender cores and values become
                 their receiver cores. This overrides the default column 0/7 sender placement.
+                When set, ``num_receiver_cores`` is inferred from the override and the automatic
+                Blackhole sender/receiver mapping is skipped.
         """
         ### Device, Global CB, Parameters
         self.pf_config: dict = ARCH_CONFIG["blackhole"]
@@ -252,13 +255,22 @@ class Prefetcher(LightweightModule):
         self.num_senders: int = len(self.pf_config["dram_banks"])
         self.global_cb_size: int = 0  # Size of the global circular buffer in bytes storing prefetched matmul weights
         self.max_tensor_block_size: int = 0  # Max tensor block size is the largest block size of a tensor in bytes
-        self.receiver_mapping_override: Optional[dict] = None
+        self.receiver_mapping_override: Optional[dict] = receiver_mapping_override
         self.model_name = os.getenv("HF_MODEL", "")
         assert self.model_name != "", "HF_MODEL is not set. DRAM Prefetcher must be run with a model."
         assert (
             num_receiver_cores is None or num_receiver_cores in self.legal_receiver_cores
         ), "num_receiver_cores must be in legal_receiver_cores"
-        if num_receiver_cores is not None:
+        if self.receiver_mapping_override is not None:
+            if num_receiver_cores is None:
+                inferred_receiver_counts = {len(v) for v in self.receiver_mapping_override.values()}
+                assert len(inferred_receiver_counts) == 1, "receiver_mapping_override must assign the same number of receivers to every sender"
+                self.num_receiver_cores = inferred_receiver_counts.pop()
+            else:
+                self.num_receiver_cores = num_receiver_cores
+            assert self.num_receiver_cores > 0, "receiver_mapping_override must define at least one receiver per sender"
+            assert len(self.receiver_mapping_override) > 0, "receiver_mapping_override must define at least one sender"
+        elif num_receiver_cores is not None:
             assert is_prefetcher_supported(
                 self.model_name, self.mesh_device.get_num_devices(), num_receiver_cores * self.num_senders
             ), "num_receiver_cores is not supported"

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -37,6 +37,35 @@ def round_up(n, multiple):
     return ((n + multiple - 1) // multiple) * multiple
 
 
+def test_prefetcher_override_infers_receiver_count(monkeypatch):
+    """Custom DRAM-core mappings should become a live constructor input, not dead test scaffolding."""
+
+    class _FakeMeshDevice:
+        def get_num_devices(self):
+            return 2
+
+        def compute_with_storage_grid_size(self):
+            return ttnn.CoreCoord(11, 10)
+
+    monkeypatch.setenv("HF_MODEL", "Llama-3.2-1B")
+
+    override = {
+        (0, 0): [(1, 0), (2, 0), (3, 0)],
+        (7, 0): [(8, 0), (9, 0), (10, 0)],
+    }
+
+    prefetcher = Prefetcher(
+        mesh_device=_FakeMeshDevice(),
+        num_tensors=5,
+        num_layers=1,
+        receiver_mapping_override=override,
+    )
+
+    assert prefetcher.receiver_mapping_override == override
+    assert prefetcher.num_receiver_cores == 3
+    assert prefetcher.ring_size == 3 * prefetcher.num_senders
+
+
 def create_weight_tensors(
     mesh_device,
     model_dims,
@@ -395,6 +424,7 @@ def run_prefetcher_all_matmuls(
         num_tensors=num_tensors_per_layer,
         num_layers=num_layers,
         num_receiver_cores=num_receiver_cores,
+        receiver_mapping_override=receiver_mapping_override,
     )
 
     # Initialize prefetcher for decode mode

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -50,8 +50,14 @@ def test_prefetcher_override_infers_receiver_count(monkeypatch):
     monkeypatch.setenv("HF_MODEL", "Llama-3.2-1B")
 
     override = {
-        (0, 0): [(1, 0), (2, 0), (3, 0)],
+        (0, 9): [(1, 9), (2, 9), (3, 9)],
+        (0, 1): [(1, 1), (2, 1), (3, 1)],
+        (0, 7): [(1, 7), (2, 7), (3, 7)],
+        (0, 3): [(1, 3), (2, 3), (3, 3)],
         (7, 0): [(8, 0), (9, 0), (10, 0)],
+        (7, 2): [(8, 2), (9, 2), (10, 2)],
+        (7, 6): [(8, 6), (9, 6), (10, 6)],
+        (7, 4): [(8, 4), (9, 4), (10, 4)],
     }
 
     prefetcher = Prefetcher(
@@ -64,6 +70,89 @@ def test_prefetcher_override_infers_receiver_count(monkeypatch):
     assert prefetcher.receiver_mapping_override == override
     assert prefetcher.num_receiver_cores == 3
     assert prefetcher.ring_size == 3 * prefetcher.num_senders
+
+
+def test_prefetcher_override_requires_full_sender_mapping(monkeypatch):
+    class _FakeMeshDevice:
+        def get_num_devices(self):
+            return 2
+
+        def compute_with_storage_grid_size(self):
+            return ttnn.CoreCoord(11, 10)
+
+    monkeypatch.setenv("HF_MODEL", "Llama-3.2-1B")
+
+    with pytest.raises(AssertionError, match="must define exactly 8 senders"):
+        Prefetcher(
+            mesh_device=_FakeMeshDevice(),
+            num_tensors=5,
+            num_layers=1,
+            receiver_mapping_override={
+                (0, 0): [(1, 0), (2, 0), (3, 0)],
+                (7, 0): [(8, 0), (9, 0), (10, 0)],
+            },
+        )
+
+
+def test_prefetcher_override_rejects_receiver_count_mismatch(monkeypatch):
+    class _FakeMeshDevice:
+        def get_num_devices(self):
+            return 2
+
+        def compute_with_storage_grid_size(self):
+            return ttnn.CoreCoord(11, 10)
+
+    monkeypatch.setenv("HF_MODEL", "Llama-3.2-1B")
+
+    override = {
+        (0, 9): [(1, 9), (2, 9), (3, 9)],
+        (0, 1): [(1, 1), (2, 1), (3, 1)],
+        (0, 7): [(1, 7), (2, 7), (3, 7)],
+        (0, 3): [(1, 3), (2, 3), (3, 3)],
+        (7, 0): [(8, 0), (9, 0), (10, 0)],
+        (7, 2): [(8, 2), (9, 2), (10, 2)],
+        (7, 6): [(8, 6), (9, 6), (10, 6)],
+        (7, 4): [(8, 4), (9, 4), (10, 4)],
+    }
+
+    with pytest.raises(AssertionError, match="must match num_receiver_cores"):
+        Prefetcher(
+            mesh_device=_FakeMeshDevice(),
+            num_tensors=5,
+            num_layers=1,
+            num_receiver_cores=2,
+            receiver_mapping_override=override,
+        )
+
+
+def test_prefetcher_override_rejects_unsupported_receiver_count(monkeypatch):
+    class _FakeMeshDevice:
+        def get_num_devices(self):
+            return 2
+
+        def compute_with_storage_grid_size(self):
+            return ttnn.CoreCoord(11, 10)
+
+    monkeypatch.setenv("HF_MODEL", "Llama-3.2-1B")
+
+    override = {
+        (0, 9): [(1, 9)] * 4,
+        (0, 1): [(1, 1)] * 4,
+        (0, 7): [(1, 7)] * 4,
+        (0, 3): [(1, 3)] * 4,
+        (7, 0): [(8, 0)] * 4,
+        (7, 2): [(8, 2)] * 4,
+        (7, 6): [(8, 6)] * 4,
+        (7, 4): [(8, 4)] * 4,
+    }
+
+    with pytest.raises(AssertionError, match="must use a supported number of receivers per sender"):
+        Prefetcher(
+            mesh_device=_FakeMeshDevice(),
+            num_tensors=5,
+            num_layers=1,
+            receiver_mapping_override=override,
+        )
 
 
 def create_weight_tensors(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Fixes #45751.
2. Wire `receiver_mapping_override` through the `Prefetcher` constructor so custom DRAM-core sender/receiver layouts become a real input instead of dead scaffolding in the test helper and constructor docs.
3. Tighten the override contract so custom mappings still obey the prefetcher's existing 8-sender Blackhole assumptions: require a full sender map, require uniform receiver counts per sender, reject mismatches against explicit `num_receiver_cores`, and keep the supported ring-size checks in place.
4. Add lightweight constructor-level tests for the happy path plus the new validation failures.

### Notes for reviewers
1. This stays a narrow Python-side entrypoint and validation fix, not a larger prefetcher scheduling rewrite.
2. Before this patch, `tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py` exposed a `receiver_mapping_override` argument but never passed it into `Prefetcher`, and `Prefetcher.__init__` did not accept it.
3. `PrefetcherCoreConfig` already had override-aware core-placement logic, but the constructor still assumed a fixed 8-sender ring in the rest of its bookkeeping. This patch makes the override path reachable and rejects partial or inconsistent mappings that would have produced a semantically mismatched `ring_size`.

### Test plan
1. `python3 -m py_compile models/tt_transformers/tt/prefetcher.py tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py`
2. Ran a minimal constructor-level validation script in WSL that stubs non-essential Python dependencies and covers:
   - full override infers `num_receiver_cores`
   - partial override is rejected
   - explicit `num_receiver_cores` mismatch is rejected
   - unsupported receiver count is rejected
3. Full Blackhole hardware prefetcher coverage was not run locally in this worktree.