### PR TITLE
Fix TG Llama embedding tests to compare against BF16 weights

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -413,7 +413,8 @@ def test_tg_llama_sharded_embedding(
     sentence_size = 1 + token_padding
     torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
     torch_weights = torch.randn(vocabulary_size, hidden_embedding_dim)
-    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+    torch_weights_bfloat16 = torch_weights.to(torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights_bfloat16)
 
     start_core = ttnn.CoreCoord(1, 0)
     core_grid = ttnn.CoreRangeSet(
@@ -439,7 +440,7 @@ def test_tg_llama_sharded_embedding(
         torch_input_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
     weights = ttnn.as_tensor(
-        torch_weights,
+        torch_weights_bfloat16,
         device=device,
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -473,7 +474,8 @@ def test_tg_llama_sharded_rm_embedding(device):
     hidden_embedding_dim = 128
     torch_input_tensor = torch.randint(0, vocabulary_size - 1, (batch_size, num_heads))
     torch_weights = torch.randn(vocabulary_size, hidden_embedding_dim)
-    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+    torch_weights_bfloat16 = torch_weights.to(torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights_bfloat16)
 
     start_core = ttnn.CoreCoord(1, 0)
     core_grid = ttnn.CoreRangeSet(
@@ -499,7 +501,7 @@ def test_tg_llama_sharded_rm_embedding(device):
         torch_input_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
     weights = ttnn.as_tensor(
-        torch_weights,
+        torch_weights_bfloat16,
         device=device,
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The WH-only TG Llama sharded embedding tests were failing exact equality checks because the tests generated FP32 `torch_weights`, computed the PyTorch golden from those FP32 weights, and then uploaded the weights to TTNN as BF16. The observed max deltas matched FP32-vs-BF16 quantization exactly, while the simulator output was bit-exact when compared against a golden computed from BF16 weights. This change explicitly derives `torch_weights_bfloat16` in both TG Llama embedding tests, uses it for the PyTorch golden, and uploads that same tensor to device, so the reference now matches the data precision actually consumed by the operation.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/embedding-bf16-golden-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/embedding-bf16-golden-fix)