### PR TITLE
ring_joint_sdpa: allow oversize persistent kv buffers

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -822,12 +822,15 @@ def run_ring_joint_sdpa_chunked(
     indexed_nd_sharded_kv_cache: bool = False,
     cache_batch_idx: int = 1,
     cache_batch: int = 2,
+    persistent_buffer_mode: str = "exact_per_chunk",
 ):
     """
     Validate ring joint SDPA chunked-prefill against a full-sequence torch oracle.
 
     SUT: n_chunks calls; each call passes a short Q chunk at absolute positions
     [i*c, (i+1)*c) against a K/V cache holding the first (i+1)*c rows.
+    If persistent_buffer_mode="reuse_max", one max-length persistent K/V buffer
+    pair is allocated once and reused across all chunks and iterations.
 
     num_iterations > 1 switches to determinism mode: replay the full n_chunks
     sequence num_iterations times and require bit-exact equality of per-chunk
@@ -842,9 +845,16 @@ def run_ring_joint_sdpa_chunked(
     assert total_seq % sp_size == 0, f"total_seq {total_seq} must divide sp_size {sp_size}"
     assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} must divide sp_size {sp_size}"
     assert total_seq % chunk_size == 0, f"total_seq {total_seq} must be a multiple of chunk_size {chunk_size}"
+    assert persistent_buffer_mode in (
+        "exact_per_chunk",
+        "reuse_max",
+    ), f"Unsupported persistent_buffer_mode={persistent_buffer_mode}"
     if indexed_nd_sharded_kv_cache:
         assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
         assert 0 <= cache_batch_idx < cache_batch, f"cache_batch_idx {cache_batch_idx} must be in [0, {cache_batch})"
+        assert (
+            persistent_buffer_mode == "exact_per_chunk"
+        ), "Reusable max buffers are not combined with indexed K/V cache"
 
     n_chunks = total_seq // chunk_size
 
@@ -992,11 +1002,33 @@ def run_ring_joint_sdpa_chunked(
             )
             return out[:, :, :expected_q_len, :]
 
+        def create_persistent_buffers(seq_len, kv_buffer_batch):
+            persistent_output_buffer_k = ttnn.from_torch(
+                torch.zeros(kv_buffer_batch, nhk, seq_len, d_k),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_k_shard_dims
+                ),
+            )
+            persistent_output_buffer_v = ttnn.from_torch(
+                torch.zeros(kv_buffer_batch, nhv, seq_len, d_v),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_persistent_shard_dims
+                ),
+            )
+            return persistent_output_buffer_k, persistent_output_buffer_v
+
         logger.info(
             f"Chunked prefill: model={model.name}, total_seq={total_seq}, "
             f"sp_size={sp_size}, per-device Q seq_len={total_seq // sp_size}, "
             f"q_chunk={q_chunk_size}, k_chunk={k_chunk_size}, "
-            f"indexed_nd_sharded_kv_cache={indexed_nd_sharded_kv_cache}"
+            f"indexed_nd_sharded_kv_cache={indexed_nd_sharded_kv_cache}, "
+            f"persistent_buffer_mode={persistent_buffer_mode}"
         )
 
         # Chunked K/V cache layout: device d's local slab c holds global rows
@@ -1008,6 +1040,9 @@ def run_ring_joint_sdpa_chunked(
 
         k_memory_config = nd_sharded_dram_memory_config(mesh_device, d_k) if indexed_nd_sharded_kv_cache else None
         v_memory_config = nd_sharded_dram_memory_config(mesh_device, d_v) if indexed_nd_sharded_kv_cache else None
+        shared_persistent_buffers = (
+            create_persistent_buffers(total_seq, b) if persistent_buffer_mode == "reuse_max" else None
+        )
 
         # SUT: per-chunk calls with growing K/V cache + growing logical_n.
         # In determinism mode (num_iterations > 1), the entire n_chunks sequence is
@@ -1040,25 +1075,13 @@ def run_ring_joint_sdpa_chunked(
                 tt_K = upload_k(K_input, memory_config=k_memory_config)
                 tt_V = upload_v(V_input, memory_config=v_memory_config)
 
-                # AllGather output buffer sized to post-gather K/V: N_global == (i+1) * chunk_size.
-                persistent_output_buffer_k = ttnn.from_torch(
-                    torch.zeros(kv_buffer_batch, nhk, e, d_k),
-                    dtype=kv_dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=mesh_device,
-                    mesh_mapper=ttnn.ShardTensor2dMesh(
-                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_k_shard_dims
-                    ),
-                )
-                persistent_output_buffer_v = ttnn.from_torch(
-                    torch.zeros(kv_buffer_batch, nhv, e, d_v),
-                    dtype=kv_dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=mesh_device,
-                    mesh_mapper=ttnn.ShardTensor2dMesh(
-                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_persistent_shard_dims
-                    ),
-                )
+                if persistent_buffer_mode == "reuse_max":
+                    persistent_output_buffer_k, persistent_output_buffer_v = shared_persistent_buffers
+                else:
+                    # AllGather output buffer sized to post-gather K/V: N_global == (i+1) * chunk_size.
+                    persistent_output_buffer_k, persistent_output_buffer_v = create_persistent_buffers(
+                        e, kv_buffer_batch
+                    )
 
                 try:
                     tt_out = call_sdpa(
@@ -2014,7 +2037,7 @@ CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs()
     ids=CHUNKED_CONFIG_IDS,
 )
 def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, q_chunk_size, k_chunk_size, chunk_size):
-    """Validate ring joint SDPA chunked prefill against a full-sequence oracle."""
+    """Validate ring joint SDPA chunked prefill with reusable max-sized K/V buffers."""
     mesh_config = MESH_CONFIG
 
     run_ring_joint_sdpa_chunked(
@@ -2023,6 +2046,7 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, q_chunk_size, k_
         chunk_size=chunk_size,
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
+        persistent_buffer_mode="reuse_max",
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.cpp
@@ -80,17 +80,32 @@ void RingAttentionAllGatherAsyncDeviceOperation::validate_on_program_cache_miss(
                     "Output tensor {} memory config should match output_mem_config",
                     i);
 
-                // Check output tensor shape
+                // Check output tensor shape. The gather dimension may be larger than the populated prefix.
                 auto output_shape = output_tensor.logical_shape();
                 auto expected_output_shape = input_tensors[i].logical_shape();
                 expected_output_shape[operation_attributes.dim] *= operation_attributes.ring_size;
 
-                TT_FATAL(
-                    output_shape == expected_output_shape,
-                    "Output tensor {} shape mismatch. Expected shape with dimension {} scaled by ring_size {}",
-                    i,
-                    operation_attributes.dim,
-                    operation_attributes.ring_size);
+                for (int d = 0; d < static_cast<int>(output_shape.rank()); ++d) {
+                    if (d == operation_attributes.dim) {
+                        TT_FATAL(
+                            output_shape[d] >= expected_output_shape[d],
+                            "Output tensor {} gather dim {} too small: got {}, expected >= {} "
+                            "(= input_dim * ring_size {})",
+                            i,
+                            d,
+                            output_shape[d],
+                            expected_output_shape[d],
+                            operation_attributes.ring_size);
+                    } else {
+                        TT_FATAL(
+                            output_shape[d] == expected_output_shape[d],
+                            "Output tensor {} non-gather dim {} mismatch: got {}, expected {}",
+                            i,
+                            d,
+                            output_shape[d],
+                            expected_output_shape[d]);
+                    }
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -387,8 +387,8 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     }
 
     TT_FATAL(
-        N_global == N_local_kv * args.ring_size,
-        "Gathered K seq length must equal per-device K shard times ring size. Got N_global: {}, N_local_kv: {}, "
+        N_global >= N_local_kv * args.ring_size,
+        "Gathered K seq length must be >= per-device K shard times ring size. Got N_global: {}, N_local_kv: {}, "
         "ring_size: {}",
         N_global,
         N_local_kv,


### PR DESCRIPTION
## Summary
- Allow ring-joint SDPA to reuse max-sized persistent K/V buffers for chunked prefill.
- Add Blackhole nightly coverage for reusable oversize K/V buffers.

## Tests
- ./build_metal.sh --release
- TT_METAL_HOME=$PWD PYTHONPATH=$PWD ./python_env/bin/python -m pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_chunked_accuracy -q

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/runs/26815626409)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-oversize-kv-buffers-tests)