### PR TITLE
Bump SD UNet 2d condition model test timeout 500s -> 600s

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_unet_2d_condition_model.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_unet_2d_condition_model.py
@@ -51,7 +51,7 @@ def unsqueeze_all_params_to_4d(params):
     return params
 
 
-@pytest.mark.timeout(500)
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE}], ids=["device_params=l1_small_size_24576"], indirect=True
 )


### PR DESCRIPTION
### Summary

The blackhole/wormhole test_unet_2d_condition_model_512x512 has been intermittently timing out on the 500s budget since late May. The test is dominated by JIT kernel compilation, and its warm-ccache worst case has crept up to ~500s, leaving almost no headroom. Bump the timeout to 600s to cover the cold-cache case while the underlying compile-time growth is measured separately.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dstoiljkovic/sd-unet-timeout-600)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dstoiljkovic/sd-unet-timeout-600)