### PR TITLE
Fix moreh_getitem buffer binding and tilized test cleanup

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
@@ -381,12 +381,7 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major
         tt_cpu = x[:, :, :, :, idx]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, [dev_idx], [index_dim])
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-
-    cpu_5d_shape = to_output_5d_shape(shape, [index_dim], index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(cpu_5d_shape)
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)
@@ -474,12 +469,7 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, row_ma
         tt_cpu = x[:, :, :, indices[0], indices[1]]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-
-    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)
@@ -561,12 +551,7 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, row_
         tt_cpu = x[:, :, indices[0], indices[1], indices[2]]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-
-    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)
@@ -643,13 +628,7 @@ def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, row_m
         tt_cpu = x[:, indices[0], indices[1], indices[2], indices[3]]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
-    tt_npu = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR)
-
-    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
-
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)
@@ -721,13 +700,7 @@ def test_getitem_tilized_five_indices(shape_index_dims, dtype, index_size, row_m
     tt_cpu = x[indices[0], indices[1], indices[2], indices[3], indices[4]]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, dev_indices, index_dims)
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-
-    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
-
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)
@@ -773,12 +746,7 @@ def run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_m
         tt_cpu = x[:, :, :, :, idx]
 
     tt_npu = ttnn.operations.moreh.getitem(dev_x, [dev_idx], [index_dim])
-    tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
-
-    cpu_5d_shape = to_output_5d_shape(shape, [index_dim], index_size)
-
-    tt_npu = tt_npu.unpad_from_tile(cpu_5d_shape)
-    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+    tt_dev = ttnn.to_torch(tt_npu).reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
     logger.info(out)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
@@ -13,7 +13,7 @@ namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 struct IndexInfo {
     bool is_defined{};
-    uint32_t address{};
+    tt::tt_metal::Buffer* buffer{};
     uint32_t unit_size{};
     tt::tt_metal::TensorAccessorArgs args;
 };
@@ -71,7 +71,7 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemRmFactory::cr
         const auto& index = index_tensors[i];
 
         index_info[dim].is_defined = true;
-        index_info[dim].address = index_tensors[i].buffer()->address();
+        index_info[dim].buffer = index_tensors[i].buffer();
         index_info[dim].args = tt::tt_metal::TensorAccessorArgs(index_tensors[i].buffer());
         index_info[dim].unit_size = index.padded_shape()[-1] * index.element_size();
     }
@@ -142,7 +142,7 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemRmFactory::cr
     KernelDescriptor::Defines writer_defines;
 
     KernelDescriptor::CompileTimeArgs reader_compile_time_args;
-    tt::tt_metal::TensorAccessorArgs(input_5d.buffer()).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_compile_time_args);
     for (auto& dim : index_info) {
         dim.args.append_to(reader_compile_time_args);
     }
@@ -188,12 +188,12 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemRmFactory::cr
             core,
             {
                 // buffers
-                input_5d.buffer(),
-                index_info[0].address,
-                index_info[1].address,
-                index_info[2].address,
-                index_info[3].address,
-                index_info[4].address,
+                input.buffer(),
+                index_info[0].buffer,
+                index_info[1].buffer,
+                index_info[2].buffer,
+                index_info[3].buffer,
+                index_info[4].buffer,
 
                 // input
                 input_stick_idx_stride_n,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
@@ -15,7 +15,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 struct IndexInfo {
     bool is_defined{};
     tt::tt_metal::TensorAccessorArgs args;
-    uint32_t address{};
+    tt::tt_metal::Buffer* buffer{};
     uint32_t unit_size{};
 };
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -93,7 +93,7 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemTilizedFactor
             const auto& index = index_tensors[i];
 
             index_info[dim].is_defined = true;
-            index_info[dim].address = index.buffer()->address();
+            index_info[dim].buffer = index.buffer();
             index_info[dim].args = tt::tt_metal::TensorAccessorArgs(index.buffer());
             index_info[dim].unit_size = index.element_size();
         }
@@ -261,11 +261,11 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemTilizedFactor
                 {
                     // buffers
                     input.buffer(),
-                    index_info[0].address,
-                    index_info[1].address,
-                    index_info[2].address,
-                    index_info[3].address,
-                    index_info[4].address,
+                    index_info[0].buffer,
+                    index_info[1].buffer,
+                    index_info[2].buffer,
+                    index_info[3].buffer,
+                    index_info[4].buffer,
 
                     // input
                     input_stick_idx_stride_n,
@@ -360,7 +360,7 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemTilizedFactor
         const auto& index = index_tensors[i];
 
         index_info[dim].is_defined = true;
-        index_info[dim].address = index_tensors[i].buffer()->address();
+        index_info[dim].buffer = index_tensors[i].buffer();
         index_info[dim].args = tt::tt_metal::TensorAccessorArgs(index_tensors[i].buffer());
         index_info[dim].unit_size = index.padded_shape()[-1] * index.element_size();
     }
@@ -509,11 +509,11 @@ tt::tt_metal::ProgramDescriptor MorehGetItemOperation::MorehGetItemTilizedFactor
             {
                 // buffers
                 input.buffer(),
-                index_info[0].address,
-                index_info[1].address,
-                index_info[2].address,
-                index_info[3].address,
-                index_info[4].address,
+                index_info[0].buffer,
+                index_info[1].buffer,
+                index_info[2].buffer,
+                index_info[3].buffer,
+                index_info[4].buffer,
 
                 // input
                 input_stick_idx_stride_n,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`test_moreh_getitem.py` was failing first with a runtime buffer-binding fatal and then, after that was addressed, with tilized host-side cleanup fatals on non-tile-aligned shapes. The binding failure came from the row-major factory passing a buffer from a local `view()` tensor into runtime args/accessor metadata, while descriptor patching only knows about the original operation tensor buffers; additionally, index tensors were passed as raw addresses, which leaves cache-hit callbacks unable to patch them correctly. The factories now bind the original input buffer and pass index buffers as patchable `Buffer*` runtime args, and the tilized tests now convert outputs with `ttnn.to_torch()` instead of manually converting to row-major and calling `unpad_from_tile()` on shapes that may no longer satisfy tile-alignment requirements. This keeps runtime args tied to the tensors owned by the operation, makes cached executions update all dynamic buffers correctly, and uses the standard tensor conversion path for tilized outputs.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/moreh-getitem-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/moreh-getitem-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/moreh-getitem-fixes)