### PR TITLE
Feature: MoE: Make `all_to_all_dispatch_metadata` work with Linear topology 

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -763,7 +763,7 @@ def get_shared_expert_to_device_map(routed_experts, devices, mode):
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
             "fabric_router_config": create_fabric_router_config(max_payload_size=4352),
             "trace_region_size": 500000,
         },
@@ -834,9 +834,95 @@ def test_correctness(mesh_device, mesh_shape, cluster_axis, routed_experts_per_d
         dtype=dtype,
         cluster_axis=cluster_axis,
         worker_mode=worker_mode,
-        dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_LINEAR,
+        dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
         use_persistent_mode=use_persistent_mode,
         shared_expert_ids_to_devices=shared_expert_ids_to_devices,
+    )
+
+
+# Correctness test on a Linear (non-wrapping) fabric. Topology is derived from the fabric config, so
+# using FABRIC_1D instead of FABRIC_1D_RING exercises the Linear path of SPARSE_MCAST_SHORTEST_PATH.
+# alternate_shared is the key case: its destination sets straddle both sides of every source device.
+@pytest.mark.skipif(
+    not (is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x16) or is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x8)),
+    reason=f"Requires TT_MESH_GRAPH_DESC_PATH to be 1x16 or 1x8 descriptor",
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=4352),
+            "trace_region_size": 500000,
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape, mesh_device, cluster_axis",
+    [
+        pytest.param(
+            (1, 8),
+            (1, 8),
+            1,
+            marks=pytest.mark.skipif(
+                not is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x8),
+                reason=f"1x8 mesh requires TT_MESH_GRAPH_DESC_PATH={MESH_GRAPH_DESC_1x8}",
+            ),
+            id="1x8",
+        ),
+        pytest.param(
+            (1, 16),
+            (1, 16),
+            1,
+            marks=pytest.mark.skipif(
+                not is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_1x16),
+                reason=f"1x16 mesh requires TT_MESH_GRAPH_DESC_PATH={MESH_GRAPH_DESC_1x16}",
+            ),
+            id="1x16",
+        ),
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("routed_experts_per_device", [2])
+def test_correctness_linear(mesh_device, mesh_shape, cluster_axis, routed_experts_per_device):
+    batches_per_device = 32
+    routed_experts = routed_experts_per_device * mesh_shape[cluster_axis]
+    select_experts_k = 8
+    hidden_size = 7168
+    seq_len = 1
+    num_iters = 20
+    warmup_iters = 5
+    num_links = 4
+    dtype = ttnn.bfloat16
+    congestion_scheme = "random_sequential_experts"
+    worker_mode = ttnn.WorkerMode.DIRECT
+    use_persistent_mode = True
+
+    dispatch_devices = mesh_shape[cluster_axis]
+    batch = batches_per_device * dispatch_devices
+    trace_mode = True
+
+    run_all_to_all_dispatch_metadata_test(
+        mesh_device,
+        mesh_shape,
+        batch,
+        routed_experts,
+        select_experts_k,
+        hidden_size,
+        seq_len,
+        num_iters,
+        warmup_iters,
+        trace_mode,
+        num_links=num_links,
+        scheme=congestion_scheme,
+        dtype=dtype,
+        cluster_axis=cluster_axis,
+        worker_mode=worker_mode,
+        dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+        use_persistent_mode=use_persistent_mode,
     )
 
 

--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -763,7 +763,7 @@ def get_shared_expert_to_device_map(routed_experts, devices, mode):
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
             "fabric_router_config": create_fabric_router_config(max_payload_size=4352),
             "trace_region_size": 500000,
         },
@@ -834,7 +834,7 @@ def test_correctness(mesh_device, mesh_shape, cluster_axis, routed_experts_per_d
         dtype=dtype,
         cluster_axis=cluster_axis,
         worker_mode=worker_mode,
-        dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH,
+        dispatch_algorithm=ttnn.DispatchAlgorithm.SPARSE_MCAST_LINEAR,
         use_persistent_mode=use_persistent_mode,
         shared_expert_ids_to_devices=shared_expert_ids_to_devices,
     )

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp
@@ -997,10 +997,11 @@ inline void fabric_send_chip_sparse_multicast_noc_unicast_1d_in_direction(
 template <tt::tt_fabric::Topology Topology, uint32_t AxisSize>
 inline uint32_t calculate_hops_direction_enforced_1D(uint32_t src_coord, uint32_t dest_coord, Polarity polarity) {
     // Currently this function has only been tested for 1D Ring topology.
-    static_assert(
-        has_wrap_around<Topology>(),
-        "calculate_hops_direction_enforced_1D has only been tested for 1D topologies with wraparound links");
-    return directional_wrap_distance<AxisSize>(src_coord, dest_coord, polarity);
+    if constexpr (has_wrap_around<Topology>()) {
+        return directional_wrap_distance<AxisSize>(src_coord, dest_coord, polarity);
+    } else {
+        return topological_distance<Topology>(src_coord, dest_coord, AxisSize);
+    }
 }
 
 // Given a list of destinations, generates a hop mask relative to the source chip

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.cpp
@@ -35,8 +35,7 @@ std::array<ttnn::Tensor, 3> all_to_all_dispatch_metadata(
     log_debug(tt::LogOp, "num_links: {}", num_links_);
 
     // Always derive topology from mesh - only RING topology is functional
-    tt::tt_fabric::Topology topology_ =
-        tt::tt_fabric::Topology::Linear;  //::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, axis);
+    tt::tt_fabric::Topology topology_ = ::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, axis);
 
     // Resolve drain_sync_tilizer_core:
     // - If explicitly provided, use it

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata.cpp
@@ -35,7 +35,8 @@ std::array<ttnn::Tensor, 3> all_to_all_dispatch_metadata(
     log_debug(tt::LogOp, "num_links: {}", num_links_);
 
     // Always derive topology from mesh - only RING topology is functional
-    tt::tt_fabric::Topology topology_ = ::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, axis);
+    tt::tt_fabric::Topology topology_ =
+        tt::tt_fabric::Topology::Linear;  //::ttnn::ccl::get_usable_topology(input_tensor, std::nullopt, axis);
 
     // Resolve drain_sync_tilizer_core:
     // - If explicitly provided, use it

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/all_to_all_dispatch_metadata_device_operation.cpp
@@ -84,6 +84,14 @@ void AllToAllDispatchMetadataDeviceOperation::validate_on_program_cache_miss(
     }
     TT_FATAL(operation_attributes.num_links > 0, "Number of links must be greater than 0");
 
+    // SPARSE_MCAST_LINEAR sends a single-direction multicast packet, which cannot reach
+    // destinations on both sides of the source on a non-wrapping (Linear) topology. Use the
+    // bidirectional SPARSE_MCAST_SHORTEST_PATH algorithm for Linear meshes instead.
+    TT_FATAL(
+        !(operation_attributes.topology == tt::tt_fabric::Topology::Linear &&
+          operation_attributes.dispatch_algorithm == DispatchAlgorithm::SPARSE_MCAST_LINEAR),
+        "DispatchAlgorithm::SPARSE_MCAST_LINEAR is not supported with Linear fabric topology");
+
     auto input_shape = input_tensor.tensor_spec().logical_shape();
     TT_FATAL(
         input_shape.rank() == 4 && (input_shape.rank() == indices_shape.rank()),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -30,6 +30,8 @@ void kernel_main() {
 
     constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
 
+    constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(23);
+
     constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
     constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
 
@@ -174,7 +176,10 @@ void kernel_main() {
         // Wait for all other devices to finish dispatching their input tokens and metadata.
         // The writer now writes metadata directly to the sharded output tensor on the drain sync tilizer core,
         // so we no longer need to copy from the intermediate buffer to the final output here.
-        noc_semaphore_wait((uint32_t*)global_semaphore_address, dispatch_devices);
-        noc_semaphore_set((uint32_t*)global_semaphore_address, 0);
+        constexpr uint32_t expected_dispatch_device_inc =
+            (topology == tt::tt_fabric::Topology::Linear) ? (dispatch_devices - 1) : dispatch_devices;
+        auto* global_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_address);
+        noc_semaphore_wait(global_semaphore_ptr, expected_dispatch_device_inc);
+        noc_semaphore_set(global_semaphore_ptr, 0);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -1030,12 +1030,7 @@ void kernel_main() {
     // - The cross_device_semaphore is double-buffered externally to avoid races between iterations
 #ifndef SKIP_INIT_SEMAPHORE
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
-    detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
-        linearized_mesh_coord,
-        mesh_rows,
-        mesh_cols,
-        axis,
-        dispatch_devices>(
+    detail::fabric_multicast_bidirectional_atomic_inc_1d<linearized_mesh_coord, topology mesh_rows, mesh_cols, axis>(
         fabric_connections, atomic_inc_packet_header_pos, atomic_inc_packet_header_neg, init_noc_semaphore_addr);
     noc_async_writes_flushed();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -43,62 +43,6 @@ void zero_buffer_async(uint32_t write_addr, int bytes) {
 
 void zero_buffer_barrier() { noc_async_read_barrier(); }
 
-// Bidirectional fabric multicast atomic increment - sends to both positive and negative directions
-// For a 1D ring with even number of devices, we multicast in both directions to cover all devices
-// with just 2 packets instead of (dispatch_devices - 1) unicast packets
-template <
-    uint32_t LinearizedSrcMeshCoord,
-    uint32_t MeshRows,
-    uint32_t MeshCols,
-    ttnn::operations::ccl::common::ReplicateGroup Axis,
-    uint32_t DispatchDevices,
-    bool DoubleAntipodalAtomicInc = false,
-    typename FabricConnectionsType>
-FORCE_INLINE void fabric_multicast_bidirectional_atomic_inc_ring_1d(
-    FabricConnectionsType& fabric_connections,
-    volatile PACKET_HEADER_TYPE* packet_header_pos,
-    volatile PACKET_HEADER_TYPE* packet_header_neg,
-    uint64_t semaphore_noc_addr) {
-    using ttnn::operations::ccl::common::ReplicateGroup;
-    const auto cmd_header = tt::tt_fabric::NocUnicastAtomicIncCommandHeader{semaphore_noc_addr, 1, true};
-
-    // Split the ring: positive direction gets half, negative direction gets the other half
-    // For dispatch_devices = 16: positive gets 8, negative gets 7 (total 15 = dispatch_devices - 1) if
-    // DoubleAntipodalAtomicInc is false For dispatch_devices = 16: positive gets 8, negative gets 8 (total 16 =
-    // dispatch_devices) if DoubleAntipodalAtomicInc is true
-    constexpr uint32_t positive_range = DoubleAntipodalAtomicInc ? (DispatchDevices + 1) / 2 : DispatchDevices / 2;
-    constexpr uint32_t negative_range =
-        DoubleAntipodalAtomicInc ? DispatchDevices - positive_range : (DispatchDevices - 1) - positive_range;
-
-    // Determine directions based on axis:
-    // COLS (axis=0): dispatch along column → SOUTH is positive, NORTH is negative
-    // ROWS (axis=1): dispatch along row → EAST is positive, WEST is negative
-    constexpr uint32_t positive_direction =
-        Axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
-    constexpr uint32_t negative_direction =
-        Axis == ReplicateGroup::COLS ? eth_chan_directions::NORTH : eth_chan_directions::WEST;
-
-    // Send multicast in positive direction (start_distance=1, range=positive_range)
-    if constexpr (positive_range > 0) {
-        tt::tt_fabric::linear::experimental::fabric_multicast_noc_unicast_atomic_inc(
-            &fabric_connections[positive_direction],
-            packet_header_pos,
-            cmd_header,
-            static_cast<uint8_t>(1),
-            static_cast<uint8_t>(positive_range));
-    }
-
-    // Send multicast in negative direction (start_distance=1, range=negative_range)
-    if constexpr (negative_range > 0) {
-        tt::tt_fabric::linear::experimental::fabric_multicast_noc_unicast_atomic_inc(
-            &fabric_connections[negative_direction],
-            packet_header_neg,
-            cmd_header,
-            static_cast<uint8_t>(1),
-            static_cast<uint8_t>(negative_range));
-    }
-}
-
 // Bidirectional multicast write - sends same payload to all devices on ring via multicast in both directions
 // Handles payloads larger than max packet size by splitting into multiple packets
 template <
@@ -188,10 +132,10 @@ FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
 // Similar to fabric_multicast_bidirectional_atomic_inc_ring_1d but for scatter writes
 template <
     uint32_t LinearizedSrcMeshCoord,
+    tt::tt_fabric::Topology Topology,
     uint32_t MeshRows,
     uint32_t MeshCols,
     ttnn::operations::ccl::common::ReplicateGroup Axis,
-    uint32_t DispatchDevices,
     typename FabricConnectionsType>
 FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
     FabricConnectionsType& fabric_connections,
@@ -202,10 +146,16 @@ FORCE_INLINE void fabric_multicast_bidirectional_scatter_write_ring_1d_async(
     const std::array<uint16_t, 2>& chunk_sizes) {
     using ttnn::operations::ccl::common::ReplicateGroup;
 
-    // Split the ring: positive direction gets half, negative direction gets the other half
-    // For dispatch_devices = 16: positive gets 8, negative gets 7 (total 15 = dispatch_devices - 1)
-    constexpr uint32_t positive_range = DispatchDevices / 2;
-    constexpr uint32_t negative_range = (DispatchDevices - 1) - positive_range;
+    constexpr uint32_t dispatch_devices =
+        Axis == ttnn::operations::ccl::common::ReplicateGroup::COLS ? MeshRows : MeshCols;
+
+    constexpr uint32_t axis_position =
+        Axis == ReplicateGroup::COLS ? (LinearizedSrcMeshCoord / MeshCols) : (LinearizedSrcMeshCoord % MeshCols);
+
+    constexpr uint32_t positive_range =
+        (Topology == tt::tt_fabric::Topology::Linear) ? (dispatch_devices - 1) - axis_position : dispatch_devices / 2;
+    constexpr uint32_t negative_range =
+        (Topology == tt::tt_fabric::Topology::Linear) ? axis_position : (dispatch_devices - 1) - positive_range;
 
     constexpr uint32_t positive_direction =
         Axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
@@ -393,6 +343,7 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
     using ttnn::operations::ccl::common::is_configured_target;
 
     bool needs_barrier = false;
+    bool sent_local = false;
 
     // Collect all unique remote destinations for this token
     uint32_t remote_token_destinations[NumDevices];
@@ -408,9 +359,12 @@ FORCE_INLINE bool dispatch_token_sparse_multicast(
             send_preparation_buffer[(local_token - token_start_idx) * NumDevices + target_device] = 1;
 
             if (target_device == LinearizedSrcMeshCoord) {
-                // If the expert lives on the current device, dispatch locally
-                noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
-                needs_barrier = true;
+                if (!sent_local) {
+                    // If the expert lives on the current device, dispatch locally
+                    noc_async_write(input_token_read_addr, output_token_write_addr, output_page_size);
+                    needs_barrier = true;
+                    sent_local = true;
+                }
             } else if (is_configured_target<LinearizedSrcMeshCoord, MeshRows, MeshCols, Axis>(target_device)) {
                 // Add to remote destinations list
                 remote_token_destinations[num_remote_token_destinations++] = target_device;
@@ -522,29 +476,42 @@ FORCE_INLINE bool dispatch_token_sparse_multicast_bidirectional(
                 sent_local = true;
             }
         } else if (is_configured_target<LinearizedSrcMeshCoord, MeshRows, MeshCols, Axis>(target_device)) {
-            // Remote device on our axis - calculate distance in both directions
-            // pos_distance: going EAST/SOUTH (ascending, with wrap)
-            // neg_distance: going WEST/NORTH (descending, with wrap)
-
+            // Remote device on our axis - select the direction(s) used to reach it.
             uint32_t intra_cluster_target_device_id =
                 get_intra_cluster_id_from_linearized_mesh_coord<MeshRows, MeshCols, Axis>(target_device);
 
-            uint32_t pos_distance =
-                (intra_cluster_target_device_id - intra_cluster_src_device_id + DispatchDevices) % DispatchDevices;
-            uint32_t neg_distance =
-                (intra_cluster_src_device_id - intra_cluster_target_device_id + DispatchDevices) % DispatchDevices;
-            // Determine shortest path direction
-            if (pos_distance < neg_distance) {
-                // Shorter via positive direction (EAST/SOUTH)
-                pos_hop_mask |= (1 << (pos_distance - 1));
-            } else if (neg_distance < pos_distance) {
-                // Shorter via negative direction (WEST/NORTH)
-                neg_hop_mask |= (1 << (neg_distance - 1));
+            if constexpr (ttnn::operations::ccl::common::has_wrap_around<Topology>()) {
+                // Ring/Torus: target is reachable in both directions (one wraps around).
+                // pos_distance: going EAST/SOUTH (ascending, with wrap)
+                // neg_distance: going WEST/NORTH (descending, with wrap)
+                uint32_t pos_distance =
+                    (intra_cluster_target_device_id - intra_cluster_src_device_id + DispatchDevices) % DispatchDevices;
+                uint32_t neg_distance =
+                    (intra_cluster_src_device_id - intra_cluster_target_device_id + DispatchDevices) % DispatchDevices;
+                // Determine shortest path direction
+                if (pos_distance < neg_distance) {
+                    // Shorter via positive direction (EAST/SOUTH)
+                    pos_hop_mask |= (1 << (pos_distance - 1));
+                } else if (neg_distance < pos_distance) {
+                    // Shorter via negative direction (WEST/NORTH)
+                    neg_hop_mask |= (1 << (neg_distance - 1));
+                } else {
+                    // Antipodal tie - use provided polarity
+                    if (antipodal_polarity == Polarity::POSITIVE) {
+                        pos_hop_mask |= (1 << (pos_distance - 1));
+                    } else {
+                        neg_hop_mask |= (1 << (neg_distance - 1));
+                    }
+                }
             } else {
-                // Antipodal tie - use provided polarity
-                if (antipodal_polarity == Polarity::POSITIVE) {
+                // Linear: no wrap-around, so exactly one direction reaches the target.
+                // Targets ahead of the source (larger id) go positive (EAST/SOUTH); targets
+                // behind (smaller id) go negative (WEST/NORTH). No antipodal tie is possible.
+                if (intra_cluster_target_device_id > intra_cluster_src_device_id) {
+                    uint32_t pos_distance = intra_cluster_target_device_id - intra_cluster_src_device_id;
                     pos_hop_mask |= (1 << (pos_distance - 1));
                 } else {
+                    uint32_t neg_distance = intra_cluster_src_device_id - intra_cluster_target_device_id;
                     neg_hop_mask |= (1 << (neg_distance - 1));
                 }
             }
@@ -1300,10 +1267,10 @@ void kernel_main() {
         uint32_t base_metadata_addr = get_read_ptr(metadata_buffer_id);
         detail::fabric_multicast_bidirectional_scatter_write_ring_1d_async<
             linearized_mesh_coord,
+            topology,
             mesh_rows,
             mesh_cols,
-            axis,
-            dispatch_devices>(
+            axis>(
             fabric_connections,
             metadata_packet_header_pos,
             metadata_packet_header_neg,
@@ -1313,13 +1280,13 @@ void kernel_main() {
         cb_pop_front(metadata_buffer_id, tokens_per_device);
         // Use DoubleAntipodalAtomicInc=true to increment semaphore on all devices including twice on the antipodal
         // device
-        detail::fabric_multicast_bidirectional_atomic_inc_ring_1d<
+        fabric_multicast_bidirectional_atomic_inc_1d<
             linearized_mesh_coord,
+            topology,
             mesh_rows,
             mesh_cols,
             axis,
-            dispatch_devices,
-            true>(
+            /*DoubleAntipodalAtomicInc=*/(topology == tt::tt_fabric::Topology::Ring)>(
             fabric_connections,
             atomic_inc_packet_header_pos,
             atomic_inc_packet_header_neg,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/kernels/dataflow/writer.cpp
@@ -359,9 +359,9 @@ void kernel_main() {
         //   (the antipodal device is incremented from both directions, summing to N senders).
         // Linear: each device receives `replicate_group_devices - 1` inc's (no antipodal doubling;
         //   each sender on the line sends to exactly N-1 other devices).
-        constexpr uint32_t expected_inc_count =
+        constexpr uint32_t expected_dispatch_device_inc =
             (topology == tt::tt_fabric::Topology::Linear) ? (replicate_group_devices - 1) : replicate_group_devices;
-        noc_semaphore_wait(semaphore_ptr, expected_inc_count);
+        noc_semaphore_wait(semaphore_ptr, expected_dispatch_device_inc);
         noc_semaphore_set(semaphore_ptr, 0);
     } else {
         // get sync core semaphore noc address


### PR DESCRIPTION
### Summary
- The full MoE decode flow, including dispatch, should work with Linear topology to facilitate development and provide generality
- This op was mostly there, just needed a couple of tweaks

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/a2a-dispatch-metadata-line)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/a2a-dispatch-metadata-line)