### PR TITLE
[Test Only] Workaround for progam hash collision in a batch_norm test

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -760,7 +760,11 @@ def test_batch_norm_aliased_running_and_affine_tensors(device):
     and weight). Since the running stats are updated in place, doing that update first overwrote
     weight and bias before batch_norm used them.
     """
-    input_shape = torch.Size([1, 152, 24, 32])
+    # Channel size 152 triggers a Shape hash collision
+    # with [3, 17, 1, 1] (an intermediate from test_batch_norm_compute_config)
+    # See issue #45821 for more details.
+    # input_shape = torch.Size([1, 152, 24, 32])
+    input_shape = torch.Size([1, 153, 24, 32])
     channels = input_shape[1]
     eps = 9.99999996e-13
     momentum = 1.0


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fix (work-around) for Sanity tests regression. A new test added in PR #45578 triggers a program hash collision. See issue #45821 for more details.

### Notes for reviewers
The workaround is by changing the input shape to avoid the collision

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/hash-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/hash-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/hash-collision)