### PR TITLE
Runtime : Fix DispatchTelemetryHostL1WaitTest crash under slow dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -79,6 +79,9 @@ class DispatchTelemetryHostL1WaitTest : public DispatchTelemetryReadApiTest {
 protected:
     void SetUp() override {
         DispatchTelemetryReadApiTest::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
 
         release_addr_ = devices_.at(0)->allocator()->get_base_allocator_addr(HalMemType::L1);
         started_addr_ = release_addr_ + sizeof(uint32_t);


### PR DESCRIPTION
## Summary
- Fix `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` crash when run under slow dispatch (`TT_METAL_SLOW_DISPATCH_MODE=1`).
- When `UnitMeshCQFixture::SetUp()` calls `GTEST_SKIP()` (slow dispatch detected), control resumes in the derived `DispatchTelemetryHostL1WaitTest::SetUp()` which immediately accesses `devices_.at(0)` on an empty vector, causing a `vector::_M_range_check` exception.
- Add `IsSkipped()` guard after parent `SetUp()` to bail out before accessing uninitialized state — converts the crash into a clean skip.

## Test plan
- [x] Verified locally: test now shows `[ SKIPPED ]` (exit 0) under `TT_METAL_SLOW_DISPATCH_MODE=1` instead of `[ FAILED ]` with exception

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-dispatch-telemetry-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-dispatch-telemetry-skip)