### PR TITLE
Support MAX + REDUCE_ROW accumulate and migrate moreh_softmax max pass

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -170,6 +170,11 @@ struct AccumulationConfig {
  * - iteration == 0: skip reload (first call, no accumulated value yet)
  * - iteration > 0: reload from accumulator CB before reducing
  *
+ * Unsupported combinations (rejected by static_assert in reduce()):
+ * - MAX + REDUCE_SCALAR: the running max cannot be reproduced by the copy_tile reload.
+ * - MAX + REDUCE_ROW on Quasar: the reload needs a within-16x16-face transpose that
+ *   copy_tile_to_dst_init_short asserts against on Quasar.
+ *
  * Usage:
  *   const auto cfg = AccumulationConfig::with_cb(cb_accum);
  *   for (uint32_t i = 0; i < num_blocks; ++i) {

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -197,6 +197,18 @@ ALWI void reduce(
         "Accumulate with PoolType::MAX + REDUCE_SCALAR is not supported: the pack edge mask "
         "keeps only DST(0,0), but GMPOOL needs that running max broadcast across face-0 row 4 "
         "on the reload pass, which the current copy_tile reload cannot reproduce.");
+#ifdef ARCH_QUASAR
+    // The MAX + REDUCE_ROW accumulator reload relies on a within-16x16-face transpose during
+    // copy_tile_to_dst_init_short (see reload_accumulator_if_needed). That transpose is rejected
+    // by copy_tile_to_dst_init_short on Quasar ("Transpose within face not supported on Quasar"),
+    // and there is no Quasar-compatible reload that restores the layout GMPOOL expects.
+    static_assert(
+        !is_accumulate_v<AccumulateT> ||
+            !(reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW),
+        "Accumulate with PoolType::MAX + REDUCE_ROW is not supported on Quasar: the accumulator "
+        "reload requires a within-16x16-face transpose, which copy_tile_to_dst_init_short asserts "
+        "against on Quasar.");
+#endif
 
     // =============================================================================
     // Runtime Assertions (parameter validation)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -106,8 +106,24 @@ ALWI void reload_accumulator_if_needed(
         if (!accumulate.is_first()) {  // Reload on all iterations except first
             constexpr uint32_t onetile = 1;
             accum_dfb.wait_front(onetile);
-            const uint32_t prev_srca_dfb = use_matmul ? scaler_dfb_id : input_dfb_id;
-            copy_tile_to_dst_init_short_with_dt(prev_srca_dfb, accumulate.config.cb_accumulator);
+            const uint32_t prev_srca_cb = use_matmul ? scaler_dfb_id : input_dfb_id;
+
+            // For MAX + REDUCE_ROW, GMPOOL's running accumulator lives at row 0 of face 0
+            // (max for rows 0-15) and row 0 of face 2 (max for rows 16-31); faces 1 and 3
+            // are never read. The LLK's reduce_row_perform_transpose then rotates those
+            // row-0 accumulators into col 0 of face 0 and col 0 of face 2 for packing.
+            // A vanilla copy_tile reload would leave the running max at col 0, but the
+            // next GMPOOL iteration only reads row 0 — so it would be silently dropped.
+            // Within-face-16x16-transpose on reload puts col 0 of each face back at row 0
+            // of that face, restoring the exact layout GMPOOL expects.
+            constexpr bool reload_within_face_transpose =
+                (reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW);
+
+            reconfig_data_format_srca(prev_srca_cb, accumulate.config.cb_accumulator);
+            copy_tile_to_dst_init_short(
+                accumulate.config.cb_accumulator,
+                /*transpose_of_faces=*/0,
+                /*transpose_within_16x16_face=*/reload_within_face_transpose ? 1u : 0u);
             copy_tile(accumulate.config.cb_accumulator, 0, accumulate.config.dst_index);
             accum_dfb.pop_front(onetile);
 
@@ -176,10 +192,11 @@ ALWI void reduce(
         is_post_reduce_op_v<PostReduceOp>,
         "PostReduceOp must be callable with a uint32_t argument");
     static_assert(
-        !is_accumulate_v<AccumulateT> || reduce_type != PoolType::MAX || reduce_dim == ReduceDim::REDUCE_COL,
-        "Accumulate::at with PoolType::MAX only works for REDUCE_COL. For REDUCE_ROW / REDUCE_SCALAR "
-        "the pack reduce edge mask drops the face-row-0 spread that GMPOOL needs as its running "
-        "accumulator on the reload pass, so the previous MAX is lost.");
+        !is_accumulate_v<AccumulateT> ||
+            !(reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_SCALAR),
+        "Accumulate with PoolType::MAX + REDUCE_SCALAR is not supported: the pack edge mask "
+        "keeps only DST(0,0), but GMPOOL needs that running max broadcast across face-0 row 4 "
+        "on the reload pass, which the current copy_tile reload cannot reproduce.");
 
     // =============================================================================
     // Runtime Assertions (parameter validation)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w.cpp
@@ -51,52 +51,24 @@ void kernel_main() {
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
                 cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
-            // Phase 1: bulk reduce of Wt-1 full tiles into cb_max (pack preserves full DEST).
-            cb_max_obj.reserve_back(1);
+            // Phase 1: reduce Wt-1 full tiles into cb_max via the helper.
+            // cb_in0 holds all Wt tiles persistently for later steps, so use
+            // WaitUpfrontNoPop — the helper waits for the slice it needs and never pops.
+            compute_kernel_lib::
+                reduce<PoolType::MAX, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::WaitUpfrontNoPop>(
+                    cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
-            tile_regs_acquire();
-#if defined FP32_DEST_ACC_EN
-            reconfig_data_format(cb_in0, cb_max_scaler);
-#endif
-            reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in0, cb_max_scaler, cb_max);
-            for (uint32_t x = 0; x < Wt - 1; ++x) {
-                cb_in0_obj.wait_front(x + 1);
-                reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in0, cb_max_scaler, x, 0, dst0);
-            }
-            reduce_uninit();
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_max);
-            tile_regs_release();
-
-            cb_max_obj.push_back(1);
-
-            // Phase 2: merge the masked last tile into cb_max.
+            // Phase 2: mask the last tile (index Wt-1, no pop) and continue reducing
+            // into cb_max via Accumulate. The accumulator and output are both cb_max:
+            // the helper waits+pops the previous tile, then packs+pushes the new one.
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, Wt - 1, 0, /*pop0=*/0, /*popm=*/0);
-
-            cb_max_obj.wait_front(1);
-            cb_tmp_obj.wait_front(1);
-
-            tile_regs_acquire();
-            copy_tile_init_with_dt(cb_max);
-            copy_tile(cb_max, 0, dst0);
-
-#if defined FP32_DEST_ACC_EN
-            reconfig_data_format(cb_tmp, cb_max_scaler);
-#endif
-            reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_tmp, cb_max_scaler, cb_max);
-            reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_tmp, cb_max_scaler, 0, 0, dst0);
-            reduce_uninit();
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_max);
-            tile_regs_release();
-
-            cb_max_obj.pop_front(1);
-            cb_tmp_obj.pop_front(1);
-            cb_max_obj.push_back(1);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
+                cb_tmp,
+                cb_max_scaler,
+                cb_max,
+                compute_kernel_lib::ReduceInputBlockShape::row(1),
+                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                compute_kernel_lib::Accumulate::at(cb_max, /*iter=*/1));
         }
 
         // compute x - max(x)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/moreh_softmax_w_large.cpp
@@ -10,7 +10,6 @@
 
 void kernel_main() {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    CircularBuffer cb_in0_obj(cb_in0);
     constexpr auto cb_mask = tt::CBIndex::c_1;
     constexpr auto cb_max_scaler = tt::CBIndex::c_2;
     constexpr auto cb_sum_scaler = tt::CBIndex::c_3;
@@ -22,12 +21,10 @@ void kernel_main() {
     constexpr auto cb_max = tt::CBIndex::c_27;
     CircularBuffer cb_max_obj(cb_max);
     constexpr auto cb_tmp = tt::CBIndex::c_28;
-    CircularBuffer cb_tmp_obj(cb_tmp);
 
     binary_op_init_common(cb_in0, cb_max_scaler, cb_out0);
 
     constexpr uint32_t onetile = 1;
-    constexpr int dst0 = 0;
 
     uint32_t N = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
@@ -40,53 +37,19 @@ void kernel_main() {
             compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
                 cb_tmp, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::single());
         } else {
-            // Phase 1: bulk reduce of Wt-1 full tiles into cb_max, popping tiles as we go.
-            cb_max_obj.reserve_back(onetile);
+            // Phase 1: reduce Wt-1 full tiles into cb_max (no accumulation, first call).
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
+                cb_in0, cb_max_scaler, cb_max, compute_kernel_lib::ReduceInputBlockShape::row(Wt - 1));
 
-            tile_regs_acquire();
-#if defined FP32_DEST_ACC_EN
-            reconfig_data_format(cb_in0, cb_max_scaler);
-#endif
-            reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in0, cb_max_scaler, cb_max);
-            for (uint32_t w = 0; w < Wt - 1; ++w) {
-                cb_in0_obj.wait_front(onetile);
-                reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_in0, cb_max_scaler, 0, 0, dst0);
-                cb_in0_obj.pop_front(onetile);
-            }
-            reduce_uninit();
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_max);
-            tile_regs_release();
-
-            cb_max_obj.push_back(onetile);
-
-            // Phase 2: merge the masked last tile into cb_max.
+            // Phase 2: mask the last tile and continue reducing into cb_max via Accumulate.
             mask_tile_to_cb(cb_in0, cb_mask, cb_tmp, 0, 0, /*pop0=*/1, /*popm=*/0);
-
-            cb_max_obj.wait_front(1);
-            cb_tmp_obj.wait_front(1);
-
-            tile_regs_acquire();
-            copy_tile_init_with_dt(cb_max);
-            copy_tile(cb_max, 0, dst0);
-
-#if defined FP32_DEST_ACC_EN
-            reconfig_data_format(cb_tmp, cb_max_scaler);
-#endif
-            reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_tmp, cb_max_scaler, cb_max);
-            reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_tmp, cb_max_scaler, 0, 0, dst0);
-            reduce_uninit();
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile_with_dt(dst0, cb_max);
-            tile_regs_release();
-
-            cb_max_obj.pop_front(1);
-            cb_tmp_obj.pop_front(1);
-            cb_max_obj.push_back(1);
+            compute_kernel_lib::reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>(
+                cb_tmp,
+                cb_max_scaler,
+                cb_max,
+                compute_kernel_lib::ReduceInputBlockShape::row(1),
+                compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                compute_kernel_lib::Accumulate::at(cb_max, /*iter=*/1));
         }
 
         // step 1

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h.cpp
@@ -15,8 +15,7 @@ void kernel_main() {
     const uint32_t tile_offset = get_arg_val<uint32_t>(2);
     const uint32_t Ht = get_arg_val<uint32_t>(3);
     const uint32_t Wt = get_arg_val<uint32_t>(4);
-    const uint32_t scaler = get_arg_val<uint32_t>(5);
-    const uint32_t mask_h = get_arg_val<uint32_t>(6);
+    const uint32_t mask_h = get_arg_val<uint32_t>(5);
 
     // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_h_large.cpp
@@ -15,8 +15,7 @@ void kernel_main() {
     const uint32_t tile_offset = get_arg_val<uint32_t>(2);
     const uint32_t Ht = get_arg_val<uint32_t>(3);
     const uint32_t Wt = get_arg_val<uint32_t>(4);
-    const uint32_t scaler = get_arg_val<uint32_t>(5);
-    const uint32_t mask_h = get_arg_val<uint32_t>(6);
+    const uint32_t mask_h = get_arg_val<uint32_t>(5);
 
     // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w.cpp
@@ -16,8 +16,7 @@ void kernel_main() {
     const uint32_t N = get_arg_val<uint32_t>(1);
     const uint32_t tile_offset = get_arg_val<uint32_t>(2);
     const uint32_t Wt = get_arg_val<uint32_t>(3);
-    const uint32_t scaler = get_arg_val<uint32_t>(4);
-    const uint32_t mask_w = get_arg_val<uint32_t>(5);
+    const uint32_t mask_w = get_arg_val<uint32_t>(4);
 
     // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/kernels/reader_moreh_softmax_w_large.cpp
@@ -16,8 +16,7 @@ void kernel_main() {
     const uint32_t N = get_arg_val<uint32_t>(1);
     const uint32_t tile_offset = get_arg_val<uint32_t>(2);
     const uint32_t Wt = get_arg_val<uint32_t>(3);
-    const uint32_t scaler = get_arg_val<uint32_t>(4);
-    const uint32_t mask_w = get_arg_val<uint32_t>(5);
+    const uint32_t mask_w = get_arg_val<uint32_t>(4);
 
     // Constants
     constexpr auto cb_in = tt::CBIndex::c_0;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <bit>
 #include <string>
 
 #include "ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
@@ -249,13 +248,11 @@ tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxHLargeFactory
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_h = input.logical_shape()[-2] % tt::constants::TILE_HEIGHT;
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, mask_h});
 
         writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
-#include <bit>
 #include <cstdint>
 #include <string>
 
@@ -250,13 +249,11 @@ tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxHSmallFactory
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_h = input.logical_shape()[-2] % tt::constants::TILE_HEIGHT;
         if (mask_h == 0) {
             mask_h = tt::constants::TILE_HEIGHT;
         }
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, mask_h});
 
         writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
-#include <bit>
 #include <cstdint>
 #include <string>
 
@@ -251,13 +250,11 @@ tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxWLargeFactory
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_w = input.logical_shape()[-1] % tt::constants::TILE_WIDTH;
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, mask_w});
 
         writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Wt});
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <bit>
 #include <string>
 
 #include <tt_stl/assert.hpp>
@@ -249,13 +248,11 @@ tt::tt_metal::ProgramDescriptor MorehSoftmaxOperation::MorehSoftmaxWSmallFactory
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_w = input.logical_shape()[-1] % tt::constants::TILE_WIDTH;
         if (mask_w == 0) {
             mask_w = tt::constants::TILE_WIDTH;
         }
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, mask_w});
 
         writer_desc.emplace_runtime_args(core, {output.buffer(), num_tiles_per_core, tile_offset, Wt});
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_large.cpp
@@ -232,17 +232,14 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryGen
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_h = input.logical_shape()[-2] % tile_height;
         if (mask_h == 0) {
             mask_h = tile_height;
         }
 
-        // BufferBinding is safe: scaler is constant 1.0f (not attribute-derived),
-        // and mask_h/num_tiles_per_core/tile_offset/Ht/Wt are shape-derived (same on
-        // cache hit because shape is part of the cache key).
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
+        // Reader computes the reduce scaler in-kernel; only shape-derived args are passed
+        // (same on cache hit because shape is part of the cache key).
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, mask_h});
 
         writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_h_small.cpp
@@ -232,15 +232,13 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryGen
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_h = input.logical_shape()[-2] % tile_height;
         if (mask_h == 0) {
             mask_h = tile_height;
         }
 
-        // BufferBinding is safe: scaler is constant 1.0f, others are shape-derived.
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, std::bit_cast<uint32_t>(scaler), mask_h});
+        // Reader computes the reduce scaler in-kernel; only shape-derived args are passed.
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Ht, Wt, mask_h});
 
         writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, tile_offset, Ht, Wt});
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_large.cpp
@@ -230,15 +230,13 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryGen
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_w = input.logical_shape()[-1] % tile_width;
         if (mask_w == 0) {
             mask_w = tile_width;
         }
 
-        // BufferBinding is safe: scaler is constant 1.0f, others are shape-derived.
-        reader_desc.emplace_runtime_args(
-            core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
+        // Reader computes the reduce scaler in-kernel; only shape-derived args are passed.
+        reader_desc.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, tile_offset, Wt, mask_w});
 
         writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, tile_offset, Wt});
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_general_w_small.cpp
@@ -232,16 +232,13 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryGen
             TT_THROW("Core not in specified core ranges");
         }
 
-        float scaler = 1.0f;
         uint32_t mask_w = input_tensor.logical_shape()[-1] % tile_width;
         if (mask_w == 0) {
             mask_w = tile_width;
         }
 
-        // BufferBinding is safe: scaler is constant 1.0f, others are shape-derived.
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_tensor.buffer(), num_tiles_per_core, tile_offset, Wt, std::bit_cast<uint32_t>(scaler), mask_w});
+        // Reader computes the reduce scaler in-kernel; only shape-derived args are passed.
+        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_tiles_per_core, tile_offset, Wt, mask_w});
 
         writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, tile_offset, Wt});
 


### PR DESCRIPTION
### What
- Add `Accumulate` support for `PoolType::MAX` + `REDUCE_ROW` in the compute reduce helper — reload the accumulator with a within-face 16×16 transpose so GMPOOL's running max survives across iterations. (`MAX` + `REDUCE_SCALAR` stays unsupported.)
- Migrate `moreh_softmax_w`/`_large` to fuse the masked last-tile reduce into the bulk max pass via `Accumulate`;
- Drop the unused scaler runtime arg from the h/w reader kernels + their moreh factories.
- **Fix:** the normalization "general" softmax factories reuse those same reader kernels but still passed the old (scaler) arg layout → reader misread `mask_h/w` → `ttnn.softmax(dim != -1)` deadlocked. Drop the stale scaler arg to match the reader's new contract.

### Test
- `unit_tests/operations/fused/test_softmax.py::test_softmax` — 108/108 (local)
- `nightly/.../moreh/test_moreh_softmax.py` — 93 passed (local)

### Pipelines
| Pipeline | Status |
|---|---|
| Sanity | [![sanity-tests.yaml](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjovic/accumulate-max-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjovic/accumulate-max-fix) |
| Blackhole post-commit | [![blackhole-post-commit.yaml](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sjovic/accumulate-max-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sjovic/accumulate-max-fix) |
| Device perf regressions | [![perf-device-models.yaml](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=sjovic/accumulate-max-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:sjovic/accumulate-max-fix) · [run](https://github.com/tenstorrent/tt-metal/actions/runs/26889499652) |
| Frequent model & ttnn | [![fast-dispatch-full-regressions-and-models.yaml](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml/badge.svg?branch=sjovic/accumulate-max-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml?query=branch:sjovic/accumulate-max-fix) · [run](https://github.com/tenstorrent/tt-metal/actions/runs/26889514569) |
| Nightly L2 (moreh+fused)¹ | [![tt-metal-l2-nightly.yaml](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjovic/accumulate-max-fix-nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjovic/accumulate-max-fix-nightly) |

Notes:
- Sanity: only failure is a pre-existing T3000 fabric test (unrelated to this PR).
- ¹ Nightly was run on `sjovic/accumulate-max-fix-nightly` (this branch + `-x` removed) so the suite runs past pre-existing `getitem`/`nll_loss`/`linear` failures and actually reaches softmax. **Softmax passes, no hangs**; remaining reds are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)