### PR TITLE
[Quasar] Compute API - Max/Min SFPU kernel

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -97,10 +97,17 @@ const map<std::string, std::map<std::string, std::string>> sfpu_binary_op_to_op_
     {"gt_int",
      {{"SFPU_OP_INIT_0", "gt_int_tile_init<DataFormat::Int32>();"},
       {"SFPU_OP_CHAIN_0", "gt_int_tile<DataFormat::Int32>(0, 1, 0);"}}},
+    {"binary_max", {{"SFPU_OP_INIT_0", "binary_max_tile_init();"}, {"SFPU_OP_CHAIN_0", "binary_max_tile(0, 1, 0);"}}},
+    {"binary_min", {{"SFPU_OP_INIT_0", "binary_min_tile_init();"}, {"SFPU_OP_CHAIN_0", "binary_min_tile(0, 1, 0);"}}},
+    {"binary_max_int32",
+     {{"SFPU_OP_INIT_0", "binary_max_int32_tile_init();"}, {"SFPU_OP_CHAIN_0", "binary_max_int32_tile(0, 1, 0);"}}},
+    {"binary_min_int32",
+     {{"SFPU_OP_INIT_0", "binary_min_int32_tile_init();"}, {"SFPU_OP_CHAIN_0", "binary_min_int32_tile(0, 1, 0);"}}},
 };
 
 bool is_int8_binary_sfpu_op(const std::string& op_name) {
-    return (op_name == "add_int") or (op_name == "mul_int") or (op_name == "gt_int");
+    return (op_name == "add_int") or (op_name == "mul_int") or (op_name == "gt_int") or
+           (op_name == "binary_max_int32") or (op_name == "binary_min_int32");
 }
 
 bfloat16 sfpu_function(const std::string& op_name, const bfloat16& input) {
@@ -158,6 +165,12 @@ bfloat16 sfpu_binary_function(const std::string& op_name, const bfloat16& lhs, c
     if (op_name == "mul_float") {
         return bfloat16(static_cast<float>(lhs) * static_cast<float>(rhs));
     }
+    if (op_name == "binary_max") {
+        return bfloat16(std::max(static_cast<float>(lhs), static_cast<float>(rhs)));
+    }
+    if (op_name == "binary_min") {
+        return bfloat16(std::min(static_cast<float>(lhs), static_cast<float>(rhs)));
+    }
     TT_THROW("Unsupported binary op_name in test");
 }
 
@@ -191,6 +204,12 @@ int32_t get_binary_int_operation_result(const std::string& op_name, int lhs, int
     }
     if (op_name == "gt_int") {
         return (lhs > rhs) ? 1 : 0;
+    }
+    if (op_name == "binary_max_int32") {
+        return std::max(lhs, rhs);
+    }
+    if (op_name == "binary_min_int32") {
+        return std::min(lhs, rhs);
     }
     TT_THROW("Unsupported int8 binary op_name in test");
 }
@@ -251,6 +270,11 @@ std::pair<vector<uint32_t>, vector<uint32_t>> generate_packed_sfpu_binary_inputs
         auto rhs = generate_div_operand(numel, seed + 1);
         return {lhs, rhs};
     }
+    if (op_name == "binary_max" || op_name == "binary_min") {
+        auto lhs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(-4.0f, 4.0f, numel, seed);
+        auto rhs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(-4.0f, 4.0f, numel, seed + 1);
+        return {lhs, rhs};
+    }
     if (is_int8_binary_sfpu_op(op_name)) {
         auto lhs = create_random_vector_of_int8(numel, seed);
         auto rhs = create_random_vector_of_int8(numel, seed + 1);
@@ -274,7 +298,7 @@ std::tuple<vector<uint32_t>, vector<uint32_t>, vector<uint32_t>> generate_packed
 
 bool is_close_packed_sfpu_output(
     const std::vector<uint32_t>& vec_a, const std::vector<uint32_t>& vec_b, const std::string& op_name) {
-    if (is_int8_binary_sfpu_op(op_name)) {
+    if (is_int8_binary_sfpu_op(op_name) || op_name == "binary_max" || op_name == "binary_min") {
         return vec_a == vec_b;
     }
     if (op_name == "where") {
@@ -666,7 +690,11 @@ bool run_sfpu_binary_two_input_buffer(
             sfpu_defines["SFPU_OP_BINARY_MUL_INT_INCLUDE"] = "1";
         } else if (test_config.sfpu_op == "gt_int") {
             sfpu_defines["SFPU_OP_BINARY_GT_INT_INCLUDE"] = "1";
+        } else {
+            sfpu_defines["SFPU_OP_BINARY_MAX_MIN_INCLUDE"] = "1";
         }
+    } else if (test_config.sfpu_op == "binary_max" || test_config.sfpu_op == "binary_min") {
+        sfpu_defines["SFPU_OP_BINARY_MAX_MIN_INCLUDE"] = "1";
     } else {
         sfpu_defines["SFPU_OP_BINARY_DIV_INCLUDE"] = "1";
     }
@@ -1333,7 +1361,11 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "mul_float"),
         std::make_tuple(1, "add_int"),
         std::make_tuple(1, "mul_int"),
-        std::make_tuple(1, "gt_int")),
+        std::make_tuple(1, "gt_int"),
+        std::make_tuple(1, "binary_max"),
+        std::make_tuple(1, "binary_min"),
+        std::make_tuple(1, "binary_max_int32"),
+        std::make_tuple(1, "binary_min_int32")),
     [](const testing::TestParamInfo<std::tuple<size_t, std::string>>& info) {
         return std::get<1>(info.param) + "_" + std::to_string(std::get<0>(info.param)) + "tiles";
     });

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -11,10 +11,8 @@
 #include "lltt.h"
 #include "sfpi.h"
 
-namespace ckernel
-{
-namespace sfpu
-{
+namespace ckernel {
+namespace sfpu {
 
 // imm12 bit 11 = 1: SFPSETCC interprets src_c as two's-complement INT32, not FP32/SMAG32
 constexpr std::uint32_t SFPSETCC_INT32_SIGNBIT = 0x800;
@@ -26,17 +24,15 @@ constexpr std::uint32_t BINARY_MAX_MIN_REPLAY_LEN = 9;
 // DEFAULT lets SFPLOAD resolve the format at runtime via ALU_ACC_CTRL_SFPU_Fp32_enabled
 // and the SrcB format register, which the unpacker already programs from formats.math.
 template <DataFormat FMT>
-inline constexpr std::uint32_t _binary_max_min_sfpmem_mode_()
-{
+inline constexpr std::uint32_t _binary_max_min_sfpmem_mode_() {
     return (FMT == DataFormat::Int32) ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::DEFAULT;
 }
 
 // Programs ADDR_MOD_6 with dest.incr=2 so the SFPSTORE in the replayed body
 // auto-advances the dest counter by one SFP-row pair per iteration. Quasar's
 // shared SFPU init only programs ADDR_MOD_7 (incr=0); this is additive.
-inline void _init_binary_max_min_()
-{
-    addr_mod_t {
+inline void _init_binary_max_min_() {
+    addr_mod_t{
         .srca = {.incr = 0},
         .srcb = {.incr = 0},
         .dest = {.incr = 2},
@@ -69,11 +65,12 @@ inline void _init_binary_max_min_()
 // @param dst_index_in1  Dest tile index of input 1 (in tile units, relative to DST_INDEX).
 // @param dst_index_out  Dest tile index where the result is written (in tile units, relative to DST_INDEX).
 template <DataFormat FMT, bool IS_MAX_OP = true, int ITERATIONS = 8>
-inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out)
-{
+inline void calculate_binary_max_min(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
-        FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b || FMT == DataFormat::Float32 || FMT == DataFormat::Tf32 || FMT == DataFormat::MxFp8R ||
-            FMT == DataFormat::MxFp8P || FMT == DataFormat::Int32,
+        FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b || FMT == DataFormat::Float32 ||
+            FMT == DataFormat::Tf32 || FMT == DataFormat::MxFp8R || FMT == DataFormat::MxFp8P ||
+            FMT == DataFormat::Int32,
         "Unsupported DataFormat for calculate_binary_max_min().");
 
     constexpr std::uint32_t SFPMEM_MODE = _binary_max_min_sfpmem_mode_<FMT>();
@@ -90,14 +87,15 @@ inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const st
 
     // Step 1: SM-min/SM-max via SFPSWAP. Correct for any pair where at least one
     // operand is non-negative; inverts ordering for (neg, neg) pairs.
-    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX); // 2-cycle
-    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);                // post-SFPSWAP stall avoidance
+    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);  // 2-cycle
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);  // post-SFPSWAP stall avoidance
 
     // Step 2: CC-guarded correction swap for (neg, neg) pairs.
     // Successive SFPSETCC calls AND into CC, so after both: CC = (LREG0<0 AND LREG1<0).
     TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG0, sfpi::SFPSETCC_MOD1_LREG_LT0);
     TTI_SFPSETCC(SFPSETCC_INT32_SIGNBIT, p_sfpu::LREG1, sfpi::SFPSETCC_MOD1_LREG_LT0);
-    TTI_SFPSWAP(0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP); // re-swap rows where both negative
+    TTI_SFPSWAP(
+        0 /* imm12 */, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPSWAP_MOD1_SWAP);  // re-swap rows where both negative
     TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
 
     // After step 2: LREG0 = min, LREG1 = max for all sign combinations.
@@ -105,11 +103,10 @@ inline void calculate_binary_max_min(const std::uint32_t dst_index_in0, const st
     TT_SFPSTORE(IS_MAX_OP ? p_sfpu::LREG1 : p_sfpu::LREG0, SFPMEM_MODE, ADDR_MOD_6, 0 /* done */, offset2);
 
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
+    for (int d = 0; d < ITERATIONS; d++) {
         lltt::replay(0, BINARY_MAX_MIN_REPLAY_LEN);
     }
 }
 
-} // namespace sfpu
-} // namespace ckernel
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_min.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu.h"
+#include "llk_math_eltwise_sfpu_common.h"
+#include "ckernel_sfpu_binary_max_min.h"
+
+namespace ckernel {
+
+// Shared init for the float/MX max and min ops; the underlying sfpu init is
+// format- and op-agnostic, so a single entry point covers both.
+inline void llk_math_eltwise_binary_sfpu_binary_max_min_init() {
+    _llk_math_eltwise_sfpu_init_();
+    sfpu::_init_binary_max_min_();
+}
+
+// Shared init for the int32 max and min ops.
+inline void llk_math_eltwise_binary_sfpu_binary_max_min_int32_init() {
+    _llk_math_eltwise_sfpu_init_();
+    sfpu::_init_binary_max_min_();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_max(
+    std::uint32_t dst_index0, std::uint32_t dst_index1, std::uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_(
+        ckernel::sfpu::calculate_binary_max_min<DataFormat::Float32, true>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
+    std::uint32_t dst_index0, std::uint32_t dst_index1, std::uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_(
+        ckernel::sfpu::calculate_binary_max_min<DataFormat::Int32, true>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min(
+    std::uint32_t dst_index0, std::uint32_t dst_index1, std::uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_(
+        ckernel::sfpu::calculate_binary_max_min<DataFormat::Float32, false>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
+    std::uint32_t dst_index0, std::uint32_t dst_index1, std::uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_(
+        ckernel::sfpu::calculate_binary_max_min<DataFormat::Int32, false>, dst_index0, dst_index1, odst, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/binary_max_min.h
+++ b/tt_metal/hw/inc/api/compute/binary_max_min.h
@@ -6,8 +6,12 @@
 
 #include "api/compute/common_globals.h"
 #ifdef TRISC_MATH
+#ifdef ARCH_QUASAR
+#include "llk_math_eltwise_binary_sfpu_max_min.h"
+#else
 #include "ckernel_sfpu_binary_max_min.h"
 #include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
 #endif
 
 namespace ckernel {
@@ -32,6 +36,9 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_int32<APPROX>(idst0, idst1, odst)));
+#else
     MATH((SFPU_BINARY_CALL_MODE(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -41,14 +48,19 @@ ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
         idst0,
         idst1,
         odst)));
+#endif
 }
 
 /**
  * Please refer to documentation.
  */
 ALWI void binary_max_int32_tile_init() {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_min_int32_init()));
+#else
     MATH((
         SFPU_BINARY_INIT_CB(max_int32, sfpu::binary_max_min_int32_init, (true /* IS_MAX */, false /* IS_UNSIGNED */))));
+#endif
 }
 
 // clang-format off
@@ -70,6 +82,7 @@ ALWI void binary_max_int32_tile_init() {
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 ALWI void binary_max_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((SFPU_BINARY_CALL_MODE(
         DST_SYNC_MODE,
@@ -89,6 +102,7 @@ ALWI void binary_max_uint32_tile_init() {
     MATH((
         SFPU_BINARY_INIT_CB(max_uint32, sfpu::binary_max_min_int32_init, (true /* IS_MAX */, true /* IS_UNSIGNED */))));
 }
+#endif
 
 // clang-format off
 /**
@@ -110,6 +124,9 @@ ALWI void binary_max_uint32_tile_init() {
  */
 // clang-format on
 ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max<APPROX>(idst0, idst1, odst, vector_mode)));
+#else
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -119,12 +136,19 @@ ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorM
         idst1,
         odst,
         vector_mode)));
+#endif
 }
 
 /**
  * Please refer to documentation.
  */
-ALWI void binary_max_tile_init() { MATH((SFPU_BINARY_INIT_CB(max, sfpu::binary_max_min_init, (true /* IS_MAX */)))); }
+ALWI void binary_max_tile_init() {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_min_init()));
+#else
+    MATH((SFPU_BINARY_INIT_CB(max, sfpu::binary_max_min_init, (true /* IS_MAX */))));
+#endif
+}
 
 // clang-format off
 /**
@@ -146,6 +170,9 @@ ALWI void binary_max_tile_init() { MATH((SFPU_BINARY_INIT_CB(max, sfpu::binary_m
  */
 // clang-format on
 ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_min_int32<APPROX>(idst0, idst1, odst)));
+#else
     MATH((SFPU_BINARY_CALL_MODE(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -155,14 +182,19 @@ ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
         idst0,
         idst1,
         odst)));
+#endif
 }
 
 /**
  * Please refer to documentation.
  */
 ALWI void binary_min_int32_tile_init() {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_min_int32_init()));
+#else
     MATH((SFPU_BINARY_INIT_CB(
         min_int32, sfpu::binary_max_min_int32_init, (false /* IS_MAX */, false /* IS_UNSIGNED */))));
+#endif
 }
 
 // clang-format off
@@ -184,6 +216,7 @@ ALWI void binary_min_int32_tile_init() {
  * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+#ifndef ARCH_QUASAR
 ALWI void binary_min_uint32_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
     MATH((SFPU_BINARY_CALL_MODE(
         DST_SYNC_MODE,
@@ -203,6 +236,7 @@ ALWI void binary_min_uint32_tile_init() {
     MATH((SFPU_BINARY_INIT_CB(
         min_uint32, sfpu::binary_max_min_int32_init, (false /* IS_MAX */, true /* IS_UNSIGNED */))));
 }
+#endif
 
 // clang-format off
 /**
@@ -224,6 +258,9 @@ ALWI void binary_min_uint32_tile_init() {
  */
 // clang-format on
 ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorMode vector_mode = VectorMode::RC) {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX>(idst0, idst1, odst, vector_mode)));
+#else
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -233,11 +270,18 @@ ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, VectorM
         idst1,
         odst,
         vector_mode)));
+#endif
 }
 
 /**
  * Please refer to documentation.
  */
-ALWI void binary_min_tile_init() { MATH((SFPU_BINARY_INIT_CB(min, sfpu::binary_max_min_init, (false /* IS_MAX */)))); }
+ALWI void binary_min_tile_init() {
+#if defined(ARCH_QUASAR)
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_min_init()));
+#else
+    MATH((SFPU_BINARY_INIT_CB(min, sfpu::binary_max_min_init, (false /* IS_MAX */))));
+#endif
+}
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
@@ -219,3 +219,7 @@
 #if SFPU_OP_BINARY_GT_INT_INCLUDE
 #include "api/compute/binary_comp.h"
 #endif
+
+#if SFPU_OP_BINARY_MAX_MIN_INCLUDE
+#include "api/compute/binary_max_min.h"
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_binary_max_min_quasar_test.cpp
@@ -115,10 +115,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #include "cfg_defines.h"
 #include "cmath_common.h"
-#include "experimental/ckernel_sfpu_binary_max_min.h"
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "llk_math_eltwise_unary_sfpu.h"
+#include "llk_sfpu/ckernel_sfpu_binary_max_min.h"
 #include "params.h"
 
 using namespace ckernel;


### PR DESCRIPTION
Implements the binary max/min SFPU compute API and adds vector mode support for binary ops, along with LLK plumbing and SFPU compute tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/max-min-compute-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/max-min-compute-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/max-min-compute-api)