### PR TITLE
[MeshTensor Integration] sharded data movement ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -25,6 +25,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Anonymous-namespace helper unique to interleaved_to_sharded to avoid unity-build collisions.
 void push_i2s_cb_pair(
@@ -34,7 +35,7 @@ void push_i2s_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    ttsl::optional_reference<const MeshTensor> bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -43,10 +44,16 @@ void push_i2s_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.buffer = bound_tensor.has_value() ? (*bound_tensor).mesh_buffer().get_reference_buffer() : nullptr;
     desc.cbs.push_back(std::move(cb));
 }
 
+// Reference-buffer alignment of the given tensor.
+uint32_t get_buffer_alignment(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().get_reference_buffer()->alignment();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 // Hardcoded for non-partial interleaved_to_sharded operation
@@ -59,7 +66,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     const InterleavedToShardedParams& /*operation_attributes*/,
     const InterleavedToShardedInputs& tensor_args,
     Tensor& output_tensor) {
-    const auto& input = tensor_args.input_tensor;
+    const MeshTensor& input = tensor_args.input_tensor.mesh_tensor();
     const auto& output = output_tensor;
     // Keep explicit bool init to match legacy behavior which forced it true
     bool keep_l1_aligned = true;  // operation_attributes.keep_l1_aligned;
@@ -76,10 +83,11 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     uint32_t padded_offset_bytes = 0;
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& dst_tensor = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(dst_tensor.dtype());
 
-    auto shard_spec = output.shard_spec().value();
-    auto shard_strategy = output.memory_config().memory_layout();
+    auto shard_spec = dst_tensor.shard_spec().value();
+    auto shard_strategy = dst_tensor.memory_config().memory_layout();
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
@@ -88,11 +96,9 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     CoreCoord end_core = cores.back();
 
     bool convert_df = input_cb_data_format != output_cb_data_format;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    bool src_is_dram = input.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool dst_is_dram = dst_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool is_blackhole = (input.device().arch() == tt::ARCH::BLACKHOLE);
 
     if (input.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
@@ -118,7 +124,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         padded_offset_bytes = (num_units_per_shard_width - num_units_per_shard_width_last) * input_unit_size;
     } else {
         input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
-        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * dst_tensor.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
@@ -135,7 +141,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         if (keep_l1_aligned) {
             padded_offset_bytes = tt::align(input_unit_size, hal::get_l1_alignment());
         } else {
-            padded_offset_bytes = tt::align(input_unit_size, input.buffer()->alignment());
+            padded_offset_bytes = tt::align(input_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(input));
         }
     }
 
@@ -143,34 +149,35 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     uint32_t scratch_cb_index = tt::CBIndex::c_1;
     uint32_t out_cb_index = input_cb_index;
     uint32_t num_input_units = num_units_per_shard;
-    uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
+    uint32_t output_page_size = tt::align(output_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(dst_tensor));
 
     ProgramDescriptor desc;
 
     if (convert_df) {
         out_cb_index = tt::CBIndex::c_16;
-        uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
+        uint32_t input_page_size = tt::align(input_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(input));
         // Non-globally-allocated input CB (interleaved input streamed via reader).
-        push_i2s_cb_pair(
+        CMAKE_UNIQUE_NAMESPACE::push_i2s_cb_pair(
             desc,
             input_cb_index,
             input_cb_data_format,
             num_input_units * input_page_size,
             input_page_size,
             all_cores,
-            /*bound_buffer=*/nullptr);
+            /*bound_tensor=*/std::nullopt);
     }
 
     // Output CB. When destination is sharded (non-DRAM) we bind it to the output buffer
     // for dynamic-CB rebinding on cache hits via cb.buffer. When dst is DRAM, no binding.
-    push_i2s_cb_pair(
+    CMAKE_UNIQUE_NAMESPACE::push_i2s_cb_pair(
         desc,
         out_cb_index,
         output_cb_data_format,
         num_input_units * output_page_size,
         output_page_size,
         all_cores,
-        /*bound_buffer=*/dst_is_dram ? nullptr : dst_buffer);
+        /*bound_tensor=*/dst_is_dram ? ttsl::optional_reference<const MeshTensor>(std::nullopt)
+                                     : ttsl::optional_reference<const MeshTensor>(dst_tensor));
 
     uint32_t dram_alignment = hal::get_dram_alignment();
     uint32_t l1_alignment = hal::get_l1_alignment();
@@ -180,14 +187,14 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
         // This is done to mitigate the alignment issues.
         // See issue #34414.
         uint32_t scratch_cb_page_size = tt::align(input_unit_size + dram_alignment, dram_alignment);
-        push_i2s_cb_pair(
+        CMAKE_UNIQUE_NAMESPACE::push_i2s_cb_pair(
             desc,
             scratch_cb_index,
             input_cb_data_format,
             num_trids * scratch_cb_page_size,
             scratch_cb_page_size,
             all_cores,
-            /*bound_buffer=*/nullptr);
+            /*bound_tensor=*/std::nullopt);
     }
 
     // Reader kernel.
@@ -197,14 +204,14 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     reader_desc.config = ReaderConfigDescriptor{};
     if (input.layout() == Layout::TILE) {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, all_cores.num_cores()};
-        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(input).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
             "reader_unary_sharded_blocks_interleaved_start_id.cpp";
         reader_desc.compile_time_args = std::move(reader_compile_time_args);
     } else {
         std::vector<uint32_t> reader_compile_time_args = {input_cb_index, scratch_cb_index, num_trids};
-        tt::tt_metal::TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(input).append_to(reader_compile_time_args);
         reader_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
             "reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp";
@@ -245,7 +252,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
     }
 
     uint32_t starting_idx_h =
-        operations::data_movement::detail::calculate_starting_idx_h(input, num_slices, slice_index);
+        operations::data_movement::detail::calculate_starting_idx_h(tensor_args.input_tensor, num_slices, slice_index);
     uint32_t curr_idx_h = 0;
     uint32_t curr_idx_w = 0;
 
@@ -287,7 +294,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
 
             // Reader run-time args: arg 0 is the source-buffer base address (binding).
             KernelDescriptor::RTArgList reader_rt;
-            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(input);
             reader_rt.push_back(shard_height);
             reader_rt.push_back(shard_width);
             reader_rt.push_back(padded_offset);
@@ -301,7 +308,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
             uint32_t pad_offset = (num_units_per_shard_width - shard_width) * output_unit_size;
             if (dst_is_dram) {
                 KernelDescriptor::RTArgList writer_rt;
-                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(dst_tensor);
                 writer_rt.push_back(shard_height);
                 writer_rt.push_back(shard_width);
                 writer_rt.push_back(pad_offset);
@@ -387,7 +394,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
 
             // Reader run-time args: arg 0 is the source-buffer base address (binding).
             KernelDescriptor::RTArgList reader_rt;
-            reader_rt.push_back(src_buffer);
+            reader_rt.push_back(input);
             reader_rt.push_back(num_units_per_row);
             reader_rt.push_back(shard_height);
             reader_rt.push_back(shard_width);
@@ -405,7 +412,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
                 uint32_t output_width_in_pages = tt::div_up(num_units_per_row, input_unit_size);
                 uint32_t start_id = (curr_idx_h * output_width_in_pages) + page_id_within_row;
                 KernelDescriptor::RTArgList writer_rt;
-                writer_rt.push_back(dst_buffer);
+                writer_rt.push_back(dst_tensor);
                 writer_rt.push_back(shard_height);
                 writer_rt.push_back(shard_width);
                 writer_rt.push_back(padded_offset_bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -12,33 +12,46 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+// Allocator-aligned page size of the tensor's storage (Buffer-only attribute).
+uint32_t get_buffer_aligned_page_size(const MeshTensor& tensor) {
+    return static_cast<uint32_t>(tensor.mesh_buffer().get_reference_buffer()->aligned_page_size());
+}
+
+// Distribution spec of the tensor's storage (the cores and shards that hold its data).
+const BufferDistributionSpec& get_buffer_distribution_spec(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().device_local_config().sharding_args.buffer_distribution_spec().value();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 template <bool local_is_input>
 ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    auto& output = output_tensor;
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
+    const auto input_accessor_args = TensorAccessorArgs(input);
+    const auto output_accessor_args = TensorAccessorArgs(output);
 
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
-
-    // Choose buffer and aligned page size based on local_is_input flag
-    auto* local_buffer = local_is_input ? input_buffer : output_buffer;
-    auto aligned_page_size = local_buffer->aligned_page_size();
-    auto other_aligned_page_size =
-        local_is_input ? output_buffer->aligned_page_size() : input_buffer->aligned_page_size();
+    // Choose local/other tensor based on local_is_input flag
+    const auto& local_tensor = local_is_input ? input : output;
+    const auto& other_tensor = local_is_input ? output : input;
+    auto aligned_page_size = CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(local_tensor);
+    auto other_aligned_page_size = CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(other_tensor);
 
     // This implementation assumes that input and output grids are the same.
-    auto cores_vec = local_buffer->buffer_distribution_spec()->cores_with_data();
+    const auto& local_distribution_spec = CMAKE_UNIQUE_NAMESPACE::get_buffer_distribution_spec(local_tensor);
+    auto cores_vec = local_distribution_spec.cores_with_data();
     auto grid = CoreRangeSet(cores_vec);
 
-    uint32_t num_shards = static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_shards());
+    uint32_t num_shards = static_cast<uint32_t>(local_distribution_spec.num_shards());
 
     // num cores with data * 2 because we have two kernels
-    uint32_t shard_id_stride =
-        static_cast<uint32_t>(local_buffer->buffer_distribution_spec()->num_cores_with_data()) * 2u;
+    uint32_t shard_id_stride = static_cast<uint32_t>(local_distribution_spec.num_cores_with_data()) * 2u;
 
     // Prepare compile time arguments
     auto logical_size = input.logical_shape();
@@ -52,15 +65,15 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
         auto output_buffer_type = output.memory_config().memory_layout();
 
         // for block sharded
-        CoreCoord input_shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord input_shard_grid = input.shard_spec()->grid.ranges()[0].grid_size();
         uint32_t input_num_shard_cores = input_shard_grid.x;
-        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (input.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             input_num_shard_cores = input_shard_grid.y;
         }
 
-        CoreCoord output_shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord output_shard_grid = output.shard_spec()->grid.ranges()[0].grid_size();
         uint32_t output_num_shard_cores = output_shard_grid.x;
-        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (output.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             output_num_shard_cores = output_shard_grid.y;
         }
         // for width sharded
@@ -71,11 +84,11 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
         }
 
         source_width =
-            static_cast<uint32_t>(input_buffer->shard_spec().shape()[1] * input.element_size() * input_num_shard_cores);
-        destination_width = static_cast<uint32_t>(
-            output_buffer->shard_spec().shape()[1] * output.element_size() * output_num_shard_cores);
-        uint32_t input_page_size = input_buffer->page_size();
-        uint32_t output_page_size = output_buffer->page_size();
+            static_cast<uint32_t>(input.shard_spec()->shape[1] * input.element_size() * input_num_shard_cores);
+        destination_width =
+            static_cast<uint32_t>(output.shard_spec()->shape[1] * output.element_size() * output_num_shard_cores);
+        uint32_t input_page_size = input.mesh_buffer().page_size();
+        uint32_t output_page_size = output.mesh_buffer().page_size();
         base_page_size = std::gcd(input_page_size, output_page_size);
     }
     auto compile_time_args = input_accessor_args.get_compile_time_args();
@@ -113,9 +126,9 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
     ncrisc_desc.compile_time_args = std::move(compile_time_args);
 
     // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
-    // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
-    brisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
-    ncrisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+    // arg 0 / arg 1 are the buffer base addresses (binding via MeshTensor).
+    brisc_desc.emplace_common_runtime_args({input, output, num_shards, shard_id_stride});
+    ncrisc_desc.emplace_common_runtime_args({input, output, num_shards, shard_id_stride});
 
     // Per-core unique runtime args: [start_shard_id]
     // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -13,6 +13,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Anonymous-namespace helper unique to nd_reshard_copy_pages to avoid unity-build collisions.
 void push_reshard_copy_pages_cb(
@@ -34,25 +35,37 @@ void push_reshard_copy_pages_cb(
     desc.cbs.push_back(std::move(cb));
 }
 
+// Aligned page size of the tensor's allocated buffer (Buffer-only: depends on the device allocator).
+uint32_t get_buffer_aligned_page_size(const MeshTensor& tensor) {
+    return static_cast<uint32_t>(tensor.mesh_buffer().get_reference_buffer()->aligned_page_size());
+}
+
+// Number of device pages in the tensor's storage, from its buffer-distribution spec.
+uint32_t get_num_dev_pages(const MeshTensor& tensor) {
+    return static_cast<uint32_t>(tensor.mesh_buffer()
+                                     .device_local_config()
+                                     .sharding_args.buffer_distribution_spec()
+                                     ->tensor_shape_in_pages()
+                                     .volume());
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input = tensor_args.input;
-    auto& output = output_tensor;
-
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
     auto input_nd_shard_spec = input.memory_config().nd_shard_spec().value();
 
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
+    const auto input_accessor_args = TensorAccessorArgs(input);
+    const auto output_accessor_args = TensorAccessorArgs(output);
 
-    auto aligned_page_size = input_buffer->aligned_page_size();
+    auto aligned_page_size = CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(input);
 
     // Create grid + cores
-    auto grid_size = input.device()->compute_with_storage_grid_size();
+    auto grid_size = input.device().compute_with_storage_grid_size();
     auto grid = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1))});
     auto cores = corerange_to_cores(grid, std::nullopt, input_nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
@@ -62,7 +75,7 @@ ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
     constexpr uint32_t cb_in0_idx = tt::CBIndex::c_0;
 
     ProgramDescriptor desc;
-    push_reshard_copy_pages_cb(
+    CMAKE_UNIQUE_NAMESPACE::push_reshard_copy_pages_cb(
         desc, cb_in0_idx, data_format, aligned_page_size * num_tiles_in_cb, aligned_page_size, grid);
 
     // Prepare compile time arguments
@@ -91,16 +104,15 @@ ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
     writer_desc.compile_time_args = std::move(compile_time_args_writer);
 
-    // Common runtime args: arg 0 is the buffer base address (binding via Buffer*).
+    // Common runtime args: arg 0 is the buffer base address (bound via the MeshTensor).
     // emplace_common_runtime_args registers a CommonBufferBinding for the framework
     // fast cache-hit path.
-    reader_desc.emplace_common_runtime_args({input_buffer});
-    writer_desc.emplace_common_runtime_args({output_buffer});
+    reader_desc.emplace_common_runtime_args({input});
+    writer_desc.emplace_common_runtime_args({output});
 
     // Per-core unique runtime args: [start_page, end_page]
     uint32_t start_page = 0;
-    uint32_t num_dev_pages =
-        static_cast<uint32_t>(input_buffer->buffer_distribution_spec()->tensor_shape_in_pages().volume());
+    uint32_t num_dev_pages = CMAKE_UNIQUE_NAMESPACE::get_num_dev_pages(input);
     uint32_t n_pages_per_core = num_dev_pages / static_cast<uint32_t>(cores.size());
     uint32_t remainder = num_dev_pages % static_cast<uint32_t>(cores.size());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -15,8 +15,9 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
-// Anonymous-namespace helper unique to reshard generic to avoid unity-build collisions.
+// Adds a circular buffer for the given tensor, bound to its sharded backing buffer.
 void push_reshard_generic_cb_pair(
     ProgramDescriptor& desc,
     uint32_t cb_index,
@@ -24,7 +25,7 @@ void push_reshard_generic_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor& bound_buffer_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -33,10 +34,19 @@ void push_reshard_generic_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.buffer = bound_buffer_tensor.mesh_buffer().get_reference_buffer();
     desc.cbs.push_back(std::move(cb));
 }
 
+// Core type of the tensor's storage (Buffer-only attribute).
+auto get_buffer_core_type(const MeshTensor& tensor) { return tensor.mesh_buffer().get_reference_buffer()->core_type(); }
+
+// Page mapping of the tensor's storage (Buffer-only attribute).
+auto get_buffer_page_mapping(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().get_reference_buffer()->get_buffer_page_mapping();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 namespace detail {
@@ -70,13 +80,13 @@ enum class ReshardStridesInRange { ALL_STRIDES, FIRST_HALF };
 
 std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_reshard(
     std::vector<std::vector<std::optional<std::pair<CoreCoord, uint32_t>>>> output_core_to_vector_input_core_page,
-    Buffer* input_buffer,
-    Buffer* output_buffer) {
+    const MeshTensor& input_buffer_tensor,
+    const MeshTensor& output_buffer_tensor) {
     std::unordered_map<CoreCoord, std::vector<detail::PageStride>> ret_map;
-    auto output_cores = output_buffer->get_buffer_page_mapping()->all_cores;
+    auto output_cores = CMAKE_UNIQUE_NAMESPACE::get_buffer_page_mapping(output_buffer_tensor)->all_cores;
     ret_map.reserve(output_cores.size());
 
-    auto* device = input_buffer->device();
+    auto* device = &input_buffer_tensor.mutable_device();
     auto full_grid = device->compute_with_storage_grid_size();
     uint32_t output_core_id = 0;
     for (auto output_core : output_cores) {
@@ -197,7 +207,7 @@ std::unordered_map<CoreCoord, std::vector<detail::PageStride>> create_map_for_re
                     }
 
                     TT_ASSERT(stride.core.x < full_grid.x and stride.core.y < full_grid.y);
-                    TT_ASSERT(data_stride < output_buffer->num_pages());
+                    TT_ASSERT(data_stride < output_buffer_tensor.mesh_buffer().num_pages());
                     uint32_t num_strides = 1;
                     while (stride_it != end and stride_it->has_value()) {
                         bool stride_not_complete = false;
@@ -372,11 +382,12 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> create
 }
 
 std::unordered_map<CoreCoord, std::vector<detail::PageStride>> get_core_page_ranges(
-    Buffer* input_buffer, Buffer* output_buffer) {
-    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
-    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+    const MeshTensor& input_buffer_tensor, const MeshTensor& output_buffer_tensor) {
+    const auto& output_buffer_page_mapping = *CMAKE_UNIQUE_NAMESPACE::get_buffer_page_mapping(output_buffer_tensor);
+    const auto& input_buffer_page_mapping = *CMAKE_UNIQUE_NAMESPACE::get_buffer_page_mapping(input_buffer_tensor);
 
-    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(input_buffer->num_pages());
+    std::vector<std::pair<CoreCoord, uint32_t>> host_page_to_input_core_mapping(
+        input_buffer_tensor.mesh_buffer().num_pages());
     for (auto mapped_page : input_buffer_page_mapping) {
         auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
         host_page_to_input_core_mapping[mapped_page.host_page] = {core, mapped_page.device_page};
@@ -395,29 +406,30 @@ std::unordered_map<CoreCoord, std::vector<detail::PageStride>> get_core_page_ran
         }
         cur_output_core_to_vector_input_core_page[mapped_page.device_page] = {input_core, input_core_page};
     }
-    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+    auto ret_map =
+        create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer_tensor, output_buffer_tensor);
     return ret_map;
 }
 
 std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_core_page_ranges_diff_width(
-    Buffer* input_buffer, Buffer* output_buffer, const Tensor& input) {
-    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
-    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
+    const MeshTensor& input_buffer_tensor, const MeshTensor& output_buffer_tensor, const MeshTensor& input) {
+    const auto& output_buffer_page_mapping = *CMAKE_UNIQUE_NAMESPACE::get_buffer_page_mapping(output_buffer_tensor);
+    const auto& input_buffer_page_mapping = *CMAKE_UNIQUE_NAMESPACE::get_buffer_page_mapping(input_buffer_tensor);
     uint32_t num_rows = 1;
     for (uint32_t i = 0; i < input.logical_shape().rank() - 1; i++) {
         num_rows *= input.logical_shape()[i];
     }
     // Find GCD of page sizes to use as the new base page size
-    uint32_t input_page_size = input_buffer->page_size();
-    uint32_t output_page_size = output_buffer->page_size();
+    uint32_t input_page_size = input_buffer_tensor.mesh_buffer().page_size();
+    uint32_t output_page_size = output_buffer_tensor.mesh_buffer().page_size();
     uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
 
     // Calculate how many base pages make up an input/output page
     uint32_t input_pages_per_original = input_page_size / base_page_size;
     uint32_t output_pages_per_original = output_page_size / base_page_size;
 
-    auto input_width = input_buffer->shard_spec().shape()[1];
-    auto output_width = output_buffer->shard_spec().shape()[1];
+    auto input_width = input_buffer_tensor.shard_spec()->shape[1];
+    auto output_width = output_buffer_tensor.shard_spec()->shape[1];
     auto total_width = input.logical_shape()[-1];
 
     uint32_t total_page_number =
@@ -440,9 +452,9 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
     // find input invalid base pages if applicable
     for (auto mapped_page : input_buffer_page_mapping) {
         auto core = input_buffer_page_mapping.all_cores[mapped_page.core_id];
-        CoreCoord shard_grid = input_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord shard_grid = input_buffer_tensor.shard_spec()->grid.ranges()[0].grid_size();
         bool is_last_in_row = (core.x == shard_grid.x - 1);
-        if (input_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (input_buffer_tensor.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             is_last_in_row = (core.y == shard_grid.y - 1);
         }
         uint32_t base_start_page = mapped_page.host_page * input_pages_per_original;
@@ -462,9 +474,9 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
     // find output invalid base pages if applicable
     for (auto mapped_page : output_buffer_page_mapping) {
         auto core = output_buffer_page_mapping.all_cores[mapped_page.core_id];
-        CoreCoord shard_grid = output_buffer->shard_spec().grid().ranges()[0].grid_size();
+        CoreCoord shard_grid = output_buffer_tensor.shard_spec()->grid.ranges()[0].grid_size();
         bool is_last_in_row = (core.x == shard_grid.x - 1);
-        if (output_buffer->shard_spec().orientation() == ShardOrientation::COL_MAJOR) {
+        if (output_buffer_tensor.shard_spec()->orientation == ShardOrientation::COL_MAJOR) {
             is_last_in_row = (core.y == shard_grid.y - 1);
         }
         uint32_t base_start_page = mapped_page.host_page * output_pages_per_original;
@@ -542,7 +554,8 @@ std::unordered_map<CoreCoord, std::vector<detail::CompressedStrideBlock>> get_co
         }
     }
 
-    auto ret_map = create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer, output_buffer);
+    auto ret_map =
+        create_map_for_reshard(output_core_to_vector_input_core_page, input_buffer_tensor, output_buffer_tensor);
 
     auto processed_ret_map = create_stride_of_strides_ret_map(ret_map);
     return processed_ret_map;
@@ -552,11 +565,11 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges_diff_width(
     const std::vector<uint32_t>& physical_core_coords,
     const std::vector<detail::CompressedStrideBlock>& compressed_stride_vector,
     const uint32_t output_page_offset,
-    const uint32_t& input_addr,
     const uint32_t starting_range,
     const uint32_t ending_range) {
     std::vector<uint32_t> runtime_args = physical_core_coords;
-    runtime_args.push_back(input_addr);
+    // Placeholder for the input buffer base address; the caller binds this slot to the input MeshTensor.
+    runtime_args.push_back(0);
     auto& num_output_pages_for_this_call = runtime_args.emplace_back(0);
     runtime_args.push_back(ending_range - starting_range);
     runtime_args.push_back(output_page_offset);
@@ -597,12 +610,12 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges(
     const std::vector<uint32_t>& physical_core_coords,
     const std::vector<PageStride>& page_stride_vector,
     const uint32_t output_page_offset,
-    const uint32_t& input_addr,
     const uint32_t starting_range,
     const uint32_t ending_range,
     const ReshardStridesInRange reshard_strides_in_range = ReshardStridesInRange::ALL_STRIDES) {
     std::vector<uint32_t> runtime_args = physical_core_coords;
-    runtime_args.push_back(input_addr);
+    // Placeholder for the input buffer base address; the caller binds this slot to the input MeshTensor.
+    runtime_args.push_back(0);
     runtime_args.push_back(0);
     runtime_args.push_back(ending_range - starting_range);
     runtime_args.push_back(output_page_offset);
@@ -654,13 +667,14 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
-    auto* device = input.device();
-    auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
+    const MeshTensor& input_mesh_tensor = input.mesh_tensor();
+    auto* device = &input_mesh_tensor.mutable_device();
+    const MeshTensor& output_mesh_tensor = output.mesh_tensor();
 
-    auto grid = input_buffer->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
-                                                                : device->compute_with_storage_grid_size();
-    auto input_core_type = input_buffer->core_type();
+    auto grid = input_mesh_tensor.memory_config().buffer_type() == BufferType::DRAM
+                    ? device->dram_grid_size()
+                    : device->compute_with_storage_grid_size();
+    auto input_core_type = CMAKE_UNIQUE_NAMESPACE::get_buffer_core_type(input_mesh_tensor);
     uint32_t dst_cb_index = 16;
     auto cores = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(cores));
@@ -668,41 +682,43 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     uint32_t total_size = 0;
     uint32_t page_size = 0;
     uint32_t unit_size = 0;
-    auto output_shard_shape = output.shard_spec().value().shape;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    auto output_shard_shape = output_mesh_tensor.shard_spec().value().shape;
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_mesh_tensor.dtype());
 
-    if (input.layout() == Layout::TILE) {
+    if (input_mesh_tensor.layout() == Layout::TILE) {
         page_size = tt::tile_size(data_format);
         unit_size = page_size;
-        total_size = static_cast<uint32_t>(output.shard_spec().value().numel() / TILE_HW) * unit_size;
+        total_size = static_cast<uint32_t>(output_mesh_tensor.shard_spec().value().numel() / TILE_HW) * unit_size;
     } else {
         // For ROW_MAJOR, use base page size from GCD calculation
-        uint32_t input_page_size = input_buffer->page_size();
-        uint32_t output_page_size = output_buffer->page_size();
+        uint32_t input_page_size = input_mesh_tensor.mesh_buffer().page_size();
+        uint32_t output_page_size = output_mesh_tensor.mesh_buffer().page_size();
         uint32_t base_page_size = std::gcd(input_page_size, output_page_size);
 
         unit_size = base_page_size;
         page_size = base_page_size;
-        total_size = static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output.element_size());
+        total_size =
+            static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output_mesh_tensor.element_size());
     }
 
     ProgramDescriptor desc;
 
     // Output sharded CB. Bind to output buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_generic_cb_pair(
+    CMAKE_UNIQUE_NAMESPACE::push_reshard_generic_cb_pair(
         desc,
         dst_cb_index,
         data_format,
         total_size,
-        output_buffer->page_size(),
+        output_mesh_tensor.mesh_buffer().page_size(),
         all_cores,
-        /*bound_buffer=*/output_buffer);
+        output_mesh_tensor);
 
-    const std::string kernel_source = input_buffer->page_size() != output_buffer->page_size()
-                                          ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader_diff_width.cpp"
-                                          : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader.cpp";
+    const std::string kernel_source =
+        input_mesh_tensor.mesh_buffer().page_size() != output_mesh_tensor.mesh_buffer().page_size()
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+              "reshard_reader_diff_width.cpp"
+            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
+              "reshard_reader.cpp";
 
     std::vector<uint32_t> compile_args = {
         dst_cb_index, static_cast<uint32_t>(grid.x), static_cast<uint32_t>(grid.y), page_size, unit_size};
@@ -735,15 +751,14 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     for (const auto& core : cores) {
         std::vector<uint32_t> runtime_args_0;
         std::vector<uint32_t> runtime_args_1;
-        if (input_buffer->page_size() != output_buffer->page_size()) {
+        if (input_mesh_tensor.mesh_buffer().page_size() != output_mesh_tensor.mesh_buffer().page_size()) {
             auto output_core_to_page_range_pair =
-                detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
+                detail::get_core_page_ranges_diff_width(input_mesh_tensor, output_mesh_tensor, input_mesh_tensor);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input_buffer->address(),
                 0,
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset = runtime_args_0[physical_core_coords.size() + 1];
@@ -751,17 +766,15 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input_buffer->address(),
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
         } else {
-            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
+            auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_mesh_tensor, output_mesh_tensor);
             const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
             runtime_args_0 = detail::get_runtime_args_for_given_ranges(
                 physical_core_coords,
                 page_stride_vector,
                 0,
-                input_buffer->address(),
                 0,
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto output_page_offset =
@@ -771,18 +784,17 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 physical_core_coords,
                 page_stride_vector,
                 output_page_offset,
-                input_buffer->address(),
                 tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u),
                 page_stride_vector.size());
         }
 
-        // Patch arg index (grid.x + grid.y) to bind the input-buffer base address.
-        // The detail helpers already pre-compute physical_core_coords (size grid.x+grid.y) followed by input addr.
+        // Bind arg index (grid.x + grid.y) to the input buffer base address by passing the input
+        // MeshTensor; the detail helpers leave a placeholder uint32 at that slot.
         KernelDescriptor::RTArgList rt_args_0;
         rt_args_0.reserve(runtime_args_0.size());
         for (size_t i = 0; i < runtime_args_0.size(); ++i) {
             if (i == grid.x + grid.y) {
-                rt_args_0.push_back(input_buffer);
+                rt_args_0.push_back(input_mesh_tensor);
             } else {
                 rt_args_0.push_back(runtime_args_0[i]);
             }
@@ -791,7 +803,7 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         rt_args_1.reserve(runtime_args_1.size());
         for (size_t i = 0; i < runtime_args_1.size(); ++i) {
             if (i == grid.x + grid.y) {
-                rt_args_1.push_back(input_buffer);
+                rt_args_1.push_back(input_mesh_tensor);
             } else {
                 rt_args_1.push_back(runtime_args_1[i]);
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -16,6 +16,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Anonymous-namespace helper unique to reshard same-height to avoid unity-build collisions.
 void push_reshard_same_height_cb_pair(
@@ -25,7 +26,7 @@ void push_reshard_same_height_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor& bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -34,10 +35,19 @@ void push_reshard_same_height_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.buffer = bound_tensor.mesh_buffer().get_reference_buffer();
     desc.cbs.push_back(std::move(cb));
 }
 
+// The core type a tensor's storage lives on.
+auto get_buffer_core_type(const MeshTensor& tensor) { return tensor.mesh_buffer().get_reference_buffer()->core_type(); }
+
+// How a tensor's pages are distributed across cores.
+const std::optional<BufferDistributionSpec>& get_buffer_distribution_spec(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().device_local_config().sharding_args.buffer_distribution_spec();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 template <bool local_is_output>
@@ -46,17 +56,17 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
-    const auto& remote_tensor = local_is_output ? input : output;
+    const auto& remote_tensor = (local_is_output ? input : output).mesh_tensor();
     const auto local_shard_spec = local_tensor.shard_spec().value();
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
     auto* device = input.device();
 
-    const auto remote_core_type = remote_tensor.buffer()->core_type();
+    const auto remote_core_type = CMAKE_UNIQUE_NAMESPACE::get_buffer_core_type(remote_tensor);
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
     auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
-    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+    auto remote_cores = CMAKE_UNIQUE_NAMESPACE::get_buffer_distribution_spec(remote_tensor).value().cores_with_data();
 
     const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
     const uint32_t element_size = tt::datum_size(data_format);
@@ -69,14 +79,13 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
 
     constexpr uint32_t cb_index = tt::CBIndex::c_0;
 
-    auto* local_buffer = local_tensor.buffer();
-    auto* remote_buffer = remote_tensor.buffer();
+    const auto& local_mesh_tensor = local_tensor.mesh_tensor();
 
     ProgramDescriptor desc;
 
     // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_height_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    CMAKE_UNIQUE_NAMESPACE::push_reshard_same_height_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, local_mesh_tensor);
 
     const std::string kernel_name =
         local_is_output
@@ -97,7 +106,7 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
     writer_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
 
-    auto remote_buffer_type = remote_buffer->buffer_type();
+    auto remote_buffer_type = remote_tensor.memory_config().buffer_type();
 
     // Generate all read/write offsets for each core
     auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
@@ -119,19 +128,19 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     for (uint32_t core_idx = 0; core_idx < local_cores.size(); core_idx++) {
         const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
 
-        // arg 3 is remote-buffer base address (binding via Buffer*).
+        // arg 3 is remote-buffer base address (bound via the remote MeshTensor).
         KernelDescriptor::RTArgList runtime_args_0;
         runtime_args_0.push_back(total_num_sticks_kernel_0);
         runtime_args_0.push_back(local_stride_bytes);
         runtime_args_0.push_back(remote_stride_bytes);
-        runtime_args_0.push_back(remote_buffer);
+        runtime_args_0.push_back(remote_tensor);
         runtime_args_0.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
 
         KernelDescriptor::RTArgList runtime_args_1;
         runtime_args_1.push_back(total_num_sticks_kernel_1);
         runtime_args_1.push_back(local_stride_bytes);
         runtime_args_1.push_back(remote_stride_bytes);
-        runtime_args_1.push_back(remote_buffer);
+        runtime_args_1.push_back(remote_tensor);
         runtime_args_1.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
 
         for (const auto& args : args_for_all_segments) {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -17,6 +17,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Anonymous-namespace helper unique to reshard same-width to avoid unity-build collisions.
 void push_reshard_same_width_cb_pair(
@@ -26,7 +27,7 @@ void push_reshard_same_width_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    const MeshTensor* bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -35,10 +36,24 @@ void push_reshard_same_width_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.buffer = bound_tensor ? bound_tensor->mesh_buffer().get_reference_buffer() : nullptr;
     desc.cbs.push_back(std::move(cb));
 }
 
+// The core type a tensor's storage lives on.
+auto get_buffer_core_type(const MeshTensor& tensor) { return tensor.mesh_buffer().get_reference_buffer()->core_type(); }
+
+// How a tensor's pages are distributed across cores.
+const std::optional<BufferDistributionSpec>& get_buffer_distribution_spec(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().device_local_config().sharding_args.buffer_distribution_spec();
+}
+
+// Allocator alignment of a tensor's storage.
+uint32_t get_buffer_alignment(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().get_reference_buffer()->alignment();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 template <bool local_is_output>
@@ -47,37 +62,40 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
     const auto& input = tensor_args.input;
     const auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
-    const auto& remote_tensor = local_is_output ? input : output;
+    const auto& remote_tensor = local_is_output ? input.mesh_tensor() : output.mesh_tensor();
 
     auto* device = input.device();
 
-    const auto local_shard_spec = local_tensor.shard_spec().value();
+    const auto& local_mesh_tensor = local_tensor.mesh_tensor();
+    const auto local_shard_spec = local_mesh_tensor.shard_spec().value();
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
-    auto remote_core_type = remote_tensor.buffer()->core_type();
+    auto remote_core_type = CMAKE_UNIQUE_NAMESPACE::get_buffer_core_type(remote_tensor);
     constexpr uint32_t cb_index = tt::CBIndex::c_0;
     constexpr uint32_t cb_scratch_index = tt::CBIndex::c_1;
     auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
-    auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
+    auto remote_cores = CMAKE_UNIQUE_NAMESPACE::get_buffer_distribution_spec(remote_tensor).value().cores_with_data();
 
     uint32_t unit_size = 0;
     uint32_t local_units_per_shard = 0;
     uint32_t remote_units_per_shard = 0;
-    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_tensor.dtype());
+    auto data_format = tt::tt_metal::datatype_to_dataformat_converter(local_mesh_tensor.dtype());
 
-    uint32_t num_units = local_tensor.buffer()->num_pages();
-    if (local_tensor.layout() == Layout::TILE) {
+    uint32_t num_units = local_mesh_tensor.mesh_buffer().num_pages();
+    if (local_mesh_tensor.layout() == Layout::TILE) {
         unit_size = tt::tile_size(data_format);
         local_units_per_shard = local_shard_spec.numel() / TILE_HW;
         remote_units_per_shard = remote_shard_spec.numel() / TILE_HW;
     } else {
-        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());
+        unit_size = static_cast<uint32_t>(local_shard_spec.shape[1] * local_mesh_tensor.element_size());
         local_units_per_shard = local_shard_spec.shape[0];
         remote_units_per_shard = remote_shard_spec.shape[0];
     }
-    uint32_t local_unit_size_padded = tt::align(unit_size, local_tensor.buffer()->alignment());
-    uint32_t remote_unit_size_padded = tt::align(unit_size, remote_tensor.buffer()->alignment());
+    uint32_t local_unit_size_padded =
+        tt::align(unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(local_mesh_tensor));
+    uint32_t remote_unit_size_padded =
+        tt::align(unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(remote_tensor));
     bool unaligned = false;
     if (remote_unit_size_padded != unit_size || local_unit_size_padded != unit_size) {
         unaligned = true;
@@ -89,26 +107,24 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
             : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
 
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
-    auto* local_buffer = local_tensor.buffer();
-    auto* remote_buffer = remote_tensor.buffer();
-    auto remote_buffer_type = remote_buffer->buffer_type();
+    auto remote_buffer_type = remote_tensor.memory_config().buffer_type();
 
     ProgramDescriptor desc;
 
     // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_width_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    CMAKE_UNIQUE_NAMESPACE::push_reshard_same_width_cb_pair(
+        desc, cb_index, data_format, total_size, unit_size, all_cores, &local_mesh_tensor);
 
     if (unaligned) {
         // Scratch CB used by kernels when local/remote alignments differ.
-        push_reshard_same_width_cb_pair(
+        CMAKE_UNIQUE_NAMESPACE::push_reshard_same_width_cb_pair(
             desc,
             cb_scratch_index,
             data_format,
             remote_units_per_shard * remote_unit_size_padded,
             unit_size,
             all_cores,
-            /*bound_buffer=*/nullptr);
+            nullptr);
     }
 
     // Reader/writer kernels share the same source and compile-time args.
@@ -148,12 +164,12 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
         uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, static_cast<uint32_t>(kernels.size()));
         uint32_t local_start_offset = 0;
         for (auto* kernel : kernels) {
-            // arg 0 is remote-buffer base address (binding via Buffer*).
+            // arg 0 is remote-buffer base address (bound via the remote MeshTensor).
             // RTArgList doesn't expose operator[] for back-patching, so we build
             // a std::vector<variant> here and pass via the vector overload of
             // emplace_runtime_args.
-            std::vector<std::variant<uint32_t, Buffer*>> kernel_args;
-            kernel_args.emplace_back(remote_buffer);
+            std::vector<std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>> kernel_args;
+            kernel_args.emplace_back(std::ref(remote_tensor));
             kernel_args.emplace_back(uint32_t{0});
             kernel_args.emplace_back(uint32_t{0});
             uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_program_factory.cpp
@@ -20,6 +20,7 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Anonymous-namespace helper unique to sharded_to_interleaved to avoid unity-build collisions.
 void push_s2i_cb_pair(
@@ -29,7 +30,7 @@ void push_s2i_cb_pair(
     uint32_t total_size,
     uint32_t page_size,
     const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
+    ttsl::optional_reference<const MeshTensor> bound_tensor) {
     CBDescriptor cb;
     cb.total_size = total_size;
     cb.core_ranges = core_ranges;
@@ -38,17 +39,23 @@ void push_s2i_cb_pair(
         .data_format = data_format,
         .page_size = page_size,
     });
-    cb.buffer = bound_buffer;
+    cb.buffer = bound_tensor.has_value() ? (*bound_tensor).mesh_buffer().get_reference_buffer() : nullptr;
     desc.cbs.push_back(std::move(cb));
 }
 
+// Reference-buffer alignment of the given tensor.
+uint32_t get_buffer_alignment(const MeshTensor& tensor) {
+    return tensor.mesh_buffer().get_reference_buffer()->alignment();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     const ShardedToInterleavedParams& operation_attributes,
     const ShardedToInterleavedInputs& tensor_args,
     Tensor& output_tensor) {
-    const auto& input = tensor_args.input_tensor;
+    const auto& input = tensor_args.input_tensor.mesh_tensor();
     const auto& output = output_tensor;
     const uint32_t num_slices = operation_attributes.num_slices;
     const uint32_t slice_index = operation_attributes.slice_index;
@@ -66,7 +73,8 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     uint32_t num_units_per_shard_width_last = 0;
 
     tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto& output_mesh = output.mesh_tensor();
+    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output_mesh.dtype());
 
     auto shard_spec = input.shard_spec().value();
     auto shard_strategy = input.memory_config().memory_layout();
@@ -78,7 +86,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     const auto cores = corerange_to_cores(all_cores, std::nullopt, rm_orientation);
 
     CoreCoord end_core = cores[num_cores - 1];
-    if (output.layout() == Layout::TILE) {
+    if (output_mesh.layout() == Layout::TILE) {
         input_unit_size = tt::tile_size(input_cb_data_format);
         output_unit_size = tt::tile_size(output_cb_data_format);
         num_units_per_shard_height = shard_spec.shape[0] / TILE_HEIGHT;
@@ -93,7 +101,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
             num_units_per_shard_width - (round_up(num_units_per_row, num_units_per_shard_width) - num_units_per_row);
     } else {
         input_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * input.element_size());
-        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output.element_size());
+        output_unit_size = static_cast<uint32_t>(shard_spec.shape[1] * output_mesh.element_size());
         num_units_per_shard_height = shard_spec.shape[0];
         num_units_per_shard_width = 1;
         num_units_per_shard = num_units_per_shard_height * num_units_per_shard_width;
@@ -110,7 +118,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     if (shard_strategy == TensorMemoryLayout::HEIGHT_SHARDED) {
         num_cores_unpadded = div_up(num_units_height, num_units_per_shard_height);
     } else if (shard_strategy == TensorMemoryLayout::WIDTH_SHARDED) {
-        if (output.layout() == Layout::TILE) {
+        if (output_mesh.layout() == Layout::TILE) {
             num_cores_unpadded = div_up(num_units_per_row, num_units_per_shard_width);
         } else {
             num_cores_unpadded = div_up(num_units_per_row, output_unit_size);
@@ -128,35 +136,34 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     uint32_t src0_cb_index = CBIndex::c_0;
     uint32_t out_cb_index = src0_cb_index;
     uint32_t num_input_units = num_units_per_shard;
-    auto* src_buffer = input.buffer();
-    auto* dst_buffer = output.buffer();
-    uint32_t input_page_size = tt::align(input_unit_size, src_buffer->alignment());
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
-    bool is_blackhole = (input.device()->arch() == tt::ARCH::BLACKHOLE);
+    uint32_t input_page_size = tt::align(input_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(input));
+    bool dst_is_dram = output_mesh.memory_config().buffer_type() == tt_metal::BufferType::DRAM;
+    bool is_blackhole = (input.device().arch() == tt::ARCH::BLACKHOLE);
 
     ProgramDescriptor desc;
 
     // Sharded input CB. Bind to src buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_s2i_cb_pair(
+    CMAKE_UNIQUE_NAMESPACE::push_s2i_cb_pair(
         desc,
         src0_cb_index,
         input_cb_data_format,
         num_input_units * input_page_size,
         input_page_size,
         used_cores,
-        /*bound_buffer=*/src_buffer);
+        input);
 
     if (convert_df) {
         out_cb_index = CBIndex::c_16;
-        uint32_t output_page_size = tt::align(output_unit_size, dst_buffer->alignment());
-        push_s2i_cb_pair(
+        uint32_t output_page_size =
+            tt::align(output_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(output_mesh));
+        CMAKE_UNIQUE_NAMESPACE::push_s2i_cb_pair(
             desc,
             out_cb_index,
             output_cb_data_format,
             num_input_units * output_page_size,
             output_page_size,
             used_cores,
-            /*bound_buffer=*/nullptr);
+            std::nullopt);
     }
 
     // Reader kernel (sharded input streamed in via globally-allocated CB).
@@ -173,7 +180,7 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
     writer_desc.core_ranges = used_cores;
     writer_desc.config = WriterConfigDescriptor{};
     std::vector<uint32_t> writer_compile_time_args = {out_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
     if (input.layout() == Layout::TILE) {
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
@@ -237,9 +244,9 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
                     }
                 }
             }
-            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            // Writer run-time args: arg 0 is the destination-buffer base address (bound via the output MeshTensor).
             KernelDescriptor::RTArgList writer_rt;
-            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(output_mesh);
             writer_rt.push_back(num_units_per_shard_height);
             writer_rt.push_back(num_units_per_shard_width);
             writer_rt.push_back(shard_height);
@@ -282,15 +289,16 @@ ProgramDescriptor ShardedToInterleavedProgramFactory::create_descriptor(
                 }
             }
             uint32_t l1_alignment = hal::get_l1_alignment();
-            uint32_t padded_shard_width = tt::align(output_unit_size, dst_buffer->alignment());
+            uint32_t padded_shard_width =
+                tt::align(output_unit_size, CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(output_mesh));
             if (is_blackhole or is_l1_aligned) {
                 if (!dst_is_dram or is_l1_aligned) {
                     padded_shard_width = tt::align(output_unit_size, l1_alignment);
                 }
             }
-            // Writer run-time args: arg 0 is the destination-buffer base address (binding via Buffer*).
+            // Writer run-time args: arg 0 is the destination-buffer base address (bound via the output MeshTensor).
             KernelDescriptor::RTArgList writer_rt;
-            writer_rt.push_back(dst_buffer);
+            writer_rt.push_back(output_mesh);
             writer_rt.push_back(num_units_per_row);
             writer_rt.push_back(shard_height);
             writer_rt.push_back(shard_width);


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Mechanical migration of the sharded data-movement op program factories to the
`MeshTensor`/`MeshBuffer` APIs.

Candidate program factories (7):

- data_movement/sharded/interleaved_to_sharded/device
- data_movement/sharded/sharded_to_interleaved/device
- data_movement/sharded/reshard/device (generic, same-height, same-width, ND copy-local, ND copy-pages)

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure. It is
closely modelled on `ttnn::Tensor` — the two share very similar semantics and
are designed to be drop-in interchangeable where appropriate.

The motivation for Runtime Tensor is that it lets the runtime capture the shape
and sharding information of the true storage data structure. That information is
plumbed through `TensorAccessorArgs` and is critical for the upcoming Metal 2.0
refactoring: gen 2 hardware needs to understand the shape and sharding of device
memory directly.

Runtime Tensor is not meant to replace `ttnn::Tensor` outright. This PR replaces
`ttnn::Tensor` usage in the program factories specifically, where Runtime Tensor
is the most appropriate abstraction level. (`MeshTensor` — the type you will see
in the diff — is the device-side part of Runtime Tensor.)

#### This refactoring

- **Primary goal:** ensure the ops leverage Runtime Tensor so we no longer lose
  shape and sharding information when passing `Buffer` into runtime / compile
  arguments (notably into `TensorAccessorArgs`).
- **Secondary goal:** complete the migration away from single-device data
  classes now that the rest of our infrastructure is multi-device-aware
  (`Buffer` → `MeshTensor`).

Beyond the type substitution, this pass also does the mechanical cleanup that
falls out of it:

- Input/output locals are routed through `MeshTensor`, so the only
  `.mesh_tensor()` calls left are the extraction points at the top of each
  `create_descriptor`.
- All raw `Tensor::buffer()` / `Buffer::address()` usage is removed. Per-core
  buffer addresses now flow through `KernelDescriptor::emplace_runtime_args` /
  `emplace_common_runtime_args` (and `RTArgList` where a slot is back-patched),
  so the framework resolves and patches them; `TensorAccessorArgs` is
  constructed directly from `MeshTensor`.
- Circular buffers stay bound via `cb.buffer = …get_reference_buffer()` (never
  `cb.tensor`).
- The remaining `Buffer`-only attribute chains (`alignment`, `aligned_page_size`,
  `core_type`, page mapping) are factored into small local `get_buffer_<attr>`
  helpers in `CMAKE_UNIQUE_NAMESPACE`; DRAM/L1 checks use
  `MeshTensor::memory_config().buffer_type()`.

Note: the classic sharded↔sharded reshard factories (generic / same-height /
same-width) address sharded memory manually (physical core coords + page
strides), so they carry no `TensorAccessorArgs` by design; only the
interleaved-side ops and the ND reshard path construct it.

#### Risk

This migration should carry minimal regression risk: it is a type-substitution +
mechanical cleanup refactor, not a behavioural change. Per-core runtime-arg
counts and slot order, CB bindings, and work-split are all preserved. Builds
cleanly locally.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-dm-sharded)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-dm-sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-dm-sharded)
