### PR TITLE
[Bug fix] Fix depthwise conv_transpose grouped lowering

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
@@ -680,6 +680,8 @@ def run_conv_transpose2d_replicate_pad(
     groups=1,
     dilation_h=1,
     dilation_w=1,
+    mirror_kernel=True,
+    config_tensors_in_dram=False,
 ):
     torch.manual_seed(0)
     conv_input_shape = [batch_size, input_channels, input_height, input_width]
@@ -728,10 +730,11 @@ def run_conv_transpose2d_replicate_pad(
 
     padded = torch.nn.functional.pad(strided, (in_pad_l, in_pad_r, in_pad_t, in_pad_b), mode="replicate")
 
-    # conv_transpose2d weight (Cin, Cout/g, kH, kW) → conv2d weight (Cout, Cin/g, kH, kW), spatial-flipped
+    # conv_transpose2d weight (Cin, Cout/g, kH, kW) -> conv2d weight (Cout, Cin/g, kH, kW).
     w_eq = torch_weight_tensor.view(groups, Cin // groups, output_channels // groups, filter_height, filter_width)
     w_eq = w_eq.transpose(1, 2).contiguous().view(output_channels, Cin // groups, filter_height, filter_width)
-    w_eq = w_eq.flip(-1).flip(-2)
+    if mirror_kernel:
+        w_eq = w_eq.flip(-1).flip(-2)
 
     torch_out_golden = torch.nn.functional.conv2d(
         padded,
@@ -759,6 +762,7 @@ def run_conv_transpose2d_replicate_pad(
         shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         deallocate_activation=True,
         padding_mode=ttnn.PaddingMode.Replicate,
+        config_tensors_in_dram=config_tensors_in_dram,
     )
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -783,6 +787,7 @@ def run_conv_transpose2d_replicate_pad(
         conv_config=conv_config,
         compute_config=compute_config,
         groups=groups,
+        mirror_kernel=mirror_kernel,
         dtype=output_dtype,
         return_output_dim=True,
         return_weights_and_bias=False,
@@ -842,6 +847,31 @@ def test_conv_transpose2d_replicate_pad(
         out_pad_h=out_pad_h,
         out_pad_w=out_pad_w,
         groups=groups,
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_conv_transpose2d_replicate_pad_depthwise_kernel12_mirror_false(device):
+    # Regression for issue #45783: this shape previously selected the 1D depthwise conv path with an invalid
+    # coalesced activation block width.
+    run_conv_transpose2d_replicate_pad(
+        device,
+        batch_size=1,
+        output_channels=48,
+        input_channels=48,
+        input_height=1,
+        input_width=64,
+        filter_height=1,
+        filter_width=12,
+        stride_h=1,
+        stride_w=2,
+        padding=(0, 5),
+        out_pad_h=0,
+        out_pad_w=0,
+        has_bias=False,
+        groups=48,
+        mirror_kernel=False,
+        config_tensors_in_dram=True,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -562,6 +562,13 @@ bool should_coalesce_1d_depthwise_conv_reads(
         return false;
     }
 
+    // Coalesced depthwise reads lay out all kernel-width channel sticks as one contiguous activation block. The
+    // coalesced compute kernel then indexes that block as kernel_width groups of channel tiles, so each stick must
+    // contain an integral number of tiles.
+    if (input_channels_padded % tt::constants::TILE_WIDTH != 0) {
+        return false;
+    }
+
     // Halo output consumed by conv is row-major FLOAT32 only for FLOAT32 input, BFLOAT16 otherwise.
     const uint32_t conv_input_datum_size = input_datatype == DataType::FLOAT32 ? 4 : 2;
     const uint64_t coalesced_read_bytes =

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -115,6 +115,8 @@ ConvTranspose2dResult conv_transpose2d_L1(
         dims.input_pad_right);
 
     const bool mm_conv = use_matmul_for_1x1_conv(kernel_size, stride, padding, dilation, groups, conv_config);
+    // Grouped conv_transpose2d embeds grouping by expanding the weights before the conv2d micro-op.
+    const uint32_t conv_groups = groups > 1 ? 1 : groups;
 
     const auto compute_grid_size = device->compute_with_storage_grid_size();
 
@@ -147,7 +149,7 @@ ConvTranspose2dResult conv_transpose2d_L1(
             ConvTranspose2dDimensions::CONV2D_STRIDE,
             dilation,
             ConvTranspose2dDimensions::CONV2D_PADDING,
-            groups,
+            conv_groups,
             bias_tensor.has_value(),
             compute_config);
         auto_shard = true;
@@ -193,6 +195,15 @@ ConvTranspose2dResult conv_transpose2d_L1(
         in_channels, get_num_cores_channels_from_parallel_config(parallel_config) * input_channels_alignment);
     uint32_t nhw_out_padded_ntile_per_core =
         conv_out_memory_config.shard_spec().value().shape[0] / tt::constants::TILE_HEIGHT;
+    const bool conv_is_1d_depthwise = is_1d_depthwise_conv(
+        conv_groups, in_channels, out_channels, kernel_size[0], input_height, bias_tensor.has_value());
+    const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
+        conv_is_1d_depthwise,
+        parallel_config.shard_scheme,
+        in_channels_padded,
+        kernel_size[1],
+        dilation[1],
+        input_tensor_post_tm.dtype());
     auto opt_conv_op_block_config = determine_per_core_conv_block_config(
         parallel_config,
         opt_conv_op_parallel_config,
@@ -204,7 +215,10 @@ ConvTranspose2dResult conv_transpose2d_L1(
         kernel_size[1],
         dims.output_width,
         get_fp32_dest_acc_en(compute_config),
-        conv_config.full_inner_dim);
+        conv_config.full_inner_dim,
+        false,
+        conv_is_1d_depthwise,
+        coalesce_1d_depthwise_kw_reads);
 
     bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
@@ -239,13 +253,15 @@ ConvTranspose2dResult conv_transpose2d_L1(
             mm_conv && auto_shard,
             out_channels,  // explicit out_channels for grouped convolutions
             bias_tensor.has_value(),
-            false,                                      // enable_kernel_stride_folding
-            false,                                      // full_inner_dim
-            false,                                      // enable_activation_reuse
-            false,                                      // coalesce_1d_depthwise_kw_reads
+            false,  // enable_kernel_stride_folding
+            false,  // full_inner_dim
+            false,  // enable_activation_reuse
+            coalesce_1d_depthwise_kw_reads,
             ConvTranspose2dDimensions::CONV2D_STRIDE);  // stride (always {1,1} for transposed conv2d)
-        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
-            transform_weights_for_conv_transpose2d(weight_for_transform, mirror_kernel), bias_tensor, params, device);
+        ttnn::Tensor transformed_weight_tensor =
+            transform_weights_for_conv_transpose2d(weight_for_transform, mirror_kernel);
+        tie(weight_tensor_on_device, bias_tensor_on_device) =
+            prepare_conv_weights_biases_and_move_to_device(transformed_weight_tensor, bias_tensor, params, device);
     }
     Tensor output;
     if (mm_conv) {
@@ -322,7 +338,7 @@ ConvTranspose2dResult conv_transpose2d_L1(
             bias_tensor_on_device,
             sliding_window_config,
             out_channels,
-            groups,
+            conv_groups,
             conv_config.output_layout == Layout::ROW_MAJOR,
             conv_config.activation,
             opt_conv_op_parallel_config,
@@ -734,6 +750,7 @@ public:
             if (!conv_config.weights_dtype.has_value()) {
                 conv_config.weights_dtype = weight_dtype_;
             }
+            const uint32_t conv_groups = groups > 1 ? 1 : groups;
             auto conv2d_dims = compute_conv_transpose2d_dimensions(
                 input_slice_height,
                 input_slice_width,
@@ -771,10 +788,10 @@ public:
                 output_dtype,
                 std::nullopt,
                 kernel_size,
-                stride,
+                ConvTranspose2dDimensions::CONV2D_STRIDE,
                 dilation,
-                padding_n4,
-                groups,
+                ConvTranspose2dDimensions::CONV2D_PADDING,
+                conv_groups,
                 has_bias,
                 compute_config);
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -433,6 +433,7 @@ ttnn::Tensor prepare_conv_transpose2d_bias(
     // Note: bias preparation doesn't receive output_padding, so we assume output_padding = 0
     auto dims =
         compute_conv_transpose2d_dimensions(input_height, input_width, kernel_size, stride, padding, {0, 0}, dilation);
+    const uint32_t groups_for_prep = groups > 1 ? 1 : groups;
 
     return prepare_conv_bias(
         bias_tensor,
@@ -447,7 +448,7 @@ ttnn::Tensor prepare_conv_transpose2d_bias(
         ConvTranspose2dDimensions::CONV2D_STRIDE,   // stride is always 1x1 for conv2d micro-op
         ConvTranspose2dDimensions::CONV2D_PADDING,  // padding is 0 (halo already added padding)
         dilation,
-        groups,
+        groups_for_prep,
         device,
         input_dtype,
         output_dtype,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #45783

Fixes depthwise conv_transpose grouped lowering so grouped/depthwise filters are reshaped and prepared with the correct group/channel semantics. Adds nightly coverage for depthwise conv_transpose2d parameter cases.

### Notes for reviewers
Focus on the grouped/depthwise path through conv_transpose2d lowering and weight preparation.

Validation re-triggered on 33f7e23c2cdb5754d97a037adcdc868d818bd2c9:
- Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/26828874651
- Blackhole post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/26828874617

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-45783-depthwise-conv-transpose2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-45783-depthwise-conv-transpose2d)