### PR TITLE
[Test]: DRISC concurrent Stream + NOC2AXI NIU modes

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -27,20 +27,6 @@ static double compute_bw_gbs(uint64_t total_bytes, uint64_t cycles, uint32_t clk
     return static_cast<double>(total_bytes) * clk_hz / cycles / 1e9;
 }
 
-// Logical DRAM endpoint that bank dram_view's reads traverse on noc.
-// The NOC-aware lookup only gives a physical coord, so invert dram_bank_endpoint_coords to get its index.
-static CoreCoord logical_dram_endpoint_for_noc(const metal_SocDescriptor& soc_desc, uint32_t dram_view, NOC noc) {
-    CoreCoord pref = soc_desc.get_preferred_worker_core_for_dram_view(dram_view, static_cast<uint8_t>(noc));
-    const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(dram_view);
-    for (uint32_t i = 0; i < endpoints.size(); i++) {
-        if (endpoints[i] == pref) {
-            return CoreCoord{dram_view, i};
-        }
-    }
-    TT_FATAL(false, "Preferred DRAM endpoint ({}, {}) for bank {} not found", pref.x, pref.y, dram_view);
-    return {};
-}
-
 // Fixture for DRISC/DRAM-kernel tests
 class DramKernelFixture : public BlackholeSingleCardFixture {
 protected:
@@ -716,7 +702,8 @@ TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
 
     // Place the DRISC kernel on the endpoint that tensix_noc reads route to, so one DRISC owns both NIUs
     // (stream on drisc_noc, NOC2AXI on tensix_noc).
-    CoreCoord drisc_logical = logical_dram_endpoint_for_noc(soc_desc, bank, tensix_noc);
+    CoreCoord pref = soc_desc.get_preferred_worker_core_for_dram_view(bank, static_cast<uint8_t>(tensix_noc));
+    CoreCoord drisc_logical = soc_desc.translate_coord_to(pref, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
     const uint32_t dram_channel = device_->dram_channel_from_logical_core(drisc_logical);
 
     // Fill GDDR with iters random distinct chunks. DRISC and the Tensix reader both walk the same region

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -27,6 +27,20 @@ static double compute_bw_gbs(uint64_t total_bytes, uint64_t cycles, uint32_t clk
     return static_cast<double>(total_bytes) * clk_hz / cycles / 1e9;
 }
 
+// Logical DRAM endpoint that bank dram_view's reads traverse on noc.
+// The NOC-aware lookup only gives a physical coord, so invert dram_bank_endpoint_coords to get its index.
+static CoreCoord logical_dram_endpoint_for_noc(const metal_SocDescriptor& soc_desc, uint32_t dram_view, NOC noc) {
+    CoreCoord pref = soc_desc.get_preferred_worker_core_for_dram_view(dram_view, static_cast<uint8_t>(noc));
+    const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(dram_view);
+    for (uint32_t i = 0; i < endpoints.size(); i++) {
+        if (endpoints[i] == pref) {
+            return CoreCoord{dram_view, i};
+        }
+    }
+    TT_FATAL(false, "Preferred DRAM endpoint ({}, {}) for bank {} not found", pref.x, pref.y, dram_view);
+    return {};
+}
+
 // Fixture for DRISC/DRAM-kernel tests
 class DramKernelFixture : public BlackholeSingleCardFixture {
 protected:
@@ -466,7 +480,8 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
          sub_worker_end_coord.x,
          sub_worker_end_coord.y,
          total_bytes,
-         num_subordinates});
+         num_subordinates,
+         1u});
 
     run_workload(std::move(program));
 
@@ -544,7 +559,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
         "tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp",
         tensix_range,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0});
-    SetRuntimeArgs(program, tensix_k_id, tensix_range, {bank_id, dram_addr, tensix_l1_base_, total_bytes});
+    SetRuntimeArgs(program, tensix_k_id, tensix_range, {bank_id, dram_addr, tensix_l1_base_, total_bytes, 1u});
 
     run_workload(std::move(program));
 
@@ -663,3 +678,124 @@ INSTANTIATE_TEST_SUITE_P(
     DramKernelDRISCGDDRBWSweepFixture,
     testing::Values(2048u, 4096u, 8192u, 16384u, 32768u, 65536u),
     [](const testing::TestParamInfo<uint32_t>& info) { return std::to_string(info.param / 1024) + "KB"; });
+
+struct DRISCNocModeParams {
+    NOC drisc_noc;   // DRISC drives this NIU in stream mode (DMA reads + multicast)
+    NOC tensix_noc;  // opposite NIU, left in NOC2AXI mode for the concurrent Tensix DRAM read
+};
+
+class DRISCNocModeFixture : public DramKernelFixture, public testing::WithParamInterface<DRISCNocModeParams> {};
+
+// Exercises both NIUs of a single DRISC simultaneously: its drisc_noc NIU runs in stream mode
+// (DRISC-initiated DMA reads from GDDR + multicast to a 4x3 Tensix grid) while its tensix_noc NIU
+// stays in NOC2AXI mode servicing a concurrent Tensix DRAM read.
+//
+// A bank's read on tensix_noc deterministically routes to that bank's preferred DRAM endpoint for that
+// NOC (NOC0 and NOC1 use different endpoints), so the DRISC kernel is placed on that same endpoint,
+// guaranteeing both NIUs belong to one DRISC. The Tensix reader sits just below the mcast grid.
+TEST_P(DRISCNocModeFixture, DRISCNocModeMcastStress) {
+    auto [drisc_noc, tensix_noc] = GetParam();
+
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
+
+    constexpr uint32_t bank = 0;
+    constexpr uint32_t mcast_cols = 4;
+    constexpr uint32_t mcast_rows = 3;
+    constexpr uint32_t num_subordinates = mcast_cols * mcast_rows;  // 4 x 3 Tensix grid
+    constexpr uint32_t iters = 1000;
+    const uint32_t bytes_per_iter = 64 * 1024;  // 64K chunks
+    const uint32_t elements_per_iter = bytes_per_iter / sizeof(uint32_t);
+    const uint32_t total_bytes = iters * bytes_per_iter;
+
+    TT_FATAL(
+        dram_unreserved_size_ >= total_bytes,
+        "Not enough DRAM: need {} bytes, have {}",
+        total_bytes,
+        dram_unreserved_size_);
+
+    // Place the DRISC kernel on the endpoint that tensix_noc reads route to, so one DRISC owns both NIUs
+    // (stream on drisc_noc, NOC2AXI on tensix_noc).
+    CoreCoord drisc_logical = logical_dram_endpoint_for_noc(soc_desc, bank, tensix_noc);
+    const uint32_t dram_channel = device_->dram_channel_from_logical_core(drisc_logical);
+
+    // Fill GDDR with iters random distinct chunks. DRISC and the Tensix reader both walk the same region
+    // Only the final chunk remains in L1 after the run, so verification compares against it
+    auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
+        .device = device_,
+        .size = total_bytes,
+        .page_size = total_bytes,  // single bank (bank 0)
+        .buffer_type = BufferType::DRAM,
+    });
+    uint32_t dram_addr = dram_buffer->address();
+
+    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    log_info(LogTest, "Random seed: {}", seed);
+    std::vector<uint32_t> data = create_random_vector_of_bfloat16(total_bytes, 1000.0f, seed);
+    tt::tt_metal::detail::WriteToDeviceDRAMChannel(device_, dram_channel, dram_addr, data);
+    std::vector<uint32_t> last_chunk(data.end() - elements_per_iter, data.end());
+
+    Program program = CreateProgram();
+
+    // DRISC stream kernel: read GDDR chunks for multiple iterations, multicasting each to the 4x3 grid
+    CoreCoord mcast_start = device_->virtual_core_from_logical_core({0, 0}, CoreType::WORKER);
+    CoreCoord mcast_end = device_->virtual_core_from_logical_core({mcast_cols - 1, mcast_rows - 1}, CoreType::WORKER);
+    auto drisc_k = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp",
+        drisc_logical,
+        DramConfig{.noc = drisc_noc, .defines = {{"MULTICAST", "1"}}});
+    SetRuntimeArgs(
+        program,
+        drisc_k,
+        drisc_logical,
+        {dram_addr,
+         drisc_l1_base_,
+         tensix_l1_base_,
+         mcast_start.x,
+         mcast_start.y,
+         mcast_end.x,
+         mcast_end.y,
+         bytes_per_iter,
+         num_subordinates,
+         iters});
+
+    // Tensix DRAM reader on tensix_noc: walks the same iters chunks through the endpoint's NOC2AXI NIU.
+    // Placed at row mcast_rows, just outside the mcast destination rows (0, 1, ... mcast_rows-1)
+    CoreCoord tensix_reader_logical{0, mcast_rows};
+    auto tensix_k = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp",
+        tensix_reader_logical,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = tensix_noc});
+    SetRuntimeArgs(program, tensix_k, tensix_reader_logical, {bank, dram_addr, tensix_l1_base_, bytes_per_iter, iters});
+
+    run_workload(std::move(program));
+
+    // Verify the 4x3 mcast grid received the last chunk.
+    for (uint32_t row = 0; row < mcast_rows; row++) {
+        for (uint32_t col = 0; col < mcast_cols; col++) {
+            CoreCoord v = device_->virtual_core_from_logical_core({col, row}, CoreType::WORKER);
+            std::vector<uint32_t> result(elements_per_iter);
+            MetalContext::instance().get_cluster().read_core(
+                result.data(), bytes_per_iter, tt_cxy_pair(mesh_device_->build_id(), v), tensix_l1_base_);
+            EXPECT_EQ(result, last_chunk) << "Mcast last-chunk mismatch at Tensix (" << col << ", " << row << ")";
+        }
+    }
+
+    // Verify the Tensix DRAM reader received the last chunk via the NOC2AXI NIU.
+    CoreCoord reader_v = device_->virtual_core_from_logical_core(tensix_reader_logical, CoreType::WORKER);
+    std::vector<uint32_t> result(elements_per_iter);
+    MetalContext::instance().get_cluster().read_core(
+        result.data(), bytes_per_iter, tt_cxy_pair(mesh_device_->build_id(), reader_v), tensix_l1_base_);
+    EXPECT_EQ(result, last_chunk) << "Tensix DRAM read via NOC2AXI NIU last-chunk mismatch";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NocModeSweep,
+    DRISCNocModeFixture,
+    testing::Values(
+        DRISCNocModeParams{NOC::NOC_0, NOC::NOC_1},   // NOC0 = stream, NOC1 = NOC2AXI
+        DRISCNocModeParams{NOC::NOC_1, NOC::NOC_0}),  // NOC1 = stream, NOC0 = NOC2AXI
+    [](const testing::TestParamInfo<DRISCNocModeParams>& info) {
+        return info.param.drisc_noc == NOC::NOC_0 ? "Noc0StreamNoc1Noc2Axi" : "Noc1StreamNoc0Noc2Axi";
+    });

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -27,6 +27,22 @@ static double compute_bw_gbs(uint64_t total_bytes, uint64_t cycles, uint32_t clk
     return static_cast<double>(total_bytes) * clk_hz / cycles / 1e9;
 }
 
+// Logical DRAM endpoint (for CreateKernel) that bank `dram_view`'s reads traverse on `noc`.
+// Not UMD translate_coord_to(.., LOGICAL): that returns the raw subchannel, but CreateKernel(DramConfig)
+// indexes dram_bank_endpoint_coords (preferred-first), so UMD would land on the wrong DRISC. Instead we
+// invert dram_bank_endpoint_coords against the preferred coord -- the value firmware uses as the read target.
+static CoreCoord logical_dram_endpoint_for_noc(const metal_SocDescriptor& soc_desc, uint32_t dram_view, NOC noc) {
+    CoreCoord pref = soc_desc.get_preferred_worker_core_for_dram_view(dram_view, static_cast<uint8_t>(noc));
+    const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(dram_view);
+    for (uint32_t i = 0; i < endpoints.size(); i++) {
+        if (endpoints[i] == pref) {
+            return CoreCoord{dram_view, i};
+        }
+    }
+    TT_FATAL(false, "Preferred DRAM endpoint ({}, {}) for bank {} not found", pref.x, pref.y, dram_view);
+    return {};
+}
+
 // Fixture for DRISC/DRAM-kernel tests
 class DramKernelFixture : public BlackholeSingleCardFixture {
 protected:
@@ -702,8 +718,7 @@ TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
 
     // Place the DRISC kernel on the endpoint that tensix_noc reads route to, so one DRISC owns both NIUs
     // (stream on drisc_noc, NOC2AXI on tensix_noc).
-    CoreCoord pref = soc_desc.get_preferred_worker_core_for_dram_view(bank, static_cast<uint8_t>(tensix_noc));
-    CoreCoord drisc_logical = soc_desc.translate_coord_to(pref, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
+    CoreCoord drisc_logical = logical_dram_endpoint_for_noc(soc_desc, bank, tensix_noc);
     const uint32_t dram_channel = device_->dram_channel_from_logical_core(drisc_logical);
 
     // Fill GDDR with iters random distinct chunks. DRISC and the Tensix reader both walk the same region

--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -684,7 +684,8 @@ struct DRISCNocModeParams {
     NOC tensix_noc;  // opposite NIU, left in NOC2AXI mode for the concurrent Tensix DRAM read
 };
 
-class DRISCNocModeFixture : public DramKernelFixture, public testing::WithParamInterface<DRISCNocModeParams> {};
+class DramKernelDRISCNocModeFixture : public DramKernelFixture,
+                                      public testing::WithParamInterface<DRISCNocModeParams> {};
 
 // Exercises both NIUs of a single DRISC simultaneously: its drisc_noc NIU runs in stream mode
 // (DRISC-initiated DMA reads from GDDR + multicast to a 4x3 Tensix grid) while its tensix_noc NIU
@@ -693,7 +694,7 @@ class DRISCNocModeFixture : public DramKernelFixture, public testing::WithParamI
 // A bank's read on tensix_noc deterministically routes to that bank's preferred DRAM endpoint for that
 // NOC (NOC0 and NOC1 use different endpoints), so the DRISC kernel is placed on that same endpoint,
 // guaranteeing both NIUs belong to one DRISC. The Tensix reader sits just below the mcast grid.
-TEST_P(DRISCNocModeFixture, DRISCNocModeMcastStress) {
+TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
     auto [drisc_noc, tensix_noc] = GetParam();
 
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
@@ -792,7 +793,7 @@ TEST_P(DRISCNocModeFixture, DRISCNocModeMcastStress) {
 
 INSTANTIATE_TEST_SUITE_P(
     NocModeSweep,
-    DRISCNocModeFixture,
+    DramKernelDRISCNocModeFixture,
     testing::Values(
         DRISCNocModeParams{NOC::NOC_0, NOC::NOC_1},   // NOC0 = stream, NOC1 = NOC2AXI
         DRISCNocModeParams{NOC::NOC_1, NOC::NOC_0}),  // NOC1 = stream, NOC0 = NOC2AXI

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Kernel is used for two tests:
-// 1. Multicast test: DRISC L1 reads from DRAM over DMA and mcasts to Tensix L1
-// 2. Double buffered DRISC L1 reads from DRAM over DMA and unicast to Tensix L1 (using TRIDs).
-//    We measure max possible bandwidth using this test
+// DRISC kernel: reads GDDR over DMA into DRISC L1, then sends to Tensix L1.
+//   MULTICAST defined   -> multicast each chunk to a Tensix grid (mcast / NOC-mode tests).
+//   MULTICAST not defined -> double-buffered unicast with TRIDs (bandwidth measurement).
 
 #include "api/dataflow/noc.h"
 #include "experimental/drisc_mode.h"
@@ -23,6 +22,7 @@ void kernel_main() {
     const uint32_t tensix_noc_y_end = get_arg_val<uint32_t>(6);
     const uint32_t num_bytes = get_arg_val<uint32_t>(7);
     const uint32_t num_subordinates = get_arg_val<uint32_t>(8);
+    const uint32_t total_iters = get_arg_val<uint32_t>(9);
 
     Noc noc;
     UnicastEndpoint src;
@@ -32,26 +32,35 @@ void kernel_main() {
 
 #if defined(MULTICAST)
     MulticastEndpoint dst;
-    // Read chunk from GDDR into DRISC L1
     constexpr uint8_t tx_stream = 0;
-    experimental::dma_async_read(tx_stream, src_gddr_addr, drisc_l1_addr, num_bytes);
-    experimental::dma_async_read_barrier(tx_stream);
-    noc.async_write_multicast(
-        src,
-        dst,
-        num_bytes,
-        num_subordinates,
-        {.addr = drisc_l1_addr},
-        {
-            .noc_x_start = tensix_noc_x_start,
-            .noc_y_start = tensix_noc_y_start,
-            .noc_x_end = tensix_noc_x_end,
-            .noc_y_end = tensix_noc_y_end,
-            .addr = tensix_l1_dst_addr,
-        });
-    noc.async_write_barrier();
+    // The two NOCs are opposing tori: pick the multicast entry corner to match the NOC's flow
+    // direction (NOC0 enters at the min corner, NOC1 at the max corner).
+    const uint32_t noc_x_start = noc_index == 0 ? tensix_noc_x_start : tensix_noc_x_end;
+    const uint32_t noc_y_start = noc_index == 0 ? tensix_noc_y_start : tensix_noc_y_end;
+    const uint32_t noc_x_end = noc_index == 0 ? tensix_noc_x_end : tensix_noc_x_start;
+    const uint32_t noc_y_end = noc_index == 0 ? tensix_noc_y_end : tensix_noc_y_start;
+    uint32_t gddr_addr = src_gddr_addr;
+    // Per iter: DMA the next GDDR chunk into DRISC L1, then multicast it to the Tensix grid
+    for (uint32_t i = 0; i < total_iters; i++) {
+        experimental::dma_async_read(tx_stream, gddr_addr, drisc_l1_addr, num_bytes);
+        experimental::dma_async_read_barrier(tx_stream);
+        noc.async_write_multicast(
+            src,
+            dst,
+            num_bytes,
+            num_subordinates,
+            {.addr = drisc_l1_addr},
+            {
+                .noc_x_start = noc_x_start,
+                .noc_y_start = noc_y_start,
+                .noc_x_end = noc_x_end,
+                .noc_y_end = noc_y_end,
+                .addr = tensix_l1_dst_addr,
+            });
+        gddr_addr += num_bytes;
+        noc.async_write_barrier();
+    }
 #else
-    const uint32_t total_iters = get_arg_val<uint32_t>(9);
     UnicastEndpoint dst;
     // Single-stream double-buffered: both halves share stream 0 and are
     // pipelined via two pre-fired DMA reads

--- a/tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/tensix_dram_reads.cpp
@@ -10,14 +10,18 @@
 
 void kernel_main() {
     const uint32_t src_dram_bank_id = get_arg_val<uint32_t>(0);
-    const uint32_t src_dram_addr = get_arg_val<uint32_t>(1);
+    uint32_t src_dram_addr = get_arg_val<uint32_t>(1);
     const uint32_t dst_l1_addr = get_arg_val<uint32_t>(2);
     const uint32_t total_bytes = get_arg_val<uint32_t>(3);
+    const uint32_t iters = get_arg_val<uint32_t>(4);
 
     Noc noc;
     AllocatorBank<AllocatorBankType::DRAM> bank;
     CoreLocalMem<uint32_t> dst(dst_l1_addr);
 
-    noc.async_read(bank, dst, total_bytes, {.bank_id = src_dram_bank_id, .addr = src_dram_addr}, {});
-    noc.async_read_barrier();
+    for (uint32_t i = 0; i < iters; i++) {
+        noc.async_read(bank, dst, total_bytes, {.bank_id = src_dram_bank_id, .addr = src_dram_addr}, {});
+        src_dram_addr += total_bytes;
+        noc.async_read_barrier();
+    }
 }


### PR DESCRIPTION
### PR Category
Test Only.

### Summary
Adds a test verifying that a single DRISC can run its two NIUs in different modes concurrently - one NIU in Stream mode (DRISC-initiated DMA reads from GDDR + multicast to a Tensix grid) while the other stays in NOC2AXI mode servicing a concurrent Tensix DRAM read. Parameterized both ways i.e. NOC0 in Stream mode with NOC1 in NOC2AXI mode and vice versa.

Two existing kernels are repurposed for this: `drisc_mcast_writes_tensix.cpp` and `tensix_dram_reads.cpp` each gained an iteration loop with address advance. Existing callers pass `iters=1` to preserve prior behavior.

### Notes for reviewers
- Endpoint placement (`logical_dram_endpoint_for_noc` helper): since the two NOCs use different preferred DRAM endpoints for the same bank, the DRISC kernel is placed on the endpoint that tensix_noc's bank reads route to. This guarantees both NIUs belong to one physical DRISC rather than two. The helper inverts dram_bank_endpoint_coords to translate the physical coord into the logical core the kernel API expects.
- NOC direction handling in the mcast kernel: start/end multicast corners are swapped for NOC1.


Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/26851986471/job/79187076269

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/drisc_noc_mode_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/drisc_noc_mode_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/drisc_noc_mode_test)