### PR TITLE
emule: route rt-args through L1 + populate DRAM/L1 bank topology

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -938,7 +938,7 @@ static void populate_bank_mapping(
     // same worker core that `SWEmuleChip::write_to_device` wrote a given page
     // to.  Without this, every page maps to bank 0 (a single core) while the
     // host scatters across all worker cores — interleaved-L1 → sharded paths
-    // see all zeros (B8.4 in round8-sharded-harvest.md).
+    // read all zeros.
     std::memset(l1_bank_to_noc_xy, 0, sizeof(l1_bank_to_noc_xy));
     std::memset(bank_to_l1_offset, 0, sizeof(bank_to_l1_offset));
     if (device) {
@@ -956,12 +956,9 @@ static void populate_bank_mapping(
                               static_cast<uint16_t>(virt.x);
             l1_bank_to_noc_xy[0][b] = noc_xy;  // NOC 0
             l1_bank_to_noc_xy[1][b] = noc_xy;  // NOC 1 (same target in emule)
-            // Intentionally leave bank_to_l1_offset[b] = 0.  On silicon
-            // `allocator->get_bank_offset(L1, b)` returns the reserved-region
-            // start (~tens of MB depending on harvest mask) that the firmware
-            // skips past; in emule each core's L1 mmap starts at offset 0 with
-            // no firmware reservation, so adding a silicon-style offset would
-            // push every NOC L1 read past the end of the mmap (OOB).
+            // Intentionally leave bank_to_l1_offset[b] = 0.  emule's per-core
+            // L1 mmap starts at byte 0 with no firmware-reserved prefix, so
+            // silicon's `allocator->get_bank_offset(L1, b)` isn't applicable.
         }
     }
 }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1021,9 +1021,40 @@ static std::map<std::string, std::string> build_kernel_defines(
         defines["ARCH_BLACKHOLE"] = "1";
     }
 
-    defines["NUM_DRAM_BANKS"] = std::to_string(num_dram_channels ? num_dram_channels : 1);
-    defines["NUM_L1_BANKS"] = std::to_string(EMULE_NUM_L1_BANKS);
+    {
+        uint32_t num_dram = num_dram_channels ? num_dram_channels : 1;
+        uint32_t num_l1 = EMULE_NUM_L1_BANKS;
+        defines["NUM_DRAM_BANKS"] = std::to_string(num_dram);
+        defines["NUM_L1_BANKS"] = std::to_string(num_l1);
+        // Mirror tt_metal/jit_build/build_env_manager.cpp:118-129. Upstream
+        // `interleaved_addr_gen::get_bank_offset_index<DRAM>` chooses bit-shift
+        // when banks are a power of two and a constant divisor otherwise.
+        // Without these defines, non-pow2 bank counts (12 on WH-N150) silently
+        // fall through to a 0-bit shift and every page lands in bank 0.
+        auto is_pow2 = [](uint32_t n) { return n > 0 && (n & (n - 1)) == 0; };
+        auto log2u = [](uint32_t n) {
+            uint32_t l = 0;
+            while ((1u << l) < n) {
+                ++l;
+            }
+            return l;
+        };
+        if (is_pow2(num_dram)) {
+            defines["LOG_BASE_2_OF_NUM_DRAM_BANKS"] = std::to_string(log2u(num_dram));
+        } else {
+            defines["IS_NOT_POW2_NUM_DRAM_BANKS"] = "1";
+        }
+        if (is_pow2(num_l1)) {
+            defines["LOG_BASE_2_OF_NUM_L1_BANKS"] = std::to_string(log2u(num_l1));
+        } else {
+            defines["IS_NOT_POW2_NUM_L1_BANKS"] = "1";
+        }
+    }
     defines["NUM_NOCS"] = std::to_string(NUM_NOCS);
+    // Upstream tensor/dspec.h gates `get_common_arg_addr` as a forward-decl
+    // under KERNEL_BUILD; emule's jit_kernel_stubs.hpp provides the definition.
+    // Without KERNEL_BUILD, dspec.h emits a stub that collides with emule's.
+    defines["KERNEL_BUILD"] = "1";
     defines["DRAM_ALIGNMENT"] = std::to_string(hal::get_dram_alignment());
     defines["L1_ALIGNMENT"] = std::to_string(hal::get_l1_alignment());
     defines["EMULE_WORKER_COL_MAP"] = worker_col_map_str;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -7,7 +7,6 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/mman.h>
 
 #include <bit>
 #include <atomic>
@@ -76,38 +75,11 @@
 // We use the real type directly here.
 using __emule_cb_state = tt_emule::CBSyncState;
 
-thread_local std::vector<uint32_t> __rt_args;
-thread_local std::vector<uint32_t> __common_rt_args;
-
-// Below-4GB scratch buffers mirroring the rt args. Kernels reach into rt-args
-// storage via `get_arg_addr(idx)`, which returns a pointer; upstream
-// silicon-side code paths (e.g. `shard_addr_gen_utils::get_shard_map`) then
-// truncate that pointer to `uint32_t` because real L1 addresses fit in 32
-// bits.  When `__rt_args.data()` lives on the heap above 4 GB the truncation
-// destroys the upper bits and the subsequent dereference segfaults; this
-// mmap MAP_32BIT scratch keeps `get_arg_addr` 32-bit-safe.  Capacity 341 ×
-// uint32_t matches the upstream tt-metal cap for unique + common rt args.
-constexpr size_t EMULE_RT_ARGS_CAP = 341;
-thread_local uint32_t* __rt_args_scratch = nullptr;
-thread_local uint32_t* __common_rt_args_scratch = nullptr;
-
-static uint32_t* __emule_alloc_32bit_scratch(size_t bytes) {
-    void* p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
-                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
-    if (p == MAP_FAILED) {
-        throw std::runtime_error("emule: MAP_32BIT scratch allocation failed");
-    }
-    return static_cast<uint32_t*>(p);
-}
-
-static void __emule_ensure_rt_args_scratch() {
-    if (!__rt_args_scratch) {
-        __rt_args_scratch = __emule_alloc_32bit_scratch(EMULE_RT_ARGS_CAP * sizeof(uint32_t));
-    }
-    if (!__common_rt_args_scratch) {
-        __common_rt_args_scratch = __emule_alloc_32bit_scratch(EMULE_RT_ARGS_CAP * sizeof(uint32_t));
-    }
-}
+// Point into this core's L1 at kernel_config_base + rta_offset[proc_idx],
+// where WriteRuntimeArgsToDevice already wrote the bytes. nullptr = sentinel
+// (kernel declared no rt-args for this RISC).
+thread_local uint32_t* __rt_args = nullptr;
+thread_local uint32_t* __common_rt_args = nullptr;
 
 thread_local tt_emule::Core* __core = nullptr;
 thread_local tt_emule::Device* __device = nullptr;
@@ -335,6 +307,9 @@ namespace tt::tt_metal::emule {
 // Shared types used across subfunctions
 // ---------------------------------------------------------------------------
 
+// Mirrors RTA_CRTA_NO_ARGS_SENTINEL in tt_metal/hw/inc/hostdev/rta_constants.h.
+constexpr uint16_t kRtaCrtaNoArgsSentinel = 0xFFFF;
+
 struct KernelInfo {
     // size 1 for normal kernels; size 4 for Quasar compute (one per TRISC).
     // Either 4 distinct compiled variants (compile-time TRISC_* guards) or 4
@@ -348,6 +323,11 @@ struct KernelInfo {
     uint8_t thread_idx = 0;    // Index within this kernel's processor list → __emule_my_thread_id
     bool is_tensix = false;    // true for Tensix/compute kernels (DFB mask uses bits 8-23)
     uint32_t num_threads = 1;  // number of engines (for get_num_threads())
+    // L1 address of rt-args = kernel_config_base + rta_offset_in_kc (per-RISC,
+    // read from kg->launch_msg). Sentinel = kernel has no args on this RISC.
+    uint32_t kernel_config_base = 0;
+    uint16_t rta_offset_in_kc = kRtaCrtaNoArgsSentinel;
+    uint16_t crta_offset_in_kc = kRtaCrtaNoArgsSentinel;
 };
 
 // Captures a Metal 2.0 kernel's named bindings. Drives both the JIT wrapper's
@@ -413,6 +393,9 @@ struct PendingKernelInfo {
     uint8_t thread_idx = 0;    // Index within this kernel's processor list
     bool is_tensix = false;
     uint32_t num_threads = 1;
+    uint32_t kernel_config_base = 0;
+    uint16_t rta_offset_in_kc = kRtaCrtaNoArgsSentinel;
+    uint16_t crta_offset_in_kc = kRtaCrtaNoArgsSentinel;
 };
 
 // DFB allocation info for a single DFB on a core. Only dfb_id and base_addr
@@ -1235,9 +1218,26 @@ static void collect_kernels(
     std::vector<std::string>& inline_src_temps) {
     static const char* trisc_define_names[] = {"TRISC_UNPACK", "TRISC_MATH", "TRISC_PACK", "TRISC_ISOLATE_SFPU"};
 
-    const uint32_t num_pct = MetalContext::instance().hal().get_programmable_core_type_count();
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t num_pct = hal.get_programmable_core_type_count();
     for (uint32_t pct = 0; pct < num_pct; ++pct) {
         auto& kernels = impl.get_kernels(pct);
+        // (kernel_id, logical_core) → kg: a kernel that runs on cores in
+        // multiple KGs has distinct per-KG launch_msg layouts, so keying by
+        // kernel alone picks the wrong one for half the cores.
+        std::map<std::pair<KernelHandle, CoreCoord>, KernelGroup*> kernel_core_to_kg;
+        for (const auto& kg : impl.get_kernel_groups(pct)) {
+            for (const auto& cr : kg->core_ranges.ranges()) {
+                for (auto x = cr.start_coord.x; x <= cr.end_coord.x; ++x) {
+                    for (auto y = cr.start_coord.y; y <= cr.end_coord.y; ++y) {
+                        CoreCoord lc(x, y);
+                        for (auto kid : kg->kernel_ids) {
+                            kernel_core_to_kg.emplace(std::make_pair(kid, lc), kg.get());
+                        }
+                    }
+                }
+            }
+        }
         for (auto& [kernel_id, kernel] : kernels) {
             const auto& ksrc = kernel->kernel_source();
             std::string src_path = resolve_kernel_source_path(ksrc, inline_src_temps);
@@ -1367,11 +1367,30 @@ static void collect_kernels(
 
             ProcIdList procs = compute_proc_ids_and_thread_count(*kernel, qdm, qck);
 
+            const uint32_t processor_index = hal.get_processor_index(
+                kernel->get_kernel_programmable_core_type(),
+                kernel->get_kernel_processor_class(),
+                kernel->get_kernel_processor_type(0));
+
             const auto& core_range_set = kernel->core_range_set();
             for (const auto& core_range : core_range_set.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                         CoreCoord logical_core(x, y);
+                        // KG lookup is per (kernel, logical_core): same kernel
+                        // on different cores may sit in different KGs with
+                        // distinct kernel_config layouts.
+                        auto kg_it = kernel_core_to_kg.find({kernel_id, logical_core});
+                        uint32_t kernel_config_base = 0;
+                        uint16_t rta_off = kRtaCrtaNoArgsSentinel;
+                        uint16_t crta_off = kRtaCrtaNoArgsSentinel;
+                        if (kg_it != kernel_core_to_kg.end()) {
+                            auto kc = kg_it->second->launch_msg.view().kernel_config();
+                            kernel_config_base = static_cast<uint32_t>(kc.kernel_config_base()[pct]);
+                            auto rta = kc.rta_offset()[processor_index];
+                            rta_off = rta.rta_offset();
+                            crta_off = rta.crta_offset();
+                        }
                         auto& rt_args_data = kernel->runtime_args(logical_core);
                         uint8_t tidx = 0;
                         for (uint8_t proc_id : procs.proc_ids) {
@@ -1383,7 +1402,10 @@ static void collect_kernels(
                                 proc_id,
                                 tidx++,
                                 is_tensix,
-                                procs.num_threads});
+                                procs.num_threads,
+                                kernel_config_base,
+                                rta_off,
+                                crta_off});
                         }
                     }
                 }
@@ -1846,18 +1868,14 @@ static void launch_cores(
                                               &kep = kernel_exceptions[kidx]]() {
                             (void)kidx;
                             auto& ki = *ki_ptr;
-                            __rt_args = ki.rt_args;
-                            __common_rt_args = ki.common_rt_args;
-                            __emule_ensure_rt_args_scratch();
-                            if (ki.rt_args.size() > EMULE_RT_ARGS_CAP ||
-                                ki.common_rt_args.size() > EMULE_RT_ARGS_CAP) {
-                                throw std::runtime_error(
-                                    "emule: rt_args size exceeds EMULE_RT_ARGS_CAP");
-                            }
-                            std::memcpy(__rt_args_scratch, ki.rt_args.data(),
-                                        ki.rt_args.size() * sizeof(uint32_t));
-                            std::memcpy(__common_rt_args_scratch, ki.common_rt_args.data(),
-                                        ki.common_rt_args.size() * sizeof(uint32_t));
+                            __rt_args = (ki.rta_offset_in_kc != kRtaCrtaNoArgsSentinel)
+                                ? reinterpret_cast<uint32_t*>(core->l1_ptr(
+                                      ki.kernel_config_base + ki.rta_offset_in_kc))
+                                : nullptr;
+                            __common_rt_args = (ki.crta_offset_in_kc != kRtaCrtaNoArgsSentinel)
+                                ? reinterpret_cast<uint32_t*>(core->l1_ptr(
+                                      ki.kernel_config_base + ki.crta_offset_in_kc))
+                                : nullptr;
                             __emule_bridge_l1 = l1_data;
                             __emule_bridge_dram = dram_data;
                             __emule_cbs = cb_array;
@@ -1896,6 +1914,8 @@ static void launch_cores(
                             }
 
                             __core = nullptr;
+                            __rt_args = nullptr;
+                            __common_rt_args = nullptr;
                             __emule_bridge_l1 = nullptr;
                             __emule_bridge_dram = nullptr;
                             __emule_cbs = nullptr;
@@ -2005,7 +2025,9 @@ void execute_program_emulated(IDevice* device, Program& program) {
     for (auto& [logical_core, pending_list] : pending_core_kernels) {
         for (auto& pk : pending_list) {
             KernelInfo ki{
-                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.thread_idx, pk.is_tensix, pk.num_threads};
+                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.thread_idx,
+                pk.is_tensix, pk.num_threads,
+                pk.kernel_config_base, pk.rta_offset_in_kc, pk.crta_offset_in_kc};
             ki.variants.reserve(pk.variant_cache_keys.size());
             for (const auto& key : pk.variant_cache_keys) {
                 ki.variants.push_back(resolved_fns.at(key));

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -7,6 +7,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/mman.h>
 
 #include <bit>
 #include <atomic>
@@ -77,6 +78,37 @@ using __emule_cb_state = tt_emule::CBSyncState;
 
 thread_local std::vector<uint32_t> __rt_args;
 thread_local std::vector<uint32_t> __common_rt_args;
+
+// Below-4GB scratch buffers mirroring the rt args. Kernels reach into rt-args
+// storage via `get_arg_addr(idx)`, which returns a pointer; upstream
+// silicon-side code paths (e.g. `shard_addr_gen_utils::get_shard_map`) then
+// truncate that pointer to `uint32_t` because real L1 addresses fit in 32
+// bits.  When `__rt_args.data()` lives on the heap above 4 GB the truncation
+// destroys the upper bits and the subsequent dereference segfaults; this
+// mmap MAP_32BIT scratch keeps `get_arg_addr` 32-bit-safe.  Capacity 341 ×
+// uint32_t matches the upstream tt-metal cap for unique + common rt args.
+constexpr size_t EMULE_RT_ARGS_CAP = 341;
+thread_local uint32_t* __rt_args_scratch = nullptr;
+thread_local uint32_t* __common_rt_args_scratch = nullptr;
+
+static uint32_t* __emule_alloc_32bit_scratch(size_t bytes) {
+    void* p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+    if (p == MAP_FAILED) {
+        throw std::runtime_error("emule: MAP_32BIT scratch allocation failed");
+    }
+    return static_cast<uint32_t*>(p);
+}
+
+static void __emule_ensure_rt_args_scratch() {
+    if (!__rt_args_scratch) {
+        __rt_args_scratch = __emule_alloc_32bit_scratch(EMULE_RT_ARGS_CAP * sizeof(uint32_t));
+    }
+    if (!__common_rt_args_scratch) {
+        __common_rt_args_scratch = __emule_alloc_32bit_scratch(EMULE_RT_ARGS_CAP * sizeof(uint32_t));
+    }
+}
+
 thread_local tt_emule::Core* __core = nullptr;
 thread_local tt_emule::Device* __device = nullptr;
 
@@ -1816,6 +1848,16 @@ static void launch_cores(
                             auto& ki = *ki_ptr;
                             __rt_args = ki.rt_args;
                             __common_rt_args = ki.common_rt_args;
+                            __emule_ensure_rt_args_scratch();
+                            if (ki.rt_args.size() > EMULE_RT_ARGS_CAP ||
+                                ki.common_rt_args.size() > EMULE_RT_ARGS_CAP) {
+                                throw std::runtime_error(
+                                    "emule: rt_args size exceeds EMULE_RT_ARGS_CAP");
+                            }
+                            std::memcpy(__rt_args_scratch, ki.rt_args.data(),
+                                        ki.rt_args.size() * sizeof(uint32_t));
+                            std::memcpy(__common_rt_args_scratch, ki.common_rt_args.data(),
+                                        ki.common_rt_args.size() * sizeof(uint32_t));
                             __emule_bridge_l1 = l1_data;
                             __emule_bridge_dram = dram_data;
                             __emule_cbs = cb_array;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -137,11 +137,12 @@ thread_local std::unordered_map<uint64_t, tt_emule::Core*>* __emule_core_map = n
 // Match firmware declarations: uint16_t[NUM_NOCS][NUM_DRAM_BANKS], etc.
 // ---------------------------------------------------------------------------
 static constexpr uint32_t NUM_NOCS = 2;
-static constexpr uint32_t MAX_NUM_BANKS = 32;
+// L1 banks scale with worker grid: 64 on WH-N150, 140 on BH P100/P150.  Must
+// match the array size declared by the JIT side in
+// `include/jit_hw/internal/dataflow/dataflow_api_addrgen.h`.
+static constexpr uint32_t MAX_NUM_BANKS = 256;
 // Wormhole has 32 CBs; JIT header cb_api.h sizes unpack_tile_size[32].
 static constexpr uint32_t EMULE_NUM_CBS = 32;
-// Emulation simplification: each worker is its own L1 bank.
-static constexpr uint32_t EMULE_NUM_L1_BANKS = 1;
 // Semaphore alignment in L1 (must match firmware layout).
 static constexpr uint32_t EMULE_SEM_ALIGN = 16;
 
@@ -861,9 +862,15 @@ static tt::umd::SWEmuleChip* get_sw_emulated_chip(ChipId device_id) {
 // populate_bank_mapping: Set up DRAM/L1 bank arrays from SoC descriptor.
 // ---------------------------------------------------------------------------
 static void populate_bank_mapping(
-    tt::umd::SWEmuleChip* sw_emu, ChipId device_id, tt_emule::Core*& dram_core_out, uint32_t& num_dram_channels_out) {
+    tt::umd::SWEmuleChip* sw_emu,
+    IDevice* device,
+    ChipId device_id,
+    tt_emule::Core*& dram_core_out,
+    uint32_t& num_dram_channels_out,
+    uint32_t& num_l1_banks_out) {
     dram_core_out = nullptr;
     num_dram_channels_out = 0;
+    num_l1_banks_out = 0;
     if (!sw_emu) {
         return;
     }
@@ -910,9 +917,32 @@ static void populate_bank_mapping(
             bank_to_dram_offset[ch]);
     }
 
-    // L1 bank mapping — for now, all worker cores use themselves as bank 0.
+    // L1 bank mapping — mirror the host allocator's bank distribution so the
+    // kernel-side `interleaved_addr_gen::get_bank_index<L1>(id)` lands on the
+    // same worker core that `SWEmuleChip::write_to_device` wrote a given page
+    // to.  Without this, every page maps to bank 0 (a single core) while the
+    // host scatters across all worker cores — interleaved-L1 → sharded paths
+    // see all zeros (B8.4 in round8-sharded-harvest.md).
     std::memset(l1_bank_to_noc_xy, 0, sizeof(l1_bank_to_noc_xy));
     std::memset(bank_to_l1_offset, 0, sizeof(bank_to_l1_offset));
+    if (device) {
+        const auto& allocator = device->allocator();
+        num_l1_banks_out = allocator->get_num_banks(BufferType::L1);
+        for (uint32_t b = 0; b < num_l1_banks_out && b < MAX_NUM_BANKS; ++b) {
+            auto logical = allocator->get_logical_core_from_bank_id(b);
+            auto virt = device->virtual_core_from_logical_core(logical, CoreType::WORKER);
+            uint16_t noc_xy = (static_cast<uint16_t>(virt.y) << NOC_NODE_ID_BITS) |
+                              static_cast<uint16_t>(virt.x);
+            l1_bank_to_noc_xy[0][b] = noc_xy;  // NOC 0
+            l1_bank_to_noc_xy[1][b] = noc_xy;  // NOC 1 (same target in emule)
+            // Intentionally leave bank_to_l1_offset[b] = 0.  On silicon
+            // `allocator->get_bank_offset(L1, b)` returns the reserved-region
+            // start (~tens of MB depending on harvest mask) that the firmware
+            // skips past; in emule each core's L1 mmap starts at offset 0 with
+            // no firmware reservation, so adding a silicon-style offset would
+            // push every NOC L1 read past the end of the mmap (OOB).
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1006,6 +1036,7 @@ static std::map<std::string, std::string> build_kernel_defines(
     Kernel& kernel,
     detail::ProgramImpl& impl,
     uint32_t num_dram_channels,
+    uint32_t num_l1_banks,
     const std::string& worker_col_map_str,
     const std::string& worker_row_map_str,
     uint32_t emule_sem_base) {
@@ -1023,7 +1054,7 @@ static std::map<std::string, std::string> build_kernel_defines(
 
     {
         uint32_t num_dram = num_dram_channels ? num_dram_channels : 1;
-        uint32_t num_l1 = EMULE_NUM_L1_BANKS;
+        uint32_t num_l1 = num_l1_banks ? num_l1_banks : 1;
         defines["NUM_DRAM_BANKS"] = std::to_string(num_dram);
         defines["NUM_L1_BANKS"] = std::to_string(num_l1);
         // Mirror tt_metal/jit_build/build_env_manager.cpp:118-129. Upstream
@@ -1161,6 +1192,7 @@ static TriscMode detect_quasar_trisc_mode(bool is_quasar_compute, const std::str
 static void collect_kernels(
     detail::ProgramImpl& impl,
     uint32_t num_dram_channels,
+    uint32_t num_l1_banks,
     const std::string& worker_col_map_str,
     const std::string& worker_row_map_str,
     uint32_t emule_sem_base,
@@ -1181,7 +1213,8 @@ static void collect_kernels(
             auto compile_args = kernel->compile_time_args();
             auto named_compile_args = kernel->named_compile_time_args();
             auto defines = build_kernel_defines(
-                *kernel, impl, num_dram_channels, worker_col_map_str, worker_row_map_str, emule_sem_base);
+                *kernel, impl, num_dram_channels, num_l1_banks,
+                worker_col_map_str, worker_row_map_str, emule_sem_base);
 
             auto& common_rt = kernel->common_runtime_args();
 
@@ -1881,7 +1914,8 @@ void execute_program_emulated(IDevice* device, Program& program) {
     // Phase 0: Populate bank mapping arrays
     tt_emule::Core* dram_core = nullptr;
     uint32_t num_dram_channels = 0;
-    populate_bank_mapping(sw_emu, device_id, dram_core, num_dram_channels);
+    uint32_t num_l1_banks = 0;
+    populate_bank_mapping(sw_emu, device, device_id, dram_core, num_dram_channels, num_l1_banks);
 
     // Build worker coordinate mapping strings
     std::string worker_col_map_str, worker_row_map_str;
@@ -1912,6 +1946,7 @@ void execute_program_emulated(IDevice* device, Program& program) {
     collect_kernels(
         impl,
         num_dram_channels,
+        num_l1_banks,
         worker_col_map_str,
         worker_row_map_str,
         emule_sem_base,

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -317,8 +317,6 @@ struct KernelInfo {
     // the launcher iterates and sets __emule_trisc_id per variant.
     std::vector<std::function<void()>> variants;
     bool run_all_variants = false;
-    std::vector<uint32_t> rt_args;
-    std::vector<uint32_t> common_rt_args;
     uint8_t processor_id = 0;  // RISC-V processor ID (mhartid); used for DFB role resolution
     uint8_t thread_idx = 0;    // Index within this kernel's processor list → __emule_my_thread_id
     bool is_tensix = false;    // true for Tensix/compute kernels (DFB mask uses bits 8-23)
@@ -387,8 +385,6 @@ struct PendingKernelInfo {
     // Parallels KernelInfo::variants but holds cache keys pending compile-resolution.
     std::vector<std::string> variant_cache_keys;
     bool run_all_variants = false;
-    std::vector<uint32_t> rt_args;
-    std::vector<uint32_t> common_rt_args;
     uint8_t processor_id = 0;
     uint8_t thread_idx = 0;    // Index within this kernel's processor list
     bool is_tensix = false;
@@ -902,6 +898,11 @@ static void populate_bank_mapping(
     // Populate bank mapping arrays using metal_SocDescriptor (matches host write path).
     auto& metal_soc = MetalContext::instance().get_cluster().get_soc_desc(device_id);
     num_dram_channels_out = static_cast<uint32_t>(metal_soc.get_num_dram_views());
+    TT_FATAL(
+        num_dram_channels_out <= MAX_NUM_BANKS,
+        "emule: num_dram_channels ({}) exceeds MAX_NUM_BANKS ({}); bump the constant or implement dynamic backing",
+        num_dram_channels_out,
+        MAX_NUM_BANKS);
 
     // noc_xy encoding: (y << 6) | x (matching Blackhole firmware encoding).
     // Populate per-NOC preferred coords separately. On Wormhole the NOC-0 and
@@ -943,6 +944,11 @@ static void populate_bank_mapping(
     if (device) {
         const auto& allocator = device->allocator();
         num_l1_banks_out = allocator->get_num_banks(BufferType::L1);
+        TT_FATAL(
+            num_l1_banks_out <= MAX_NUM_BANKS,
+            "emule: num_l1_banks ({}) exceeds MAX_NUM_BANKS ({}); bump the constant or implement dynamic backing",
+            num_l1_banks_out,
+            MAX_NUM_BANKS);
         for (uint32_t b = 0; b < num_l1_banks_out && b < MAX_NUM_BANKS; ++b) {
             auto logical = allocator->get_logical_core_from_bank_id(b);
             auto virt = device->virtual_core_from_logical_core(logical, CoreType::WORKER);
@@ -1248,8 +1254,6 @@ static void collect_kernels(
                 *kernel, impl, num_dram_channels, num_l1_banks,
                 worker_col_map_str, worker_row_map_str, emule_sem_base);
 
-            auto& common_rt = kernel->common_runtime_args();
-
             // Tensix/compute kernels use bits 8+ in the DFB RISC mask (TENSIX_RISC_OFFSET),
             // while DM kernels use bits 0-7 directly.
             bool is_tensix = (kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE);
@@ -1391,14 +1395,11 @@ static void collect_kernels(
                             rta_off = rta.rta_offset();
                             crta_off = rta.crta_offset();
                         }
-                        auto& rt_args_data = kernel->runtime_args(logical_core);
                         uint8_t tidx = 0;
                         for (uint8_t proc_id : procs.proc_ids) {
                             pending_core_kernels[logical_core].push_back(PendingKernelInfo{
                                 variant_cache_keys,
                                 run_all_variants,
-                                rt_args_data,
-                                common_rt,
                                 proc_id,
                                 tidx++,
                                 is_tensix,
@@ -1899,8 +1900,8 @@ static void launch_cores(
 
                             log_debug(
                                 tt::LogMetal,
-                                "  Launching kernel[{}] on logical ({},{}) phys ({},{}) rt_args={} common_rt_args={}",
-                                kidx, lx, ly, px, py, ki.rt_args.size(), ki.common_rt_args.size());
+                                "  Launching kernel[{}] on logical ({},{}) phys ({},{}) rta_off=0x{:x} crta_off=0x{:x}",
+                                kidx, lx, ly, px, py, ki.rta_offset_in_kc, ki.crta_offset_in_kc);
 
                             try {
                                 for (size_t t = 0; t < ki.variants.size(); ++t) {
@@ -2025,7 +2026,7 @@ void execute_program_emulated(IDevice* device, Program& program) {
     for (auto& [logical_core, pending_list] : pending_core_kernels) {
         for (auto& pk : pending_list) {
             KernelInfo ki{
-                {}, pk.run_all_variants, pk.rt_args, pk.common_rt_args, pk.processor_id, pk.thread_idx,
+                {}, pk.run_all_variants, pk.processor_id, pk.thread_idx,
                 pk.is_tensix, pk.num_threads,
                 pk.kernel_config_base, pk.rta_offset_in_kc, pk.crta_offset_in_kc};
             ki.variants.reserve(pk.variant_cache_keys.size());


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Three host-side emule runtime fixes, all in
`tt_metal/impl/emulation/emulated_program_runner.cpp` and gated by
`TT_METAL_USE_EMULE=ON`. Pairs with the kernel-side work in
tenstorrent/tt-emule#52.

**1. Emit DRAM bank topology to JIT defines.** `NUM_DRAM_BANKS` /
`LOG_BASE_2_OF_NUM_DRAM_BANKS` / `IS_NOT_POW2_NUM_DRAM_BANKS` /
`KERNEL_BUILD` reach the kernel so
`interleaved_addr_gen::get_bank_index<DRAM>(id)` takes the right
fast/slow path on non-pow2 bank counts (WH-N150 has 12 DRAM
channels).

**2. Populate `l1_bank_to_noc_xy` from the SoC descriptor.**
Previously the runner ran with `EMULE_NUM_L1_BANKS = 1`, collapsing
every interleaved-L1 page onto bank 0. Now reads
`device->allocator()->get_num_banks(L1)` (64 on WH-N150, ~140 on
BH) and fills the noc_xy table per bank via
`virtual_core_from_logical_core`. `MAX_NUM_BANKS` bumped 32 → 256
for the backing storage; matching JIT defines emitted to the
kernel.

**3. Route `__rt_args` through L1.** The host's
`WriteRuntimeArgsToDevice` (`tt_metal.cpp:836`, called by
`EnqueueProgram` before `execute_program_emulated`) already
memcpys each kernel's rt-args into the per-core L1 mmap at
`kernel_config_base + rta_offset[processor_index].rta_offset()` —
the silicon-canonical layout. The emule runner now reads the same
per-RISC offsets out of `kg->launch_msg` in `collect_kernels`,
stashes them on `KernelInfo`, and the kernel-launch lambda sets
the thread-local `__rt_args` / `__common_rt_args` to point at
those L1 bytes. The L1 mmap is `MAP_32BIT` so silicon-side callers
narrowing `uintptr_t → uint32_t` (e.g.
`shard_addr_gen_utils::get_shard_map`) stay lossless. No parallel
storage, no memcpy on the emule side.

### Notes for reviewers

Verification (tt-emule regression sweep, sequential, JIT-cache rule):

```
test_untilize.py -k 'sharded'             : 476 P / 8 F  → 484 P / 0 F
test_pad.py -k 'sharded'                  :  78 P / 23 F → 101 P / 0 F
test_interleaved_to_sharded_hash          :  12 P / 12 F → 24 P / 0 F
test_interleaved_to_sharded.py -k 'dram'  : crashes      → 52 P / 4 F
test_full_like sharded                    : 648 / 0      → 648 / 0 (no regression)
```

The 4 residual `dram` failures are BFP8 numerical (tracked as
tt-emule#51). The 8 `test_permute_sharded` failures are a separate
shard-spec ordering mismatch (tt-emule#50). Neither regressed by
this PR.

Companion PR: tenstorrent/tt-emule#52 — kernel-side and JIT-time
defines that pair with these three commits.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-tensor-accessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-tensor-accessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-tensor-accessor)