### PR TITLE
Fix permute program cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.cpp
@@ -84,6 +84,24 @@ PermuteDeviceOperation::tensor_return_value_t PermuteDeviceOperation::create_out
     return create_device_tensor(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
+
+ttsl::hash::hash_t PermuteDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    const auto program_factory = select_program_factory(operation_attributes, tensor_args);
+
+    return tt::tt_metal::operation::hash_operation<PermuteDeviceOperation>(
+        operation_attributes.dims,
+        operation_attributes.output_mem_config,
+        operation_attributes.pad_value,
+        program_factory.index(),
+        input_tensor.tensor_spec(),
+        input_tensor.padded_shape(),
+        output_spec,
+        output_spec.padded_shape());
+}
+
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_device_operation.hpp
@@ -98,6 +98,7 @@ struct PermuteDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 };


### PR DESCRIPTION
## Summary

Add a custom `PermuteDeviceOperation::compute_program_hash` so permute program-cache entries include the shape and factory-specific state that affects descriptor/runtime-arg layout.

The hash now includes:

- permutation dims
- output memory config
- pad value
- selected program factory index
- input tensor spec and padded shape
- output tensor spec and padded shape

This prevents stale ProgramDescriptor cache hits from reusing an incompatible permute program and hitting missing runtime args.

## Regression tracking

The reported failure was `Sanity tests` run `26804028773`, job `79026657617`, on `main` at `d2d5adbe47f4b2c4e9c006269d8546cc74465ea0`:

https://github.com/tenstorrent/tt-metal/actions/runs/26804028773/job/79026657617

That commit only changed infra data collection, so it is not the functional culprit.

The first `main` Sanity run I found with the same `ttnn fused group 2 [wh_n300_civ2]` failure was run `26767258843` on `ef24b397822767d534b3ad19c4c83069953593cb`, merged on 2026-06-01 14:26 UTC via #45578:

https://github.com/tenstorrent/tt-metal/actions/runs/26767258843

#45578 added `test_batch_norm_aliased_running_and_affine_tensors`, which exposed the issue immediately. The previous `main` commit, `51fa6ab61e583961ae151efea1a6b7cce01915c8`, did not contain that test and its `ttnn fused group 2 [wh_n300_civ2]` job passed.

The underlying cache-key bug was likely latent since #45071, merged on 2026-05-25 15:39 UTC, when permute was moved to ProgramDescriptor.

## Failure mode

The CI failure and local repro hit:

```text
TT_FATAL: Index 0 is larger than runtime args size 0 at runtime_args_data.hpp:29
```

The failing pytest node was:

```text
tests/ttnn/unit_tests/operations/fused/test_batch_norm.py::test_batch_norm_aliased_running_and_affine_tensors
```

## Testing

Local verification after the fix:

```bash
cmake --build build -j 16
cmake --build build --target install -j 16
TT_METAL_OPERATION_TIMEOUT_SECONDS=5 PYTHONFAULTHANDLER=1 python3 -m pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv --splits 2 --group 2 --splitting-algorithm least_duration -m 'not disable_fast_runtime_mode'
```

Result:

```text
1618 passed, 272 skipped, 2267 deselected, 377 xfailed
```

Sanity tests are queued on this branch/SHA:

https://github.com/tenstorrent/tt-metal/actions/runs/26816414201

A stale queued Sanity run on the pre-amend SHA `9210451818e48dd8217d28fd6b8e58e4c10741d8` had cancellation submitted:

https://github.com/tenstorrent/tt-metal/actions/runs/26815549792

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-permute-program-cache-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-permute-program-cache-hash)