### PR TITLE
[Models CI] [Sweep Pipeline] Add seqlen sweep tests for Tier 1 and Tier 2 models

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -366,7 +366,7 @@ models:
   sweep_tier2:
     wh_n150: 30
     wh_llmbox_perf: 60
-    bh_quietbox_2: 60
+    bh_quietbox_2: 30
     bh_p150: 30
 umd:
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -360,11 +360,11 @@ models:
     bh_p300: 800
     bh_quietbox_2: 280
   sweep_tier1:
-    wh_n150: 10
-    wh_galaxy: 30
+    wh_n150: 60
+    wh_galaxy: 60
   sweep_tier2:
-    wh_llmbox_perf: 30
-
+    wh_n150: 60
+    wh_llmbox_perf: 150
 umd:
   unit:
     wh_galaxy_perf: 35

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -360,11 +360,14 @@ models:
     bh_p300: 800
     bh_quietbox_2: 280
   sweep_tier1:
-    wh_n150: 60
-    wh_galaxy: 60
+    wh_n150: 30
+    wh_galaxy: 30
+    bh_p150: 30
   sweep_tier2:
-    wh_n150: 60
-    wh_llmbox_perf: 150
+    wh_n150: 30
+    wh_llmbox_perf: 60
+    bh_quietbox_2: 60
+    bh_p150: 30
 umd:
   unit:
     wh_galaxy_perf: 35

--- a/.github/workflows/models-t1-sweep-tests.yaml
+++ b/.github/workflows/models-t1-sweep-tests.yaml
@@ -1,6 +1,9 @@
 name: "(Tier 1) Models Sweep Tests"
 
 on:
+  schedule:
+    # Weekly, Saturdays at 06:00 UTC. (GitHub Actions cron is always UTC; scheduled runs fire on the default branch only.)
+    - cron: "0 6 * * 6"
   workflow_dispatch:
     inputs:
       model:
@@ -53,6 +56,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access to populate tensor caches)"
 
 permissions:
   packages: write
@@ -102,3 +110,5 @@ jobs:
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       model: ${{ inputs.model || 'all' }}
       tier: "1"
+      # `!= false` so unset inputs on scheduled runs default to read-only (true)
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/.github/workflows/models-t2-sweep-tests.yaml
+++ b/.github/workflows/models-t2-sweep-tests.yaml
@@ -1,6 +1,9 @@
 name: "(Tier 2) Models Sweep Tests"
 
 on:
+  schedule:
+    # Weekly, Saturdays at 06:00 UTC. (GitHub Actions cron is always UTC; scheduled runs fire on the default branch only.)
+    - cron: "0 6 * * 6"
   workflow_dispatch:
     inputs:
       model:
@@ -10,7 +13,9 @@ on:
         type: choice
         options:
           - all
-          - llama3.1-8b
+          - llama3.3-70b
+          - qwen3-32b
+          - gemma-3-4b
       sku:
         description: "Select SKU to test"
         required: false
@@ -52,6 +57,11 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access to populate tensor caches)"
 
 permissions:
   packages: write
@@ -101,3 +111,5 @@ jobs:
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}
       model: ${{ inputs.model || 'all' }}
       tier: "2"
+      # `!= false` so unset inputs on scheduled runs default to read-only (true)
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -396,6 +396,33 @@ def prepare_gpt_oss_generator_args(
             False,  # stop_at_eos
             False,  # run_in_ci
         ),
+        # Seqlen sweep: 1k-128k context lengths, one step per seqlen (on single-row meshes, >64k steps are skipped)
+        (
+            [
+                "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_2k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",
+            ],  # input_prompts: list of 8 files, one per sweep step
+            1,  # data_parallel
+            1,  # batch_size
+            8,  # repeat_batches (one per seqlen step)
+            128 * 1024,  # max_seq_len (single-row meshes cap at 64k via is_seqlen_sweep guard)
+            32,  # max_generated_tokens (minimal decode to verify prefill works)
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params
+            True,  # enable_decode_trace
+            False,  # enable_prefill_trace (avoid trace memory issues at 128k)
+            False,  # warmup_prefill
+            False,  # users_row_sharded
+            False,  # long_context_mode
+            True,  # stop_at_eos
+            True,  # run_in_ci
+        ),
     ],
     ids=[
         "prefill_128",
@@ -410,6 +437,7 @@ def prepare_gpt_oss_generator_args(
         "batch128_logprobs",
         "long_context_128k",
         "long_context_short_prefill_long_decode",
+        "seqlen-sweep",
     ],
 )
 @parametrize_mesh_with_fabric()
@@ -437,12 +465,17 @@ def test_gpt_oss_demo(
 ):
     """GPT-OSS demo using full tt_transformers generation pipeline"""
     mesh_shape = tuple(mesh_device.shape)
+    test_id = request.node.callspec.id if hasattr(request.node, "callspec") else request.node.name
+    is_seqlen_sweep = "seqlen-sweep" in test_id
+    # On single-row meshes (T3K, LoudBox), cap max_seq_len at 64k for seqlen-sweep so steps >64k are skipped
+    actual_max_seq_len = min(max_seq_len, 64 * 1024) if (is_seqlen_sweep and mesh_shape[0] == 1) else max_seq_len
     if mesh_shape[0] == 1:
         if batch_size > 1:
             pytest.skip(
                 f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
             )
-        elif max_seq_len > 64 * 1024:
+        elif max_seq_len > 64 * 1024 and not is_seqlen_sweep:
+            # Seqlen sweep uses actual_max_seq_len (capped at 64k) for execution; skip only non-sweep tests
             pytest.skip(f"Long context demo with >64k tokens skipped for mesh shape {mesh_shape} due to OOM.")
     if is_blackhole() and batch_size > 1:
         pytest.skip(
@@ -486,13 +519,17 @@ def test_gpt_oss_demo(
     num_real_users = mesh_device.shape[0] if long_context_mode else global_batch_size
     users_per_row = global_batch_size // mesh_device.shape[0]
 
-    if isinstance(input_prompts, list) and len(input_prompts) == 1:  # Manual input
+    seqlen_sweep_files = None
+    if is_seqlen_sweep:  # seqlen-sweep: list of file paths, loaded per step during repeat_batch_prompts construction
+        seqlen_sweep_files = input_prompts
+        real_prompts = None  # not used; each step loads its own prompts
+    elif isinstance(input_prompts, list) and len(input_prompts) == 1:  # Manual input
         real_prompts = input_prompts * num_real_users
     elif isinstance(input_prompts, str):  # Inputs from file
         real_prompts, _ = load_inputs(input_prompts, num_real_users, instruct=False)
     else:
         raise ValueError(
-            f"Invalid input prompts: {input_prompts}. Expected a list of prompts or a string path to a json file."
+            f"Invalid input prompts: {input_prompts}. Expected a list of prompts, a single-item list, or a string path to a json file."
         )
 
     # Prepare GPT-OSS with tt_transformers infrastructure
@@ -511,7 +548,7 @@ def test_gpt_oss_demo(
         mesh_device=mesh_device,
         global_batch_size=global_batch_size,
         optimizations=optimizations,
-        max_seq_len=max_seq_len,
+        max_seq_len=actual_max_seq_len,
         page_params=page_params,
         paged_attention=paged_attention,
         mesh_config=mesh_config,  # Pass our refactored mesh config
@@ -589,8 +626,28 @@ def test_gpt_oss_demo(
 
     # Create repeat batches (like tt-transformers)
     repeat_batch_prompts = []
-    for i in range(repeat_batches):
-        repeat_batch_prompts.append([input_prompts[(j + i) % len(input_prompts)] for j in range(len(input_prompts))])
+    if is_seqlen_sweep:
+        # Load each seqlen step from its own file; skip steps exceeding the mesh's seqlen cap.
+        # Extract target seqlen from filename (e.g. "input_data_long_16k.json" -> "16k" -> 16384).
+        from pathlib import Path
+
+        for sweep_file in seqlen_sweep_files:
+            label = Path(sweep_file).stem.split("_")[-1]  # e.g. "16k"
+            if not (label.endswith("k") and label[:-1].isdigit()):
+                continue
+            step_len = int(label[:-1]) * 1024
+            if step_len > actual_max_seq_len:
+                logger.info(
+                    f"Seqlen sweep step ({step_len // 1024}k) skipped: exceeds mesh cap of {actual_max_seq_len // 1024}k"
+                )
+                continue
+            step_prompts, _ = load_inputs(sweep_file, num_real_users, instruct=False)
+            repeat_batch_prompts.append(step_prompts)
+    else:
+        for i in range(repeat_batches):
+            repeat_batch_prompts.append(
+                [input_prompts[(j + i) % len(input_prompts)] for j in range(len(input_prompts))]
+            )
 
     num_tokens_generated_decode = []
 

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -421,7 +421,11 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
-            True,  # run_in_ci
+            # run_in_ci=False: the GPT-OSS e2e pipeline runs this demo file without a -k filter, so a
+            # CI-enabled seqlen-sweep case would be collected by the regular e2e job and fail. GPT-OSS is
+            # descoped from the sweep pipeline pending #48533; keep this case out of CI until re-scoped
+            # (the sweep pipeline will select it explicitly via -k "seqlen-sweep").
+            False,  # run_in_ci
         ),
     ],
     ids=[

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -745,6 +745,36 @@ def create_tt_model(
             True,  # use_prefix_caching
             0.5,  # prefix_cached_ratio
         ),
+        (  # seqlen-sweep - Sweeps all powers-of-two seqlens up to model's max (128k), one prefill+decode per batch
+            [
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_1k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_2k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_4k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_8k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_16k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_32k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_64k.json",
+                "models/demos/llama3_70b_galaxy/demo/sample_prompts/input_data_long_128k.json",
+            ],  # input_prompts (list of files, one per sweep step)
+            True,  # instruct mode
+            8,  # repeat_batches (one per seqlen step; adjusted dynamically by sweep logic)
+            128 * 1024,  # max_seq_len (model maximum; filters out files that exceed this)
+            1,  # batch_size
+            32,  # max_generated_tokens (minimal decode to verify prefill succeeds at each length)
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # apc_test
+            False,  # pcc_check
+            False,  # prefill-only profile
+            80,  # num layers
+            False,  # print_outputs
+            False,  # is_cur_pos_sharded
+            False,  # is_page_table_sharded
+            False,  # use_prefix_caching
+            0.0,  # prefix_cached_ratio
+        ),
     ],
     ids=[
         "batch-32",  # throughput
@@ -768,6 +798,7 @@ def create_tt_model(
         "pcc-80L",  # pcc check for 80L + teacher forced
         "batch-1-prefix-caching-perf",  # 1 user, prefix caching (performance)
         "batch-1-prefix-caching-pcc",  # 1 user, prefix caching with PCC (correctness)
+        "seqlen-sweep",  # Sweep prefill across all powers-of-two seqlens up to model's max (128k)
     ],
 )
 @pytest.mark.parametrize(
@@ -880,10 +911,13 @@ def test_demo_text(
     if token_accuracy and batch_size != 1:
         raise ValueError("Token accuracy mode only supports batch_size=1")
 
+    test_id = request.node.callspec.id
+    is_seqlen_sweep = "seqlen-sweep" in test_id
+
     enable_trace = True  # Use tracing for better perf
     if token_accuracy:
         enable_trace = False  # Teacher forcing uses fresh host tokens each iteration.
-    prefill_enable_trace = True
+    prefill_enable_trace = not is_seqlen_sweep  # disable only for sweep to avoid 80MB trace budget
     print_to_file = False  # Enable this flag to print the output of all users to a file
     instruct = num_layers == 80 and instruct  # if using instruct weights it must be full model
     input_lengths = (
@@ -925,11 +959,22 @@ def test_demo_text(
 
     logger.info(f"Reading inputs...")
     profiler.start("loading_inputs")
-    input_prompts, all_prompts = load_inputs(
-        input_prompts,
-        input_lengths,
-        instruct,
-    )
+    sweep_prompt_files = None
+    if is_seqlen_sweep:
+        # In seqlen-sweep mode, input_prompts is a list of file paths (one per sweep step).
+        # Load the first file now for initial setup; per-step loading happens later.
+        sweep_prompt_files = input_prompts
+        input_prompts, all_prompts = load_inputs(
+            sweep_prompt_files[0],
+            input_lengths,
+            instruct,
+        )
+    else:
+        input_prompts, all_prompts = load_inputs(
+            input_prompts,
+            input_lengths,
+            instruct,
+        )
     profiler.end("loading_inputs")
 
     # Load expected outputs for comparison
@@ -972,10 +1017,30 @@ def test_demo_text(
     # To simulate a deployment environment, the demo supports repeating batched prompts.
     # This loop will rotate the prompts between the users for each batch, to simulate users sending different requests
     repeat_batch_prompts = []
-    for i in range(repeat_batches):
-        repeat_batch_prompts.append(
-            [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][:batch_size]
+    if is_seqlen_sweep:
+        # Seqlen sweep: load each prompt file individually, filtering out lengths that exceed the model's max.
+        # Extract target seqlen from filename (e.g. "input_data_long_16k.json" -> stem "input_data_long_16k" -> "16k" -> 16384).
+        filtered_files = []
+        for f in sweep_prompt_files:
+            label = Path(f).stem.split("_")[-1]  # e.g. "16k"
+            if label.endswith("k") and label[:-1].isdigit():
+                min_seqlen = int(label[:-1]) * 1024
+                if min_seqlen <= max_seq_len:
+                    filtered_files.append(f)
+        if not filtered_files:
+            pytest.skip(f"No sweep prompt files fit within model's max context length ({max_seq_len})")
+        repeat_batches = len(filtered_files)
+        logger.info(
+            f"Seqlen sweep: running {repeat_batches} steps with files: {[Path(f).name for f in filtered_files]}"
         )
+        for f in filtered_files:
+            batch_prompts, _ = load_inputs(f, input_lengths, instruct)
+            repeat_batch_prompts.append(batch_prompts[:batch_size])
+    else:
+        for i in range(repeat_batches):
+            repeat_batch_prompts.append(
+                [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][:batch_size]
+            )
 
     model_args, model, page_table, tt_kv_cache = create_tt_model(
         mesh_device,

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -695,6 +695,33 @@ def _gemma3_text_demo_device_params():
             False,  # stress_test
             False,  # enable_trace
         ),
+        # Seqlen sweep: 1k-128k context lengths, one step per seqlen
+        (
+            [
+                "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_2k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",
+            ],  # input_prompts: list of 8 files, one per sweep step
+            True,  # instruct mode
+            8,  # repeat_batches (one per seqlen step)
+            64 * 1024,  # max_seq_len (capped for single-N150 memory; steps above this are filtered out)
+            1,  # batch_size
+            32,  # max_generated_tokens (minimal decode to verify prefill works)
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+        ),
     ],
     ids=[
         "batch-1",  # latency
@@ -717,6 +744,7 @@ def _gemma3_text_demo_device_params():
         "ci-b1-DP-32",  # CI DP 32 batch 1
         "ci-stress-1",  # CI Stress test batch-1
         "ci-token-matching",  # CI performs token accuracy matching with reference procomputed tokens
+        "seqlen-sweep",  # sweep 1k-128k context lengths
     ],
 )
 @pytest.mark.parametrize(
@@ -891,12 +919,30 @@ def test_demo_text(
 
     logger.info(f"Reading inputs...")
     profiler.start("loading_inputs")
-    if len(input_prompts) == 1:  # Manual input
+    is_seqlen_sweep = "seqlen-sweep" in test_id
+    # The paged KV-cache pool is sized by page_max_num_blocks_per_dp, independent of max_seq_len, so a
+    # capped sweep (e.g. --max_seq_len on a single-N150 SKU) would still allocate the full pool and OOM.
+    # Shrink the pool to the swept context so the cache fits smaller-DRAM SKUs. min() only ever reduces it.
+    if is_seqlen_sweep:
+        blocks_needed = -(-(max_seq_len + max_generated_tokens) // page_params["page_block_size"])  # ceil div
+        page_params = {
+            **page_params,
+            "page_max_num_blocks_per_dp": min(page_params["page_max_num_blocks_per_dp"], blocks_needed),
+        }
+        logger.info(
+            f"Seqlen sweep: page_max_num_blocks_per_dp capped to {page_params['page_max_num_blocks_per_dp']} "
+            f"(max_seq_len={max_seq_len}, block_size={page_params['page_block_size']})"
+        )
+    if is_seqlen_sweep:  # seqlen-sweep: list of file paths, loaded per step in repeat_batch_prompts
+        seqlen_sweep_files = input_prompts
+        logger.info(
+            f"Seqlen sweep: running {len(seqlen_sweep_files)} steps: {[f.split('_')[-1] for f in seqlen_sweep_files]}"
+        )
+    elif len(input_prompts) == 1:  # Manual input
         input_prompts = input_prompts * global_batch_size
     else:  # Inputs from file
-        input_prompts = load_inputs(input_prompts, global_batch_size, input_prompts)
+        input_prompts = load_inputs(input_prompts, global_batch_size, instruct)
     profiler.end("loading_inputs")
-
     # To simulate a deployment environment, the demo supports repeating batched prompts.
     # This loop will rotate the prompts between the users for each batch, to simulate users sending different requests
     # If batch_size=1, the same prompt is repeated for each batch
@@ -963,9 +1009,22 @@ def test_demo_text(
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)
 
     repeat_batch_prompts = []
-    for i in range(repeat_batches):
-        repeat_batch_prompts.append([input_prompts[(j + i) % len(input_prompts)] for j in range(len(input_prompts))])
+    if is_seqlen_sweep:
+        # Extract target seqlen from filename (e.g. "input_data_long_16k.json" -> "16k" -> 16384)
+        def _seqlen_from_file(f):
+            label = Path(f).stem.split("_")[-1]  # e.g. "16k"
+            return int(label[:-1]) * 1024 if label.endswith("k") and label[:-1].isdigit() else 0
 
+        filtered_files = [f for f in seqlen_sweep_files if 0 < _seqlen_from_file(f) <= max_seq_len]
+        if not filtered_files:
+            pytest.skip(f"No sweep prompt files fit within max_seq_len={max_seq_len}")
+        for f in filtered_files:
+            repeat_batch_prompts.append(load_inputs(f, global_batch_size, instruct))
+    else:
+        for i in range(repeat_batches):
+            repeat_batch_prompts.append(
+                [input_prompts[(j + i) % len(input_prompts)] for j in range(len(input_prompts))]
+            )
     num_tokens_generated_decode = []
 
     logger.info("Starting inference...")
@@ -1182,7 +1241,7 @@ def test_demo_text(
                 expected_accuracy_metrics={"top1": min_top1_acc, "top5": min_top5_acc},
             )
 
-    profiler.end(f"inference_decode", iteration=batch_idx)
+        profiler.end(f"inference_decode", iteration=batch_idx)
 
     # Finish profiling at the end of inference for all repeated batches
     profiler.end("run")
@@ -1346,6 +1405,7 @@ def test_demo_text(
                 step_warm_up_num_iterations=None,
                 target=None,
             )
+
         if token_accuracy:
             benchmark_data.add_measurement(
                 profiler,

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -766,6 +766,37 @@ def prepare_generator_args(
             10,  # num_layers, if None -> defaults to all layers
             "prefill",  # mode
         ),
+        (  # seqlen-sweep - Sweeps all powers-of-two seqlens up to model's max, one prefill per batch
+            [
+                "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_2k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",
+                "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",
+            ],  # input_prompts (list of files, one per sweep step)
+            True,  # instruct mode
+            8,  # repeat_batches (one per seqlen step)
+            128 * 1024,  # max_seq_len (matches ci-1 config for N150; Galaxy overrides via --max_seq_len)
+            1,  # batch_size
+            32,  # max_generated_tokens (minimal decode to verify prefill works)
+            True,  # paged_attention
+            {
+                "page_block_size": 64,
+                "page_max_num_blocks_per_dp": 2048,
+            },  # page_params (fits N150; Galaxy overrides via --page_params)
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
     ],
     ids=[
         "batch-1",  # latency
@@ -790,6 +821,7 @@ def prepare_generator_args(
         "ci-eval-32",  # CI batch 32 with 3 repeat batches and output comparison
         "ci-long-context-16k",  # 16k context, max_seq_len=32k, used for testing --max_seq_len=16k override
         "device-perf",  # Device perf
+        "seqlen-sweep",  # Sweep prefill across all powers-of-two seqlens up to model's max
     ],
 )
 # NOTE: Please do not add new pytest parameters between optimizations and the demo parameters above, certain tests ids depend on the order of the parameters.
@@ -947,7 +979,7 @@ def test_demo_text(
 
         tg_enabled = (data_parallel == 4 and is_33_70b) or (data_parallel in [4, 16, 32] and is_31_8b)
 
-        if num_devices == 32 and not tg_enabled:
+        if num_devices == 32 and not tg_enabled and "seqlen-sweep" not in test_id:
             pytest.skip("CI only runs Llama3 70b DP = 4, TP = 8 or Llama3 8b DP = 4/16/32, TP = 8/2/1 on TG")
         if num_devices == 8 and data_parallel > 1 and not (is_32_1b or is_31_8b) and is_wormhole_b0():
             pytest.skip("CI only runs hybrid Llama3 1b and 8b on T3K")
@@ -974,9 +1006,40 @@ def test_demo_text(
     profiler = BenchmarkProfiler()
     profiler.start("run")
 
+    is_seqlen_sweep = "seqlen-sweep" in test_id
+
+    # The paged KV-cache pool is sized by page_max_num_blocks_per_dp, independent of max_seq_len, so a
+    # capped sweep (e.g. --max_seq_len on a single-N150 SKU) would still allocate the full 128k-capacity
+    # pool and OOM. Shrink the pool to the swept context so the cache fits smaller-DRAM SKUs. min() only
+    # ever reduces it, so multi-device SKUs running the full 128k keep their original pool.
+    if is_seqlen_sweep:
+        block_size = page_params["page_block_size"]
+        blocks_needed = -(-(max_seq_len + max_generated_tokens) // block_size)  # ceil div
+        if blocks_needed < page_params["page_max_num_blocks_per_dp"]:
+            # Capped sweep (small-DRAM single-device SKU, e.g. N150). Mirror the proven N150 config
+            # (block_size=32): the larger block_size=64 inflates the prefill circular buffers and clashes
+            # with L1 at prefill. Smaller blocks keep CBs within L1; size the pool to the swept context.
+            block_size = 32
+            blocks_needed = -(-(max_seq_len + max_generated_tokens) // block_size)
+            page_params = {
+                **page_params,
+                "page_block_size": block_size,
+                "page_max_num_blocks_per_dp": blocks_needed,
+            }
+            logger.info(
+                f"Seqlen sweep: capped page params for small SKU — block_size={block_size}, "
+                f"page_max_num_blocks_per_dp={blocks_needed} (max_seq_len={max_seq_len})"
+            )
+
     logger.info(f"Reading inputs...")
     profiler.start("loading_inputs")
-    if len(input_prompts) == 1:  # Manual input
+    sweep_prompt_files = None
+    if is_seqlen_sweep:
+        # In seqlen-sweep mode, input_prompts is a list of file paths (one per sweep step).
+        # Load the first file for initial setup; per-batch loading happens later.
+        sweep_prompt_files = input_prompts
+        input_prompts, all_prompts = load_inputs(sweep_prompt_files[0], global_batch_size, instruct)
+    elif len(input_prompts) == 1:  # Manual input
         input_prompts = input_prompts * global_batch_size
         all_prompts = input_prompts
     else:  # Inputs from file
@@ -1025,9 +1088,14 @@ def test_demo_text(
 
     for m_args in model_args:
         if m_args.max_context_len < max_seq_len:
-            pytest.skip(
-                f"Max seq len {max_seq_len} not supported by model {m_args.model_name}. The model's max context len is {m_args.max_context_len}"
-            )
+            if is_seqlen_sweep:
+                # For sweep mode, cap max_seq_len to model's max instead of skipping entirely
+                max_seq_len = m_args.max_context_len
+                logger.info(f"Seqlen sweep: capping max_seq_len to model's max_context_len={max_seq_len}")
+            else:
+                pytest.skip(
+                    f"Max seq len {max_seq_len} not supported by model {m_args.model_name}. The model's max context len is {m_args.max_context_len}"
+                )
 
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
@@ -1035,19 +1103,41 @@ def test_demo_text(
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)
 
     repeat_batch_prompts = []
-    for i in range(repeat_batches):
-        # For token accuracy, use input_prompts without rotation
-        if token_accuracy:
-            repeat_batch_prompts.append(input_prompts)
-        else:
-            global_prompts_for_batch = [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][
-                : batch_size * data_parallel
-            ]
+    if is_seqlen_sweep:
+        # Seqlen sweep: load each prompt file separately, filtering by model's max context.
+        # Extract target seqlen from filename (e.g. "input_data_long_16k.json" -> "16k" -> 16384).
+        filtered_files = []
+        for f in sweep_prompt_files:
+            label = Path(f).stem.split("_")[-1]  # e.g. "16k"
+            if label.endswith("k") and label[:-1].isdigit():
+                min_seqlen = int(label[:-1]) * 1024
+                if min_seqlen <= max_seq_len:
+                    filtered_files.append(f)
+        if not filtered_files:
+            pytest.skip(f"No sweep prompt files fit within model's max context length ({max_seq_len})")
+        repeat_batches = len(filtered_files)
+        logger.info(
+            f"Seqlen sweep: running {repeat_batches} steps with files: {[Path(f).name for f in filtered_files]}"
+        )
+        for f in filtered_files:
+            batch_prompts, _ = load_inputs(f, global_batch_size, instruct)
             repeat_batch_prompts.append(
-                select_local_data_parallel_items(
-                    global_prompts_for_batch, batch_size, data_parallel, local_submesh_indices
-                )
+                select_local_data_parallel_items(batch_prompts, batch_size, data_parallel, local_submesh_indices)
             )
+    else:
+        for i in range(repeat_batches):
+            # For token accuracy, use input_prompts without rotation
+            if token_accuracy:
+                repeat_batch_prompts.append(input_prompts)
+            else:
+                global_prompts_for_batch = [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][
+                    : batch_size * data_parallel
+                ]
+                repeat_batch_prompts.append(
+                    select_local_data_parallel_items(
+                        global_prompts_for_batch, batch_size, data_parallel, local_submesh_indices
+                    )
+                )
 
     num_tokens_generated_decode = []
 

--- a/tests/pipeline_reorg/models_sweep_tests.yaml
+++ b/tests/pipeline_reorg/models_sweep_tests.yaml
@@ -12,21 +12,23 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
-- name: Llama 3.1-8B sweep tests
+# Entries are grouped by model.
+
+# Full Llama-3.1-8B prefill does not fit a single N150 L1, so run a reduced 10-layer smoke for
+# pipeline liveness on N150. Full-model sweep coverage lives on multi-device SKUs. See #44482.
+- name: Llama 3.1-8B seqlen sweep
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
-    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-32"
+    pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep" --num_layers 10
   model: llama3.1-8b
   skus:
     wh_n150:
-      timeout: 10
-      tier: 1
-    wh_llmbox_perf:
       timeout: 30
-      tier: 2
+      tier: 1
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
-- name: Llama 3.3-70B sweep tests
+
+- name: Llama 3.3-70B prefix-caching benchmark
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ MESH_DEVICE=TG
     pytest --timeout 1800 models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
@@ -36,4 +38,40 @@
       timeout: 30
       tier: 1
   owner_id: U09LTAPEU2U # Viktor Pus
+  team: models
+
+- name: Llama 3.3-70B seqlen sweep (LoudBox)
+  cmd: |
+    export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
+    pytest --timeout 3600 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
+  model: llama3.3-70b
+  skus:
+    wh_llmbox_perf:
+      timeout: 60
+      tier: 2
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models
+
+- name: Qwen3-32B seqlen sweep (LoudBox)
+  cmd: |
+    export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
+    pytest --timeout 3600 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
+  model: qwen3-32b
+  skus:
+    wh_llmbox_perf:
+      timeout: 60
+      tier: 2
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models
+
+- name: Gemma-3-4B seqlen sweep
+  cmd: |
+    export HF_MODEL=google/gemma-3-4b-it TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/google/gemma-3-4b-it
+    pytest --timeout 1800 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance-seqlen-sweep" --max_seq_len 32768
+  model: gemma-3-4b
+  skus:
+    wh_n150:
+      timeout: 30
+      tier: 2
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models

--- a/tests/pipeline_reorg/models_sweep_tests.yaml
+++ b/tests/pipeline_reorg/models_sweep_tests.yaml
@@ -19,11 +19,14 @@
 - name: Llama 3.1-8B seqlen sweep
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
-    pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep" --num_layers 10
+    pytest --timeout 840 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep" --num_layers 10
   model: llama3.1-8b
   skus:
     wh_n150:
-      timeout: 30
+      timeout: 15
+      tier: 1
+    bh_p150:
+      timeout: 15
       tier: 1
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
@@ -31,11 +34,11 @@
 - name: Llama 3.3-70B prefix-caching benchmark
   cmd: |
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ MESH_DEVICE=TG
-    pytest --timeout 1800 models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
+    pytest --timeout 1140 models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
   model: llama3.3-70b
   skus:
     wh_galaxy:
-      timeout: 30
+      timeout: 20
       tier: 1
   owner_id: U09LTAPEU2U # Viktor Pus
   team: models
@@ -43,11 +46,14 @@
 - name: Llama 3.3-70B seqlen sweep (LoudBox)
   cmd: |
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
-    pytest --timeout 3600 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
+    pytest --timeout 1440 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
   model: llama3.3-70b
   skus:
     wh_llmbox_perf:
-      timeout: 60
+      timeout: 25
+      tier: 2
+    bh_quietbox_2:
+      timeout: 25
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
@@ -55,11 +61,14 @@
 - name: Qwen3-32B seqlen sweep (LoudBox)
   cmd: |
     export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
-    pytest --timeout 3600 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
+    pytest --timeout 840 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
   model: qwen3-32b
   skus:
     wh_llmbox_perf:
-      timeout: 60
+      timeout: 15
+      tier: 2
+    bh_quietbox_2:
+      timeout: 15
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
@@ -67,11 +76,14 @@
 - name: Gemma-3-4B seqlen sweep
   cmd: |
     export HF_MODEL=google/gemma-3-4b-it TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/google/gemma-3-4b-it
-    pytest --timeout 1800 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance-seqlen-sweep" --max_seq_len 32768
+    pytest --timeout 540 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance-seqlen-sweep" --max_seq_len 32768
   model: gemma-3-4b
   skus:
     wh_n150:
-      timeout: 30
+      timeout: 10
+      tier: 2
+    bh_p150:
+      timeout: 10
       tier: 2
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models

--- a/tests/pipeline_reorg/models_sweep_tests.yaml
+++ b/tests/pipeline_reorg/models_sweep_tests.yaml
@@ -52,9 +52,7 @@
     wh_llmbox_perf:
       timeout: 25
       tier: 2
-    bh_quietbox_2:
-      timeout: 25
-      tier: 2
+    # bh_quietbox_2 descoped: 70B prefill exceeds Blackhole 4-device L1 (circular-buffer clash). See #48533.
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 


### PR DESCRIPTION
Closes #44482 — sub-task of #42850 (Sweep pipeline + missing sweep tests).

## Summary
Adds **seqlen sweep tests** for a first set of Tier-1/2 models on **both Wormhole and Blackhole** SKUs: each sweep loads the model and runs one **prefill + 32-token decode per power-of-two seqlen** (1k → 2k → … up to the model's max). **Phase-1 pass criterion:** runs to completion without crashing/hanging at every swept seqlen (no output validation yet). Also adds weekly scheduling + an MLPerf write toggle to the sweep pipelines.

## Implemented sweep entries (`tests/pipeline_reorg/models_sweep_tests.yaml`)
| Entry | WH SKU | BH SKU | Tier | Notes |
|---|---|---|---|---|
| Llama 3.1-8B seqlen sweep | wh_n150 | **bh_p150** | 1 | `--num_layers 10` smoke — full 8B doesn't fit a single N150's DRAM **and** L1 |
| Llama 3.3-70B prefix-caching benchmark | wh_galaxy | — | 1 | Pre-existing entry (renamed from "sweep tests"; not a seqlen sweep) |
| Llama 3.3-70B seqlen sweep (LoudBox) | wh_llmbox_perf | — (BH descoped, #48533) | 2 | full model; 70B prefill exceeds BH 4-device L1 |
| Qwen3-32B seqlen sweep (LoudBox) | wh_llmbox_perf | **bh_quietbox_2** | 2 | full model |
| Gemma-3-4B seqlen sweep | wh_n150 | **bh_p150** | 2 | capped 32k via `--max_seq_len 32768` |

**Blackhole coverage:** every single-card (wh_n150) sweep also runs on **bh_p150**, and every LoudBox (wh_llmbox_perf) sweep also runs on **bh_quietbox_2** — same cmd/caps per entry, so they run automatically under `sku=all`. (BH timeouts mirror the WH values; they'll be re-tightened once we have BH runtime data.)

## Per-SKU job timeouts (tightened to measured runtimes)
| Entry | wh / bh timeout |
|---|---|
| Llama 3.1-8B | 15 / 15 |
| Llama 3.3-70B prefix-caching | 20 (wh_galaxy) |
| Llama 3.3-70B (LoudBox) | 25 / 25 |
| Qwen3-32B (LoudBox) | 15 / 15 |
| Gemma-3-4B | 10 / 10 |

Each `pytest --timeout` is aligned ~1 min under the job timeout; `time_budget.yaml` sweep budgets sized to the per-SKU sums + margin (incl. bh_p150 / bh_quietbox_2); `verify_time_budget` passes for both tiers.

## Key implementation details
- **`simple_text_demo.py` / `gemma3` / `gpt_oss` / `llama3_70b_galaxy`:** new `seqlen-sweep` parametrize + sweep loop — loads one prompt file per step, caps `max_seq_len` to the model's max, filters steps that exceed it.
- **Paged KV-cache pool scaling:** the pool (`page_max_num_blocks_per_dp`) is sized by config, not `max_seq_len`, so a capped sweep would still allocate the full 128k-capacity pool and OOM. In sweep mode the pool is shrunk to the swept context (and `block_size`→32 on capped single-device SKUs to keep prefill CBs within L1); `min()` only ever reduces it.
- **Pipelines:** weekly **Saturday 06:00 UTC** `schedule` cron + a **`mlperf-read-only`** dispatch toggle (default read-only; schedule-safe `!= false` forwarding; uncheck for read-write to populate caches) on both t1/t2 sweep workflows.

## Validation
- ✅ **Llama 3.1-8B (N150, 10-layer)**, **Llama 3.3-70B (LoudBox)**, **Qwen3-32B (LoudBox)**, **Gemma-3-4B (N150, 32k)** run to completion on WH. BH runs pending (first dispatch).
- Prefill-caching benchmark writes to a read-only `/mnt/MLPerf/tt_dnn-models` subtree (pre-existing infra note).

## Descoped → tracked in #48533 (assigned @fbuticTT)
- **GPT-OSS 20B / 120B** seqlen sweeps — device hang in the sweep path (sweep-specific; base e2e passes on main; batch-0 hang at 128 tokens; GIL-holding native hang).
- **Llama 3.3-70B / Qwen3-32B seqlen sweep (Galaxy)** — Galaxy node failures (one run hit a degraded 24-device node); need validation on healthy 32-device Galaxy.

The descoped models' `seqlen-sweep` demo parametrize is retained (runnable via `-k seqlen-sweep`) for easy re-scoping once #48533 is resolved.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbuticTT/seqlen-sweep-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbuticTT/seqlen-sweep-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbuticTT/seqlen-sweep-tests)



