### PR TITLE
[skip ci] [Models CI] bump GPT-OSS 120B unit wh_galaxy timeout 30 -> 40 min

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -427,7 +427,7 @@
       timeout: 25
       tier: 1
     wh_galaxy:
-      timeout: 30
+      timeout: 40
       tier: 1
     # Blackhole
     bh_quietbox_2:


### PR DESCRIPTION
## Summary

- Bumps `models / unit / wh_galaxy` timeout for `GPT-OSS 120B unit tests` from **30** to **40** minutes.
- No update to `.github/time_budget.yaml` needed: the `models / unit / wh_galaxy` budget is 45 min and this entry is currently the only consumer, so the new sum (40) stays under budget.

## Why

The scheduled tier-1 unit run on 2026-06-03 hit the 30-min cap on wh_galaxy with all subtests still running cleanly — the test isn't hung, it just needs more headroom on the slower wh_galaxy SKU.

Job that timed out: https://github.com/tenstorrent/tt-metal/actions/runs/26866181871/job/79231459152

## Test plan
- [ ] Wait for the next scheduled tier-1 unit run and confirm the wh_galaxy GPT-OSS 120B unit job completes within the new 40-min cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/gpt-oss-120b-unit-timeout-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/gpt-oss-120b-unit-timeout-bump)