### PR TITLE
[Bugfix] Fix zigzag logits PCC comparison in test_prefill_transformer

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -295,9 +295,13 @@ class TtPrefillTransformer(LightweightModule):
             intermediates["lm_head"] = logits_host
             intermediates["logits"] = first_token_logits
 
-        # Reorder intermediates if balanced
+        # Reorder intermediates if balanced. Skip reordering for logits and lm_head in zigzag mode.
+        no_reorder_keys = {"logits", "lm_head"}
         if return_intermediates and self.is_balanced:
             for key, tensor in intermediates.items():
+                if key in no_reorder_keys:
+                    logger.debug(f"Skipping reordering for non-sequence intermediate {key}")
+                    continue
                 if isinstance(tensor, torch.Tensor):
                     logger.debug(f"Reordering intermediate {key} with shape {tensor.shape}")
                     intermediates[key] = reverse_reorder_tensor_chunks(tensor, self.chunk_order, seq_dim=-2)

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -56,7 +56,7 @@
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_prefill_transformer -k "mesh-8x4 and 61_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter1 and pcc and pretrained and regular and right_pad" -vvv --tb=short --timeout=3600
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_prefill_transformer -k "mesh-8x4 and 61_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter1 and pcc and pretrained and balanced and right_pad" -vvv --tb=short --timeout=3600
   test_type: prefill_transformer
   test_group: module
   skus:


### PR DESCRIPTION

### Summary
when `is_balanced = True`, `reverse_reorder_tensor_chunks(tensor, chunk_order, seq_dim=-2)` undoes the zigzag shuffle so that the host-side outputs are back in the original token order before comparing against the reference trace. 

The bug was that the loop applied this same reorder to **every** tensor, including logits. But logits has dim -2 of size 1, so:

`chunk_size = seq_len // num_chunks = 1 // 8 = 0`

With `chunk_size = 0`, every chunk slice is empty `(tensor[..., 0:0, :])`, and concatenating 8 empty slices yields shape `[1, 0, vocab]` — the logits are gone.

### CI Status

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ddjekic/test_prefill_transformer_logits_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ddjekic/test_prefill_transformer_logits_fix)