### PR TITLE
Fix LLK soft reset timeout polling

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -176,13 +176,15 @@ def commit_tensix_soft_reset(
         "RISCV_DEBUG_REG_SOFT_RESET_0", soft_reset
     )
 
-    end_time = time.time() + 0.1  # 100ms
-    while time.time() < end_time:
+    end_time = time.monotonic() + 0.1  # 100ms
+    while True:
         temp_reg_value = get_register_store(location, device_id).read_register(
             "RISCV_DEBUG_REG_SOFT_RESET_0"
         )
         if temp_reg_value == soft_reset:
             return
+        if time.monotonic() >= end_time:
+            break
 
     raise TimeoutError(
         f"Polling for committed soft reset value times out | Last read value: {temp_reg_value}"


### PR DESCRIPTION
## Summary
- use monotonic time for LLK soft-reset polling
- make the polling path perform at least one register read before timing out
- preserve the existing TimeoutError path with the last observed register value instead of crashing with UnboundLocalError

## Validation
- `git diff --check -- tt_metal/tt-llk/tests/python_tests/helpers/device.py`
- `.venv/bin/python -m py_compile tt_metal/tt-llk/tests/python_tests/helpers/device.py`
- craq-sim targeted BH rerun of 8 prior failing nightly nodeids: `8 passed in 25.23s`
- craq-sim targeted WH rerun of 17 prior failing nightly nodeids after paired simulator readback fix: `17 passed in 36.58s`

Note: local pre-commit in the temp checkout failed before commit because repo-root hook files (`infra/fix_cstdint.py`, `.codespellignore`) were missing from that checkout; Python formatting/lint hooks that did run passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/fix-llk-soft-reset-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/fix-llk-soft-reset-timeout)