### PR TITLE
Bug fix: precompile-fw ships a stale weakened firmware ELF in pre-compiled bundles

### DIFF
--- a/tt_metal/tools/precompile_fw/precompile_fw.cpp
+++ b/tt_metal/tools/precompile_fw/precompile_fw.cpp
@@ -197,6 +197,15 @@ const auto supported_configs = std::to_array<PrecompileConfig>({
 
 int main() {
     tt::llrt::RunTimeOptions rtoptions;
+    // Regenerate firmware into the JIT cache (out_firmware_root_), not an existing
+    // pre-compiled bundle. Otherwise add_build_env() redirects firmware_binary_root_ to
+    // the existing bundle, and since weaken() writes the weakened ELF to
+    // firmware_binary_root_ while link() writes the .elf to out_firmware_root_, the
+    // freshly-weakened ELF lands in the bundle but is then clobbered when
+    // copy_firmware_to_precompiled_dir() copies the JIT cache's (never-refreshed,
+    // stale) weakened ELF over it. Disabling precompiled FW keeps both in the JIT
+    // cache so the .elf and its weakened ELF stay consistent before the copy.
+    rtoptions.set_disable_precompiled_fw(true);
     const std::string core_descriptors_dir = rtoptions.get_root_dir() + "tt_metal/core_descriptors/";
     for (const auto& [arch, core_descriptor_name] : supported_configs) {
         std::string full_core_descriptor_path = core_descriptors_dir + core_descriptor_name;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`precompile_fw` builds firmware and then copies every `*.elf` from the JIT cache (`out_firmware_root_`) into the pre-compiled bundle. But when a bundle for that build key already exists, `add_build_env()` redirects `firmware_binary_root_` to that bundle. Because `weaken()` writes the weakened ELF to `firmware_binary_root_` while `link()` writes the `.elf` to `out_firmware_root_`, the freshly-weakened ELF lands in the bundle and the JIT cache's own weakened ELF is **never refreshed** (frozen at its first-ever build). `copy_firmware_to_precompiled_dir()` then copies that stale JIT-cache weakened ELF over the fresh one — leaving the bundle with a current `.elf` and a **stale `*_weakened.elf`**.

Kernels link against the bundle's weakened ELF to import firmware symbols (e.g. `__fw_export_text_end`). So after any firmware-layout change, a kernel can link against the old firmware's text-end, load at the wrong address, and hang. (It also explains the stale-but-cosmetic elf/weakened mismatches visible in older bundles.)

Fix: set `disable_precompiled_fw` in `precompile_fw` so `firmware_binary_root_` stays the JIT cache. `weaken()` then writes alongside the `.elf`, the JIT cache is self-consistent, and the copy produces a consistent bundle.

### Notes for reviewers
- The behavioral change is one line (`rtoptions.set_disable_precompiled_fw(true)` in `precompile_fw.cpp::main()`); the rest is an explanatory comment.
- Verified: after a clean build, every pre-compiled bundle regenerated by `precompile_fw` is internally consistent (`.elf` and `*_weakened.elf` agree on `__fw_export_text_end`). Before the fix, a firmware-layout change left them inconsistent and hung the Blackhole DRAM-core prefetcher; after, the bw bench runs end-to-end on P150.
- Stale bundles from obsolete build configs that the current `precompile_fw` no longer enumerates are not retroactively cleaned (they aren't regenerated) — only currently-enumerated configs are refreshed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/precompile-fw-weakened-elf-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/precompile-fw-weakened-elf-fix)