### PR TITLE
Avoid setting invalid/reserved bit in INCRWC instructions

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -262,8 +262,8 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                     {
                         if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                         {
-                            // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                            TTI_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0);
+                            // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
+                            TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
                         }
                     }
                     // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -284,8 +284,8 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                 {
                     if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                     {
-                        // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                        TTI_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0);
+                        // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
+                        TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
                     }
                 }
                 // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -256,8 +256,8 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                     {
                         if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                         {
-                            // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                            TTI_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0);
+                            // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
+                            TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
                         }
                     }
                     // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -278,8 +278,8 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                 {
                     if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                     {
-                        // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                        TTI_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0);
+                        // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
+                        TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
                     }
                 }
                 // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
rwc_cr field is 3 bits, per https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/INCRWC.md. This code was attempting to put the value 8 in that field. Pass 0 instead, which is the same value mod 8 (i.e. the value put in the actual 3 bits is the same before and after this change).

### Notes for reviewers
I updated comments to reflect the actual state of the code after this change. It's possible that the intent was to put 4 in this field (DstCr enabled). I'm not opposed to this if it's what was intended all along, but right now the comment is actively misleading, so I think it's better to change the comment than to leave it be.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/incrwc-invalid-rwccr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/incrwc-invalid-rwccr)