### PR TITLE
[skip ci] [docs] MIGRATING_TO_TIERED_CI: refresh for Blackhole + centralized targets

### DIFF
--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -107,14 +107,15 @@ When porting `<your-model>`:
   section to the tiered pipeline's section, not adding net new budget,
   unless new tests were added.
 - **9. Set a valid Slack `owner_id` and `team`** on every entry.
-- **10. Bake performance / accuracy assertions into the test itself**
-  (e.g. `assert pcc > 0.99`, `assert tokens_per_second >= …`) so
-  regressions fail the run. Tier 3 models are exempt from perf
-  targets, but accuracy assertions still apply. Once the centralized
-  targets YAML
-  ([#42671](https://github.com/tenstorrent/tt-metal/issues/42671))
-  ships, those numbers will migrate there. See
-  [Performance / accuracy targets](#performance--accuracy-targets).
+- **10. Declare performance / accuracy targets** in
+  [`models/model_targets.yaml`](./model_targets.yaml) for every (model,
+  SKU, batch_size) combination your test runs. The CI verifier checks
+  the test's benchmark payload against these on every run and fails on
+  drift. Tier 3 models are exempt from perf targets, but accuracy
+  targets still apply. See
+  [Performance / accuracy targets](#performance--accuracy-targets) for
+  the schema and SKU-aliasing rules. Ongoing standardization is
+  tracked in [#42671](https://github.com/tenstorrent/tt-metal/issues/42671).
 - **11. Run the pipeline manually** (`workflow_dispatch`) end-to-end
   before merging. Schedule will pick it up automatically afterwards.
   The easiest way to do a one-off run for your model is via the
@@ -158,15 +159,28 @@ matching the SKUs declared in the registry YAML — e.g.:
 | Qwen3-Embedding-4B | N150 |
 ```
 
-Use **N150 / N300 / T3000 / WH LoudBox / WH Galaxy** in the SKU column
-(human-readable hardware names, matching neighbouring rows), not the
-internal `wh_n150` / `wh_llmbox_perf` SKU keys.
+Use the **human-readable hardware names** in the SKU column, matching
+neighbouring rows — not the internal `wh_n150` / `bh_quietbox_2` SKU
+keys. Common values:
 
-> **Note:** the 3-tier CI is wormhole-only today. **Blackhole SKUs**
-> (`bh_p100`, `bh_p150`, `bh_loudbox`, `bh_quietbox`, …) will be
-> added to the tiered registries / workflows / `model_ci_tiers.md`
-> at a later stage. Until then, keep Blackhole tests in their existing
-> location and don't pre-emptively add BH rows to the tiered index.
+| Display name      | Internal SKU key            |
+|---|---|
+| WH N150           | `wh_n150`                   |
+| WH N300           | `wh_n300`                   |
+| WH LLMBox         | `wh_llmbox` / `wh_llmbox_perf` |
+| WH Galaxy         | `wh_galaxy` / `wh_galaxy_perf` |
+| BH P150           | `bh_p150`                   |
+| BH P300           | `bh_p300` (LFC-mode — see [Blackhole weight-cache modes](#blackhole-weight-cache-modes)) |
+| BH QuietBox 2     | `bh_quietbox_2` (2× P300)   |
+| BH Galaxy         | `bh_galaxy` / `bh_galaxy_perf` |
+
+> **Blackhole status:** BH SKUs are first-class citizens of the 3-tier
+> CI as of June 2026 (see PR #45300). Add BH rows to
+> `models/model_ci_tiers.md`, the registry yamls, and the relevant
+> workflow `model:` dropdowns the same way you'd add WH rows — but
+> read [Blackhole weight-cache modes](#blackhole-weight-cache-modes)
+> first if your model targets BH P300 (LFC) or any of the local-disk
+> runners.
 
 ---
 
@@ -178,6 +192,7 @@ If your model is currently running in any of:
   `t3k_unit_tests.yaml`, `t3k_demo_tests.yaml`, `t3k_perf_tests.yaml`,
   `t3k_integration_tests.yaml`
 - `tests/pipeline_reorg/galaxy_*_tests.yaml`
+- `tests/pipeline_reorg/blackhole_demo_tests.yaml`
 - single-card / standalone workflow files
 - or any other relevant pipelines
 
@@ -264,6 +279,74 @@ CI owners with a clear justification. Use these in your `cmd:` block:
 | `TT_CACHE_PATH` | `/mnt/MLPerf/huggingface/tt_cache/<HF/Org>/<HF-Name>` | TT-side compiled-kernel / weight-conversion cache. The path must mirror `HF_MODEL` so caches don't collide between models. |
 | `MESH_DEVICE` (only when needed) | `T3K` / `TG` / `N300` / etc. | When a test needs a non-default mesh shape. Most single-device runs can omit this. |
 
+The same `/mnt/MLPerf/...` paths work transparently on Blackhole runners
+too — the per-job impl yaml mounts the right host path under
+`/mnt/MLPerf/huggingface` based on the SKU's cache mode. See
+[Blackhole weight-cache modes](#blackhole-weight-cache-modes) below for
+the LFC exception (BH P300).
+
+---
+
+## Blackhole weight-cache modes
+
+Different BH runners host their model-weight cache in different places.
+The mapping lives in [`.github/blackhole_demo_systems.yaml`](../.github/blackhole_demo_systems.yaml)
+and is consumed by [`models-e2e-tests-impl.yaml`](../.github/workflows/models-e2e-tests-impl.yaml)
+/ [`models-unit-tests-impl.yaml`](../.github/workflows/models-unit-tests-impl.yaml)
+when each tier job spins up its container.
+
+| `weights-cache-mode` | Host source mounted at `/mnt/MLPerf/huggingface` | Used by SKUs |
+|---|---|---|
+| `cloud-mlperf` | `/mnt/MLPerf/huggingface` (shared NFS) | `bh_p150`, `bh_loudbox`, `bh_deskbox`, BH Galaxy SKUs, all WH SKUs |
+| `local-disk` | `/localdev/blackhole_demos/huggingface_data` (per-runner) | `bh_quietbox_2`, `bh_llmbox`, `bh_p150_perf` |
+| `lfc` | (no mount — weights fetched at job start) | `bh_p300`, `bh_p150b_civ2` |
+
+For most BH SKUs you don't need to do anything special — the standard
+`HF_MODEL=<org>/<name>` + `TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/<org>/<name>`
+pattern works because the impl yaml maps the host cache into the
+canonical path.
+
+**Exception: LFC-mode SKUs (`bh_p300`).** The cache is not pre-populated
+on these runners; the test job must pull the weights itself at the
+start of each run. Bundle the `wget` into the test's `cmd:` (not into
+the workflow yaml — keep SKU-specific behavior co-located with the
+test definition). Use `/mnt/MLPerf/huggingface/...` paths inside the
+cmd; the impl yaml mounts the per-runner LFC cache at that path so
+the wget output persists across jobs.
+
+Reference entry (see
+[`tests/pipeline_reorg/models_e2e_tests.yaml`](../tests/pipeline_reorg/models_e2e_tests.yaml)
+for the live version):
+
+```yaml
+- name: Llama 3.1-8B data-parallel e2e tests (P300 LFC)
+  cmd: |
+    set -e
+    mkdir -p /mnt/MLPerf/huggingface/meta-llama
+    wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" \
+      -P /mnt/MLPerf/huggingface/meta-llama \
+      http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
+    export HF_MODEL=/mnt/MLPerf/huggingface/meta-llama/Llama-3.1-8B-Instruct
+    export TT_CACHE_PATH=/mnt/MLPerf/huggingface/meta-llama/Llama-3.1-8B-Instruct
+    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "<your selector>"
+  model: llama3.1-8b-dp
+  skus:
+    bh_p300:
+      timeout: 25
+      tier: 2
+```
+
+Note that the LFC entry uses **file-path** `HF_MODEL` (the local
+checkpoint directory) rather than the `<org>/<name>` hub id, because
+the LFC cache is laid out as a flat checkpoint tree, not the HF hub
+cache structure.
+
+If you add a new BH SKU that isn't covered above, register its
+cache mode in `.github/blackhole_demo_systems.yaml` before adding tier
+yaml entries for it — otherwise the impl yaml will fall back to the
+default mount and the job will fail at container start on hosts
+without `/mnt/MLPerf`.
+
 ---
 
 ## Naming
@@ -328,6 +411,19 @@ workflow file's `model` enum:
 - `.github/workflows/models-tN-sweep-tests.yaml` (Tier 1 / 2 only)
 - `.github/workflows/models-t1-device-perf-tests.yaml` (Tier 1 only)
 
+### Adding a brand-new SKU to the dropdowns
+
+Each tier workflow also exposes a `sku:` dispatch input listing every
+SKU that pipeline accepts. If you add a tier yaml entry that targets a
+SKU not already in the dropdown of that workflow, also add it to:
+- The `sku:` input `options:` list (e.g. `- "bh_quietbox_2 (BH QB2)"`).
+- The `ALL_SKUS=` shell variable in the workflow's `resolve-skus` step.
+- The corresponding lists in
+  [`.github/workflows/all-model-tests.yaml`](../.github/workflows/all-model-tests.yaml)
+  — `BH_SKUS` / `WH_SKUS`, `VALID_SKUS`, the `description:` string,
+  and the `::error::` message. The `wh_all` and `bh_all` expansion
+  macros in that wrapper drive what runs on a full-matrix dispatch.
+
 ---
 
 ## Time budgets
@@ -372,24 +468,77 @@ team: models
 
 ## Performance / accuracy targets
 
-A **centralized targets YAML** for performance and accuracy is
-planned — see [issue #42671](https://github.com/tenstorrent/tt-metal/issues/42671).
+Targets live in [`models/model_targets.yaml`](./model_targets.yaml).
+The CI verifier loads this file at the end of every job, looks up the
+entry that matches the running (model, SKU, batch_size, seq_len), and
+diffs the measured benchmark payload against it. Drift in either
+direction fails the job — too-slow flags a regression, too-fast flags
+an outdated target.
 
-When that lands, every tiered model will be expected to declare:
+Every tiered model is expected to declare:
 
-- **Accuracy** target (e.g. minimum PCC, minimum eval score, expected
-  generation token-matching).
-- **Performance** target (e.g. minimum tokens/s, maximum prefill latency)
-  per SKU — **Tier 3 models are exempt from perf targets.**
+- **Accuracy** target (top1 / top5 token-matching against a reference).
+- **Performance** target (`prefill_time_to_token` in seconds,
+  `decode_t/s/u`, `decode_t/s`, with a `decode_tolerance` for slack).
 
-For now:
-- Bake the assertions into your test (e.g. `assert pcc > 0.99`,
-  `assert tokens_per_second >= …`) where applicable.
-- Note your target numbers in the PR description that adds the model
-  to tiered CI, so they can be migrated into the centralized YAML
-  cleanly when it ships.
-- Track the issue (#42671) and migrate when it's available — do
-  **not** invent a parallel one-off targets file in the meantime.
+**Tier 3 models are exempt from perf targets** (the perf fields can be
+omitted or set to `{}`), but accuracy targets still apply.
+
+### Entry schema
+
+```yaml
+targets:
+  <model-key>:                       # short kebab-case; matches `model:` in registry yaml
+    aliases: ["<HF-Name>", "<HF/Org>/<HF-Name>"]   # what the resolver matches against
+    skus:
+      <sku-key>:
+        entries:
+          - batch_size: 32           # optional; omit for a generic entry
+            seq_len: 1024            # optional; omit for a generic entry
+            status: active           # active | TODO
+            perf:
+              prefill_time_to_token: 0.136   # seconds
+              decode_t/s/u: 16.30
+              decode_t/s: 521.6              # = batch_size * decode_t/s/u
+              decode_tolerance: 1.15         # 15% slack on decode_t/s/u
+            accuracy:
+              top1: 96.0                     # percent
+              top5: 100.0
+            owner_id: U03XXXXXXXX
+            team: models
+```
+
+The resolver picks the entry whose `batch_size` and `seq_len` best
+match the caller. Generic entries (no `batch_size` / `seq_len`) match
+any call but lose to a more specific entry when both exist.
+
+### SKU naming in the targets yaml
+
+The resolver normalizes the SKU input via aliases declared in
+[`models/demos/utils/model_targets.py`](./demos/utils/model_targets.py).
+The notable one for BH: `p300x2`, `p150x4`, and `bh_quietbox_2` all
+resolve to the same canonical entry — because `determine_device_name`
+labels 2× P300 hardware as `"P150x4"` today even though it's really a
+P300x2. Use whichever SKU key you prefer in the yaml; the resolver
+finds it from any alias.
+
+### In-test perf checks
+
+In addition to the centralized YAML, `tt_transformers` demos that
+ship a hardcoded `ci_target_ttft` / `ci_target_decode_tok_s_u` dict
+inside `simple_text_demo.py` keep using those for an in-test
+`verify_perf` call. When you add or update a model in
+`model_targets.yaml`, add the matching `<device_name>_<model_name>`
+entry in those dicts too so both checks agree. The keys use the value
+`determine_device_name` returns (e.g. `P150x4_Llama-3.3-70B`).
+
+### When you don't have numbers yet
+
+If your model is new and you haven't measured perf or accuracy yet,
+add a `status: TODO` entry with empty `perf: {}` / `accuracy: {}` and
+populate it after the first CI run. The resolver skips TODO entries
+by default so the test doesn't fail on missing numbers, but the
+entry is on the books so it's not forgotten.
 
 ---
 
@@ -430,4 +579,6 @@ pipeline filtered to your tier + type + the new `model:` identifier
 | `.github/workflows/models-tN-sweep-tests.yaml` | Same, if you registered a sweep test (Tier 1/2). |
 | `.github/workflows/models-t1-device-perf-tests.yaml` | Same, if you registered a device-perf test. |
 | `.github/time_budget.yaml` | Verify or extend the budget for the SKU you target. |
-| Legacy `t3k_*` / `galaxy_*` YAMLs | **Remove** any old entries for this model. (Blackhole legacy yamls stay untouched until BH support lands in the 3-tier CI.) |
+| Legacy `t3k_*` / `galaxy_*` / `blackhole_demo_tests.yaml` | **Remove** any old entries for this model — duplicate scheduling wastes runners and produces conflicting signal. |
+| `models/model_targets.yaml` | Add (model, SKU, batch_size) entries with perf + accuracy targets. |
+| `.github/blackhole_demo_systems.yaml` | Only if you're adding a brand-new BH SKU — register its weight-cache mode here before adding tier yaml entries. |


### PR DESCRIPTION
## Summary

The Blackhole migration ([#45300](https://github.com/tenstorrent/tt-metal/pull/45300)) and the centralized [`models/model_targets.yaml`](../tree/main/models/model_targets.yaml) are both live on main now, but [`models/MIGRATING_TO_TIERED_CI.md`](../tree/main/models/MIGRATING_TO_TIERED_CI.md) still tells contributors:

- "the 3-tier CI is wormhole-only today" and "don't pre-emptively add BH rows to the tiered index" (line 165, blockquote callout)
- the centralized targets YAML is "planned" — referencing #42671 as a future item (lines 113-115, 458-475)
- "(Blackhole legacy yamls stay untouched until BH support lands in the 3-tier CI.)" in the files-table (line 433)

All of those are now wrong. This PR refreshes the guide.

## What changed

- **Drop the wormhole-only callout** and the matching files-table caveat. Replace with a positive statement that BH SKUs are first-class as of June 2026.
- **Expand the SKU-name table** to include `BH P150`, `BH P300`, `BH QuietBox 2`, `BH Galaxy` alongside the WH names.
- **Add `blackhole_demo_tests.yaml`** to the list of legacy pipelines a migrating model should drain entries from.
- **New section: _Blackhole weight-cache modes_.** Documents the `cloud-mlperf` / `local-disk` / `lfc` mapping in [`.github/blackhole_demo_systems.yaml`](../tree/main/.github/blackhole_demo_systems.yaml), with the bundled-wget reference entry for the LFC case (`bh_p300`).
- **Rewrite _Performance / accuracy targets_** to describe how `models/model_targets.yaml` actually works today: entry schema, SKU aliasing (`p300x2` / `p150x4` / `bh_quietbox_2` canonicalize together), the in-test `simple_text_demo.py` hardcoded dicts that must stay in sync, and the `status: TODO` pattern for unmeasured models.
- **New subsection** on adding a brand-new SKU to the workflow dropdowns + the `all-model-tests.yaml` wrapper macros (`bh_all` / `wh_all`).
- **Files-table** gains `models/model_targets.yaml` and `.github/blackhole_demo_systems.yaml` rows.

Doc grows from 433 → 584 lines.

## Test plan
- [ ] Render the diff on GitHub and check the new tables / code blocks display correctly
- [ ] Confirm all internal anchors still resolve (`#blackhole-weight-cache-modes`, `#performance--accuracy-targets`, etc.)
- [ ] Spot-check that the BH cache-mode mapping in the new section matches the live `.github/blackhole_demo_systems.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/migrating-tiered-ci-doc-update-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/migrating-tiered-ci-doc-update-bh)