### PR TITLE
Fix missing models/e2e time budgets for bh_loudbox and bh_llmbox

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -180,6 +180,8 @@ models:
     bh_p150b_civ2: 55
     bh_p150: 60
     bh_p300: 50
+    bh_loudbox: 120
+    bh_llmbox: 45
     bh_quietbox_2: 235
     bh_galaxy: 78
   unit:


### PR DESCRIPTION
### Summary

BH e2e tests [fail on load-test-matrix](https://github.com/tenstorrent/tt-metal/actions/runs/26856372761/job/79207618380)

Fix missing models/e2e time budgets for bh_loudbox and bh_llmbox
                                                                                                      
  PR #45300 ("migrate blackhole models to tier 1 2 3 pipelines") added bh_lb_DeepSeek_PREFILL (90   
  min), bh_lb_DeepSeek_PREFILL_PERF (30 min) on bh_loudbox, and bh_qb_DeepSeek_PREFILL (45 min) on    
  bh_llmbox to blackhole_e2e_tests.yaml with team: models — but didn't add corresponding entries in 
  .github/time_budget.yaml. The CI budget verification step (verify_time_budget.py) fails with:       
                                                                                                    
  Configuration FAILED! Could not find a 'time_budget' for Team 'models', Workflow 'e2e', SKU
  'bh_loudbox'                                                                                        
  Configuration FAILED! Could not find a 'time_budget' for Team 'models', Workflow 'e2e', SKU
  'bh_llmbox'                                                                                         
                                                                                                    
  Adds the two missing entries under models: → e2e::                                                  
  - bh_loudbox: 120 (90 + 30 min)
  - bh_llmbox: 45                

After the change [load-test-matrix passes](https://github.com/tenstorrent/tt-metal/actions/runs/26872631033/job/79253159486)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/add-e2e-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/add-e2e-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/add-e2e-timeout)