### PR TITLE
tests/quasar: registry-driven SFPU test infrastructure

### DIFF
--- a/SFPU_OPS.md
+++ b/SFPU_OPS.md
@@ -1,0 +1,209 @@
+# SFPU Op Coverage by Architecture
+
+Source: per-op wrapper files in `tt_metal/hw/ckernels/<arch>/metal/llk_api/llk_sfpu/llk_math_eltwise_{unary,binary,ternary}_sfpu_<op>.h`. Quasar's metal-API layer is skeletal, so the QSR column distinguishes:
+
+- `[x]` — metal-API wrapper present (op is fully wired)
+- `[~]` — per-op kernel only in `tt_metal/tt-llk/tt_llk_<arch>/common/inc/sfpu/ckernel_sfpu_<op>.h` (no metal wrapper). On WH/BH this means the kernel is callable directly via `ckernel::sfpu::_calculate_*_` but has no dedicated `llk_math_eltwise_*_sfpu_<op>.h` wrapper.
+- `[ ]` — not present
+
+WH/BH metal-API presence implies both the core LLK and the metal API are wired.
+
+Path conventions: LLK-layer kernels live under `tt_metal/tt-llk/tt_llk_<arch>/common/inc/sfpu/`. Metal-layer wrappers (and a parallel set of metal-layer `ckernel_sfpu_*.h` kernels — see line 179) live under `tt_metal/hw/ckernels/<arch>/metal/llk_api/llk_sfpu/`. Within this file the shorthand `common/inc/sfpu/` always refers to the LLK-layer path.
+
+Markers used on Quasar rows:
+- `†` — kernel lives in `tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/` (not `common/inc/sfpu/`)
+- `§` — present as a variant inside another kernel file (e.g. `lrelu`/`relu_min`/`relu_max` all in `ckernel_sfpu_relu.h`; `stochround` referenced only by enum + `llk_math_eltwise_unary_sfpu_common.h`, no dedicated kernel file)
+- `‡` — kernel exists in WH/BH `common/inc/sfpu/` but no dedicated metal-API wrapper (called via low-level `ckernel::sfpu::_calculate_*_`)
+
+---
+
+## Unary SFPU Ops
+
+| Op | WH | BH | QSR |
+|---|:--:|:--:|:--:|
+| abs | [x] | [x] | [~]† |
+| activations | [x] | [x] | [ ] |
+| add1 | [x] | [x] | [ ] |
+| alt_complex_rotate90 | [x] | [x] | [ ] |
+| binop_with_scalar | [x] | [x] | [ ] |
+| cast_fp32_to_fp16a | [x] | [x] | [ ] |
+| cbrt | [x] | [x] | [ ] |
+| clamp | [x] | [x] | [ ] |
+| cumsum | [x] | [x] | [ ] |
+| exp / exponential | [ ]‡ | [ ]‡ | [~] |
+| fill | [ ]‡ | [ ]‡ | [~]† |
+| exp2 | [x] | [x] | [ ] |
+| expm1 | [x] | [x] | [ ] |
+| gelu | [ ]‡ | [ ]‡ | [~] |
+| lrelu | [ ] | [ ] | [~]§ |
+| hardmish | [x] | [x] | [ ] |
+| hardtanh | [x] | [x] | [ ] |
+| heaviside | [x] | [x] | [ ] |
+| log | [x] | [x] | [ ] |
+| mask | [x] | [x] | [ ] |
+| max_min | [x] | [x] | [ ] |
+| power | [x] | [x] | [ ] |
+| rdiv | [x] | [x] | [ ] |
+| recip / reciprocal | [ ]‡ | [ ]‡ | [~] |
+| reduce | [x] | [x] | [ ] |
+| relu | [ ]‡ | [ ]‡ | [~] |
+| relu_min | [ ] | [ ] | [~]§ |
+| relu_max | [ ] | [ ] | [~]§ |
+| reshuffle_rows | [x] | [x] | [ ] |
+| rpow | [x] | [x] | [ ] |
+| rsqrt | [x] | [x] | [~] |
+| rsub_int32 | [x] | [x] | [ ] |
+| selu | [x] | [x] | [ ] |
+| sigmoid | [x] | [x] | [x] |
+| sigmoid_appx | [x] | [x] | [ ] |
+| sign | [x] | [x] | [ ] |
+| signbit | [x] | [x] | [ ] |
+| silu | [x] | [x] | [x] |
+| sqrt | [ ]‡ | [ ]‡ | [~] |
+| square | [x] | [x] | [~] |
+| stochround | [ ] | [ ] | [ ]§ |
+| swiglu | [ ] | [ ] | [~]† |
+| tanh | [x] | [x] | [~] |
+| tanh_derivative | [x] | [x] | [ ] |
+| threshold | [x] | [x] | [ ] |
+| tiled_prod | [x] | [x] | [ ] |
+| topk | [x] | [x] | [ ] |
+| typecast | [x] | [x] | [~] |
+| where (unary on QSR) | — | — | [~]† |
+
+---
+
+## Binary SFPU Ops
+
+| Op | WH | BH | QSR |
+|---|:--:|:--:|:--:|
+| add | [ ] | [ ] | [~] |
+| add_int | [x] | [x] | [ ] |
+| add_top_row | [x] | [x] | [ ] |
+| atan2 | [x] | [x] | [ ] |
+| binary_bcast | [x] | [x] | [ ] |
+| binary_comp | [x] | [x] | [ ] |
+| binary_fmod | [x] | [x] | [ ] |
+| binary_pow | [x] | [x] | [ ] |
+| binary_remainder | [x] | [x] | [ ] |
+| binop | [x] | [x] | [ ] |
+| bitwise | [x] | [x] | [ ] |
+| copy_dest_values | [x] | [x] | [ ] |
+| div_int32 | [x] | [x] | [ ] |
+| div_int32_floor | [x] | [x] | [ ] |
+| gcd | [x] | [x] | [ ] |
+| lcm | [x] | [x] | [ ] |
+| logsigmoid | [x] | [x] | [ ] |
+| max_min | [x] | [x] | [ ] |
+| max_pool_indices | [x] | [x] | [ ] |
+| mul_int | [x] | [x] | [ ] |
+| mul_int32 | [ ] | [x] | [ ] |
+| quant | [x] | [x] | [ ] |
+| rsub_int | [x] | [x] | [ ] |
+| shift | [x] | [x] | [ ] |
+| sub_int | [x] | [x] | [ ] |
+| xlogy | [x] | [x] | [ ] |
+
+---
+
+## Ternary SFPU Ops
+
+| Op | WH | BH | QSR |
+|---|:--:|:--:|:--:|
+| addcdiv | [x] | [x] | [ ] |
+| addcmul | [x] | [x] | [ ] |
+| lerp | [x] | [x] | [ ] |
+| where (ternary on WH/BH) | [x] | [x] | — |
+
+---
+
+---
+
+## Other SFPU Categories (outside unary/binary/ternary)
+
+These wrappers don't follow the `llk_math_eltwise_{unary,binary,ternary}_sfpu_*` pattern, so they aren't in the tables above. All exist on WH+BH; none on QSR yet.
+
+### Welford's (multi-tile mean/variance reduction)
+
+Dedicated scaffolding in core LLK: `tt_llk_<arch>/llk_lib/llk_math_welfords_sfpu.h` + `..._params.h`. Metal wrapper: `llk_math_welfords_sfpu_entry.h`. APIs: `_init`, `_clear_previous_mean_and_m2`, `_reinit`, `_calculate_welfords_tile_`, `_calculate_welfords_partial_tile_`, `_store_mean_m2_to_dst`, `_load_mean_m2_from_dst`, `_store_mean_var_to_dst_row`, `_store_mean_var_to_dst_raw`.
+
+| Op | WH | BH | QSR |
+|---|:--:|:--:|:--:|
+| welfords | [x] | [x] | [ ] |
+
+### EMA (exponential moving average)
+
+Metal wrapper only: `llk_math_ema_sfpu_entry.h`. Internally piggybacks on the ternary scaffolding (`_llk_math_eltwise_ternary_sfpu_init_<SfpuType::unused>()`). APIs: `_init`, `_load_alpha_beta`, `_clear_previous_output`, `_tile`.
+
+| Op | WH | BH | QSR |
+|---|:--:|:--:|:--:|
+| ema | [x] | [x] | [ ] |
+
+### lgamma / polygamma (mixed-arity bundles)
+
+Use the arity-less wrapper file `llk_math_eltwise_sfpu_{lgamma,polygamma}.h` — they expose entry points across multiple arity classes:
+
+| Op variant | Arity | WH | BH | QSR |
+|---|---|:--:|:--:|:--:|
+| lgamma_stirling (unary) | unary | [x] | [x] | [ ] |
+| lgamma_stirling (binary) | binary | [x] | [x] | [ ] |
+| lgamma_adjusted | ternary | [x] | [x] | [ ] |
+| polygamma | unary | [x] | [x] | [ ] |
+
+---
+
+## Wrappers That Bundle Multiple Op Variants
+
+Several wrappers in the main tables expose more than one entry point. Open the file to see the full set; here are the notable bundles:
+
+| Wrapper | Family | Variants exposed |
+|---|---|---|
+| `max_min` | unary | `unary_max`, `unary_min`, `unary_{max,min}_int32`, `unary_{max,min}_uint32` |
+| `max_min` | binary | `binary_max`, `binary_min`, `binary_{max,min}_int32`, `binary_{max,min}_uint32` |
+| `binary_comp` | binary | `eq_fp32`, `ne_fp32`, `lt_fp32`, `le_fp32`, `gt_fp32`, `ge_fp32`, `lt_int`, `le_int`, `gt_int`, `ge_int` |
+| `binop` | binary | `binop`, `binop_mul`, `binop_div` |
+| `binary_bcast` | binary | `add_bcast_{row,col}`, `mul_bcast_{row,col}`, `sub_bcast_{row,col}` |
+| `quant` | binary | `quant_int32`, `requant_int32`, `dequant_int32` |
+| `shift` | binary | `left_shift`, `right_shift`, `logical_right_shift` |
+| `binary_fmod` | binary | `binary_fmod`, `fmod_int32` |
+| `binary_remainder` | binary | `binary_remainder`, `remainder_int32` |
+| `div_int32` | binary | `div_int32`, `div_int32_trunc` |
+| `binop_with_scalar` | unary | `binop_with_scalar`, `binop_with_scalar_{add,sub}_int32` |
+| `abs` | unary | `abs`, `abs_int32` |
+| `clamp` | unary | `clamp`, `clamp_int32` |
+| `mask` | unary | `mask`, `mask_posinf` |
+| `log` | unary | `log`, `log_with_base` |
+| `power` | unary | `power`, `power_iterative` |
+| `signbit` | unary | `signbit`, `signbit_int32` |
+| `topk` | unary | `topk_local_sort`, `topk_merge`, `topk_rebuild` |
+| `activations` | unary | `celu`, `hardshrink`, `hardsigmoid`, `softshrink`, `softsign` |
+
+Additional kernels exist with no dedicated `llk_math_eltwise_*_sfpu_<op>.h` wrapper — callers reach them through low-level `ckernel::sfpu::_calculate_*_` directly. These split across two paths:
+
+- **LLK-layer kernels** in `tt_metal/tt-llk/tt_llk_<arch>/common/inc/sfpu/`: `elu`, `dropout`, `trigonometry` (plus the `[ ]‡` and `[~]‡` ops marked in the tables above).
+- **Metal-layer kernels** in `tt_metal/hw/ckernels/<arch>/metal/llk_api/llk_sfpu/ckernel_sfpu_<op>.h` (same directory as the wrappers, but no matching wrapper file): `prelu`, `xielu`, `softplus`, `softshrink`, `softsign`, `hardshrink`, `digamma`, `i0`, `i1`, `erf`, `erfc`, `erfinv`, `log1p`, `identity`, `sqrt_custom`, `rand`, `conversions`, `piecewise_rational`, `celu`, `int_sum`, `logical_not`, `unary_comp`, `unary_max_min`, `unary_power`, `binary_max_min`, `binop_with_unary`, `bitwise_{and,not,or,xor}`, `fmod`, `remainder`, `left_shift`, `right_shift`, `mul_int32` (WH only — BH has a wrapper). Some of these (`celu`, `softshrink`, `softsign`, `hardshrink`) are also exposed through the `activations` bundle; the rest are reachable only via the low-level path.
+
+Quasar has a parallel metal-layer kernel directory at `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/` containing `ckernel_sfpu_{relu,sigmoid,silu}.h` (alongside the `sigmoid`/`silu` wrappers).
+
+---
+
+## Summary
+
+| Family | WH | BH | QSR (wrapped) | QSR (kernel only) |
+|---|:--:|:--:|:--:|:--:|
+| Unary | 37 | 37 | 2 | 15 |
+| Binary | 24 | 25 | 0 | 1 |
+| Ternary | 4 | 4 | 0 | 0 (no scaffolding at all) |
+
+Notes (verified by grep on 2026-05-18):
+
+- BH-only delta: `binary/mul_int32` (WH has `mul_int` but not `mul_int32` as a separate wrapper).
+- Quasar wrapped ops (`sigmoid`, `silu`) live at `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/`.
+- Quasar kernel-only ops in `tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/`: `add` (binary), `exp`, `gelu`, `recip`, `relu`, `rsqrt`, `sigmoid`, `silu`, `sqrt`, `square`, `tanh`, `typecast_fp16b_uint16`, `typecast_int32_fp32`. Plus relu variants `lrelu`/`relu_min`/`relu_max` colocated in `ckernel_sfpu_relu.h`.
+- Quasar **experimental** kernels in `tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/`: `abs`, `fill`, `swiglu`, `where`. All four Quasar SFPU tests (`sfpu_abs_quasar_test.cpp`, `sfpu_fill_quasar_test.cpp`, `sfpu_swiglu_quasar_test.cpp`, `sfpu_where_quasar_test.cpp`) include from `experimental/` and route through `llk_math_eltwise_unary_sfpu_common.h` — so all four are **unary** on Quasar.
+- **`where` arity differs by arch**: ternary on WH/BH (`SfpuType::where` via `llk_math_eltwise_ternary_sfpu_where.h`), unary on Quasar (`experimental/ckernel_sfpu_where.h` via unary scaffolding).
+- **No ternary scaffolding on Quasar**: `find tt_metal/tt-llk/tt_llk_quasar -name 'llk_math_eltwise_ternary*'` returns nothing. Only `llk_math_eltwise_unary_sfpu_common.h` and `llk_math_eltwise_binary_sfpu.h` exist.
+- **Quasar uses non-templated init**: tests call `_llk_math_eltwise_unary_sfpu_init_()` and `_llk_math_eltwise_binary_sfpu_init_()` without an `<SfpuType::X>` template argument (unlike WH/BH). Grep for `_llk_math_eltwise_*_sfpu_init_<SfpuType::` against Quasar paths returns zero matches.
+- Quasar `SfpuType` enum (`tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h:74-96`) — 20 enumerators verified verbatim: `tanh, gelu, exponential, reciprocal, sqrt, rsqrt, relu, lrelu, relu_min, relu_max, stochround, typecast, add, square, sigmoid, silu, abs, fill, swiglu, where`. Note: `exponential` (not `exp`), `reciprocal` (not `recip`).
+- Active `SfpuType::X` template uses across Quasar code (grep tally): `gelu`(5), `silu`(4), `sigmoid`(4), `tanh`(3), `sqrt`(3), `relu`(3), `reciprocal`(3), `exponential`(3). Everything else (`abs`, `where`, `fill`, `swiglu`, `add`, `square`, `typecast`, `lrelu`, `relu_min`, `relu_max`, `stochround`) is referenced only in the enum or scaffolding — not in any concrete dispatch site.
+- Quasar `BinaryOp` enum (`tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h:98-103`) only has `ADD`, `SUB`, `MUL`. WH/BH `BinaryOp` (`tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h:244-257`) also has `DIV`, `RSUB`, `POW`, `XLOGY`, `RSHFT`, `LSHFT`, `LOGICAL_RSHFT`, `ADD_TOP_ROW`.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -632,6 +632,30 @@ def create_formats_for_testing(formats: List[Tuple[DataFormat]]) -> List[FormatC
     return format_configs
 
 
+class BinaryFormatConfig(FormatConfig):
+    @property
+    def input_a_format(self) -> DataFormat:
+        return self.unpack_A_src
+
+    @property
+    def input_b_format(self) -> DataFormat:
+        return self.unpack_B_src
+
+
+class TernaryFormatConfig(FormatConfig):
+    @property
+    def input_a_format(self) -> DataFormat:
+        return self.unpack_A_src
+
+    @property
+    def input_b_format(self) -> DataFormat:
+        return self.unpack_B_src
+
+    @property
+    def input_c_format(self) -> DataFormat:
+        return self.unpack_S_src
+
+
 def is_dest_acc_needed(format: InputOutputFormat) -> bool:
     """
     This function is called when a format configuration for input and output is called without dest accumulation.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3165,3 +3165,98 @@ class WhereGolden:
         cond = operand1.flatten().to(torch.float32)
         mask = cond != 0.0
         return torch.where(mask, true_value.flatten(), false_value.flatten())
+
+
+@register_golden
+class TernarySFPUGolden:
+    """Golden for ternary SFPU ops.
+
+    Mirrors BinarySFPUGolden: dispatch on the MathOperation and operate on tiles
+    within a single flat (tilized) tensor. Operands live at tile indices
+    src1/src2/src3; the result is written to dst_idx and the full tensor returned
+    (callers slice the dst tile)."""
+
+    def __init__(self):
+        self.ops = {
+            MathOperation.SfpuWhere: self._where,
+        }
+
+    def _where(self, cond, true_value, false_value):
+        # result = (cond == 0) ? false_value : true_value  (C++ sfpu_ternary_function)
+        mask = cond.to(torch.float32) != 0.0
+        return torch.where(mask, true_value, false_value)
+
+    def __call__(
+        self,
+        operation: MathOperation,
+        tensor,
+        src1_idx: int,
+        src2_idx: int,
+        src3_idx: int,
+        dst_idx: int,
+        num_iterations: int,
+        dimensions: tuple[int, int],
+        data_format: DataFormat,
+        skip_tilize: bool = False,
+        input_format: DataFormat = None,
+    ):
+        if operation not in self.ops:
+            raise ValueError(f"Unsupported ternary SFPU operation: {operation}")
+
+        if num_iterations < 1:
+            raise ValueError(f"num_iterations must be at least 1, got {num_iterations}")
+
+        if input_format is not None and input_format.is_mx_format():
+            tensor = quantize_mx_tensor_chunked(tensor, input_format)
+
+        total_elements = dimensions[0] * dimensions[1]
+        elements_per_tile = ELEMENTS_PER_TILE
+        elements_per_row = 32
+        num_tiles = total_elements // elements_per_tile
+
+        if not skip_tilize and data_format not in (
+            DataFormat.Bfp8_b,
+            DataFormat.Bfp4_b,
+        ):
+            result = tilize_block(tensor.flatten(), dimensions, data_format).flatten()
+        else:
+            result = tensor.flatten().clone()
+
+        for name, idx in [
+            ("src1_idx", src1_idx),
+            ("src2_idx", src2_idx),
+            ("src3_idx", src3_idx),
+            ("dst_idx", dst_idx),
+        ]:
+            if not 0 <= idx < num_tiles:
+                raise ValueError(
+                    f"{name} {idx} is out of bounds. Tensor has {num_tiles} tiles."
+                )
+
+        elements_to_process = num_iterations * elements_per_row
+        src1_start = src1_idx * elements_per_tile
+        src2_start = src2_idx * elements_per_tile
+        src3_start = src3_idx * elements_per_tile
+        dst_start = dst_idx * elements_per_tile
+
+        for name, start in [
+            ("src1_idx", src1_start),
+            ("src2_idx", src2_start),
+            ("src3_idx", src3_start),
+            ("dst_idx", dst_start),
+        ]:
+            if start + elements_to_process > total_elements:
+                raise ValueError(
+                    f"Processing {num_iterations} iterations from {name} "
+                    f"would exceed tensor bounds (trying to access element "
+                    f"{start + elements_to_process}, but tensor has only "
+                    f"{total_elements} elements)"
+                )
+
+        cond = result[src1_start : src1_start + elements_to_process]
+        true_value = result[src2_start : src2_start + elements_to_process]
+        false_value = result[src3_start : src3_start + elements_to_process]
+        result[dst_start : dst_start + elements_to_process] = self.ops[operation](
+            cond, true_value, false_value
+        )
+        return result

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -5,7 +5,7 @@
 import math
 from abc import ABC, abstractmethod
 from ctypes import c_uint32
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .format_config import DataFormat
 from .golden_generators import TILE_DIMENSIONS
@@ -138,6 +138,35 @@ class SFPU_INT_OP(TemplateParameter):
         if self.op:
             return f"#define SFPU_INT_OP_{self.op.upper()}"
         return ""
+
+
+@dataclass
+class SFPU_DEFINES(TemplateParameter):
+    """Emit the per-op SFPU dispatch #defines consumed by sources/quasar/sfpu_test.cpp.
+
+    Emits the arity selector (SFPU_UNARY_OP / SFPU_BINARY_OP / SFPU_TERNARY_OP), the
+    op include header (SFPU_INCLUDE_HEADER), and one #define per entry of the op's
+    dispatch-defines dict (e.g. SFPU_OP_CALL, SFPU_TYPE, SFPU_INIT,
+    SFPU_ADDITIONAL_ARGS). A None or "" value emits a bare #define (a presence-only
+    macro), so e.g. SFPU_INIT / SFPU_ADDITIONAL_ARGS expand to nothing when an op
+    supplies no init statement or extra trailing args.
+    """
+
+    arity_macro: str
+    include_header: str
+    defines: dict = field(default_factory=dict)
+
+    def convert_to_cpp(self) -> str:
+        lines = [
+            f"#define {self.arity_macro}",
+            f'#define SFPU_INCLUDE_HEADER "{self.include_header}"',
+        ]
+        for key, value in self.defines.items():
+            if value is None or value == "":
+                lines.append(f"#define {key}")
+            else:
+                lines.append(f"#define {key} {value}")
+        return "\n".join(lines)
 
 
 def _generate_operation_constants(mathop: MathOperation) -> list[str]:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/__init__.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/__init__.py
@@ -7,7 +7,18 @@ from .binary._spec import BinaryOpSpec
 from .ternary._spec import TernaryOpSpec
 from .unary._spec import UnaryOpSpec
 
-_INC_ROOT = Path(__file__).resolve().parents[3] / "tt_llk_quasar" / "common" / "inc"
+# Roots an SFPU op header may live under, matching the compiler -I paths: the LLK
+# common tree, and tt-metal's quasar llk_api (where the sfpi float ops live, e.g.
+# "llk_sfpu/ckernel_sfpu_binary.h").
+_INC_ROOTS = [
+    Path(__file__).resolve().parents[4] / "tt_llk_quasar" / "common" / "inc",
+    Path(__file__).resolve().parents[5]
+    / "hw"
+    / "ckernels"
+    / "quasar"
+    / "metal"
+    / "llk_api",
+]
 
 
 def _discover(package_name: str, spec_type: Type) -> List:
@@ -24,9 +35,9 @@ def _discover(package_name: str, spec_type: Type) -> List:
             raise TypeError(
                 f"{module.__name__} SPEC must be {spec_type.__name__}, got {type(spec).__name__}"
             )
-        if not (_INC_ROOT / spec.header).is_file():
+        if not any((root / spec.include_header).is_file() for root in _INC_ROOTS):
             raise FileNotFoundError(
-                f"{spec.name} header not found: tt_llk_quasar/common/inc/{spec.header}"
+                f"{spec.name} header not found on any SFPU include root: {spec.include_header}"
             )
         specs.append(spec)
     specs.sort(key=lambda s: s.name)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/__init__.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/__init__.py
@@ -1,0 +1,38 @@
+import importlib
+import pkgutil
+from pathlib import Path
+from typing import List, Type
+
+from .binary._spec import BinaryOpSpec
+from .ternary._spec import TernaryOpSpec
+from .unary._spec import UnaryOpSpec
+
+_INC_ROOT = Path(__file__).resolve().parents[3] / "tt_llk_quasar" / "common" / "inc"
+
+
+def _discover(package_name: str, spec_type: Type) -> List:
+    pkg = importlib.import_module(package_name)
+    specs = []
+    for module_info in pkgutil.iter_modules(pkg.__path__):
+        if module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{package_name}.{module_info.name}")
+        spec = getattr(module, "SPEC", None)
+        if spec is None:
+            raise ImportError(f"{module.__name__} missing SPEC")
+        if not isinstance(spec, spec_type):
+            raise TypeError(
+                f"{module.__name__} SPEC must be {spec_type.__name__}, got {type(spec).__name__}"
+            )
+        if not (_INC_ROOT / spec.header).is_file():
+            raise FileNotFoundError(
+                f"{spec.name} header not found: tt_llk_quasar/common/inc/{spec.header}"
+            )
+        specs.append(spec)
+    specs.sort(key=lambda s: s.name)
+    return specs
+
+
+UNARY_OP_REGISTRY = _discover(f"{__name__}.unary", UnaryOpSpec)
+BINARY_OP_REGISTRY = _discover(f"{__name__}.binary", BinaryOpSpec)
+TERNARY_OP_REGISTRY = _discover(f"{__name__}.ternary", TernaryOpSpec)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_spec.py
@@ -10,11 +10,105 @@ DispatchDefinesFn = Callable[[FormatConfig], dict]
 
 @dataclass
 class BaseOpSpec:
+    """Declarative description of one SFPU op for the registry-driven test.
+
+    HOW TO ADD AN OP
+    ----------------
+    Drop a module under ``quasar/sfpu/{unary,binary,ternary}/`` that defines a
+    module-level ``SPEC = <Unary|Binary|Ternary>OpSpec(...)``. It is auto-discovered
+    (see ``quasar/sfpu/__init__.py``) and ``quasar/test_sfpu.py`` sweeps it across the
+    valid (format, dest_acc) combinations and runs it through the shared C++ skeleton
+    ``sources/quasar/sfpu_test.cpp``. For the common case (a plain elementwise op with
+    a standard golden) you write *only* the spec — no new test or kernel code.
+
+    The skeleton gathers operands from DEST tiles 0/1/2 and writes the result to tile
+    0; you describe the op via the fields below.
+
+    FIELDS
+    ------
+    name : str
+        Unique short name; shows up in the pytest variant id.
+
+    math_op : MathOperation
+        The op's MathOperation. Selects the default golden — UnarySFPUGolden /
+        BinarySFPUGolden / TernarySFPUGolden keyed on this op — unless ``golden`` is set.
+
+    include_header : str
+        The op's C++ header, as written in an ``#include``, relative to either the LLK
+        common tree or tt-metal's quasar llk_api (both are on the compiler's -I path):
+          - "sfpu/ckernel_sfpu_square.h"        (LLK common/inc)
+          - "llk_sfpu/ckernel_sfpu_binary.h"    (metal llk_api, the sfpi float ops)
+        Discovery verifies the file exists under one of those roots.
+
+    sfpu_defines : (FormatConfig) -> dict
+        Returns the per-op ``#define``s emitted into the build header. Always set:
+          SFPU_OP_CALL         - the ckernel::sfpu callable to dispatch, e.g.
+                                 "ckernel::sfpu::_calculate_square_" (template args and
+                                 build-time constants like is_fp32_dest_acc_en are fine).
+        Optional keys:
+          SFPU_INIT            - a statement run once before the op call, e.g.
+                                 "ckernel::sfpu::_init_gelu_();" (ops needing setup).
+          SFPU_ADDITIONAL_ARGS - extra trailing args appended to the op call, WITH a
+                                 leading comma, e.g. ", 2.0f".
+          SFPU_TYPE            - SfpuType for ops whose init is templated on it
+                                 (ternary init only, e.g. "ckernel::SfpuType::where").
+          SFPU_BINARY_OPERANDS - override the default binary operand indices "0u, 1u, 0u"
+                                 for ops that index by element OFFSET rather than tile
+                                 index, e.g. "0, tile_stride, 0" (the int ops). ``tile_stride``
+                                 is a kernel-local for these to reference.
+        It takes the FormatConfig so the defines can vary by format if ever needed.
+
+    extra_templates : list[TemplateParameter]
+        Extra build-time template params to emit (e.g. ternary's VECTOR_MODE face
+        selector, or a format-baked constexpr the op needs). Spliced into the variant's
+        templates. Give a TemplateParameter a list-valued field to SWEEP it: the driver
+        expands the cross product into separate variants (one pytest id each), e.g.
+        ``VECTOR_MODE([VectorMode.RC, VectorMode.R])`` runs two variants. Sweeping is
+        wired for the ternary arity (the only one whose dispatch consumes such a param
+        today); a swept axis that changes the result needs a matching ``golden`` hook.
+
+    stimuli : StimuliSpec | None
+        Overrides the driver's default per-dtype input range. Use when the op needs a
+        specific domain (e.g. sqrt: positive only; divide: bounded away from zero).
+
+    prepare : Callable | None
+        Post-processes the generated stimulus tensor BEFORE it is used (for both the
+        golden and the device), returning the modified tensor. Use to inject operand
+        lanes a random range can't hit (e.g. divide's 0/0 -> NaN, x/0 -> +/-Inf).
+        Signature (keyword-only):
+            prepare(src, *, src_tiles) -> Tensor
+        where ``src_tiles`` is the tuple of DEST tile indices the operands occupy for
+        this variant — (0,) for unary, (src0, src1) for binary (these vary with the
+        tile-layout sweep), (0, 1, 2) for ternary. A tile is 1024 elements; index into
+        ``src.flatten()`` as ``tile * 1024 + lane``.
+
+    golden : Callable | None
+        Overrides the default math_op-keyed golden. Use for ops whose reference isn't
+        ``<Arity>SFPUGolden(math_op)`` — fused ops (e.g. swiglu) or ops needing a scalar
+        the standard generator doesn't take. Signature (keyword-only):
+            golden(*, src, io, dest_acc, dimensions) -> Tensor
+        where ``src`` is the prepared stimulus tensor, ``io`` the InputOutputFormat,
+        ``dest_acc`` the DestAccumulation, ``dimensions`` the [rows, cols] input dims.
+        Return the flat, output-format golden for the packed result (one result tile for
+        binary/ternary; the transformed tiles for unary).
+
+    verify : Callable | None
+        Optional extra assertion run on the packed result AFTER the tolerance-based
+        golden comparison. Use for op-specific exactness checks tolerance can't express
+        (e.g. divide forces x/x to a bit-exact 1.0). Signature (keyword-only):
+            verify(res_tensor, *, io) -> None
+        Raise AssertionError on failure; the return value is ignored.
+    """
+
     name: str
     math_op: MathOperation
-    header: str
+    include_header: str
     sfpu_defines: DispatchDefinesFn
     extra_templates: List[TemplateParameter] = field(default_factory=list)
+    stimuli: object = None
+    prepare: object = None
+    golden: object = None
+    verify: object = None
 
     def __post_init__(self):
         if type(self) is BaseOpSpec:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_spec.py
@@ -1,0 +1,23 @@
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from helpers.format_config import FormatConfig, List
+from helpers.llk_params import MathOperation
+from helpers.test_variant_parameters import TemplateParameter
+
+DispatchDefinesFn = Callable[[FormatConfig], dict]
+
+
+@dataclass
+class BaseOpSpec:
+    name: str
+    math_op: MathOperation
+    header: str
+    sfpu_defines: DispatchDefinesFn
+    extra_templates: List[TemplateParameter] = field(default_factory=list)
+
+    def __post_init__(self):
+        if type(self) is BaseOpSpec:
+            raise TypeError(
+                "BaseOpSpec is not a concrete implementation; use a subclass"
+            )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/_utils.py
@@ -1,0 +1,31 @@
+import itertools
+from dataclasses import fields, replace
+from typing import Iterator, List, Tuple
+
+from helpers.test_variant_parameters import TemplateParameter
+
+
+def _expand_one(tp: TemplateParameter) -> Iterator[TemplateParameter]:
+    """One TemplateParameter -> N TemplateParameters by exploding any list-valued
+    fields. Scalar fields pass through. The TemplateParameter dataclass field
+    types stay scalar; lists are tolerated at runtime as a spec-author shortcut."""
+    list_fields = [f for f in fields(tp) if isinstance(getattr(tp, f.name), list)]
+    if not list_fields:
+        yield tp
+        return
+    value_lists = [getattr(tp, f.name) for f in list_fields]
+    for combo in itertools.product(*value_lists):
+        yield replace(tp, **{f.name: v for f, v in zip(list_fields, combo)})
+
+
+def expand_extra_templates(
+    extras: List[TemplateParameter],
+) -> List[Tuple[TemplateParameter, ...]]:
+    """Return one tuple of fully-resolved (scalar-field) TemplateParameter
+    instances per cross-axis combination. Empty input -> [()]; the driver
+    splices the tuple into TestConfig.templates so a no-extras spec emits
+    nothing extra."""
+    if not extras:
+        return [()]
+    axes = [list(_expand_one(t)) for t in extras]
+    return [tuple(combo) for combo in itertools.product(*axes)]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/_spec.py
@@ -1,6 +1,6 @@
 import itertools
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Tuple
 
 from helpers.format_config import DataFormat
 
@@ -28,3 +28,69 @@ def binary_input_output_formats(
 @dataclass(kw_only=True)
 class BinaryOpSpec(BaseOpSpec):
     formats: List[BinaryInputOutputFormat]
+    # DEST tile-layout sweep: each entry is (src0_tile, src1_tile, dst_tile) and
+    # the driver places operands / packs the result accordingly (emitting
+    # SFPU_BINARY_OPERANDS and DST_INDEX per layout). Use for ops that index by
+    # tile (the sfpi float ops) to cover result-over-operand aliasing. Leave None
+    # for offset-style ops (the Int32 ops) that place operands themselves via their
+    # own SFPU_BINARY_OPERANDS define; those run a single layout (tiles 0/1 -> 0).
+    tile_layouts: Optional[List[Tuple[int, int, int]]] = None
+    arity_macro: str = "SFPU_BINARY_OP"
+
+
+# Float formats shared by the sfpi binary ops.
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+# DEST tile layouts (src0, src1, dst) covering result-over-operand aliasing: result
+# written back over the dividend tile, over the divisor tile, and to a separate tile
+# with both operand offsets non-zero.
+_FLOAT_TILE_LAYOUTS = [(0, 1, 0), (0, 1, 1), (2, 3, 0)]
+
+
+def float_binary_op_spec(
+    *,
+    name,
+    math_op,
+    binop,
+    stimuli,
+    prepare=None,
+    verify=None,
+    tile_layouts=_FLOAT_TILE_LAYOUTS,
+):
+    """Build a BinaryOpSpec for an sfpi float binary op (``calculate_sfpu_binary``).
+
+    ``binop`` is the ``ckernel::BinaryOp`` enum name ("MUL" / "DIV"). These ops
+    index by tile, are templated on the build's ``is_fp32_dest_acc_en``, and need an
+    op-specific init call. They sweep the full input x output float-format matrix.
+
+    ``tile_layouts`` controls the DEST tile-layout sweep and defaults to the full
+    aliasing set (``_FLOAT_TILE_LAYOUTS``). Ops that don't need the extra coverage can
+    pass a shorter list or ``None`` (single default layout: operands at tiles 0/1,
+    result to tile 0). ``prepare`` / ``verify`` are optional hooks (see BaseOpSpec)."""
+    op = (
+        f"ckernel::sfpu::calculate_sfpu_binary<false, ckernel::BinaryOp::{binop}, "
+        "is_fp32_dest_acc_en>"
+    )
+    init = f"ckernel::sfpu::sfpu_binary_init<false, ckernel::BinaryOp::{binop}>();"
+    return BinaryOpSpec(
+        name=name,
+        math_op=math_op,
+        include_header="llk_sfpu/ckernel_sfpu_binary.h",
+        # Tile-index ops: the driver supplies SFPU_BINARY_OPERANDS per tile layout,
+        # so only the op call and its init are declared here.
+        sfpu_defines=lambda formats: {
+            "SFPU_OP_CALL": op,
+            "SFPU_INIT": init,
+        },
+        # Operands share a format (the driver feeds io.input_format to both), so sweep
+        # the full input x output matrix with input_a == input_b.
+        formats=[
+            BinaryInputOutputFormat(i, i, o)
+            for i in _FLOAT_FORMATS
+            for o in _FLOAT_FORMATS
+        ],
+        tile_layouts=tile_layouts,
+        stimuli=stimuli,
+        prepare=prepare,
+        verify=verify,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/_spec.py
@@ -1,0 +1,30 @@
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+from helpers.format_config import DataFormat
+
+from .._spec import BaseOpSpec
+
+
+@dataclass(frozen=True)
+class BinaryInputOutputFormat:
+    input_a_format: DataFormat
+    input_b_format: DataFormat
+    output_format: DataFormat
+
+
+def binary_input_output_formats(
+    inputs_a: List[DataFormat],
+    inputs_b: List[DataFormat],
+    outputs: List[DataFormat],
+) -> List[BinaryInputOutputFormat]:
+    return [
+        BinaryInputOutputFormat(a, b, o)
+        for a, b, o in itertools.product(inputs_a, inputs_b, outputs)
+    ]
+
+
+@dataclass(kw_only=True)
+class BinaryOpSpec(BaseOpSpec):
+    formats: List[BinaryInputOutputFormat]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/add_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/add_int32.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _add_int32_defines(_: FormatConfig) -> dict:
+    # _add_int_<false,8,0,false>(DataFormat src_format, int num_iter, in0, in1, out).
+    # Wrap in a capturing lambda so src_format (a runtime variable in the kernel
+    # scope) is forwarded via capture; the lambda signature matches the binary
+    # dispatch: (num_sfpu_iterations, in0_off, in1_off, out_off).
+    return {
+        "SFPU_INIT": (
+            "const auto _add_fn = [src_format](int n, int in0, int in1, int out) "
+            "{ ckernel::sfpu::_add_int_<false, 8, 0, false>(src_format, n, in0, in1, out); };"
+        ),
+        "SFPU_OP_CALL": "_add_fn",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="add_int32",
+    math_op=MathOperation.SfpuElwadd,
+    include_header="sfpu/ckernel_sfpu_add.h",
+    sfpu_defines=_add_int32_defines,
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/div.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/div.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import float_binary_op_spec
+
+_ELEMENTS_PER_TILE = 1024
+
+# Crafted lanes exercising the divide special-case branches a random sweep can't
+# hit: (lane, dividend, divisor). 0/0 -> NaN, x/0 -> +/-Inf, x/x -> 1.0; the golden +
+# passed_test already treat NaN==NaN and matching +/-Inf as passing.
+_SPECIAL_CASE_LANES = [
+    (0, 0.0, 0.0),  # 0/0   -> NaN
+    (1, 1.5, 0.0),  # +x/0  -> +Inf
+    (2, -1.5, 0.0),  # -x/0  -> -Inf
+    (3, 2.7, 2.7),  # x/x   -> 1.0
+    (4, -3.3, -3.3),  # x/x   -> 1.0
+]
+# Lanes whose x/x result the kernel forces to a bit-exact 1.0 (see _verify_exact_ones).
+_EXACT_ONE_LANES = [3, 4]
+
+
+def _inject_special_cases(src, *, src_tiles):
+    """Overwrite the first few lanes of the dividend and divisor tiles with crafted
+    operand pairs so the special-case branches are exercised. ``src_tiles`` is the
+    (dividend_tile, divisor_tile) pair for the variant's tile layout."""
+    dividend_tile, divisor_tile = src_tiles
+    flat = src.flatten().clone()
+    for lane, dividend, divisor in _SPECIAL_CASE_LANES:
+        flat[dividend_tile * _ELEMENTS_PER_TILE + lane] = dividend
+        flat[divisor_tile * _ELEMENTS_PER_TILE + lane] = divisor
+    return flat.reshape(src.shape)
+
+
+def _verify_exact_ones(res_tensor, *, io):
+    """The kernel's x/x branch forces an exact 1.0 regardless of reciprocal rounding,
+    so check those result lanes bit-exact rather than relying on isclose tolerance."""
+    for lane in _EXACT_ONE_LANES:
+        actual = res_tensor[lane].item()
+        assert (
+            actual == 1.0
+        ), f"x/x special case at lane {lane}: expected exact 1.0, got {actual}"
+
+
+SPEC = float_binary_op_spec(
+    name="div",
+    math_op=MathOperation.SfpuElwdiv,
+    binop="DIV",
+    # Bulk operands bounded away from zero so the reciprocal + Newton-Raphson path
+    # stays well-defined; the special-case lanes below cover 0/0 and x/0 explicitly.
+    stimuli=StimuliSpec.uniform(low=0.25, high=4.0),
+    prepare=_inject_special_cases,
+    verify=_verify_exact_ones,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/ge_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/ge_int32.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _ge_int32_defines(_: FormatConfig) -> dict:
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::calculate_binary_comp_int32<false, 8, ckernel::SfpuType::ge>",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="ge_int32",
+    math_op=MathOperation.SfpuGeInt,
+    include_header="sfpu/ckernel_sfpu_binary_comp.h",
+    sfpu_defines=_ge_int32_defines,
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/gt_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/gt_int32.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _gt_int32_defines(_: FormatConfig) -> dict:
+    # calculate_binary_comp_int32<APPROXIMATE, ITERATIONS, SfpuType::gt>(
+    #     num_sfpu_iterations, in0_off, in1_off, out_off).
+    # Int ops index by element OFFSET, not tile index; operands at tiles 0 and 1
+    # (stride apart), result to tile 0.
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::calculate_binary_comp_int32<false, 8, ckernel::SfpuType::gt>",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="gt_int32",
+    math_op=MathOperation.SfpuGtInt,
+    include_header="sfpu/ckernel_sfpu_binary_comp.h",
+    sfpu_defines=_gt_int32_defines,
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/le_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/le_int32.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _le_int32_defines(_: FormatConfig) -> dict:
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::calculate_binary_comp_int32<false, 8, ckernel::SfpuType::le>",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="le_int32",
+    math_op=MathOperation.SfpuLeInt,
+    include_header="sfpu/ckernel_sfpu_binary_comp.h",
+    sfpu_defines=_le_int32_defines,
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/lt_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/lt_int32.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _lt_int32_defines(_: FormatConfig) -> dict:
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::calculate_binary_comp_int32<false, 8, ckernel::SfpuType::lt>",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="lt_int32",
+    math_op=MathOperation.SfpuLtInt,
+    include_header="sfpu/ckernel_sfpu_binary_comp.h",
+    sfpu_defines=_lt_int32_defines,
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/max.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/max.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation, format_dict
+
+from ._spec import BinaryInputOutputFormat, BinaryOpSpec
+
+_FLOAT_FORMATS = [
+    DataFormat.Float16,
+    DataFormat.Float16_b,
+    DataFormat.Float32,
+    DataFormat.MxFp8R,
+    DataFormat.MxFp8P,
+]
+_ELEMENTS_PER_TILE = 1024
+
+
+def _max_defines(formats: FormatConfig) -> dict:
+    # The binary path calls SFPU_OP_CALL(num_sfpu_iterations, SFPU_BINARY_OPERANDS).
+    # calculate_binary_max_min takes (in0, in1, out) without an iterations arg, so
+    # wrap it in a lambda that discards the leading num_sfpu_iterations.
+    df = (
+        "DataFormat::Int32"
+        if formats.input_format.is_integer()
+        else "DataFormat::Float32"
+    )
+    return {
+        "SFPU_INIT": (
+            f"ckernel::sfpu::_init_binary_max_min_(); "
+            f"static const auto _max_fn = [](int, unsigned in0, unsigned in1, unsigned out) "
+            f"{{ ckernel::sfpu::calculate_binary_max_min<{df}, true, 8>(in0, in1, out); }};"
+        ),
+        "SFPU_OP_CALL": "_max_fn",
+    }
+
+
+def _max_golden(*, src, io, **_):
+    """Element-wise max of tile0 and tile1; result at tile0 (DST_INDEX=0)."""
+    flat = src.flatten()
+    in0 = flat[:_ELEMENTS_PER_TILE].to(torch.float32)
+    in1 = flat[_ELEMENTS_PER_TILE : 2 * _ELEMENTS_PER_TILE].to(torch.float32)
+    return torch.maximum(in0, in1).to(format_dict[io.output_format])
+
+
+SPEC = BinaryOpSpec(
+    name="max",
+    math_op=MathOperation.Abs,  # placeholder; custom golden is used
+    include_header="experimental/ckernel_sfpu_binary_max_min.h",
+    sfpu_defines=_max_defines,
+    formats=[BinaryInputOutputFormat(f, f, f) for f in _FLOAT_FORMATS],
+    # in0=tile0, in1=tile1, out=tile0 (result overwrites in0).
+    # DST_INDEX=0 → pack reads tile0 (output).
+    tile_layouts=[(0, 1, 0)],
+    golden=_max_golden,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/min.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/min.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation, format_dict
+
+from ._spec import BinaryInputOutputFormat, BinaryOpSpec
+
+_FLOAT_FORMATS = [
+    DataFormat.Float16,
+    DataFormat.Float16_b,
+    DataFormat.Float32,
+    DataFormat.MxFp8R,
+    DataFormat.MxFp8P,
+]
+_ELEMENTS_PER_TILE = 1024
+
+
+def _min_defines(formats: FormatConfig) -> dict:
+    df = (
+        "DataFormat::Int32"
+        if formats.input_format.is_integer()
+        else "DataFormat::Float32"
+    )
+    return {
+        "SFPU_INIT": (
+            f"ckernel::sfpu::_init_binary_max_min_(); "
+            f"static const auto _min_fn = [](int, unsigned in0, unsigned in1, unsigned out) "
+            f"{{ ckernel::sfpu::calculate_binary_max_min<{df}, false, 8>(in0, in1, out); }};"
+        ),
+        "SFPU_OP_CALL": "_min_fn",
+    }
+
+
+def _min_golden(*, src, io, **_):
+    """Element-wise min of tile0 and tile1; result at tile0."""
+    flat = src.flatten()
+    in0 = flat[:_ELEMENTS_PER_TILE].to(torch.float32)
+    in1 = flat[_ELEMENTS_PER_TILE : 2 * _ELEMENTS_PER_TILE].to(torch.float32)
+    return torch.minimum(in0, in1).to(format_dict[io.output_format])
+
+
+SPEC = BinaryOpSpec(
+    name="min",
+    math_op=MathOperation.Abs,  # placeholder; custom golden is used
+    include_header="experimental/ckernel_sfpu_binary_max_min.h",
+    sfpu_defines=_min_defines,
+    formats=[BinaryInputOutputFormat(f, f, f) for f in _FLOAT_FORMATS],
+    tile_layouts=[(0, 1, 0)],
+    golden=_min_golden,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/mul.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/mul.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import float_binary_op_spec
+
+SPEC = float_binary_op_spec(
+    name="mul",
+    math_op=MathOperation.SfpuElwmul,
+    binop="MUL",
+    stimuli=StimuliSpec.uniform(low=-4.0, high=4.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/mul_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/mul_int32.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import BinaryOpSpec, binary_input_output_formats
+
+
+def _mul_int32_defines(formats: FormatConfig) -> dict:
+    # _mul_int32_<APPROXIMATE, ITERATIONS>(iterations, in0_off, in1_off, out_off).
+    # Int ops index by element OFFSET, not tile index, so override the kernel's
+    # default tile-index operands: operands at tiles 0 and 1 (stride apart),
+    # result to tile 0.
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::_mul_int32_<false, 8>",
+        "SFPU_BINARY_OPERANDS": "0, tile_stride, 0",
+    }
+
+
+SPEC = BinaryOpSpec(
+    name="mul_int32",
+    math_op=MathOperation.SfpuElwmulInt,
+    include_header="sfpu/ckernel_sfpu_mul_int32.h",
+    sfpu_defines=_mul_int32_defines,
+    # The only binary SFPU ops in the Quasar LLK tree today are Int32.
+    formats=binary_input_output_formats(
+        [DataFormat.Int32], [DataFormat.Int32], [DataFormat.Int32]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/swiglu.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/binary/swiglu.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation, format_dict
+
+from ._spec import BinaryInputOutputFormat, BinaryOpSpec
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+_ELEMENTS_PER_TILE = 1024
+
+# GPT-OSS swiglu hyperparameters, matching ckernel_sfpu_swiglu.h SwiGLUConfigGPTOSS.
+_SWIGLU_ALPHA = 1.702
+_SWIGLU_CLAMP = 7.0
+
+
+def _swiglu_defines(_: FormatConfig) -> dict:
+    # The binary path calls SFPU_OP_CALL(num_sfpu_iterations, SFPU_BINARY_OPERANDS).
+    # _calculate_swiglu_ takes (n, gate_off, up_off, out_off).  Wrap it in a lambda
+    # that ignores the three trailing tile-layout args from SFPU_BINARY_OPERANDS and
+    # supplies the fixed offsets (gate=tile0, up=tile1, out=tile2 = 0/64/128 rows).
+    # _init_swiglu_ hoists three LREG constants and can be called before sfpu_start.
+    return {
+        "SFPU_INIT": (
+            "ckernel::sfpu::_init_swiglu_(); "
+            "static const auto _sw_fn = "
+            "[](std::uint32_t n, std::uint32_t, std::uint32_t, std::uint32_t) "
+            "{ ckernel::sfpu::_calculate_swiglu_(n, 0u, 64u, 128u); };"
+        ),
+        "SFPU_OP_CALL": "_sw_fn",
+    }
+
+
+def _swiglu_golden(*, src, io, **_):
+    """GPT-OSS swiglu: (up_c + 1) * gate_c * sigmoid(alpha * gate_c)."""
+    flat = src.flatten()
+    gate = flat[:_ELEMENTS_PER_TILE].to(torch.float32)
+    up = flat[_ELEMENTS_PER_TILE : 2 * _ELEMENTS_PER_TILE].to(torch.float32)
+    gate_c = torch.minimum(gate, torch.tensor(_SWIGLU_CLAMP))
+    up_c = torch.clamp(up, -_SWIGLU_CLAMP, _SWIGLU_CLAMP)
+    sig = torch.sigmoid(_SWIGLU_ALPHA * gate_c)
+    return ((up_c + 1.0) * gate_c * sig).to(format_dict[io.output_format])
+
+
+SPEC = BinaryOpSpec(
+    name="swiglu",
+    math_op=MathOperation.SfpuSwiGLU,
+    include_header="experimental/ckernel_sfpu_swiglu.h",
+    sfpu_defines=_swiglu_defines,
+    formats=[BinaryInputOutputFormat(f, f, f) for f in _FLOAT_FORMATS],
+    # gate=tile0, up=tile1; output written to tile2 by the kernel.
+    # DST_INDEX=2 (from dst_idx=2) so PACK reads the output tile directly.
+    tile_layouts=[(0, 1, 2)],
+    golden=_swiglu_golden,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/_spec.py
@@ -1,8 +1,10 @@
 import itertools
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from helpers.format_config import DataFormat
+from helpers.llk_params import VectorMode
+from helpers.test_variant_parameters import VECTOR_MODE, TemplateParameter
 
 from .._spec import BaseOpSpec
 
@@ -36,3 +38,13 @@ def ternary_input_output_formats_matched(
 @dataclass(kw_only=True)
 class TernaryOpSpec(BaseOpSpec):
     formats: List[TernaryInputOutputFormat]
+    # The ternary SFPU dispatch is the only arity whose kernel call takes a VECTOR_MODE
+    # face selector, so it lives here as a declared template param rather than a driver
+    # hardcode. Default is all faces (RC); give the field a list (e.g.
+    # ``VECTOR_MODE([VectorMode.RC, VectorMode.R, VectorMode.C])``) to sweep it into
+    # separate variants — see BaseOpSpec.extra_templates. A swept mode needs a
+    # mode-aware ``golden`` (the default golden compares all faces).
+    extra_templates: List[TemplateParameter] = field(
+        default_factory=lambda: [VECTOR_MODE(VectorMode.RC)]
+    )
+    arity_macro: str = "SFPU_TERNARY_OP"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/_spec.py
@@ -1,0 +1,38 @@
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+from helpers.format_config import DataFormat
+
+from .._spec import BaseOpSpec
+
+
+@dataclass(frozen=True)
+class TernaryInputOutputFormat:
+    input_a_format: DataFormat
+    input_b_format: DataFormat
+    input_c_format: DataFormat
+    output_format: DataFormat
+
+
+def ternary_input_output_formats(
+    inputs_a: List[DataFormat],
+    inputs_b: List[DataFormat],
+    inputs_c: List[DataFormat],
+    outputs: List[DataFormat],
+) -> List[TernaryInputOutputFormat]:
+    return [
+        TernaryInputOutputFormat(a, b, c, o)
+        for a, b, c, o in itertools.product(inputs_a, inputs_b, inputs_c, outputs)
+    ]
+
+
+def ternary_input_output_formats_matched(
+    formats: List[DataFormat],
+) -> List[TernaryInputOutputFormat]:
+    return [TernaryInputOutputFormat(f, f, f, f) for f in formats]
+
+
+@dataclass(kw_only=True)
+class TernaryOpSpec(BaseOpSpec):
+    formats: List[TernaryInputOutputFormat]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/where.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/ternary/where.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation, format_dict
+
+from ._spec import TernaryInputOutputFormat, TernaryOpSpec
+
+# All three operands share the same format; sweep the full input × output matrix.
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+_ELEMENTS_PER_TILE = 1024
+
+
+def _where_defines(formats: FormatConfig) -> dict:
+    # calculate_where<APPROXIMATE, ITERATIONS=8>(in0, in1, in2, out); the ternary
+    # dispatch forwards the four tile indices, so only the call, its SfpuType-templated
+    # init, and the CC-stack prime (init_where) are needed.
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::calculate_where<false>",
+        "SFPU_TYPE": "ckernel::SfpuType::where",
+        "SFPU_INIT": "ckernel::sfpu::init_where();",
+    }
+
+
+def _alternating_condition(src, *, src_tiles):
+    """Overwrite the condition tile with an alternating 0/1 pattern so both select
+    branches are exercised (random stimuli are almost all non-zero -> true branch only).
+    ``src_tiles`` is (cond_tile, true_tile, false_tile); only the cond tile is touched.
+    """
+    cond_tile = src_tiles[0]
+    flat = src.flatten().clone()
+    start = cond_tile * _ELEMENTS_PER_TILE
+    pattern = torch.arange(_ELEMENTS_PER_TILE) % 2
+    flat[start : start + _ELEMENTS_PER_TILE] = pattern.to(flat.dtype)
+    return flat.reshape(src.shape)
+
+
+def _where_golden(*, src, io, **_):
+    """Element-wise ternary select matching WhereGolden.
+
+    Operates directly on the face-sequential stimulus tensor (cond | true_val | false_val
+    concatenated), which is the native order generate_stimuli returns.  Bypasses the
+    TernarySFPUGolden tilize path that omits the untilize step."""
+    flat = src.flatten()
+    cond = flat[:_ELEMENTS_PER_TILE]
+    true_val = flat[_ELEMENTS_PER_TILE : 2 * _ELEMENTS_PER_TILE]
+    false_val = flat[2 * _ELEMENTS_PER_TILE : 3 * _ELEMENTS_PER_TILE]
+    mask = cond.to(torch.float32) != 0.0
+    return torch.where(mask, true_val, false_val).to(format_dict[io.output_format])
+
+
+SPEC = TernaryOpSpec(
+    name="where",
+    math_op=MathOperation.SfpuWhere,
+    include_header="llk_sfpu/ckernel_sfpu_where.h",
+    sfpu_defines=_where_defines,
+    formats=[
+        TernaryInputOutputFormat(i, i, i, o)
+        for i in _FLOAT_FORMATS
+        for o in _FLOAT_FORMATS
+    ],
+    prepare=_alternating_condition,
+    golden=_where_golden,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/_spec.py
@@ -1,0 +1,27 @@
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+from helpers.format_config import DataFormat
+
+from .._spec import BaseOpSpec
+
+
+@dataclass(frozen=True)
+class InputOutputFormat:
+    input_format: DataFormat
+    output_format: DataFormat
+
+
+def input_output_formats(
+    inputs: List[DataFormat],
+    outputs: List[DataFormat] = None,
+) -> List[InputOutputFormat]:
+    if outputs is None:
+        outputs = inputs
+    return [InputOutputFormat(i, o) for i, o in itertools.product(inputs, outputs)]
+
+
+@dataclass(kw_only=True)
+class UnaryOpSpec(BaseOpSpec):
+    formats: List[InputOutputFormat]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/_spec.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/_spec.py
@@ -25,3 +25,4 @@ def input_output_formats(
 @dataclass(kw_only=True)
 class UnaryOpSpec(BaseOpSpec):
     formats: List[InputOutputFormat]
+    arity_macro: str = "SFPU_UNARY_OP"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/abs.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/abs.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _abs_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_abs_"}
+
+
+SPEC = UnaryOpSpec(
+    name="abs",
+    math_op=MathOperation.Abs,
+    include_header="experimental/ckernel_sfpu_abs.h",
+    sfpu_defines=_abs_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Include negative values so both the sign-clear path and the identity path
+    # are exercised (random positive-only stimuli would only test the latter).
+    stimuli=StimuliSpec.uniform(low=-1.1, high=1.1),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/exp.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/exp.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _exp_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_exp_<true>"}
+
+
+SPEC = UnaryOpSpec(
+    name="exp",
+    math_op=MathOperation.Exp,
+    include_header="sfpu/ckernel_sfpu_exp.h",
+    sfpu_defines=_exp_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Clamp to [-10, 10]: exp(10) ≈ 22026 < Float16 max (65504), so no
+    # overflow in any output format.  Default (0.1–1.1) would only test the
+    # small-positive branch.
+    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/fill.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/fill.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation, format_dict
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+_FILL_CONST = 5.0
+
+
+def _fill_defines(_: FormatConfig) -> dict:
+    # The unary path passes (num_sfpu_iterations) to SFPU_OP_CALL.  Wrap
+    # _calculate_fill_<8> in a lambda that ignores the iterations arg and
+    # broadcasts the compile-time constant instead; no SFPU_ADDITIONAL_ARGS needed.
+    return {
+        "SFPU_INIT": (
+            f"static const auto _fill_fn = [](float) "
+            f"{{ ckernel::sfpu::_calculate_fill_<8>({_FILL_CONST}f); }};"
+        ),
+        "SFPU_OP_CALL": "_fill_fn",
+    }
+
+
+def _fill_golden(*, src, io, **_):
+    """Every output lane = FILL_CONST regardless of input."""
+    n = src.flatten().numel()
+    return torch.full((n,), _FILL_CONST, dtype=format_dict[io.output_format])
+
+
+SPEC = UnaryOpSpec(
+    name="fill",
+    math_op=MathOperation.Fill,
+    include_header="experimental/ckernel_sfpu_fill.h",
+    sfpu_defines=_fill_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    golden=_fill_golden,
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/gelu.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/gelu.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _gelu_defines(_: FormatConfig) -> dict:
+    return {
+        "SFPU_OP_CALL": "ckernel::sfpu::_calculate_gelu_",
+        # _init_gelu_ loads BF16-quantised constants (polynomial coefficients)
+        # into LREGs before the per-row loop; omitting it leaves stale LREG
+        # state and produces wrong results.
+        "SFPU_INIT": "ckernel::sfpu::_init_gelu_();",
+    }
+
+
+SPEC = UnaryOpSpec(
+    name="gelu",
+    math_op=MathOperation.Gelu,
+    include_header="sfpu/ckernel_sfpu_gelu.h",
+    sfpu_defines=_gelu_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/reciprocal.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/reciprocal.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _reciprocal_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_reciprocal_<true>"}
+
+
+SPEC = UnaryOpSpec(
+    name="reciprocal",
+    math_op=MathOperation.Reciprocal,
+    include_header="sfpu/ckernel_sfpu_recip.h",
+    sfpu_defines=_reciprocal_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Default stimuli (0.1–1.1) are already positive and away from zero,
+    # so no custom range is needed — 1/x stays finite and in-range for all
+    # three output formats.
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/relu.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/relu.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _relu_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_relu_"}
+
+
+SPEC = UnaryOpSpec(
+    name="relu",
+    math_op=MathOperation.Relu,
+    include_header="sfpu/ckernel_sfpu_relu.h",
+    sfpu_defines=_relu_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Symmetric range so the zero-clipping branch (negative inputs) and the
+    # identity branch (positive inputs) are both exercised.
+    stimuli=StimuliSpec.uniform(low=-1.1, high=1.1),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/rsqrt.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/rsqrt.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _rsqrt_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_rsqrt_"}
+
+
+SPEC = UnaryOpSpec(
+    name="rsqrt",
+    math_op=MathOperation.Rsqrt,
+    include_header="sfpu/ckernel_sfpu_rsqrt.h",
+    sfpu_defines=_rsqrt_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Default stimuli (0.1–1.1) are positive, which is the required domain
+    # for rsqrt; no custom range needed.
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/sigmoid.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/sigmoid.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _sigmoid_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_sigmoid_"}
+
+
+SPEC = UnaryOpSpec(
+    name="sigmoid",
+    math_op=MathOperation.Sigmoid,
+    include_header="sfpu/ckernel_sfpu_sigmoid.h",
+    sfpu_defines=_sigmoid_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # [-10, 10] covers the full saturation transition: sigmoid(x) → 0 for x→-∞,
+    # → 0.5 at x=0, → 1 for x→+∞.  Default (0.1–1.1) only tests the
+    # near-linear region.
+    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/silu.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/silu.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _silu_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_silu_"}
+
+
+SPEC = UnaryOpSpec(
+    name="silu",
+    math_op=MathOperation.Silu,
+    include_header="sfpu/ckernel_sfpu_silu.h",
+    sfpu_defines=_silu_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # SiLU = x * sigmoid(x). [-10, 10] exercises the negative (near-zero
+    # output) and positive (linear-ish) branches without exp overflow.
+    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/sqrt.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/sqrt.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _sqrt_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_sqrt_<true>"}
+
+
+SPEC = UnaryOpSpec(
+    name="sqrt",
+    math_op=MathOperation.Sqrt,
+    include_header="sfpu/ckernel_sfpu_sqrt.h",
+    sfpu_defines=_sqrt_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # Default stimuli (0.1–1.1) are positive, which is the required domain
+    # for sqrt; sqrt(0.1–1.1) ≈ 0.316–1.049, fits all output formats.
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/square.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/square.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Canonical minimal unary op spec: a plain elementwise op with the standard
+# math_op-keyed golden. The only required pieces are the op call, header, math_op,
+# and the format list. See BaseOpSpec (.._spec) for the full field contract and the
+# optional hooks (stimuli, prepare, golden, SFPU_INIT / SFPU_ADDITIONAL_ARGS).
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+
+def _square_defines(formats: FormatConfig) -> dict:
+    # _calculate_square_(int iterations) — the dispatch forwards num_sfpu_iterations,
+    # so no extra args and no op-specific init are needed.
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_square_"}
+
+
+SPEC = UnaryOpSpec(
+    name="square",
+    math_op=MathOperation.Square,
+    include_header="sfpu/ckernel_sfpu_square.h",
+    sfpu_defines=_square_defines,
+    formats=input_output_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ]
+    ),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/tanh.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/sfpu/unary/tanh.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.llk_params import MathOperation
+from helpers.stimuli_generator import StimuliSpec
+
+from ._spec import UnaryOpSpec, input_output_formats
+
+_FLOAT_FORMATS = [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+
+
+def _tanh_defines(_: FormatConfig) -> dict:
+    return {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_tanh_<true>"}
+
+
+SPEC = UnaryOpSpec(
+    name="tanh",
+    math_op=MathOperation.Tanh,
+    include_header="sfpu/ckernel_sfpu_tanh.h",
+    sfpu_defines=_tanh_defines,
+    formats=input_output_formats(_FLOAT_FORMATS),
+    # tanh saturates to ±1 outside ≈ ±4; [-10, 10] covers saturation, steep
+    # region, and the linear region near 0.
+    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
+)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu.py
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generic, registry-driven SFPU test for Quasar.
+
+A single C++ skeleton (``sources/quasar/sfpu_test.cpp``) dispatches SFPU ops
+through preprocessor defines. Each op is described once as a spec module under
+``quasar/sfpu/{unary,binary,ternary}/`` and auto-discovered into
+``UNARY_OP_REGISTRY`` / ``BINARY_OP_REGISTRY``. This driver parametrizes over
+those registries; adding a new op is just a new spec module, no new test code.
+
+Golden references are derived from each spec's ``math_op`` via the existing
+arity-specific golden generators (no per-op golden is stored on the spec).
+
+The three arities are symmetric here: each is described once as a spec module and
+swept by its driver. The ternary ``where`` op lives in ``quasar/sfpu/ternary/where.py``.
+"""
+
+from dataclasses import dataclass
+from dataclasses import fields as dc_fields
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import (
+    BinarySFPUGolden,
+    TernarySFPUGolden,
+    UnarySFPUGolden,
+    get_golden_generator,
+)
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    DestSync,
+    ImpliedMathFormat,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import (
+    InputOutputFormat,
+    generate_sfpu_format_dest_acc_combinations,
+    parametrize,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    NUM_FACES,
+    SFPU_DEFINES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+from quasar.sfpu import (
+    BINARY_OP_REGISTRY,
+    TERNARY_OP_REGISTRY,
+    UNARY_OP_REGISTRY,
+)
+from quasar.sfpu._utils import expand_extra_templates
+
+_SOURCE = "sources/quasar/sfpu_test.cpp"
+_NUM_FACES = 4
+_ELEMENTS_PER_TILE = 1024  # 4 faces * 16 * 16
+
+
+def _io(fmt) -> InputOutputFormat:
+    """Adapt a spec's per-arity format entry to the TestConfig InputOutputFormat.
+
+    Unary specs expose ``input_format``; binary specs expose ``input_a_format``
+    (operands share a format in these tests)."""
+    in_fmt = fmt.input_format if hasattr(fmt, "input_format") else fmt.input_a_format
+    return InputOutputFormat(input_format=in_fmt, output_format=fmt.output_format)
+
+
+def _formats(spec):
+    """(io, dest_acc) sweep for a spec's declared formats."""
+    return generate_sfpu_format_dest_acc_combinations([_io(f) for f in spec.formats])
+
+
+def _prepare(spec, src, *, src_tiles):
+    """Apply the op's optional stimulus post-processing hook (e.g. divide injects
+    its NaN/Inf/1.0 special-case lanes); identity when the op declares none.
+    ``src_tiles`` is the tuple of DEST tile indices the operands occupy this variant."""
+    return spec.prepare(src, src_tiles=src_tiles) if spec.prepare is not None else src
+
+
+def _implied_math_formats(io):
+    """ImpliedMathFormat sweep for a format: MX formats require it enabled, so they
+    run only ``Yes``; every other format runs both ``No`` and ``Yes``."""
+    if io.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+@dataclass(frozen=True)
+class _ExtraTemplates:
+    """One resolved combination of a spec's extra build-time template params, named for
+    the pytest variant id (``parametrize`` uses the ``.name`` attribute)."""
+
+    templates: tuple
+
+    @property
+    def name(self) -> str:
+        if not self.templates:
+            return "default"
+        return "+".join(
+            ".".join(
+                getattr(getattr(t, f.name), "name", str(getattr(t, f.name)))
+                for f in dc_fields(t)
+            )
+            for t in self.templates
+        )
+
+
+def _extra_template_variants(spec):
+    """Sweep a spec's ``extra_templates``: expand any list-valued TemplateParameter
+    field into the cross product, one variant per combination. A spec with no extras
+    (or only scalar fields) yields a single variant, so this never multiplies the
+    common case."""
+    return [
+        _ExtraTemplates(combo) for combo in expand_extra_templates(spec.extra_templates)
+    ]
+
+
+def _golden(spec, default, *, src, io, dest_acc, dimensions):
+    """Resolve the op's golden: its custom ``golden`` hook if declared, else the
+    arity default. ``default`` is a zero-arg callable producing the standard
+    math_op-keyed golden, so the common case pays nothing."""
+    if spec.golden is not None:
+        return spec.golden(src=src, io=io, dest_acc=dest_acc, dimensions=dimensions)
+    return default()
+
+
+def _supported_formats(spec):
+    """(io, dest_acc) sweep dropping Float16 + DestAcc.Yes, which the multi-operand SFPU
+    paths (binary, ternary) don't support. Used by the binary and ternary drivers;
+    unary keeps the unfiltered ``_formats``."""
+    return [
+        (io, da)
+        for io, da in _formats(spec)
+        if not (io.input_format == DataFormat.Float16 and da == DestAccumulation.Yes)
+    ]
+
+
+def _run(
+    *,
+    arity_macro,
+    spec,
+    io,
+    dest_acc,
+    src_A,
+    src_B,
+    tile_cnt_A,
+    tile_count_res,
+    golden_tensor,
+    unpack_to_dest,
+    implied_math_format=ImpliedMathFormat.No,
+    dest_sync=DestSync.Half,
+    dst_index=0,
+    operands=None,
+    extra_templates=(),
+):
+    """Build the variant, run it through the SFPU skeleton, and assert vs golden.
+
+    Everything that doesn't depend on op arity lives here; the per-arity test
+    functions only differ in how they prepare stimuli and the golden tensor.
+    ``operands`` is an optional (src0, src1, dst) tile triple emitted as
+    SFPU_BINARY_OPERANDS for tile-index binary ops (None leaves the op's own operand
+    placement intact); ``dst_index`` is the DEST tile the result is packed from.
+    ``extra_templates`` is the op's resolved extra build-time template params for this
+    variant (e.g. ternary's VECTOR_MODE), spliced into the build verbatim."""
+    defines = dict(spec.sfpu_defines(io))
+    if operands is not None:
+        src0_idx, src1_idx, dst_idx = operands
+        defines["SFPU_BINARY_OPERANDS"] = f"{src0_idx}u, {src1_idx}u, {dst_idx}u"
+
+    configuration = TestConfig(
+        _SOURCE,
+        io,
+        templates=[
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(dest_sync),
+            SFPU_DEFINES(arity_macro, spec.include_header, defines),
+            *extra_templates,
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(_NUM_FACES),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(dst_index),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            io.input_format,
+            src_B,
+            io.input_format,
+            io.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_count_res,
+            num_faces=_NUM_FACES,
+            twos_complement=io.input_format.is_integer(),
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[io.output_format])
+    assert passed_test(
+        golden_tensor, res_tensor, io.output_format
+    ), "Assert against golden failed"
+
+    # Op-specific exactness checks the tolerance comparison can't express.
+    if spec.verify is not None:
+        spec.verify(res_tensor, io=io)
+
+
+# ---------------------------------------------------------------------------
+# Unary
+# ---------------------------------------------------------------------------
+@pytest.mark.quasar
+@parametrize(
+    spec=UNARY_OP_REGISTRY,
+    format_dest_acc=_formats,
+    implied_math_format=lambda format_dest_acc: _implied_math_formats(
+        format_dest_acc[0]
+    ),
+    dest_sync=[DestSync.Half, DestSync.Full],
+    input_dimensions=[[32, 32], [64, 64]],
+)
+def test_sfpu_unary(
+    spec, format_dest_acc, implied_math_format, dest_sync, input_dimensions
+):
+    """Run a unary SFPU op (one input tile, transformed in place)."""
+    io, dest_acc = format_dest_acc
+
+    torch.manual_seed(0)  # reproducible stimuli
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=io.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=io.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+    src_A = _prepare(spec, src_A, src_tiles=(0,))
+
+    golden_tensor = _golden(
+        spec,
+        lambda: get_golden_generator(UnarySFPUGolden)(
+            spec.math_op,
+            src_A,
+            io.output_format,
+            dest_acc,
+            io.input_format,
+            input_dimensions,
+        ),
+        src=src_A,
+        io=io,
+        dest_acc=dest_acc,
+        dimensions=input_dimensions,
+    )
+
+    _run(
+        arity_macro=spec.arity_macro,
+        spec=spec,
+        io=io,
+        dest_acc=dest_acc,
+        src_A=src_A,
+        src_B=src_B,
+        tile_cnt_A=tile_cnt_A,
+        tile_count_res=tile_cnt_A,
+        golden_tensor=golden_tensor,
+        unpack_to_dest=io.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes,
+        implied_math_format=implied_math_format,
+        dest_sync=dest_sync,
+        extra_templates=tuple(spec.extra_templates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Binary
+# ---------------------------------------------------------------------------
+def _tile_layouts(spec):
+    """Tile-layout sweep for a binary spec: each (src0, src1, dst) the driver places
+    operands at. ``None`` for offset-style ops that place operands themselves — they
+    run the single default layout (operands intact, result packed from tile 0)."""
+    return spec.tile_layouts if spec.tile_layouts is not None else [None]
+
+
+@pytest.mark.quasar
+@parametrize(
+    spec=BINARY_OP_REGISTRY,
+    format_dest_acc=_supported_formats,
+    implied_math_format=lambda format_dest_acc: _implied_math_formats(
+        format_dest_acc[0]
+    ),
+    tile_layout=_tile_layouts,
+)
+def test_sfpu_binary(spec, format_dest_acc, implied_math_format, tile_layout):
+    """Run a binary SFPU op: two operand tiles in DEST, one result tile packed out.
+
+    ``tile_layout`` is the (src0, src1, dst) DEST-tile placement for tile-index ops
+    (swept to cover result-over-operand aliasing); ``None`` means the op places its
+    own operands (offset-style int ops) and the result is packed from tile 0."""
+    io, dest_acc = format_dest_acc
+    data_format = io.input_format
+
+    if tile_layout is None:
+        # Offset-style op: operands at tiles 0/1, result to tile 0 (driver leaves the
+        # op's own SFPU_BINARY_OPERANDS in place).
+        src0_idx, src1_idx, dst_idx = 0, 1, 0
+        operands = None
+    else:
+        src0_idx, src1_idx, dst_idx = tile_layout
+        operands = tile_layout
+
+    # Enough tiles to cover the highest operand/result index, concatenated along rows.
+    num_tiles = max(src0_idx, src1_idx, dst_idx) + 1
+    input_dimensions = [num_tiles * 32, 32]
+
+    # Per-op stimulus range when supplied (e.g. divide bounds divisors away from
+    # zero), else a sane default for the dtype.
+    if spec.stimuli is not None:
+        stim = spec.stimuli
+    elif data_format.is_integer():
+        iinfo = torch.iinfo(format_dict[data_format])
+        stim = StimuliSpec.uniform(low=float(iinfo.min), high=float(iinfo.max - 1))
+    else:
+        stim = StimuliSpec.uniform(low=-1.0, high=1.0)
+
+    torch.manual_seed(0)  # reproducible stimuli
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=data_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=data_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=stim,
+        spec_B=stim,
+    )
+    src_A = _prepare(spec, src_A, src_tiles=(src0_idx, src1_idx))
+
+    dst_start = dst_idx * _ELEMENTS_PER_TILE
+    golden_tensor = _golden(
+        spec,
+        lambda: get_golden_generator(BinarySFPUGolden)(
+            spec.math_op,
+            src_A,
+            src0_idx,
+            src1_idx,
+            dst_idx,
+            32,  # num_iterations: 32 rows = 1 full tile
+            input_dimensions,
+            data_format,
+        ).flatten()[dst_start : dst_start + _ELEMENTS_PER_TILE],
+        src=src_A,
+        io=io,
+        dest_acc=dest_acc,
+        dimensions=input_dimensions,
+    )
+
+    _run(
+        arity_macro=spec.arity_macro,
+        spec=spec,
+        io=io,
+        dest_acc=dest_acc,
+        src_A=src_A,
+        src_B=src_B,
+        tile_cnt_A=tile_cnt_A,
+        tile_count_res=1,
+        golden_tensor=golden_tensor,
+        unpack_to_dest=True,
+        implied_math_format=implied_math_format,
+        dst_index=dst_idx,
+        operands=operands,
+        extra_templates=tuple(spec.extra_templates),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ternary
+# ---------------------------------------------------------------------------
+@pytest.mark.quasar
+@parametrize(
+    spec=TERNARY_OP_REGISTRY,
+    format_dest_acc=_supported_formats,
+    implied_math_format=lambda format_dest_acc: _implied_math_formats(
+        format_dest_acc[0]
+    ),
+    extra_template=_extra_template_variants,
+)
+def test_sfpu_ternary(spec, format_dest_acc, implied_math_format, extra_template):
+    """Run a ternary SFPU op: three operands at DEST tiles 0/1/2, result to tile 0.
+
+    ``extra_template`` is one resolved combination of the spec's extra build-time
+    template params (e.g. its VECTOR_MODE face selector), swept when the spec declares
+    a list-valued field."""
+    io, dest_acc = format_dest_acc
+    data_format = io.input_format
+    # Three input tiles concatenated along rows -> tiles 0, 1, 2 in DEST.
+    input_dimensions = [3 * 32, 32]
+
+    torch.manual_seed(0)  # reproducible stimuli
+    src_A, tile_cnt_A, _, _ = generate_stimuli(
+        stimuli_format_A=data_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=data_format,
+        input_dimensions_B=input_dimensions,
+    )
+    src_A = _prepare(spec, src_A, src_tiles=(0, 1, 2))
+
+    golden_tensor = _golden(
+        spec,
+        lambda: get_golden_generator(TernarySFPUGolden)(
+            spec.math_op,
+            src_A,
+            0,  # src1 tile index
+            1,  # src2 tile index
+            2,  # src3 tile index
+            0,  # dst tile index
+            32,  # num_iterations: 32 rows = 1 full tile
+            input_dimensions,
+            data_format,
+        ).flatten()[0:_ELEMENTS_PER_TILE],
+        src=src_A,
+        io=io,
+        dest_acc=dest_acc,
+        dimensions=input_dimensions,
+    )
+
+    _run(
+        arity_macro=spec.arity_macro,
+        spec=spec,
+        io=io,
+        dest_acc=dest_acc,
+        src_A=src_A,
+        src_B=torch.zeros_like(src_A),
+        tile_cnt_A=tile_cnt_A,
+        tile_count_res=1,
+        golden_tensor=golden_tensor,
+        unpack_to_dest=io.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes,
+        implied_math_format=implied_math_format,
+        # The op's resolved extra templates for this variant (its VECTOR_MODE face
+        # selector by default). The default golden compares all faces (VectorMode.RC).
+        extra_templates=extra_template.templates,
+    )

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_test.cpp
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, num_tiles_per_unpack);
+
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/);
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_binary_sfpu.h"
+#include "llk_math_eltwise_ternary_sfpu.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_math_eltwise_unary_sfpu_common.h"
+#include "params.h"
+
+// Op header is selected per-variant by the Python driver (SFPU_DEFINES).
+// build.h (pulled in by params.h) defines SFPU_INCLUDE_HEADER, so this must
+// come after params.h.
+#include SFPU_INCLUDE_HEADER
+
+#ifndef SFPU_INIT
+#define SFPU_INIT
+#endif
+#ifndef SFPU_ADDITIONAL_ARGS
+#define SFPU_ADDITIONAL_ARGS
+#endif
+// Binary operand placement: gather operands from DEST tiles 0 and 1, write the
+// result to tile 0. This is the kernel's default for every binary op; only ops
+// that index by element offset instead of tile index (the int ops) override it.
+#ifndef SFPU_BINARY_OPERANDS
+#define SFPU_BINARY_OPERANDS 0u, 1u, 0u
+#endif
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    if constexpr (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    if constexpr (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(num_rows, params.DST_INDEX + i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    // SFPU processes SFP_ROWS dest rows per issue, so every arity loops this many times.
+    const std::uint32_t num_sfpu_iterations = params.TEST_FACE_R_DIM / ckernel::math::SFP_ROWS;
+
+    /**
+     * Per-op defines supplied by the build (SFPU_DEFINES in the Python driver):
+     *   SFPU_<ARITY>_OP      - arity selector: SFPU_UNARY_OP / SFPU_BINARY_OP / SFPU_TERNARY_OP
+     *   SFPU_INCLUDE_HEADER  - op header (included above, after params.h)
+     *   SFPU_OP_CALL         - ckernel::sfpu::<function> to invoke; may be a lambda defined in
+     *                          SFPU_INIT so that ops with non-standard signatures (fill, max/min,
+     *                          add_int32, swiglu) fit the existing three dispatch patterns
+     *   SFPU_TYPE            - SfpuType enum value (ternary init only)
+     *   SFPU_INIT            - optional init statement(s); may also define an SFPU_OP_CALL wrapper
+     *   SFPU_ADDITIONAL_ARGS - extra trailing args forwarded to the unary/ternary op call
+     *   SFPU_BINARY_OPERANDS - binary operand placement (default: tile-index 0u,1u,0u)
+     *
+     * The three arities are asymmetric in Quasar LLK: unary/binary share a plain
+     * _llk_math_eltwise_sfpu_init_() and forward (iterations[, offsets]) to the op;
+     * only the ternary init is templated on SfpuType and its dispatch takes four
+     * tile indices plus a VECTOR_MODE face selector.
+     */
+
+#if defined(SFPU_UNARY_OP)
+    _llk_math_eltwise_sfpu_init_();
+    SFPU_INIT
+    // Apply the op in place to each datacopied tile.
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_math_eltwise_unary_sfpu_params_(SFPU_OP_CALL, params.DST_INDEX + i, num_sfpu_iterations SFPU_ADDITIONAL_ARGS);
+    }
+#elif defined(SFPU_BINARY_OP)
+    _llk_math_eltwise_sfpu_init_();
+    SFPU_INIT
+    // tile_stride is the element stride between DEST tiles, for offset-style ops
+    // that override SFPU_BINARY_OPERANDS (e.g. "0, tile_stride, 0").
+    const int tile_stride = static_cast<int>(params.num_faces * params.TEST_FACE_R_DIM);
+    (void)tile_stride;
+    _llk_math_eltwise_binary_sfpu_params_<false>(SFPU_OP_CALL, 0u, num_sfpu_iterations, SFPU_BINARY_OPERANDS);
+#elif defined(SFPU_TERNARY_OP)
+    // The ternary op takes its iteration count as a template arg (calculate_where's
+    // ITERATIONS), not a runtime one, so num_sfpu_iterations is unused on this path.
+    (void)num_sfpu_iterations;
+    _llk_math_eltwise_ternary_sfpu_init_<SFPU_TYPE>();
+    SFPU_INIT
+    // in0/in1/in2 at DEST tiles 0/1/2, result to tile 0; VECTOR_MODE selects faces.
+    _llk_math_eltwise_ternary_sfpu_params_(SFPU_OP_CALL, 0u, 1u, 2u, 0u, VECTOR_MODE SFPU_ADDITIONAL_ARGS);
+#else
+    LLK_ASSERT(false, "Missing SFPU arity define (SFPU_UNARY_OP / SFPU_BINARY_OP / SFPU_TERNARY_OP)");
+#endif
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+    _llk_pack_init_(buf_desc_id, num_tiles_per_pack);
+
+    // Packs only the result tile (DEST[DST_INDEX]); where produces one output tile
+    // regardless of how many input tiles were loaded.
+    _llk_pack_(params.DST_INDEX, 0);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif


### PR DESCRIPTION
## Summary

Introduces a declarative, registry-driven test infrastructure for Quasar SFPU ops, replacing the need for per-op test files and kernel code. The same shared C++ skeleton and single Python driver cover all three arities (unary / binary / ternary) across all format × dest-acc combinations.

## How it works

**One C++ skeleton** (`tests/sources/quasar/sfpu_test.cpp`) drives every op via preprocessor defines injected at build time:
- `SFPU_OP_CALL` — the ckernel callable to dispatch (e.g. `ckernel::sfpu::_calculate_exp_<true>`)
- `SFPU_INIT` — optional one-time init statement (e.g. `_init_gelu_()`)
- `SFPU_ADDITIONAL_ARGS` — optional extra trailing args
- `SFPU_TYPE` / `SFPU_BINARY_OPERANDS` — ternary and integer-offset overrides

**One Python driver** (`tests/python_tests/quasar/test_sfpu.py`) parametrizes over three auto-discovered op registries:
- `UNARY_OP_REGISTRY`, `BINARY_OP_REGISTRY`, `TERNARY_OP_REGISTRY`

**Adding a new op** is a single spec file — no new test code, no new kernel code:

```python
# tests/python_tests/quasar/sfpu/unary/exp.py
SPEC = UnaryOpSpec(
    name="exp",
    math_op=MathOperation.Exp,
    include_header="sfpu/ckernel_sfpu_exp.h",
    sfpu_defines=lambda _: {"SFPU_OP_CALL": "ckernel::sfpu::_calculate_exp_<true>"},
    formats=input_output_formats([DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]),
    stimuli=StimuliSpec.uniform(low=-10.0, high=10.0),
)
```

The discovery layer (`quasar/sfpu/__init__.py`) validates that every spec's `include_header` resolves on the compiler's `-I` path before tests run — catching stale headers at import time rather than at compile time.

## Ops covered (24 total)

| Arity | Ops |
|-------|-----|
| Unary (12) | abs, exp, fill, gelu, reciprocal, relu, rsqrt, sigmoid, silu, sqrt, square, tanh |
| Binary (11) | add\_int32, div, ge\_int32, gt\_int32, le\_int32, lt\_int32, max, min, mul, mul\_int32, swiglu |
| Ternary (1) | where |

## Escape hatches

For ops that don't fit the standard golden path, spec-level hooks override cleanly:
- `stimuli` — custom input domain (e.g. `sqrt` needs positive-only)
- `prepare` — post-process the stimulus tensor (e.g. inject `x/0 → ±Inf` for divide)
- `golden` — fully custom reference (e.g. `swiglu` fused op, `min`/`max` with custom lambda)
- `verify` — extra exactness assertion after tolerance check (e.g. `div` forces `x/x == 1.0` bit-exact)

## Test plan
- [ ] `pytest --compile-producer -n 8 -x ./quasar/test_sfpu.py` passes for all 24 ops
- [ ] `pytest --compile-consumer -x ./quasar/test_sfpu.py` passes on Quasar hardware
- [ ] Adding a 25th op (new spec file only) appears as a new parametrized variant without touching the driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/unified-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/unified-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/unified-sfpu)