### PR TITLE
Fix moe_compute C++ weight prep functions missing BH ring size support

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -672,9 +672,9 @@ def validate_matmul(
 
                 if not allclose_passed:
                     mask = (tt_layer_output - torch_layer_output).abs() > ATOL_THRESHOLD
-                    # logger.warning(
-            #                         f"AllClose variation result: {tt_layer_output[mask]}, ref: {torch_layer_output[mask]} indices: {mask.nonzero(as_tuple=True)}"
-            #                     )
+                    logger.warning(
+                        f"AllClose variation result: {tt_layer_output[mask]}, ref: {torch_layer_output[mask]} indices: {mask.nonzero(as_tuple=True)}"
+                    )
             else:
                 logger.info(
                     f"Layer {layer_id}, Expert {expert_id} (buffer {buffer_idx}): PCC={pcc_val:.6f} RMSE: {relative_rmse_val} (Passed)"
@@ -722,7 +722,7 @@ def validate_combine(layer_id, mesh_device, cluster_axis, tt_combine_output, com
             logger.warning(f"Layer {layer_id}, k: {k} PCC={pcc_val:.6f}, AllClose passed: {allclose_passed}")
             if not allclose_passed:
                 mask = (vals - refs).abs() > ATOL_THRESHOLD
-                # logger.warning(f"AllClose variation result: {vals[mask]}, ref: {refs[mask]}")
+                logger.warning(f"AllClose variation result: {vals[mask]}, ref: {refs[mask]}")
         else:
             logger.info(f"Combine, layer: {layer_id}, k: {k} PCC={pcc_val:.6f}, AllClose passed: {allclose_passed}")
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -183,7 +183,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         &ttnn::experimental::get_weight_core_shard_maps,
         nb::arg("mesh_device"),
         nb::arg("hidden_size"),
-        nb::arg("intermediate_size"));
+        nb::arg("intermediate_size"),
+        nb::arg("bh_ring_size") = 12);
 
     nb::class_<ttnn::experimental::WeightMemoryConfigs>(mod, "WeightMemoryConfigs")
         .def_ro("w0_w1", &ttnn::experimental::WeightMemoryConfigs::w0_w1)
@@ -208,7 +209,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("experts_per_device"),
         nb::arg("hidden_size"),
         nb::arg("intermediate_size"),
-        nb::arg("has_bias") = false);
+        nb::arg("has_bias") = false,
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"add_shared_expert_weights", "ttnn.experimental.">(
         mod,
@@ -250,7 +252,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("K"),
-        nb::arg("N"));
+        nb::arg("N"),
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"prepare_w2_tensor_for_moe_compute", "ttnn.experimental.">(
         mod,
@@ -268,7 +271,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("N"),
-        nb::arg("K"));
+        nb::arg("K"),
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"prepare_w0_w1_tensor_with_bias", "ttnn.experimental.">(
         mod,
@@ -289,7 +293,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("K"),
-        nb::arg("N"));
+        nb::arg("N"),
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"prepare_w2_tensor_with_bias", "ttnn.experimental.">(
         mod,
@@ -308,7 +313,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("N"),
-        nb::arg("K"));
+        nb::arg("K"),
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"quantize_weights_via_host", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt_stl/assert.hpp>
+#include <umd/device/types/arch.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
@@ -219,13 +220,16 @@ ttnn::Tensor prepare_w2_no_n_pad(
 }  // namespace
 
 WeightCoreShardMaps get_weight_core_shard_maps(
-    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size) {
+    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size, uint32_t bh_ring_size) {
     const auto in0_core_coords =
         mesh_device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::RISCV_0_default);
-    const uint32_t n_cores = static_cast<uint32_t>(in0_core_coords.size());
+    const uint32_t n_dram_banks = static_cast<uint32_t>(in0_core_coords.size());
+
+    const bool is_blackhole = mesh_device->arch() == tt::ARCH::BLACKHOLE;
+    const uint32_t target_ring_size = is_blackhole ? bh_ring_size : n_dram_banks;
 
     // Ring ordering: sort the DRAM-bank logical core coords by (y, x) descending.
-    std::vector<uint32_t> ring_to_dram_bank(n_cores);
+    std::vector<uint32_t> ring_to_dram_bank(n_dram_banks);
     std::iota(ring_to_dram_bank.begin(), ring_to_dram_bank.end(), 0u);
     std::sort(ring_to_dram_bank.begin(), ring_to_dram_bank.end(), [&](uint32_t a, uint32_t b) {
         const auto& ca = in0_core_coords[a];
@@ -238,29 +242,30 @@ WeightCoreShardMaps get_weight_core_shard_maps(
 
     const uint32_t Nt = intermediate_size / TILE_SIZE;
     const uint32_t Ht = hidden_size / TILE_SIZE;
-    const uint32_t max_w2_tiles = ceil_div(Ht, n_cores);
+    const uint32_t max_w2_tiles = ceil_div(Ht, target_ring_size);
     const uint32_t groups_per_core = ceil_div(max_w2_tiles, BLOCK_TILES_W);
 
     WeightCoreShardMaps result;
-    result.w0_w1_shard_map.reserve(n_cores);
-    result.w2_shard_map.reserve(n_cores);
+    result.w0_w1_shard_map.reserve(target_ring_size);
+    result.w2_shard_map.reserve(target_ring_size);
 
     std::vector<ttnn::CoreRange> dram_core_ranges;
-    dram_core_ranges.reserve(n_cores);
+    dram_core_ranges.reserve(n_dram_banks);
 
-    for (uint32_t ring_pos = 0; ring_pos < n_cores; ++ring_pos) {
-        const uint32_t dram_bank_id = ring_to_dram_bank[ring_pos];
+    for (uint32_t ring_pos = 0; ring_pos < target_ring_size; ++ring_pos) {
+        if (ring_pos < n_dram_banks) {
+            const uint32_t dram_bank_id = ring_to_dram_bank[ring_pos];
+            const ttnn::CoreCoord dram_core(dram_bank_id, 0);
+            dram_core_ranges.emplace_back(dram_core, dram_core);
+        }
 
-        const uint32_t w0_w1_tiles = ::moe_ring::shard_tiles(Nt, ring_pos, n_cores);
+        const uint32_t w0_w1_tiles = ::moe_ring::shard_tiles(Nt, ring_pos, target_ring_size);
         result.w0_w1_shard_map.push_back(w0_w1_tiles);
 
-        const uint32_t w2_tiles = ::moe_ring::w2_shard_tiles(Ht, ring_pos, Nt, n_cores);
+        const uint32_t w2_tiles = ::moe_ring::w2_shard_tiles(Ht, ring_pos, Nt, target_ring_size);
         const uint32_t last_group_tiles = w2_tiles - (groups_per_core - 1) * BLOCK_TILES_W;
         const uint32_t last_group_pad_tiles = groups_per_core * BLOCK_TILES_W - w2_tiles;
         result.w2_shard_map.emplace_back(last_group_tiles, last_group_pad_tiles);
-
-        const ttnn::CoreCoord dram_core(dram_bank_id, 0);
-        dram_core_ranges.emplace_back(dram_core, dram_core);
     }
 
     result.dram_core_range_set = ttnn::CoreRangeSet(std::move(dram_core_ranges));
@@ -273,7 +278,8 @@ WeightMemoryConfigs get_weight_mem_configs(
     uint32_t experts_per_device,
     uint32_t hidden_size,
     uint32_t intermediate_size,
-    bool has_bias) {
+    bool has_bias,
+    uint32_t bh_ring_size) {
     TT_FATAL(
         hidden_size % TILE_SIZE == 0, "hidden_size ({}) must be divisible by TILE_SIZE ({})", hidden_size, TILE_SIZE);
     TT_FATAL(
@@ -282,7 +288,7 @@ WeightMemoryConfigs get_weight_mem_configs(
         intermediate_size,
         TILE_SIZE);
 
-    const auto shard_maps = get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size);
+    const auto shard_maps = get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size, bh_ring_size);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 
@@ -292,9 +298,21 @@ WeightMemoryConfigs get_weight_mem_configs(
     const uint32_t K_for_shard =
         (has_bias ? ceil_div(Ht + 1, BLOCK_TILES_H) : ceil_div(Ht, BLOCK_TILES_H)) * BLOCK_TILES_H * TILE_SIZE;
 
+    const uint32_t num_cores = static_cast<uint32_t>(w0_w1_shard_map.size());
+    const uint32_t num_banks = shard_maps.dram_core_range_set.num_cores();
+
     const uint32_t max_w0_w1 = *std::max_element(w0_w1_shard_map.begin(), w0_w1_shard_map.end());
     const uint32_t w1_w0_groups_per_core = (max_w0_w1 + (max_w0_w1 % 2)) / 2;
-    const uint32_t w0_w1_shard_height = num_layers * experts_per_device * w1_w0_groups_per_core * K_for_shard;
+    const uint32_t w0_w1_total_rows = num_layers * experts_per_device * num_cores * w1_w0_groups_per_core * K_for_shard;
+    TT_FATAL(
+        w0_w1_total_rows % num_banks == 0,
+        "w0_w1 total rows {} not divisible by num_banks {} (num_cores={}, groups_per_core={}, K_for_shard={})",
+        w0_w1_total_rows,
+        num_banks,
+        num_cores,
+        w1_w0_groups_per_core,
+        K_for_shard);
+    const uint32_t w0_w1_shard_height = w0_w1_total_rows / num_banks;
     constexpr uint32_t shard_width = 4 * TILE_SIZE;
 
     const ttnn::MemoryConfig w0_w1_mem_config{
@@ -311,10 +329,18 @@ WeightMemoryConfigs get_weight_mem_configs(
     const uint32_t w2_N_total =
         (has_bias ? ceil_div(Nt + 1, BLOCK_TILES_H) : ceil_div(Nt, BLOCK_TILES_H)) * BLOCK_TILES_H * TILE_SIZE;
 
-    const uint32_t num_cores = static_cast<uint32_t>(w2_shard_map.size());
     const uint32_t first_pair_sum = w2_shard_map[0].first + w2_shard_map[0].second;
     const uint32_t w2_groups_per_core = ceil_div(Ht, num_cores * first_pair_sum);
-    const uint32_t w2_shard_height = num_layers * experts_per_device * w2_groups_per_core * w2_N_total;
+    const uint32_t w2_total_rows = num_layers * experts_per_device * num_cores * w2_groups_per_core * w2_N_total;
+    TT_FATAL(
+        w2_total_rows % num_banks == 0,
+        "w2 total rows {} not divisible by num_banks {} (num_cores={}, w2_groups_per_core={}, w2_N_total={})",
+        w2_total_rows,
+        num_banks,
+        num_cores,
+        w2_groups_per_core,
+        w2_N_total);
+    const uint32_t w2_shard_height = w2_total_rows / num_banks;
 
     const ttnn::MemoryConfig w2_mem_config{
         tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
@@ -346,12 +372,19 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
 }
 
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w0, const ttnn::Tensor& tt_w1, uint32_t L, uint32_t E, uint32_t K, uint32_t N) {
+    const ttnn::Tensor& tt_w0,
+    const ttnn::Tensor& tt_w1,
+    uint32_t L,
+    uint32_t E,
+    uint32_t K,
+    uint32_t N,
+    uint32_t bh_ring_size) {
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
 
     const auto shard_map =
-        get_weight_core_shard_maps(tt_w0.device(), /*hidden_size=*/K, /*intermediate_size=*/N).w0_w1_shard_map;
+        get_weight_core_shard_maps(tt_w0.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size)
+            .w0_w1_shard_map;
     const uint32_t Nt = N / TILE_SIZE;
     // Pad K up to a multiple of (TILE_SIZE * BLOCK_TILES_H) — matches the DRAM read transaction.
     const uint32_t Kp = ceil_div(K / TILE_SIZE, BLOCK_TILES_H) * TILE_SIZE * BLOCK_TILES_H;
@@ -486,11 +519,12 @@ ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
 }
 
 ttnn::Tensor prepare_w2_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K) {
+    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K, uint32_t bh_ring_size) {
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
 
-    const auto shard_maps = get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N);
+    const auto shard_maps =
+        get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 
@@ -527,7 +561,8 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     uint32_t L,
     uint32_t E,
     uint32_t K,
-    uint32_t N) {
+    uint32_t N,
+    uint32_t bh_ring_size) {
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
 
@@ -548,18 +583,25 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     b0_tiled.deallocate(/*force=*/true);
     b1_tiled.deallocate(/*force=*/true);
 
-    auto result = prepare_w0_w1_tensor_for_moe_compute(w0_b0, w1_b1, L, E, K_with_bias, N);
+    auto result = prepare_w0_w1_tensor_for_moe_compute(w0_b0, w1_b1, L, E, K_with_bias, N, bh_ring_size);
     w0_b0.deallocate(/*force=*/true);
     w1_b1.deallocate(/*force=*/true);
     return result;
 }
 
 ttnn::Tensor prepare_w2_tensor_with_bias(
-    const ttnn::Tensor& tt_w2, const ttnn::Tensor& tt_b2, uint32_t L, uint32_t E, uint32_t N, uint32_t K) {
+    const ttnn::Tensor& tt_w2,
+    const ttnn::Tensor& tt_b2,
+    uint32_t L,
+    uint32_t E,
+    uint32_t N,
+    uint32_t K,
+    uint32_t bh_ring_size) {
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
 
-    const auto shard_maps = get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N);
+    const auto shard_maps =
+        get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -39,7 +39,7 @@ struct WeightCoreShardMaps {
 // ``w2_shard_tiles`` (complementary when ``Nt%n_cores + Ht%n_cores == n_cores``)
 // for W2. Ring ordering: DRAM bank logical coords sorted by ``(y, x)`` descending.
 WeightCoreShardMaps get_weight_core_shard_maps(
-    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size);
+    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size, uint32_t bh_ring_size = 12);
 
 // DRAM-sharded memory configs for the packed W0/W1 and W2 weight tensors. The
 // shard maps and DRAM-bank CoreRangeSet are computed internally to match
@@ -58,7 +58,8 @@ WeightMemoryConfigs get_weight_mem_configs(
     uint32_t experts_per_device,
     uint32_t hidden_size,
     uint32_t intermediate_size,
-    bool has_bias = false);
+    bool has_bias = false,
+    uint32_t bh_ring_size = 12);
 
 // Append per-device shared experts after routed experts along the experts dim.
 //
@@ -80,14 +81,20 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
 // The per-core shard map is derived internally from ``K`` (hidden_size) and
 // ``N`` (intermediate_size) via ``get_weight_core_shard_maps``.
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w0, const ttnn::Tensor& tt_w1, uint32_t L, uint32_t E, uint32_t K, uint32_t N);
+    const ttnn::Tensor& tt_w0,
+    const ttnn::Tensor& tt_w1,
+    uint32_t L,
+    uint32_t E,
+    uint32_t K,
+    uint32_t N,
+    uint32_t bh_ring_size = 12);
 
 // Pack W2 into the ring-rotated per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, w2_groups_per_core, N_padded, 4*TILE)``.
 // The per-core shard maps are derived internally from ``K`` (hidden_size) and
 // ``N`` (intermediate_size) via ``get_weight_core_shard_maps``.
 ttnn::Tensor prepare_w2_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K);
+    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K, uint32_t bh_ring_size = 12);
 
 // Bias-aware W0/W1 packer: appends bias tiles along K, then delegates to the
 // no-bias packer. Bias inputs are PyTorch-format ``(L, E, N)``; output matches
@@ -100,13 +107,20 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     uint32_t L,
     uint32_t E,
     uint32_t K,
-    uint32_t N);
+    uint32_t N,
+    uint32_t bh_ring_size = 12);
 
 // Bias-aware W2 packer: weight tiles get ring-rotated as usual; bias tile row
 // is column-sharded and concatenated along N **without** rotation, then N is
 // padded to a multiple of BLOCK_TILES_H tiles.
 ttnn::Tensor prepare_w2_tensor_with_bias(
-    const ttnn::Tensor& tt_w2, const ttnn::Tensor& tt_b2, uint32_t L, uint32_t E, uint32_t N, uint32_t K);
+    const ttnn::Tensor& tt_w2,
+    const ttnn::Tensor& tt_b2,
+    uint32_t L,
+    uint32_t E,
+    uint32_t N,
+    uint32_t K,
+    uint32_t bh_ring_size = 12);
 
 // Round-trip a device tensor through host to change its dtype and re-upload
 // it under the supplied memory config. Used to quantize the packed weight


### PR DESCRIPTION
## Summary
- The C++ port of `get_weight_core_shard_maps` (introduced in #45368) always used `n_dram_banks` as the ring size, but on Blackhole (8 DRAM banks) the MoE ring uses a configurable `target_ring_size` (default 12). This produced wrong shard maps, wrong shard heights, and incompatible tensor layouts — breaking the BH LB `moe_compute` tests.
- Added `bh_ring_size` parameter (default 12) to all affected C++ functions (`get_weight_core_shard_maps`, `get_weight_mem_configs`, `prepare_w0_w1_tensor_for_moe_compute`, `prepare_w2_tensor_for_moe_compute`, `prepare_w0_w1_tensor_with_bias`, `prepare_w2_tensor_with_bias`) and their nanobind bindings, matching the Python implementation's arch-aware `target_ring_size` logic.
- Fixed `get_weight_mem_configs` to compute `shard_height = total_rows / num_banks` instead of assuming `num_cores == num_banks`.
- Restored two diagnostic `logger.warning` lines that were incorrectly commented out with broken indentation.

## Test plan
- [x] Run `TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_lb_1x8_line_graph_descriptor.textproto scripts/run_safe_pytest.sh tests/nightly/tg/ccl/moe/test_moe_compute_6U.py -k "bh_lb_1x8 and deepseek_v3"` on BH hardware
    - All tests passed on BH LB
- [x] Verify WH tests still pass (default `bh_ring_size=12` is a no-op on WH since `target_ring_size = n_dram_banks`)
    - All tests passed on WH Galaxy
- [x] Run `test_moe_compute_utils_tt.py` parity tests (C++ vs Python) on both architectures
    - All tests pass on WH Galaxy
    - Manual, unrelated tweaks to the textproto file and 1x8 config also gets all tests to pass on BH LB

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/fix-moe-compute-bh-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/fix-moe-compute-bh-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/fix-moe-compute-bh-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/fix-moe-compute-bh-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/fix-moe-compute-bh-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/fix-moe-compute-bh-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/fix-moe-compute-bh-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/fix-moe-compute-bh-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/fix-moe-compute-bh-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/fix-moe-compute-bh-ring-size)