### PR TITLE
Port embedding / paged_cache / plusone kernels to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embedding_ind_tilized.cpp
@@ -3,10 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
 #include "api/debug/dprint.h"
 
 void kernel_main() {
+    Noc noc;
+
     const std::uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
     const std::uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
     const std::uint32_t tile_offset = get_arg_val<uint32_t>(2);
@@ -33,47 +39,24 @@ void kernel_main() {
     constexpr uint32_t tile_height = 32;
     constexpr uint32_t face_hw = face_size * face_size;
 
-    prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
+    prepare_local_cache(noc, cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
 
-    cb_reserve_back(cb_id_in1, 1);
-    uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    cb_in1.reserve_back(1);
+    uint32_t input_l1_addr = cb_in1.get_write_ptr();
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
-    auto read_block = [&](const uint32_t& token_idx, const uint32_t& width_size, const uint32_t& offset = 0) {
-        cb_reserve_back(cb_id_in0, 1);
-        uint32_t weight_l1_addr = get_write_ptr(cb_id_in0);
-        volatile tt_l1_ptr uint16_t* weight_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(weight_l1_addr);
-        uint64_t src_noc_addr;
-        uint32_t token = input_l1_ptr[token_idx + offset];
+    const uint32_t input_page_size = input.get_aligned_page_size();
 
-#if defined PADDED
-        if (token == pad_token) {
-            src_noc_addr = pad_noc_addr;
-        } else {
-            src_noc_addr = weights.get_noc_addr(token);
-        }
-#elif defined BINARY
-        if (token == 0) {
-            src_noc_addr = zero_noc_addr;
-        } else {
-            src_noc_addr = one_noc_addr;
-        }
-#else
-#if defined BFP16
-        union {
-            float f;
-            uint32_t u;
-        } u;
-        u.u = (uint32_t)input_l1_ptr[token_idx] << 16;
-        uint32_t token_casted = static_cast<uint32_t>(u.f);
-        src_noc_addr = weights.get_noc_addr(token_casted);
-#else
-        src_noc_addr = weights.get_noc_addr(token);
-#endif
-#endif
-        noc_async_read(src_noc_addr, weight_l1_addr, width_size);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, 1);
+    auto read_block = [&](const uint32_t& token_idx, const uint32_t& width_size, const uint32_t& offset = 0) {
+        cb_in0.reserve_back(1);
+        uint32_t weight_l1_addr = cb_in0.get_write_ptr();
+        input_token_t token = static_cast<input_token_t>(input_l1_ptr[token_idx + offset]);
+        read_token_async(noc, token, weights, weight_l1_addr, width_size);
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
     };
 
     uint32_t curr_tile = tile_offset;
@@ -82,13 +65,11 @@ void kernel_main() {
     bool read_indices = true;
     uint32_t col_offset = curr_col;
     uint32_t tiles_per_row = (row_length + tile_height - 1) / tile_height;
-    const auto s = TensorAccessor(input_args, input_buffer_src_addr);
 
     for (uint32_t i = 0; i < num_rows; ++i) {
         if (read_indices) {
-            uint64_t noc_input_src_addr = input.get_noc_addr(curr_tile) + (offset * sizeof(uint32_t));
-            noc_async_read_page(curr_tile, s, input_l1_addr);
-            noc_async_read_barrier();
+            noc.async_read(input, CoreLocalMem<uint32_t>(input_l1_addr), input_page_size, {.page_id = curr_tile}, {});
+            noc.async_read_barrier();
             read_indices = false;
         }
         read_block(index, weight_stick_size, offset);

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings.cpp
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     const std::uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
     const std::uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
     const std::uint32_t batch_offset = get_arg_val<uint32_t>(2);
@@ -33,10 +39,13 @@ void kernel_main() {
     const auto input = TensorAccessor(input_args, input_buffer_src_addr);
     const auto weights = TensorAccessor(weights_args, weight_buffer_src_addr);
 
-    prepare_local_cache(cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
+    prepare_local_cache(noc, cb_id_in2, weights, weight_stick_size, /*pad_token_arg_idx=*/6);
 
-    cb_reserve_back(cb_id_in1, 1);
-    uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    cb_in1.reserve_back(1);
+    uint32_t input_l1_addr = cb_in1.get_write_ptr();
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
     uint32_t curr_row = batch_offset;  // Number of pages/rows we have read from input so far
@@ -47,22 +56,25 @@ void kernel_main() {
     bool read_indices = true;
     for (uint32_t i = 0; i < num_rows; ++i) {
         if (read_indices) {
-            uint64_t noc_input_src_addr = input.get_noc_addr(curr_row) + offset;
-            noc_async_read(noc_input_src_addr, input_l1_addr, input_block_size_bytes);
-            noc_async_read_barrier();
+            noc.async_read(
+                input,
+                CoreLocalMem<uint32_t>(input_l1_addr),
+                input_block_size_bytes,
+                {.page_id = curr_row, .offset_bytes = offset},
+                {});
+            noc.async_read_barrier();
             read_indices = false;
         }
         input_token_t token = input_l1_ptr[index];
-        uint64_t src_noc_addr = get_token_noc_addr(token, weights);
 
         for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
-            cb_reserve_back(cb_id_in0, 1);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(1);
+            uint32_t l1_write_addr = cb_in0.get_write_ptr();
             uint32_t current_chunk_size = (chunk < num_chunks - 1) ? chunk_size : last_chunk_size;
             uint32_t chunk_offset = chunk * chunk_size;
-            noc_async_read(src_noc_addr + chunk_offset, l1_write_addr, current_chunk_size);
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, 1);
+            read_token_async(noc, token, weights, l1_write_addr, current_chunk_size, chunk_offset);
+            noc.async_read_barrier();
+            cb_in0.push_back(1);
         }
 
         index++;

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -20,8 +20,7 @@ using input_token_t = uint16_t;
 using input_token_t = uint32_t;
 #endif
 
-// Local-L1 cached pad/zero/one weights. Set by prepare_local_cache, read by read_token_async.
-// Stored as plain L1 addresses; the kernel's own NoC coordinates are looked up at read time.
+// TODO: Can probably make this not global
 uint32_t pad_token;
 uint32_t pad_local_addr;
 uint32_t zero_local_addr;

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -54,8 +54,7 @@ FORCE_INLINE constexpr void prepare_local_cache(
 }
 
 // Issues an async read of one token's weight stick (or a chunk of it) into the destination L1
-// address. PADDED/BINARY builds consult the local cache populated by prepare_local_cache;
-// other builds read straight from the weights TensorAccessor. Caller must barrier before use.
+// address. Caller must barrier before use.
 template <typename T>
 FORCE_INLINE void read_token_async(
     const Noc& noc,

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -5,6 +5,11 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // TODO: Should get this from somewhere
 constexpr uint32_t tile_height = 32;
@@ -15,62 +20,98 @@ using input_token_t = uint16_t;
 using input_token_t = uint32_t;
 #endif
 
-// TODO: Can probably make this not global
+// Local-L1 cached pad/zero/one weights. Set by prepare_local_cache, read by read_token_async.
+// Stored as plain L1 addresses; the kernel's own NoC coordinates are looked up at read time.
 uint32_t pad_token;
-uint64_t pad_noc_addr;
-uint64_t zero_noc_addr;
-uint64_t one_noc_addr;
+uint32_t pad_local_addr;
+uint32_t zero_local_addr;
+uint32_t one_local_addr;
 
 template <typename T>
 FORCE_INLINE constexpr void prepare_local_cache(
-    uint32_t local_cache_cb, const T& weights, uint32_t weight_stick_size, uint32_t pad_token_arg_idx = 0) {
+    const Noc& noc,
+    uint32_t local_cache_cb,
+    const T& weights,
+    uint32_t weight_stick_size,
+    uint32_t pad_token_arg_idx = 0) {
 #if defined PADDED
     pad_token = get_arg_val<uint32_t>(pad_token_arg_idx);
-    cb_reserve_back(local_cache_cb, 1);
-    uint32_t local_pad_addr = get_write_ptr(local_cache_cb);
-    uint64_t src_noc_addr = weights.get_noc_addr(pad_token);
-    noc_async_read(src_noc_addr, local_pad_addr, weight_stick_size);
-    noc_async_read_barrier();
-    pad_noc_addr = get_noc_addr(local_pad_addr);
+    CircularBuffer cb(local_cache_cb);
+    cb.reserve_back(1);
+    pad_local_addr = cb.get_write_ptr();
+    noc.async_read(weights, CoreLocalMem<uint32_t>(pad_local_addr), weight_stick_size, {.page_id = pad_token}, {});
+    noc.async_read_barrier();
 #elif defined BINARY
-    cb_reserve_back(local_cache_cb, 2);
-    uint32_t local_write_addr = get_write_ptr(local_cache_cb);
-    uint64_t src_noc_addr = weights.get_noc_addr(0);
-    noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-    zero_noc_addr = get_noc_addr(local_write_addr);
+    CircularBuffer cb(local_cache_cb);
+    cb.reserve_back(2);
+    zero_local_addr = cb.get_write_ptr();
+    noc.async_read(weights, CoreLocalMem<uint32_t>(zero_local_addr), weight_stick_size, {.page_id = 0}, {});
 
-    local_write_addr += weight_stick_size;
-    src_noc_addr = weights.get_noc_addr(1);
-    noc_async_read(src_noc_addr, local_write_addr, weight_stick_size);
-    one_noc_addr = get_noc_addr(local_write_addr);
+    one_local_addr = zero_local_addr + weight_stick_size;
+    noc.async_read(weights, CoreLocalMem<uint32_t>(one_local_addr), weight_stick_size, {.page_id = 1}, {});
 
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 #endif
 }
 
+// Issues an async read of one token's weight stick (or a chunk of it) into the destination L1
+// address. PADDED/BINARY builds consult the local cache populated by prepare_local_cache;
+// other builds read straight from the weights TensorAccessor. Caller must barrier before use.
 template <typename T>
-FORCE_INLINE uint64_t get_token_noc_addr(input_token_t token, const T& weights) {
+FORCE_INLINE void read_token_async(
+    const Noc& noc,
+    input_token_t token,
+    const T& weights,
+    uint32_t dst_l1_addr,
+    uint32_t size_bytes,
+    uint32_t weight_offset_bytes = 0) {
 #if defined PADDED
     if (token == pad_token) {
-        return pad_noc_addr;
-    } else {
-        return weights.get_noc_addr(token);
+        const uint8_t noc_id = noc.get_noc_id();
+        UnicastEndpoint src;
+        noc.async_read(
+            src,
+            CoreLocalMem<uint32_t>(dst_l1_addr),
+            size_bytes,
+            {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = pad_local_addr + weight_offset_bytes},
+            {});
+        return;
     }
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(dst_l1_addr),
+        size_bytes,
+        {.page_id = static_cast<uint32_t>(token), .offset_bytes = weight_offset_bytes},
+        {});
 #elif defined BINARY
-    if (token == 0) {
-        return zero_noc_addr;
-    } else {
-        return one_noc_addr;
-    }
+    const uint8_t noc_id = noc.get_noc_id();
+    UnicastEndpoint src;
+    const uint32_t local_addr = (token == 0) ? zero_local_addr : one_local_addr;
+    noc.async_read(
+        src,
+        CoreLocalMem<uint32_t>(dst_l1_addr),
+        size_bytes,
+        {.noc_x = my_x[noc_id], .noc_y = my_y[noc_id], .addr = local_addr + weight_offset_bytes},
+        {});
 #elif defined BFP16
     union {
         float f;
         uint32_t u;
     } u;
-    u.u = (uint32_t)token << 16;
+    u.u = static_cast<uint32_t>(token) << 16;
     uint32_t token_casted = static_cast<uint32_t>(u.f);
-    return weights.get_noc_addr(token_casted);
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(dst_l1_addr),
+        size_bytes,
+        {.page_id = token_casted, .offset_bytes = weight_offset_bytes},
+        {});
 #else
-    return weights.get_noc_addr(token);
+    noc.async_read(
+        weights,
+        CoreLocalMem<uint32_t>(dst_l1_addr),
+        size_bytes,
+        {.page_id = static_cast<uint32_t>(token), .offset_bytes = weight_offset_bytes},
+        {});
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_rm_writer_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_rm_writer_chunked.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t num_sticks = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
@@ -19,17 +25,22 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(dst0_args, dst_addr, output_page_size);
 
+    CircularBuffer cb_out0(cb_id_out0);
+
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t row = start_id; row < end_id; ++row) {
-        uint64_t row_base_addr = s0.get_noc_addr(row);
         for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
-            cb_wait_front(cb_id_out0, 1);
-            uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+            cb_out0.wait_front(1);
+            uint32_t l1_read_addr = cb_out0.get_read_ptr();
             uint32_t write_size = (chunk < num_chunks - 1) ? chunk_size : last_chunk_size;
-            uint64_t dst_noc_addr = row_base_addr + chunk * chunk_size;
-            noc_async_write(l1_read_addr, dst_noc_addr, write_size);
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_out0, 1);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr),
+                s0,
+                write_size,
+                {},
+                {.page_id = row, .offset_bytes = chunk * chunk_size});
+            noc.async_write_barrier();
+            cb_out0.pop_front(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_tilize.cpp
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp"
 
 void kernel_main() {
+    Noc noc;
+
     const uint32_t input_buffer_src_addr = get_arg_val<uint32_t>(0);
     const uint32_t weight_buffer_src_addr = get_arg_val<uint32_t>(1);
     const uint32_t input_start_id = get_arg_val<uint32_t>(2);
@@ -28,23 +34,30 @@ void kernel_main() {
     auto input = TensorAccessor(input_args, input_buffer_src_addr);
     auto weights = TensorAccessor(weights_args, weight_buffer_src_addr + weight_offset);
 
-    prepare_local_cache(cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6);
+    prepare_local_cache(noc, cb_id_in2, weights, weight_block_size, /*pad_token_arg_idx=*/6);
 
-    cb_reserve_back(cb_id_in1, 1);
-    uint32_t input_l1_addr = get_write_ptr(cb_id_in1);
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    cb_in1.reserve_back(1);
+    uint32_t input_l1_addr = cb_in1.get_write_ptr();
 
     volatile tt_l1_ptr input_token_t* input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr input_token_t*>(input_l1_addr);
 
     uint32_t curr_row = input_start_id;
     uint32_t offset = input_start_offset;
     for (uint32_t i = 0; i < num_blocks; ++i) {
-        uint64_t noc_input_src_addr = input.get_noc_addr(curr_row) + offset;
-        noc_async_read<input_block_size_bytes>(noc_input_src_addr, input_l1_addr, input_block_size_bytes);
-        noc_async_read_barrier();
+        noc.async_read<NocOptions::DEFAULT, input_block_size_bytes>(
+            input,
+            CoreLocalMem<uint32_t>(input_l1_addr),
+            input_block_size_bytes,
+            {.page_id = curr_row, .offset_bytes = offset},
+            {});
+        noc.async_read_barrier();
 
         for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
-            cb_reserve_back(cb_id_in0, tiles_per_chunk);
-            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            cb_in0.reserve_back(tiles_per_chunk);
+            uint32_t l1_write_addr = cb_in0.get_write_ptr();
 
             // Calculate the chunk size and offset within the embedding vector
             uint32_t weight_chunk_size = weight_block_size / num_chunks;
@@ -52,13 +65,11 @@ void kernel_main() {
 
             for (uint32_t k = 0; k < tile_height; ++k) {
                 input_token_t token = input_l1_ptr[k];
-                uint64_t src_noc_addr = get_token_noc_addr(token, weights);
-
-                noc_async_read(src_noc_addr + weight_chunk_offset, l1_write_addr, weight_chunk_size);
+                read_token_async(noc, token, weights, l1_write_addr, weight_chunk_size, weight_chunk_offset);
                 l1_write_addr += weight_chunk_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in0, tiles_per_chunk);
+            noc.async_read_barrier();
+            cb_in0.push_back(tiles_per_chunk);
         }
 
         offset += input_block_size_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -4,8 +4,14 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
 
@@ -24,18 +30,19 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr);
 
+    CircularBuffer cb_in(cb_id_in);
+
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
-    // uint32_t end_id = start_id + num_tiles;
     uint32_t tile_id = start_tile_id;
     for (uint32_t row_num = 0; row_num < num_rows; ++row_num) {
-        cb_reserve_back(cb_id_in, Wt);
-        uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+        cb_in.reserve_back(Wt);
+        uint32_t l1_write_addr = cb_in.get_write_ptr();
         for (uint32_t w = 0; w < Wt; ++w) {
-            noc_async_read_page(tile_id, s, l1_write_addr);
+            noc.async_read(s, CoreLocalMem<uint32_t>(l1_write_addr), tile_bytes, {.page_id = tile_id}, {});
             l1_write_addr += tile_bytes;
             tile_id++;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in, Wt);
+        noc.async_read_barrier();
+        cb_in.push_back(Wt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t rt_args_idx = 0;
     const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
     if (!has_work) {
@@ -48,7 +55,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(18);
 
     const uint32_t St = get_compile_time_arg_val(19);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(20));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(20);  // semaphore for receiver
     constexpr uint32_t batch_size = get_compile_time_arg_val(21);
 
     constexpr auto s0_args = TensorAccessorArgs<22>();
@@ -57,9 +64,14 @@ void kernel_main() {
 
     constexpr uint32_t head_offset_t = Wt * St;
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     // Kick off compute
-    cb_reserve_back(input_cb_id, Wt);
-    cb_push_back(input_cb_id, Wt);
+    cb_input.reserve_back(Wt);
+    cb_input.push_back(Wt);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -74,15 +86,14 @@ void kernel_main() {
 
     if constexpr (use_index_tensor) {
         const auto addrg = TensorAccessor(index_tensor_args, index_tensor_addr);
-        cb_reserve_back(cb_index_id, 1);
-        uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
+        cb_index.reserve_back(1);
+        uint32_t index_cb_wr_ptr = cb_index.get_write_ptr();
         if constexpr (index_is_dram) {
             // index_tensor has one page to read
-            uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
-            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-            noc_async_read_barrier();
+            noc.async_read(addrg, CoreLocalMem<uint32_t>(index_cb_wr_ptr), index_stick_size_B, {.page_id = 0}, {});
+            noc.async_read_barrier();
         }
-        cb_push_back(cb_index_id, 1);
+        cb_index.push_back(1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
         const uint32_t update_idx = index_ptr[my_batch_idx];
@@ -92,19 +103,23 @@ void kernel_main() {
         } else {
             if constexpr (is_paged_cache) {
                 uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-                cb_reserve_back(page_table_cb_id, num_pages_to_read);
-                uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
+                cb_page_table.reserve_back(num_pages_to_read);
+                uint32_t page_table_cb_wr_ptr = cb_page_table.get_write_ptr();
 
                 if constexpr (page_table_is_dram) {
                     const auto page_table_gen = TensorAccessor(page_table_args, page_table_tensor_addr);
-                    uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(my_batch_idx);
-                    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                    noc_async_read_barrier();
+                    noc.async_read(
+                        page_table_gen,
+                        CoreLocalMem<uint32_t>(page_table_cb_wr_ptr),
+                        page_table_stick_size,
+                        {.page_id = my_batch_idx},
+                        {});
+                    noc.async_read_barrier();
                 } else {
                     page_table_cb_wr_ptr += my_batch_idx * page_table_stick_size;
                 }
 
-                cb_push_back(page_table_cb_id, num_pages_to_read);
+                cb_page_table.push_back(num_pages_to_read);
                 // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
                 volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
                 volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
@@ -134,25 +149,25 @@ void kernel_main() {
     }
 
     if (wait_to_start_signal) {
-        // wait for signal to start pushing tensor
-        volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
-        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, 1);
-        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+        // wait for signal from writer that it has finished using the input CB
+        Semaphore<> receiver_sem(receiver_sem_id);
+        receiver_sem.wait(1);
+        receiver_sem.set(0);
     }
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        cb_reserve_back(cache_cb_id, Wt);
+        cb_cache.reserve_back(Wt);
         if (!skip_update) {
-            uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
+            uint32_t cache_l1_write_addr = cb_cache.get_write_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
+                noc.async_read(
+                    s0, CoreLocalMem<uint32_t>(cache_l1_write_addr), cache_tile_bytes, {.page_id = curr_cache_id}, {});
                 cache_l1_write_addr += cache_tile_bytes;
             }
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
         }
-        cb_push_back(cache_cb_id, Wt);
+        cb_cache.push_back(Wt);
 
         cache_id += head_offset_t;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t rt_args_idx = 0;
     const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
     if (!has_work) {
@@ -48,7 +55,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(18);
 
     const uint32_t St = get_compile_time_arg_val(19);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(20));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(20);  // semaphore for receiver
     constexpr uint32_t batch_size = get_compile_time_arg_val(21);
 
     constexpr auto s0_args = TensorAccessorArgs<22>();
@@ -57,9 +64,14 @@ void kernel_main() {
 
     constexpr uint32_t head_offset_t = Wt * St;
 
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     // Kick off compute
-    cb_reserve_back(input_cb_id, 1);
-    cb_push_back(input_cb_id, 1);
+    cb_input.reserve_back(1);
+    cb_input.push_back(1);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -75,16 +87,15 @@ void kernel_main() {
     if constexpr (use_index_tensor) {
         const auto addrg = TensorAccessor(index_tensor_args, index_tensor_addr);
 
-        cb_reserve_back(cb_index_id, 1);
-        uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
+        cb_index.reserve_back(1);
+        uint32_t index_cb_wr_ptr = cb_index.get_write_ptr();
         // index_tensor has one page to read
         if constexpr (index_is_dram) {
-            uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
-            noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-            noc_async_read_barrier();
+            noc.async_read(addrg, CoreLocalMem<uint32_t>(index_cb_wr_ptr), index_stick_size_B, {.page_id = 0}, {});
+            noc.async_read_barrier();
         }
 
-        cb_push_back(cb_index_id, 1);
+        cb_index.push_back(1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
         const uint32_t update_idx = index_ptr[my_batch_idx];
@@ -96,18 +107,22 @@ void kernel_main() {
             if constexpr (is_paged_cache) {
                 uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
 
-                cb_reserve_back(page_table_cb_id, num_pages_to_read);
-                uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
+                cb_page_table.reserve_back(num_pages_to_read);
+                uint32_t page_table_cb_wr_ptr = cb_page_table.get_write_ptr();
 
                 if constexpr (page_table_is_dram) {
                     const auto page_table_gen = TensorAccessor(page_table_args, page_table_tensor_addr);
-                    uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(my_batch_idx);
-                    noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                    noc_async_read_barrier();
+                    noc.async_read(
+                        page_table_gen,
+                        CoreLocalMem<uint32_t>(page_table_cb_wr_ptr),
+                        page_table_stick_size,
+                        {.page_id = my_batch_idx},
+                        {});
+                    noc.async_read_barrier();
                 } else {
                     page_table_cb_wr_ptr += my_batch_idx * page_table_stick_size;
                 }
-                cb_push_back(page_table_cb_id, num_pages_to_read);
+                cb_page_table.push_back(num_pages_to_read);
                 // DRAM uses uint32 entries; L1-sharded page table uses uint16 entries
                 volatile tt_l1_ptr uint32_t* page_table_ptr_u32 = nullptr;
                 volatile tt_l1_ptr uint16_t* page_table_ptr_u16 = nullptr;
@@ -136,25 +151,25 @@ void kernel_main() {
     }
 
     if (wait_to_start_signal) {
-        // wait for signal to start pushing tensor
-        volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
-        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, 1);
-        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+        // wait for signal from writer that it has finished using the input CB
+        Semaphore<> receiver_sem(receiver_sem_id);
+        receiver_sem.wait(1);
+        receiver_sem.set(0);
     }
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        cb_reserve_back(cache_cb_id, Wt);
+        cb_cache.reserve_back(Wt);
         if (!skip_update) {
-            uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
+            uint32_t cache_l1_write_addr = cb_cache.get_write_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
+                noc.async_read(
+                    s0, CoreLocalMem<uint32_t>(cache_l1_write_addr), cache_tile_bytes, {.page_id = curr_cache_id}, {});
                 cache_l1_write_addr += cache_tile_bytes;
             }
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
         }
-        cb_push_back(cache_cb_id, Wt);
+        cb_cache.push_back(Wt);
 
         cache_id += head_offset_t;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
     const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
     const uint32_t index_tensor_addr = get_arg_val<uint32_t>(2);
@@ -33,7 +40,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(15);
 
     const uint32_t St = get_compile_time_arg_val(16);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(17);  // semaphore for receiver
     // 0 = legacy unbounded behavior; nonzero = wrap update_idx mod this value before
     // page_table lookup (bounded sliding-window cache support).
     constexpr uint32_t cache_position_modulo = get_compile_time_arg_val(18);
@@ -44,9 +51,14 @@ void kernel_main() {
 
     constexpr uint32_t head_offset_t = Wt * St;
 
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_input(input_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     // Kick off compute
-    cb_reserve_back(input_cb_id, Wt);
-    cb_push_back(input_cb_id, Wt);
+    cb_input.reserve_back(Wt);
+    cb_input.push_back(Wt);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -62,13 +74,12 @@ void kernel_main() {
     if constexpr (use_index_tensor) {
         const auto addrg = TensorAccessor(index_tensor_args, index_tensor_addr);
 
-        cb_reserve_back(cb_index_id, 1);
-        uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
+        cb_index.reserve_back(1);
+        uint32_t index_cb_wr_ptr = cb_index.get_write_ptr();
         // index_tensor has one page to read
-        uint64_t tensor_index_noc_addr = addrg.get_noc_addr(0);
-        noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
-        noc_async_read_barrier();
-        cb_push_back(cb_index_id, 1);
+        noc.async_read(addrg, CoreLocalMem<uint32_t>(index_cb_wr_ptr), index_stick_size_B, {.page_id = 0}, {});
+        noc.async_read_barrier();
+        cb_index.push_back(1);
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
 
         const uint32_t raw_update_idx = index_ptr[my_batch_idx];
@@ -83,12 +94,16 @@ void kernel_main() {
                 cache_position_modulo > 0 ? raw_update_idx % cache_position_modulo : raw_update_idx;
             if constexpr (is_paged_cache) {
                 const auto page_table_gen = TensorAccessor(page_table_args, page_table_tensor_addr);
-                cb_reserve_back(page_table_cb_id, 1);
-                uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
-                uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(my_batch_idx);
-                noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-                noc_async_read_barrier();
-                cb_push_back(page_table_cb_id, 1);
+                cb_page_table.reserve_back(1);
+                uint32_t page_table_cb_wr_ptr = cb_page_table.get_write_ptr();
+                noc.async_read(
+                    page_table_gen,
+                    CoreLocalMem<uint32_t>(page_table_cb_wr_ptr),
+                    page_table_stick_size,
+                    {.page_id = my_batch_idx},
+                    {});
+                noc.async_read_barrier();
+                cb_page_table.push_back(1);
                 volatile tt_l1_ptr uint32_t* page_table_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 
@@ -108,25 +123,25 @@ void kernel_main() {
     }
 
     if (wait_to_start_signal) {
-        // wait for signal to start pushing tensor
-        volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
-        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, 1);
-        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+        // wait for signal from writer that it has finished using the input CB
+        Semaphore<> receiver_sem(receiver_sem_id);
+        receiver_sem.wait(1);
+        receiver_sem.set(0);
     }
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
-        cb_reserve_back(cache_cb_id, Wt);
+        cb_cache.reserve_back(Wt);
         if (!skip_update) {
-            uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
+            uint32_t cache_l1_write_addr = cb_cache.get_write_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_read_page(curr_cache_id, s0, cache_l1_write_addr);
+                noc.async_read(
+                    s0, CoreLocalMem<uint32_t>(cache_l1_write_addr), cache_tile_bytes, {.page_id = curr_cache_id}, {});
                 cache_l1_write_addr += cache_tile_bytes;
             }
 
-            noc_async_read_barrier();
+            noc.async_read_barrier();
         }
-        cb_push_back(cache_cb_id, Wt);
+        cb_cache.push_back(Wt);
 
         cache_id += head_offset_t;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -4,6 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Define the sentinel value for a page table entry that indicates a skip.
 constexpr uint32_t SKIP_PAGE_TABLE_ENTRY = (uint32_t)-1;
@@ -29,6 +33,8 @@ uint32_t virtual_seq_tile_id_to_physical_tile_id(
 }
 
 void kernel_main() {
+    Noc noc;
+
     constexpr uint32_t cb_id_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_page_table = get_compile_time_arg_val(1);
     constexpr uint32_t num_heads = get_compile_time_arg_val(2);
@@ -68,6 +74,10 @@ void kernel_main() {
     constexpr auto page_table_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
     constexpr auto batch_idx_tensor_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
 
+    CircularBuffer cb_in(cb_id_in);
+    CircularBuffer cb_page_table(cb_id_page_table);
+    CircularBuffer cb_batch_idx(cb_id_batch_idx);
+
     // Resolve batch_idx source. For use_batch_idx_tensor=true we load the
     // (small) 1D tensor into an L1 CB once so per-row lookups stay local.
     // For use_batch_idx_tensor=false the scalar fallback in arg 4 is used.
@@ -75,13 +85,17 @@ void kernel_main() {
     uint32_t scalar_batch_idx = 0;
     if constexpr (use_batch_idx_tensor) {
         const auto batch_idx_gen = TensorAccessor(batch_idx_tensor_args, batch_arg);
-        cb_reserve_back(cb_id_batch_idx, 1);
-        const uint32_t batch_idx_cb_wr_ptr = get_write_ptr(cb_id_batch_idx);
+        cb_batch_idx.reserve_back(1);
+        const uint32_t batch_idx_cb_wr_ptr = cb_batch_idx.get_write_ptr();
         // The tensor is a contiguous 1D int (uint32/int32) tensor in DRAM with
         // `batch_idx_num_elements` entries; one TensorAccessor stick covers it.
-        const uint64_t batch_idx_noc_addr = batch_idx_gen.get_noc_addr(0);
-        noc_async_read(batch_idx_noc_addr, batch_idx_cb_wr_ptr, batch_idx_stick_size * batch_idx_num_elements);
-        noc_async_read_barrier();
+        noc.async_read(
+            batch_idx_gen,
+            CoreLocalMem<uint32_t>(batch_idx_cb_wr_ptr),
+            batch_idx_stick_size * batch_idx_num_elements,
+            {.page_id = 0},
+            {});
+        noc.async_read_barrier();
         batch_idx_arr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(batch_idx_cb_wr_ptr);
     } else {
         scalar_batch_idx = batch_arg;
@@ -93,8 +107,8 @@ void kernel_main() {
     const auto out_gen = TensorAccessor(s0_args, dst_addr);
     const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr);
 
-    cb_reserve_back(cb_id_page_table, 1);
-    const uint32_t page_table_cb_wr_ptr = get_write_ptr(cb_id_page_table);
+    cb_page_table.reserve_back(1);
+    const uint32_t page_table_cb_wr_ptr = cb_page_table.get_write_ptr();
     volatile tt_l1_ptr uint32_t* page_table_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
 
     // Cache the last batch for which page_table was loaded. Legacy path loads
@@ -134,8 +148,8 @@ void kernel_main() {
         // later iteration anyway. The input CB still has to be drained so the
         // reader doesn't stall, but no NOC writes go out.
         if (seq_tile_id < skip_tiles) {
-            cb_wait_front(cb_id_in, Wt);
-            cb_pop_front(cb_id_in, Wt);
+            cb_in.wait_front(Wt);
+            cb_in.pop_front(Wt);
             continue;
         }
 
@@ -148,9 +162,13 @@ void kernel_main() {
 
         // Reload page_table row only on batch boundary.
         if (batch_idx != cached_batch) {
-            const uint64_t page_table_noc_addr = page_table_gen.get_noc_addr(batch_idx);
-            noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
-            noc_async_read_barrier();
+            noc.async_read(
+                page_table_gen,
+                CoreLocalMem<uint32_t>(page_table_cb_wr_ptr),
+                page_table_stick_size,
+                {.page_id = batch_idx},
+                {});
+            noc.async_read_barrier();
             cached_batch = batch_idx;
         }
 
@@ -165,19 +183,20 @@ void kernel_main() {
 
         if (physical_tile_id == SKIP_PAGE_TABLE_ENTRY) {
             // Block should be skipped. Consume the input tiles from the CB and discard.
-            cb_wait_front(cb_id_in, Wt);
-            cb_pop_front(cb_id_in, Wt);
+            cb_in.wait_front(Wt);
+            cb_in.pop_front(Wt);
         } else {
             // Valid block, proceed with writing.
-            cb_wait_front(cb_id_in, Wt);
-            uint32_t l1_read_addr = get_read_ptr(cb_id_in);
+            cb_in.wait_front(Wt);
+            uint32_t l1_read_addr = cb_in.get_read_ptr();
             for (uint32_t w = 0; w < Wt; ++w) {
-                noc_async_write_page(physical_tile_id, out_gen, l1_read_addr);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(l1_read_addr), out_gen, tile_bytes, {}, {.page_id = physical_tile_id});
                 l1_read_addr += tile_bytes;
                 physical_tile_id += 1;
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_id_in, Wt);
+            noc.async_write_barrier();
+            cb_in.pop_front(Wt);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,16 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t rt_args_idx = 0;
     const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
     if (!has_work) {
@@ -39,7 +47,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(14);
 
     constexpr uint32_t St = get_compile_time_arg_val(15);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(16);  // semaphore for receiver
     constexpr uint32_t head_offset_t = Wt * St;
     constexpr uint32_t batch_size = get_compile_time_arg_val(17);
     constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(18);
@@ -53,14 +61,21 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
 
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_untilized_cache(untilized_cache_cb_id);
+    CircularBuffer cb_untilized_cache2(untilized_cache2_cb_id);
+    CircularBuffer cb_untilized_input(untilized_input_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        cb_wait_front(cb_index_id, 1);
-        uint32_t index_cb_ptr = get_read_ptr(cb_index_id);
+        cb_index.wait_front(1);
+        uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t update_idx = index_ptr[my_batch_idx];
 
@@ -70,8 +85,8 @@ void kernel_main() {
         } else {
             if constexpr (is_paged_cache) {
                 uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-                cb_wait_front(page_table_cb_id, num_pages_to_read);
-                uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
+                cb_page_table.wait_front(num_pages_to_read);
+                uint32_t page_table_cb_rd_ptr = cb_page_table.get_read_ptr();
                 if constexpr (!page_table_is_dram) {
                     page_table_cb_rd_ptr += my_batch_idx * page_table_stick_size;
                 }
@@ -102,36 +117,46 @@ void kernel_main() {
         }
     }
 
-    cb_wait_front(untilized_input_cb_id, Wt);  // input tensor
-    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+    cb_untilized_input.wait_front(Wt);  // input tensor
+    const uint8_t noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[noc_id];
+    const uint32_t my_noc_y = my_y[noc_id];
+    uint32_t input_l1_read_addr = cb_untilized_input.get_read_ptr();
+    UnicastEndpoint local_src;
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
         // Wait on compute to untilize a block. Update that block in L1.
-        cb_wait_front(untilized_cache_cb_id, Wt);
-        cb_reserve_back(untilized_cache2_cb_id, Wt);
+        cb_untilized_cache.wait_front(Wt);
+        cb_untilized_cache2.reserve_back(Wt);
 
-        uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + cache_tile_offset_B;
-        noc_async_read(input_l1_read_addr, cache_l1_write_addr, Wbytes);
-        noc_async_read_barrier();
-        cb_push_back(untilized_cache2_cb_id, Wt);
-        cb_pop_front(untilized_cache_cb_id, Wt);  // NEW
+        uint32_t cache_l1_write_addr = cb_untilized_cache.get_read_ptr() + cache_tile_offset_B;
+        noc.async_read(
+            local_src,
+            CoreLocalMem<uint32_t>(cache_l1_write_addr),
+            Wbytes,
+            {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = input_l1_read_addr},
+            {});
+        noc.async_read_barrier();
+        cb_untilized_cache2.push_back(Wt);
+        cb_untilized_cache.pop_front(Wt);  // NEW
 
         // Wait on compute to tilize an updated block. Write that block to DRAM
-        cb_wait_front(cache_cb_id, Wt);
+        cb_cache.wait_front(Wt);
         if (!skip_update) {
-            uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
+            uint32_t out_l1_read_addr = cb_cache.get_read_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(out_l1_read_addr), s0, cache_tile_bytes, {}, {.page_id = curr_cache_id});
                 out_l1_read_addr += cache_tile_bytes;
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
         }
-        cb_pop_front(cache_cb_id, Wt);
+        cb_cache.pop_front(Wt);
 
         if (!skip_update) {
             // Delay syncing the writes to maximize perf.
-            noc_async_write_barrier();
+            noc.async_write_barrier();
         }
 
         // read from next head
@@ -139,11 +164,10 @@ void kernel_main() {
         cache_id += head_offset_t;
     }
 
-    cb_pop_front(untilized_input_cb_id, Wt);
+    cb_untilized_input.pop_front(Wt);
 
     if (send_signal) {
-        // send signal to start compute
-        const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(send_core_x, send_core_y, semaphore_addr);
-        noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+        // send signal to receiver core that we are done using the input CB
+        Semaphore<>(receiver_sem_id).up(noc, send_core_x, send_core_y, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,16 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t rt_args_idx = 0;
     const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
     if (!has_work) {
@@ -41,7 +49,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(15);
 
     constexpr uint32_t St = get_compile_time_arg_val(16);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(17);  // semaphore for receiver
     constexpr uint32_t batch_size = get_compile_time_arg_val(18);
     constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(19);
     constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(20);
@@ -61,14 +69,21 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
 
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_untilized_cache(untilized_cache_cb_id);
+    CircularBuffer cb_untilized_cache2(untilized_cache2_cb_id);
+    CircularBuffer cb_untilized_input(untilized_input_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        cb_wait_front(cb_index_id, 1);
-        uint32_t index_cb_ptr = get_read_ptr(cb_index_id);
+        cb_index.wait_front(1);
+        uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t update_idx = index_ptr[my_batch_idx];
 
@@ -78,8 +93,8 @@ void kernel_main() {
         } else {
             if constexpr (is_paged_cache) {
                 uint32_t num_pages_to_read = page_table_is_dram ? 1 : batch_size;
-                cb_wait_front(page_table_cb_id, num_pages_to_read);
-                uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
+                cb_page_table.wait_front(num_pages_to_read);
+                uint32_t page_table_cb_rd_ptr = cb_page_table.get_read_ptr();
                 if constexpr (!page_table_is_dram) {
                     page_table_cb_rd_ptr += my_batch_idx * page_table_stick_size;
                 }
@@ -110,36 +125,46 @@ void kernel_main() {
         }
     }
 
-    cb_wait_front(untilized_input_cb_id, 1);  // input tensor
-    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+    cb_untilized_input.wait_front(1);  // input tensor
+    const uint8_t noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[noc_id];
+    const uint32_t my_noc_y = my_y[noc_id];
+    uint32_t input_l1_read_addr = cb_untilized_input.get_read_ptr();
+    UnicastEndpoint local_src;
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
         // Wait on compute to untilize a block. Update that block in L1.
-        cb_wait_front(untilized_cache_cb_id, Wt);
-        cb_reserve_back(untilized_cache2_cb_id, Wt);
+        cb_untilized_cache.wait_front(Wt);
+        cb_untilized_cache2.reserve_back(Wt);
 
-        uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + cache_tile_offset_B;
-        noc_async_read(input_l1_read_addr, cache_l1_write_addr, Wbytes);
-        noc_async_read_barrier();
-        cb_push_back(untilized_cache2_cb_id, Wt);
-        cb_pop_front(untilized_cache_cb_id, Wt);  // NEW
+        uint32_t cache_l1_write_addr = cb_untilized_cache.get_read_ptr() + cache_tile_offset_B;
+        noc.async_read(
+            local_src,
+            CoreLocalMem<uint32_t>(cache_l1_write_addr),
+            Wbytes,
+            {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = input_l1_read_addr},
+            {});
+        noc.async_read_barrier();
+        cb_untilized_cache2.push_back(Wt);
+        cb_untilized_cache.pop_front(Wt);  // NEW
 
         // Wait on compute to tilize an updated block. Write that block to DRAM
-        cb_wait_front(cache_cb_id, Wt);
+        cb_cache.wait_front(Wt);
         if (!skip_update) {
-            uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
+            uint32_t out_l1_read_addr = cb_cache.get_read_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(out_l1_read_addr), s0, cache_tile_bytes, {}, {.page_id = curr_cache_id});
                 out_l1_read_addr += cache_tile_bytes;
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
         }
-        cb_pop_front(cache_cb_id, Wt);
+        cb_cache.pop_front(Wt);
 
         if (!skip_update) {
             // Delay syncing the writes to maximize perf.
-            noc_async_write_barrier();
+            noc.async_write_barrier();
         }
 
         // read from next head
@@ -147,11 +172,10 @@ void kernel_main() {
         cache_id += head_offset_t;
     }
 
-    cb_pop_front(untilized_input_cb_id, 1);
+    cb_untilized_input.pop_front(1);
 
     if (send_signal) {
-        // send signal to start compute
-        const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(send_core_x, send_core_y, semaphore_addr);
-        noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+        // send signal to receiver core that we are done using the input CB
+        Semaphore<>(receiver_sem_id).up(noc, send_core_x, send_core_y, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -4,8 +4,16 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     const uint32_t cache_addr = get_arg_val<uint32_t>(0);
     const uint32_t cache_start_id = get_arg_val<uint32_t>(1);
     uint32_t cache_tile_offset_B = get_arg_val<uint32_t>(2);
@@ -33,7 +41,7 @@ void kernel_main() {
     constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(14);
 
     constexpr uint32_t St = get_compile_time_arg_val(15);
-    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(16));  // semaphore for receiver
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(16);  // semaphore for receiver
     // 0 = legacy unbounded behavior; nonzero = wrap update_idx mod this value before
     // page_table lookup (bounded sliding-window cache support).
     constexpr uint32_t cache_position_modulo = get_compile_time_arg_val(17);
@@ -49,14 +57,21 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
 
+    CircularBuffer cb_cache(cache_cb_id);
+    CircularBuffer cb_untilized_cache(untilized_cache_cb_id);
+    CircularBuffer cb_untilized_cache2(untilized_cache2_cb_id);
+    CircularBuffer cb_untilized_input(untilized_input_cb_id);
+    CircularBuffer cb_index(cb_index_id);
+    CircularBuffer cb_page_table(page_table_cb_id);
+
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;
 
     bool skip_update = false;
 
     if constexpr (use_index_tensor) {
-        cb_wait_front(cb_index_id, 1);
-        uint32_t index_cb_ptr = get_read_ptr(cb_index_id);
+        cb_index.wait_front(1);
+        uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t raw_update_idx = index_ptr[my_batch_idx];
 
@@ -70,8 +85,8 @@ void kernel_main() {
             const uint32_t update_idx =
                 cache_position_modulo > 0 ? raw_update_idx % cache_position_modulo : raw_update_idx;
             if constexpr (is_paged_cache) {
-                cb_wait_front(page_table_cb_id, 1);
-                uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
+                cb_page_table.wait_front(1);
+                uint32_t page_table_cb_rd_ptr = cb_page_table.get_read_ptr();
                 volatile tt_l1_ptr uint32_t* page_table_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
 
@@ -91,36 +106,46 @@ void kernel_main() {
         }
     }
 
-    cb_wait_front(untilized_input_cb_id, Wt);  // input tensor
-    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+    cb_untilized_input.wait_front(Wt);  // input tensor
+    const uint8_t noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[noc_id];
+    const uint32_t my_noc_y = my_y[noc_id];
+    uint32_t input_l1_read_addr = cb_untilized_input.get_read_ptr();
+    UnicastEndpoint local_src;
 
     for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
         // Wait on compute to untilize a block. Update that block in L1.
-        cb_wait_front(untilized_cache_cb_id, Wt);
-        cb_reserve_back(untilized_cache2_cb_id, Wt);
+        cb_untilized_cache.wait_front(Wt);
+        cb_untilized_cache2.reserve_back(Wt);
 
-        uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + cache_tile_offset_B;
-        noc_async_read(input_l1_read_addr, cache_l1_write_addr, Wbytes);
-        noc_async_read_barrier();
-        cb_push_back(untilized_cache2_cb_id, Wt);
-        cb_pop_front(untilized_cache_cb_id, Wt);  // NEW
+        uint32_t cache_l1_write_addr = cb_untilized_cache.get_read_ptr() + cache_tile_offset_B;
+        noc.async_read(
+            local_src,
+            CoreLocalMem<uint32_t>(cache_l1_write_addr),
+            Wbytes,
+            {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = input_l1_read_addr},
+            {});
+        noc.async_read_barrier();
+        cb_untilized_cache2.push_back(Wt);
+        cb_untilized_cache.pop_front(Wt);  // NEW
 
         // Wait on compute to tilize an updated block. Write that block to DRAM
-        cb_wait_front(cache_cb_id, Wt);
+        cb_cache.wait_front(Wt);
         if (!skip_update) {
-            uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
+            uint32_t out_l1_read_addr = cb_cache.get_read_ptr();
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
-                noc_async_write_page(curr_cache_id, s0, out_l1_read_addr);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(out_l1_read_addr), s0, cache_tile_bytes, {}, {.page_id = curr_cache_id});
                 out_l1_read_addr += cache_tile_bytes;
             }
 
-            noc_async_writes_flushed();
+            noc.async_writes_flushed();
         }
-        cb_pop_front(cache_cb_id, Wt);
+        cb_cache.pop_front(Wt);
 
         if (!skip_update) {
             // Delay syncing the writes to maximize perf.
-            noc_async_write_barrier();
+            noc.async_write_barrier();
         }
 
         // read from next head
@@ -128,12 +153,11 @@ void kernel_main() {
         cache_id += head_offset_t;
     }
 
-    cb_pop_front(untilized_input_cb_id, Wt);
+    cb_untilized_input.pop_front(Wt);
 
     if (send_signal) {
-        // send signal to start compute
-        const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(send_core_x, send_core_y, semaphore_addr);
-        noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-        noc_async_atomic_barrier();
+        // send signal to receiver core that we are done using the input CB
+        Semaphore<>(receiver_sem_id).up(noc, send_core_x, send_core_y, 1);
+        noc.async_atomic_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
@@ -5,8 +5,14 @@
 #include <stdint.h>
 #include <limits.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
@@ -19,14 +25,16 @@ void kernel_main() {
     constexpr auto s0_args = TensorAccessorArgs<6>();
     const auto s0 = TensorAccessor(s0_args, src_addr);
 
+    CircularBuffer cb_in0(cb_id_in0);
+
     // Use cb as L1 scratch memory
-    uint32_t cb_addr = get_write_ptr(cb_id_in0);
+    uint32_t cb_addr = cb_in0.get_write_ptr();
     volatile tt_l1_ptr uint32_t* stick = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_addr);
 
     for (uint32_t h = 0; h < H; h++) {
         if (src0_is_dram) {
-            noc_async_read_page(h, s0, cb_addr);
-            noc_async_read_barrier();
+            noc.async_read(s0, CoreLocalMem<uint32_t>(cb_addr), stick_size, {.page_id = h}, {});
+            noc.async_read_barrier();
         }
         for (uint32_t i = 0; i < W; i++) {
             int32_t val = stick[i];
@@ -41,9 +49,8 @@ void kernel_main() {
             }
         }
         if (src0_is_dram) {
-            uint64_t dst_noc_addr = s0.get_noc_addr(h);
-            noc_async_write(cb_addr, dst_noc_addr, stick_size);
-            noc_async_write_barrier();
+            noc.async_write(CoreLocalMem<uint32_t>(cb_addr), s0, stick_size, {}, {.page_id = h});
+            noc.async_write_barrier();
         }
     }
 }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Migrates 14 kernel files in `embedding/`, `experimental/paged_cache/`, and `experimental/plusone/` from the legacy free-function dataflow API to the typed device-2.0 wrappers (`Noc`, `Semaphore<>`, `CircularBuffer`, `CoreLocalMem<T>`, `UnicastEndpoint`). Next work item in #45003 after #45015 (transformer/sdpa family).

Three commits, one per op directory:
- `embedding/` — 5 files. Shared `embeddings_common.hpp` now takes `const Noc&`; a new `read_token_async` helper is added.
- `experimental/paged_cache/` — 8 files.  three cases with update_cache pairs that use a single producer/consumer semaphore. Migrates to `Semaphore<>::up` / `Semaphore<>::wait`/`set(0)`.
- `experimental/plusone/` — 1 file, fully mechanical.

No algorithmic change: tile counts, NoC traffic, runtime-arg layout, and compile-time-arg ordering are preserved.

### Notes for reviewers
- **Focus area:** the three semaphore pairs in `paged_cache` — `(reader, writer)_update_cache_interleaved_start_id.cpp`, `_paged_fused_*`, `_paged_row_major_fused_*`. The semaphore-id compile-time slots match what the host-side program factory already binds; no host changes needed.
- **`embeddings_common.hpp` reshape:** legacy code baked the local-cache pad/zero/one weights into `uint64_t` NoC addresses and re-fed them into `noc_async_read`. Under Device 2.0 the helper now reads them via `UnicastEndpoint{ my_x[noc_id], my_y[noc_id], local_addr }` so PADDED/BINARY paths stay self-contained.
- **Self-L1 read in `paged_cache` writers** (e.g. `writer_update_cache_interleaved_start_id.cpp` line ~118): legacy `noc_async_read(get_noc_addr(get_read_ptr(...)), ...)` now goes through `UnicastEndpoint` with the kernel's own NoC coords — same pattern as `fill_zeros_async` in PR #45015's `dataflow_common.hpp`.
- **Compute kernels (4 files) left untouched.** Grep confirmed zero legacy dataflow-API hits in compute (they're pure `llk_*`/`pack_tile`/`tile_regs_*`). PR #45015 likewise touched no compute files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/45003-embedding-paged-cache-plusone)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/45003-embedding-paged-cache-plusone)