### PR TITLE
[skip ci] ci: restore TTSim integration input for sanity workflow

### DIFF
--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -114,6 +114,7 @@ jobs:
       enable-llk-asserts: ${{ needs.determine-debug-flags.outputs.enable-llk-asserts == 'true' }}
       run-profiler-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-debug-flags.outputs.enable-watcher != 'true' }}
+      run-ttsim-integration-tests: false
       dev-docker-image: ${{ needs.build-artifacts-ubuntu-22.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifacts-ubuntu-22.outputs.wheel-artifact-name }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -58,6 +58,11 @@ on:
         type: boolean
         default: true
         description: "Run TTSim tests (unit + integration)"
+      run-ttsim-integration-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run TTSim integration tests"
       enable-watcher:
         required: false
         type: boolean
@@ -163,6 +168,11 @@ on:
         default: true
         type: boolean
         description: "Run TTSim tests (unit + integration)"
+      run-ttsim-integration-tests:
+        required: false
+        default: true
+        type: boolean
+        description: "Run TTSim integration tests"
       enable-watcher:
         required: false
         default: false
@@ -418,5 +428,5 @@ jobs:
       package-artifact-name: ${{ needs.resolve-artifacts.outputs.packages-artifact-name }}
       build-artifact-name: ${{ needs.resolve-artifacts.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.resolve-artifacts.outputs.wheel-artifact-name }}
-      run-ttsim-integration-tests: true
+      run-ttsim-integration-tests: ${{ github.event_name == 'push' || inputs.run-ttsim-integration-tests }}
       run-metal-cpp-unit-tests: true


### PR DESCRIPTION
## Summary
- Restore `run-ttsim-integration-tests` as an input on `sanity-tests.yaml`.
- Forward that input to `ttsim.yaml` so callers can disable TTSim integration while still allowing the broader `run-ttsim-tests` input to control the TTSim workflow.
- Explicitly pass `run-ttsim-integration-tests: false` from the debug sanity call sites in `sanity-tests-debug.yaml` for both Ubuntu 22.04 and Ubuntu 24.04.
- Preserve standalone `Sanity tests` push behavior by forcing TTSim integration on for push events, matching the previous hardcoded `true`.

## Regression
`sanity-tests-debug.yaml` needs to disable TTSim integration for debug pipelines. After `a13a7c73874` / #45270 was merged on 2026-05-31, `sanity-tests.yaml` no longer declared `run-ttsim-integration-tests` and instead introduced the broader `run-ttsim-tests` input.

GitHub rejects unknown inputs to reusable workflows during workflow startup, so the nightly debug runs failed as `startup_failure` with no jobs or logs.

## Notes
The Blackhole debug jobs call `blackhole-post-commit.yaml`, which does not have a TTSim integration path/input. The explicit false is therefore applied only to the debug jobs that call `sanity-tests.yaml`.

## Validation
- Pre-commit hooks passed, including YAML checks.
- Debug workflow dispatched on this branch and passed startup validation / created jobs: https://github.com/tenstorrent/tt-metal/actions/runs/26830591609
- Regular Sanity tests workflow dispatched on this branch and passed startup validation / created jobs: https://github.com/tenstorrent/tt-metal/actions/runs/26830591177