### PR TITLE
[tt-triage] Fix kernel offset overflow when trace was on

### DIFF
--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -627,7 +627,9 @@ class DispatcherData:
                 # not at address 0 like Tensix kernels, so no base adjustment is needed.
                 kernel_offset = kernel_text_offset
             else:
-                kernel_offset = kernel_config_base + kernel_text_offset
+                # For most blocks, the kernel is loaded at an offset from the config base, so we add them together to get the actual load address.
+                # The & 0xFFFFFFFF is needed to wrap around to 32 bits, since the offset can be negative and Python ints are unbounded.
+                kernel_offset = (kernel_config_base + kernel_text_offset) & 0xFFFFFFFF
         else:
             kernel_path = None
             kernel_xip_path = None


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes https://github.com/tenstorrent/tt-exalens/issues/1056

When triage runs on a hang that has traced operations (trace/replay), the kernel binaries are set at different address compared to normal runs, but still L1.

What runtime does is respect the formula `binary_address  = kernel_base_config (non_binary_address) + kernel_text_offset` which usually means that the binary sits after the config (and they sit together). In traced runs the binary can sit before the config (and not be close), and because everything is `uint32_t` the sum overflows 32 bits and lands behind the config.

We have a discrepancy for this in triage, as in python ints are unbounded so our sum does not overflow and we get a number like `0x1000103a0`.

When this happens, scripts like callstacks and binary integrity dump garbage and we don't get meaningful triage output and suspect that something in the mailbox got corrupted which is wrong direction.