### PR TITLE
Revert "ci: add CPM source cache to clang-tidy-reusable workflow"

### DIFF
--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -165,36 +165,12 @@ jobs:
           SHIMEOF
           chmod +x ./clang-tidy-shim
 
-      - name: 📦 Restore CPM source cache
-        id: cpm-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .cpmcache.tar.zst
-          key: cpm-z22-${{ hashFiles('third_party/CMakeLists.txt', 'tt_metal/third_party/umd/third_party/CMakeLists.txt', 'tt-train/cmake/dependencies.cmake') }}
-          restore-keys: cpm-z22-
-
-      - name: Unpack CPM cache
-        run: |
-          [ -f .cpmcache.tar.zst ] && tar -I 'zstd -T0' -xf .cpmcache.tar.zst || true
-
       - name: 🔧 CMake configure
         run: |
           CLANG_TIDY_CMD="$(pwd)/clang-tidy-shim;--warnings-as-errors=*"
           cmake --preset clang-tidy \
             -DCMAKE_CXX_CLANG_TIDY="$CLANG_TIDY_CMD" \
             -DCMAKE_C_CLANG_TIDY="$CLANG_TIDY_CMD"
-
-      - name: Pack CPM cache
-        if: steps.cpm-cache.outputs.cache-hit != 'true'
-        run: |
-          [ -d .cpmcache ] && tar -I 'zstd -T0 --ultra -22' -cf .cpmcache.tar.zst .cpmcache || true
-
-      - name: Save CPM source cache
-        if: steps.cpm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: .cpmcache.tar.zst
-          key: ${{ steps.cpm-cache.outputs.cache-primary-key }}
 
       - name: Prepare ccache summary
         run: ccache -z


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#45672

Investigating if this PR caused a slow down in code-analysis workflow due to accidental cache busting.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-45672-nsexton/clang-tidy-cpm-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-45672-nsexton/clang-tidy-cpm-cache)