### PR TITLE
[Quasar] fp32 testing in unary SFPU compute APIs

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -315,6 +315,7 @@ struct SfpuConfig {
     CoreRangeSet cores;
     std::string sfpu_op;
     bool approx_mode = true;
+    bool en_32bit_dest = false;
 };
 
 /// @brief Does Dram --> Reader --> CB --> Sfpu Compute --> CB --> Writer --> Dram. So far, enqueue APIs only added to
@@ -464,6 +465,7 @@ bool run_sfpu_all_same_buffer(
             {{"per_core_block_cnt", static_cast<uint32_t>(test_config.num_tiles)}, {"per_core_block_size", 1u}},
         .hw_config =
             experimental::ComputeHardwareConfig{
+                .fp32_dest_acc_en = test_config.en_32bit_dest,
                 .math_approx_mode = test_config.approx_mode,
             },
     };
@@ -1118,6 +1120,119 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedApproxFixture, TensixSfpuCompu
 INSTANTIATE_TEST_SUITE_P(
     SingleCoreSfpuCompute,
     SingleCoreSingleMeshDeviceSfpuParameterizedApproxFixture,
+    ::testing::Values(
+        std::make_tuple(1, "relu"),
+        std::make_tuple(1, "exponential"),
+        std::make_tuple(1, "reciprocal"),
+        std::make_tuple(1, "gelu"),
+        std::make_tuple(1, "sqrt"),
+        std::make_tuple(1, "sigmoid"),
+        std::make_tuple(1, "silu"),
+        std::make_tuple(1, "log"),
+        std::make_tuple(1, "tanh"),
+        std::make_tuple(1, "sign"),
+        std::make_tuple(1, "rsqrt"),
+        std::make_tuple(4, "relu"),
+        std::make_tuple(4, "exponential"),
+        std::make_tuple(4, "reciprocal"),
+        std::make_tuple(4, "gelu"),
+        std::make_tuple(4, "sqrt"),
+        std::make_tuple(4, "sigmoid"),
+        std::make_tuple(4, "silu"),
+        std::make_tuple(4, "log"),
+        std::make_tuple(4, "tanh"),
+        std::make_tuple(4, "sign"),
+        std::make_tuple(4, "rsqrt")),
+    [](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
+        return std::get<1>(info.param) + "_" + std::to_string(std::get<0>(info.param)) + "tiles";
+    });
+
+class SingleCoreSingleMeshDeviceSfpuParameterized32BitDestFixture
+    : public LLKMeshDeviceFixture,
+      public testing::WithParamInterface<std::tuple<size_t, std::string>> {};
+TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestFixture, TensixSfpuCompute) {
+    size_t num_tiles = std::get<0>(GetParam());
+    std::string sfpu_op = std::get<1>(GetParam());
+
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+    unit_tests::compute::sfpu::SfpuConfig test_config = {
+        .num_tiles = num_tiles,
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .cores = core_range_set,
+        .sfpu_op = sfpu_op,
+        .approx_mode = false,
+        .en_32bit_dest = true};
+    log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SingleCoreSfpuCompute,
+    SingleCoreSingleMeshDeviceSfpuParameterized32BitDestFixture,
+    ::testing::Values(
+        std::make_tuple(1, "relu"),
+        std::make_tuple(1, "exponential"),
+        std::make_tuple(1, "reciprocal"),
+        std::make_tuple(1, "gelu"),
+        std::make_tuple(1, "sqrt"),
+        std::make_tuple(1, "sigmoid"),
+        std::make_tuple(1, "silu"),
+        std::make_tuple(1, "log"),
+        std::make_tuple(1, "tanh"),
+        std::make_tuple(1, "sign"),
+        std::make_tuple(1, "rsqrt"),
+        std::make_tuple(4, "relu"),
+        std::make_tuple(4, "exponential"),
+        std::make_tuple(4, "reciprocal"),
+        std::make_tuple(4, "gelu"),
+        std::make_tuple(4, "sqrt"),
+        std::make_tuple(4, "sigmoid"),
+        std::make_tuple(4, "silu"),
+        std::make_tuple(4, "log"),
+        std::make_tuple(4, "tanh"),
+        std::make_tuple(4, "sign"),
+        std::make_tuple(4, "rsqrt")),
+    [](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
+        return std::get<1>(info.param) + "_" + std::to_string(std::get<0>(info.param)) + "tiles";
+    });
+
+class SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture
+    : public LLKMeshDeviceFixture,
+      public testing::WithParamInterface<std::tuple<size_t, std::string>> {};
+
+TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture, TensixSfpuCompute) {
+    size_t num_tiles = std::get<0>(GetParam());
+    std::string sfpu_op = std::get<1>(GetParam());
+
+    if (((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "relu")) or
+        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "exponential")) or
+        ((arch_ == tt::ARCH::WORMHOLE_B0) and (sfpu_op == "log"))) {
+        GTEST_SKIP();
+    }
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+    unit_tests::compute::sfpu::SfpuConfig test_config = {
+        .num_tiles = num_tiles,
+        .tile_byte_size = 2 * 32 * 32,
+        .l1_input_data_format = tt::DataFormat::Float16_b,
+        .l1_output_data_format = tt::DataFormat::Float16_b,
+        .cores = core_range_set,
+        .sfpu_op = sfpu_op,
+        .approx_mode = true,
+        .en_32bit_dest = true};
+    log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    }
+}
+INSTANTIATE_TEST_SUITE_P(
+    SingleCoreSfpuCompute,
+    SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture,
     ::testing::Values(
         std::make_tuple(1, "relu"),
         std::make_tuple(1, "exponential"),

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -19,7 +19,6 @@ template <
     int ITERATIONS = 8,
     [[maybe_unused]] bool CLAMP_NEGATIVE = true>
 void calculate_exponential([[maybe_unused]] const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
-    static_assert(EN_32BIT_DEST == false, "Non-default EN_32BIT_DEST not supported in Quasar exp");
     static_assert(SCALE_EN == false, "Non-default SCALE_EN not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");
     LLK_ASSERT(
@@ -34,7 +33,6 @@ template <
     [[maybe_unused]] bool CLAMP_NEGATIVE = true,
     [[maybe_unused]] bool EN_32BIT_DEST>
 void exp_init() {
-    static_assert(EN_32BIT_DEST == false, "Non-default EN_32BIT_DEST not supported in Quasar exp");
     static_assert(scale == 0x3F800000, "Non-default scale not supported in Quasar exp");
     static_assert(CLAMP_NEGATIVE == true, "Non-default CLAMP_NEGATIVE not supported in Quasar exp");
     llk_math_eltwise_unary_sfpu_init<SfpuType::exponential>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -17,7 +17,6 @@ template <
     int ITERATIONS = 8,
     [[maybe_unused]] bool legacy_compat = true>
 inline void calculate_reciprocal() {
-    static_assert(EN_32BIT_DEST == false, "Non-default EN_32BIT_DEST (true) not supported in Quasar reciprocal");
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
     _calculate_reciprocal_<APPROXIMATION_MODE>(ITERATIONS);
 }
@@ -28,7 +27,6 @@ template <
     [[maybe_unused]] bool legacy_compat = true>
 void recip_init() {
     // Kept for backwards compatibility
-    static_assert(EN_32BIT_DEST == false, "Non-default EN_32BIT_DEST (true) not supported in Quasar reciprocal");
     static_assert(legacy_compat == true, "Non-default legacy_compat (false) not supported in Quasar reciprocal");
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -17,7 +17,6 @@ template <
     [[maybe_unused]] bool EN_32BIT_DEST,
     [[maybe_unused]] bool FAST_APPROX = false>
 inline void calculate_sqrt() {
-    static_assert(EN_32BIT_DEST == false, "Non-default EN_32BIT_DEST (true) not supported in Quasar sqrt");
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar sqrt");
     _calculate_sqrt_<APPROXIMATION_MODE>(ITERATIONS);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_rsqrt.h
@@ -23,7 +23,6 @@ template <
     [[maybe_unused]] bool legacy_compat = false,
     int ITERATIONS = SFPU_ITERATIONS>
 inline void llk_math_eltwise_unary_sfpu_rsqrt(uint dst_index) {
-    static_assert(is_fp32_dest_acc_en == false, "Non-default is_fp32_dest_acc_en (true) not supported in Quasar rsqrt");
     static_assert(FAST_APPROX == false, "Non-default FAST_APPROX (true) not supported in Quasar rsqrt");
     static_assert(legacy_compat == false, "Non-default legacy_compat (true) not supported in Quasar rsqrt");
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::calculate_rsqrt, dst_index, ITERATIONS);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test/feature
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Issue: https://github.com/tenstorrent/tt-metal/issues/45619
- Adds a test suite to `tt-metal/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp` for toggling `fp32_dest_acc_en`, which was previously hardcoded to false always
- Removes the static assert safeguards which were in place for some of the unary SFPU metal APIs before they were tested
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ryanzhu/unary-sfpu-32bd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ryanzhu/unary-sfpu-32bd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ryanzhu/unary-sfpu-32bd)