### PR TITLE
kernel_lib: Lossless docs + byte_offset_within_page + accumulate_reduce<MAX,REDUCE_ROW>

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -6,6 +6,7 @@
 // Do not include directly - include reduce_helpers_compute.hpp instead
 
 #include "api/compute/matmul.h"
+#include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack.h"
 #include "api/debug/assert.h"
@@ -107,7 +108,26 @@ ALWI void reload_accumulator_if_needed(
             constexpr uint32_t onetile = 1;
             accum_dfb.wait_front(onetile);
             const uint32_t prev_srca_dfb = use_matmul ? scaler_dfb_id : input_dfb_id;
-            copy_tile_to_dst_init_short_with_dt(prev_srca_dfb, accumulate.config.cb_accumulator);
+            // For MAX + REDUCE_ROW, the LLK runs reduce_row_perform_transpose after GMPOOL to
+            // convert the natural DST-row-0 result into DST-col-0 output layout. A vanilla
+            // copy_tile reload would therefore land the running max at DST col 0, but the
+            // next GMPOOL chain accumulates into DST row 0 — so the running max would be
+            // silently dropped. We undo the LLK's transpose on reload by setting the
+            // unpacker into within-face-16x16-transpose mode, which puts col 0 of each face
+            // back at row 0 of that face (the layout GMPOOL expects as its accumulator).
+            //
+            // CRITICAL: transpose_of_faces must stay 0 (per-face transpose only). A full
+            // 32x32 transpose would also swap face positions BL<->TR, moving the running
+            // max for global rows 16-31 (stored in BL col 0) into TR — where the LLK's
+            // second-phase BL/BR GMPOOL chain never reads it.
+            constexpr bool reload_within_face_transpose =
+                (reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW);
+
+            reconfig_data_format_srca(prev_srca_dfb, accumulate.config.cb_accumulator);
+            copy_tile_to_dst_init_short(
+                accumulate.config.cb_accumulator,
+                /*transpose_of_faces=*/0,
+                /*transpose_within_16x16_face=*/reload_within_face_transpose ? 1u : 0u);
             copy_tile(accumulate.config.cb_accumulator, 0, accumulate.config.dst_index);
             accum_dfb.pop_front(onetile);
 
@@ -177,10 +197,10 @@ ALWI void reduce(
         is_post_reduce_op_v<PostReduceOp>,
         "PostReduceOp must be callable with a uint32_t argument");
     static_assert(
-        !is_accumulate_v<AccumulateT> || reduce_type != PoolType::MAX || reduce_dim == ReduceDim::REDUCE_COL,
-        "Accumulate::at with PoolType::MAX only works for REDUCE_COL. For REDUCE_ROW / REDUCE_SCALAR "
-        "the pack reduce edge mask drops the face-row-0 spread that GMPOOL needs as its running "
-        "accumulator on the reload pass, so the previous MAX is lost.");
+        !is_accumulate_v<AccumulateT> || reduce_type != PoolType::MAX || reduce_dim != ReduceDim::REDUCE_SCALAR,
+        "Accumulate::at with PoolType::MAX is not supported for REDUCE_SCALAR. The LLK transposes the "
+        "scalar position post-GMPOOL via MOVD2B/TRNSPSRCB, which does not have a symmetric reload "
+        "remedy like REDUCE_ROW does (DST-only transpose via transpose_wh_dest).");
 
     // =============================================================================
     // Runtime Assertions (parameter validation)

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
@@ -45,11 +45,29 @@ enum class WaitMode : uint8_t {
 };
 
 // Controls whether fast tilize is used for Float32 data.
-// Fast tilize truncates fp32 to tf32 precision during tilization (lossy).
-// Use Lossless when exact fp32 preservation is required.
+//
+// You almost never want Lossless, even in "max-precision" kernels. Fast tilize
+// truncates fp32 → tf32 on the way into Dest, but every FPU consumer downstream
+// (matmul, FPU reduce, FPU binary eltwise) re-reads the tiled output through
+// SrcA/SrcB, which is tf32-only. So the precision Lossless "preserves" is
+// destroyed by the very next FPU op, and the only cost is a slower tilize path.
+//
+// Lossless is correct ONLY when ALL of these hold:
+//   1. The tiled output is consumed exclusively by SFPU ops reading directly
+//      from Dest (e.g. SFPU eltwise via copy_tile / Dest-resident SFPU chains).
+//      Any FPU op anywhere in the consumer chain — even one matmul or one
+//      add_tiles — invalidates the use case.
+//   2. fp32_dest_acc_en = true in the ComputeConfig.
+//   3. The input CB is configured with UnpackToDestMode::UnpackToDestFp32.
+// If any one is missing, prefer Fast.
 enum class Fp32Mode : uint8_t {
-    Fast,     // Default — uses fast_tilize for fp32 (lossy, truncates to tf32 precision)
-    Lossless  // Forces standard tilize path for fp32 data (exact, no truncation)
+    Fast,     // Default — uses fast_tilize for fp32 (truncates to tf32 precision).
+              // This matches what FPU ops downstream would do anyway, so it is the
+              // right default even when the surrounding kernel is "max precision".
+    Lossless  // Forces standard tilize path for fp32 data. Rarely useful — see
+              // enum comment above. Do not pick this just because the kernel is
+              // "max precision"; pick it only when the SFPU-only consumer chain
+              // and the two CB/ComputeConfig prerequisites are actually in place.
 };
 
 // Controls whether BH fast tilize configures DEST remap during init.
@@ -83,8 +101,17 @@ enum class RemapMode : uint8_t {
  *   wait_mode        — How to synchronize on input data (default: WaitBlock).
  *   reconfig_mode     — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
  *   fp32_mode        — Float32 precision control (default: Fast).
- *                       Fast: uses fast_tilize when possible (lossy for fp32 — truncates to tf32 precision).
- *                       Lossless: forces standard tilize path, preserving exact fp32 values.
+ *                       Fast: uses fast_tilize when possible (truncates fp32 → tf32 in Dest).
+ *                             This is the right default — every FPU op downstream
+ *                             (matmul, FPU reduce, FPU binary eltwise) re-reads through
+ *                             SrcA/SrcB and truncates to tf32 anyway. "Max precision"
+ *                             kernels still want Fast unless the tiled output flows
+ *                             exclusively to SFPU via Dest.
+ *                       Lossless: forces standard tilize path. RARELY USEFUL. Only helps
+ *                             when ALL of: (a) the tiled output is consumed exclusively
+ *                             by SFPU ops reading from Dest (any FPU consumer voids it),
+ *                             (b) fp32_dest_acc_en=true, (c) the input CB uses
+ *                             UnpackToDestFp32. See the Fp32Mode enum comment.
  *   remap_mode       — BH DEST remap setup control (default: Configure).
  *                       Configure: helper configures remap when the selected tilize path needs it.
  *                       AssumeConfigured: caller already enabled BH DEST remap and no intervening code changes it.
@@ -143,7 +170,14 @@ enum class RemapMode : uint8_t {
  *   compute_kernel_lib::tilize<w, dfb_in, dfb_out, tilize_config::InitUninitMode::Neither>(blocks);    // middle
  *   compute_kernel_lib::tilize<w, dfb_in, dfb_out, tilize_config::InitUninitMode::UninitOnly>(blocks); // last
  *
- *   // 7. Lossless fp32 tilize — exact fp32 preservation (no truncation to tf32)
+ *   // 7. Lossless fp32 tilize — RARELY USEFUL. Only correct when the tiled
+ *   //    output is consumed exclusively by SFPU ops reading from Dest, AND
+ *   //    fp32_dest_acc_en=true, AND the input CB uses UnpackToDestFp32. Any
+ *   //    FPU consumer (matmul, FPU reduce, FPU binary eltwise) re-truncates
+ *   //    fp32 → tf32 on the way back through SrcA/SrcB — so Lossless gains
+ *   //    nothing precision-wise and only costs you a slower tilize path.
+ *   //    Default (Fast) is the right choice for almost every kernel, including
+ *   //    ones prompted to use "max precision" defaults.
  *   compute_kernel_lib::tilize<block_w, dfb_in, dfb_out,
  *          tilize_config::InitUninitMode::InitAndUninit,
  *          tilize_config::WaitMode::WaitBlock,

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.hpp
@@ -69,14 +69,28 @@ enum class TilizeGranularity : uint8_t {
  * @tparam Accessor TensorAccessor type (deduced)
  * @param accessor TensorAccessor for the source tensor (stick-indexed)
  * @param total_num_rows Total number of sticks to read
- * @param row_bytes Actual bytes per stick (may be non-tile-aligned)
+ * @param row_bytes Actual bytes per stick to read (may be non-tile-aligned).
+ *        Combined with byte_offset_within_page this selects a chunk along W:
+ *        each stick contributes `row_bytes` bytes starting at byte
+ *        `byte_offset_within_page` of its source page.
  * @param start_page Starting page/stick index in the accessor (default 0).
  *        For multi-core work distribution, pass the per-core start_row offset
  *        so the accessor reads from the correct tensor slice.
+ * @param byte_offset_within_page Byte offset inside each source page where
+ *        reading begins (default 0). Used for wide-W chunking: wrap this
+ *        helper in a chunk-outer loop and pass
+ *        `byte_offset_within_page = chunk_id * row_bytes` so each call reads a
+ *        different W-chunk of the same set of sticks. CB sizing (per call)
+ *        then scales with `row_bytes` (the chunk width), not the full row,
+ *        bounding L1 footprint regardless of total W.
  */
 template <uint32_t cb_id, TilizeGranularity granularity = TilizeGranularity::TILE, typename Accessor>
 FORCE_INLINE void read_sticks_for_tilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page = 0);
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page = 0,
+    uint32_t byte_offset_within_page = 0);
 
 /**
  * @brief Write untilized sticks from a CB to DRAM
@@ -99,14 +113,26 @@ FORCE_INLINE void read_sticks_for_tilize(
  * @tparam Accessor TensorAccessor type (deduced)
  * @param accessor TensorAccessor for the destination tensor (stick-indexed)
  * @param total_num_rows Total number of sticks to write
- * @param row_bytes Actual bytes per stick to write (may be non-tile-aligned)
+ * @param row_bytes Actual bytes per stick to write (may be non-tile-aligned).
+ *        Combined with byte_offset_within_page this selects a chunk along W:
+ *        each stick writes `row_bytes` bytes starting at byte
+ *        `byte_offset_within_page` of its destination page.
  * @param start_page Starting page/stick index in the accessor (default 0).
  *        For multi-core work distribution, pass the per-core start_row offset
  *        so the accessor writes to the correct tensor slice.
+ * @param byte_offset_within_page Byte offset inside each destination page
+ *        where writing begins (default 0). Symmetric to the read helper's
+ *        parameter: wrap this helper in a chunk-outer loop and pass
+ *        `byte_offset_within_page = chunk_id * row_bytes` so each call writes
+ *        a different W-chunk of the same set of sticks.
  */
 template <uint32_t cb_id, typename Accessor>
 FORCE_INLINE void write_sticks_after_untilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page = 0);
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page = 0,
+    uint32_t byte_offset_within_page = 0);
 
 }  // namespace dataflow_kernel_lib
 

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.inl
@@ -66,7 +66,11 @@ constexpr uint32_t div_up(uint32_t a, uint32_t b) {
 //
 template <uint32_t cb_id, TilizeGranularity granularity, typename Accessor>
 FORCE_INLINE void read_sticks_for_tilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page) {
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page,
+    uint32_t byte_offset_within_page) {
     // Derive tile geometry from CB configuration (all constexpr)
     constexpr uint32_t tile_h = unpack_tile_r_dim[cb_id];
     constexpr uint32_t tile_w = unpack_tile_c_dim[cb_id];
@@ -114,7 +118,7 @@ FORCE_INLINE void read_sticks_for_tilize(
             uint32_t l1_addr = get_write_ptr(cb_id);
 
             for (uint32_t row = 0; row < rows_this_block; row++) {
-                uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row);
+                uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row, byte_offset_within_page);
                 noc_async_read(noc_addr, l1_addr, row_bytes);
                 l1_addr += padded_row_bytes;
             }
@@ -145,7 +149,7 @@ FORCE_INLINE void read_sticks_for_tilize(
             cb_reserve_back(cb_id, 1);
             uint32_t l1_addr = get_write_ptr(cb_id);
 
-            uint64_t noc_addr = accessor.get_noc_addr(start_page + row);
+            uint64_t noc_addr = accessor.get_noc_addr(start_page + row, byte_offset_within_page);
             noc_async_read(noc_addr, l1_addr, row_bytes);
 
             noc_async_read_barrier();
@@ -180,7 +184,11 @@ FORCE_INLINE void read_sticks_for_tilize(
 //
 template <uint32_t cb_id, typename Accessor>
 FORCE_INLINE void write_sticks_after_untilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page) {
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page,
+    uint32_t byte_offset_within_page) {
     // Derive tile geometry from CB configuration (all constexpr)
     constexpr uint32_t tile_h = unpack_tile_r_dim[cb_id];
     constexpr uint32_t tile_w = unpack_tile_c_dim[cb_id];
@@ -222,7 +230,7 @@ FORCE_INLINE void write_sticks_after_untilize(
         uint32_t l1_addr = get_read_ptr(cb_id);
 
         for (uint32_t row = 0; row < rows_this_block; row++) {
-            uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row);
+            uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row, byte_offset_within_page);
             noc_async_write(l1_addr, noc_addr, row_bytes);
             l1_addr += padded_row_bytes;
         }


### PR DESCRIPTION
## What

Three independent, branch-agnostic improvements to the shared kernel_lib helpers.

1. **`tilize_helpers`: warn against `Fp32Mode::Lossless` in the public docs.**
   Doc/comment-only. `Lossless` is rarely useful — any FPU consumer downstream re-truncates
   fp32→tf32 through SrcA/SrcB anyway, so it only buys a slower tilize path unless the tiled output
   is consumed exclusively by SFPU ops from Dest (+ `fp32_dest_acc_en` + `UnpackToDestFp32`).
   Rewrites the enum comment, the `fp32_mode` docstring, and example #7.

2. **`kernel_lib`: add `byte_offset_within_page` to the tilize/untilize dataflow helpers.**
   Generic capability add to the dataflow helpers.

3. **`kernel_lib`: support `accumulate_reduce<MAX, REDUCE_ROW>` via per-face reload transpose.**
   The LLK's `reduce_row_perform_transpose` moves GMPOOL's DST-row-0 result to DST col 0; a vanilla
   `copy_tile` reload then lands the running max at col 0 while the next GMPOOL accumulates into row 0,
   silently dropping it. Fix the reload to set the unpacker's `transpose_within_16x16_face` flag
   (`transpose_of_faces` stays 0). Relaxes the static assert to permit MAX + REDUCE_ROW (REDUCE_SCALAR
   still banned). *(The toy demo op that accompanied this on the source branch is intentionally
   excluded — helper change only.)*

## Test
Verified on device on the rebased branch: tilize/untilize helpers (`toy_tilize_untilize`, 320/320)
and the accumulate_reduce path (`toy_max_w`, 9/9, incl. partial-tile cases).

> Draft for review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_kernel_lib_improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_kernel_lib_improvements)