### PR TITLE
[MeshTensor Integration] transpose op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -16,13 +16,19 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+uint32_t get_buffer_aligned_page_size(const MeshTensor& t) {
+    return static_cast<uint32_t>(t.mesh_buffer().get_reference_buffer()->aligned_page_size());
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
     auto input_shape = input_tensor.padded_shape();
     bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
 
     ProgramDescriptor desc;
 
@@ -35,8 +41,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     uint32_t page_size = page_shape[0] * page_shape[1];
     uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
-    IDevice* device = input_tensor.device();
+    IDevice* device = &input_tensor.mutable_device();
 
     uint32_t num_tensor_pages = input_tensor.physical_volume() / page_size;
 
@@ -49,7 +54,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages);
 
-    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
+    const MeshTensor& c = output_tensor.mesh_tensor();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;
@@ -65,15 +70,17 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
 
     KernelDescriptor::Defines reader_defines;
     std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
+        static_cast<uint32_t>(src0_cb_index),
+        CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(input_tensor),
+        stick_size};
     std::vector<uint32_t> reader_common_runtime_args;
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(input_tensor, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
     KernelDescriptor::Defines writer_defines;
     std::vector<uint32_t> writer_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
+        static_cast<uint32_t>(src0_cb_index), CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(c), stick_size};
     std::vector<uint32_t> writer_common_runtime_args;
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(c, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     if (row_major) {
@@ -130,8 +137,8 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
         uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
 
         reader_desc.emplace_runtime_args(
-            core, {src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
-        writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_read});
+            core, {input_tensor, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
+        writer_desc.emplace_runtime_args(core, {c, num_pages_per_core, num_pages_read});
 
         num_pages_read += num_pages_per_core;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -23,7 +23,6 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -36,7 +35,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     uint32_t page_size = page_shape[0] * page_shape[1];
     uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     IDevice* device = input_tensor.device();
 
     uint32_t num_tensor_pages = input_tensor.physical_volume() / page_size;
@@ -50,8 +49,7 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_pages_per_core_group_1, num_pages_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -18,27 +18,26 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+uint32_t get_buffer_aligned_page_size(const MeshTensor& t) {
+    return static_cast<uint32_t>(t.mesh_buffer().get_reference_buffer()->aligned_page_size());
+}
 
-// Compute per-core runtime args (reader+writer) for HC RM transpose and append them to the
-// supplied KernelDescriptors. The traversal logic that advances (curr_c, curr_h, curr_n) was
-// previously shared between `create` and `override_runtime_arguments`; now it has a single home.
 void emit_runtime_args_hc_rm(
     KernelDescriptor& reader_desc,
     KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const MeshTensor& input_mesh,
+    const MeshTensor& output_mesh,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_2) {
-    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
-    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
     auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
-    uint32_t W_bytes = W * input_mesh.element_size();
+    uint32_t W_bytes = W * static_cast<uint32_t>(input_mesh.element_size());
 
     uint32_t max_read_size = 2048;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
@@ -92,27 +91,26 @@ void emit_runtime_args_hc_rm(
     }
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
+    const MeshTensor& a = tensor_args.input.mesh_tensor();
+    const MeshTensor& c = output_tensor.mesh_tensor();
 
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
-
-    const auto& a_shape = input_tensor.logical_shape();
+    const auto& a_shape = a.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
     uint32_t NCH = N * C * H;
 
     ProgramDescriptor desc;
 
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(a.dtype());
 
     log_debug(tt::LogOp, "transpose_hc_rm");
     log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
 
-    IDevice* device = input_tensor.device();
+    IDevice* device = &a.mutable_device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -122,17 +120,15 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, NCH);
 
-    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
     uint32_t src0_cb_index = 0;
 
     auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                 : num_sticks_per_core_group_2;
 
-    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
-    uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
-    auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
+    uint32_t src0_aligned_page_size = CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(a);
+    uint32_t dst_aligned_page_size = CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(c);
+    uint32_t aligned_page = std::max(src0_aligned_page_size, dst_aligned_page_size);
+    auto stick_size = std::max(static_cast<uint32_t>(W * a.element_size()), aligned_page);
 
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_sticks * stick_size,
@@ -150,15 +146,15 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     reader_compile_time_args.push_back(H);
     reader_compile_time_args.push_back(C);
     reader_compile_time_args.push_back(stick_size);
-    reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    reader_compile_time_args.push_back(src0_aligned_page_size);
+    TensorAccessorArgs(a, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
     std::vector<uint32_t> writer_common_runtime_args;
     writer_compile_time_args.push_back(stick_size);
-    writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    writer_compile_time_args.push_back(dst_aligned_page_size);
+    TensorAccessorArgs(c, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelDescriptor reader_desc;
@@ -181,11 +177,11 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
-    emit_runtime_args_hc_rm(
+    CMAKE_UNIQUE_NAMESPACE::emit_runtime_args_hc_rm(
         reader_desc,
         writer_desc,
-        input_tensor,
-        output_tensor,
+        a,
+        c,
         num_cores_total,
         num_cores_y,
         core_group_1,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -33,12 +33,12 @@ void emit_runtime_args_hc_rm(
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
+    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
+    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
+    auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
-    uint32_t W_bytes = W * input_tensor.element_size();
+    uint32_t W_bytes = W * input_mesh.element_size();
 
     uint32_t max_read_size = 2048;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
@@ -66,10 +66,10 @@ void emit_runtime_args_hc_rm(
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
+            {input_mesh, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
 
         writer_desc.emplace_runtime_args(
-            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+            core, {output_mesh, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -122,7 +122,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, NCH);
 
-    Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src0_cb_index = 0;
@@ -130,7 +130,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                 : num_sticks_per_core_group_2;
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
     auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -287,7 +287,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -331,7 +330,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -343,7 +342,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     std::vector<uint32_t> reader_compile_time_args;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -18,9 +18,10 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded(
-    const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
+    const MeshTensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t H = input_shape[2], C = input_shape[1];
@@ -29,18 +30,18 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     uint32_t shard_height = shard_spec.shape[0];
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    IDevice* device = input_tensor.device();
+    const auto& device = input_tensor.device();
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
 
     std::vector<uint32_t> shard_grid_x_map;
     for (uint32_t i = 0; i < num_cores_x; ++i) {
-        auto physical_core = device->worker_core_from_logical_core(CoreCoord(i, 0));
+        auto physical_core = device.worker_core_from_logical_core(CoreCoord(i, 0));
         shard_grid_x_map.push_back(physical_core.x);
     }
     std::vector<uint32_t> shard_grid_y_map;
     for (uint32_t i = 0; i < num_cores_y; ++i) {
-        auto physical_core = device->worker_core_from_logical_core(CoreCoord(0, i));
+        auto physical_core = device.worker_core_from_logical_core(CoreCoord(0, i));
         shard_grid_y_map.push_back(physical_core.y);
     }
 
@@ -84,7 +85,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 }
 
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded_special_case(
-    const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
+    const MeshTensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
@@ -95,7 +96,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     uint32_t shard_height = shard_spec.shape[0];
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    IDevice* device = input_tensor.device();
+    const auto& device = input_tensor.device();
 
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores);
 
@@ -163,7 +164,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
             if (worker_x_logical < num_cores_x && worker_y_logical < num_cores_y) {
                 auto core_physical =
-                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                    device.worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
 
                 read_cores_indices.push_back(shard_id);
                 read_stick_offset.push_back(stick_id_in_shard * stick_size_bytes);
@@ -280,13 +281,12 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     return ret_val;
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -330,7 +330,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .tensor = &input_tensor.mesh_tensor(),
+        .buffer = input_tensor.mesh_buffer().get_reference_buffer(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -342,7 +342,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .tensor = &output_tensor.mesh_tensor(),
+        .buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer(),
     });
 
     std::vector<uint32_t> reader_compile_time_args;
@@ -376,15 +376,13 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     reader_desc.defines = std::move(reader_defines);
     reader_desc.config = ReaderConfigDescriptor{};
 
-    // Writer kernel only exists in the special case path; the generic path puts
-    // everything through the reader (writer args returned by the generic helper
-    // are empty, matching the legacy `KernelHandle writer_kernel_id{}` behavior).
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> all_runtime_args;
     if (is_special_case) {
-        all_runtime_args =
-            get_runtime_args_hc_rm_sharded_special_case(input_tensor, num_cores, num_cores_x, num_cores_y);
+        all_runtime_args = CMAKE_UNIQUE_NAMESPACE::get_runtime_args_hc_rm_sharded_special_case(
+            input_tensor, num_cores, num_cores_x, num_cores_y);
     } else {
-        all_runtime_args = get_runtime_args_hc_rm_sharded(input_tensor, num_cores, num_cores_x, num_cores_y);
+        all_runtime_args =
+            CMAKE_UNIQUE_NAMESPACE::get_runtime_args_hc_rm_sharded(input_tensor, num_cores, num_cores_x, num_cores_y);
     }
 
     reader_desc.runtime_args.reserve(num_cores);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -22,6 +22,7 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Per-core runtime args for the reader + writer kernels. The work split uses
 // two parallel partitions (unpadded vs padded tile counts) so each core needs a
@@ -30,21 +31,17 @@ namespace {
 void emit_runtime_args_hc_tiled_interleaved(
     KernelDescriptor& reader_desc,
     KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const MeshTensor& a,
+    const MeshTensor& c,
     const CoreRange& total_cores) {
-    const tt::tt_metal::MeshTensor& input_buffer_meshtensor_rename_me = input_tensor.mesh_tensor();
-    const tt::tt_metal::MeshTensor& output_buffer_meshtensor_rename_me = output_tensor.mesh_tensor();
-
-    auto tile_shape = input_buffer_meshtensor_rename_me.tensor_spec().tile().get_tile_shape();
+    auto tile_shape = a.tensor_spec().tile().get_tile_shape();
     auto tile_hw = tile_shape[0] * tile_shape[1];
-    uint32_t num_tensor_tiles = input_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
-    uint32_t num_output_tiles = output_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
-    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_buffer_meshtensor_rename_me.padded_shape()[2] /
-                                                           tile_shape[0]);  // only last row of Ct should have padding
+    uint32_t num_tensor_tiles = a.physical_volume() / tile_hw;
+    uint32_t num_output_tiles = c.physical_volume() / tile_hw;
+    uint32_t padded_num_tensor_tiles =
+        num_output_tiles / (c.padded_shape()[2] / tile_shape[0]);  // only last row of Ct should have padding
 
-    auto compute_with_storage_grid_size =
-        input_buffer_meshtensor_rename_me.mutable_device().compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = a.mutable_device().compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
     auto
@@ -85,27 +82,22 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer_meshtensor_rename_me.address(), num_tiles_per_core, start_idx});
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                output_buffer_meshtensor_rename_me.address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+        reader_desc.emplace_runtime_args(core, {a, num_tiles_per_core, start_idx});
+        writer_desc.emplace_runtime_args(core, {c, start_idx, end_idx, padded_start_idx, padded_end_idx});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
     }
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::create_descriptor(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
     // pad_value is always defined at API level; padding is decided purely by shape
     const float pad_value = operation_attributes.pad_value;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
 
     ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
@@ -117,7 +109,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
 
-    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = input_tensor.mutable_device().compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
@@ -148,8 +140,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         });
     }
 
-    Buffer* src_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
-    uint32_t element_size = input_tensor.element_size();
+    uint32_t element_size = static_cast<uint32_t>(input_tensor.element_size());
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
     uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
@@ -190,7 +181,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         {"tile_height", 1u},
         {"tile_width", 1u},
     };
-    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(input_tensor, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     KernelDescriptor reader_desc;
@@ -204,7 +195,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> writer_compile_time_args = {
         element_size,
         tt::CBIndex::c_0,
@@ -217,7 +207,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         face_shape[1],
         static_cast<uint32_t>(needs_padding)};
     std::vector<uint32_t> writer_common_runtime_args;
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(output_tensor.mesh_tensor(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelDescriptor writer_desc;
@@ -230,7 +220,8 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     writer_desc.config = WriterConfigDescriptor{};
     writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
 
-    emit_runtime_args_hc_tiled_interleaved(reader_desc, writer_desc, input_tensor, output_tensor, total_cores);
+    CMAKE_UNIQUE_NAMESPACE::emit_runtime_args_hc_tiled_interleaved(
+        reader_desc, writer_desc, input_tensor, output_tensor.mesh_tensor(), total_cores);
 
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -33,17 +33,18 @@ void emit_runtime_args_hc_tiled_interleaved(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const CoreRange& total_cores) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
+    const tt::tt_metal::MeshTensor& input_buffer_meshtensor_rename_me = input_tensor.mesh_tensor();
+    const tt::tt_metal::MeshTensor& output_buffer_meshtensor_rename_me = output_tensor.mesh_tensor();
 
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    auto tile_shape = input_buffer_meshtensor_rename_me.tensor_spec().tile().get_tile_shape();
     auto tile_hw = tile_shape[0] * tile_shape[1];
-    uint32_t num_tensor_tiles = input_tensor.physical_volume() / tile_hw;
-    uint32_t num_output_tiles = output_tensor.physical_volume() / tile_hw;
-    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_tensor.padded_shape()[2] /
+    uint32_t num_tensor_tiles = input_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
+    uint32_t num_output_tiles = output_buffer_meshtensor_rename_me.physical_volume() / tile_hw;
+    uint32_t padded_num_tensor_tiles = num_output_tiles / (output_buffer_meshtensor_rename_me.padded_shape()[2] /
                                                            tile_shape[0]);  // only last row of Ct should have padding
 
-    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size =
+        input_buffer_meshtensor_rename_me.mutable_device().compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
     auto
@@ -85,10 +86,11 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
         reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
+            core, std::vector<uint32_t>{input_buffer_meshtensor_rename_me.address(), num_tiles_per_core, start_idx});
         writer_desc.runtime_args.emplace_back(
             core,
-            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+            std::vector<uint32_t>{
+                output_buffer_meshtensor_rename_me.address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
@@ -104,7 +106,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     const float pad_value = operation_attributes.pad_value;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
@@ -147,7 +148,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         });
     }
 
-    Buffer* src_buffer = input_tensor.buffer();
+    Buffer* src_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     uint32_t element_size = input_tensor.element_size();
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
@@ -203,7 +204,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     reader_desc.config = ReaderConfigDescriptor{};
     reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
 
-    Buffer* dst_buffer = output_tensor.buffer();
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> writer_compile_time_args = {
         element_size,
         tt::CBIndex::c_0,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -18,20 +18,23 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+uint32_t get_buffer_alignment(const MeshTensor& t) { return t.mesh_buffer().get_reference_buffer()->alignment(); }
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 
 void emit_runtime_args_hc_tiled(
     KernelDescriptor& reader_desc,
     KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const MeshTensor& input_mesh,
+    const MeshTensor& output_mesh,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_tiles_per_core_group_2) {
-    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
-    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
     auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
@@ -62,26 +65,24 @@ void emit_runtime_args_hc_tiled(
         uint32_t h = num_tiles_read / CtWt % H;
         uint32_t ct = num_tiles_read / Wt % Ct;
 
-        reader_desc.runtime_args.emplace_back(
+        reader_desc.emplace_runtime_args(
             core,
-            std::vector<uint32_t>{
-                input_mesh.address(),
-                Wt,
-                H,
-                Ct,
-                HW_bytes,
-                CHW_bytes,
-                num_tiles_read,
-                num_tiles_per_core,
-                num_tiles_read / CtHWt * CHW_bytes,
-                h,
-                h / TILE_HEIGHT * Wt,
-                ct,
-                ct * TILE_HEIGHT * HW_bytes,
-                num_tiles_read % Wt});
+            {input_mesh,
+             Wt,
+             H,
+             Ct,
+             HW_bytes,
+             CHW_bytes,
+             num_tiles_read,
+             num_tiles_per_core,
+             num_tiles_read / CtHWt * CHW_bytes,
+             h,
+             h / TILE_HEIGHT * Wt,
+             ct,
+             ct * TILE_HEIGHT * HW_bytes,
+             num_tiles_read % Wt});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_mesh.address(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_mesh, num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -91,11 +92,11 @@ void emit_runtime_args_hc_tiled(
 
 tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
 
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
+    const MeshTensor& c = output_tensor.mesh_tensor();
 
-    uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
+    uint32_t sub_tile_line_bytes = static_cast<uint32_t>(16 * input_tensor.element_size());
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
 
     ProgramDescriptor desc;
@@ -108,7 +109,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
     log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
 
-    IDevice* device = input_tensor.device();
+    IDevice* device = &input_tensor.mutable_device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -117,8 +118,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
-
-    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     // check if we need to allocate a scratch buffer
@@ -129,7 +128,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     // TODO: noc_async_write only require 16B alignment for both DRAM and L1 for Blackhole, so instead of reading in
     // face-lines from C tiles to form a single tile, we can load a single tile and then write out its face-lines to C
     // tiles
-    uint32_t alignment = dst_buffer->alignment();
+    uint32_t alignment = CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(c);
     bool misaligned = alignment > sub_tile_line_bytes;
 
     uint32_t num_input_tiles = 2;
@@ -158,15 +157,14 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
         });
     }
 
-    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> reader_compile_time_args;
     reader_compile_time_args.push_back(sub_tile_line_bytes);
     reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);
     reader_compile_time_args.push_back(alignment);
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
 
     std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(c).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -189,7 +187,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
         reader_desc,
         writer_desc,
         input_tensor,
-        output_tensor,
+        c,
         num_cores_total,
         num_cores_y,
         core_group_1,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -30,14 +30,14 @@ void emit_runtime_args_hc_tiled(
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_tiles_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
+    const MeshTensor& input_mesh = input_tensor.mesh_tensor();
+    const MeshTensor& output_mesh = output_tensor.mesh_tensor();
+    auto input_shape = input_mesh.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
     uint32_t HW = H * W;
-    uint32_t HW_bytes = HW * input_tensor.element_size();
-    uint32_t CHW_bytes = C * HW * input_tensor.element_size();
+    uint32_t HW_bytes = HW * input_mesh.element_size();
+    uint32_t CHW_bytes = C * HW * input_mesh.element_size();
 
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ct = C / TILE_HEIGHT;
@@ -65,7 +65,7 @@ void emit_runtime_args_hc_tiled(
         reader_desc.runtime_args.emplace_back(
             core,
             std::vector<uint32_t>{
-                input_buffer->address(),
+                input_mesh.address(),
                 Wt,
                 H,
                 Ct,
@@ -81,7 +81,7 @@ void emit_runtime_args_hc_tiled(
                 num_tiles_read % Wt});
 
         writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+            core, std::vector<uint32_t>{output_mesh.address(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -94,7 +94,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
     uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
@@ -119,8 +118,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     // check if we need to allocate a scratch buffer
@@ -160,7 +158,7 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
         });
     }
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     std::vector<uint32_t> reader_compile_time_args;
     reader_compile_time_args.push_back(sub_tile_line_bytes);
     reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -17,13 +17,18 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+uint32_t get_buffer_aligned_page_size(const MeshTensor& t) {
+    return static_cast<uint32_t>(t.mesh_buffer().get_reference_buffer()->aligned_page_size());
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 
 void emit_runtime_args_wh_tiled(
     KernelDescriptor& reader_desc,
     KernelDescriptor& compute_desc,
     KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const MeshTensor& input_tensor,
+    const MeshTensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
@@ -60,7 +65,7 @@ void emit_runtime_args_wh_tiled(
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_tensor.mesh_tensor(),
+            {input_tensor,
              num_tiles_per_core,
              tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
              h,
@@ -71,7 +76,7 @@ void emit_runtime_args_wh_tiled(
 
         compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_tensor, num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -81,8 +86,8 @@ void emit_runtime_args_wh_rm(
     KernelDescriptor& reader_desc,
     KernelDescriptor& compute_desc,
     KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    const MeshTensor& input_tensor,
+    const MeshTensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
@@ -109,11 +114,11 @@ void emit_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        reader_desc.emplace_runtime_args(core, {input_tensor.mesh_tensor(), num_sticks_read, num_hw_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {input_tensor, num_sticks_read, num_hw_blocks_per_core});
 
         compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_sticks_write, num_hw_blocks_per_core});
+        writer_desc.emplace_runtime_args(core, {output_tensor, num_sticks_write, num_hw_blocks_per_core});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
@@ -124,9 +129,7 @@ void emit_runtime_args_wh_rm(
 
 tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
 
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
@@ -143,8 +146,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
-    IDevice* device = input_tensor.device();
+    IDevice* device = &input_tensor.mutable_device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
                             src0_cb_data_format == tt::DataFormat::Int32 ||
@@ -158,8 +160,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, row_major ? NC : num_tensor_tiles);
-
-    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;
@@ -220,11 +220,11 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
         reader_compile_time_args.push_back(wt);
         reader_compile_time_args.push_back(W);
         reader_compile_time_args.push_back(ht * wt);
-        reader_compile_time_args.push_back(W * input_tensor.element_size());
-        reader_compile_time_args.push_back(wt * input_tensor.element_size() * TILE_WIDTH);
-        reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
+        reader_compile_time_args.push_back(W * static_cast<uint32_t>(input_tensor.element_size()));
+        reader_compile_time_args.push_back(wt * static_cast<uint32_t>(input_tensor.element_size()) * TILE_WIDTH);
+        reader_compile_time_args.push_back(CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(input_tensor));
     }
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(input_tensor, tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_compile_time_args, reader_common_runtime_args);
 
     std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
@@ -238,9 +238,10 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
         writer_compile_time_args.push_back(ht * wt);
         writer_compile_time_args.push_back(H * output_tensor.element_size());
         writer_compile_time_args.push_back(ht * output_tensor.element_size() * TILE_HEIGHT);
-        writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
+        writer_compile_time_args.push_back(
+            CMAKE_UNIQUE_NAMESPACE::get_buffer_aligned_page_size(output_tensor.mesh_tensor()));
     }
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+    TensorAccessorArgs(output_tensor.mesh_tensor(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(writer_compile_time_args, writer_common_runtime_args);
 
     KernelDescriptor reader_desc;
@@ -309,7 +310,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
             compute_desc,
             writer_desc,
             input_tensor,
-            output_tensor,
+            output_tensor.mesh_tensor(),
             num_cores_total,
             num_cores_y,
             core_group_1,
@@ -322,7 +323,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
             compute_desc,
             writer_desc,
             input_tensor,
-            output_tensor,
+            output_tensor.mesh_tensor(),
             num_cores_total,
             num_cores_y,
             core_group_1,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -60,7 +60,7 @@ void emit_runtime_args_wh_tiled(
 
         reader_desc.emplace_runtime_args(
             core,
-            {input_tensor.buffer(),
+            {input_tensor.mesh_tensor(),
              num_tiles_per_core,
              tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
              h,
@@ -71,7 +71,7 @@ void emit_runtime_args_wh_tiled(
 
         compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
+        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_tiles_per_core, num_tiles_read});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -109,11 +109,11 @@ void emit_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
+        reader_desc.emplace_runtime_args(core, {input_tensor.mesh_tensor(), num_sticks_read, num_hw_blocks_per_core});
 
         compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
+        writer_desc.emplace_runtime_args(core, {output_tensor.mesh_tensor(), num_sticks_write, num_hw_blocks_per_core});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
@@ -127,7 +127,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
     uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
@@ -144,7 +143,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.buffer();
+    Buffer* src0_buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
     IDevice* device = input_tensor.device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
@@ -160,8 +159,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, row_major ? NC : num_tensor_tiles);
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -20,7 +20,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -60,7 +59,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = src0_single_tile_size,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -73,7 +72,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = dst_single_tile_size,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -17,9 +17,7 @@ namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -31,10 +29,10 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     const auto tile = input_tensor.tensor_spec().tile();
     const uint32_t tile_hw = tile.get_tile_hw();
 
-    IDevice* device = input_tensor.device();
+    const auto& device = input_tensor.device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
@@ -45,10 +43,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     auto& all_cores = shard_spec.grid;
     uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
 
-    // Sharded CBs: total_size depends on num_tiles_per_shard which can vary across
-    // cache hits; .buffer triggers UpdateDynamicCircularBufferAddress. total_size
-    // is not in the program hash so the framework re-applies the combined update
-    // via apply_descriptor_runtime_args.
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = num_tiles_per_shard;
     desc.cbs.push_back(CBDescriptor{
@@ -59,7 +53,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = src0_cb_data_format,
             .page_size = src0_single_tile_size,
         }}},
-        .tensor = &input_tensor.mesh_tensor(),
+        .buffer = input_tensor.mesh_buffer().get_reference_buffer(),
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_16;
@@ -72,7 +66,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             .data_format = dst_cb_data_format,
             .page_size = dst_single_tile_size,
         }}},
-        .tensor = &output_tensor.mesh_tensor(),
+        .buffer = output_tensor.mesh_tensor().mesh_buffer().get_reference_buffer(),
     });
 
     std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
@@ -133,8 +127,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     std::vector<CoreCoord> cores =
         grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
 
-    // Active shard cores get the real arg values; the trailing no-op cores keep the
-    // default-constructed slots (matching legacy std::fill behavior on cores.size()).
     const std::vector<uint32_t> reader_rt = {num_blocks};
     const std::vector<uint32_t> compute_rt = {num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts};
     const std::vector<uint32_t> writer_rt = {num_blocks};
@@ -149,7 +141,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
             compute_desc.runtime_args.emplace_back(cores[i], compute_rt);
             writer_desc.runtime_args.emplace_back(cores[i], writer_rt);
         } else {
-            // No-op core: matches legacy std::vector<uint32_t>(1)/(5) zero-initialized rows.
             reader_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
             compute_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(5));
             writer_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -3,13 +3,10 @@
 
 #include "transpose_wh_sharded_rm_program_factory.hpp"
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
-
-#include <algorithm>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -18,9 +15,7 @@ namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descriptor(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
-    const auto& input_tensor = tensor_args.input;
-
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
+    const MeshTensor& input_tensor = tensor_args.input.mesh_tensor();
 
     ProgramDescriptor desc;
 
@@ -95,7 +90,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .tensor = &input_tensor.mesh_tensor(),
+        .buffer = input_tensor.mesh_buffer().get_reference_buffer(),
     });
 
     // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
@@ -108,7 +103,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = dst_cb_data_format,
             .page_size = output_page_size,
         }}},
-        .tensor = &output_tensor.mesh_tensor(),
+        .buffer = output_tensor.mesh_buffer().get_reference_buffer(),
     });
 
     // cb_in (double-buffered intermediate)

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -21,7 +21,6 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
-    TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
     ProgramDescriptor desc;
 
@@ -96,7 +95,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = src0_cb_data_format,
             .page_size = stick_size_bytes,
         }}},
-        .buffer = input_tensor.buffer(),
+        .tensor = &input_tensor.mesh_tensor(),
     });
 
     // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
@@ -109,7 +108,7 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
             .data_format = dst_cb_data_format,
             .page_size = output_page_size,
         }}},
-        .buffer = output_tensor.buffer(),
+        .tensor = &output_tensor.mesh_tensor(),
     });
 
     // cb_in (double-buffered intermediate)


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Mechanical migration of the `data_movement/transpose` op program factories to the
`MeshTensor`/`MeshBuffer` APIs.

Candidate program factories (8):

- data_movement/transpose/device
  - `transpose_cn_program_factory.cpp`
  - `transpose_hc_rm_program_factory.cpp`
  - `transpose_hc_sharded_program_factory.cpp`
  - `transpose_hc_tiled_interleaved_program_factory.cpp`
  - `transpose_hc_tiled_program_factory.cpp`
  - `transpose_wh_program_factory.cpp`
  - `transpose_wh_sharded_program_factory.cpp`
  - `transpose_wh_sharded_rm_program_factory.cpp`

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is a recently introduced core runtime data structure. It is
closely modelled on `ttnn::Tensor` — the two share very similar semantics and
are designed to be drop-in interchangeable where appropriate.

The motivation for Runtime Tensor is that it lets the runtime capture the shape
and sharding information of the true storage data structure. That information is
plumbed through `TensorAccessorArgs` and is critical for the upcoming Metal 2.0
refactoring: gen 2 hardware needs to understand the shape and sharding of device
memory directly.

Runtime Tensor is not meant to replace `ttnn::Tensor` outright. This PR replaces
`ttnn::Tensor` usage in the program factory specifically, where Runtime Tensor is
the most appropriate abstraction level. (`MeshTensor` — the type you will see in
the diff — is the device-side part of Runtime Tensor.)

#### This refactoring

- **Primary goal:** ensure the op leverages Runtime Tensor so we no longer lose
  shape and sharding information when passing `Buffer` into runtime / compile
  arguments (notably into `TensorAccessorArgs`).
- **Secondary goal:** complete the migration away from single-device data
  classes now that the rest of our infrastructure is multi-device-aware
  (`Buffer` → `MeshTensor`).

#### Risk

This migration should carry minimal regression risk: it is a type-substitution +
mechanical cleanup refactor, not a behavioural change. Per-core runtime-arg
counts and slot order, CB bindings, and work-split are all preserved.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-dm-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-dm-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-dm-transpose)
