### PR TITLE
Fix: data_movement kernel compile failures from NoC 2.0 API migration on runtime pipeline

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_mcast_non_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_mcast_non_stateful.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
 
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Stateful", 0);
-    DeviceTimestampedData("Posted writes", 0);
+DeviceTimestampedData("Posted writes", 1);
     DeviceTimestampedData("Number of transactions", num_writes);
     DeviceTimestampedData("Transaction size in bytes", 32);
     DeviceTimestampedData("Multicast", 1);

--- a/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_mcast_non_stateful.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/kernels/sender_mcast_non_stateful.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
 
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Stateful", 0);
-    DeviceTimestampedData("Posted writes", use_posted_writes);
+    DeviceTimestampedData("Posted writes", 0);
     DeviceTimestampedData("Number of transactions", num_writes);
     DeviceTimestampedData("Transaction size in bytes", 32);
     DeviceTimestampedData("Multicast", 1);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
     Semaphore<> sender_valid_sem(sender_valid_sem_id);
     Semaphore<> receiver_sem(receiver_sem_id);
 
-    constexpr Noc::McastMode mcast_mode = loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+    constexpr NocOptions mcast_opts = loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
 
     {
         DeviceZoneScopedN("RISCV0");
@@ -62,7 +62,7 @@ void kernel_main() {
             sender_sem.wait(num_subordinates);
             sender_sem.set(0);
 
-            noc.async_write_multicast<mcast_mode>(
+            noc.async_write_multicast<mcast_opts>(
                 unicast_endpoint,
                 multicast_endpoint,
                 bytes_per_transaction,
@@ -75,7 +75,7 @@ void kernel_main() {
                  .addr = sub_base_addr},
                 is_linked);
 
-            sender_valid_sem.template relay_multicast<mcast_mode>(
+            sender_valid_sem.template relay_multicast<mcast_opts>(
                 noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, is_linked);
         }
 
@@ -83,7 +83,7 @@ void kernel_main() {
         sender_sem.wait(num_subordinates);
         sender_sem.set(0);
 
-        noc.async_write_multicast<mcast_mode>(
+        noc.async_write_multicast<mcast_opts>(
             unicast_endpoint,
             multicast_endpoint,
             bytes_per_transaction,
@@ -95,7 +95,7 @@ void kernel_main() {
              .noc_y_end = end_y,
              .addr = sub_base_addr});
 
-        sender_valid_sem.template relay_multicast<mcast_mode>(
+        sender_valid_sem.template relay_multicast<mcast_opts>(
             noc, receiver_sem, start_x, start_y, end_x, end_y, num_subordinates, false);
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_sem_2_0.cpp
@@ -51,13 +51,13 @@ void kernel_main() {
 
                 uint32_t current_virtual_channel = i % num_virtual_channels;
 
-                noc.async_write(
+                noc.async_write<NocOptions::CUSTOM_VC>(
                     unicast_endpoint,
                     unicast_endpoint,
                     bytes_per_transaction,
                     {.addr = mst_base_addr},
                     {.noc_x = dest_coord_x, .noc_y = dest_coord_y, .addr = sub_base_addr},
-                    current_virtual_channel);
+                    {.vc = current_virtual_channel});
 
                 // Flush: async_write uses caller-supplied VC; relay_unicast goes through
                 // noc_semaphore_set_remote which hardcodes NOC_UNICAST_WRITE_VC. Same NoC,


### PR DESCRIPTION
## Summary
- Three JIT-compiled data_movement test kernels were not updated when the NoC 2.0 API replaced `Noc::McastMode` with `NocOptions` flags and changed `Noc::async_write` to accept `NocOptVals` instead of raw `uint32_t` VC arguments.
- **`sender_mcast_non_stateful.cpp`**: replaced undeclared `use_posted_writes` with literal `0` (multicast kernel never uses posted writes)
- **`sender_multicast_sem_2_0.cpp`**: replaced removed `Noc::McastMode` enum with `NocOptions::MCAST_INCL_SRC` / `NocOptions::DEFAULT` flags
- **`sender_unicast_sem_2_0.cpp`**: use `NocOptions::CUSTOM_VC` template flag and pass `NocOptVals{.vc = ...}` instead of raw `uint32_t`

## Failing tests fixed
- `GenericMeshDeviceFixture.TensixDirectWriteMulticast`
- `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastSemaphore2x2_2_0`
- `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x2_2_0`
- `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphore5x5_2_0`
- `GenericMeshDeviceFixture.TensixDataMovementOneToAllUnicastSemaphore2x2_2_0`

## Test plan
- [ ] CI runtime unit tests pass for data_movement tests on WH and BH
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-data-movement-noc-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-data-movement-noc-api)