### PR TITLE
scripts: fix hang triage (--llm-output) + preserve device timing in EXIT trap

### DIFF
--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -218,7 +218,7 @@ emit_missing_ttexalens_warning() {
         echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
-trap emit_missing_ttexalens_warning EXIT
+trap '_emit_device_timing; emit_missing_ttexalens_warning' EXIT
 
 if [[ "$DEV_MODE" == true ]]; then
     # Lightweight asserts: compiles ASSERT() as ebreak, halting the core at the

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -37,11 +37,11 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DISPATCH_TIMEOUT=5
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
 WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
-TRIAGE_JSON_DIR="${REPO_DIR}/generated/tt-triage"
+TRIAGE_OUT_DIR="${REPO_DIR}/generated/tt-triage"
 LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/safe-pytest-triage-$$.log"
-TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
+TRIAGE_REPORT="${TRIAGE_OUT_DIR}/triage.txt"
 
 # --- Device-lock contention profiling ---
 # When $TT_DEVICE_TIMING_LOG is set, on EXIT we append one JSON line:
@@ -193,11 +193,11 @@ fi
 # zero overhead for passing tests. On sim there is no hang detection because
 # wall-clock timeouts are meaningless at kHz clock speeds.
 rm -f "$TRIAGE_LOG"
-# Also clear any stale triage JSON from a previous run. Downstream consumers
-# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# Also clear any stale triage report from a previous run. Downstream consumers
+# (hooks, CI) treat the report's presence as the hang signal — leaving a stale
 # file around causes false-positive "hang detected" classification on the
 # next ordinary test failure.
-rm -f "$TRIAGE_JSON"
+rm -f "$TRIAGE_REPORT"
 MISSING_TTEXALENS=false
 if [[ "$SIM_MODE" == false ]]; then
     export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
@@ -207,8 +207,8 @@ if [[ "$SIM_MODE" == false ]]; then
     if ! python3 -c "import ttexalens" 2>/dev/null; then
         MISSING_TTEXALENS=true
     fi
-    mkdir -p "${TRIAGE_JSON_DIR}"
-    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --json-path=${TRIAGE_JSON} > ${TRIAGE_LOG} 2>&1"
+    mkdir -p "${TRIAGE_OUT_DIR}"
+    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --llm-output --llm-output-path=${TRIAGE_REPORT} > ${TRIAGE_LOG} 2>&1"
 fi
 
 emit_missing_ttexalens_warning() {
@@ -370,9 +370,9 @@ if [[ "$IS_HANG" == true ]]; then
         echo ""
     fi
 
-    # Print the JSON triage path as the last line so machine-readers can find it.
-    if [[ -f "$TRIAGE_JSON" ]]; then
-        echo "SAFE_PYTEST: JSON triage: ${TRIAGE_JSON}"
+    # Print the triage report path as the last line so machine-readers can find it.
+    if [[ -f "$TRIAGE_REPORT" ]]; then
+        echo "SAFE_PYTEST: triage report: ${TRIAGE_REPORT}"
     fi
 
     rm -f "$TRIAGE_LOG"

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -15,8 +15,8 @@
 #
 # Flags:
 #   --dev   Enables polling watcher (NoC sanitizer, waypoints, CB sanitization),
-#           lightweight ebreak asserts (ASSERT + LLK_ASSERT), and JSON triage
-#           to generated/tt-triage/triage.json. Same semantics as run_safe_pytest.sh --dev.
+#           lightweight ebreak asserts (ASSERT + LLK_ASSERT), and an llm-friendly triage report
+#           to generated/tt-triage/triage.txt. Same semantics as run_safe_pytest.sh --dev.
 #
 # With DPRINT:
 #   TT_METAL_DPRINT_CORES=0,0 TT_METAL_DPRINT_RISCVS=TR0 \
@@ -28,7 +28,7 @@
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
-#   --dev    - Debug mode: watcher + lightweight asserts + JSON triage on hang.
+#   --dev    - Debug mode: watcher + lightweight asserts + llm-friendly triage on hang.
 #              Probes a suspected hang or bad kernel state, letting ASSERT()/
 #              LLK_ASSERT() halt at the exact failing instruction for triage.
 #
@@ -42,8 +42,8 @@ set -o pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
-TRIAGE_JSON_DIR="${REPO_DIR}/generated/tt-triage"
-TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
+TRIAGE_OUT_DIR="${REPO_DIR}/generated/tt-triage"
+TRIAGE_REPORT="${TRIAGE_OUT_DIR}/triage.txt"
 LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/tt-probe-triage-$$.log"
@@ -139,22 +139,22 @@ if [[ "$SIM_MODE" == false ]]; then
 fi
 
 # --- Hang detection setup ---
-# Triage writes JSON to generated/tt-triage/triage.json for machine-readable
-# inspection (same location run_safe_pytest.sh uses), plus a text log for the
-# stderr dump. Grep targets are documented in CLAUDE.md § "Hang triage".
+# Triage writes an llm-friendly report to generated/tt-triage/triage.txt for
+# machine-readable inspection (same location run_safe_pytest.sh uses), plus a
+# text log for the stderr dump. Grep targets are documented in CLAUDE.md § "Hang triage".
 rm -f "$TRIAGE_LOG"
-# Also clear any stale triage JSON from a previous run. Downstream consumers
-# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# Also clear any stale triage report from a previous run. Downstream consumers
+# (hooks, CI) treat the report's presence as the hang signal — leaving a stale
 # file around causes false-positive "hang detected" classification on the
 # next ordinary probe failure.
-rm -f "$TRIAGE_JSON"
+rm -f "$TRIAGE_REPORT"
 MISSING_TTEXALENS=false
 if [[ "$SIM_MODE" == true ]]; then
     export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="echo HANG > ${TRIAGE_LOG}"
 else
     if python3 -c "import ttexalens" 2>/dev/null; then
-        mkdir -p "${TRIAGE_JSON_DIR}"
-        export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --json-path=${TRIAGE_JSON} > ${TRIAGE_LOG} 2>&1"
+        mkdir -p "${TRIAGE_OUT_DIR}"
+        export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --llm-output --llm-output-path=${TRIAGE_REPORT} > ${TRIAGE_LOG} 2>&1"
     else
         # Defer the missing-tool warning to EXIT via trap — otherwise it gets
         # buried in probe output and users never see it.
@@ -287,8 +287,8 @@ if [[ -s "$TRIAGE_LOG" ]]; then
     echo "TT_PROBE: HANG DETECTED"
     if [[ "$SIM_MODE" == false ]]; then
         cat "$TRIAGE_LOG"
-        if [[ -s "$TRIAGE_JSON" ]]; then
-            echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}"
+        if [[ -s "$TRIAGE_REPORT" ]]; then
+            echo "TT_PROBE: triage report: ${TRIAGE_REPORT}"
         fi
     fi
     rm -f "$TRIAGE_LOG"

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -170,7 +170,7 @@ emit_missing_ttexalens_warning() {
         echo "TT_PROBE: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
-trap emit_missing_ttexalens_warning EXIT
+trap '_emit_device_timing; emit_missing_ttexalens_warning' EXIT
 
 # --- Dev-mode instrumentation ---
 # Mirrors run_safe_pytest.sh --dev. On hardware this enables ebreak ASSERTs and


### PR DESCRIPTION
## What

Two small fixes to the device test wrappers (`run_safe_pytest.sh`, `tt-probe.sh`).

### 1. Hang triage is currently broken on `llk_helper_library`
Both wrappers invoke `tools/tt-triage.py --json-path=<path>` on a dispatch-timeout hang, but
`tt-triage.py` does **not** define `--json-path` (it exposes `--llm-output` / `--llm-output-path`).
`docopt` rejects the unknown option, so **triage never runs on a hang and the artifact is lost**.

Fix: invoke `--llm-output --llm-output-path=<report>`; the report is written to
`generated/tt-triage/triage.txt` (CSV-formatted, the upstream machine-readable format). Variables
and the stdout marker are renamed accordingly (`TRIAGE_JSON*` → `TRIAGE_REPORT`/`TRIAGE_OUT_DIR`,
`JSON triage:` → `triage report:`).

### 2. Device timing dropped from the EXIT trap
`trap emit_missing_ttexalens_warning EXIT` replaces the earlier `trap _emit_device_timing EXIT`
(bash replaces, not chains), so `_emit_device_timing` never fires. Chain both:
`trap '_emit_device_timing; emit_missing_ttexalens_warning' EXIT`.

## Test
`bash -n` on both scripts; verified end-to-end against the `intentional_hang` op (triage report
produced, path printed).

> Draft for review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_triage_llm_output_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_triage_llm_output_fix)