### PR TITLE
[fuser] multi output pack support

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/datacopy.py
@@ -41,10 +41,10 @@ class DatacopyFpu(Fpu):
         golden_generator = get_golden_generator(DataCopyGolden)
         golden_tensor = golden_generator(
             source_tensor,
-            operation.output.data_format,
-            num_faces=operation.output.tile_shape.total_num_faces(),
+            config.sentinel.golden_math_format,
+            num_faces=operation.tile_shape.total_num_faces(),
             input_dimensions=compute_unit.src_a.dimensions,
-            face_r_dim=operation.output.tile_shape.face_r_dim,
+            face_r_dim=operation.tile_shape.face_r_dim,
         )
 
         return (tensor_a, tensor_b, golden_tensor)
@@ -61,7 +61,7 @@ class DatacopyFpu(Fpu):
         pack_mode = operation.bh_tilize.pack_mode_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         data_copy_type = compute_unit.data_copy_type.cpp_enum_value
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
         _int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
         is_int_fpu_en = (
             "true"
@@ -92,15 +92,15 @@ class DatacopyFpu(Fpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         data_copy_type = f"DataCopyType::{compute_unit.data_copy_type.name}"
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
 
         return (
-            f"    _llk_math_eltwise_unary_datacopy_<{data_copy_type}, dest_sync{stage}, {dest_acc}, {broadcast_type}, {unpack_to_dest}>(\n"
+            f"    _llk_math_eltwise_unary_datacopy_<{data_copy_type}, {dest_sync}, {dest_acc}, {broadcast_type}, {unpack_to_dest}>(\n"
             f"        {block.tile_id_block}, {config.sentinel.math_format}, {config.sentinel.math_format}, {num_faces}\n"
             f"    );\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/eltwise.py
@@ -40,7 +40,7 @@ class EltwiseFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         math_fidelity = compute_unit.math_fidelity
 
         if compute_unit.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
@@ -71,8 +71,8 @@ class EltwiseFpu(Fpu):
         stage = operation.stage_id
         math_fidelity = compute_unit.math_fidelity.cpp_enum_value
         op = self.operation.cpp_enum_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        face_c_dim = operation.output.tile_shape.face_c_dim
+        face_r_dim = operation.tile_shape.face_r_dim
+        face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim
         num_faces_c_dim = compute_unit.src_a.tile_shape.total_col_dim() // face_c_dim
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
@@ -92,12 +92,12 @@ class EltwiseFpu(Fpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         math_fidelity = compute_unit.math_fidelity.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         op = self.operation.cpp_enum_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        face_c_dim = operation.output.tile_shape.face_c_dim
+        face_r_dim = operation.tile_shape.face_r_dim
+        face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim
         num_faces_c_dim = compute_unit.src_a.tile_shape.total_col_dim() // face_c_dim
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
@@ -105,7 +105,7 @@ class EltwiseFpu(Fpu):
         clear_fp32_dst_acc = compute_unit.clear_fp32_dst_acc.cpp_enum_value
 
         return (
-            f"_llk_math_eltwise_binary_<ckernel::EltwiseBinaryType::{op}, {broadcast_type}, dest_sync{stage},\n"
+            f"_llk_math_eltwise_binary_<ckernel::EltwiseBinaryType::{op}, {broadcast_type}, {dest_sync},\n"
             f"{dest_acc}, {math_fidelity}, {reuse_dest}>"
             f"(ckernel::TensorShape{{{face_r_dim}, {face_c_dim}, {num_faces_r_dim}, {num_faces_c_dim}}}, {block.tile_id_block}, {clear_fp32_dst_acc}\n"
             f");\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/matmul.py
@@ -16,6 +16,7 @@ from helpers.golden_generators import MatmulGolden, get_golden_generator
 
 class MatmulFpu(Fpu):
     loop: FusedLoop = LoopBlock()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [
@@ -32,7 +33,7 @@ class MatmulFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         math_fidelity = compute_unit.math_fidelity
 
         generate_golden = get_golden_generator(MatmulGolden)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce.py
@@ -38,10 +38,10 @@ class ReduceFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         dimensions = operation.max_output_dimensions
         tile_cnt = (dimensions[0] * dimensions[1]) // 1024
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
 
         reduce_dim = self.reduce_dim
         pool_type = self.reduce_pool

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max.py
@@ -19,6 +19,8 @@ class ReduceBlockMaxFpu(Fpu):
     loop: FusedLoop = LoopTileByTile()
     reduce_dim: ReduceDimension = ReduceDimension.Row
 
+    per_block_init = True
+
     def init(
         self,
         operation: FusedOperation,
@@ -66,14 +68,18 @@ class ReduceBlockMaxFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
 
         golden_tensor = torch.zeros_like(tensor_dst)
         src_a_reduced_tensor = torch.zeros_like(tensor_a)
         dest_golden_tensor = torch.zeros_like(tensor_dst)
 
-        tile_count_x = operation.output.tile_count_x
-        tile_count_y = operation.output.tile_count_y
+        tile_count_x = (
+            operation.max_output_dimensions[1] // operation.tile_shape.total_col_dim()
+        )
+        tile_count_y = (
+            operation.max_output_dimensions[0] // operation.tile_shape.total_row_dim()
+        )
         block_tiles_x = operation.block_tiles_x
         block_tiles_y = operation.block_tiles_y
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/packer.py
@@ -6,11 +6,11 @@ from typing import List
 
 import torch
 from fuser.block_data import BlockData
-from fuser.compute_node import ComputeNode
 from fuser.fused_loop import FusedLoop
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
+from fuser.pack_node import PackNode
 from helpers.llk_params import L1Accumulation, PackerReluType
 
 
@@ -27,44 +27,42 @@ class Packer(BasePacker):
     def golden(
         self,
         tensor: torch.Tensor,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
     ) -> torch.Tensor:
-        if operation.pack_relu != PackerReluType.NoRelu:
-            tensor = self._relu_golden(tensor, operation, config)
+        if pack_node.pack_relu != PackerReluType.NoRelu:
+            tensor = self._relu_golden(tensor, pack_node, config)
 
-        if operation.pack_l1_accumulation == L1Accumulation.Yes:
-            tensor = self._l1_acc_golden(tensor, operation, config)
+        if pack_node.pack_l1_accumulation == L1Accumulation.Yes:
+            tensor = self._l1_acc_golden(tensor, pack_node, operation, config)
 
         return tensor
 
     def init(
         self,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
-        compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        dest_acc = config.dest_acc.cpp_enum_value
         bh_pack_mode = operation.bh_tilize.pack_mode_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        num_faces = operation.output.tile_shape.total_num_faces()
-        dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
+        face_r_dim = pack_node.output.tile_shape.face_r_dim
+        num_faces = pack_node.output.tile_shape.total_num_faces()
         return (
             f"    _llk_pack_init_<{bh_pack_mode}, false /* zero_output */, false /* skip_addrmod_config */>(\n"
             f"        {config.sentinel.pack_src_format}, {face_r_dim}, TILE_C_DIM, {num_faces}, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */\n"
             f"    );\n"
-            f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
         )
 
     def pack(
         self,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
-        compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
         dest_acc = config.dest_acc.cpp_enum_value
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
-        buffer = operation.output.cpp_name
+        buffer = pack_node.output.cpp_name
         return f"_llk_pack_<{dest_sync}, {dest_acc}, ckernel::PackMode::Default>({block.tile_id_block}, L1_ADDRESS({buffer}[{block.tile_id_global}]));\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/sfpu/binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/sfpu/binary.py
@@ -59,7 +59,7 @@ class BinarySfpu(Sfpu):
         batch_dims: tuple,
         batch_tile_cnt: int,
     ) -> torch.Tensor:
-        math_format = operation.output.data_format
+        math_format = config.sentinel.golden_math_format
 
         generate_binary_golden = get_golden_generator(BinarySFPUGolden)
         golden_tensor = generate_binary_golden(
@@ -106,7 +106,7 @@ class BinarySfpu(Sfpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         op = f"ckernel::BinaryOp::{self.operation.cpp_enum_value}"
         approx_mode = self.approx_mode.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
@@ -118,7 +118,7 @@ class BinarySfpu(Sfpu):
 
         return (
             f"    test_utils::call_binary_sfpu_operation<"
-            f"dest_sync{stage}, {dest_acc}, "
+            f"{dest_sync}, {dest_acc}, "
             f"{approx_mode}, {op}, {iterations}, {format}"
             f">({src1} /* dst_index_in0 */, {src2} /* dst_index_in1 */, {dst} /* dst_index_out */);\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/sfpu/unary.py
@@ -57,8 +57,8 @@ class UnarySfpu(Sfpu):
         batch_dims: tuple,
         batch_tile_cnt: int,
     ) -> torch.Tensor:
-        format_input = operation.output.data_format
-        format_output = operation.output.data_format
+        format_input = config.sentinel.golden_math_format
+        format_output = config.sentinel.golden_math_format
         dest_acc = config.dest_acc
 
         generate_sfpu_golden = get_golden_generator(UnarySFPUGolden)
@@ -100,14 +100,14 @@ class UnarySfpu(Sfpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
         op = f"SfpuType::{self.operation.cpp_enum_value}"
 
         return (
             f"    test_utils::call_unary_sfpu_operation<"
-            f"dest_sync{stage}, {dest_acc}, "
+            f"{dest_sync}, {dest_acc}, "
             f"{op}, {approx_mode}, {dest_acc}, {self.iterations}"
             f">({self.dest_idx}, {config.sentinel.math_format}, {self.fill_const_value});\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
@@ -17,6 +17,7 @@ from helpers.llk_params import Transpose
 
 class MatmulUnpacker(Unpacker):
     loop: FusedLoop = LoopBlock()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max.py
@@ -16,6 +16,8 @@ from fuser.fuser_config import GlobalConfig
 class ReduceBlockMaxUnpacker(Unpacker):
     loop: FusedLoop = LoopTileByTile()
 
+    per_block_init = True
+
     def init(
         self,
         operation: FusedOperation,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
@@ -15,6 +15,7 @@ from fuser.fuser_config import GlobalConfig
 
 class ReduceBlockMaxRuntimeUnpacker(Unpacker):
     loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return ["experimental/llk_unpack_AB_reduce_custom_runtime.h"]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/compute_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/compute_node.py
@@ -18,7 +18,6 @@ from helpers.llk_params import (
     EltwiseBinaryReuseDestType,
     EnforceFP32Accumulation,
     MathFidelity,
-    PerfRunType,
     Transpose,
     UnpackToDest,
 )
@@ -88,7 +87,26 @@ class ComputeNode:
         if self.src_a is None and self.src_b is None:
             return
 
-    def unpack(
+    def unpack_reconfig(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ):
+        if self.unpacker is None or config.skip_unpack_init:
+            return ""
+        return config.sentinel.configure_unpack(config, operation, self)
+
+    def unpack_init(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        block: BlockData,
+    ):
+        if self.unpacker is None or config.skip_unpack_init:
+            return ""
+        return self.unpacker.init(operation, config, self, block)
+
+    def unpack_run(
         self,
         operation: "FusedOperation",
         config: "GlobalConfig",
@@ -96,80 +114,68 @@ class ComputeNode:
     ):
         if self.unpacker is None:
             return ""
+        return self.unpacker.loop.unpack_loop(operation, config, self, block)
 
-        code = ""
-        skip_init = config.perf_run_type in (
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.MATH_ISOLATE,
-        )
-        if not skip_init:
-            code += config.sentinel.configure_unpack(config, operation, self)
-            code += self.unpacker.init(operation, config, self, block)
-
-        code += self.unpacker.loop.unpack_loop(operation, config, self, block)
-        if not skip_init:
-            code += self.unpacker.uninit(operation, config, self, block)
-
-        return code
-
-    def fpu_calculate(
+    def unpack_uninit(
         self,
         operation: "FusedOperation",
         config: "GlobalConfig",
         block: BlockData,
     ):
-        if self.fpu is None:
+        if self.unpacker is None or config.skip_unpack_init:
             return ""
+        return self.unpacker.uninit(operation, config, self, block)
 
-        code = ""
-        skip_init = config.perf_run_type in (
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        )
-        if not skip_init:
-            code += config.sentinel.configure_math(config, operation, self)
-            code += self.fpu.init(operation, config, self, block)
+    def math_reconfig(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ):
+        if config.skip_math_init or self.fpu is None:
+            return ""
+        return config.sentinel.configure_math(config, operation, self)
 
-        code += self.fpu.loop.math_loop(operation, config, self, block)
-        if not skip_init:
-            code += self.fpu.uninit(operation, config, self, block)
-
-        return code
-
-    def sfpu_calculate(
+    def math_init(
         self,
         operation: "FusedOperation",
         config: "GlobalConfig",
         block: BlockData,
     ):
-        if self.sfpu is None:
+        if config.skip_math_init:
             return ""
-
-        if config.perf_run_type in (
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        ):
-            return ""
-
-        code = self.sfpu.init(operation, config, self, block)
-        code += self.sfpu.calculate(operation, config, self, block)
-        code += self.sfpu.uninit(operation, config, self, block)
-        return code
-
-    def math_calculate(
-        self,
-        operation: "FusedOperation",
-        config: "GlobalConfig",
-        block: BlockData,
-    ) -> str:
         if self.fpu is not None:
-            return self.fpu_calculate(operation, config, block)
+            return self.fpu.init(operation, config, self, block)
         elif self.sfpu is not None:
-            return self.sfpu_calculate(operation, config, block)
-        else:
-            raise ValueError("fpu and sfpu are not defined")
+            return self.sfpu.init(operation, config, self, block)
+        return ""
+
+    def math_run(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        block: BlockData,
+    ):
+        if self.fpu is not None:
+            return self.fpu.loop.math_loop(operation, config, self, block)
+        elif self.sfpu is not None:
+            if config.skip_math_init:
+                return ""
+            return self.sfpu.calculate(operation, config, self, block)
+        return ""
+
+    def math_uninit(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        block: BlockData,
+    ):
+        if config.skip_math_init:
+            return ""
+        if self.fpu is not None:
+            return self.fpu.uninit(operation, config, self, block)
+        elif self.sfpu is not None:
+            return self.sfpu.uninit(operation, config, self, block)
+        return ""
 
     def golden(
         self,
@@ -201,11 +207,17 @@ class ComputeNode:
             tilized_dst = tilize_block(
                 tensor_dst,
                 operation.max_output_dimensions,
-                operation.output.data_format,
+                config.sentinel.golden_math_format,
             )
 
-            tile_count_x = operation.output.tile_count_x
-            tile_count_y = operation.output.tile_count_y
+            tile_count_x = (
+                operation.max_output_dimensions[1]
+                // operation.tile_shape.total_col_dim()
+            )
+            tile_count_y = (
+                operation.max_output_dimensions[0]
+                // operation.tile_shape.total_row_dim()
+            )
             block_tiles_x = operation.block_tiles_x
             block_tiles_y = operation.block_tiles_y
 
@@ -270,7 +282,7 @@ class ComputeNode:
 
             tensor_dst = untilize_block(
                 tilized_dst.flatten(),
-                operation.output.data_format,
+                config.sentinel.golden_math_format,
                 operation.max_output_dimensions,
             ).reshape(operation.max_output_dimensions)
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_fpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_fpu.py
@@ -23,11 +23,14 @@ class Fpu:
     and override methods to emit the C++ LLK calls that configure and drive the
     Math thread, plus a Python golden function for test validation.
 
-    The lifecycle called by ComputeNode.fpu_calculate() is:
+    The lifecycle called by the pipeline is:
         init() -> loop.math_loop() [which calls calculate()] -> uninit()
 
     Override `loop` with an appropriate FusedLoop subclass to control
     the tile iteration pattern used by the math phase.
+
+    Set `per_block_init = True` if init() needs block dimensions and must
+    be called per-block inside the batch loop rather than hoisted out.
 
     To create a new FPU:
         1. Subclass Fpu
@@ -39,6 +42,7 @@ class Fpu:
 
     # Controls the tile iteration pattern for the math loop.
     loop: FusedLoop = FusedLoop()
+    per_block_init: bool = False
 
     def init(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
@@ -92,7 +92,8 @@ class PackKernelGenerator:
         # Collect all unique headers from all operations
         all_headers = set()
         for op in self.config.pipeline:
-            all_headers.update(op.math.packer().get_headers())
+            for pack_node in op.math.pack_nodes:
+                all_headers.update(pack_node.get_headers())
 
         # Generate include statements
         includes = "\n".join([f'#include "{header}"' for header in sorted(all_headers)])

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Dict
 
@@ -184,4 +186,5 @@ class FusedKernelGenerator:
         with open(cpp_path, "w") as f:
             f.write(combined)
 
-        os.system(f'clang-format -i "{cpp_path}"')
+        if shutil.which("clang-format"):
+            subprocess.run(["clang-format", "-i", str(cpp_path)])

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_golden.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_golden.py
@@ -18,16 +18,10 @@ DEFAULT_BASE_PCC = 0.99
 class FusedGolden:
     def __init__(self, verbose: bool = True):
         self.verbose = verbose
-        self.results = []
 
     _FORMAT_PCC = {DataFormat.Bfp4_b: 0.98, DataFormat.MxFp4: 0.95}
 
-    def check_operation(self, operation: FusedOperation) -> bool:
-        output = operation.output
-
-        if self.verbose:
-            logger.info("{}", operation)
-
+    def _check_output(self, output) -> bool:
         res_tensor = torch.tensor(
             output.raw_data, dtype=format_dict[output.data_format]
         )
@@ -42,7 +36,7 @@ class FusedGolden:
         l1_golden = l1_golden.flatten()
         master_golden = master_golden.flatten()
 
-        logger.info("L1 golden check:")
+        logger.info(f"L1 golden check for {output.name}:")
         l1_passed = passed_test(
             l1_golden,
             res_tensor,
@@ -53,7 +47,7 @@ class FusedGolden:
         )
 
         logger.info(
-            f"Master golden check (stage {operation.stage_id}, format {output.data_format.name},"
+            f"Master golden check for {output.name} (format {output.data_format.name},"
             f"atol {output.acc_atol:.2f}, rtol {output.acc_rtol:.2f}, pcc {output.acc_pcc:.2f}):"
         )
         master_passed = passed_test(
@@ -66,7 +60,16 @@ class FusedGolden:
             custom_pcc_threshold=output.acc_pcc,
         )
 
-        passed = l1_passed and master_passed
+        return l1_passed and master_passed
+
+    def check_operation(self, operation: FusedOperation) -> bool:
+        if self.verbose:
+            logger.info(f"{operation}")
+
+        passed = True
+        for pack_node in operation.math.pack_nodes:
+            if not self._check_output(pack_node.output):
+                passed = False
 
         if self.verbose:
             if passed:
@@ -99,29 +102,29 @@ class FusedGolden:
         max_input_rtol = max((s.acc_rtol for s in sources), default=0.0)
         max_input_atol = max((s.acc_atol for s in sources), default=0.0)
 
-        base_tol = tolerances.get(operation.output.data_format)
-        base_rtol = base_tol.rtol if base_tol else DEFAULT_BASE_RTOL
-        base_atol = base_tol.atol if base_tol else DEFAULT_BASE_ATOL
+        for pack in operation.math.pack_nodes:
+            output = pack.output
+            base_tol = tolerances.get(output.data_format)
+            base_rtol = base_tol.rtol if base_tol else DEFAULT_BASE_RTOL
+            base_atol = base_tol.atol if base_tol else DEFAULT_BASE_ATOL
 
-        min_input_pcc = min((s.acc_pcc for s in sources), default=1.0)
-        base_pcc = FusedGolden._FORMAT_PCC.get(
-            operation.output.data_format, DEFAULT_BASE_PCC
-        )
+            min_input_pcc = min((s.acc_pcc for s in sources), default=1.0)
+            base_pcc = FusedGolden._FORMAT_PCC.get(output.data_format, DEFAULT_BASE_PCC)
 
-        # Relative errors multiply together because the new operation
-        # introduces its own error on top of the error from previous stages.
-        # e.g. input with 5% error through an op with 3% error gives
-        # (1.05)*(1.03)-1 = 0.0815, not 8%.
-        operation.output.acc_rtol = (1 + max_input_rtol) * (1 + base_rtol) - 1
+            # Relative errors multiply together because the new operation
+            # introduces its own error on top of the error from previous stages.
+            # e.g. input with 5% error through an op with 3% error gives
+            # (1.05)*(1.03)-1 = 0.0815, not 8%.
+            output.acc_rtol = (1 + max_input_rtol) * (1 + base_rtol) - 1
 
-        # The input already carries some absolute error. The new operation can
-        # scale that error (by 1 + base_rtol), then adds its own absolute error.
-        # e.g. input atol=0.02 through an op with rtol=0.03, atol=0.01 gives
-        # 0.02*(1.03) + 0.01 = 0.0306.
-        operation.output.acc_atol = max_input_atol * (1 + base_rtol) + base_atol
+            # The input already carries some absolute error. The new operation can
+            # scale that error (by 1 + base_rtol), then adds its own absolute error.
+            # e.g. input atol=0.02 through an op with rtol=0.03, atol=0.01 gives
+            # 0.02*(1.03) + 0.01 = 0.0306.
+            output.acc_atol = max_input_atol * (1 + base_rtol) + base_atol
 
-        # Correlation degrades multiplicatively through each stage.
-        operation.output.acc_pcc = min_input_pcc * base_pcc
+            # Correlation degrades multiplicatively through each stage.
+            output.acc_pcc = min_input_pcc * base_pcc
 
     def check_pipeline(self, config: FuserConfig) -> bool:
         result = True

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from .fused_operation import FusedOperation
     from .fuser_config import GlobalConfig
     from .block_data import BlockData
+    from .pack_node import PackNode
 
 from helpers.llk_params import L1Accumulation, PerfRunType
 
@@ -36,6 +37,7 @@ class FusedLoop:
         self,
         operation: "FusedOperation",
         config: "GlobalConfig",
+        pack_node: "PackNode",
         block: "BlockData",
     ) -> str:
         code = ""
@@ -46,7 +48,7 @@ class FusedLoop:
             return code
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
-        if operation.pack_l1_accumulation == L1Accumulation.Yes:
+        if pack_node.pack_l1_accumulation == L1Accumulation.Yes:
             code += (
                 f"std::uint32_t l1_tile_id = tile_y * {block.tile_count_x} + tile_x;\n"
             )
@@ -57,7 +59,7 @@ class FusedLoop:
         )
         block.tile_id_global = "l1_tile_id"
         block.tile_id_block = "dest_tile_id"
-        code += operation.math.packer().pack(operation, config, None, block)
+        code += pack_node.packer.pack(pack_node, operation, config, block)
         code += "}\n"
         code += "}\n"
         return code

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -50,21 +50,13 @@ class ComputePipeline:
         return math_units
 
     def _all_same_operand_formats(self, ops: List[ComputeNode]) -> bool:
-        if len(ops) <= 1:
-            return True
-        first = ops[0]
-        for cu in ops[1:]:
-            if (cu.src_a is not None) != (first.src_a is not None):
-                return False
-            if (cu.src_b is not None) != (first.src_b is not None):
-                return False
-            if cu.src_a is not None and first.src_a is not None:
-                if cu.src_a.data_format != first.src_a.data_format:
-                    return False
-            if cu.src_b is not None and first.src_b is not None:
-                if cu.src_b.data_format != first.src_b.data_format:
-                    return False
-        return True
+        def signature(op: ComputeNode):
+            return (
+                op.src_a.data_format if op.src_a is not None else None,
+                op.src_b.data_format if op.src_b is not None else None,
+            )
+
+        return len({signature(op) for op in ops}) <= 1
 
     def _batch_loop(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -428,7 +428,7 @@ class ComputePipeline:
         operation: "FusedOperation",
         config: "GlobalConfig",
         golden_type: GoldenType,
-    ) -> torch.Tensor:
+    ):
         first_fpu = next((op for op in self.operations if op.src_a is not None), None)
         if first_fpu is not None:
             tensor_a = torch.zeros(first_fpu.src_a.dimensions)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -398,8 +398,7 @@ class ComputePipeline:
         def batch_body(block: BlockData):
             body = self._packer_wait_for_math(config)
             if not hoist_reconfig:
-                config.sentinel._pack_src = None
-                config.sentinel._pack_dst = None
+                config.sentinel.reset_pack_formats()
             for pack_node in self.pack_nodes:
                 if not hoist_reconfig:
                     body += pack_node.reconfig(operation, config)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -397,6 +397,9 @@ class ComputePipeline:
 
         def batch_body(block: BlockData):
             body = self._packer_wait_for_math(config)
+            if not hoist_reconfig:
+                config.sentinel._pack_src = None
+                config.sentinel._pack_dst = None
             for pack_node in self.pack_nodes:
                 if not hoist_reconfig:
                     body += pack_node.reconfig(operation, config)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -10,23 +10,23 @@ if TYPE_CHECKING:
     from .fused_operation import FusedOperation
     from .fuser_config import GlobalConfig
 
-from helpers.llk_params import GoldenType, PerfRunType
+from helpers.llk_params import GoldenType
 
 from .block_data import BlockData
 from .compute_node import ComputeNode
 from .fused_fpu import Fpu
-from .fused_packer import Packer
 from .fused_sfpu import Sfpu
 from .fused_unpacker import Unpacker
+from .pack_node import PackNode
 
 
 class ComputePipeline:
     operations: List[ComputeNode]
-    packer: Packer
+    pack_nodes: List[PackNode]
 
-    def __init__(self, operations: List[ComputeNode], packer: Packer):
+    def __init__(self, operations: List[ComputeNode], pack_nodes: List[PackNode]):
         self.operations = operations
-        self.packer = packer
+        self.pack_nodes = pack_nodes
 
     def get_unpackers(self) -> List["Unpacker"]:
         unpackers: List["Unpacker"] = []
@@ -49,13 +49,39 @@ class ComputePipeline:
 
         return math_units
 
+    def _all_same_operand_formats(self, ops: List[ComputeNode]) -> bool:
+        if len(ops) <= 1:
+            return True
+        first = ops[0]
+        for cu in ops[1:]:
+            if (cu.src_a is not None) != (first.src_a is not None):
+                return False
+            if (cu.src_b is not None) != (first.src_b is not None):
+                return False
+            if cu.src_a is not None and first.src_a is not None:
+                if cu.src_a.data_format != first.src_a.data_format:
+                    return False
+            if cu.src_b is not None and first.src_b is not None:
+                if cu.src_b.data_format != first.src_b.data_format:
+                    return False
+        return True
+
     def _batch_loop(
-        self, operation: "FusedOperation", config: "GlobalConfig", body_fn
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        body_fn,
+        init_fn=None,
+        uninit_fn=None,
     ) -> str:
         block_tiles_x = operation.block_tiles_x
         block_tiles_y = operation.block_tiles_y
-        tile_count_x = operation.output.tile_count_x
-        tile_count_y = operation.output.tile_count_y
+        tile_count_x = (
+            operation.max_output_dimensions[1] // operation.tile_shape.total_col_dim()
+        )
+        tile_count_y = (
+            operation.max_output_dimensions[0] // operation.tile_shape.total_row_dim()
+        )
 
         full_blocks_x = tile_count_x // block_tiles_x
         full_blocks_y = tile_count_y // block_tiles_y
@@ -79,38 +105,85 @@ class ComputePipeline:
                 tile_id_block="0",
             )
 
+        def wrap(block, body):
+            code = ""
+            if init_fn is not None:
+                code += init_fn(block)
+            code += body
+            if uninit_fn is not None:
+                code += uninit_fn(block)
+            return code
+
         code = ""
 
         if full_blocks_x > 0 and full_blocks_y > 0:
-            code += f"for (std::uint32_t block_x = 0; block_x < {full_x_limit}; block_x += {block_tiles_x}) {{\n"
-            code += f"for (std::uint32_t block_y = 0; block_y < {full_y_limit}; block_y += {block_tiles_y}) {{\n"
-            code += body_fn(
-                make_block("block_x", "block_y", block_tiles_x, block_tiles_y)
+            block = make_block("block_x", "block_y", block_tiles_x, block_tiles_y)
+            code += wrap(
+                block,
+                (
+                    f"for (std::uint32_t block_x = 0; block_x < {full_x_limit}; block_x += {block_tiles_x}) {{\n"
+                    f"for (std::uint32_t block_y = 0; block_y < {full_y_limit}; block_y += {block_tiles_y}) {{\n"
+                    + body_fn(block)
+                    + "}\n"
+                    "}\n"
+                ),
             )
-            code += "}\n"
-            code += "}\n"
 
         if remaining_tiles_y > 0 and full_blocks_x > 0:
-            code += f"for (std::uint32_t block_x = 0; block_x < {full_x_limit}; block_x += {block_tiles_x}) {{\n"
-            code += body_fn(
-                make_block("block_x", full_y_limit, block_tiles_x, remaining_tiles_y)
+            block = make_block(
+                "block_x", full_y_limit, block_tiles_x, remaining_tiles_y
             )
-            code += "}\n"
+            code += wrap(
+                block,
+                (
+                    f"for (std::uint32_t block_x = 0; block_x < {full_x_limit}; block_x += {block_tiles_x}) {{\n"
+                    + body_fn(block)
+                    + "}\n"
+                ),
+            )
 
         if remaining_tiles_x > 0 and full_blocks_y > 0:
-            code += f"for (std::uint32_t block_y = 0; block_y < {full_y_limit}; block_y += {block_tiles_y}) {{\n"
-            code += body_fn(
-                make_block(full_x_limit, "block_y", remaining_tiles_x, block_tiles_y)
+            block = make_block(
+                full_x_limit, "block_y", remaining_tiles_x, block_tiles_y
             )
-            code += "}\n"
+            code += wrap(
+                block,
+                (
+                    f"for (std::uint32_t block_y = 0; block_y < {full_y_limit}; block_y += {block_tiles_y}) {{\n"
+                    + body_fn(block)
+                    + "}\n"
+                ),
+            )
 
         if remaining_tiles_x > 0 and remaining_tiles_y > 0:
-            code += body_fn(
-                make_block(
-                    full_x_limit, full_y_limit, remaining_tiles_x, remaining_tiles_y
-                )
+            block = make_block(
+                full_x_limit, full_y_limit, remaining_tiles_x, remaining_tiles_y
             )
+            code += wrap(block, body_fn(block))
 
+        return code
+
+    def _zone(self, config: "GlobalConfig", name: str, body: str) -> str:
+        if not config.profiler_enabled:
+            return body
+        code = "{\n"
+        code += f'ZONE_SCOPED("{name}")\n'
+        code += body
+        code += "PROFILER_SYNC();\n"
+        code += "}\n"
+        return code
+
+    def _zone_loop(self, config: "GlobalConfig", name: str, body: str) -> str:
+        if not config.profiler_enabled:
+            return body
+        code = "{\n"
+        code += f'ZONE_SCOPED("{name}")\n'
+        code += f"for(int loop = 0; loop < {config.loop_factor}; loop++)\n"
+        code += "{\n"
+        code += body
+        code += "}\n"
+        code += "PROFILER_SYNC();\n"
+        code += "}\n"
         return code
 
     def unpacker_sync_with_packer(
@@ -127,145 +200,147 @@ class ComputePipeline:
         return ""
 
     def unpack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
-        code = ""
+        unpack_ops = [cu for cu in self.operations if cu.unpacker is not None]
+        hoist = len(unpack_ops) == 1
+        hoist_reconfig = hoist or self._all_same_operand_formats(unpack_ops)
 
-        if config.profiler_enabled:
-            code += "{\n"
-            code += 'ZONE_SCOPED("INIT")\n'
-
-        code += config.sentinel.hw_configure_unpack(config, operation)
-
-        if config.profiler_enabled:
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
-            code += "{\n"
-            code += 'ZONE_SCOPED("TILE_LOOP")\n'
+        init_code = config.sentinel.hw_configure_unpack(config, operation)
+        if hoist_reconfig and unpack_ops:
+            init_code += unpack_ops[0].unpack_reconfig(operation, config)
+        if hoist and not unpack_ops[0].unpacker.per_block_init:
+            init_code += unpack_ops[0].unpack_init(operation, config, None)
+        code = self._zone(config, "INIT", init_code)
 
         code += self.unpacker_sync_with_packer(operation, config)
 
-        if config.profiler_enabled:
-            code += f"for(int loop = 0; loop < {config.loop_factor}; loop++)\n"
-            code += "{\n"
+        init_fn = None
+        uninit_fn = None
+        if hoist and unpack_ops[0].unpacker.per_block_init:
+            init_fn = lambda block: unpack_ops[0].unpack_init(operation, config, block)
+            uninit_fn = lambda block: unpack_ops[0].unpack_uninit(
+                operation, config, block
+            )
 
         def batch_body(block: BlockData):
             body = ""
-            for compute_unit in self.operations:
-                body += compute_unit.unpack(operation, config, block)
+            for cu in self.operations:
+                if not hoist_reconfig and cu.unpacker is not None:
+                    body += cu.unpack_reconfig(operation, config)
+                if not hoist:
+                    body += cu.unpack_init(operation, config, block)
+                body += cu.unpack_run(operation, config, block)
+                if not hoist:
+                    body += cu.unpack_uninit(operation, config, block)
             return body
 
-        code += self._batch_loop(operation, config, batch_body)
+        code += self._zone_loop(
+            config,
+            "TILE_LOOP",
+            self._batch_loop(operation, config, batch_body, init_fn, uninit_fn),
+        )
 
-        if config.profiler_enabled:
-            code += "}\n"
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
-            code += "{\n"
-            code += 'ZONE_SCOPED("INIT")\n'
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
+        uninit_code = ""
+        if hoist and not unpack_ops[0].unpacker.per_block_init:
+            uninit_code += unpack_ops[0].unpack_uninit(operation, config, None)
+        code += self._zone(config, "INIT", uninit_code)
 
         return code
 
     def _math_wait_for_dest(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
-        if config.perf_run_type in (
-            PerfRunType.MATH_ISOLATE,
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        ):
+        if config.skip_sync:
             return ""
-
-        return f"_llk_math_wait_for_dest_available_<dest_sync{operation.stage_id}>();\n"
+        dest_sync = operation.dest_sync.cpp_enum_value
+        return f"_llk_math_wait_for_dest_available_<{dest_sync}>();\n"
 
     def _math_dest_section_done(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
-        if config.perf_run_type in (
-            PerfRunType.MATH_ISOLATE,
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        ):
+        if config.skip_sync:
             return ""
-
+        dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
-        return f"_llk_math_dest_section_done_<dest_sync{operation.stage_id}, {dest_acc}>();\n"
+        return f"_llk_math_dest_section_done_<{dest_sync}, {dest_acc}>();\n"
+
+    def _math_pack_sync_init(
+        self, operation: "FusedOperation", config: "GlobalConfig"
+    ) -> str:
+        dest_sync = operation.dest_sync.cpp_enum_value
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_math_pack_sync_init_<{dest_sync}, {dest_acc}>();\n"
 
     def _math_constants(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
-        stage = operation.stage_id
-        dest_sync = operation.dest_sync.cpp_enum_value
-
-        code = f"// Operation {stage}: Math Setup\n"
-        code += f"constexpr DstSync dest_sync{stage} = {dest_sync};\n"
-
-        return code
+        return f"// Operation {operation.stage_id}: Math Setup\n"
 
     def math_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
         code = self._math_constants(operation, config)
+        fpu_ops = [cu for cu in self.operations if cu.fpu is not None]
+        hoist = len(fpu_ops) == 1
+        hoist_reconfig = hoist or self._all_same_operand_formats(fpu_ops)
 
-        if config.profiler_enabled:
-            code += "{\n"
-            code += 'ZONE_SCOPED("INIT")\n'
+        init_code = config.sentinel.hw_configure_math(config, operation)
+        init_code += self._math_pack_sync_init(operation, config)
+        if hoist_reconfig and fpu_ops:
+            init_code += fpu_ops[0].math_reconfig(operation, config)
+        if hoist and not fpu_ops[0].fpu.per_block_init:
+            init_code += fpu_ops[0].math_init(operation, config, None)
+        code += self._zone(config, "INIT", init_code)
 
-        code += config.sentinel.hw_configure_math(config, operation)
-
-        stage = operation.stage_id
-        dest_acc = config.dest_acc.cpp_enum_value
-        code += f"_llk_math_pack_sync_init_<dest_sync{stage}, {dest_acc}>();\n"
-
-        if config.profiler_enabled:
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
-            code += "{\n"
-            code += 'ZONE_SCOPED("TILE_LOOP")\n'
-            code += f"for(int loop = 0; loop < {config.loop_factor}; loop++)\n"
-            code += "{\n"
+        init_fn = None
+        uninit_fn = None
+        if hoist and fpu_ops[0].fpu.per_block_init:
+            init_fn = lambda block: fpu_ops[0].math_init(operation, config, block)
+            uninit_fn = lambda block: fpu_ops[0].math_uninit(operation, config, block)
 
         def batch_body(block: BlockData):
             body = self._math_wait_for_dest(operation, config)
-            for compute_unit in self.operations:
-                body += compute_unit.math_calculate(operation, config, block)
+            for cu in self.operations:
+                if not hoist_reconfig and cu.fpu is not None:
+                    body += cu.math_reconfig(operation, config)
+                if not hoist or cu.fpu is None:
+                    body += cu.math_init(operation, config, block)
+                body += cu.math_run(operation, config, block)
+                if not hoist or cu.fpu is None:
+                    body += cu.math_uninit(operation, config, block)
             body += self._math_dest_section_done(operation, config)
             return body
 
-        code += self._batch_loop(operation, config, batch_body)
+        code += self._zone_loop(
+            config,
+            "TILE_LOOP",
+            self._batch_loop(operation, config, batch_body, init_fn, uninit_fn),
+        )
 
-        if config.profiler_enabled:
-            code += "}\n"
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
+        uninit_code = ""
+        if hoist and not fpu_ops[0].fpu.per_block_init:
+            uninit_code += fpu_ops[0].math_uninit(operation, config, None)
+        code += self._zone(config, "INIT", uninit_code)
 
         return code
 
     def _packer_wait_for_math(self, config: "GlobalConfig") -> str:
-        if config.perf_run_type in (
-            PerfRunType.MATH_ISOLATE,
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        ):
+        if config.skip_sync:
             return ""
-
         return "_llk_packer_wait_for_math_done_();\n"
 
     def _packer_dest_section_done(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
-        if config.perf_run_type in (
-            PerfRunType.MATH_ISOLATE,
-            PerfRunType.UNPACK_ISOLATE,
-            PerfRunType.PACK_ISOLATE,
-            PerfRunType.L1_CONGESTION,
-        ):
+        if config.skip_sync:
             return ""
-
         dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         return f"_llk_pack_dest_section_done_<{dest_sync}, {dest_acc}>();\n"
+
+    def _pack_dest_init(
+        self, operation: "FusedOperation", config: "GlobalConfig"
+    ) -> str:
+        dest_sync = operation.dest_sync.cpp_enum_value
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
 
     def _pack_constants(
         self, operation: "FusedOperation", config: "GlobalConfig"
@@ -298,69 +373,50 @@ class ComputePipeline:
 
         return code
 
-    @staticmethod
-    def _pack_relu_config(config: "GlobalConfig", operation: "FusedOperation") -> str:
-        from helpers.golden_generators import PackGolden
-
-        pack_src_format = config.sentinel._pack_format.pack_src
-
-        relu_config = PackGolden.generate_relu_config(
-            operation.pack_relu, operation.relu_threshold, pack_src_format
-        )
-        return f"_llk_pack_relu_config_(ReluConfig::from_packed({relu_config}));\n"
-
-    @staticmethod
-    def _pack_l1_accumulation_config(
-        config: "GlobalConfig", operation: "FusedOperation"
-    ) -> str:
-        l1_acc = operation.pack_l1_accumulation.cpp_enum_value
-        return f"_llk_pack_reconfig_l1_acc_({l1_acc});\n"
+    def _all_same_pack_formats(self) -> bool:
+        if len(self.pack_nodes) <= 1:
+            return True
+        first_fmt = self.pack_nodes[0].output.data_format
+        return all(pn.output.data_format == first_fmt for pn in self.pack_nodes[1:])
 
     def pack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
         code = self._pack_constants(operation, config)
+        hoist = len(self.pack_nodes) == 1
+        hoist_reconfig = hoist or self._all_same_pack_formats()
 
-        if config.profiler_enabled:
-            code += "{\n"
-            code += 'ZONE_SCOPED("INIT")\n'
-
-        code += config.sentinel.hw_configure_pack(config, operation)
-        code += self._pack_reduce_mask_config(operation)
-        code += self.packer().init(operation, config, None, None)
-        code += self._pack_relu_config(config, operation)
-        code += self._pack_l1_accumulation_config(config, operation)
-
-        if config.profiler_enabled:
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
-            code += "{\n"
-            code += 'ZONE_SCOPED("TILE_LOOP")\n'
-
-        if config.profiler_enabled:
-            code += f"for(int loop = 0; loop < {config.loop_factor}; loop++)\n"
-            code += "{\n"
+        init_code = config.sentinel.hw_configure_pack(
+            config, operation, self.pack_nodes
+        )
+        init_code += self._pack_dest_init(operation, config)
+        init_code += self._pack_reduce_mask_config(operation)
+        if hoist_reconfig:
+            init_code += self.pack_nodes[0].reconfig(operation, config)
+        if hoist:
+            init_code += self.pack_nodes[0].configure(operation, config, None)
+        code += self._zone(config, "INIT", init_code)
 
         def batch_body(block: BlockData):
             body = self._packer_wait_for_math(config)
-            body += self.packer().loop.pack_loop(operation, config, block)
+            for pack_node in self.pack_nodes:
+                if not hoist_reconfig:
+                    body += pack_node.reconfig(operation, config)
+                if not hoist:
+                    body += pack_node.configure(operation, config, block)
+                body += pack_node.pack_loop(operation, config, block)
+                if not hoist:
+                    body += pack_node.uninit(operation, config)
             body += self._packer_dest_section_done(operation, config)
             return body
 
-        code += self._batch_loop(operation, config, batch_body)
+        code += self._zone_loop(
+            config, "TILE_LOOP", self._batch_loop(operation, config, batch_body)
+        )
 
-        if config.profiler_enabled:
-            code += "}\n"
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
-            code += "{\n"
-            code += 'ZONE_SCOPED("INIT")\n'
-
-        code += self.packer_sync_with_unpacker(operation, config)
-        code += self.packer().uninit(operation, config, None, None)
-        code += self._pack_reduce_mask_clear(operation)
-
-        if config.profiler_enabled:
-            code += "PROFILER_SYNC();\n"
-            code += "}\n"
+        uninit_code = self.packer_sync_with_unpacker(operation, config)
+        if hoist:
+            uninit_code += self.pack_nodes[0].uninit(operation, config)
+        uninit_code += self._pack_reduce_mask_clear(operation)
+        code += self._zone(config, "INIT", uninit_code)
 
         return code
 
@@ -370,8 +426,13 @@ class ComputePipeline:
         config: "GlobalConfig",
         golden_type: GoldenType,
     ) -> torch.Tensor:
-        tensor_a = torch.zeros(operation.math.operations[0].src_a.dimensions)
-        tensor_b = torch.zeros(operation.math.operations[0].src_b.dimensions)
+        first_fpu = next((op for op in self.operations if op.src_a is not None), None)
+        if first_fpu is not None:
+            tensor_a = torch.zeros(first_fpu.src_a.dimensions)
+            tensor_b = torch.zeros(first_fpu.src_b.dimensions)
+        else:
+            tensor_a = torch.zeros(operation.max_output_dimensions)
+            tensor_b = torch.zeros(operation.max_output_dimensions)
         tensor_dst = torch.zeros(operation.max_output_dimensions)
         for op in self.operations:
             config.sentinel.configure_golden(config, operation, op)
@@ -401,15 +462,29 @@ class ComputePipeline:
                 config,
             )
 
-        dimensions = operation.output.dimensions
-        return tensor_dst.reshape(operation.max_output_dimensions)[
-            : dimensions[0], : dimensions[1]
-        ]
+        for pack_node in self.pack_nodes:
+            config.sentinel.configure_golden(
+                config, operation, output_format=pack_node.output.data_format
+            )
+
+            dimensions = pack_node.output.dimensions
+            cropped = tensor_dst.reshape(operation.max_output_dimensions)[
+                : dimensions[0], : dimensions[1]
+            ]
+            result = pack_node.golden(cropped, operation, config)
+
+            if golden_type == GoldenType.L1_GOLDEN:
+                pack_node.output.l1_golden = result
+            else:
+                pack_node.output._master_golden = result
 
     def __str__(self):
-        str = "Math:"
+        result = "Math:"
         for op in self.operations:
-            str += "\n    "
-            str += op.__str__()
-
-        return str
+            result += "\n    "
+            result += op.__str__()
+        result += f"\n  Pack:"
+        for pn in self.pack_nodes:
+            result += f"\n    "
+            result += pn.output.__str__()
+        return result

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -5,26 +5,26 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-import torch
 from helpers.llk_params import (
     DestSync,
     GoldenType,
-    L1Accumulation,
-    PackerReluType,
     ReduceDimension,
     StochasticRounding,
     Tilize,
 )
+from helpers.tile_constants import DEFAULT_TILE_C_DIM, DEFAULT_TILE_R_DIM
+from helpers.tile_shape import TileShape, construct_tile_shape
 
 from .fused_math import ComputePipeline
-from .fused_operand import Operand
 
 
 @dataclass
 class FusedOperation:
     math: ComputePipeline
-    output: Operand
     max_output_dimensions: Tuple[int, int]
+    tile_shape: TileShape = construct_tile_shape(
+        (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+    )
     stage_id: int = 0
     num_stages: int = 1
     throttle: int = 0
@@ -32,18 +32,12 @@ class FusedOperation:
     tiny_tiles: bool = False
     dest_sync: DestSync = DestSync.Half
     block_size: Tuple[int, int] = (32, 32)
-    pack_relu: PackerReluType = PackerReluType.NoRelu
-    relu_threshold: float = 0.0
-    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
     reduce_dim: Optional[ReduceDimension] = None
     bh_tilize: Tilize = Tilize.No
 
     def __post_init__(self):
-        num_rows = self.output.tile_shape.total_row_dim()
-        num_cols = self.output.tile_shape.total_col_dim()
-
-        self.block_tiles_x = self.block_size[1] // num_cols
-        self.block_tiles_y = self.block_size[0] // num_rows
+        self.block_tiles_x = self.block_size[1] // self.tile_shape.total_col_dim()
+        self.block_tiles_y = self.block_size[0] // self.tile_shape.total_row_dim()
 
     def unpack(self, config) -> str:
         return self.math.unpack_body(self, config)
@@ -54,26 +48,12 @@ class FusedOperation:
     def pack(self, config) -> str:
         return self.math.pack_body(self, config)
 
-    def golden(self, config) -> torch.Tensor:
+    def golden(self, config):
         # calculate l1 golden
-        l1_golden_tensor = self.math.golden(
-            self, config, golden_type=GoldenType.L1_GOLDEN
-        )
-        l1_golden_tensor = self.math.packer().golden(l1_golden_tensor, self, config)
-
-        self.output.l1_golden = l1_golden_tensor
+        self.math.golden(self, config, GoldenType.L1_GOLDEN)
 
         # calculate master golden
-        master_golden_tensor = self.math.golden(
-            self, config, golden_type=GoldenType.MASTER_GOLDEN
-        )
-        master_golden_tensor = self.math.packer().golden(
-            master_golden_tensor, self, config
-        )
-
-        self.output._master_golden = master_golden_tensor
-
-        return master_golden_tensor
+        self.math.golden(self, config, GoldenType.MASTER_GOLDEN)
 
     def __str__(self):
         return (
@@ -81,8 +61,6 @@ class FusedOperation:
             f"Operation {self.stage_id}\n"
             f"{'=' * 60}\n"
             f"  {self.math}\n"
-            f"  Output: {self.output}\n"
             f"  Block Size: {self.block_size}\n"
             f"  Dest Sync: {self.dest_sync}\n"
-            f"  Pack L1 Accumulation: {self.pack_l1_accumulation}\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .fused_operation import FusedOperation
     from .fuser_config import GlobalConfig
     from .block_data import BlockData
-    from .compute_node import ComputeNode
+    from .pack_node import PackNode
 
 from helpers.golden_generators import PackGolden
 from helpers.tilize_untilize import tilize_block, untilize_block
@@ -42,15 +42,16 @@ class Packer:
     @staticmethod
     def _l1_acc_golden(
         tensor: torch.Tensor,
+        pack_node: "PackNode",
         operation: "FusedOperation",
         config: "GlobalConfig",
     ) -> torch.Tensor:
         """Golden helper: simulate L1 accumulation across blocks."""
-        output_dims = operation.output.dimensions
-        output_format = operation.output.data_format
-        tile_size = operation.output.tile_shape.total_tile_size()
-        tile_count_x = operation.output.tile_count_x
-        tile_count_y = operation.output.tile_count_y
+        output_dims = pack_node.output.dimensions
+        output_format = pack_node.output.data_format
+        tile_size = pack_node.output.tile_shape.total_tile_size()
+        tile_count_x = pack_node.output.tile_count_x
+        tile_count_y = pack_node.output.tile_count_y
         block_tiles_x = operation.block_tiles_x
         block_tiles_y = operation.block_tiles_y
 
@@ -75,13 +76,13 @@ class Packer:
     @staticmethod
     def _relu_golden(
         tensor: torch.Tensor,
-        operation: "FusedOperation",
+        pack_node: "PackNode",
         config: "GlobalConfig",
     ) -> torch.Tensor:
         """Golden helper: apply packer ReLU activation."""
-        intermediate_format = config.sentinel.golden_format.pack_src
+        intermediate_format = config.sentinel.golden_pack_src
         relu_config = PackGolden.generate_relu_config(
-            operation.pack_relu, operation.relu_threshold, intermediate_format
+            pack_node.pack_relu, pack_node.relu_threshold, intermediate_format
         )
         return PackGolden.apply_relu(tensor, relu_config, intermediate_format)
 
@@ -97,6 +98,7 @@ class Packer:
     def golden(
         self,
         tensor: torch.Tensor,
+        pack_node: "PackNode",
         operation: "FusedOperation",
         config: "GlobalConfig",
     ) -> torch.Tensor:
@@ -104,15 +106,15 @@ class Packer:
 
         Returns the tensor after applying pack transforms.
         Override and call _relu_golden() or _l1_acc_golden()
-        as needed based on the operation config.
+        as needed based on the pack_node config.
         """
         return tensor
 
     def init(
         self,
+        pack_node: "PackNode",
         operation: "FusedOperation",
         config: "GlobalConfig",
-        compute_unit: "ComputeNode",
         block: "BlockData",
     ) -> str:
         """Return C++ code that initializes the packer before the pack loop.
@@ -124,9 +126,9 @@ class Packer:
 
     def pack(
         self,
+        pack_node: "PackNode",
         operation: "FusedOperation",
         config: "GlobalConfig",
-        compute_unit: "ComputeNode",
         block: "BlockData",
     ) -> str:
         """Return C++ code that packs a single tile from dest to L1.
@@ -140,9 +142,9 @@ class Packer:
 
     def uninit(
         self,
+        pack_node: "PackNode",
         operation: "FusedOperation",
         config: "GlobalConfig",
-        compute_unit: "ComputeNode",
         block: "BlockData",
     ) -> str:
         """Return C++ code that uninitializes the packer after the pack loop.

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_sfpu.py
@@ -24,7 +24,7 @@ class Sfpu:
     by a prior FPU stage or loaded via datacopy. It has no unpacker the
     ComputeNode enforces that sfpu and unpacker are mutually exclusive.
 
-    The lifecycle called by ComputeNode.sfpu_calculate() is:
+    The lifecycle called by ComputeNode.math_run() is:
         init() -> calculate() -> uninit()
 
     Entirely skipped during UNPACK_ISOLATE, PACK_ISOLATE, and L1_CONGESTION perf runs.

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_unpacker.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_unpacker.py
@@ -22,11 +22,14 @@ class Unpacker:
     and override methods to emit the C++ LLK calls that configure and
     drive the Unpack thread, plus a Python golden function for test validation.
 
-    The lifecycle called by ComputeNode.unpack() is:
+    The lifecycle called by the pipeline is:
         init() -> loop.unpack_loop() [which calls unpack()] -> uninit()
 
     Override `loop` with an appropriate FusedLoop subclass to control
     the tile iteration pattern used by the unpack phases.
+
+    Set `per_block_init = True` if init() needs block dimensions and must
+    be called per-block inside the batch loop rather than hoisted out.
 
     To create a new unpacker:
         1. Subclass Unpacker
@@ -39,6 +42,7 @@ class Unpacker:
 
     # Controls the tile iteration pattern for unpack and math loops.
     loop: FusedLoop = FusedLoop()
+    per_block_init: bool = False
 
     def init(
         self,
@@ -47,7 +51,7 @@ class Unpacker:
         compute_unit: "ComputeNode",
         block: "BlockData",
     ) -> str:
-        """Return C++ code that initializes the unpacker before the tile loop.
+        """Return C++ code that initializes the unpacker.
 
         Called once per block before the unpack loop begins. Override to emit
         the _llk_unpack_*_init_<>() call with the appropriate parameters

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -10,7 +10,6 @@ from typing import List
 import pandas as pd
 import pytest
 from helpers.chip_architecture import ChipArchitecture
-from helpers.data_format_inference import is_format_combination_outlier
 from helpers.llk_params import DestAccumulation, DestSync, PerfRunType
 from helpers.logger import logger
 from helpers.perf import PerfReport
@@ -34,6 +33,30 @@ class GlobalConfig:
     loop_factor: int = 16
     sentinel: FuserSentinel = field(default_factory=FuserSentinel)
 
+    @property
+    def skip_unpack_init(self) -> bool:
+        return self.perf_run_type in (
+            PerfRunType.PACK_ISOLATE,
+            PerfRunType.MATH_ISOLATE,
+        )
+
+    @property
+    def skip_math_init(self) -> bool:
+        return self.perf_run_type in (
+            PerfRunType.UNPACK_ISOLATE,
+            PerfRunType.PACK_ISOLATE,
+            PerfRunType.L1_CONGESTION,
+        )
+
+    @property
+    def skip_sync(self) -> bool:
+        return self.perf_run_type in (
+            PerfRunType.MATH_ISOLATE,
+            PerfRunType.UNPACK_ISOLATE,
+            PerfRunType.PACK_ISOLATE,
+            PerfRunType.L1_CONGESTION,
+        )
+
 
 class FuserConfig(TestConfig):
     pipeline: List[FusedOperation]
@@ -54,16 +77,6 @@ class FuserConfig(TestConfig):
 
         if self.global_config.architecture is None:
             self.global_config.architecture = self.CHIP_ARCH
-
-        for operation in self.pipeline:
-            if is_format_combination_outlier(
-                operation.math.operations[0].src_a.data_format,
-                operation.output.data_format,
-                self.global_config.dest_acc,
-            ):
-                raise ValueError(
-                    f"Dest Accumulation must be enabled for {operation.math.operations[0].src_a.data_format} input and {operation.output.data_format} output"
-                )
 
         num_stages = len(self.pipeline)
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -12,6 +12,7 @@ import yaml
 from helpers.data_format_inference import is_format_combination_outlier
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation
+from helpers.logger import logger
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -132,6 +133,16 @@ class FuserConfigSchema(BaseModel):
                         raise ValueError(
                             f"Dest Accumulation must be enabled for {input_fmt.name} input and {output_fmt.name} output"
                         )
+
+            if len(op.pack) > 1:
+                pack_formats = [formats[e.output] for e in op.pack]
+                first_exp_b = pack_formats[0].is_exponent_B()
+                if any(f.is_exponent_B() != first_exp_b for f in pack_formats[1:]):
+                    names = [e.output for e in op.pack]
+                    logger.warning(
+                        f"Pack outputs {names} have mixed exponent families, "
+                        f"unpack/math format inference will use {op.pack[0].output} as reference",
+                    )
 
         return self
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -9,6 +9,7 @@ from typing import Annotated, List, Optional, Tuple
 
 import pytest
 import yaml
+from helpers.data_format_inference import is_format_combination_outlier
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation
 from pydantic import (
@@ -102,19 +103,35 @@ class FuserConfigSchema(BaseModel):
 
     @model_validator(mode="after")
     def validate_config(self) -> "FuserConfigSchema":
+        formats = {op_def.name: op_def.format for op_def in self.operands}
         seen_operands: set[str] = set()
 
         for op in self.operations:
+            src_a_name = None
             for node in op.math:
                 if hasattr(node, "src_a"):
+                    if src_a_name is None:
+                        src_a_name = node.src_a
                     seen_operands.add(node.src_a)
                 if hasattr(node, "src_b"):
                     seen_operands.add(node.src_b)
 
-            if op.output in seen_operands:
-                raise ValueError(f"cannot use '{op.output}' as output twice")
+            for pack_entry in op.pack:
+                if pack_entry.output in seen_operands:
+                    raise ValueError(
+                        f"cannot use '{pack_entry.output}' as output twice"
+                    )
+                seen_operands.add(pack_entry.output)
 
-            seen_operands.add(op.output)
+                if src_a_name is not None:
+                    input_fmt = formats[src_a_name]
+                    output_fmt = formats[pack_entry.output]
+                    if is_format_combination_outlier(
+                        input_fmt, output_fmt, self.dest_acc
+                    ):
+                        raise ValueError(
+                            f"Dest Accumulation must be enabled for {input_fmt.name} input and {output_fmt.name} output"
+                        )
 
         return self
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -307,7 +307,8 @@ class FuserSentinel:
         if srca_changed:
             to_from_int8 = (
                 "true"
-                if self._unpack_A_src.is_int8_format() or new_A_src.is_int8_format()
+                if self._unpack_A_src.needs_int8_math_config()
+                or new_A_src.needs_int8_math_config()
                 else "false"
             )
             code += (
@@ -325,7 +326,8 @@ class FuserSentinel:
             if srcb_tile_size is not None:
                 to_from_int8 = (
                     "true"
-                    if self._unpack_B_src.is_int8_format() or new_B_src.is_int8_format()
+                    if self._unpack_B_src.needs_int8_math_config()
+                    or new_B_src.needs_int8_math_config()
                     else "false"
                 )
                 code += (
@@ -394,7 +396,8 @@ class FuserSentinel:
 
         to_from_int8 = (
             "true"
-            if self._math_format.is_int8_format() or new_math.is_int8_format()
+            if self._math_format.needs_int8_math_config()
+            or new_math.needs_int8_math_config()
             else "false"
         )
         dest_acc = config.dest_acc.cpp_enum_value

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -409,10 +409,8 @@ class FuserSentinel:
                 f");\n"
             )
 
-        last = pack_nodes[-1]
-        last_src, last_dst = self._resolve_pack_formats(config, operation, last)
-        self._pack_src = last_src
-        self._pack_dst = last_dst
+        self._pack_src = pack_src
+        self._pack_dst = pack_dst
 
         return code
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -305,8 +305,13 @@ class FuserSentinel:
         code = ""
 
         if srca_changed:
+            to_from_int8 = (
+                "true"
+                if self._unpack_A_src.is_int8_format() or new_A_src.is_int8_format()
+                else "false"
+            )
             code += (
-                f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
+                f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, p_dim_stride_target::IGNORE, {to_from_int8}>(\n"
                 f"    {self._fmt(new_A_src)}, {self._fmt(new_A_dst)}, {compute_node.src_a.tile_size}\n"
                 f");\n"
             )
@@ -318,8 +323,13 @@ class FuserSentinel:
                 else (compute_node.src_b.tile_size if compute_node.src_b else None)
             )
             if srcb_tile_size is not None:
+                to_from_int8 = (
+                    "true"
+                    if self._unpack_B_src.is_int8_format() or new_B_src.is_int8_format()
+                    else "false"
+                )
                 code += (
-                    f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
+                    f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, {to_from_int8}>(\n"
                     f"    {self._fmt(new_B_src)}, {self._fmt(new_B_dst)}, {srcb_tile_size}\n"
                     f");\n"
                 )
@@ -382,9 +392,14 @@ class FuserSentinel:
         if self._math_format == new_math:
             return ""
 
+        to_from_int8 = (
+            "true"
+            if self._math_format.is_int8_format() or new_math.is_int8_format()
+            else "false"
+        )
         dest_acc = config.dest_acc.cpp_enum_value
         code = (
-            f"_llk_math_reconfig_data_format_<{dest_acc}, false>(\n"
+            f"_llk_math_reconfig_data_format_<{dest_acc}, {to_from_int8}>(\n"
             f"    {self._fmt(new_math)}, {self._fmt(new_math)}\n"
             f");\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -3,32 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from helpers.chip_architecture import ChipArchitecture
-from helpers.data_format_inference import infer_data_formats
-from helpers.format_config import DataFormat, FormatConfig
+from helpers.data_format_inference import (
+    infer_math_format,
+    infer_pack_in,
+    infer_unpack_out,
+)
+from helpers.format_config import DataFormat
 from helpers.llk_params import EltwiseBinaryReuseDestType
 
 if TYPE_CHECKING:
     from .compute_node import ComputeNode
     from .fused_operation import FusedOperation
     from .fuser_config import GlobalConfig
+    from .pack_node import PackNode
 
 
 @dataclass
 class FuserSentinel:
     """Tracks format state for unpack, math, and pack threads across a fused pipeline.
 
-    Each _format field is None until the first hw_configure call, then holds the
-    currently configured FormatConfig. Subsequent calls compare against the stored
+    Each format field is None until the first hw_configure call, then holds the
+    currently configured DataFormat. Subsequent calls compare against the stored
     state and emit reconfig only when formats actually change.
     """
 
-    _unpack_format: Optional[FormatConfig] = field(default=None, repr=False)
-    _math_format: Optional[FormatConfig] = field(default=None, repr=False)
-    _pack_format: Optional[FormatConfig] = field(default=None, repr=False)
-    golden_format: Optional[FormatConfig] = field(default=None, repr=False)
+    _unpack_A_src: Optional[DataFormat] = field(default=None, repr=False)
+    _unpack_A_dst: Optional[DataFormat] = field(default=None, repr=False)
+    _unpack_B_src: Optional[DataFormat] = field(default=None, repr=False)
+    _unpack_B_dst: Optional[DataFormat] = field(default=None, repr=False)
+
+    _math_format: Optional[DataFormat] = field(default=None, repr=False)
+
+    _pack_src: Optional[DataFormat] = field(default=None, repr=False)
+    _pack_dst: Optional[DataFormat] = field(default=None, repr=False)
+
+    golden_math_format: Optional[DataFormat] = field(default=None, repr=False)
+    golden_pack_src: Optional[DataFormat] = field(default=None, repr=False)
 
     @staticmethod
     def _find_format_node(
@@ -49,64 +62,119 @@ class FuserSentinel:
         return None
 
     @staticmethod
-    def _compute_format_config(
-        config: "GlobalConfig",
-        operation: "FusedOperation",
+    def _get_src_formats(
         compute_node: "ComputeNode",
-    ) -> FormatConfig:
-        """Infer all pipeline formats from a compute node's operands and the operation output.
+    ) -> Tuple[DataFormat, Optional[DataFormat]]:
+        """Extract src_a and src_b data formats, handling DEST_TO_SRCA routing."""
+        src_a_fmt = compute_node.src_a.data_format
+        if compute_node.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
+            return src_a_fmt, src_a_fmt
+        if compute_node.src_b is not None:
+            return src_a_fmt, compute_node.src_b.data_format
+        return src_a_fmt, None
 
-        Args:
-            config: Global pipeline configuration (dest_acc, architecture)
-            operation: Current fused operation (provides output format)
-            compute_node: Node whose src_a/src_b drive format inference
+    def _infer_node_formats(
+        self,
+        config: "GlobalConfig",
+        compute_node: "ComputeNode",
+        output_format: DataFormat = DataFormat.Float16_b,
+    ) -> Tuple[DataFormat, DataFormat, DataFormat, DataFormat, DataFormat, DataFormat]:
+        """Infer all pipeline formats from a compute node's operands.
 
         Returns:
-            FormatConfig with inferred unpack, math, and pack formats
+            (unpack_A_src, unpack_A_dst, unpack_B_src, unpack_B_dst, math_fmt, pack_src)
         """
+        src_a_fmt, src_b_fmt = self._get_src_formats(compute_node)
+        unpack_to_dest = compute_node.unpack_to_dest.value
+        dest_acc = config.dest_acc
 
-        src_a_format = compute_node.src_a.data_format
-        src_b_format = compute_node.src_b.data_format if compute_node.src_b else None
-
-        if compute_node.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
-            # DEST_TO_SRCA routes src_a L1 data to srcB, so srcB format
-            # must match src_a's format, not src_b's.
-            src_b_format = src_a_format
-
-        return infer_data_formats(
-            input_format=src_a_format,
-            input_format_B=src_b_format,
-            output_format=operation.output.data_format,
-            is_fp32_dest_acc_en=config.dest_acc,
-            unpacking_to_dest=compute_node.unpack_to_dest.value,
-            chip_arch=config.architecture,
+        unpack_A_dst = infer_unpack_out(
+            src_a_fmt, output_format, dest_acc, unpack_to_dest
         )
+        if src_b_fmt is not None:
+            unpack_B_src = src_b_fmt
+            unpack_B_dst = infer_unpack_out(
+                src_b_fmt, output_format, dest_acc, unpack_to_dest
+            )
+        else:
+            unpack_B_src = src_a_fmt
+            unpack_B_dst = unpack_A_dst
 
-    @staticmethod
-    def _compute_format_config_from_output(
+        math_fmt = infer_math_format(unpack_A_dst, unpack_B_dst)
+        if math_fmt == DataFormat.Fp8_e4m3:
+            math_fmt = DataFormat.Float16
+
+        pack_src = infer_pack_in(
+            src_a_fmt,
+            output_format,
+            math_fmt,
+            dest_acc,
+            unpack_to_dest,
+            config.architecture,
+        )
+        if output_format == DataFormat.Fp8_e4m3:
+            pack_src = (
+                DataFormat.Float16_b if math_fmt.is_exponent_B() else DataFormat.Float16
+            )
+
+        return src_a_fmt, unpack_A_dst, unpack_B_src, unpack_B_dst, math_fmt, pack_src
+
+    def _infer_output_formats(
+        self,
         config: "GlobalConfig",
-        operation: "FusedOperation",
-    ) -> FormatConfig:
+        output_format: DataFormat = DataFormat.Float16_b,
+    ) -> Tuple[DataFormat, DataFormat, DataFormat, DataFormat, DataFormat, DataFormat]:
         """Infer formats for SFPU only operations that have no input operands.
 
-        When all compute nodes are SFPU (no src_a/src_b), there are no L1 inputs
-        to drive format inference. We use the output format as both input and output,
-        with unpacking_to_dest=True since SFPU operates directly on the dest register.
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation (provides output format)
+        Uses the output format as both input and output with unpacking_to_dest=True
+        since SFPU operates directly on the dest register.
 
         Returns:
-            FormatConfig compatible with the operation's output format
+            (unpack_A_src, unpack_A_dst, unpack_B_src, unpack_B_dst, math_fmt, pack_src)
         """
-        return infer_data_formats(
-            input_format=operation.output.data_format,
-            output_format=operation.output.data_format,
-            is_fp32_dest_acc_en=config.dest_acc,
+        dest_acc = config.dest_acc
+
+        unpack_dst = infer_unpack_out(
+            output_format, output_format, dest_acc, unpacking_to_dest=True
+        )
+
+        math_fmt = infer_math_format(unpack_dst)
+        if math_fmt == DataFormat.Fp8_e4m3:
+            math_fmt = DataFormat.Float16
+
+        pack_src = infer_pack_in(
+            output_format,
+            output_format,
+            math_fmt,
+            dest_acc,
             unpacking_to_dest=True,
             chip_arch=config.architecture,
         )
+        if output_format == DataFormat.Fp8_e4m3:
+            pack_src = (
+                DataFormat.Float16_b if math_fmt.is_exponent_B() else DataFormat.Float16
+            )
+
+        return output_format, unpack_dst, output_format, unpack_dst, math_fmt, pack_src
+
+    def _resolve_pack_formats(
+        self,
+        config: "GlobalConfig",
+        operation: "FusedOperation",
+        pack_node: "PackNode",
+    ) -> Tuple[DataFormat, DataFormat]:
+        """Infer pack_src and pack_dst formats for a given pack node."""
+        output_format = pack_node.output.data_format
+
+        compute_node = self._find_format_node(operation)
+        if compute_node is not None:
+            _, _, _, _, _, pack_src = self._infer_node_formats(
+                config, compute_node, output_format
+            )
+        else:
+            _, _, _, _, _, pack_src = self._infer_output_formats(config, output_format)
+
+        return pack_src, output_format
 
     @staticmethod
     def _fmt(data_format: DataFormat) -> str:
@@ -115,31 +183,31 @@ class FuserSentinel:
     # Properties for reading the current format state
     @property
     def unpack_a_src_format(self) -> str:
-        return self._fmt(self._unpack_format.unpack_A_src)
+        return self._fmt(self._unpack_A_src)
 
     @property
     def unpack_a_dst_format(self) -> str:
-        return self._fmt(self._unpack_format.unpack_A_dst)
+        return self._fmt(self._unpack_A_dst)
 
     @property
     def unpack_b_src_format(self) -> str:
-        return self._fmt(self._unpack_format.unpack_B_src)
+        return self._fmt(self._unpack_B_src)
 
     @property
     def unpack_b_dst_format(self) -> str:
-        return self._fmt(self._unpack_format.unpack_B_dst)
+        return self._fmt(self._unpack_B_dst)
 
     @property
     def math_format(self) -> str:
-        return self._fmt(self._math_format.math)
+        return self._fmt(self._math_format)
 
     @property
     def pack_src_format(self) -> str:
-        return self._fmt(self._pack_format.pack_src)
+        return self._fmt(self._pack_src)
 
     @property
     def pack_dst_format(self) -> str:
-        return self._fmt(self._pack_format.pack_dst)
+        return self._fmt(self._pack_dst)
 
     def hw_configure_unpack(
         self,
@@ -149,28 +217,24 @@ class FuserSentinel:
         """Emit _llk_unpack_hw_configure_ once for the first operation in the pipeline.
 
         Called at the top of each operation's unpack_body(). On the first call
-        (when _unpack_format is None), emits the full hw_configure with tile shape
+        (when _unpack_A_src is None), emits the full hw_configure with tile shape
         parameters from the first node that has operand inputs.
-
-        Returns "" if no compute node in the operation has an unpacker.
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation
-
-        Returns:
-            C++ hw_configure call string, or "" if already configured or no inputs exist
         """
         compute_node = self._find_format_node(operation)
         if compute_node is None:
             return ""
 
-        if self._unpack_format is not None:
+        if self._unpack_A_src is not None:
             return ""
 
-        fmt = self._compute_format_config(config, operation, compute_node)
+        unpack_A_src, unpack_A_dst, unpack_B_src, unpack_B_dst, _, _ = (
+            self._infer_node_formats(config, compute_node)
+        )
 
-        self._unpack_format = fmt
+        self._unpack_A_src = unpack_A_src
+        self._unpack_A_dst = unpack_A_dst
+        self._unpack_B_src = unpack_B_src
+        self._unpack_B_dst = unpack_B_dst
 
         dest_acc = config.dest_acc.cpp_enum_value
 
@@ -189,8 +253,8 @@ class FuserSentinel:
 
         return (
             f"_llk_unpack_hw_configure_<{dest_acc}>(\n"
-            f"    {self._fmt(fmt.unpack_A_src)}, {self._fmt(fmt.unpack_B_src)},\n"
-            f"    {self._fmt(fmt.unpack_A_dst)}, {self._fmt(fmt.unpack_B_dst)},\n"
+            f"    {self._fmt(unpack_A_src)}, {self._fmt(unpack_B_src)},\n"
+            f"    {self._fmt(unpack_A_dst)}, {self._fmt(unpack_B_dst)},\n"
             f"    {face_r_dim_a}, {face_r_dim_b}, {num_faces_a}, {num_faces_b},\n"
             f"    {tile_size_a}, {tile_size_b}\n"
             f");\n"
@@ -204,28 +268,19 @@ class FuserSentinel:
     ) -> str:
         """Emit unpack reconfig calls when formats change between compute nodes.
 
-        Called per node from ComputeNode.unpack() inside the tile loop. Compares
+        Called per node from ComputeNode.unpack_configure() inside the tile loop. Compares
         the node's inferred formats against the currently configured state and emits
         _llk_unpack_reconfig_data_format_src{a,b}_impl_ only for channels that changed.
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation
-            compute_node: The compute node requesting format configuration
-
-        Returns:
-            C++ reconfig call(s), or "" if formats match current state
         """
-        new_fmt = self._compute_format_config(config, operation, compute_node)
-        old = self._unpack_format
+        new_A_src, new_A_dst, new_B_src, new_B_dst, _, _ = self._infer_node_formats(
+            config, compute_node
+        )
 
         srca_changed = (
-            old.unpack_A_src != new_fmt.unpack_A_src
-            or old.unpack_A_dst != new_fmt.unpack_A_dst
+            self._unpack_A_src != new_A_src or self._unpack_A_dst != new_A_dst
         )
         srcb_changed = (
-            old.unpack_B_src != new_fmt.unpack_B_src
-            or old.unpack_B_dst != new_fmt.unpack_B_dst
+            self._unpack_B_src != new_B_src or self._unpack_B_dst != new_B_dst
         )
 
         if not (srca_changed or srcb_changed):
@@ -237,7 +292,7 @@ class FuserSentinel:
         if srca_changed:
             code += (
                 f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
-                f"    {self._fmt(new_fmt.unpack_A_src)}, {self._fmt(new_fmt.unpack_A_dst)}, {compute_node.src_a.tile_size}\n"
+                f"    {self._fmt(new_A_src)}, {self._fmt(new_A_dst)}, {compute_node.src_a.tile_size}\n"
                 f");\n"
             )
 
@@ -250,11 +305,14 @@ class FuserSentinel:
             if srcb_tile_size is not None:
                 code += (
                     f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
-                    f"    {self._fmt(new_fmt.unpack_B_src)}, {self._fmt(new_fmt.unpack_B_dst)}, {srcb_tile_size}\n"
+                    f"    {self._fmt(new_B_src)}, {self._fmt(new_B_dst)}, {srcb_tile_size}\n"
                     f");\n"
                 )
 
-        self._unpack_format = new_fmt
+        self._unpack_A_src = new_A_src
+        self._unpack_A_dst = new_A_dst
+        self._unpack_B_src = new_B_src
+        self._unpack_B_dst = new_B_dst
         return code
 
     def hw_configure_math(
@@ -266,32 +324,22 @@ class FuserSentinel:
 
         For SFPU only operations (no node with src_a), infers a format compatible
         with the output so the math hardware is always configured.
-
-        Returns "" for subsequent operations since configure_math() handles reconfig.
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation
-
-        Returns:
-            C++ hw_configure call string, or "" if already configured
         """
-        compute_node = self._find_format_node(operation)
-
         if self._math_format is not None:
             return ""
 
+        compute_node = self._find_format_node(operation)
         if compute_node is not None:
-            fmt = self._compute_format_config(config, operation, compute_node)
+            _, _, _, _, math_fmt, _ = self._infer_node_formats(config, compute_node)
         else:
-            fmt = self._compute_format_config_from_output(config, operation)
+            _, _, _, _, math_fmt, _ = self._infer_output_formats(config)
 
-        self._math_format = fmt
+        self._math_format = math_fmt
 
         dest_acc = config.dest_acc.cpp_enum_value
         return (
             f"_llk_math_hw_configure_<{dest_acc}>(\n"
-            f"    {self._fmt(fmt.math)}, {self._fmt(fmt.math)}\n"
+            f"    {self._fmt(math_fmt)}, {self._fmt(math_fmt)}\n"
             f");\n"
         )
 
@@ -303,111 +351,107 @@ class FuserSentinel:
     ) -> str:
         """Emit math reconfig when the math format changes between compute nodes.
 
-        Called per node from ComputeNode.fpu_calculate() inside the tile loop.
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation
-            compute_node: The compute node requesting format configuration
-
-        Returns:
-            C++ reconfig call, or "" if math format matches current state
+        Called per node from ComputeNode.math_configure() inside the tile loop.
         """
         if compute_node.src_a is None:
             return ""
 
-        new_fmt = self._compute_format_config(config, operation, compute_node)
+        _, _, _, _, new_math, _ = self._infer_node_formats(config, compute_node)
 
-        if self._math_format.math == new_fmt.math:
+        if self._math_format == new_math:
             return ""
 
         dest_acc = config.dest_acc.cpp_enum_value
         code = (
             f"_llk_math_reconfig_data_format_<{dest_acc}, false>(\n"
-            f"    {self._fmt(new_fmt.math)}, {self._fmt(new_fmt.math)}\n"
+            f"    {self._fmt(new_math)}, {self._fmt(new_math)}\n"
             f");\n"
         )
-        self._math_format = new_fmt
+        self._math_format = new_math
         return code
 
     def hw_configure_pack(
         self,
         config: "GlobalConfig",
         operation: "FusedOperation",
+        pack_nodes: List["PackNode"],
     ) -> str:
-        """Emit pack hw_configure (first operation) or reconfig (subsequent operations).
+        """Emit _llk_pack_hw_configure_ once for the first operation in the pipeline.
 
-        Unlike unpack and math, the pack thread has no per node configure_pack() calls
-        in the tile loop. This method is the only place pack format changes are emitted.
-        Therefore it handles both initial hw_configure AND reconfig for later operations.
-
-        Architecture differences:
-        - Blackhole: _llk_pack_hw_configure_ takes extra bh_tilize and TILE_C_DIM params
-        - Wormhole: simpler signature without tilize parameters
-        - Reconfig call is the same for both architectures
-
-        Args:
-            config: Global pipeline configuration
-            operation: Current fused operation
-
-        Returns:
-            C++ hw_configure or reconfig call, or "" if formats unchanged
+        Called at the top of each operation's pack_body(). On the first call
+        (when _pack_src is None), emits the full hw_configure for the first
+        pack_node's format and sets sentinel state. Subsequent operations
+        rely on configure_pack() to emit reconfig as needed.
         """
-        compute_node = self._find_format_node(operation)
+        if self._pack_src is not None:
+            return ""
 
-        if compute_node is not None:
-            fmt = self._compute_format_config(config, operation, compute_node)
-        else:
-            fmt = self._compute_format_config_from_output(config, operation)
-
-        # Reconfig path: emit _llk_pack_reconfig_data_format_ only if pack formats changed
-        if self._pack_format is not None:
-            if (
-                self._pack_format.pack_src == fmt.pack_src
-                and self._pack_format.pack_dst == fmt.pack_dst
-            ):
-                return ""
-
-            dest_acc = config.dest_acc.cpp_enum_value
-            pack_size = operation.output.tile_size
-
-            code = (
-                f"_llk_pack_reconfig_data_format_<{dest_acc}>(\n"
-                f"    {self._fmt(fmt.pack_src)}, {self._fmt(fmt.pack_dst)}, {pack_size}\n"
-                f");\n"
-            )
-            self._pack_format = fmt
-            return code
-
-        # First time path: emit full _llk_pack_hw_configure_
-        self._pack_format = fmt
+        first = pack_nodes[0]
+        pack_src, pack_dst = self._resolve_pack_formats(config, operation, first)
 
         dest_acc = config.dest_acc.cpp_enum_value
-        pack_size = operation.output.tile_size
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        num_faces = operation.output.tile_shape.total_num_faces()
+        pack_size = first.output.tile_size
+        face_r_dim = first.output.tile_shape.face_r_dim
+        tile_c_dim = first.output.tile_shape.total_col_dim()
+        num_faces = first.output.tile_shape.total_num_faces()
 
         if config.architecture == ChipArchitecture.BLACKHOLE:
             bh_pack_mode = operation.bh_tilize.pack_mode_value
-            return (
+            code = (
                 f"_llk_pack_hw_configure_<{dest_acc}, {bh_pack_mode}>(\n"
-                f"    {self._fmt(fmt.pack_src)}, {self._fmt(fmt.pack_dst)}, {pack_size}, {face_r_dim}, TILE_C_DIM, {num_faces}\n"
+                f"    {self._fmt(pack_src)}, {self._fmt(pack_dst)}, {pack_size}, {face_r_dim}, {tile_c_dim}, {num_faces}\n"
+                f");\n"
+            )
+        else:
+            code = (
+                f"_llk_pack_hw_configure_<{dest_acc}, PackMode::Default>(\n"
+                f"    {self._fmt(pack_src)}, {self._fmt(pack_dst)}, {pack_size}, {face_r_dim}, {num_faces}\n"
                 f");\n"
             )
 
-        return (
-            f"_llk_pack_hw_configure_<{dest_acc}, PackMode::Default>(\n"
-            f"    {self._fmt(fmt.pack_src)}, {self._fmt(fmt.pack_dst)}, {pack_size}, {face_r_dim}, {num_faces}\n"
+        last = pack_nodes[-1]
+        last_src, last_dst = self._resolve_pack_formats(config, operation, last)
+        self._pack_src = last_src
+        self._pack_dst = last_dst
+
+        return code
+
+    def configure_pack(
+        self,
+        config: "GlobalConfig",
+        operation: "FusedOperation",
+        pack_node: "PackNode",
+    ) -> str:
+        """Update pack format state for a specific pack node and emit reconfig if needed.
+
+        Called from PackNode.configure() before packer.init() and _relu_config()
+        so that each pack node reads its own correct formats from the sentinel.
+        """
+        pack_src, pack_dst = self._resolve_pack_formats(config, operation, pack_node)
+
+        if self._pack_src == pack_src and self._pack_dst == pack_dst:
+            return ""
+
+        dest_acc = config.dest_acc.cpp_enum_value
+        pack_size = pack_node.output.tile_size
+
+        code = (
+            f"_llk_pack_reconfig_data_format_<{dest_acc}>(\n"
+            f"    {self._fmt(pack_src)}, {self._fmt(pack_dst)}, {pack_size}\n"
             f");\n"
         )
+        self._pack_src = pack_src
+        self._pack_dst = pack_dst
+        return code
 
     def configure_golden(
         self,
         config: "GlobalConfig",
         operation: "FusedOperation",
         compute_node: "ComputeNode" = None,
+        output_format: DataFormat = DataFormat.Float16_b,
     ):
-        """Compute and store the FormatConfig for golden generation.
+        """Compute and store format values for golden generation.
 
         Called per compute node during golden computation. When called without
         a compute_node (at operation start), initializes from the first format
@@ -417,17 +461,22 @@ class FuserSentinel:
         if compute_node is None:
             fmt_node = self._find_format_node(operation)
             if fmt_node is not None:
-                self.golden_format = self._compute_format_config(
-                    config, operation, fmt_node
+                _, _, _, _, math_fmt, pack_src = self._infer_node_formats(
+                    config, fmt_node, output_format
                 )
             else:
-                self.golden_format = self._compute_format_config_from_output(
-                    config, operation
+                _, _, _, _, math_fmt, pack_src = self._infer_output_formats(
+                    config, output_format
                 )
+            self.golden_math_format = math_fmt
+            self.golden_pack_src = pack_src
             return
 
         if compute_node.src_a is None and compute_node.src_b is None:
             return
 
-        new_fmt = self._compute_format_config(config, operation, compute_node)
-        self.golden_format = new_fmt
+        _, _, _, _, math_fmt, pack_src = self._infer_node_formats(
+            config, compute_node, output_format
+        )
+        self.golden_math_format = math_fmt
+        self.golden_pack_src = pack_src

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -43,6 +43,19 @@ class FuserSentinel:
     golden_math_format: Optional[DataFormat] = field(default=None, repr=False)
     golden_pack_src: Optional[DataFormat] = field(default=None, repr=False)
 
+    def reset_unpack_formats(self):
+        self._unpack_A_src = None
+        self._unpack_A_dst = None
+        self._unpack_B_src = None
+        self._unpack_B_dst = None
+
+    def reset_math_format(self):
+        self._math_format = None
+
+    def reset_pack_formats(self):
+        self._pack_src = None
+        self._pack_dst = None
+
     @staticmethod
     def _find_format_node(
         operation: "FusedOperation",
@@ -77,7 +90,7 @@ class FuserSentinel:
         self,
         config: "GlobalConfig",
         compute_node: "ComputeNode",
-        output_format: DataFormat = DataFormat.Float16_b,
+        output_format: DataFormat,
     ) -> Tuple[DataFormat, DataFormat, DataFormat, DataFormat, DataFormat, DataFormat]:
         """Infer all pipeline formats from a compute node's operands.
 
@@ -122,7 +135,7 @@ class FuserSentinel:
     def _infer_output_formats(
         self,
         config: "GlobalConfig",
-        output_format: DataFormat = DataFormat.Float16_b,
+        output_format: DataFormat,
     ) -> Tuple[DataFormat, DataFormat, DataFormat, DataFormat, DataFormat, DataFormat]:
         """Infer formats for SFPU only operations that have no input operands.
 
@@ -227,8 +240,9 @@ class FuserSentinel:
         if self._unpack_A_src is not None:
             return ""
 
+        output_format = operation.math.pack_nodes[0].output.data_format
         unpack_A_src, unpack_A_dst, unpack_B_src, unpack_B_dst, _, _ = (
-            self._infer_node_formats(config, compute_node)
+            self._infer_node_formats(config, compute_node, output_format)
         )
 
         self._unpack_A_src = unpack_A_src
@@ -272,8 +286,9 @@ class FuserSentinel:
         the node's inferred formats against the currently configured state and emits
         _llk_unpack_reconfig_data_format_src{a,b}_impl_ only for channels that changed.
         """
+        output_format = operation.math.pack_nodes[0].output.data_format
         new_A_src, new_A_dst, new_B_src, new_B_dst, _, _ = self._infer_node_formats(
-            config, compute_node
+            config, compute_node, output_format
         )
 
         srca_changed = (
@@ -328,11 +343,14 @@ class FuserSentinel:
         if self._math_format is not None:
             return ""
 
+        output_format = operation.math.pack_nodes[0].output.data_format
         compute_node = self._find_format_node(operation)
         if compute_node is not None:
-            _, _, _, _, math_fmt, _ = self._infer_node_formats(config, compute_node)
+            _, _, _, _, math_fmt, _ = self._infer_node_formats(
+                config, compute_node, output_format
+            )
         else:
-            _, _, _, _, math_fmt, _ = self._infer_output_formats(config)
+            _, _, _, _, math_fmt, _ = self._infer_output_formats(config, output_format)
 
         self._math_format = math_fmt
 
@@ -356,7 +374,10 @@ class FuserSentinel:
         if compute_node.src_a is None:
             return ""
 
-        _, _, _, _, new_math, _ = self._infer_node_formats(config, compute_node)
+        output_format = operation.math.pack_nodes[0].output.data_format
+        _, _, _, _, new_math, _ = self._infer_node_formats(
+            config, compute_node, output_format
+        )
 
         if self._math_format == new_math:
             return ""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/pack_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/pack_node.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import TYPE_CHECKING, List
+
+import torch
+
+if TYPE_CHECKING:
+    from .fused_operation import FusedOperation
+    from .fuser_config import GlobalConfig
+
+from helpers.golden_generators import PackGolden
+from helpers.llk_params import L1Accumulation, PackerReluType
+
+from .block_data import BlockData
+from .fused_operand import Operand
+from .fused_packer import Packer
+
+
+class PackNode:
+    """Wraps a packer with its output operand and pack settings.
+
+    Analogous to ComputeNode on the math side. Each PackNode represents
+    one pack destination within an operation. Multiple PackNodes allow a
+    single math result to be packed to different output buffers with
+    independent relu or L1 accumulation configs.
+    """
+
+    def __init__(
+        self,
+        packer: Packer,
+        output: Operand,
+        pack_relu: PackerReluType = PackerReluType.NoRelu,
+        relu_threshold: float = 0.0,
+        pack_l1_accumulation: L1Accumulation = L1Accumulation.No,
+    ):
+        self.packer = packer
+        self.output = output
+        self.pack_relu = pack_relu
+        self.relu_threshold = relu_threshold
+        self.pack_l1_accumulation = pack_l1_accumulation
+
+    def _relu_config(self, config: "GlobalConfig") -> str:
+        pack_src_format = config.sentinel._pack_src
+
+        relu_config = PackGolden.generate_relu_config(
+            self.pack_relu, self.relu_threshold, pack_src_format
+        )
+        return f"_llk_pack_relu_config_(ReluConfig::from_packed({relu_config}));\n"
+
+    def _l1_accumulation_config(self) -> str:
+        l1_acc = self.pack_l1_accumulation.cpp_enum_value
+        return f"_llk_pack_reconfig_l1_acc_({l1_acc});\n"
+
+    def reconfig(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ) -> str:
+        return config.sentinel.configure_pack(config, operation, self)
+
+    def configure(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        block: BlockData,
+    ) -> str:
+        code = self.packer.init(self, operation, config, block)
+        code += self._relu_config(config)
+        code += self._l1_accumulation_config()
+        return code
+
+    def pack_loop(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        block: BlockData,
+    ) -> str:
+        return self.packer.loop.pack_loop(operation, config, self, block)
+
+    def uninit(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ) -> str:
+        return self.packer.uninit(self, operation, config, None)
+
+    def golden(
+        self,
+        tensor: torch.Tensor,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+    ) -> torch.Tensor:
+        return self.packer.golden(tensor, self, operation, config)
+
+    def get_headers(self) -> List[str]:
+        return self.packer.get_headers()
+
+    def __str__(self):
+        return f"PackNode({self.packer}, output={self.output})"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
@@ -19,6 +19,7 @@ from typing import Annotated, ClassVar, List, Literal, Optional, Tuple
 from fuser.compute_node import ComputeNode
 from fuser.fused_math import ComputePipeline
 from fuser.fused_operation import FusedOperation
+from fuser.pack_node import PackNode
 from helpers.llk_params import (
     AccToDest,
     ApproximationMode,
@@ -36,6 +37,7 @@ from helpers.llk_params import (
     Transpose,
     UnpackToDest,
 )
+from helpers.tile_shape import TileShape
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -78,7 +80,7 @@ class UnarySfpuMathSchema(BaseModel):
             raise ValueError(f"{v.name} is not a supported unary SFPU operation")
         return v
 
-    def to_compute_node(self, operands, output):
+    def to_compute_node(self, operands):
         sfpu = type(self)._sfpu_cls(
             self.operation,
             self.approximation_mode,
@@ -126,7 +128,7 @@ class BinarySfpuMathSchema(BaseModel):
             raise ValueError(f"{v.name} is not a supported binary SFPU operation")
         return v
 
-    def to_compute_node(self, operands, output):
+    def to_compute_node(self, operands):
         sfpu = type(self)._sfpu_cls(
             self.operation,
             self.approximation_mode,
@@ -196,7 +198,7 @@ class FpuMathSchemaBase(BaseModel):
                 pass
         return v
 
-    def to_compute_node(self, operands, output):
+    def to_compute_node(self, operands):
         src_a = operands.get(self.src_a)
         src_b = operands.get(self.src_b)
 
@@ -208,9 +210,9 @@ class FpuMathSchemaBase(BaseModel):
                     raise ValueError(error_msg)
 
         if self.unpacker is not None:
-            unpacker_factory, unpacker_checks = type(self)._unpacker_map[self.unpacker]
-            if unpacker_checks is not None:
-                for check, error_msg in unpacker_checks:
+            _, checks = type(self)._unpacker_map[self.unpacker]
+            if checks is not None:
+                for check, error_msg in checks:
                     if check(self, src_a, src_b):
                         raise ValueError(error_msg)
 
@@ -235,6 +237,7 @@ class FpuMathSchemaBase(BaseModel):
             "unpack_to_dest": self.unpack_to_dest,
         }
         if self.unpacker is not None:
+            unpacker_factory, _ = type(self)._unpacker_map[self.unpacker]
             kwargs["unpacker"] = unpacker_factory(self)
 
         return ComputeNode(fpu=fpu, src_a=src_a, src_b=src_b, sfpu=None, **kwargs)
@@ -246,6 +249,16 @@ class FpuMathSchemaBase(BaseModel):
         src_a = operands.get(self.src_a).dimensions
         src_b = operands.get(self.src_b).dimensions
         return fn(src_a, src_b)
+
+
+class PackSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    output: str = Field(..., min_length=1)
+    packer: str = "Packer"
+    pack_relu: PackerReluType = PackerReluType.NoRelu
+    relu_threshold: float = 0.0
+    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
 
 
 class OperationSchemaBase(BaseModel):
@@ -260,18 +273,16 @@ class OperationSchemaBase(BaseModel):
 
     _packer_map: ClassVar[dict] = {}
 
-    output: str = Field(..., min_length=1)
-    packer: str = "Packer"
     dest_sync: DestSync = DestSync.Half
     block_size: Annotated[List[int], Field(min_length=2, max_length=2)] = [32, 32]
-    pack_relu: PackerReluType = PackerReluType.NoRelu
-    relu_threshold: float = 0.0
-    pack_l1_accumulation: L1Accumulation = L1Accumulation.No
+    pack: List[PackSchema] = Field(..., min_length=1)
 
     @model_validator(mode="after")
     def validate_operation(self) -> "OperationSchemaBase":
-        if self.packer not in type(self)._packer_map:
-            raise ValueError(f"Unknown packer: {self.packer}")
+        for entry in self.pack:
+            if entry.packer not in type(self)._packer_map:
+                raise ValueError(f"Unknown packer: {entry.packer}")
+
         self._arch_validate()
         return self
 
@@ -281,25 +292,51 @@ class OperationSchemaBase(BaseModel):
     def _arch_kwargs(self) -> dict:
         return {}
 
-    def _get_packer_class(self):
-        cls, _ = type(self)._packer_map[self.packer]
-        return cls
+    def _resolve_tile_shape(self, operands) -> TileShape:
+        tile_shapes = []
+        for m in self.math:
+            if hasattr(m, "src_a"):
+                tile_shapes.append(operands.get(m.src_a).tile_shape)
+            if hasattr(m, "src_b"):
+                tile_shapes.append(operands.get(m.src_b).tile_shape)
+        for entry in self.pack:
+            tile_shapes.append(operands.get(entry.output).tile_shape)
+
+        first = tile_shapes[0]
+        for ts in tile_shapes[1:]:
+            if ts != first:
+                raise ValueError(
+                    f"All operands in an operation must have the same tile shape"
+                )
+        return first
 
     def to_fused_operation(self, operands):
-        output = operands.get(name=self.output)
-        math_ops = [m.to_compute_node(operands, output) for m in self.math]
-        output.is_output = True
+        tile_shape = self._resolve_tile_shape(operands)
+
+        pack_nodes = []
+        for entry in self.pack:
+            output = operands.get(name=entry.output)
+            output.is_output = True
+
+            packer_cls, checks = type(self)._packer_map[entry.packer]
+            if checks is not None:
+                for check, error_msg in checks:
+                    if check(entry, output):
+                        raise ValueError(error_msg)
+
+            pack_nodes.append(
+                PackNode(
+                    packer=packer_cls(),
+                    output=output,
+                    pack_relu=entry.pack_relu,
+                    relu_threshold=entry.relu_threshold,
+                    pack_l1_accumulation=entry.pack_l1_accumulation,
+                )
+            )
+
+        math_ops = [m.to_compute_node(operands) for m in self.math]
 
         max_out_dims = self._calculate_max_output_dimensions(operands)
-        resolved_max_out_dims = (
-            max_out_dims if max_out_dims is not None else output.dimensions
-        )
-
-        _, checks = type(self)._packer_map[self.packer]
-        if checks is not None:
-            for check, error_msg in checks:
-                if check(self, output):
-                    raise ValueError(error_msg)
 
         reduce_dim = None
         for node in math_ops:
@@ -309,22 +346,19 @@ class OperationSchemaBase(BaseModel):
 
         kwargs = {
             "block_size": self.block_size,
-            "pack_relu": self.pack_relu,
-            "relu_threshold": self.relu_threshold,
-            "pack_l1_accumulation": self.pack_l1_accumulation,
+            "tile_shape": tile_shape,
             "dest_sync": self.dest_sync,
             "reduce_dim": reduce_dim,
         }
         kwargs.update(self._arch_kwargs())
 
         return FusedOperation(
-            math=ComputePipeline(math_ops, self._get_packer_class()),
-            output=output,
-            max_output_dimensions=resolved_max_out_dims,
+            math=ComputePipeline(math_ops, pack_nodes),
+            max_output_dimensions=max_out_dims,
             **kwargs,
         )
 
-    def _calculate_max_output_dimensions(self, operands) -> Optional[Tuple[int, int]]:
+    def _calculate_max_output_dimensions(self, operands) -> Tuple[int, int]:
         dims = []
         for m in self.math:
             op_dims = m.get_output_dimensions(operands)
@@ -332,7 +366,7 @@ class OperationSchemaBase(BaseModel):
                 dims.append(op_dims)
 
         if not dims:
-            return None
+            dims = [operands.get(e.output).dimensions for e in self.pack]
 
         bound_r = min(d[0] for d in dims)
         bound_c = min(d[1] for d in dims)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/datacopy.py
@@ -41,10 +41,10 @@ class DatacopyFpu(Fpu):
         golden_generator = get_golden_generator(DataCopyGolden)
         golden_tensor = golden_generator(
             source_tensor,
-            operation.output.data_format,
-            num_faces=operation.output.tile_shape.total_num_faces(),
+            config.sentinel.golden_math_format,
+            num_faces=operation.tile_shape.total_num_faces(),
             input_dimensions=compute_unit.src_a.dimensions,
-            face_r_dim=operation.output.tile_shape.face_r_dim,
+            face_r_dim=operation.tile_shape.face_r_dim,
         )
 
         return (tensor_a, tensor_b, golden_tensor)
@@ -59,7 +59,7 @@ class DatacopyFpu(Fpu):
         dest_acc = config.dest_acc.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         data_copy_type = compute_unit.data_copy_type.cpp_enum_value
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
         _int_fpu_formats = {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
         is_int_fpu_en = (
             "true"
@@ -89,14 +89,14 @@ class DatacopyFpu(Fpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         data_copy_type = f"DataCopyType::{compute_unit.data_copy_type.name}"
 
         code = (
-            f"    _llk_math_eltwise_unary_datacopy_<{data_copy_type}, dest_sync{stage}, {dest_acc}, {broadcast_type}, {unpack_to_dest}>(\n"
+            f"    _llk_math_eltwise_unary_datacopy_<{data_copy_type}, {dest_sync}, {dest_acc}, {broadcast_type}, {unpack_to_dest}>(\n"
             f"        {block.tile_id_block}, {config.sentinel.math_format}, {config.sentinel.math_format}\n"
             f"    );\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/eltwise.py
@@ -40,7 +40,7 @@ class EltwiseFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         math_fidelity = compute_unit.math_fidelity
 
         if compute_unit.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
@@ -74,8 +74,8 @@ class EltwiseFpu(Fpu):
         stage = operation.stage_id
         math_fidelity = compute_unit.math_fidelity.cpp_enum_value
         op = self.operation.cpp_enum_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        face_c_dim = operation.output.tile_shape.face_c_dim
+        face_r_dim = operation.tile_shape.face_r_dim
+        face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim
         num_faces_c_dim = compute_unit.src_a.tile_shape.total_col_dim() // face_c_dim
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
@@ -95,12 +95,12 @@ class EltwiseFpu(Fpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         math_fidelity = compute_unit.math_fidelity.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         op = self.operation.cpp_enum_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        face_c_dim = operation.output.tile_shape.face_c_dim
+        face_r_dim = operation.tile_shape.face_r_dim
+        face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim
         num_faces_c_dim = compute_unit.src_a.tile_shape.total_col_dim() // face_c_dim
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
@@ -108,7 +108,7 @@ class EltwiseFpu(Fpu):
         clear_fp32_dst_acc = compute_unit.clear_fp32_dst_acc.cpp_enum_value
 
         return (
-            f"_llk_math_eltwise_binary_<ckernel::EltwiseBinaryType::{op}, {broadcast_type}, dest_sync{stage},\n"
+            f"_llk_math_eltwise_binary_<ckernel::EltwiseBinaryType::{op}, {broadcast_type}, {dest_sync},\n"
             f"{dest_acc}, {math_fidelity}, {reuse_dest}>"
             f"(ckernel::TensorShape{{{face_r_dim}, {face_c_dim}, {num_faces_r_dim}, {num_faces_c_dim}}}, {block.tile_id_block}, {clear_fp32_dst_acc});\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/matmul.py
@@ -16,6 +16,7 @@ from helpers.golden_generators import MatmulGolden, get_golden_generator
 
 class MatmulFpu(Fpu):
     loop: FusedLoop = LoopBlock()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [
@@ -32,7 +33,7 @@ class MatmulFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         math_fidelity = compute_unit.math_fidelity
 
         generate_golden = get_golden_generator(MatmulGolden)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/matmul_no_mop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/matmul_no_mop.py
@@ -15,6 +15,7 @@ from .matmul import MatmulFpu
 
 class MatmulNoMopFpu(MatmulFpu):
     loop: FusedLoop = LoopBlock()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce.py
@@ -38,10 +38,10 @@ class ReduceFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
         dimensions = operation.max_output_dimensions
         tile_cnt = (dimensions[0] * dimensions[1]) // 1024
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
 
         reduce_dim = self.reduce_dim
         pool_type = self.reduce_pool

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max.py
@@ -19,6 +19,8 @@ class ReduceBlockMaxFpu(Fpu):
     loop: FusedLoop = LoopBlockRow()
     reduce_dim: ReduceDimension = ReduceDimension.Row
 
+    per_block_init = True
+
     def init(
         self,
         operation: FusedOperation,
@@ -48,7 +50,8 @@ class ReduceBlockMaxFpu(Fpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        return "_llk_math_reduce_block_max_row_uninit_();\n"
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_math_reduce_block_max_row_uninit_<{dest_acc}>();\n"
 
     def golden(
         self,
@@ -59,14 +62,18 @@ class ReduceBlockMaxFpu(Fpu):
         config: GlobalConfig,
         compute_unit: ComputeNode,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        output_format = operation.output.data_format
+        output_format = config.sentinel.golden_math_format
 
         golden_tensor = torch.zeros_like(tensor_dst)
         src_a_reduced_tensor = torch.zeros_like(tensor_a)
         dest_golden_tensor = torch.zeros_like(tensor_dst)
 
-        tile_count_x = operation.output.tile_count_x
-        tile_count_y = operation.output.tile_count_y
+        tile_count_x = (
+            operation.max_output_dimensions[1] // operation.tile_shape.total_col_dim()
+        )
+        tile_count_y = (
+            operation.max_output_dimensions[0] // operation.tile_shape.total_row_dim()
+        )
         block_tiles_x = operation.block_tiles_x
         block_tiles_y = operation.block_tiles_y
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/reduce_block_max_runtime.py
@@ -50,4 +50,5 @@ class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        return "_llk_math_reduce_block_max_row_uninit_runtime_();\n"
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_math_reduce_block_max_row_uninit_runtime_<{dest_acc}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/sub_bcast_col_custom.py
@@ -16,6 +16,7 @@ from .eltwise import EltwiseFpu
 
 class SubBcastColCustomFpu(EltwiseFpu):
     loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def __init__(self):
         super().__init__(MathOperation.Elwsub)
@@ -34,7 +35,7 @@ class SubBcastColCustomFpu(EltwiseFpu):
         block: BlockData,
     ) -> str:
         stage = operation.stage_id
-        num_faces = operation.output.tile_shape.total_num_faces()
+        num_faces = operation.tile_shape.total_num_faces()
         return (
             f"// Operation {stage}: SubBcastColCustom FPU\n"
             f"_llk_math_eltwise_binary_init_custom_<ckernel::EltwiseBinaryType::ELWSUB, ckernel::BroadcastType::COL>({num_faces});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/packer.py
@@ -7,10 +7,10 @@ from typing import List
 import torch
 from fuser.block_data import BlockData
 from fuser.fused_loop import FusedLoop
-from fuser.fused_math import ComputeNode
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
 from fuser.fuser_config import GlobalConfig
+from fuser.pack_node import PackNode
 from helpers.llk_params import L1Accumulation, PackerReluType
 
 
@@ -26,43 +26,41 @@ class Packer(BasePacker):
     def golden(
         self,
         tensor: torch.Tensor,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
     ) -> torch.Tensor:
-        if operation.pack_relu != PackerReluType.NoRelu:
-            tensor = self._relu_golden(tensor, operation, config)
+        if pack_node.pack_relu != PackerReluType.NoRelu:
+            tensor = self._relu_golden(tensor, pack_node, config)
 
-        if operation.pack_l1_accumulation == L1Accumulation.Yes:
-            tensor = self._l1_acc_golden(tensor, operation, config)
+        if pack_node.pack_l1_accumulation == L1Accumulation.Yes:
+            tensor = self._l1_acc_golden(tensor, pack_node, operation, config)
 
         return tensor
 
     def init(
         self,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
-        compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        dest_acc = config.dest_acc.cpp_enum_value
-        face_r_dim = operation.output.tile_shape.face_r_dim
-        num_faces = operation.output.tile_shape.total_num_faces()
-        dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
+        face_r_dim = pack_node.output.tile_shape.face_r_dim
+        num_faces = pack_node.output.tile_shape.total_num_faces()
         return (
             f"    _llk_pack_init_<PackMode::Default, false /* zero_output */>(\n"
             f"        {config.sentinel.pack_dst_format}, {face_r_dim}, {num_faces}\n"
             f"    );\n"
-            f"    _llk_pack_dest_init_<{dest_sync}, {dest_acc}, PackMode::Default>();\n"
         )
 
     def pack(
         self,
+        pack_node: PackNode,
         operation: FusedOperation,
         config: GlobalConfig,
-        compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
         dest_acc = config.dest_acc.cpp_enum_value
         dest_sync = f"DstSync::Sync{operation.dest_sync.name}"
-        buffer = operation.output.cpp_name
+        buffer = pack_node.output.cpp_name
         return f"_llk_pack_<{dest_sync}, {dest_acc}, ckernel::PackMode::Default>({block.tile_id_block}, L1_ADDRESS({buffer}[{block.tile_id_global}]));\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/sfpu/binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/sfpu/binary.py
@@ -59,7 +59,7 @@ class BinarySfpu(Sfpu):
         batch_dims: tuple,
         batch_tile_cnt: int,
     ) -> torch.Tensor:
-        math_format = operation.output.data_format
+        math_format = config.sentinel.golden_math_format
 
         generate_binary_golden = get_golden_generator(BinarySFPUGolden)
         golden_tensor = generate_binary_golden(
@@ -106,7 +106,7 @@ class BinarySfpu(Sfpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         op = f"ckernel::BinaryOp::{self.operation.cpp_enum_value}"
         approx_mode = self.approx_mode.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
@@ -118,7 +118,7 @@ class BinarySfpu(Sfpu):
 
         return (
             f"    test_utils::call_binary_sfpu_operation<"
-            f"dest_sync{stage}, {dest_acc}, "
+            f"{dest_sync}, {dest_acc}, "
             f"{approx_mode}, {op}, {iterations}, {format}"
             f">({src1} /* dst_index_in0 */, {src2} /* dst_index_in1 */, {dst} /* dst_index_out */);\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/sfpu/unary.py
@@ -57,8 +57,8 @@ class UnarySfpu(Sfpu):
         batch_dims: tuple,
         batch_tile_cnt: int,
     ) -> torch.Tensor:
-        format_input = operation.output.data_format
-        format_output = operation.output.data_format
+        format_input = config.sentinel.golden_math_format
+        format_output = config.sentinel.golden_math_format
         dest_acc = config.dest_acc
 
         generate_sfpu_golden = get_golden_generator(UnarySFPUGolden)
@@ -100,14 +100,14 @@ class UnarySfpu(Sfpu):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        stage = operation.stage_id
+        dest_sync = operation.dest_sync.cpp_enum_value
         dest_acc = config.dest_acc.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
         op = f"SfpuType::{self.operation.cpp_enum_value}"
 
         return (
             f"test_utils::call_unary_sfpu_operation<"
-            f"dest_sync{stage}, {dest_acc}, "
+            f"{dest_sync}, {dest_acc}, "
             f"{op}, {approx_mode}, {dest_acc}, {self.iterations}"
             f">({self.dest_idx}, {config.sentinel.math_format}, {self.fill_const_value});\n"
         )

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
@@ -17,6 +17,7 @@ from helpers.llk_params import Transpose
 
 class MatmulUnpacker(Unpacker):
     loop: FusedLoop = LoopBlock()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max.py
@@ -16,6 +16,8 @@ from fuser.fuser_config import GlobalConfig
 class ReduceBlockMaxUnpacker(Unpacker):
     loop: FusedLoop = LoopBlockRow()
 
+    per_block_init = True
+
     def init(
         self,
         operation: FusedOperation,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/reduce_block_max_runtime.py
@@ -15,6 +15,7 @@ from fuser.fuser_config import GlobalConfig
 
 class ReduceBlockMaxRuntimeUnpacker(Unpacker):
     loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return ["experimental/llk_unpack_AB_reduce_custom_runtime.h"]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/sub_bcast_col_custom.py
@@ -18,6 +18,7 @@ from helpers.tilize_untilize import tilize_block, untilize_block
 
 class SubBcastColCustomUnpacker(Unpacker):
     loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/tilize_a.py
@@ -16,6 +16,7 @@ from helpers.tilize_untilize import tilize_block
 
 class UnpackerTilizeA(Unpacker):
     loop: FusedLoop = LoopTileByTile()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/example.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/example.yaml
@@ -37,8 +37,7 @@ operands:
     format: "Float32"
 
 operations:
-  - output: "datacopy_output"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -57,11 +56,12 @@ operations:
         src_b: "input_B1"
         operation: "Elwadd"
         unpacker: "UnpackerAB"
-    packer: "Packer"
     block_size: [64, 64]
 
-  - output: "tilized_output"
-    math:
+    pack:
+      - output: "datacopy_output"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "datacopy_output"
         src_b: "input_B"
@@ -83,11 +83,12 @@ operations:
         src1_dest_tile_index: 0
         src2_dest_tile_index: 1
         dst_dest_tile_index: 1
-    packer: "Packer"
     block_size: [64, 64]
 
-  - output: "elwadd_output"
-    math:
+    pack:
+      - output: "tilized_output"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "tilized_output"
         src_b: "input_B"
@@ -101,11 +102,12 @@ operations:
         operation: "Neg"
         approximation_mode: false
         iterations: 32
-    packer: "Packer"
     dest_sync: "SyncFull"
 
-  - output: "matmul_result"
-    math:
+    pack:
+      - output: "elwadd_output"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "elwadd_output"
         src_b: "input_C"
@@ -120,10 +122,11 @@ operations:
         operation: "Sqrt"
         approximation_mode: false
         iterations: 32
-    packer: "Packer"
 
-  - output: "final_output"
-    math:
+    pack:
+      - output: "matmul_result"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "matmul_result"
         src_b: "input_D"
@@ -141,4 +144,6 @@ operations:
         src1_dest_tile_index: 0
         src2_dest_tile_index: 0
         dst_dest_tile_index: 0
-    packer: "Packer"
+    pack:
+      - output: "final_output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/example.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/example.yaml
@@ -1,3 +1,8 @@
+# Stress test that chains five fused operations together to exercise as many
+# fuser features as possible: datacopy with fill, tilize with SFPU ops,
+# elwadd with transpose, two matmul stages with SFPU chains, dest accumulation,
+# looping, broadcast scalar, acc_to_dest, SyncFull, and mixed formats.
+
 dest_acc: true
 loop_factor: 16
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_a.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_a.yaml
@@ -13,13 +13,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "datacopy_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [32, 128]
+    pack:
+      - output: "datacopy_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_a.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_a.yaml
@@ -1,3 +1,5 @@
+# Basic datacopy test that reads from source A only.
+
 dest_acc: true
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_tilize_a.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_tilize_a.yaml
@@ -1,3 +1,5 @@
+# Datacopy test that reads through the tilize unpack path.
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_tilize_a.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_datacopy_unpacker_tilize_a.yaml
@@ -10,13 +10,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "datacopy_tilize_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Datacopy"
         unpacker: "UnpackerTilizeA"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "datacopy_tilize_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwadd.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwadd.yaml
@@ -1,3 +1,5 @@
+# Element-wise addition of two inputs (A + B).
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwmul.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwmul.yaml
@@ -10,13 +10,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "elwmul_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Elwmul"
         unpacker: "UnpackerAB"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "elwmul_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwmul.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwmul.yaml
@@ -1,3 +1,5 @@
+# Element-wise multiplication of two inputs (A * B).
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwsub.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwsub.yaml
@@ -1,3 +1,5 @@
+# Element-wise subtraction of two inputs (A - B).
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwsub.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_elwsub.yaml
@@ -10,13 +10,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "elwsub_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Elwsub"
         unpacker: "UnpackerAB"
         math_fidelity: "LoFi"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "elwsub_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul.yaml
@@ -10,13 +10,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "matmul_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Matmul"
         unpacker: "MatmulUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "matmul_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul.yaml
@@ -1,3 +1,5 @@
+# Matrix multiply with HiFi2 fidelity.
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul_no_mop.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul_no_mop.yaml
@@ -1,3 +1,5 @@
+# Matrix multiply that bypasses the MOP sequencer.
+
 supported_archs: ["wormhole"]
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul_no_mop.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_matmul_no_mop.yaml
@@ -12,13 +12,14 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "matmul_no_mop_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "MatmulNoMop"
         unpacker: "MatmulUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "matmul_no_mop_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
@@ -1,3 +1,5 @@
+# Block max reduce. Source B is all ones as the identity scale.
+
 dest_acc: true
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
@@ -13,13 +13,14 @@ operands:
     format: "Float32"
 
 operations:
-  - output: "reduce_block_max_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "ReduceBlockMax"
         unpacker: "ReduceBlockMaxUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
+    pack:
+      - output: "reduce_block_max_out"
+        packer: "Packer"
     block_size: [64, 64]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
@@ -13,13 +13,14 @@ operands:
     format: "Float32"
 
 operations:
-  - output: "reduce_block_max_runtime_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "ReduceBlockMaxRuntime"
         unpacker: "ReduceBlockMaxRuntimeUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
+    pack:
+      - output: "reduce_block_max_runtime_out"
+        packer: "Packer"
     block_size: [64, 64]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
@@ -1,3 +1,6 @@
+# Same as fpu_reduce_block_max but the unpacker is configured at runtime
+# instead of compile time.
+
 dest_acc: true
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_column.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_column.yaml
@@ -1,3 +1,5 @@
+# Column reduce that sums across rows with FP32 accumulation.
+
 dest_acc: true
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_column.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_column.yaml
@@ -13,8 +13,7 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "reduce_col_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -24,5 +23,7 @@ operations:
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi2"
         enforce_fp32_accumulation: true
-    packer: "Packer"
     block_size: [32, 128]
+    pack:
+      - output: "reduce_col_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row.yaml
@@ -1,3 +1,5 @@
+# Row reduce that sums across columns.
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_row.yaml
@@ -11,8 +11,7 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "reduce_row_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -21,5 +20,7 @@ operations:
         reduce_pool: "SUM"
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "reduce_row_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_scalar.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_scalar.yaml
@@ -11,8 +11,7 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "reduce_scalar_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -21,5 +20,7 @@ operations:
         reduce_pool: "SUM"
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
     block_size: [64, 128]
+    pack:
+      - output: "reduce_scalar_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_scalar.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_scalar.yaml
@@ -1,3 +1,5 @@
+# Scalar reduce that sums all elements in each tile down to one value.
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_sub_bcast_col_custom.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_sub_bcast_col_custom.yaml
@@ -1,3 +1,5 @@
+# Subtraction where source B is a column vector broadcast across every column.
+
 supported_archs: ["wormhole"]
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_sub_bcast_col_custom.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_sub_bcast_col_custom.yaml
@@ -2,23 +2,24 @@ supported_archs: ["wormhole"]
 
 operands:
   - name: "input_A"
-    dims: [256, 256]
+    dims: [32, 256]
     format: "Float16_b"
   - name: "input_B"
-    dims: [256, 256]
+    dims: [32, 256]
     format: "Float16_b"
   - name: "sub_bcast_col_custom_out"
-    dims: [256, 256]
+    dims: [32, 256]
     format: "Float16_b"
 
 operations:
-  - output: "sub_bcast_col_custom_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "SubBcastColCustom"
         unpacker: "SubBcastColCustomUnpacker"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    block_size: [64, 128]
+    block_size: [32, 256]
+    pack:
+      - output: "sub_bcast_col_custom_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/l1_accumulation.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/l1_accumulation.yaml
@@ -10,14 +10,15 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "l1_acc_out"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Elwadd"
         unpacker: "UnpackerAB"
         math_fidelity: "LoFi"
-    packer: "Packer"
     block_size: [64, 64]
-    pack_l1_accumulation: 1
+    pack:
+      - output: "l1_acc_out"
+        packer: "Packer"
+        pack_l1_accumulation: 1

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/l1_accumulation.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/l1_accumulation.yaml
@@ -1,3 +1,5 @@
+# Element-wise add where the packer accumulates results in L1 across iterations.
+
 operands:
   - name: "input_A"
     dims: [128, 128]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/mish.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/mish.yaml
@@ -1,3 +1,6 @@
+# Mish activation fused into a single operation: x * tanh(log(1 + exp(x))).
+# Chains datacopy, exp, log1p, tanh, and elwmul with dest to srcB reuse.
+
 operands:
   - name: "input_A"
     dims: [256, 256]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/mish.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/mish.yaml
@@ -40,6 +40,7 @@ operations:
         reuse_dest: "DEST_TO_SRCB"
         # acc_to_dest: true # only for DEST_TO_SRCA
         math_fidelity: "LoFi"
-    packer: "Packer"
-    output: "mish"
     block_size: [32, 32]
+    pack:
+      - output: "mish"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
@@ -1,3 +1,6 @@
+# One elwadd packed into two separate outputs with different formats.
+# The first output is plain Float16, the second is Float32 with zero relu.
+
 dest_acc: true
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
@@ -1,13 +1,18 @@
+dest_acc: true
+
 operands:
   - name: "input_A"
-    dims: [256, 256]
+    dims: [64, 64]
     format: "Float16_b"
   - name: "input_B"
-    dims: [256, 256]
+    dims: [64, 64]
     format: "Float16_b"
-  - name: "elwadd_out"
-    dims: [256, 256]
+  - name: "out_plain"
+    dims: [64, 64]
     format: "Float16_b"
+  - name: "out_relu"
+    dims: [64, 64]
+    format: "Float32"
 
 operations:
   - math:
@@ -17,7 +22,10 @@ operations:
         operation: "Elwadd"
         unpacker: "UnpackerAB"
         math_fidelity: "LoFi"
-    block_size: [64, 128]
+    block_size: [32, 32]
     pack:
-      - output: "elwadd_out"
+      - output: "out_plain"
         packer: "Packer"
+      - output: "out_relu"
+        packer: "Packer"
+        pack_relu: "ZERO_RELU"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/multi_pack.yaml
@@ -9,7 +9,7 @@ operands:
     format: "Float16_b"
   - name: "out_plain"
     dims: [64, 64]
-    format: "Float16_b"
+    format: "Float16"
   - name: "out_relu"
     dims: [64, 64]
     format: "Float32"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/pack_relu.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/pack_relu.yaml
@@ -21,8 +21,7 @@ operands:
 operations:
   # Stage 1: NO_RELU — Datacopy A then negate.
   # Input [0, 1.1] → Neg → [-1.1, 0]. No relu, negatives preserved.
-  - output: "out_no_relu"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -33,47 +32,52 @@ operations:
         operation: "Neg"
         approximation_mode: false
         iterations: 32
-    packer: "Packer"
-    pack_relu: "NO_RELU"
     block_size: [32, 32]
+    pack:
+      - output: "out_no_relu"
+        packer: "Packer"
+        pack_relu: "NO_RELU"
   # Stage 2: ZERO_RELU — Elwsub(A, B).
   # A - B ∈ [-1.1, 1.1], mix of pos/neg. ZERO_RELU zeros negatives.
-  - output: "out_zero_relu"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Elwsub"
         unpacker: "UnpackerAB"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    pack_relu: "ZERO_RELU"
     block_size: [32, 32]
+    pack:
+      - output: "out_zero_relu"
+        packer: "Packer"
+        pack_relu: "ZERO_RELU"
   # Stage 3: MIN_THRESHOLD_RELU — Datacopy A.
   # A ∈ [0.0, 1.1]. Values ≤ 0.5 zeroed, values > 0.5 kept.
-  - output: "out_min_thresh"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    pack_relu: "MIN_THRESHOLD_RELU"
-    relu_threshold: 0.5
     block_size: [32, 32]
+    pack:
+      - output: "out_min_thresh"
+        packer: "Packer"
+        pack_relu: "MIN_THRESHOLD_RELU"
+        relu_threshold: 0.5
   # Stage 4: MAX_THRESHOLD_RELU — Elwmul(A, B).
   # A * B ∈ [0, 1.21]. Clamped to [0, 0.5] by max threshold=0.5.
-  - output: "out_max_thresh"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Elwmul"
         unpacker: "UnpackerAB"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    pack_relu: "MAX_THRESHOLD_RELU"
-    relu_threshold: 0.5
     block_size: [32, 32]
+    pack:
+      - output: "out_max_thresh"
+        packer: "Packer"
+        pack_relu: "MAX_THRESHOLD_RELU"
+        relu_threshold: 0.5

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/pack_relu.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/pack_relu.yaml
@@ -1,3 +1,6 @@
+# Walks through all four pack relu modes in separate stages:
+# no relu, zero relu, min threshold at 0.5, and max threshold at 0.5.
+
 operands:
   - name: "input_A"
     dims: [32, 32]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/reconfigure.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/reconfigure.yaml
@@ -1,3 +1,7 @@
+# Three stages that each use different data formats, forcing the unpack, math,
+# and pack pipelines to reconfigure between every stage. Goes from Float16_b
+# through Bfp8_b to Float32.
+
 dest_acc: true
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/reconfigure.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/reconfigure.yaml
@@ -58,10 +58,11 @@ operations:
         unpacker: "UnpackerA"
         reuse_dest: "DEST_TO_SRCB"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    output: "output_A"
     block_size: [32, 32]
 
+    pack:
+      - output: "output_A"
+        packer: "Packer"
   - math:
       - type: "Fpu"
         src_a: "input_D"
@@ -77,10 +78,11 @@ operations:
         reuse_dest: "DEST_TO_SRCA"
         acc_to_dest: true
         math_fidelity: "LoFi"
-    packer: "Packer"
-    output: "output_B"
     block_size: [32, 32]
 
+    pack:
+      - output: "output_B"
+        packer: "Packer"
   - math:
       - type: "Fpu"
         src_a: "input_E"
@@ -88,6 +90,7 @@ operations:
         operation: "Matmul"
         unpacker: "MatmulUnpacker"
         math_fidelity: "LoFi"
-    packer: "Packer"
-    output: "output_C"
     block_size: [32, 32]
+    pack:
+      - output: "output_C"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
@@ -11,8 +11,7 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "reduced_output"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -21,4 +20,6 @@ operations:
         reduce_pool: "MAX"
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi2"
-    packer: "Packer"
+    pack:
+      - output: "reduced_output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/reduce.yaml
@@ -1,3 +1,5 @@
+# Column reduce with max pooling.
+
 operands:
   - name: "input_A"
     dims: [64, 64]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_inner_loop_step.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_inner_loop_step.yaml
@@ -1,0 +1,143 @@
+supported_archs: ["wormhole"]
+
+# SDPA inner loop step — simplified single-iteration pipeline.
+# Models sdpa_inner_loop_step from compute_streaming.hpp without SALAD correction.
+# Exercises: multi-stage reconfigs, multi-pack with different formats,
+# L1 accumulation, pack relu, SubBcastColCustom+Exp fusion,
+# MatmulNoMop, ReduceBlockMaxRuntime, broadcast col multiply.
+
+operands:
+  # Q: query tile block
+  - name: "Q"
+    dims: [32, 64]
+    format: "Float16_b"
+  # KT: key transposed
+  - name: "KT"
+    dims: [64, 64]
+    format: "Float16_b"
+    const_value: 0.01
+  # V: value matrix
+  - name: "V"
+    dims: [64, 64]
+    format: "Float16_b"
+  # identity_scale: all-ones for reduce
+  - name: "identity_scale"
+    dims: [64, 64]
+    format: "Float16_b"
+    const_value: 1.0
+  # intermediates and outputs
+  - name: "qkt"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "row_max"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sub_exp_out"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sub_exp_sum"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "attn_v"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sum_recip"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "output"
+    dims: [32, 64]
+    format: "Float16_b"
+
+operations:
+  # Step 1: QKT = Q[32,64] × KT[64,64] → [32,64]
+  - math:
+      - type: "Fpu"
+        src_a: "Q"
+        src_b: "KT"
+        operation: "MatmulNoMop"
+        unpacker: "MatmulUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [32, 64]
+    pack:
+      - output: "qkt"
+        packer: "Packer"
+
+  # Step 2: row_max = reduce_block_max_row(qkt)
+  - math:
+      - type: "Fpu"
+        src_a: "qkt"
+        src_b: "identity_scale"
+        operation: "ReduceBlockMaxRuntime"
+        unpacker: "ReduceBlockMaxRuntimeUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [32, 64]
+    pack:
+      - output: "row_max"
+        packer: "Packer"
+
+  # Step 3: sub_exp = exp(qkt - bcast_col(row_max))
+  # Dual pack: sub_exp_out with ZERO_RELU, sub_exp_sum with L1 accumulation
+  # Models the real kernel's inline row sum during sub+exp
+  - math:
+      - type: "Fpu"
+        src_a: "qkt"
+        src_b: "row_max"
+        operation: "SubBcastColCustom"
+        unpacker: "SubBcastColCustomUnpacker"
+        math_fidelity: "LoFi"
+      - type: "UnarySfpu"
+        operation: "Exp"
+        approximation_mode: true
+        iterations: 32
+    block_size: [32, 64]
+    pack:
+      - output: "sub_exp_out"
+        packer: "Packer"
+        pack_relu: "ZERO_RELU"
+      - output: "sub_exp_sum"
+        packer: "Packer"
+        pack_l1_accumulation: 1
+
+  # Step 4: attn_v = sub_exp_out[32,64] × V[64,64] → [32,64]
+  - math:
+      - type: "Fpu"
+        src_a: "sub_exp_out"
+        src_b: "V"
+        operation: "MatmulNoMop"
+        unpacker: "MatmulUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [32, 64]
+    pack:
+      - output: "attn_v"
+        packer: "Packer"
+
+  # Step 5: sum_recip = reciprocal(sub_exp_sum)
+  # Datacopy loads sum into DEST, then SFPU reciprocal
+  - math:
+      - type: "Fpu"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+        src_a: "sub_exp_sum"
+        src_b: "identity_scale"
+      - type: "UnarySfpu"
+        operation: "Reciprocal"
+        iterations: 8
+    block_size: [32, 64]
+    pack:
+      - output: "sum_recip"
+        packer: "Packer"
+
+  # Step 6: output = attn_v * bcast_col(sum_recip) — normalize
+  - math:
+      - type: "Fpu"
+        src_a: "attn_v"
+        src_b: "sum_recip"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
+    block_size: [32, 64]
+    pack:
+      - output: "output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_reinits.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_reinits.yaml
@@ -21,28 +21,29 @@ operands:
     format: "Float16_b"
 
 operations:
-  - output: "output1"
-    math:
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Matmul"
         unpacker: "MatmulUnpacker"
         math_fidelity: "LoFi"
-    packer: "Packer"
 
-  - output: "output2"
-    math:
+    pack:
+      - output: "output1"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "ReduceBlockMax"
         unpacker: "ReduceBlockMaxUnpacker"
         math_fidelity: "LoFi"
-    packer: "Packer"
 
-  - output: "output3"
-    math:
+    pack:
+      - output: "output2"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
@@ -50,14 +51,17 @@ operations:
         unpacker: "UnpackerAB"
         broadcast_type: "COL"
         math_fidelity: "LoFi"
-    packer: "Packer"
 
-  - output: "output4"
-    math:
+    pack:
+      - output: "output3"
+        packer: "Packer"
+  - math:
       - type: "Fpu"
         src_a: "input_A"
         src_b: "input_B"
         operation: "Matmul"
         unpacker: "MatmulUnpacker"
         math_fidelity: "LoFi"
-    packer: "Packer"
+    pack:
+      - output: "output4"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_reinits.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/sdpa_reinits.yaml
@@ -1,3 +1,6 @@
+# Four operations that mimic an SDPA sequence: matmul, block max reduce,
+# column broadcast elwadd, and matmul again. Each stage uses a different
+# unpacker type, so the init and uninit transitions all get exercised.
 
 operands:
   - name: "input_A"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -106,6 +106,10 @@ class DataFormat(Enum):
             DataFormat.UInt8,
         }
 
+    def is_int8_format(self) -> bool:
+        """Checks if the format requires int8 math mode in the ALU."""
+        return self in {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
+
     def is_32_bit(self) -> bool:
         """Checks if the data format is a 32-bit type."""
         return self in {DataFormat.Float32, DataFormat.Int32, DataFormat.UInt32}

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -106,7 +106,7 @@ class DataFormat(Enum):
             DataFormat.UInt8,
         }
 
-    def is_int8_format(self) -> bool:
+    def needs_int8_math_config(self) -> bool:
         """Checks if the format requires int8 math mode in the ALU."""
         return self in {DataFormat.Int8, DataFormat.UInt8, DataFormat.Int32}
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -561,6 +561,7 @@ class SrcFormatModel:
             DataFormat.Bfp2_b: SrcFormatModel._bfp8b_to_tf32,
             DataFormat.Float16_b: SrcFormatModel._fp16b_to_tf32,
             DataFormat.Float16: SrcFormatModel._fp16_to_tf32,
+            DataFormat.Tf32: SrcFormatModel._fp32_to_tf32,
             DataFormat.Float32: SrcFormatModel._fp32_to_tf32,
             DataFormat.MxFp8R: SrcFormatModel._mxfp8r_to_tf32,
             DataFormat.MxFp8P: SrcFormatModel._mxfp8p_to_tf32,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -9,6 +9,7 @@ import torch
 from .format_config import DataFormat
 
 format_dict = {
+    DataFormat.Tf32: torch.float32,
     DataFormat.Float32: torch.float32,
     DataFormat.Float16: torch.float16,
     DataFormat.Float16_b: torch.bfloat16,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
This PR adds support for packing to multiple outputs from a single math operation, which is needed for SDPA. Codegen phases were broken into smaller reconfig, init, run and uninit steps with a new PackNode that carries its own output format, relu and L1 accumulation config. The sentinel was also reworked to track individual data formats and correctly emit reconfig calls when pack nodes use different output formats inside a loop.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
There seems to be a bug in the `sub_bcast_col_custom` operation because it requires init to be called before every run. The test has been slightly adjusted as a workaround until this is fixed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=markoradosavljevic/fuser-sdpa-pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:markoradosavljevic/fuser-sdpa-pack)