### PR TITLE
Fix RMSNorm large-tensor row-major packer initialization

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -90,7 +90,11 @@ void kernel_main() {
     // This initializes llk_pack_dest_init, which sets up the MATH-PACK DST semaphore
     // in the "available for MATH" state.  Without it, the first tilize_block call's
     // internal llk_math_wait_for_dest_available() spins forever (deadlock).
+#ifdef RMSNORM
+    binary_op_init_common(cb_in, cb_scaler, cb_xmm2);
+#else
     binary_op_init_common(cb_in, cb_scaler, cb_ex);
+#endif
 #endif
     cb_eps_obj.wait_front(1);  // comes from the reader
 
@@ -123,7 +127,11 @@ void kernel_main() {
         for (auto block : generic::blocks(Wt, block_size)) {
 #ifdef TILIZE_IN
             tilize_row_major_block(cb_in_rm, cb_in, block_size, block);
+#ifdef RMSNORM
+            binary_op_init_common(cb_in, cb_scaler, cb_xmm2);
+#else
             binary_op_init_common(cb_in, cb_scaler, cb_ex);
+#endif
 #endif
             cb_in_obj.wait_front(block.full_block_size());
             tile_regs_acquire();
@@ -268,7 +276,11 @@ void kernel_main() {
             // Reader supplies this second pass of data after the variance data.
             tilize_row_major_block(cb_in_rm, cb_in, block_size, block);
 
+#ifdef RMSNORM
+            binary_op_init_common(cb_in, cb_scaler, cb_xmm2);
+#else
             binary_op_init_common(cb_in, cb_scaler, cb_ex);
+#endif
 #endif
             tile_regs_acquire();
             cb_in_obj.wait_front(block.full_block_size());


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`tests/ttnn/nightly/unit_tests/operations/experimental/test_dit_rms_norm_unary_fused.py` was failing on WH simulator for row-major large-tensor RMSNorm cases, including `test_dit_rms_norm_unary_fused_basic_shapes[row_major-large]`, with an invalid packer configuration. The large-tensor kernel uses `binary_op_init_common` as an initialization shim after row-major tilization, but the RMSNorm path was passing `cb_ex` as the output CB even though `cb_ex` is not allocated for RMSNorm; that caused the packer to be configured with an invalid format (`15`). The change uses `cb_xmm2` for those RMSNorm-only initialization calls, which is allocated on the large-tensor path and has the correct data format, while leaving the non-RMSNorm path on `cb_ex`. This keeps the existing initialization behavior but ensures PACK is configured from a valid CB before subsequent PACR operations.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/rmsnorm-packer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/rmsnorm-packer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/rmsnorm-packer)