### PR TITLE
tests: add intentional_hang generic_op for hang-detection validation

### DIFF
--- a/tests/ttnn/unit_tests/operations/intentional_hang/__init__.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/ttnn/unit_tests/operations/intentional_hang/intentional_hang_op.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/intentional_hang_op.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+intentional_hang — a test-only op whose writer blocks forever waiting
+for a tile that is never produced. Used to validate that the eval
+hang_plugin detects real device hangs and skips subsequent
+parametrizations of the same test function.
+
+Not exported through ttnn.operations. Import directly:
+    from tests.ttnn.unit_tests.operations.intentional_hang.intentional_hang_op import intentional_hang
+"""
+
+import ttnn
+
+from .program_descriptor import create_program_descriptor
+
+
+def intentional_hang(input_tensor: ttnn.Tensor) -> ttnn.Tensor:
+    device = input_tensor.device()
+    output_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(list(input_tensor.shape)),
+        input_tensor.dtype,
+        input_tensor.layout,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    program_descriptor = create_program_descriptor(input_tensor, output_tensor)
+    return ttnn.generic_op([input_tensor, output_tensor], program_descriptor)

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/compute_noop.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/compute_noop.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op compute for intentional_hang. Produces no output tiles.
+
+#include "api/compute/compute_kernel_api.h"
+
+void kernel_main() {
+    // intentionally empty — never pushes to cb_out
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/reader_noop.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/reader_noop.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op reader for intentional_hang. Pushes zero tiles into cb_input.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    // intentionally empty — leaves cb_out empty so writer hangs on cb_wait_front
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/writer_hang.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/writer_hang.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer for intentional_hang. Blocks forever on cb_wait_front since
+// the compute kernel never pushes any tile into cb_out. This produces
+// a deterministic device-side hang that surfaces to the host as a
+// dispatch/operation timeout from system_memory_manager.cpp.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_out = 16;
+    cb_wait_front(cb_out, 1);  // deadlock — compute never pushes
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/program_descriptor.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/program_descriptor.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program descriptor for the intentional_hang test op.
+
+Wires up a no-op reader, no-op compute, and a writer that blocks on
+cb_wait_front for a tile that never arrives — guaranteed device hang.
+"""
+
+from pathlib import Path
+import ttnn
+
+KERNEL_DIR = Path(__file__).parent / "kernels"
+
+
+def create_program_descriptor(
+    input_tensor: ttnn.Tensor,
+    output_tensor: ttnn.Tensor,
+) -> ttnn.ProgramDescriptor:
+    input_page_size = input_tensor.buffer_page_size()
+    output_page_size = output_tensor.buffer_page_size()
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+
+    CB_INPUT = 0
+    CB_OUTPUT = 16
+
+    cb_input_descriptor = ttnn.CBDescriptor(
+        total_size=2 * input_page_size,
+        core_ranges=core_grid,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=CB_INPUT,
+                data_format=input_tensor.dtype,
+                page_size=input_page_size,
+            )
+        ],
+    )
+    cb_output_descriptor = ttnn.CBDescriptor(
+        total_size=2 * output_page_size,
+        core_ranges=core_grid,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=CB_OUTPUT,
+                data_format=output_tensor.dtype,
+                page_size=output_page_size,
+            )
+        ],
+    )
+
+    reader_ct_args = list(ttnn.TensorAccessorArgs(input_tensor).get_compile_time_args())
+    reader_rt_args = ttnn.RuntimeArgs()
+    reader_rt_args[core.x][core.y] = [input_tensor.buffer_address()]
+    reader_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "reader_noop.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=reader_ct_args,
+        runtime_args=reader_rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+    writer_ct_args = list(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args())
+    writer_rt_args = ttnn.RuntimeArgs()
+    writer_rt_args[core.x][core.y] = [output_tensor.buffer_address()]
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "writer_hang.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=writer_ct_args,
+        runtime_args=writer_rt_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    compute_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "compute_noop.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=[],
+        runtime_args=[],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    return ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel, compute_kernel],
+        semaphores=[],
+        cbs=[cb_input_descriptor, cb_output_descriptor],
+    )

--- a/tests/ttnn/unit_tests/operations/intentional_hang/test_intentional_hang.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/test_intentional_hang.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Inner test for the hang_plugin device validation. NOT meant to be run
+directly under normal CI — it always hangs and costs a device reset.
+
+The outer test at .claude/eval/tests/test_hang_plugin_device.py invokes
+this as a subprocess to validate that hang_plugin.py:
+  1. Detects the device timeout from the first parametrization.
+  2. Skips the remaining parametrizations with "previous parametrization
+     of test_intentional_hang hung".
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import ttnn
+
+# Allow `from tests....` imports when invoked from the repo root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")))
+
+from tests.ttnn.unit_tests.operations.intentional_hang.intentional_hang_op import (  # noqa: E402
+    intentional_hang,
+)
+
+
+@pytest.mark.parametrize("shape", [(32, 32), (32, 64), (32, 96)])
+def test_intentional_hang(shape, device):
+    torch_in = torch.ones(shape, dtype=torch.bfloat16)
+    tt_in = ttnn.from_torch(
+        torch_in,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = intentional_hang(tt_in)
+    # Force a synchronous read-back so the device-side deadlock manifests
+    # as a Python exception during the call phase, not during teardown.
+    ttnn.to_torch(tt_out)


### PR DESCRIPTION
## What
Adds a small self-contained `generic_op` whose writer kernel deliberately hangs
(`tests/ttnn/unit_tests/operations/intentional_hang/`): op + ProgramDescriptor +
noop reader/compute + hanging writer kernels + a test.

Purely additive (no edits to existing files). Imports only stdlib + `ttnn` + its own
local modules; uses the ProgramDescriptor API (already available on this branch).

## Why
A deterministic hang fixture to validate the dispatch-timeout hang-detection path
(`run_safe_pytest.sh --dev` / `tt-probe.sh --dev`) and any downstream hang plumbing —
useful as a CI/dev smoke for "does triage actually fire on a hang." Pairs naturally with
the triage `--llm-output` fix (separate PR).

> Draft for review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_intentional_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_intentional_hang)