### PR TITLE
[MeshTensor Integration] pool/generic op

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -17,6 +17,7 @@
 #include "ttnn/tensor/storage.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <algorithm>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
@@ -255,9 +256,9 @@ std::vector<uint32_t> generate_core_starting_indices(
 }
 
 static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_impl_new(
-    const Tensor& input,
-    tt::tt_metal::Buffer* reader_indices_buffer,
-    tt::tt_metal::Buffer* scalar_config_buffer,
+    const tt::tt_metal::MeshTensor& input,
+    const tt::tt_metal::MeshTensor& reader_indices,
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> scalar_config,
     uint32_t reader_indices_size,
     std::vector<Tensor>& outputs,
     Pool2DType pool_type,
@@ -292,10 +293,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     bool config_tensor_in_dram) {
     using namespace tt::tt_metal;
 
-    TT_FATAL(
-        reader_indices_buffer != nullptr,
-        "Pool2D::MultiCore::create_workload_descriptor must populate the reader-indices buffer before building "
-        "programs");
+    const MeshTensor& out = outputs[0].mesh_tensor();
 
     const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
@@ -305,7 +303,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     const uint32_t ncores = all_cores.num_cores();
     const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
     const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
-    const uint32_t max_out_nhw_per_core = outputs[0].shard_spec()->shape[0];
+    const uint32_t max_out_nhw_per_core = out.shard_spec()->shape[0];
     const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
     TT_FATAL(
         max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
@@ -318,7 +316,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     FactoryParameters params = get_factory_parameters(
         num_shards_c,
         input.dtype(),
-        outputs[0].dtype(),
+        out.dtype(),
         kernel_h,
         kernel_w,
         in_c,
@@ -342,17 +340,17 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     // falls back to the worst case because the buffers do not exist yet there. The scalar config
     // tensor (only created for avg pool without one_scalar_per_core) is not yet known at this
     // point, so its prediction remains the worst case; that matches how the CB is created below.
-    auto output_shard_shape = outputs[0].shard_spec().value().shape;
+    auto output_shard_shape = out.shard_spec().value().shape;
     std::optional<uint32_t> reader_indices_actual_page_size;
     if (config_tensor_in_dram) {
-        reader_indices_actual_page_size = reader_indices_buffer->page_size();
+        reader_indices_actual_page_size = reader_indices.mesh_buffer().page_size();
     }
     PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
         params,
         one_scalar_per_core,
         return_indices,
         output_layout,
-        outputs[0].dtype(),
+        out.dtype(),
         {output_shard_shape[0], output_shard_shape[1]},
         config_tensor_in_dram,
         reader_indices_actual_page_size);
@@ -398,7 +396,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
                               uint32_t page_size,
                               uint32_t num_pages,
                               tt::DataFormat data_format,
-                              tt::tt_metal::Buffer* buffer) {
+                              const MeshTensor& tensor) {
         desc.cbs.push_back(CBDescriptor{
             .total_size = page_size * num_pages,
             .core_ranges = all_cores,
@@ -407,7 +405,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
                 .data_format = data_format,
                 .page_size = page_size,
             }}},
-            .buffer = buffer,
+            .buffer = tensor.mesh_buffer().get_reference_buffer(),
         });
     };
 
@@ -436,7 +434,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
     const uint32_t raw_in_cb_pagesize = in_nbytes_c;
     const uint32_t raw_in_cb_id = next_cb_index++;
-    add_sharded_cb(raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input.buffer());
+    add_sharded_cb(raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input);
 
     log_debug(tt::LogOp, "Raw In CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
 
@@ -448,7 +446,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
 
     const uint32_t max_reader_indices_size =
         (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
-    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_buffer->page_size();
+    const uint32_t actual_reader_indices_buffer_page_size = reader_indices.mesh_buffer().page_size();
     TT_FATAL(
         actual_reader_indices_buffer_page_size <= max_reader_indices_size,
         "Reader indices buffer page size {} exceeds max expected size {}",
@@ -471,7 +469,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
             in_reader_indices_cb_pagesize,
             in_reader_indices_cb_npages,
             tt::DataFormat::UInt16,
-            reader_indices_buffer);
+            reader_indices);
     }
 
     log_debug(
@@ -592,7 +590,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     }
 
     const bool is_output_tiled = output_layout == Layout::TILE;
-    const bool is_output_block_format = is_block_float(outputs[0].dtype());
+    const bool is_output_block_format = is_block_float(out.dtype());
     const bool zero_pages = is_output_tiled && is_output_block_format;
 
     // Conditionally allocate temporary CB - only needed for TILED output
@@ -614,7 +612,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     const uint32_t out_cb_npages = cb_sizes.out_cb_npages;
 
     const uint32_t out_cb_id = next_cb_index++;
-    add_sharded_cb(out_cb_id, out_cb_pagesize, out_cb_npages, params.output_data_format, outputs[0].buffer());
+    add_sharded_cb(out_cb_id, out_cb_pagesize, out_cb_npages, params.output_data_format, out);
 
     uint32_t out_idx_cb_id = INVALID_CB_ID;
     if (cb_sizes.has_out_idx) {
@@ -622,13 +620,10 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
             outputs.size() == 2,
             "When return_indices is true, there should be two outputs, but got {}",
             outputs.size());
+        const MeshTensor& out_idx = outputs[1].mesh_tensor();
         out_idx_cb_id = next_cb_index++;
         add_sharded_cb(
-            out_idx_cb_id,
-            cb_sizes.out_idx_cb_pagesize,
-            cb_sizes.out_idx_cb_npages,
-            params.index_format,
-            outputs[1].buffer());
+            out_idx_cb_id, cb_sizes.out_idx_cb_pagesize, cb_sizes.out_idx_cb_npages, params.index_format, out_idx);
     }
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
 
@@ -643,25 +638,23 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
      * Reader Kernel: input rows -> input cb
      */
     uint32_t config_cb_id = INVALID_CB_ID;
-    tt::tt_metal::Buffer* config_buffer = nullptr;
     if (!one_scalar_per_core) {
         // The scalar config tensor was uploaded once in create_workload_descriptor
         // and parked in WorkloadDescriptor::buffers; the framework keeps it
-        // alive for the cached workload's lifetime.  scalar_config_buffer must
-        // be non-null whenever !one_scalar_per_core (avg-pool with non-trivial
+        // alive for the cached workload's lifetime.  scalar_config must
+        // be populated whenever !one_scalar_per_core (avg-pool with non-trivial
         // scalar layout).
-        TT_FATAL(scalar_config_buffer != nullptr, "scalar config buffer must be populated when !one_scalar_per_core");
+        TT_FATAL(scalar_config.has_value(), "scalar config tensor must be populated when !one_scalar_per_core");
 
         constexpr tt::DataFormat config_df = tt::DataFormat::RawUInt32;
-        config_buffer = scalar_config_buffer;
-        const uint32_t config_buffer_page_size = config_buffer->page_size();
+        const uint32_t config_buffer_page_size = scalar_config->mesh_buffer().page_size();
         uint32_t max_config_tensor_size =
             max_out_nhw_per_core * 3 * sizeof(uint16_t);  // worst case of 3 entries per output element
 
         TT_FATAL(
-            config_buffer->page_size() <= max_config_tensor_size,
+            config_buffer_page_size <= max_config_tensor_size,
             "Config tensor buffer page size {} exceeds max expected size {}",
-            config_buffer->page_size(),
+            config_buffer_page_size,
             max_config_tensor_size);
 
         config_cb_id = next_cb_index++;
@@ -670,47 +663,47 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
             // local scratch sized to the worst-case payload of one page.
             add_local_cb(config_cb_id, max_config_tensor_size, 1, config_df);
         } else {
-            add_sharded_cb(config_cb_id, config_buffer_page_size, 1, config_df, config_buffer);
+            add_sharded_cb(config_cb_id, config_buffer_page_size, 1, config_df, *scalar_config);
         }
     }
     KernelDescriptor::CompileTimeArgs reader0_ct_args = {
-        max_out_nhw_per_core,                                  // 0
-        kernel_h,                                              // 1
-        kernel_w,                                              // 2
-        pad_w,                                                 // 3
-        in_nbytes_leftover,                                    // 4
-        in_w,                                                  // 5
-        in_c_per_shard_ceil,                                   // 6
-        params.split_reader,                                   // enable split reader //7
-        0,                                                     // split reader id //8
-        bf16_scalar,                                           // 9
-        bf16_init_value,                                       // 10
-        in_nblocks_c,                                          // 11
-        cb_sizes.in_cb_raw_size,                               // 12
-        params.max_rows_for_reduction,                         // 13
-        ceil_pad_w,                                            // 14
-        in_cb_id_0,                                            // 15
-        in_cb_id_1,                                            // 16
-        raw_in_cb_id,                                          // 17
-        in_reader_indices_cb_id,                               // 18
-        in_scalar_cb_id_0,                                     // 19
-        in_scalar_cb_id_1,                                     // 20
-        clear_value_cb_id,                                     // 21
-        static_cast<uint32_t>(pool_type),                      // 22
-        one_scalar_per_core,                                   // 23
-        config_cb_id,                                          // 24
-        in_nbytes_c,                                           // 25
-        shard_width_bytes,                                     // 26
-        params.multi_buffering_factor,                         // 27
-        stride_w,                                              // 28
-        dilation_h,                                            // 29
-        dilation_w,                                            // 30
-        static_cast<uint32_t>(zero_pages),                     // 31
-        config_tensor_in_dram,                                 // 32
-        one_scalar_per_core ? 0 : config_buffer->address(),    // 33
-        one_scalar_per_core ? 0 : config_buffer->page_size(),  // 34
-        reader_indices_buffer->address(),                      // 35
-        reader_indices_buffer->page_size(),                    // 36
+        max_out_nhw_per_core,                                                        // 0
+        kernel_h,                                                                    // 1
+        kernel_w,                                                                    // 2
+        pad_w,                                                                       // 3
+        in_nbytes_leftover,                                                          // 4
+        in_w,                                                                        // 5
+        in_c_per_shard_ceil,                                                         // 6
+        params.split_reader,                                                         // enable split reader //7
+        0,                                                                           // split reader id //8
+        bf16_scalar,                                                                 // 9
+        bf16_init_value,                                                             // 10
+        in_nblocks_c,                                                                // 11
+        cb_sizes.in_cb_raw_size,                                                     // 12
+        params.max_rows_for_reduction,                                               // 13
+        ceil_pad_w,                                                                  // 14
+        in_cb_id_0,                                                                  // 15
+        in_cb_id_1,                                                                  // 16
+        raw_in_cb_id,                                                                // 17
+        in_reader_indices_cb_id,                                                     // 18
+        in_scalar_cb_id_0,                                                           // 19
+        in_scalar_cb_id_1,                                                           // 20
+        clear_value_cb_id,                                                           // 21
+        static_cast<uint32_t>(pool_type),                                            // 22
+        one_scalar_per_core,                                                         // 23
+        config_cb_id,                                                                // 24
+        in_nbytes_c,                                                                 // 25
+        shard_width_bytes,                                                           // 26
+        params.multi_buffering_factor,                                               // 27
+        stride_w,                                                                    // 28
+        dilation_h,                                                                  // 29
+        dilation_w,                                                                  // 30
+        static_cast<uint32_t>(zero_pages),                                           // 31
+        config_tensor_in_dram,                                                       // 32
+        one_scalar_per_core ? 0u : static_cast<uint32_t>(scalar_config->address()),  // 33
+        one_scalar_per_core ? 0u : scalar_config->mesh_buffer().page_size(),         // 34
+        static_cast<uint32_t>(reader_indices.address()),                             // 35
+        reader_indices.mesh_buffer().page_size(),                                    // 36
         // MPWI-only args start here (for reader_mpwi.cpp, not used by reader_pool_2d.cpp)
         in_idx_cb_id,                           // 37
         pack_tmp_cb_id,                         // 38
@@ -732,9 +725,9 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
         static_cast<uint32_t>(indexes_32_bit),  // 54
     };
 
-    tt::tt_metal::TensorAccessorArgs(reader_indices_buffer).append_to(reader0_ct_args);
+    tt::tt_metal::TensorAccessorArgs(reader_indices).append_to(reader0_ct_args);
     if (!one_scalar_per_core) {
-        tt::tt_metal::TensorAccessorArgs(config_buffer).append_to(reader0_ct_args);
+        tt::tt_metal::TensorAccessorArgs(scalar_config).append_to(reader0_ct_args);
     }
     KernelDescriptor::CompileTimeArgs reader1_ct_args = reader0_ct_args;
     reader1_ct_args[8] = 1;  // split reader id for reader1
@@ -816,7 +809,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     };
 
     // Get device arch for compute kernel config initialization
-    auto device_arch = input.device()->arch();
+    auto device_arch = input.device().arch();
 
     // Initialize device compute kernel config with user-provided config or defaults
     auto device_compute_kernel_config = init_device_compute_kernel_config(
@@ -911,7 +904,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
     }
 
     uint32_t post_allocate_size =
-        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+        input.device().allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
     uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
 
     // For now assume that if post_op_l1_allocation_size == 0 op is being run
@@ -938,11 +931,11 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
             in_reader_indices_cb_npages);
         log_debug(tt::LogOp, "in_scalar_cb :: PS = {}, NP = {}", in_scalar_cb_pagesize, in_scalar_cb_npages);
         log_debug(tt::LogOp, "out_cb :: PS = {}, NP = {}", out_cb_pagesize, out_cb_npages);
-        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices_buffer->address());
+        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices.address());
         log_debug(
             tt::LogOp,
             "scalar_config_addr: {}",
-            config_buffer != nullptr ? std::to_string(config_buffer->address()) : "not set");
+            scalar_config.has_value() ? std::to_string(scalar_config->address()) : "not set");
         log_debug(tt::LogOp, "kernel_h: {}", kernel_h);
         log_debug(tt::LogOp, "kernel_w: {}", kernel_w);
         log_debug(tt::LogOp, "stride_h: {}", stride_h);
@@ -965,7 +958,7 @@ static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_im
         log_debug(tt::LogOp, "multi_buffering_factor: {}", params.multi_buffering_factor);
         log_debug(tt::LogOp, "is_wide_reduction: {}", params.is_wide_reduction);
         log_debug(tt::LogOp, "is_in_sharded: {}", input.memory_config().is_sharded());
-        log_debug(tt::LogOp, "is_out_sharded: {}", outputs[0].memory_config().is_sharded());
+        log_debug(tt::LogOp, "is_out_sharded: {}", out.memory_config().is_sharded());
     }
 
     return desc;
@@ -991,7 +984,7 @@ struct PoolSetup {
     uint32_t num_shards_c;
 };
 
-PoolSetup compute_pool_setup(const Pool2D::operation_attributes_t& op_attr, const Tensor& input) {
+PoolSetup compute_pool_setup(const Pool2D::operation_attributes_t& op_attr, const tt::tt_metal::MeshTensor& input) {
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     PoolSetup setup;
     setup.parallel_config = sliding_window::ParallelConfig{
@@ -1033,7 +1026,7 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensors,
     const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    const auto& input = tensor_args.input_tensor_;
+    const auto& input = tensor_args.input_tensor_.mesh_tensor();
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     PoolSetup setup = compute_pool_setup(op_attr, input);
 
@@ -1053,7 +1046,7 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
         reader_indices_host,
         setup.parallel_config,
         setup.is_block_sharded,
-        input.device(),
+        &input.mutable_device(),
         op_attr.config_tensor_in_dram);
 
     tt::tt_metal::WorkloadDescriptor workload_descriptor;
@@ -1065,8 +1058,9 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
     // a shared_ptr held by WorkloadBuffer.owner defers ~Tensor until the
     // cached workload itself is evicted.
     auto reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(reader_indices_on_device));
-    tt::tt_metal::Buffer* reader_indices_buffer = reader_indices_tensor_owner->buffer();
-    workload_descriptor.buffers.push_back({reader_indices_tensor_owner, reader_indices_buffer});
+    const auto& reader_indices = reader_indices_tensor_owner->mesh_tensor();
+    workload_descriptor.buffers.push_back(
+        {reader_indices_tensor_owner, reader_indices.mesh_buffer().get_reference_buffer()});
 
     // For avg-pool, decide whether a single bf16 scalar per core is sufficient.  When it isn't
     // (ceil_mode w/ ceil_pad, or !count_include_pad with non-zero padding, both with no
@@ -1083,6 +1077,9 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
         pad_w,
         op_attr.divisor_override_);
 
+    // Bound to the scalar config tensor below when it exists; the owning Tensor is parked in
+    // workload_descriptor.buffers, so this reference stays valid for the cached workload's lifetime.
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> scalar_config;
     if (!one_scalar_per_core) {
         const uint32_t max_out_nhw_per_core = output_tensors[0].shard_spec()->shape[0];
         const uint32_t ncores = input.shard_spec().value().grid.num_cores();
@@ -1123,13 +1120,12 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
             TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
 
         Tensor config_tensor_on_device = config_tensor.to_device(
-            input.device(), op_attr.config_tensor_in_dram ? DRAM_MEMORY_CONFIG : l1_small_memory_config);
+            &input.mutable_device(), op_attr.config_tensor_in_dram ? DRAM_MEMORY_CONFIG : l1_small_memory_config);
         auto scalar_config_tensor_owner = std::make_shared<Tensor>(std::move(config_tensor_on_device));
-        tt::tt_metal::Buffer* scalar_config_buf = scalar_config_tensor_owner->buffer();
-        workload_descriptor.buffers.push_back({std::move(scalar_config_tensor_owner), scalar_config_buf});
+        scalar_config = scalar_config_tensor_owner->mesh_tensor();
+        workload_descriptor.buffers.push_back(
+            {scalar_config_tensor_owner, scalar_config->mesh_buffer().get_reference_buffer()});
     }
-    tt::tt_metal::Buffer* scalar_config_buffer =
-        workload_descriptor.buffers.size() > 1 ? workload_descriptor.buffers[1].buffer : nullptr;
 
     // Single-device op: the kernel program is structurally identical for every
     // coord in `tensor_coords` (Pool2D doesn't depend on cluster position).
@@ -1152,9 +1148,9 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
     }
 
     tt::tt_metal::ProgramDescriptor desc = pool2d_multi_core_sharded_with_halo_v2_impl_new(
-        tensor_args.input_tensor_,
-        reader_indices_buffer,
-        scalar_config_buffer,
+        input,
+        reader_indices,
+        scalar_config,
         top_left_indices[0].size(),
         output_tensors,
         pool_type,


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Mechanical migration of the `pool` (generic Pool2D / MaxPool2D / AvgPool2D) op program factory to the `MeshTensor` / `MeshBuffer` APIs.

Candidate program factories (1):
- `ttnn/cpp/ttnn/operations/pool/generic/device` (`pool_multi_core_program_factory.cpp`)

This is a de-risking refactoring running in front of metal2.0, where pool/generic is deemed as a critical op needed to be prioritized.

### Notes for reviewers

#### Runtime Tensor overview

Runtime Tensor is modelled on `ttnn::Tensor` and captures the shape + sharding of the true device storage. It is plumbed into kernels via `TensorAccessorArgs`, which is what the upcoming Metal 2.0 / gen-2 hardware needs to address device memory directly. `MeshTensor` is the device-side part of Runtime Tensor. This is **not** a wholesale `ttnn::Tensor` replacement — the change is scoped to program-factory usage.

#### This refactoring

- **Primary goal:** stop losing shape/sharding information when passing storage into compile-time / runtime args — in particular, the factory-internal `reader_indices` (sliding-window halo LUT) and `scalar_config` (avg-pool scalar) tensors now reach `TensorAccessorArgs(...)` as a `MeshTensor` / `optional_reference<const MeshTensor>` rather than a bare `Buffer*`.
- **Secondary goal:** retire the single-device `Buffer*` / `ttnn::Tensor` surface inside the factory now that the infra is multi-device-aware.

#### Risk

Minimal regression risk: type-substitution + mechanical cleanup, not behavioural. Preserved invariants: compile-time / runtime arg counts and slot order, CB bindings (still `.buffer`, sharded vs local unchanged), and the work-split / sharding logic are all untouched. `MeshTensor`'s `dtype`/`tensor_spec`/`shape`/`memory_config`/`page_size` delegate to the same `TensorSpec` as `ttnn::Tensor`, so the queried values are identical.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mt-pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mt-pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mt-pool)
