### PR TITLE
[MeshTensor Integration] concat op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -14,6 +14,14 @@
 
 namespace ttnn::prim {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+uint32_t get_buffer_alignment(const tt::tt_metal::MeshTensor& t) {
+    return t.mesh_buffer().get_reference_buffer()->alignment();
+}
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     const ConcatParams& operation_attributes, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
@@ -22,6 +30,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     const auto& input_tensors = tensor_args.input_tensors;
     const uint32_t dim = operation_attributes.dim;
     Tensor& output = tensor_return_value;
+    const MeshTensor& c = tensor_return_value.mesh_tensor();
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
 
     ProgramDescriptor desc;
@@ -34,8 +43,8 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     uint32_t num_output_pages;
     uint32_t single_page_size;
     const uint32_t common_align_len = std::max(
-        input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment(),
-        output.mesh_tensor().mesh_buffer().get_reference_buffer()->alignment());
+        CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(input_tensors[0].mesh_tensor()),
+        CMAKE_UNIQUE_NAMESPACE::get_buffer_alignment(c));
     if (rm_layout) {
         num_output_pages = output.physical_volume() / output.padded_shape()[-1];
         single_page_size = tt::align(output.element_size() * output.padded_shape()[-1], common_align_len);
@@ -106,7 +115,6 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     }
 
     const uint32_t num_input_tensors = input_tensors.size();
-    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     const uint32_t src0_cb_index = 0;
     // Depth=2 is a prefetch optimization; fall back to depth=1 when it would overflow L1.
@@ -136,7 +144,6 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     const uint32_t num_dims = output.padded_shape().rank();
 
-    std::vector<uint32_t> src_addr(num_input_tensors);
     std::vector<uint32_t> num_pages_per_block(num_input_tensors);
     std::vector<uint32_t> page_id_per_tensor(num_input_tensors);
     std::vector<uint32_t> page_size_per_tensor(num_input_tensors);
@@ -173,7 +180,6 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             const auto& input_tensor = input_tensors[i].mesh_tensor();
-            src_addr[i] = input_tensor.address();
             page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
@@ -189,17 +195,12 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     } else {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
             const auto& input_tensor = input_tensors[i].mesh_tensor();
-            src_addr[i] = input_tensor.address();
             page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             uint32_t dim_pages = input_tensors[i].padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
         }
     }
-    std::vector<uint32_t> common_reader_kernel_args = {0, 0, 0};
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), src_addr.cbegin(), src_addr.cend());
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_pages_per_block.cbegin(), num_pages_per_block.cend());
 
     // Reader compile-time args
     // Data is 32 byte aligned
@@ -217,11 +218,11 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     KernelDescriptor::CompileTimeArgs writer_compile_time_args;
     if (rm_layout) {
-        writer_compile_time_args = {(std::uint32_t)src0_cb_index, dst_buffer->page_size()};
+        writer_compile_time_args = {(std::uint32_t)src0_cb_index, c.mesh_buffer().page_size()};
     } else {
         writer_compile_time_args = {(std::uint32_t)src0_cb_index};
     }
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(c).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source = rm_layout ? "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/"
@@ -273,22 +274,23 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
             }
         }
 
-        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        reader_kernel_args[0] = num_pages_per_core;
-        reader_kernel_args[1] = curr_tensor;
-        reader_kernel_args[2] = curr_tensor_id;
-        reader_kernel_args.insert(reader_kernel_args.end(), page_id_per_tensor.begin(), page_id_per_tensor.end());
-
-        std::vector<uint32_t> writer_kernel_args;
-        if (rm_layout) {
-            writer_kernel_args = {
-                dst_buffer->address(), output.buffer()->page_size(), num_pages_per_core, num_pages_written};
-        } else {
-            writer_kernel_args = {dst_buffer->address(), num_pages_per_core, num_pages_written};
+        KernelDescriptor::RTArgList reader_kernel_args;
+        reader_kernel_args.push_back(num_pages_per_core);
+        reader_kernel_args.push_back(curr_tensor);
+        reader_kernel_args.push_back(curr_tensor_id);
+        for (uint32_t j = 0; j < num_input_tensors; ++j) {
+            reader_kernel_args.push_back(input_tensors[j].mesh_tensor());
         }
+        reader_kernel_args.append(num_pages_per_block);
+        reader_kernel_args.append(page_id_per_tensor);
 
-        reader_desc.runtime_args.emplace_back(core, std::move(reader_kernel_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_kernel_args));
+        reader_desc.emplace_runtime_args(core, reader_kernel_args);
+        if (rm_layout) {
+            writer_desc.emplace_runtime_args(
+                core, {c, c.mesh_buffer().page_size(), num_pages_per_core, num_pages_written});
+        } else {
+            writer_desc.emplace_runtime_args(core, {c, num_pages_per_core, num_pages_written});
+        }
         num_pages_written += num_pages_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp
@@ -33,7 +33,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     uint32_t num_output_pages;
     uint32_t single_page_size;
-    const uint32_t common_align_len = std::max(input_tensors[0].buffer()->alignment(), output.buffer()->alignment());
+    const uint32_t common_align_len = std::max(
+        input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment(),
+        output.mesh_tensor().mesh_buffer().get_reference_buffer()->alignment());
     if (rm_layout) {
         num_output_pages = output.physical_volume() / output.padded_shape()[-1];
         single_page_size = tt::align(output.element_size() * output.padded_shape()[-1], common_align_len);
@@ -104,8 +106,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     }
 
     const uint32_t num_input_tensors = input_tensors.size();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    Buffer* dst_buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer();
 
     const uint32_t src0_cb_index = 0;
     // Depth=2 is a prefetch optimization; fall back to depth=1 when it would overflow L1.
@@ -171,9 +172,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
 
     if (rm_layout) {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
-            page_size_per_tensor[i] = buffer->page_size();
+            const auto& input_tensor = input_tensors[i].mesh_tensor();
+            src_addr[i] = input_tensor.address();
+            page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             if (dim == num_dims - 1) {
                 num_pages_per_block[i] = num_accum_pages;
             } else {
@@ -187,9 +188,9 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
         }
     } else {
         for (uint32_t i = 0; i < num_input_tensors; ++i) {
-            auto* buffer = input_tensors[i].buffer();
-            src_addr[i] = buffer->address();
-            page_size_per_tensor[i] = buffer->page_size();
+            const auto& input_tensor = input_tensors[i].mesh_tensor();
+            src_addr[i] = input_tensor.address();
+            page_size_per_tensor[i] = input_tensor.mesh_buffer().page_size();
             uint32_t dim_pages = input_tensors[i].padded_shape()[dim] / scale_factor;
             num_pages_per_block[i] = num_accum_pages * dim_pages;
             num_output_pages_per_block += num_accum_pages * dim_pages;
@@ -206,7 +207,7 @@ tt::tt_metal::ProgramDescriptor ConcatProgramFactory::create_descriptor(
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), page_size_per_tensor.cbegin(), page_size_per_tensor.cend());
     for (uint32_t i = 0; i < num_input_tensors; ++i) {
-        TensorAccessorArgs(*input_tensors[i].buffer()).append_to(reader_compile_time_args);
+        TensorAccessorArgs(input_tensors[i].mesh_tensor()).append_to(reader_compile_time_args);
     }
 
     KernelDescriptor::Defines concat_defines;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -42,13 +42,13 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
     }
 
     KernelDescriptor::CompileTimeArgs reader_compile_time_args = {num_input_tensors};
     KernelDescriptor::CompileTimeArgs writer_compile_time_args = {num_input_tensors, input_unit_size};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs(output.mesh_tensor()).append_to(writer_compile_time_args);
 
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
@@ -79,7 +79,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
         std::vector<uint32_t> reader_runtime_args;
         reader_runtime_args.reserve(num_input_tensors * 2);
         std::vector<uint32_t> writer_runtime_args = {
-            output.buffer()->address(),
+            output.mesh_tensor().address(),
             core_id,
             curr_num_output_rows,
             num_input_tensors * input_shard_spec.shape[0],

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp
@@ -42,7 +42,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .tensor = &input_tensors[input_id].mesh_tensor(),
+            .buffer = input_tensors[input_id].mesh_tensor().mesh_buffer().get_reference_buffer(),
         });
     }
 
@@ -78,19 +78,21 @@ tt::tt_metal::ProgramDescriptor ConcatS2IProgramFactory::create_descriptor(
 
         std::vector<uint32_t> reader_runtime_args;
         reader_runtime_args.reserve(num_input_tensors * 2);
-        std::vector<uint32_t> writer_runtime_args = {
-            output.mesh_tensor().address(),
-            core_id,
-            curr_num_output_rows,
-            num_input_tensors * input_shard_spec.shape[0],
-            input_shard_spec.shape[0]};
+        // Writer arg 0 is the destination-buffer base address; bind the output tensor so the
+        // framework resolves and patches the address.
+        KernelDescriptor::RTArgList writer_runtime_args;
+        writer_runtime_args.push_back(output.mesh_tensor());
+        writer_runtime_args.push_back(core_id);
+        writer_runtime_args.push_back(curr_num_output_rows);
+        writer_runtime_args.push_back(num_input_tensors * input_shard_spec.shape[0]);
+        writer_runtime_args.push_back(input_shard_spec.shape[0]);
         for (uint32_t input_id = 0; input_id < num_input_tensors; input_id++) {
             reader_runtime_args.push_back(input_id);
             reader_runtime_args.push_back(input_shard_spec.shape[0]);
             writer_runtime_args.push_back(input_id);
         }
         reader_desc.runtime_args.emplace_back(core, std::move(reader_runtime_args));
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_runtime_args));
+        writer_desc.emplace_runtime_args(core, writer_runtime_args);
         core_id++;
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -46,7 +46,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
 
     // Assume inputs and output have the same element size and alignment.
     const uint32_t element_size = input_tensors[0].element_size();
-    const uint32_t alignment = input_tensors[0].buffer()->alignment();
+    const uint32_t alignment = input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment();
 
     uint32_t page_size;
     uint32_t elements_per_page_width;
@@ -95,7 +95,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
 
         curr_input_write_offset +=
@@ -114,7 +114,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = page_size,
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     const uint32_t output_stride = page_size * output_num_pages_per_stick;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp
@@ -15,6 +15,7 @@
 namespace ttnn::prim {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint32_t alignment) {
     TT_FATAL(!stick_sizes.empty(), "Need at least one stick size to find page size");
@@ -26,12 +27,18 @@ uint32_t find_greatest_common_page_size(std::vector<uint32_t>& stick_sizes, uint
     return page_size;
 }
 
+uint32_t get_buffer_alignment(const tt::tt_metal::MeshTensor& t) {
+    return t.mesh_buffer().get_reference_buffer()->alignment();
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
     const ConcatParams& operation_attributes, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
     using namespace tt::constants;
     using namespace tt::tt_metal;
+    using namespace CMAKE_UNIQUE_NAMESPACE;
 
     const auto& input_tensors = tensor_args.input_tensors;
     Tensor& output = tensor_return_value;
@@ -46,7 +53,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
 
     // Assume inputs and output have the same element size and alignment.
     const uint32_t element_size = input_tensors[0].element_size();
-    const uint32_t alignment = input_tensors[0].mesh_tensor().mesh_buffer().get_reference_buffer()->alignment();
+    const uint32_t alignment = get_buffer_alignment(input_tensors[0].mesh_tensor());
 
     uint32_t page_size;
     uint32_t elements_per_page_width;
@@ -95,7 +102,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = page_size,
             }}},
-            .tensor = &input_tensors[input_id].mesh_tensor(),
+            .buffer = input_tensors[input_id].mesh_tensor().mesh_buffer().get_reference_buffer(),
         });
 
         curr_input_write_offset +=
@@ -114,7 +121,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SMultiProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = page_size,
         }}},
-        .tensor = &output.mesh_tensor(),
+        .buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer(),
     });
 
     const uint32_t output_stride = page_size * output_num_pages_per_stick;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
@@ -66,7 +66,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .tensor = &input_tensors[input_id].mesh_tensor(),
+            .buffer = input_tensors[input_id].mesh_buffer().get_reference_buffer(),
         });
         cb_ids[input_id] = input_id;
     }
@@ -83,7 +83,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = output_page_size,
         }}},
-        .tensor = &output.mesh_tensor(),
+        .buffer = output.mesh_buffer().get_reference_buffer(),
     });
 
     const ShardSpec output_shard_spec = output.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp
@@ -66,7 +66,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
                 .data_format = cb_data_format,
                 .page_size = input_page_size,
             }}},
-            .buffer = input_tensors[input_id].buffer(),
+            .tensor = &input_tensors[input_id].mesh_tensor(),
         });
         cb_ids[input_id] = input_id;
     }
@@ -83,7 +83,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2SRMProgramFactory::create_descriptor(
             .data_format = cb_data_format,
             .page_size = output_page_size,
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     const ShardSpec output_shard_spec = output.shard_spec().value();

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -99,7 +99,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
                 .data_format = datatype_to_dataformat_converter(input_tensor.dtype()),
                 .page_size = tt::tile_size(datatype_to_dataformat_converter(input_tensor.dtype())),
             }}},
-            .tensor = &input_tensor.mesh_tensor(),
+            .buffer = input_tensor.mesh_tensor().mesh_buffer().get_reference_buffer(),
         });
     }
 
@@ -113,7 +113,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
             .data_format = datatype_to_dataformat_converter(output.dtype()),
             .page_size = tt::tile_size(datatype_to_dataformat_converter(output.dtype())),
         }}},
-        .tensor = &output.mesh_tensor(),
+        .buffer = output.mesh_tensor().mesh_buffer().get_reference_buffer(),
     });
 
     tt::DataFormat cb_data_format = data_format;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp
@@ -99,7 +99,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
                 .data_format = datatype_to_dataformat_converter(input_tensor.dtype()),
                 .page_size = tt::tile_size(datatype_to_dataformat_converter(input_tensor.dtype())),
             }}},
-            .buffer = input_tensor.buffer(),
+            .tensor = &input_tensor.mesh_tensor(),
         });
     }
 
@@ -113,7 +113,7 @@ tt::tt_metal::ProgramDescriptor ConcatS2STiledProgramFactory::create_descriptor(
             .data_format = datatype_to_dataformat_converter(output.dtype()),
             .page_size = tt::tile_size(datatype_to_dataformat_converter(output.dtype())),
         }}},
-        .buffer = output.buffer(),
+        .tensor = &output.mesh_tensor(),
     });
 
     tt::DataFormat cb_data_format = data_format;


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Mechanical migration of the `concat` op program factory to the `MeshTensor`/`MeshBuffer` APIs.

Candidate program factories (5):
- `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_program_factory.cpp`
- `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2i_program_factory.cpp`
- `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_multi_program_factory.cpp`
- `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_rm_program_factory.cpp`
- `ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_s2s_tiled_program_factory.cpp`

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is modelled on `ttnn::Tensor` and captures the shape/sharding of the true storage backing a kernel argument. It is plumbed into kernels via `TensorAccessorArgs` and is a critical building block for Metal 2.0, where the host must hand the kernel enough information to reconstruct the tensor's layout rather than just a raw `Buffer` address. `MeshTensor` is the device-side part of this model. This is not a wholesale replacement of `ttnn::Tensor` — the change is confined to program-factory usage.

#### This refactoring

**Primary goal:** stop losing shape/sharding information when passing a `Buffer` into runtime/compile args (especially `TensorAccessorArgs`) — feed the `MeshTensor` instead so the accessor carries full layout.

**Secondary goal:** migrate `Buffer` → `MeshTensor` so the program factories are multi-device-aware.

#### Risk

Minimal regression risk: this is type-substitution plus mechanical cleanup, not behavioural change. Preserved invariants: runtime-arg counts and order, circular-buffer bindings, and the per-core work-split are all unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-dm-concat) (T3K infra flakyness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-dm-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-dm-concat) (all to all fail (non related), conv fail (non related)).
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-dm-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-dm-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-dm-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-dm-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-dm-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-dm-concat)
