### PR TITLE
ds prefill stress + monitor scripts

### DIFF
--- a/models/demos/deepseek_v3_d_p/scripts/README.md
+++ b/models/demos/deepseek_v3_d_p/scripts/README.md
@@ -1,0 +1,62 @@
+# DeepSeek-V3 prefill stress + monitor scripts
+
+| File | Purpose |
+|---|---|
+| `common.sh` | Shared config + helpers (`TT_METAL_HOME`, `LOG_DIR`, `KFILTER`, derived `INNER_ITERS`, `ENV_VARS`, `log_for`, `scan_log_dir`). Sourced by the others — not run directly. |
+| `stress.sh` | Outer loop (`$LOOP`×): `tt-smi -glx_reset` then pytest. Each run's stdout is `tee`'d to `<log dir>/log_NN`. No timeout — pytest stays alive on hang for manual debug. |
+| `watch.sh` | Refreshing status table (PASS / HANG? / FAIL / RUN / STALE / PENDING) over the run logs. Refresh 15s (override via `REFRESH`). |
+| `watch_multiple_dirs.sh` | Same status table across several log dirs at once — one block per dir name passed as an arg. |
+| `tail.sh` | `tail -10` of the newest `log_NN`, refresh 30s (override via `REFRESH`). |
+| `parse_iteration_times.py` | Per-iteration timing extractor (min / avg / max). Reads any pytest log with `Starting iteration:` markers. |
+
+All scripts take the same args: `<log_name> [loop_count]`. Logs go to `/data/$USER/<log_name>/log_NN`.
+
+---
+
+## Launch a run (3 tmux sessions: stress + watch + tail)
+
+```bash
+export TT_METAL_HOME=/data/$USER/tt-metal
+cd "$TT_METAL_HOME"
+
+LOOP_CNT=20
+COMMIT_HASH=$(git rev-parse --short HEAD)
+DATE=$(date +%Y_%m_%d_%H_%M)
+LOG_NAME="LOG_${DATE}_${HOSTNAME}_${COMMIT_HASH}_balanced_A_loop_${LOOP_CNT}"
+SCRIPTS="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/scripts"
+
+# 1) stress loop
+tmux new-session -d -s "stress_${HOSTNAME}"       -E "bash -l -c '$SCRIPTS/stress.sh $LOG_NAME $LOOP_CNT |& tee $TT_METAL_HOME/$LOG_NAME.log'"
+# 2) status table
+tmux new-session -d -s "stress_watch_${HOSTNAME}" -E "bash -l -c '$SCRIPTS/watch.sh  $LOG_NAME $LOOP_CNT'"
+# 3) tail latest log
+tmux new-session -d -s "stress_tail_${HOSTNAME}"  -E "bash -l -c '$SCRIPTS/tail.sh   $LOG_NAME $LOOP_CNT'"
+```
+
+Attach (read-only):
+
+```bash
+tmux attach -t "stress_${HOSTNAME}" -r        # stress loop
+tmux attach -t "stress_watch_${HOSTNAME}" -r  # status table
+tmux attach -t "stress_tail_${HOSTNAME}" -r   # tail
+```
+
+## Monitoring several runs at once — `watch_multiple_dirs.sh`
+
+When you have multiple stress runs going in parallel (e.g. different commits or
+configs), pass each run's `<log_name>` as an argument to get one stacked status
+block per run, all on one screen:
+
+```bash
+SCRIPTS=$TT_METAL_HOME/models/demos/deepseek_v3_d_p/scripts
+$SCRIPTS/watch_multiple_dirs.sh LOG_runA LOG_runB LOG_runC
+```
+
+With no args it falls back to the single default log dir (`deepseek_v3_d_p_log`).
+
+Env overrides (all optional):
+- `LOOP` — outer iterations to scan per dir (default 20; raise it if your runs use
+  a larger `loop_count`, e.g. `LOOP=50 ... watch_multiple_dirs.sh ...`).
+- `REFRESH` — refresh interval in seconds (default 15).
+- `STALE_SECS` — idle seconds before a still-running iteration is flagged STALE
+  (default 240).

--- a/models/demos/deepseek_v3_d_p/scripts/README.md
+++ b/models/demos/deepseek_v3_d_p/scripts/README.md
@@ -5,11 +5,12 @@
 | `common.sh` | Shared config + helpers (`TT_METAL_HOME`, `LOG_DIR`, `KFILTER`, derived `INNER_ITERS`, `ENV_VARS`, `log_for`, `scan_log_dir`). Sourced by the others — not run directly. |
 | `stress.sh` | Outer loop (`$LOOP`×): `tt-smi -glx_reset` then pytest. Each run's stdout is `tee`'d to `<log dir>/log_NN`. No timeout — pytest stays alive on hang for manual debug. |
 | `watch.sh` | Refreshing status table (PASS / HANG? / FAIL / RUN / STALE / PENDING) over the run logs. Refresh 15s (override via `REFRESH`). |
-| `watch_multiple_dirs.sh` | Same status table across several log dirs at once — one block per dir name passed as an arg. |
+| `watch_multiple_dirs.sh` | Same status table across several log dirs at once — one block per `<log_name>` arg. Args are all log names (no positional `loop_count`); set scan depth via `LOOP=` env. |
 | `tail.sh` | `tail -10` of the newest `log_NN`, refresh 30s (override via `REFRESH`). |
 | `parse_iteration_times.py` | Per-iteration timing extractor (min / avg / max). Reads any pytest log with `Starting iteration:` markers. |
 
-All scripts take the same args: `<log_name> [loop_count]`. Logs go to `/data/$USER/<log_name>/log_NN`.
+Most scripts take the same args: `<log_name> [loop_count]`. Logs go to `/data/$USER/<log_name>/log_NN`.
+(Exception: `watch_multiple_dirs.sh` takes one or more `<log_name>` args and reads the scan depth from the `LOOP` env var — see below.)
 
 ---
 
@@ -22,7 +23,7 @@ cd "$TT_METAL_HOME"
 LOOP_CNT=20
 COMMIT_HASH=$(git rev-parse --short HEAD)
 DATE=$(date +%Y_%m_%d_%H_%M)
-LOG_NAME="LOG_${DATE}_${HOSTNAME}_${COMMIT_HASH}_balanced_A_loop_${LOOP_CNT}"
+LOG_NAME="LOG_${DATE}_${HOSTNAME}_${COMMIT_HASH}_loop_${LOOP_CNT}"
 SCRIPTS="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/scripts"
 
 # 1) stress loop

--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -13,7 +13,9 @@ case ":${PYTHONPATH:-}:" in
 esac
 
 LOG_NAME="${1:-deepseek_v3_d_p_log}"
-LOOP="${2:-20}"
+# Loop count: prefer an explicit LOOP env var (used by watch_multiple_dirs.sh,
+# whose positional args are all log names), else the positional [loop_count].
+LOOP="${LOOP:-${2:-20}}"
 
 # Per-run logs: one log_NN under here per outer iteration.
 LOG_DIR="/data/$USER/$LOG_NAME"

--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Shared config + helpers for the DeepSeek-V3 prefill stress scripts.
 # Sourced (not executed) by stress.sh / watch.sh / tail.sh / watch_multiple_dirs.sh.
 #

--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Shared config + helpers for the DeepSeek-V3 prefill stress scripts.
+# Sourced (not executed) by stress.sh / watch.sh / tail.sh / watch_multiple_dirs.sh.
+#
+# Common positional args: <log_name> [loop_count]
+
+TT_METAL_HOME="${TT_METAL_HOME:-/data/$USER/tt-metal}"
+
+# Make sure TT_METAL_HOME is on PYTHONPATH (only add it if not already present).
+case ":${PYTHONPATH:-}:" in
+  *":$TT_METAL_HOME:"*) ;;
+  *) export PYTHONPATH="$TT_METAL_HOME${PYTHONPATH:+:$PYTHONPATH}" ;;
+esac
+
+LOG_NAME="${1:-deepseek_v3_d_p_log}"
+LOOP="${2:-20}"
+
+# Per-run logs: one log_NN under here per outer iteration.
+LOG_DIR="/data/$USER/$LOG_NAME"
+
+# Test selection — single source of truth.
+TEST_FILE="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py"
+KFILTER="pretrained and e256_device_fp32 and mesh-8x4 and 61_layers and balanced and right_pad and smoke and iter25 and 25600 and pie960"
+
+# Inner-iteration count, derived from the iterNN token in the filter above.
+INNER_ITERS=$(grep -oE 'iter[0-9]+' <<<"$KFILTER" | grep -oE '[0-9]+' | head -1)
+
+# Model + cache paths handed to pytest.
+ENV_VARS='TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/'
+
+# Seconds without log growth before a still-running iteration is flagged STALE.
+STALE_SECS="${STALE_SECS:-240}"
+
+# Path of the Nth outer-iteration log (zero-padded): log_for 3 -> <dir>/log_03
+log_for() { printf "%s/log_%02d" "$1" "$2"; }
+
+# Scan one log dir over outer iterations 1..LOOP.
+# Sets globals: pass fail hang running pending, and the `details` array.
+scan_log_dir() {
+  local dir="$1"
+  pass=0; fail=0; hang=0; running=0; pending=0
+  details=()
+
+  local i f next N iter layer mtime now idle elapsed
+  for i in $(seq 1 "$LOOP"); do
+    f=$(log_for "$dir" "$i")
+    next=$(log_for "$dir" $((i + 1)))
+    N=$(printf "%02d" "$i")
+    if [ ! -f "$f" ]; then
+      ((pending++))
+      continue
+    fi
+    if grep -qE 'smoke test passed|^=+.*1 passed' "$f" 2>/dev/null; then
+      elapsed=$(grep -oE '[0-9]+\.[0-9]+s \([0-9:]+\)' "$f" | tail -1)
+      details+=("  $N: PASS  $elapsed")
+      ((pass++))
+    elif grep -qE '^=+.*(1 failed|1 error)' "$f" 2>/dev/null; then
+      details+=("  $N: FAIL")
+      ((fail++))
+    else
+      iter=$(grep -c 'Starting iteration:' "$f" 2>/dev/null)
+      layer=$(grep -oE 'forward_layer_[0-9]+_(start|end)' "$f" 2>/dev/null | tail -1)
+      mtime=$(stat -c %Y "$f" 2>/dev/null || echo 0)
+      now=$(date +%s)
+      idle=$((now - mtime))
+
+      if [ -f "$next" ]; then
+        details+=("  $N: HANG?  iter=$iter/$INNER_ITERS  $layer")
+        ((hang++))
+      elif [ "$idle" -gt "$STALE_SECS" ]; then
+        details+=("  $N: STALE ${idle}s  iter=$iter/$INNER_ITERS  $layer")
+        ((running++))
+      else
+        details+=("  $N: RUN    iter=$iter/$INNER_ITERS  $layer  (idle ${idle}s)")
+        ((running++))
+      fi
+    fi
+  done
+}

--- a/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
+++ b/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import re
 import statistics

--- a/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
+++ b/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import statistics
+import subprocess
+from datetime import datetime
+
+
+def parse_timestamp(ts_str):
+    return datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f")
+
+
+def filter_outliers(values, threshold=2.0):
+    if len(values) < 2:
+        return values, []
+    median = statistics.median(values)
+    cutoff = median * threshold
+    filtered = [v for v in values if v <= cutoff]
+    outliers = [v for v in values if v > cutoff]
+    return filtered, outliers
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse iteration timing from log files")
+    parser.add_argument("-f", "--file", default="./260421-log5", help="Log file path")
+    args = parser.parse_args()
+
+    iter_pattern = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}).*Starting iteration: (\d+)")
+    sync_pattern = re.compile(
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}).*Starting completion sync on iteration: (\d+)"
+    )
+
+    iterations = {}
+    syncs = {}
+
+    proc = subprocess.Popen(
+        ["grep", "Starting", args.file],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    for line in proc.stdout:
+        m = iter_pattern.search(line)
+        if m:
+            ts, num = m.groups()
+            iterations[int(num)] = parse_timestamp(ts)
+            continue
+
+        m = sync_pattern.search(line)
+        if m:
+            ts, num = m.groups()
+            syncs[int(num)] = parse_timestamp(ts)
+
+    proc.wait()
+
+    iter_deltas = []
+    sorted_iters = sorted(iterations.keys())
+    for i in range(1, len(sorted_iters)):
+        prev, curr = sorted_iters[i - 1], sorted_iters[i]
+        if curr == prev + 1:
+            delta = (iterations[curr] - iterations[prev]).total_seconds()
+            iter_deltas.append(delta)
+
+    sync_deltas = []
+    for sync_num, sync_ts in syncs.items():
+        next_iter = sync_num + 1
+        if next_iter in iterations:
+            delta = (iterations[next_iter] - sync_ts).total_seconds()
+            sync_deltas.append(delta)
+
+    print("=== Iteration Period ===")
+    if iter_deltas:
+        filtered, outliers = filter_outliers(iter_deltas)
+        print(f"Samples: {len(filtered)} (filtered {len(outliers)} outliers)")
+        print(f"Min: {min(filtered):.3f}s | Avg: {statistics.mean(filtered):.3f}s | Max: {max(filtered):.3f}s")
+    else:
+        print("No data")
+
+    print()
+    print("=== Sync to Next Iteration ===")
+    if sync_deltas:
+        filtered, outliers = filter_outliers(sync_deltas)
+        print(f"Samples: {len(filtered)} (filtered {len(outliers)} outliers)")
+        print(f"Min: {min(filtered):.3f}s | Avg: {statistics.mean(filtered):.3f}s | Max: {max(filtered):.3f}s")
+    else:
+        print("No sync data found")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
+++ b/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
@@ -22,7 +22,7 @@ def filter_outliers(values, threshold=2.0):
 
 def main():
     parser = argparse.ArgumentParser(description="Parse iteration timing from log files")
-    parser.add_argument("-f", "--file", default="./260421-log5", help="Log file path")
+    parser.add_argument("-f", "--file", required=True, help="Log file path")
     args = parser.parse_args()
 
     iter_pattern = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}).*Starting iteration: (\d+)")

--- a/models/demos/deepseek_v3_d_p/scripts/stress.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/stress.sh
@@ -25,7 +25,7 @@ for i in $(seq 1 "$LOOP"); do
   tt-smi -glx_reset 2>&1 | tail -3
 
   cd "$TT_METAL_HOME"
-  bash -c "$ENV_VARS pytest -vs $TEST_FILE -k \"$KFILTER\" |& tee $LOG; echo TEST_DONE_EXIT=\$?"
+  bash -c "$ENV_VARS pytest -vs \"$TEST_FILE\" -k \"$KFILTER\" |& tee \"$LOG\"; echo TEST_DONE_EXIT=\${PIPESTATUS[0]}"
 
   pkill -9 -f pytest 2>/dev/null || true
   pkill -9 -f test_prefill 2>/dev/null || true

--- a/models/demos/deepseek_v3_d_p/scripts/stress.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/stress.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Outer loop: each iteration does `tt-smi -glx_reset` then a foreground pytest run
+# (no timeout — stays alive on hang for manual debug). Per-run log: <log_dir>/log_NN.
+#
+# Usage: stress.sh [log_name] [loop_count]
+
+source "$(dirname "$0")/common.sh" "$@"
+set -u
+
+echo "TT_METAL_HOME=$TT_METAL_HOME"
+echo "LOG_DIR=$LOG_DIR"
+echo "LOOP=$LOOP  INNER_ITERS=$INNER_ITERS"
+
+mkdir -p "$LOG_DIR"
+
+for i in $(seq 1 "$LOOP"); do
+  LOG=$(log_for "$LOG_DIR" "$i")
+  echo ""
+  echo "############################################################"
+  printf "###  Run %02d / %d  (%s inner iter)  @ %s\n" "$i" "$LOOP" "$INNER_ITERS" "$(date)"
+  echo "###  log: $LOG"
+  echo "############################################################"
+
+  source "$TT_METAL_HOME/python_env/bin/activate"
+  tt-smi -glx_reset 2>&1 | tail -3
+
+  cd "$TT_METAL_HOME"
+  bash -c "$ENV_VARS pytest -vs $TEST_FILE -k \"$KFILTER\" |& tee $LOG; echo TEST_DONE_EXIT=\$?"
+
+  pkill -9 -f pytest 2>/dev/null || true
+  pkill -9 -f test_prefill 2>/dev/null || true
+  sleep 2
+done
+
+echo ""
+echo "############################################################"
+printf "###  ALL %d DONE @ %s\n" "$LOOP" "$(date)"
+echo "############################################################"

--- a/models/demos/deepseek_v3_d_p/scripts/stress.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/stress.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Outer loop: each iteration does `tt-smi -glx_reset` then a foreground pytest run
 # (no timeout — stays alive on hang for manual debug). Per-run log: <log_dir>/log_NN.
 #

--- a/models/demos/deepseek_v3_d_p/scripts/tail.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/tail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Tails the newest log_NN file in the log dir.
 #
 # Usage: tail.sh [log_name] [loop_count]    (REFRESH overridable via env)

--- a/models/demos/deepseek_v3_d_p/scripts/tail.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/tail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Tails the newest log_NN file in the log dir.
+#
+# Usage: tail.sh [log_name] [loop_count]    (REFRESH overridable via env)
+
+source "$(dirname "$0")/common.sh" "$@"
+REFRESH="${REFRESH:-30}"
+
+while true; do
+  clear
+  echo "══ TAIL LATEST LOG  $(date '+%H:%M:%S')  refresh ${REFRESH}s ═══════════════════════"
+  LATEST=$(ls -1t "$LOG_DIR"/log_?? 2>/dev/null | head -1)
+  if [ -n "$LATEST" ]; then
+    echo "  file: $LATEST"
+    echo "  size: $(stat -c %s "$LATEST") bytes"
+    echo "  mtime: $(stat -c '%y' "$LATEST")"
+    echo "  ──────────────────────────────────────────────"
+    tail -10 "$LATEST"
+  else
+    echo "  (no log_NN file yet — waiting)"
+  fi
+  sleep "$REFRESH"
+done

--- a/models/demos/deepseek_v3_d_p/scripts/watch.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/watch.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Refreshing status table (PASS / HANG? / FAIL / RUN / STALE / PENDING) over the
+# outer-loop logs in one log dir.
+#
+# Usage: watch.sh [log_name] [loop_count]    (REFRESH / STALE_SECS overridable via env)
+
+source "$(dirname "$0")/common.sh" "$@"
+REFRESH="${REFRESH:-15}"
+
+while true; do
+  clear
+  echo "══ STRESS x${LOOP}  $LOG_NAME  iter${INNER_ITERS}  $(date '+%Y-%m-%d %H:%M:%S') ══════════════════"
+  echo ""
+
+  scan_log_dir "$LOG_DIR"
+
+  printf "  PASS=%d  HANG?=%d  FAIL=%d  RUN=%d  PENDING=%d\n" "$pass" "$hang" "$fail" "$running" "$pending"
+  echo "  ─────────────────────────────────────────────────────────────"
+  printf '%s\n' "${details[@]}"
+
+  echo ""
+  echo "  refresh: ${REFRESH}s    log dir: $LOG_DIR"
+  sleep "$REFRESH"
+done

--- a/models/demos/deepseek_v3_d_p/scripts/watch.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/watch.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Refreshing status table (PASS / HANG? / FAIL / RUN / STALE / PENDING) over the
 # outer-loop logs in one log dir.
 #

--- a/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
@@ -3,7 +3,9 @@
 #
 # Usage: watch_multiple_dirs.sh [log_name ...]    (REFRESH / LOOP / STALE_SECS via env)
 
-source "$(dirname "$0")/common.sh" "$@"
+# Don't forward positional args: here every arg is a log_name (handled below as
+# DIRS), not common.sh's <log_name> [loop_count]. LOOP comes from the env.
+source "$(dirname "$0")/common.sh"
 REFRESH="${REFRESH:-15}"
 
 # Each positional arg is a log_name; default to the single common LOG_NAME.

--- a/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Status table over several log dirs at once — one stacked block per dir.
 #
 # Usage: watch_multiple_dirs.sh [log_name ...]    (REFRESH / LOOP / STALE_SECS via env)

--- a/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/watch_multiple_dirs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Status table over several log dirs at once — one stacked block per dir.
+#
+# Usage: watch_multiple_dirs.sh [log_name ...]    (REFRESH / LOOP / STALE_SECS via env)
+
+source "$(dirname "$0")/common.sh" "$@"
+REFRESH="${REFRESH:-15}"
+
+# Each positional arg is a log_name; default to the single common LOG_NAME.
+DIRS=("$@")
+[ ${#DIRS[@]} -eq 0 ] && DIRS=("$LOG_NAME")
+
+while true; do
+  clear
+  echo "══ STRESS MONITOR  iter${INNER_ITERS}  $(date '+%Y-%m-%d %H:%M:%S') ══════════════════════════════"
+
+  for name in "${DIRS[@]}"; do
+    dir="/data/$USER/$name"
+    echo "── Folder: $name ────────────────────────────────────────────────"
+
+    scan_log_dir "$dir"
+
+    printf "  PASS=%d  HANG?=%d  FAIL=%d  RUN=%d  PENDING=%d\n" "$pass" "$hang" "$fail" "$running" "$pending"
+    printf '%s\n' "${details[@]}"
+    echo ""
+  done
+
+  echo "  refresh: ${REFRESH}s"
+  sleep "$REFRESH"
+done


### PR DESCRIPTION
### PR Category
Utility

### Summary

| File | Purpose |
|---|---|
| `common.sh` | Shared config + helpers (`TT_METAL_HOME`, `LOG_DIR`, `KFILTER`, derived `INNER_ITERS`, `ENV_VARS`, `log_for`, `scan_log_dir`). Sourced by the others — not run directly. |
| `stress.sh` | Outer loop (`$LOOP`×): `tt-smi -glx_reset` then pytest. Each run's stdout is `tee`'d to `<log dir>/log_NN`. No timeout — pytest stays alive on hang for manual debug. |
| `watch.sh` | Refreshing status table (PASS / HANG? / FAIL / RUN / STALE / PENDING) over the run logs. Refresh 15s (override via `REFRESH`). |
| `watch_multiple_dirs.sh` | Same status table across several log dirs at once — one block per `<log_name>` arg. Args are all log names (no positional `loop_count`); set scan depth via `LOOP=` env. |
| `tail.sh` | `tail -10` of the newest `log_NN`, refresh 30s (override via `REFRESH`). |
| `parse_iteration_times.py` | Per-iteration timing extractor (min / avg / max). Reads any pytest log with `Starting iteration:` markers. |


See `models/demos/deepseek_v3_d_p/scripts/README.md` for exact instructions

<img width="481" height="54" alt="image" src="https://github.com/user-attachments/assets/0728bfe7-9580-49d7-a26f-a1112e7bd3d0" />

<img width="794" height="201" alt="image" src="https://github.com/user-attachments/assets/987a5284-8f4d-4d2c-b681-f02403938fb1" />


### Notes for reviewers
Skipping CI runs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2606-stress-scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2606-stress-scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2606-stress-scripts)