### PR TITLE
Add ring_mla shared-KV streaming support

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -477,6 +477,7 @@ Transformer
    ttnn.transformer.paged_scaled_dot_product_attention_decode
    ttnn.transformer.ring_distributed_scaled_dot_product_attention
    ttnn.transformer.ring_joint_scaled_dot_product_attention
+   ttnn.transformer.ring_mla
    ttnn.transformer.scaled_dot_product_attention
    ttnn.transformer.scaled_dot_product_attention_decode
    ttnn.transformer.split_query_key_value_and_split_heads

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -430,7 +430,7 @@ def call_sdpa(
     ccl_column,
     *,
     scale=None,
-    cache_batch_idx=None,
+    kv_cache_batch_idx=None,
     kv_actual_isl=None,
 ):
     tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
@@ -458,7 +458,7 @@ def call_sdpa(
         ccl_core_grid_offset=(ccl_column, 0),
         use_column_major_ccl=True,
         scale=scale,
-        cache_batch_idx=cache_batch_idx,
+        kv_cache_batch_idx=kv_cache_batch_idx,
         kv_actual_isl=kv_actual_isl,
     )
     return tt_out
@@ -793,6 +793,202 @@ def run_ring_joint_sdpa(
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
 
+def run_ring_mla_sdpa(
+    mesh_config,
+    b,
+    nhq,
+    nhk,
+    sq,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    q_dtype,
+    kv_dtype,
+    *,
+    is_balanced=True,
+    pcc_threshold=DEFAULT_PCC_THRESHOLD,
+    rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+    do_check=True,
+    num_iterations=1,
+    kv_cache_batch_idx=None,
+    cache_batch=2,
+):
+    """Run ring_mla where V is the first d_v columns of the single KV tensor."""
+    if mesh_config.sp_size < 2:
+        pytest.skip(f"ring_mla requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
+    if nhk != 1:
+        pytest.skip(f"Focused ring_mla test covers MLA shared-KV-head shapes, got nhk={nhk}")
+
+    torch.manual_seed(1234)
+
+    use_ring = mesh_config.sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+    sp_axis = 1
+    tp_axis = 0
+
+    ttnn.set_fabric_config(
+        fabric_config,
+        ttnn.FabricReliabilityMode.STRICT_INIT,
+        None,
+        ttnn.FabricTensixConfig.DISABLED,
+        ttnn.FabricUDMMode.DISABLED,
+        ttnn.FabricManagerMode.DEFAULT,
+    )
+
+    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    num_links = 2
+
+    try:
+        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
+        ccl_column = mesh_config.ccl_column
+        full_compute_grid = mesh_device.compute_with_storage_grid_size()
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+        )
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        mesh_device.load_sub_device_manager(sub_device_manager)
+        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
+
+        Q = fa_rand(b, nhq, sq, d_q)
+        KV = fa_rand(b, nhk, sq, d_k)
+        V_prefix = KV[:, :, :, :d_v]
+        Q_original, KV_original, V_original = Q, KV, V_prefix
+        if kv_cache_batch_idx is not None:
+            assert b == 1, f"ring_mla indexed K/V cache requires Q batch 1, got {b}"
+            assert (
+                0 <= kv_cache_batch_idx < cache_batch
+            ), f"kv_cache_batch_idx {kv_cache_batch_idx} must be in [0, {cache_batch})"
+
+        chunk_order = None
+        if is_balanced:
+            chunk_order = create_balanced_chunk_order(mesh_config.sp_size)
+            Q = reorder_tensor_chunks(Q, chunk_order)
+            KV = reorder_tensor_chunks(KV, chunk_order)
+
+        kv_cache_batch = b
+        KV_input = KV
+        if kv_cache_batch_idx is not None:
+            kv_cache_batch = cache_batch
+            KV_input = fa_rand(cache_batch, nhk, sq, d_k)
+            KV_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = KV
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=sdpa_compute_grid,
+            q_chunk_size=q_chunk_size,
+            k_chunk_size=k_chunk_size,
+            exp_approx_mode=False,
+        )
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        sdpa_input_shard_dims = [None, None]
+        sdpa_input_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            sdpa_input_shard_dims[tp_axis] = 1
+
+        sdpa_kv_shard_dims = [None, None]
+        sdpa_kv_shard_dims[sp_axis] = 2
+
+        persistent_kv_shard_dims = [None, None]
+        persistent_kv_shard_dims[sp_axis] = None
+
+        tt_Q = ttnn.from_torch(
+            Q,
+            dtype=q_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+            ),
+        )
+        tt_KV = ttnn.from_torch(
+            KV_input,
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_kv_shard_dims
+            ),
+        )
+        persistent_output_buffer_kv = ttnn.from_torch(
+            torch.zeros(kv_cache_batch, nhk, sq, d_k),
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_kv_shard_dims
+            ),
+        )
+
+        main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
+        main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+        reference_output = None
+        for i in range(num_iterations):
+            tt_out, _ = ttnn.transformer.ring_mla(
+                tt_Q,
+                tt_KV,
+                persistent_output_buffer_kv=persistent_output_buffer_kv,
+                head_dim_v=d_v,
+                logical_n=sq,
+                is_balanced=is_balanced,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=ccl_semaphore_handles,
+                num_links=num_links,
+                cluster_axis=sp_axis,
+                mesh_device=mesh_device,
+                topology=topology,
+                subdevice_id=worker_sub_device_id,
+                ccl_core_grid_offset=(ccl_column, 0),
+                use_column_major_ccl=True,
+                kv_cache_batch_idx=kv_cache_batch_idx,
+            )
+
+            tt_out_torch = ttnn.to_torch(
+                tt_out,
+                mesh_composer=ttnn.create_mesh_composer(
+                    mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
+                ),
+            )
+            tt_out_torch = tt_out_torch[:, :, :sq, :d_v]
+            if is_balanced and chunk_order is not None:
+                tt_out_torch = reverse_reorder_tensor_chunks(tt_out_torch, chunk_order)
+
+            if num_iterations > 1:
+                if reference_output is None:
+                    reference_output = tt_out_torch
+                elif not torch.equal(reference_output, tt_out_torch):
+                    max_diff = (reference_output - tt_out_torch).abs().max().item()
+                    pytest.fail(f"ring_mla output at iteration {i} differs from iteration 0, max diff={max_diff}")
+
+        if num_iterations > 1 or not do_check:
+            return
+
+        gt_main = torch_sdpa_reference(Q_original, KV_original, V_original, is_causal=True)
+        out_pass, out_pcc = comp_pcc(gt_main, tt_out_torch, pcc_threshold)
+        rmse = torch.sqrt(((gt_main - tt_out_torch) ** 2).mean()).item()
+        logger.info(f"ring_mla output - PCC: {out_pcc}, RMSE: {rmse:.6f}")
+        assert rmse < rmse_threshold, f"ring_mla RMSE {rmse:.6f} exceeds threshold {rmse_threshold}"
+        assert out_pass, f"ring_mla PCC {out_pcc} below threshold {pcc_threshold}"
+
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
 # ============================================================================
 # CHUNKED-PREFILL VALIDATION
 # ============================================================================
@@ -820,7 +1016,7 @@ def run_ring_joint_sdpa_chunked(
     k_chunk_size: int = None,
     num_iterations: int = 1,
     indexed_nd_sharded_kv_cache: bool = False,
-    cache_batch_idx: int = 1,
+    kv_cache_batch_idx: int = 1,
     cache_batch: int = 2,
     persistent_buffer_mode: str = "exact_per_chunk",
 ):
@@ -851,7 +1047,9 @@ def run_ring_joint_sdpa_chunked(
     ), f"Unsupported persistent_buffer_mode={persistent_buffer_mode}"
     if indexed_nd_sharded_kv_cache:
         assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
-        assert 0 <= cache_batch_idx < cache_batch, f"cache_batch_idx {cache_batch_idx} must be in [0, {cache_batch})"
+        assert (
+            0 <= kv_cache_batch_idx < cache_batch
+        ), f"kv_cache_batch_idx {kv_cache_batch_idx} must be in [0, {cache_batch})"
         assert (
             persistent_buffer_mode == "exact_per_chunk"
         ), "Reusable max buffers are not combined with indexed K/V cache"
@@ -1058,15 +1256,15 @@ def run_ring_joint_sdpa_chunked(
                 V_balanced = to_balanced_growing_cache_layout(V_full, sp_size, chunk_size, i)
                 Q_chunk = Q_full[:, :, s:e, :].contiguous()
                 kv_buffer_batch = b
-                cache_batch_idx_arg = None
+                kv_cache_batch_idx_arg = None
 
                 if indexed_nd_sharded_kv_cache:
                     kv_buffer_batch = cache_batch
-                    cache_batch_idx_arg = cache_batch_idx
+                    kv_cache_batch_idx_arg = kv_cache_batch_idx
                     K_input = torch.randn(cache_batch, nhk, e, d_k, dtype=K_balanced.dtype) * 100
                     V_input = torch.randn(cache_batch, nhv, e, d_v, dtype=V_balanced.dtype) * 100
-                    K_input[cache_batch_idx : cache_batch_idx + 1] = K_balanced
-                    V_input[cache_batch_idx : cache_batch_idx + 1] = V_balanced
+                    K_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = K_balanced
+                    V_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = V_balanced
                 else:
                     K_input = K_balanced
                     V_input = V_balanced
@@ -1102,7 +1300,7 @@ def run_ring_joint_sdpa_chunked(
                         topology=topology,
                         worker_sub_device_id=worker_sub_device_id,
                         ccl_column=ccl_column,
-                        cache_batch_idx=cache_batch_idx_arg,
+                        kv_cache_batch_idx=kv_cache_batch_idx_arg,
                     )
                 except Exception as exc:
                     pytest.fail(
@@ -1267,6 +1465,62 @@ def build_kv_pad_rotation_inputs(
     assert all(row is not None for row in valid_rows)
 
     return q_host, k_host, v_host, valid_rows, num_cache_slabs
+
+
+def build_kv_pad_rotation_mla_inputs(
+    old_cache_kv,
+    new_tokens_q,
+    new_tokens_kv,
+    kv_actual_isl,
+    sp_size,
+    chunk_size_local,
+):
+    """Build padded Q/KV host tensors for one KV-pad-aware ring_mla call."""
+    assert old_cache_kv.shape[0] == 1
+    assert new_tokens_q.shape[0] == 1
+
+    nhq = new_tokens_q.shape[1]
+    nhk = new_tokens_kv.shape[1]
+    d_q = new_tokens_q.shape[3]
+    d_k = new_tokens_kv.shape[3]
+    new_actual_isl = new_tokens_q.shape[2]
+    chunk_size_global = sp_size * chunk_size_local
+    logical_n = kv_actual_isl + new_actual_isl
+    num_cache_slabs = max(2, math.ceil(logical_n / chunk_size_global))
+    cache_seq_per_dev = num_cache_slabs * chunk_size_local
+
+    kv_per_dev = torch.zeros(sp_size, nhk, cache_seq_per_dev, d_k, dtype=torch.bfloat16)
+    for global_pos in range(kv_actual_isl):
+        group = global_pos // chunk_size_global
+        within_group = global_pos % chunk_size_global
+        dev = within_group // chunk_size_local
+        cell = within_group % chunk_size_local
+        cache_row = group * chunk_size_local + cell
+        kv_per_dev[dev, :, cache_row, :] = old_cache_kv[0, :, global_pos, :]
+
+    q_per_dev = torch.zeros(sp_size, nhq, chunk_size_local, d_q, dtype=torch.bfloat16)
+    q_global_pos_per_dev = [[None] * chunk_size_local for _ in range(sp_size)]
+    destinations = kv_pad_rotation_destinations(kv_actual_isl, new_actual_isl, sp_size, chunk_size_local)
+    assert len(destinations) == new_actual_isl
+    for token_idx, dev, cache_row, q_row, global_pos in destinations:
+        kv_per_dev[dev, :, cache_row, :] = new_tokens_kv[0, :, token_idx, :]
+        q_per_dev[dev, :, q_row, :] = new_tokens_q[0, :, token_idx, :]
+        q_global_pos_per_dev[dev][q_row] = global_pos
+
+    q_host = q_per_dev.permute(1, 0, 2, 3).reshape(1, nhq, chunk_size_global, d_q)
+    kv_host = kv_per_dev.permute(1, 0, 2, 3).reshape(1, nhk, sp_size * cache_seq_per_dev, d_k)
+
+    combined_q_global_pos = []
+    for dev in range(sp_size):
+        combined_q_global_pos.extend(q_global_pos_per_dev[dev])
+
+    valid_rows = [None] * new_actual_isl
+    for row, q_pos in enumerate(combined_q_global_pos):
+        if q_pos is not None:
+            valid_rows[q_pos - kv_actual_isl] = row
+    assert all(row is not None for row in valid_rows)
+
+    return q_host, kv_host, valid_rows, num_cache_slabs
 
 
 def run_ring_joint_sdpa_kv_pad_rotation_case(
@@ -1462,9 +1716,513 @@ def run_ring_joint_sdpa_kv_pad_rotation_case(
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
 
-@pytest.mark.timeout(600)
+def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
+    mesh_config,
+    chunk_size_local=32,
+    num_chunks=5,
+    num_iterations=2,
+    kv_cache_batch_idx=1,
+    cache_batch=2,
+    pcc_threshold=CHUNKED_PREFILL_PCC_THRESHOLD,
+    rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+):
+    sp_size = mesh_config.sp_size
+    if sp_size < 2:
+        pytest.skip(f"ring_mla chunked kv_actual_isl requires at least 2 devices in ring, got SP={sp_size}")
+
+    tile_height = 32
+    assert chunk_size_local % tile_height == 0
+    assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
+    assert (
+        0 <= kv_cache_batch_idx < cache_batch
+    ), f"kv_cache_batch_idx {kv_cache_batch_idx} must be in [0, {cache_batch})"
+
+    b = BATCH_SIZE
+    local_heads = 4
+    nhq = local_heads * mesh_config.tp_size
+    nhk = 1
+    d_q = 64
+    d_k = 64
+    d_v = 32
+    q_dtype = ttnn.bfloat16
+    kv_dtype = ttnn.bfloat16
+    chunk_size_global = chunk_size_local * sp_size
+    # Drift chunk starts across cache-slab boundaries while keeping each chunk within one fixed Q slab.
+    new_actual_isl = chunk_size_global // 2 + tile_height
+    total_seq = new_actual_isl * num_chunks
+    assert new_actual_isl % tile_height == 0
+    assert new_actual_isl <= chunk_size_global
+    assert total_seq % tile_height == 0
+
+    max_cache_slabs = max(2, math.ceil(total_seq / chunk_size_global) + 1)
+    max_cache_seq_per_dev = max_cache_slabs * chunk_size_local
+    persistent_seq_len = sp_size * max_cache_seq_per_dev
+
+    torch.manual_seed(CHUNKED_PREFILL_SEED)
+    q_full = fa_rand(b, nhq, total_seq, d_q)
+    kv_full = fa_rand(b, nhk, total_seq, d_k)
+
+    use_ring = sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+    ttnn.set_fabric_config(
+        fabric_config,
+        ttnn.FabricReliabilityMode.STRICT_INIT,
+        None,
+        ttnn.FabricTensixConfig.DISABLED,
+        ttnn.FabricUDMMode.DISABLED,
+        ttnn.FabricManagerMode.DEFAULT,
+    )
+
+    sp_axis = 1
+    tp_axis = 0
+    num_links = 2
+    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    try:
+        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
+        ccl_column = mesh_config.ccl_column
+        full_compute_grid = mesh_device.compute_with_storage_grid_size()
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+        )
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        mesh_device.load_sub_device_manager(sub_device_manager)
+        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
+
+        sdpa_input_shard_dims = [None, None]
+        sdpa_input_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            sdpa_input_shard_dims[tp_axis] = 1
+
+        sdpa_kv_shard_dims = [None, None]
+        sdpa_kv_shard_dims[sp_axis] = 2
+
+        persistent_kv_shard_dims = [None, None]
+        main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
+        main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+
+        def upload(host_tensor, dtype, shard_dims):
+            return ttnn.from_torch(
+                host_tensor,
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+            )
+
+        persistent_output_buffer_kv = ttnn.from_torch(
+            torch.zeros(cache_batch, nhk, persistent_seq_len, d_k),
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_kv_shard_dims
+            ),
+        )
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=sdpa_compute_grid,
+            q_chunk_size=32,
+            k_chunk_size=32,
+            exp_approx_mode=False,
+        )
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        logger.info(
+            f"ring_mla chunked kv_actual_isl reuse-max: sp_size={sp_size}, "
+            f"chunk_size_global={chunk_size_global}, new_actual_isl={new_actual_isl}, "
+            f"num_chunks={num_chunks}, num_iterations={num_iterations}, "
+            f"kv_cache_batch_idx={kv_cache_batch_idx}, cache_batch={cache_batch}, persistent_seq_len={persistent_seq_len}"
+        )
+
+        reference_outputs = None
+        per_chunk_results = []
+        for it in range(num_iterations):
+            iter_outputs = []
+            for i in range(num_chunks):
+                kv_actual_isl = i * new_actual_isl
+                logical_n = kv_actual_isl + new_actual_isl
+                new_tokens_q = q_full[:, :, kv_actual_isl:logical_n, :].contiguous()
+                new_tokens_kv = kv_full[:, :, kv_actual_isl:logical_n, :].contiguous()
+
+                q_host, kv_host, valid_rows, num_cache_slabs = build_kv_pad_rotation_mla_inputs(
+                    kv_full[:, :, :kv_actual_isl, :],
+                    new_tokens_q,
+                    new_tokens_kv,
+                    kv_actual_isl,
+                    sp_size,
+                    chunk_size_local,
+                )
+                assert persistent_seq_len > kv_host.shape[2], (
+                    f"test requires oversized persistent buffer, got persistent_seq_len={persistent_seq_len}, "
+                    f"input KV seq={kv_host.shape[2]}"
+                )
+                kv_input = torch.randn(cache_batch, nhk, kv_host.shape[2], d_k, dtype=kv_host.dtype) * 100
+                kv_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = kv_host
+
+                tt_q = upload(q_host, q_dtype, sdpa_input_shard_dims)
+                tt_kv = upload(kv_input, kv_dtype, sdpa_kv_shard_dims)
+
+                try:
+                    tt_out, _ = ttnn.transformer.ring_mla(
+                        tt_q,
+                        tt_kv,
+                        persistent_output_buffer_kv=persistent_output_buffer_kv,
+                        head_dim_v=d_v,
+                        logical_n=logical_n,
+                        is_balanced=False,
+                        program_config=program_config,
+                        compute_kernel_config=compute_kernel_config,
+                        dim=2,
+                        multi_device_global_semaphore=ccl_semaphore_handles,
+                        num_links=num_links,
+                        cluster_axis=sp_axis,
+                        mesh_device=mesh_device,
+                        topology=topology,
+                        subdevice_id=worker_sub_device_id,
+                        ccl_core_grid_offset=(ccl_column, 0),
+                        use_column_major_ccl=True,
+                        kv_cache_batch_idx=kv_cache_batch_idx,
+                        kv_actual_isl=kv_actual_isl,
+                    )
+                except Exception as exc:
+                    pytest.fail(
+                        f"ring_mla chunked kv_actual_isl call raised on iter {it}, chunk {i} "
+                        f"(kv_actual_isl={kv_actual_isl}, logical_n={logical_n}, "
+                        f"input_kv_seq={kv_host.shape[2]}, kv_cache_batch_idx={kv_cache_batch_idx}, "
+                        f"persistent_seq={persistent_seq_len}): "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+
+                out_host = ttnn.to_torch(
+                    tt_out,
+                    mesh_composer=ttnn.create_mesh_composer(
+                        mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
+                    ),
+                )
+                out_valid_natural = out_host[:, :, valid_rows, :]
+                iter_outputs.append(out_valid_natural)
+
+                if it == 0:
+                    ref_out = torch_chunked_causal_sdpa_reference(
+                        new_tokens_q, kv_full[:, :, :logical_n, :], kv_full[:, :, :logical_n, :d_v], kv_actual_isl
+                    )
+                    passed, pcc = comp_pcc(ref_out, out_valid_natural, pcc_threshold)
+                    rmse = torch.sqrt(((ref_out - out_valid_natural) ** 2).mean()).item()
+                    rmse_passed = rmse_threshold is None or rmse < rmse_threshold
+                    logger.info(
+                        f"ring_mla kv_actual_isl chunk {i:2d}: kv_actual_isl={kv_actual_isl}, "
+                        f"logical_n={logical_n}, input_kv_seq={kv_host.shape[2]}, "
+                        f"kv_cache_batch_idx={kv_cache_batch_idx}, persistent_seq={persistent_seq_len}, "
+                        f"cache_slabs={num_cache_slabs}, "
+                        f"PCC={pcc}, RMSE={rmse:.6f} -> {'PASS' if passed and rmse_passed else 'FAIL'}"
+                    )
+                    per_chunk_results.append((i, kv_actual_isl, logical_n, passed, pcc, rmse_passed, rmse))
+
+            if reference_outputs is None:
+                reference_outputs = iter_outputs
+            else:
+                diffs = []
+                for i, (ref, cur) in enumerate(zip(reference_outputs, iter_outputs)):
+                    if not torch.equal(ref, cur):
+                        num_diffs = (ref != cur).sum().item()
+                        max_diff = (ref - cur).abs().max().item()
+                        diffs.append((i, num_diffs, max_diff))
+                        logger.warning(f"  iter {it} chunk {i}: {num_diffs} diffs, max={max_diff}")
+                if diffs:
+                    details = "; ".join(f"chunk {i}: {n} diffs, max={m}" for i, n, m in diffs)
+                    pytest.fail(f"ring_mla chunked kv_actual_isl determinism failed at iter {it}: {details}")
+
+        failures = [
+            (i, kv_actual_isl, logical_n, pcc, rmse)
+            for i, kv_actual_isl, logical_n, passed, pcc, rmse_passed, rmse in per_chunk_results
+            if not passed or not rmse_passed
+        ]
+        if failures:
+            details = "; ".join(
+                f"chunk {i} (kv_actual_isl={kv_actual_isl}, logical_n={logical_n}): PCC={pcc}, RMSE={rmse:.6f}"
+                for i, kv_actual_isl, logical_n, pcc, rmse in failures
+            )
+            pytest.fail(
+                f"ring_mla chunked kv_actual_isl PCC/RMSE failures "
+                f"(pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}): {details}"
+            )
+        logger.info(
+            f"ring_mla chunked kv_actual_isl verified: {num_chunks} chunks replayed {num_iterations} times with "
+            f"kv_cache_batch_idx={kv_cache_batch_idx}, persistent_seq_len={persistent_seq_len}"
+        )
+
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
+def run_ring_mla_sdpa_chunked_indexed_kv_cache(
+    mesh_config,
+    model: ModelConfig,
+    chunk_size: int,
+    total_seq: int,
+    pcc_threshold: float = DEFAULT_PCC_THRESHOLD,
+    rmse_threshold: float = DEFAULT_RMSE_THRESHOLD,
+    q_chunk_size: int = None,
+    k_chunk_size: int = None,
+    num_iterations: int = 2,
+    kv_cache_batch_idx: int = 1,
+    cache_batch: int = 2,
+):
+    """
+    Validate ring_mla chunked-prefill with an indexed shared K/V cache.
+
+    The SUT replays a sequence of short Q chunks. For chunk i, the indexed cache
+    slot contains K/V rows [0, (i + 1) * chunk_size), packed in the same growing
+    cache layout used by ring_joint_sdpa chunked prefill. The unselected cache
+    slots contain random data and must not affect output.
+    """
+    torch.manual_seed(CHUNKED_PREFILL_SEED)
+
+    sp_size = mesh_config.sp_size
+    if sp_size < 2:
+        pytest.skip(f"ring_mla chunked prefill requires at least 2 devices in ring, got SP={sp_size}")
+    if model.nhk != 1:
+        pytest.skip(f"ring_mla chunked prefill requires one shared KV head, got nhk={model.nhk}")
+
+    assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
+    assert total_seq % sp_size == 0, f"total_seq {total_seq} must divide sp_size {sp_size}"
+    assert chunk_size % sp_size == 0, f"chunk_size {chunk_size} must divide sp_size {sp_size}"
+    assert total_seq % chunk_size == 0, f"total_seq {total_seq} must be a multiple of chunk_size {chunk_size}"
+    assert (
+        0 <= kv_cache_batch_idx < cache_batch
+    ), f"kv_cache_batch_idx {kv_cache_batch_idx} must be in [0, {cache_batch})"
+
+    n_chunks = total_seq // chunk_size
+    if q_chunk_size is None:
+        q_chunk_size = model.q_chunk_sizes[0]
+    if k_chunk_size is None:
+        k_chunk_size = model.k_chunk_sizes[0]
+
+    b = BATCH_SIZE
+    nhq = model.nhq * mesh_config.tp_size
+    nhk = model.nhk
+    d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
+    q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
+
+    use_ring = sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+
+    ttnn.set_fabric_config(
+        fabric_config,
+        ttnn.FabricReliabilityMode.STRICT_INIT,
+        None,
+        ttnn.FabricTensixConfig.DISABLED,
+        ttnn.FabricUDMMode.DISABLED,
+        ttnn.FabricManagerMode.DEFAULT,
+    )
+
+    sp_axis = 1
+    tp_axis = 0
+    num_links = 2
+    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    try:
+        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
+        ccl_column = mesh_config.ccl_column
+        full_compute_grid = mesh_device.compute_with_storage_grid_size()
+
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+        )
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        mesh_device.load_sub_device_manager(sub_device_manager)
+        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
+
+        Q_full = fa_rand(b, nhq, total_seq, d_q)
+        KV_full = fa_rand(b, nhk, total_seq, d_k)
+        V_full = KV_full[:, :, :, :d_v]
+        ref_full = torch_sdpa_reference(Q_full, KV_full, V_full, is_causal=True)
+
+        sdpa_input_shard_dims = [None, None]
+        sdpa_input_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            sdpa_input_shard_dims[tp_axis] = 1
+
+        sdpa_kv_shard_dims = [None, None]
+        sdpa_kv_shard_dims[sp_axis] = 2
+
+        persistent_kv_shard_dims = [None, None]
+        main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
+        main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=sdpa_compute_grid,
+            q_chunk_size=q_chunk_size,
+            k_chunk_size=k_chunk_size,
+            exp_approx_mode=False,
+        )
+        compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        kv_memory_config = nd_sharded_dram_memory_config(mesh_device, d_k)
+
+        def upload_q(q_host):
+            return ttnn.from_torch(
+                q_host,
+                dtype=q_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+                ),
+            )
+
+        def upload_kv(kv_host):
+            return ttnn.from_torch(
+                kv_host,
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                memory_config=kv_memory_config,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_kv_shard_dims
+                ),
+            )
+
+        def to_host(tt_out, expected_q_len):
+            out = ttnn.to_torch(
+                tt_out,
+                mesh_composer=ttnn.create_mesh_composer(
+                    mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
+                ),
+            )
+            return out[:, :, :expected_q_len, :d_v]
+
+        logger.info(
+            f"ring_mla chunked indexed cache: model={model.name}, total_seq={total_seq}, "
+            f"chunk_size={chunk_size}, n_chunks={n_chunks}, q_chunk={q_chunk_size}, k_chunk={k_chunk_size}, "
+            f"kv_cache_batch_idx={kv_cache_batch_idx}, cache_batch={cache_batch}"
+        )
+
+        reference_outputs = None
+        per_chunk_results = []
+        for it in range(num_iterations):
+            iter_outputs = []
+            for i in range(n_chunks):
+                s, e = i * chunk_size, (i + 1) * chunk_size
+                KV_balanced = to_balanced_growing_cache_layout(KV_full, sp_size, chunk_size, i)
+                Q_chunk = Q_full[:, :, s:e, :].contiguous()
+                KV_input = torch.randn(cache_batch, nhk, e, d_k, dtype=KV_balanced.dtype) * 100
+                KV_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = KV_balanced
+
+                tt_Q = upload_q(Q_chunk)
+                tt_KV = upload_kv(KV_input)
+                persistent_output_buffer_kv = ttnn.from_torch(
+                    torch.zeros(cache_batch, nhk, e, d_k),
+                    dtype=kv_dtype,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=mesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_kv_shard_dims
+                    ),
+                )
+
+                try:
+                    tt_out, _ = ttnn.transformer.ring_mla(
+                        tt_Q,
+                        tt_KV,
+                        persistent_output_buffer_kv=persistent_output_buffer_kv,
+                        head_dim_v=d_v,
+                        logical_n=e,
+                        is_balanced=False,
+                        program_config=program_config,
+                        compute_kernel_config=compute_kernel_config,
+                        dim=2,
+                        multi_device_global_semaphore=ccl_semaphore_handles,
+                        num_links=num_links,
+                        cluster_axis=sp_axis,
+                        mesh_device=mesh_device,
+                        topology=topology,
+                        subdevice_id=worker_sub_device_id,
+                        ccl_core_grid_offset=(ccl_column, 0),
+                        use_column_major_ccl=True,
+                        kv_cache_batch_idx=kv_cache_batch_idx,
+                    )
+                except Exception as exc:
+                    pytest.fail(
+                        f"ring_mla chunked indexed-cache call raised on iter {it}, chunk {i} "
+                        f"(Q rows [{s}, {e}), logical_n={e}): {type(exc).__name__}: {exc}"
+                    )
+
+                out_i = to_host(tt_out, chunk_size)
+                iter_outputs.append(out_i)
+
+                if it == 0:
+                    expected_i = ref_full[:, :, s:e, :]
+                    passed, pcc = comp_pcc(expected_i, out_i, pcc_threshold)
+                    rmse = torch.sqrt(((expected_i - out_i) ** 2).mean()).item()
+                    rmse_passed = rmse < rmse_threshold
+                    logger.info(
+                        f"ring_mla chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: "
+                        f"PCC={pcc} RMSE={rmse:.6f} -> {'PASS' if passed and rmse_passed else 'FAIL'}"
+                    )
+                    per_chunk_results.append((i, e, passed, pcc, rmse_passed, rmse))
+
+            if reference_outputs is None:
+                reference_outputs = iter_outputs
+            else:
+                diffs = []
+                for i, (ref, cur) in enumerate(zip(reference_outputs, iter_outputs)):
+                    if not torch.equal(ref, cur):
+                        num_diffs = (ref != cur).sum().item()
+                        max_diff = (ref - cur).abs().max().item()
+                        diffs.append((i, num_diffs, max_diff))
+                        logger.warning(f"  iter {it} chunk {i}: {num_diffs} diffs, max={max_diff}")
+                if diffs:
+                    details = "; ".join(f"chunk {i}: {n} diffs, max={m}" for i, n, m in diffs)
+                    pytest.fail(f"ring_mla chunked indexed-cache determinism failed at iter {it}: {details}")
+
+        failures = [
+            (i, e, pcc, rmse)
+            for i, e, passed, pcc, rmse_passed, rmse in per_chunk_results
+            if not passed or not rmse_passed
+        ]
+        if failures:
+            details = "; ".join(
+                f"chunk {i} (logical_n={e}): PCC={pcc}, RMSE={rmse:.6f}" for i, e, pcc, rmse in failures
+            )
+            pytest.fail(
+                f"ring_mla chunked indexed-cache PCC/RMSE failures "
+                f"(pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}): {details}"
+            )
+        logger.info(f"ring_mla chunked indexed-cache verified: {n_chunks} chunks replayed {num_iterations} times")
+
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
 def test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy():
-    """Validate chunked direct ND-sharded K/V cache inputs selected by cache_batch_idx."""
+    """Validate chunked direct ND-sharded K/V cache inputs selected by kv_cache_batch_idx."""
     mesh_config = MESH_CONFIG
     local_heads = 4
     chunk_seq_len = 64
@@ -1499,7 +2257,6 @@ def test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy():
     )
 
 
-@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "case_name",
     [
@@ -1530,9 +2287,108 @@ def test_ring_joint_attention_kv_pad_aware_rotation_accuracy(case_name):
     )
 
 
+def test_ring_mla_chunked_kv_actual_isl_indexed_reuse_max_accuracy_and_determinism():
+    """Validate chunked ring_mla with kv_cache_batch_idx, kv_actual_isl, and oversized reusable persistent KV cache."""
+    mesh_config = MESH_CONFIG
+    run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
+        mesh_config,
+    )
+
+
+def test_ring_mla_chunked_nd_sharded_indexed_kv_cache_accuracy_and_determinism():
+    """Validate ring_mla chunked prefill with indexed ND-sharded shared K/V cache."""
+    mesh_config = MESH_CONFIG
+    local_heads = 4
+    chunk_seq_len = 64
+    total_seq_len = 128
+    model = ModelConfig(
+        name="mla_chunked_indexed_nd_sharded_kv",
+        nhq=local_heads,
+        nhk=1,
+        nhv=local_heads,
+        d_q=64,
+        d_k=64,
+        d_v=32,
+        is_causal=True,
+        is_balanced=False,
+        q_dtype=ttnn.bfloat16,
+        kv_dtype=ttnn.bfloat16,
+        q_chunk_sizes=[32],
+        k_chunk_sizes=[32],
+        seq_len=total_seq_len,
+    )
+
+    run_ring_mla_sdpa_chunked_indexed_kv_cache(
+        mesh_config,
+        model,
+        chunk_size=chunk_seq_len * mesh_config.sp_size,
+        total_seq=total_seq_len * mesh_config.sp_size,
+        pcc_threshold=DEFAULT_PCC_THRESHOLD,
+        rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+        q_chunk_size=model.q_chunk_sizes[0],
+        k_chunk_size=model.k_chunk_sizes[0],
+        num_iterations=2,
+        kv_cache_batch_idx=1,
+        cache_batch=2,
+    )
+
+
+def test_ring_mla_nd_sharded_indexed_kv_cache_accuracy():
+    """Validate ring_mla selects the requested batch slot from an indexed K/V cache."""
+    mesh_config = MESH_CONFIG
+    local_heads = 4
+    per_device_seq_len = 128
+
+    run_ring_mla_sdpa(
+        mesh_config,
+        b=1,
+        nhq=local_heads * mesh_config.tp_size,
+        nhk=1,
+        sq=per_device_seq_len * mesh_config.sp_size,
+        d_q=64,
+        d_k=64,
+        d_v=32,
+        q_chunk_size=32,
+        k_chunk_size=32,
+        q_dtype=ttnn.bfloat16,
+        kv_dtype=ttnn.bfloat16,
+        is_balanced=False,
+        pcc_threshold=DEFAULT_PCC_THRESHOLD,
+        rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+        kv_cache_batch_idx=1,
+        cache_batch=2,
+    )
+
+
 # Generate test parameters dynamically based on detected hardware for different models (WAN, MLA, VideGen...)
 TEST_CONFIGS, TEST_CONFIG_IDS = generate_test_configs(MESH_CONFIG, MODEL_CONFIGS)
 TEST_CONFIG_MODELS = list(MODEL_CONFIGS.keys())
+
+
+def generate_ring_mla_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]):
+    if mesh_config.sp_size < 2 or "mla_100k" not in model_configs:
+        return [], []
+    model = model_configs["mla_100k"]
+    q_chunk_size = 160
+    k_chunk_size = 320
+    config = (
+        BATCH_SIZE,
+        model.seq_len * mesh_config.sp_size,
+        model.nhq * mesh_config.tp_size,
+        model.nhk,
+        model.d_q,
+        model.d_k,
+        model.d_v,
+        q_chunk_size,
+        k_chunk_size,
+        model.is_balanced,
+        model.q_dtype,
+        model.kv_dtype,
+    )
+    return [config], [f"ring_mla-{model.name}-q{q_chunk_size}-k{k_chunk_size}"]
+
+
+RING_MLA_TEST_CONFIGS, RING_MLA_TEST_CONFIG_IDS = generate_ring_mla_test_configs(MESH_CONFIG, MODEL_CONFIGS)
 
 
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
@@ -1580,6 +2436,44 @@ def test_ring_joint_attention_sdpa_sweep_perf_impl(
         d_v=d_v,
         kv_dtype=kv_dtype,
         is_causal=is_causal,
+        is_balanced=is_balanced,
+        do_check=False,
+    )
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
+@pytest.mark.parametrize(
+    "b,sq,nhq,nhk,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_balanced,q_dtype,kv_dtype",
+    RING_MLA_TEST_CONFIGS,
+    ids=RING_MLA_TEST_CONFIG_IDS,
+)
+def test_ring_mla_sweep_perf_impl(
+    b,
+    sq,
+    nhq,
+    nhk,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_balanced,
+    q_dtype,
+    kv_dtype,
+):
+    run_ring_mla_sdpa(
+        MESH_CONFIG,
+        b,
+        nhq,
+        nhk,
+        sq,
+        d_q,
+        d_k,
+        d_v,
+        q_chunk_size,
+        k_chunk_size,
+        q_dtype,
+        kv_dtype,
         is_balanced=is_balanced,
         do_check=False,
     )
@@ -1643,6 +2537,42 @@ def test_ring_joint_attention_sdpa_accuracy(
     )
 
 
+@pytest.mark.parametrize(
+    "b,sq,nhq,nhk,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_balanced,q_dtype,kv_dtype",
+    RING_MLA_TEST_CONFIGS,
+    ids=RING_MLA_TEST_CONFIG_IDS,
+)
+def test_ring_mla_accuracy(
+    b,
+    sq,
+    nhq,
+    nhk,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_balanced,
+    q_dtype,
+    kv_dtype,
+):
+    run_ring_mla_sdpa(
+        MESH_CONFIG,
+        b,
+        nhq,
+        nhk,
+        sq,
+        d_q,
+        d_k,
+        d_v,
+        q_chunk_size,
+        k_chunk_size,
+        q_dtype,
+        kv_dtype,
+        is_balanced=is_balanced,
+    )
+
+
 # === TEST 3: DETERMINISM VERIFICATION ===
 @pytest.mark.parametrize(
     "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
@@ -1688,6 +2618,44 @@ def test_ring_joint_attention_sdpa_determinism(
         is_causal=is_causal,
         is_balanced=is_balanced,
         num_iterations=num_iterations,
+    )
+
+
+@pytest.mark.parametrize(
+    "b,sq,nhq,nhk,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_balanced,q_dtype,kv_dtype",
+    RING_MLA_TEST_CONFIGS,
+    ids=RING_MLA_TEST_CONFIG_IDS,
+)
+def test_ring_mla_determinism(
+    b,
+    sq,
+    nhq,
+    nhk,
+    d_q,
+    d_k,
+    d_v,
+    q_chunk_size,
+    k_chunk_size,
+    is_balanced,
+    q_dtype,
+    kv_dtype,
+):
+    run_ring_mla_sdpa(
+        MESH_CONFIG,
+        b,
+        nhq,
+        nhk,
+        sq,
+        d_q,
+        d_k,
+        d_v,
+        q_chunk_size,
+        k_chunk_size,
+        q_dtype,
+        kv_dtype,
+        is_balanced=is_balanced,
+        do_check=False,
+        num_iterations=10,
     )
 
 
@@ -1987,6 +2955,70 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
         f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("SDPA_PERF_CHECKS") != "1",
+    reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
+)
+def test_ring_mla_perf_better_than_separate_v_ring_joint():
+    """Profile ring_mla against the existing separate-V MLA ring joint path and require a speedup."""
+    from tracy.process_model_log import run_device_profiler
+
+    model_name = "mla_100k"
+    q_chunk_size = 160
+    k_chunk_size = 320
+    ring_size_expected = 4
+
+    if MESH_CONFIG.sp_size != ring_size_expected:
+        pytest.skip(f"Expected ring size {ring_size_expected}, current topology has ring size {MESH_CONFIG.sp_size}")
+    if model_name not in MODEL_CONFIGS or not RING_MLA_TEST_CONFIG_IDS:
+        pytest.skip("ring_mla perf config unavailable for current mesh")
+
+    model = MODEL_CONFIGS[model_name]
+    joint_config_id = get_test_case_id(model, q_chunk_size, k_chunk_size)
+    mla_config_id = RING_MLA_TEST_CONFIG_IDS[0]
+
+    float_cols = ["CORE COUNT", "DEVICE KERNEL DURATION [ns]"]
+    cols = ["ATTRIBUTES"]
+
+    def profile_duration(command, subdir):
+        with mock.patch.dict(os.environ, {"CI": "false"}):
+            run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+        result = post_process_ops_log(
+            subdir,
+            float_columns=float_cols,
+            columns=cols,
+            op_name="RingJointSDPADeviceOperation",
+            sum_vals=False,
+            has_signposts=False,
+        )
+        assert len(result["DEVICE KERNEL DURATION [ns]"]) > 0, f"profiler returned no SDPA ops for {command}"
+        return int(result["DEVICE KERNEL DURATION [ns]"].max())
+
+    ring_mla_duration_ns = profile_duration(
+        (
+            "pytest tests/nightly/blackhole/sdpa/"
+            f"test_ring_joint_sdpa.py::test_ring_mla_sweep_perf_impl[{mla_config_id}]"
+        ),
+        "ttnn_ring_mla_perf_check",
+    )
+    separate_v_duration_ns = profile_duration(
+        (
+            "pytest tests/nightly/blackhole/sdpa/"
+            f"test_ring_joint_sdpa.py::test_ring_joint_attention_sdpa_sweep_perf_impl[{joint_config_id}]"
+        ),
+        "ttnn_ring_mla_baseline_perf_check",
+    )
+
+    logger.info(
+        f"ring_mla perf: {ring_mla_duration_ns/1e6:.3f} ms, "
+        f"separate-V ring_joint: {separate_v_duration_ns/1e6:.3f} ms"
+    )
+    assert ring_mla_duration_ns < separate_v_duration_ns, (
+        f"ring_mla must beat separate-V ring_joint for {model_name} q={q_chunk_size} k={k_chunk_size}: "
+        f"{ring_mla_duration_ns/1e6:.3f} ms >= {separate_v_duration_ns/1e6:.3f} ms"
     )
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -831,7 +831,8 @@ template <
     bool kv_pad_rotation_enabled = false,
     uint32_t kv_pad_q_local_padded_Nt = 0,
     uint32_t kv_pad_chunk_size_t = 0,
-    uint32_t kv_pad_kv_local_padded_Nt = 0>
+    uint32_t kv_pad_kv_local_padded_Nt = 0,
+    uint32_t v_cb_physical_width_t = vDHt>
 static void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
@@ -1076,7 +1077,7 @@ static void sdpa_inner_loop_step(
                 }
                 if (kt_sub == 0) {
                     cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-                    cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
+                    cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
                 }
                 if (kt_sub > 0) {
                     PACK((llk_pack_reconfig_l1_acc(1)));
@@ -1327,7 +1328,7 @@ static void sdpa_inner_loop_step(
 
         // All rows pushed individually — no bulk push needed.
 
-        cb_pop_front(cb_v_in, KT_stride * vDHt);
+        cb_pop_front(cb_v_in, KT_stride * v_cb_physical_width_t);
         cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
     }
 }
@@ -1642,7 +1643,9 @@ template <
     bool local_n_mask_enabled = false,
     bool joint_n_mask_enabled = false,
     bool straddle_mask_enabled = false,
-    bool kv_pad_rotation_enabled = false>
+    bool kv_pad_rotation_enabled = false,
+    uint32_t v_cb_physical_width_t = vDHt,
+    bool v_shares_k_buffer = false>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1766,8 +1769,8 @@ void sdpa_ring_v2(
             if (is_causal_iter && k_chunk >= causal_k_limit) {
                 cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
                 sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
-                cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
-                sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * vDHt);
+                cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+                sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
                 KV_chunks_processed_in_iter++;
                 return true;
             }
@@ -2033,7 +2036,8 @@ void sdpa_ring_v2(
                 kv_pad_rotation_enabled,
                 q_local_padded_Nt,
                 chunk_size_t,
-                local_padded_Nt>(
+                local_padded_Nt,
+                v_cb_physical_width_t>(
                 q_prev,
                 q_cur,
                 is_last_k_of_last_ring_iter,
@@ -2098,11 +2102,13 @@ void sdpa_ring_v2(
         // On last ring_iter: normalized output already in cb_out from normalize_row_streaming
     }
 
-    // Dummy KV pop for double-buffer alignment (same as sdpa_inner_loop for RING)
-    if (KV_chunks_processed_in_iter % 2 == 0) {
+    // Dummy KV pop for CB write-pointer phase alignment across chained reader cores.
+    for (uint32_t dummy_chunk = 0;
+         dummy_chunk < dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer>(KV_chunks_processed_in_iter);
+         ++dummy_chunk) {
         cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
         sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
-        cb_wait_front(cb_v_in, Sk_chunk_t * vDHt);
-        sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * vDHt);
+        cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+        sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -71,6 +71,8 @@ void kernel_main() {
     constexpr uint32_t kv_pad_q_valid_tile_count = get_compile_time_arg_val(45);
     constexpr uint32_t active_ring_iter_mask = get_compile_time_arg_val(46);
     constexpr uint32_t last_active_ring_iter = get_compile_time_arg_val(47);
+    constexpr bool v_shares_k_buffer = get_compile_time_arg_val(48) == 1;
+    constexpr uint32_t v_cb_physical_width_t = v_shares_k_buffer ? DHt : vDHt;
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. kernel_is_causal is masked off by the program factory when chunked is on, so only
     // one of the two paths drives the stamp per program — but they share the CB slot layout.
@@ -109,7 +111,7 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 48;
+    constexpr uint32_t cb_arg_offset = 49;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -289,7 +291,9 @@ void kernel_main() {
                 local_n_has_padding,
                 joint_has_padding,
                 has_straddle && is_causal && is_balanced,
-                kv_pad_rotation_enabled>(
+                kv_pad_rotation_enabled,
+                v_cb_physical_width_t,
+                v_shares_k_buffer>(
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp
@@ -36,6 +36,31 @@ struct ChunkedContext {
     KVPadRotationContext kv_pad_rotation = {};
 };
 
+constexpr uint32_t chunks_until_next_multiple(uint32_t processed_chunks, uint32_t alignment) {
+    const uint32_t remainder = processed_chunks % alignment;
+    return remainder == 0 ? 0 : alignment - remainder;
+}
+
+template <bool v_shares_k_buffer>
+constexpr uint32_t dummy_kv_chunks_for_phase_alignment(uint32_t processed_chunks) {
+    // Reader pushes one K entry and one V entry per real chunk; compute pops the
+    // same entries. The dummy count pads the iteration so the next iteration
+    // starts on the same CB phase on every chained reader core.
+    if constexpr (v_shares_k_buffer) {
+        // Latent-V aliases cb_v_in to cb_k_in. Each real chunk consumes two
+        // entries in a three-entry CB cycle: K^T, then materialized V. Pad to
+        // the next multiple of three so the next K^T lands in the K phase.
+        constexpr uint32_t aliased_kv_cb_entries = 3;
+        return chunks_until_next_multiple(processed_chunks, aliased_kv_cb_entries);
+    }
+
+    // Separate K and V CBs keep the legacy two-phase chain cadence. Even chunk
+    // counts need one dummy K/V pair; odd counts already leave the next writer
+    // on the expected phase.
+    constexpr uint32_t separate_kv_phase_count = 2;
+    return (processed_chunks % separate_kv_phase_count) == 0 ? 1 : 0;
+}
+
 /**
  * Map a device-local K tile index to its global attention K position. Used by the
  * logical_n skip predicate and the diagonal-stamp mask coords. Under chunked-prefill

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -120,6 +120,29 @@ inline void fetch_v_from_source(
     }
 }
 
+template <typename LocalVGenerator, typename GatheredVGenerator>
+struct VSourceGenerators {
+    LocalVGenerator local;
+    GatheredVGenerator gathered;
+};
+
+template <uint32_t cb_v_in, uint32_t v_cb_entry_tiles, uint32_t Sk_chunk_t, uint32_t vDHt, uint32_t k_tile_bytes>
+inline void materialize_v_prefix_from_k(uint32_t kt_base_addr, uint32_t rows_to_materialize) {
+    cb_reserve_back(cb_v_in, v_cb_entry_tiles);
+    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+    noc_async_read_one_packet_set_state(get_noc_addr(kt_base_addr), k_tile_bytes);
+    for (uint32_t sk = 0; sk < rows_to_materialize; ++sk) {
+        uint32_t kt_read_ptr = kt_base_addr + sk * k_tile_bytes;
+        for (uint32_t vd = 0; vd < vDHt; ++vd) {
+            noc_async_read_one_packet_with_state<true>(kt_read_ptr, v_write_ptr);
+            v_write_ptr += k_tile_bytes;
+            kt_read_ptr += Sk_chunk_t * k_tile_bytes;
+        }
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_v_in, v_cb_entry_tiles);
+}
+
 void kernel_main() {
     constexpr uint32_t B = get_compile_time_arg_val(0);
     constexpr uint32_t NH = get_compile_time_arg_val(1);
@@ -156,6 +179,10 @@ void kernel_main() {
     constexpr bool indexed_kv_cache = get_compile_time_arg_val(27) == 1;
     constexpr bool kv_pad_rotation_enabled = get_compile_time_arg_val(28) == 1;
     constexpr uint32_t active_ring_iter_mask = get_compile_time_arg_val(29);
+    constexpr uint32_t NHV = get_compile_time_arg_val(30);
+    // Latent-V mode: absent V is materialized from the prefix of K tiles already in L1.
+    constexpr bool v_shares_k_buffer = get_compile_time_arg_val(31) == 1;
+    constexpr uint32_t q_heads_per_v = NH / NHV;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and joint generator uses.
@@ -163,7 +190,7 @@ void kernel_main() {
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
     constexpr bool has_joint_inputs = has_joint_q || has_joint_k;
 
-    constexpr auto q_args = TensorAccessorArgs<30>();
+    constexpr auto q_args = TensorAccessorArgs<32>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -188,7 +215,7 @@ void kernel_main() {
     }
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t cache_batch_idx = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     // Head chain runtime args (always present)
@@ -248,6 +275,7 @@ void kernel_main() {
 
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
+    constexpr uint32_t v_cb_entry_tiles = v_shares_k_buffer ? k_chunk_tiles : v_chunk_tiles;
 
     // Head chain (head-level): matches (batch, head), used by V and optionally K
     ChainLink<head_mcast_enabled, true> head_chain(
@@ -297,7 +325,7 @@ void kernel_main() {
         0,  // chain_head unused for batch-level chain
         batch_cfg.next_core_q_chunks);
 
-    // V always uses head chain
+    // Non-shared V uses the head chain. Latent-V reads V from K and does not need a separate V chain.
     auto& v_chain = head_chain;
 
     // K uses batch chain when NHK == 1 (MLA), else head chain (compile-time IIFE selection)
@@ -318,23 +346,26 @@ void kernel_main() {
 
     const auto q_reader = TensorAccessor(q_args, q_addr);
     const auto local_k_reader = TensorAccessor(k_args, k_addr);
-    const auto local_v_reader = TensorAccessor(v_args, v_addr);
     const auto gathered_k_reader = TensorAccessor(gathered_k_args, gathered_k_addr);
-    const auto gathered_v_reader = TensorAccessor(gathered_v_args, gathered_v_addr);
 
-    const uint32_t kv_batch_dim = indexed_kv_cache ? cache_batch_idx + 1 : B;
+    const uint32_t kv_batch_dim = indexed_kv_cache ? kv_cache_batch_idx + 1 : B;
     const auto input_q_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, DHt);
     const auto input_k_tile_logical = TensorTileShape(kv_batch_dim, NHK, kv_local_padded_Nt, DHt);
-    const auto input_v_tile_logical = TensorTileShape(kv_batch_dim, NH, kv_local_padded_Nt, vDHt);
     const auto gathered_k_input_tile_logical = TensorTileShape(kv_batch_dim, NHK, padded_Nt, DHt);
-    const auto gathered_v_input_tile_logical = TensorTileShape(kv_batch_dim, NH, padded_Nt, vDHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
 
     const auto q_generator = PaddedAddrGenerator(q_reader, input_q_tile_logical);
     const auto local_k_generator = PaddedAddrGenerator(local_k_reader, input_k_tile_logical);
-    const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
     const auto gathered_k_generator = PaddedAddrGenerator(gathered_k_reader, gathered_k_input_tile_logical);
+    const auto local_v_reader = TensorAccessor(v_args, v_addr);
+    const auto input_v_tile_logical = TensorTileShape(kv_batch_dim, NHV, kv_local_padded_Nt, vDHt);
+    const auto gathered_v_reader = TensorAccessor(gathered_v_args, gathered_v_addr);
+    const auto gathered_v_input_tile_logical = TensorTileShape(kv_batch_dim, NHV, padded_Nt, vDHt);
+    const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
     const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_v_input_tile_logical);
+    [[maybe_unused]] const auto v_generators =
+        VSourceGenerators<decltype(local_v_generator), decltype(gathered_v_generator)>{
+            local_v_generator, gathered_v_generator};
 
     // Tracks whether Q has been pushed for q_per_core == 1 optimization.
     // When q_per_core == 1, Q is identical across ring iterations so we only push it once.
@@ -469,32 +500,23 @@ void kernel_main() {
 
                 // Default to local/gathered KV; override below for joint KV when applicable.
                 Slice k_slice;
-                Slice v_slice;
-                uint32_t k_end_seq_tile;
-                uint32_t v_end_seq_tile;
+                uint32_t end_seq_tile;
                 const uint32_t nk = nq / q_heads_per_k;
-                const uint32_t kv_batch = indexed_kv_cache ? cache_batch_idx : nb;
+                const uint32_t kv_batch = indexed_kv_cache ? kv_cache_batch_idx : nb;
                 if (ring_iter == 0) {
                     const uint32_t local_k_start_tile = k_chunk * Sk_chunk_t;
-                    const uint32_t local_v_start_tile = k_chunk * Sk_chunk_t;
                     k_slice = Slice(kv_batch, nk, local_k_start_tile, local_k_start_tile + Sk_chunk_t, 0, DHt);
-                    v_slice = Slice(kv_batch, nq, local_v_start_tile, local_v_start_tile + Sk_chunk_t, 0, vDHt);
-                    k_end_seq_tile = ring_iter_valid_kv_tiles;
-                    v_end_seq_tile = ring_iter_valid_kv_tiles;
+                    end_seq_tile = ring_iter_valid_kv_tiles;
                 } else {
                     const uint32_t gathered_start_tile = ring_id * kv_local_padded_Nt + k_chunk * Sk_chunk_t;
                     k_slice = Slice(kv_batch, nk, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, DHt);
-                    v_slice = Slice(kv_batch, nq, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, vDHt);
-                    k_end_seq_tile = ring_id * kv_local_padded_Nt + ring_iter_valid_kv_tiles;
-                    v_end_seq_tile = k_end_seq_tile;
+                    end_seq_tile = ring_id * kv_local_padded_Nt + ring_iter_valid_kv_tiles;
                 }
                 if constexpr (has_joint_k) {
                     if (kv_chunk_is_joint) {
                         const uint32_t joint_k_row_start_tile = (k_chunk - num_local_k_chunks) * Sk_chunk_t;
                         k_slice = Slice(nb, nk, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, DHt);
-                        v_slice = Slice(nb, nq, joint_k_row_start_tile, joint_k_row_start_tile + Sk_chunk_t, 0, vDHt);
-                        k_end_seq_tile = Lt;
-                        v_end_seq_tile = Lt;
+                        end_seq_tile = Lt;
                     }
                 }
 
@@ -515,7 +537,7 @@ void kernel_main() {
                     // local and gathered tensors may use different accessor types.
                     const auto fetch_k = [&](const auto& k_gen) {
                         fetch_block(
-                            k_gen, k_slice, k_end_seq_tile, cb_k_start_address, k_tile_bytes, true /*transpose*/);
+                            k_gen, k_slice, end_seq_tile, cb_k_start_address, k_tile_bytes, true /*transpose*/);
                     };
                     fetch_k_from_source<has_joint_k, joint_tensor_args_offset>(
                         kv_chunk_is_joint,
@@ -532,15 +554,17 @@ void kernel_main() {
                     k_chain.forward(cb_k_start_address, k_chunk_tiles, k_tile_bytes);
                 }
 
-                // Skip Q, V reads and V forward for padded iterations (K mcast sync only).
+                // Skip Q and compute-visible pushes for padded K-mcast iterations.
                 // Note: cb_push_back is intentionally skipped — without it, the write pointer
                 // doesn't advance, so cb_reserve_back returns the same address each iteration.
                 // This lets the buffer act as a reusable staging area for the mcast.
                 if (is_padded_iter) {
+                    // Padded iterations participate in the chain handshake but do not generate
+                    // compute-visible K/V. In latent-V mode, only the K^T segment is transported.
                     continue;
                 }
 
-                // Make K available to compute
+                // Make K available to compute.
                 cb_push_back(cb_k_in, k_chunk_tiles);
                 KV_chunks_processed_in_iter++;
 
@@ -580,41 +604,79 @@ void kernel_main() {
                     q_pushed = true;
                 }
 
-                // V: either read locally (injector or not participant) or receive from chain
-                cb_reserve_back(cb_v_in, v_chunk_tiles);
-                uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
-                if (v_chain.should_receive(nb, nq)) {
-                    v_chain.receive();
+                if constexpr (v_shares_k_buffer) {
+                    bool skip_v_materialization = false;
+                    uint32_t v_rows_to_materialize = Sk_chunk_t;
+                    if constexpr (is_causal && !chunked_enabled) {
+                        if (ring_iter == 0) {
+                            // Local causal chunks beyond this limit are fully masked. Compute still
+                            // advances the K/V FIFO phase, but does not consume V values for them.
+                            const uint32_t causal_k_limit =
+                                (q_row_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
+                            skip_v_materialization = k_chunk >= causal_k_limit;
+                            if (!skip_v_materialization && k_chunk == causal_k_limit - 1) {
+                                const uint32_t active_rows = q_row_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
+                                if (active_rows < Sk_chunk_t) {
+                                    // Compute narrows active_Sk to this same row count, so the unfilled tail
+                                    // of the fixed-size V entry is kept for FIFO phase only and is never read.
+                                    v_rows_to_materialize = active_rows;
+                                }
+                            }
+                        }
+                    }
+
+                    // Same physical CB as K. K^T is already pushed; reserve a second fixed-size
+                    // FIFO entry whose prefix is compact V[Sk, vDHt] via local L1-to-L1 NoC reads.
+                    if (skip_v_materialization) {
+                        // Preserve the logical V FIFO entry for phase alignment. No fill is needed
+                        // because compute skips the fully masked K chunk.
+                        cb_reserve_back(cb_v_in, v_cb_entry_tiles);
+                        cb_push_back(cb_v_in, v_cb_entry_tiles);
+                    } else {
+                        materialize_v_prefix_from_k<cb_v_in, v_cb_entry_tiles, Sk_chunk_t, vDHt, k_tile_bytes>(
+                            cb_k_start_address, v_rows_to_materialize);
+                    }
                 } else {
-                    const auto fetch_v = [&](const auto& v_gen) {
-                        fetch_block(
-                            v_gen, v_slice, v_end_seq_tile, cb_v_start_address, v_tile_bytes, false /*transpose*/);
-                    };
-                    fetch_v_from_source<has_joint_k, joint_tensor_args_offset>(
-                        kv_chunk_is_joint,
-                        ring_iter,
-                        joint_v_addr,
-                        local_v_generator,
-                        gathered_v_generator,
-                        joint_input_tile_logical,
-                        fetch_v);
-                }
+                    // V: either read locally (injector or not participant) or receive from chain.
+                    const uint32_t nv = nq / q_heads_per_v;
+                    const Slice v_slice(k_slice.d0, nv, k_slice.d2_start, k_slice.d2_end, 0, vDHt);
+                    cb_reserve_back(cb_v_in, v_cb_entry_tiles);
+                    uint32_t cb_v_start_address = get_write_ptr(cb_v_in);
+                    if (v_chain.should_receive(nb, nv)) {
+                        v_chain.receive();
+                    } else {
+                        const auto fetch_v = [&](const auto& v_gen) {
+                            fetch_block(
+                                v_gen, v_slice, end_seq_tile, cb_v_start_address, v_tile_bytes, false /*transpose*/);
+                        };
+                        fetch_v_from_source<has_joint_k, joint_tensor_args_offset>(
+                            kv_chunk_is_joint,
+                            ring_iter,
+                            joint_v_addr,
+                            v_generators.local,
+                            v_generators.gathered,
+                            joint_input_tile_logical,
+                            fetch_v);
+                    }
 
-                // Forward V to next core(s) before push_back — prevents compute from
-                // popping the buffer while the mcast is still reading from it.
-                if (v_chain.should_forward(nb, nq, q_iter_local)) {
-                    v_chain.forward(cb_v_start_address);
-                }
+                    // Forward V to next core(s) before push_back — prevents compute from
+                    // popping the buffer while the mcast is still reading from it.
+                    if (v_chain.should_forward(nb, nv, q_iter_local)) {
+                        v_chain.forward(cb_v_start_address);
+                    }
 
-                // Make V available to compute
-                cb_push_back(cb_v_in, v_chunk_tiles);
+                    // Make V available to compute.
+                    cb_push_back(cb_v_in, v_cb_entry_tiles);
+                }
             }
         }
-        if (KV_chunks_processed_in_iter % 2 == 0) {
+        for (uint32_t dummy_chunk = 0;
+             dummy_chunk < dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer>(KV_chunks_processed_in_iter);
+             ++dummy_chunk) {
             cb_reserve_back(cb_k_in, k_chunk_tiles);
-            cb_reserve_back(cb_v_in, v_chunk_tiles);
             cb_push_back(cb_k_in, k_chunk_tiles);
-            cb_push_back(cb_v_in, v_chunk_tiles);
+            cb_reserve_back(cb_v_in, v_cb_entry_tiles);
+            cb_push_back(cb_v_in, v_cb_entry_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -125,10 +125,11 @@ void validate_ring_joint_all_gather_on_program_cache_miss(
 void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input_tensor_q = tensor_args.input_q;
-
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
-    const auto& gathered_input_tensor_v = tensor_args.gathered_v;
 
+    const bool has_input_v = tensor_args.input_v.has_value();
+    const bool has_gathered_v = tensor_args.gathered_v.has_value();
+    const bool has_latent_v = tensor_args.has_latent_v();
     const bool has_joint_tensors =
         tensor_args.joint_q.has_value() || tensor_args.joint_k.has_value() || tensor_args.joint_v.has_value();
     TT_FATAL(
@@ -136,7 +137,10 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
             tensor_args.joint_v.has_value() == has_joint_tensors,
         "Joint tensors must be provided all together or omitted altogether");
 
-    std::vector<Tensor> sdpa_input_tensors = {input_tensor_q, gathered_input_tensor_k, gathered_input_tensor_v};
+    std::vector<Tensor> sdpa_input_tensors = {input_tensor_q, gathered_input_tensor_k};
+    if (has_gathered_v) {
+        sdpa_input_tensors.push_back(tensor_args.gathered_v.value());
+    }
     if (has_joint_tensors) {
         sdpa_input_tensors.push_back(tensor_args.joint_q.value());
         sdpa_input_tensors.push_back(tensor_args.joint_k.value());
@@ -165,12 +169,13 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     // Get shapes
     const auto& q_shape = input_tensor_q.logical_shape();
     const auto& k_shape = gathered_input_tensor_k.logical_shape();
-    const auto& v_shape = gathered_input_tensor_v.logical_shape();
+    const auto v_shape = has_gathered_v ? tensor_args.gathered_v->logical_shape() : k_shape;
     const auto joint_q_shape = has_joint_tensors ? tensor_args.joint_q.value().logical_shape() : q_shape;
     const auto joint_k_shape = has_joint_tensors ? tensor_args.joint_k.value().logical_shape() : q_shape;
     const auto joint_v_shape = has_joint_tensors ? tensor_args.joint_v.value().logical_shape() : q_shape;
-
     const bool has_indexed_kv_cache = args.has_indexed_kv_cache();
+    const uint32_t NVH = tensor_args.v_num_heads();
+    const uint32_t VDH = tensor_args.v_head_dim(args.latent_v_head_dim);
 
     // Chunked-prefill (`tensor_args.is_chunked()`): Q is shorter than the per-device K shard
     // (latest slab against a growing K cache). Chunk 0 has equal shapes and uses the regular
@@ -206,12 +211,13 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto B = q_shape[0];
     const auto NQH = q_shape[1];
     const auto NKH = k_shape[1];
-    const auto NVH = v_shape[1];
     const auto N_local_q = q_shape[2];
     const auto N_local_kv = tensor_args.local_kv_seq_len();
     const auto N_global = k_shape[2];
     const auto L = has_joint_tensors ? joint_q_shape[2] : 0;
     const auto DH = q_shape[3];
+    const uint32_t v_local_seq =
+        has_input_v ? static_cast<uint32_t>(tensor_args.input_v->logical_shape()[2]) : N_local_kv;
 
     auto q_chunk_size = args.get_q_chunk_size();
     auto k_chunk_size = args.get_k_chunk_size();
@@ -301,29 +307,54 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         !(args.is_balanced && (N_local_q / 2) % q_chunk_size != 0),
         "q_chunk_size must divide half of local q seq_len in balanced case");
 
+    TT_FATAL(
+        has_input_v == has_gathered_v,
+        "input_tensor_v and persistent_output_buffer_v must both be provided for tensor-V mode, or both omitted for "
+        "latent-V mode");
+    TT_FATAL(VDH > 0, "V head dimension must be provided and non-zero");
+    if (has_latent_v) {
+        TT_FATAL(NKH == 1, "Latent-V mode currently supports one shared KV head. Got K/V heads: {}", NKH);
+        TT_FATAL(
+            NVH == NKH,
+            "Latent-V mode reads V from K's prefix, so V head count must match K head count. Got V: {}, K: {}",
+            NVH,
+            NKH);
+        TT_FATAL(
+            VDH < DH,
+            "Latent-V mode reads V from K's strict prefix, so V head dim must be < K head dim. Got V: {}, K: {}",
+            VDH,
+            DH);
+        TT_FATAL(
+            VDH % tt::constants::TILE_WIDTH == 0,
+            "Latent-V head dim must be tile aligned. Got V: {}, tile width: {}",
+            VDH,
+            tt::constants::TILE_WIDTH);
+    }
+
     if (has_indexed_kv_cache) {
         const auto K_cache_batch = tensor_args.input_k.logical_shape()[0];
-        const auto V_cache_batch = tensor_args.input_v.logical_shape()[0];
+        const auto V_cache_batch = has_input_v ? tensor_args.input_v->logical_shape()[0] : K_cache_batch;
         TT_FATAL(
             B == 1,
-            "cache_batch_idx currently selects one shared K/V cache slot for the whole query batch; indexed K/V cache "
+            "kv_cache_batch_idx currently selects one shared K/V cache slot for the whole query batch; indexed K/V "
+            "cache "
             "mode requires Q batch size 1. Got Q batch size {}",
             B);
         TT_FATAL(
-            args.cache_batch_idx.value() < K_cache_batch,
-            "cache_batch_idx={} is outside K cache batch={}",
-            args.cache_batch_idx.value(),
+            args.kv_cache_batch_idx.value() < K_cache_batch,
+            "kv_cache_batch_idx={} is outside K cache batch={}",
+            args.kv_cache_batch_idx.value(),
             K_cache_batch);
-        TT_FATAL(
-            args.cache_batch_idx.value() < V_cache_batch,
-            "cache_batch_idx={} is outside V cache batch={}",
-            args.cache_batch_idx.value(),
-            V_cache_batch);
         TT_FATAL(
             k_shape[0] == K_cache_batch,
             "Gathered K cache batch must match input K cache batch. Got gathered K: {}, input K: {}",
             k_shape[0],
             K_cache_batch);
+        TT_FATAL(
+            args.kv_cache_batch_idx.value() < V_cache_batch,
+            "kv_cache_batch_idx={} is outside V cache batch={}",
+            args.kv_cache_batch_idx.value(),
+            V_cache_batch);
         TT_FATAL(
             v_shape[0] == V_cache_batch,
             "Gathered V cache batch must match input V cache batch. Got gathered V: {}, input V: {}",
@@ -346,11 +377,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     // Chunked-prefill targets MLA (K head dim == Q != V) — use is_causal's relaxed K-only check.
     if (!args.is_causal && !is_chunked) {
         TT_FATAL(
-            k_shape[3] == DH && v_shape[3] == DH,
-            "Head dimensions must match. Got Q: {}, K: {}, V: {}",
-            DH,
-            k_shape[3],
-            v_shape[3]);
+            k_shape[3] == DH && VDH == DH, "Head dimensions must match. Got Q: {}, K: {}, V: {}", DH, k_shape[3], VDH);
         if (has_joint_tensors) {
             TT_FATAL(
                 joint_q_shape[3] == DH && joint_k_shape[3] == DH && joint_v_shape[3] == DH,
@@ -399,7 +426,11 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         k_shape[2],
         v_shape[2]);
 
-    TT_FATAL(NQH == NVH, "Q num_heads must be equal to V num_heads. Got Q: {}, V: {}", NQH, NVH);
+    TT_FATAL(
+        has_latent_v || NQH == NVH,
+        "Tensor-V mode requires Q num_heads to equal V num_heads. Got Q: {}, V: {}",
+        NQH,
+        NVH);
     TT_FATAL(NKH == NVH || NKH == 1, "K num_heads must be equal to V num_heads or 1. Got K: {}, V: {}", NKH, NVH);
 
     // Validate chunk sizes if program config is provided
@@ -426,9 +457,9 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         N_local_kv,
         tt::constants::TILE_HEIGHT);
     TT_FATAL(
-        tensor_args.input_v.logical_shape()[2] == N_local_kv,
+        v_local_seq == N_local_kv,
         "V local seq length must match K local seq length. Got V: {}, K: {}",
-        tensor_args.input_v.logical_shape()[2],
+        v_local_seq,
         N_local_kv);
 
     // Validate padding: Only the sequence dimension may be padded
@@ -449,12 +480,14 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input = tensor_args.input_q;
     const bool has_joint_tensors = tensor_args.joint_q.has_value();
+    const auto v_head_dim = tensor_args.v_head_dim(args.latent_v_head_dim);
     auto joint_output_shape = input.logical_shape();
     joint_output_shape[2] = 0;
-    joint_output_shape[3] = tensor_args.input_v.logical_shape()[3];
+    joint_output_shape[3] = v_head_dim;
     uint32_t joint_padded_seq = 0;
     if (has_joint_tensors) {
         joint_output_shape = tensor_args.joint_q.value().logical_shape();
+        joint_output_shape[3] = v_head_dim;
         joint_padded_seq = tensor_args.joint_q.value().padded_shape()[2];
     }
 
@@ -466,7 +499,7 @@ RingJointSDPAResultSpec RingJointSDPADeviceOperation::compute_output_specs(
 
     auto out_shape = input.logical_shape();
     // head dim as v head dim
-    out_shape[3] = tensor_args.input_v.logical_shape()[3];
+    out_shape[3] = v_head_dim;
 
     return {
         TensorSpec(out_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), args.output_memory_config)),
@@ -487,15 +520,21 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
-    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k, tensor_args.input_v};
+    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k};
+    if (tensor_args.input_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.input_v.value());
+    }
     if (tensor_args.joint_q.has_value()) {
         input_tensors.emplace_back(tensor_args.joint_q.value());
         input_tensors.emplace_back(tensor_args.joint_k.value());
+    }
+    if (tensor_args.joint_v.has_value()) {
         input_tensors.emplace_back(tensor_args.joint_v.value());
     }
     input_tensors.emplace_back(tensor_args.gathered_k);
-    input_tensors.emplace_back(tensor_args.gathered_v);
-
+    if (tensor_args.gathered_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.gathered_v.value());
+    }
     return tt::tt_metal::operation::hash_operation<RingJointSDPADeviceOperation>(
         input_tensors,
         args.joint_strategy,
@@ -507,10 +546,13 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         args.compute_kernel_config,
         args.program_config,
         args.ccl_core_grid_offset,
-        // cache_batch_idx is a reader runtime arg, but descriptor cache-hit patching only updates buffer rt args.
+        // kv_cache_batch_idx is a reader runtime arg, but descriptor cache-hit patching only updates buffer rt args.
         // Keep the value in the op hash so a cached Program never reuses stale scalar rt args for another slot.
-        args.cache_batch_idx,
+        args.kv_cache_batch_idx,
         args.kv_actual_isl,
+        tensor_args.has_latent_v(),
+        tensor_args.v_num_heads(),
+        tensor_args.v_head_dim(args.latent_v_head_dim),
         ttnn::experimental::prim::RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash(
             args.all_gather_operation_attributes, args.all_gather_tensor_args) /*all_gather input tensors*/
     );
@@ -518,14 +560,21 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
-    Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k, tensor_args.input_v};
+    Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k};
+    if (tensor_args.input_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.input_v.value());
+    }
     if (tensor_args.joint_q.has_value()) {
         input_tensors.emplace_back(tensor_args.joint_q.value());
         input_tensors.emplace_back(tensor_args.joint_k.value());
+    }
+    if (tensor_args.joint_v.has_value()) {
         input_tensors.emplace_back(tensor_args.joint_v.value());
     }
     input_tensors.emplace_back(tensor_args.gathered_k);
-    input_tensors.emplace_back(tensor_args.gathered_v);
+    if (tensor_args.gathered_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.gathered_v.value());
+    }
 
     auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
     auto arch = output_tensor.storage_type() == StorageType::DEVICE ? output_tensor.device()->arch()
@@ -538,7 +587,6 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
 
     const auto& q_shape = tensor_args.input_q.logical_shape();
     const auto& gathered_k_shape = tensor_args.gathered_k.logical_shape();
-    const auto& v_shape = tensor_args.gathered_v.logical_shape();
 
     CoreCoord grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
                                                      : output_tensor.device()->compute_with_storage_grid_size();
@@ -550,7 +598,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const uint32_t N_global = gathered_k_shape[2];
     const uint32_t L = tensor_args.joint_q.has_value() ? tensor_args.joint_q.value().logical_shape()[2] : 0;
     const uint32_t DH = q_shape[3];
-    const uint32_t DV = v_shape[3];
+    const uint32_t DV = tensor_args.v_head_dim(args.latent_v_head_dim);
 
     // RingJointSDPA: local Q and joint Q attend to (gathered K + joint K)
     // Total Q dimension: N_local + L, Total K dimension: N_global + L
@@ -564,19 +612,15 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
 }
 
-}  // namespace ttnn::prim
-
-namespace ttnn::prim {
-
 RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
-    const ttnn::Tensor& input_tensor_v,
+    const std::optional<ttnn::Tensor>& input_tensor_v,
     const std::optional<ttnn::Tensor>& joint_tensor_q,
     const std::optional<ttnn::Tensor>& joint_tensor_k,
     const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
-    ttnn::Tensor& persistent_output_buffer_v,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer_v,
     const std::string& joint_strategy,
     const std::size_t logical_n,
     ttnn::operations::transformer::SDPAProgramConfig program_config,
@@ -584,17 +628,18 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
     const uint32_t num_links,
     const uint32_t cluster_axis,
-    const MeshDevice& mesh_device,
+    const ttnn::MeshDevice& mesh_device,
     const ttnn::ccl::Topology topology,
     const CoreCoord ccl_core_grid_offset,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     const bool is_causal,
     const bool is_balanced,
     const std::optional<float> scale,
-    const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
-    const std::optional<uint32_t> cache_batch_idx,
-    const std::optional<uint32_t> kv_actual_isl) {
+    const std::optional<uint32_t> kv_cache_batch_idx,
+    const std::optional<uint32_t> kv_actual_isl,
+    const std::optional<uint32_t> latent_v_head_dim) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -635,8 +680,29 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         subdevice_id,
         cluster_axis,
         core_allocation_strategy};
+    std::vector<Tensor> all_gather_input_tensors = {input_tensor_k};
+    std::vector<std::optional<Tensor>> all_gather_output_tensors = {persistent_output_buffer_k};
+    if (input_tensor_v.has_value()) {
+        TT_FATAL(
+            persistent_output_buffer_v.has_value(),
+            "persistent_output_buffer_v must be provided when input_tensor_v is provided");
+        TT_FATAL(
+            !latent_v_head_dim.has_value(),
+            "latent_v_head_dim is only valid when input_tensor_v is omitted for latent-V mode");
+        all_gather_input_tensors.push_back(input_tensor_v.value());
+        all_gather_output_tensors.push_back(persistent_output_buffer_v);
+    } else {
+        TT_FATAL(
+            !persistent_output_buffer_v.has_value(),
+            "persistent_output_buffer_v must be omitted when input_tensor_v is omitted for latent-V mode");
+        TT_FATAL(latent_v_head_dim.has_value(), "latent_v_head_dim must be provided when input_tensor_v is omitted");
+        TT_FATAL(
+            !joint_tensor_q.has_value() && !joint_tensor_k.has_value() && !joint_tensor_v.has_value(),
+            "joint tensors must be omitted when input_tensor_v is omitted for latent-V mode");
+    }
+
     auto all_gather_tensor_args = ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs{
-        {input_tensor_k, input_tensor_v}, {persistent_output_buffer_k, persistent_output_buffer_v}};
+        std::move(all_gather_input_tensors), std::move(all_gather_output_tensors)};
 
     auto operation_attributes = OperationType::operation_attributes_t(
         joint_strategy,
@@ -651,8 +717,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         std::move(all_gather_operation_attributes),
         std::move(all_gather_tensor_args),
         ccl_core_grid_offset,
-        cache_batch_idx,
-        kv_actual_isl);
+        kv_cache_batch_idx,
+        kv_actual_isl,
+        latent_v_head_dim.value_or(0));
 
     auto tensor_args = OperationType::tensor_args_t{
         .input_q = input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -34,12 +34,12 @@ struct RingJointSDPADeviceOperation {
 RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const ttnn::Tensor& input_tensor_q,
     const ttnn::Tensor& input_tensor_k,
-    const ttnn::Tensor& input_tensor_v,
+    const std::optional<ttnn::Tensor>& input_tensor_v,
     const std::optional<ttnn::Tensor>& joint_tensor_q,
     const std::optional<ttnn::Tensor>& joint_tensor_k,
     const std::optional<ttnn::Tensor>& joint_tensor_v,
     ttnn::Tensor& persistent_output_buffer_k,
-    ttnn::Tensor& persistent_output_buffer_v,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer_v,
     const std::string& joint_strategy,
     std::size_t logical_n,
     ttnn::operations::transformer::SDPAProgramConfig program_config,
@@ -56,7 +56,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt,
-    std::optional<uint32_t> kv_actual_isl = std::nullopt);
+    std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> kv_actual_isl = std::nullopt,
+    std::optional<uint32_t> latent_v_head_dim = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -29,8 +29,9 @@ struct RingJointSDPAParams {
     experimental::prim::RingAttentionAllGatherAsyncParams all_gather_operation_attributes;
     experimental::prim::RingAttentionAllGatherAsyncInputs all_gather_tensor_args;
     CoreCoord ccl_core_grid_offset;
-    std::optional<std::uint32_t> cache_batch_idx = std::nullopt;
+    std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt;
     std::optional<std::uint32_t> kv_actual_isl = std::nullopt;
+    uint32_t latent_v_head_dim = 0;
 
     // We need a constructor, because all_gather_struct is not default initializable.
     RingJointSDPAParams(
@@ -46,8 +47,9 @@ struct RingJointSDPAParams {
         experimental::prim::RingAttentionAllGatherAsyncParams all_gather_operation_attributes,
         experimental::prim::RingAttentionAllGatherAsyncInputs all_gather_tensor_args,
         CoreCoord ccl_core_grid_offset,
-        std::optional<std::uint32_t> cache_batch_idx = std::nullopt,
-        std::optional<std::uint32_t> kv_actual_isl = std::nullopt) :
+        std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt,
+        std::optional<std::uint32_t> kv_actual_isl = std::nullopt,
+        uint32_t latent_v_head_dim = 0) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
         is_causal(is_causal),
@@ -60,8 +62,9 @@ struct RingJointSDPAParams {
         all_gather_operation_attributes(std::move(all_gather_operation_attributes)),
         all_gather_tensor_args(std::move(all_gather_tensor_args)),
         ccl_core_grid_offset(ccl_core_grid_offset),
-        cache_batch_idx(cache_batch_idx),
-        kv_actual_isl(kv_actual_isl) {}
+        kv_cache_batch_idx(kv_cache_batch_idx),
+        kv_actual_isl(kv_actual_isl),
+        latent_v_head_dim(latent_v_head_dim) {}
 
     auto attributes() const {
         using ttsl::reflection::Attribute;
@@ -74,12 +77,13 @@ struct RingJointSDPAParams {
         attrs.emplace_back("output_memory_config", output_memory_config);
         attrs.emplace_back("compute_kernel_config", compute_kernel_config);
         attrs.emplace_back("ccl_core_grid_offset", ccl_core_grid_offset);
-        if (cache_batch_idx.has_value()) {
-            attrs.emplace_back("cache_batch_idx", cache_batch_idx.value());
+        if (kv_cache_batch_idx.has_value()) {
+            attrs.emplace_back("kv_cache_batch_idx", kv_cache_batch_idx.value());
         }
         if (kv_actual_isl.has_value()) {
             attrs.emplace_back("kv_actual_isl", kv_actual_isl.value());
         }
+        attrs.emplace_back("latent_v_head_dim", latent_v_head_dim);
         if (scale.has_value()) {
             attrs.emplace_back("scale", scale);
         }
@@ -93,7 +97,7 @@ struct RingJointSDPAParams {
 
     std::uint32_t get_k_chunk_size() const { return program_config.has_value() ? program_config->k_chunk_size : 32; }
 
-    bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+    bool has_indexed_kv_cache() const { return kv_cache_batch_idx.has_value(); }
 
     bool has_kv_pad_rotation() const { return kv_actual_isl.has_value(); }
 };
@@ -101,18 +105,31 @@ struct RingJointSDPAParams {
 struct RingJointSDPAInputs {
     Tensor input_q;
     Tensor input_k;
-    Tensor input_v;
+    std::optional<Tensor> input_v;
     std::optional<Tensor> joint_q;
     std::optional<Tensor> joint_k;
     std::optional<Tensor> joint_v;
     Tensor gathered_k;
-    Tensor gathered_v;
+    std::optional<Tensor> gathered_v;
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.
     uint32_t local_kv_seq_len() const { return static_cast<uint32_t>(input_k.logical_shape()[2]); }
 
     bool is_chunked() const { return input_q.logical_shape()[2] < local_kv_seq_len(); }
+
+    // Latent-V optimization: absent V means the reader reuses K's buffer
+    // and reads the first vDHt head-dim tiles (V's logical head dim).
+    bool has_latent_v() const { return !input_v.has_value(); }
+
+    uint32_t v_num_heads() const {
+        return input_v.has_value() ? static_cast<uint32_t>(input_v->logical_shape()[1])
+                                   : static_cast<uint32_t>(input_k.logical_shape()[1]);
+    }
+
+    uint32_t v_head_dim(uint32_t latent_v_head_dim) const {
+        return input_v.has_value() ? static_cast<uint32_t>(input_v->logical_shape()[3]) : latent_v_head_dim;
+    }
 };
 
 // Index constants for RingJointSDPAResult vector

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -237,19 +237,22 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         - if this is not the first ring iteration, do the LSE update.
     */
 
-    log_debug(tt::LogOp, "DEBUG: create_descriptor is called");
+    log_debug(tt::LogOp, "RingJointSDPA create_descriptor");
 
     const auto& input_tensor_q = tensor_args.input_q;
     const auto& input_tensor_k = tensor_args.input_k;
-    const auto& input_tensor_v = tensor_args.input_v;
+    const bool v_shares_k_buffer = tensor_args.has_latent_v();
+    const auto& input_tensor_v = tensor_args.input_v.has_value() ? tensor_args.input_v.value() : input_tensor_k;
 
     const bool has_joint_tensors = tensor_args.joint_q.has_value();
     const Tensor* joint_tensor_q = has_joint_tensors ? &tensor_args.joint_q.value() : nullptr;
     const Tensor* joint_tensor_k = has_joint_tensors ? &tensor_args.joint_k.value() : nullptr;
-    const Tensor* joint_tensor_v = has_joint_tensors ? &tensor_args.joint_v.value() : nullptr;
+    const Tensor* joint_tensor_v =
+        has_joint_tensors ? (tensor_args.joint_v.has_value() ? &tensor_args.joint_v.value() : joint_tensor_k) : nullptr;
 
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
-    const auto& gathered_input_tensor_v = tensor_args.gathered_v;
+    const auto& gathered_input_tensor_v =
+        tensor_args.gathered_v.has_value() ? tensor_args.gathered_v.value() : gathered_input_tensor_k;
 
     auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
     auto& joint_output_tensor = output_tensors[RING_JOINT_SDPA_JOINT_OUTPUT_IDX];
@@ -315,25 +318,35 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     const auto& q_shape = input_tensor_q.logical_shape();
     const auto& k_shape = gathered_input_tensor_k.logical_shape();
-    const auto& v_shape = gathered_input_tensor_v.logical_shape();
 
     log_debug(tt::LogOp, "q_shape: {}", q_shape);
     log_debug(tt::LogOp, "k_shape (gathered): {}", k_shape);
-    log_debug(tt::LogOp, "v_shape (gathered): {}", v_shape);
+    if (tensor_args.gathered_v.has_value()) {
+        log_debug(tt::LogOp, "v_shape (gathered): {}", tensor_args.gathered_v->logical_shape());
+    } else {
+        log_debug(
+            tt::LogOp,
+            "v_shape (latent): [B={}, NHV=1, N=0, DH={}]",
+            q_shape[0],
+            tensor_args.v_head_dim(args.latent_v_head_dim));
+    }
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
     const bool indexed_kv_cache = args.has_indexed_kv_cache();
+    // Latent-V mode: V tensors are omitted; the reader reuses K's buffer and
+    // reads only the first vDHt head-dim tiles.
     const uint32_t B = q_shape[0];
     const uint32_t NH = q_shape[1];
     const uint32_t NHK = k_shape[1];
+    const uint32_t NHV = tensor_args.v_num_heads();
     const uint32_t DH = q_shape[3];
     const uint32_t q_local_padded_N = q_shape[2];
     const uint32_t kv_local_padded_N = tensor_args.local_kv_seq_len();
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
     const uint32_t padded_N = k_shape[2];
-    const uint32_t cache_batch_idx = args.cache_batch_idx.value_or(0);
+    const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
     const uint32_t L = has_joint_tensors ? joint_tensor_q->logical_shape()[2] : 0;
-    const uint32_t vDH = v_shape[3];
+    const uint32_t vDH = tensor_args.v_head_dim(args.latent_v_head_dim);
 
     const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t kv_local_padded_Nt = kv_local_padded_N / tt::constants::TILE_HEIGHT;
@@ -399,6 +412,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "B: {}", B);
     log_debug(tt::LogOp, "NH: {}", NH);
     log_debug(tt::LogOp, "NHK: {}", NHK);
+    log_debug(tt::LogOp, "NHV: {}", NHV);
     log_debug(tt::LogOp, "L: {}", L);
     log_debug(tt::LogOp, "DH: {}", DH);
     log_debug(tt::LogOp, "vDH: {}", vDH);
@@ -503,7 +517,9 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
-    uint32_t k_tiles = Sk_chunk_t * DHt * 2;   // double buffer
+    // Latent-V reuses the K CB for K^T and compact V. A third fixed-size entry lets the reader
+    // materialize next V while compute still consumes current V.
+    uint32_t k_tiles = Sk_chunk_t * DHt * (v_shares_k_buffer ? 3 : 2);
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;  // double buffer
     uint32_t mask_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
@@ -547,6 +563,9 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         !kv_pad_rotation_enabled || use_streaming_compute,
         "kv_actual_isl requires the ring-joint streaming compute path; the compute_common.hpp path selected by "
         "fp32_dest_acc_en=true is not supported.");
+    TT_FATAL(
+        use_streaming_compute || !v_shares_k_buffer,
+        "Latent-V ring attention is implemented only for streaming compute (fp32_dest_acc_en must be false)");
     log_debug(
         tt::LogOp,
         "use_streaming_compute: {} (is_causal={}, Sq_chunk_t={}, Sk_chunk_t={}, sbh={}, sbw={})",
@@ -559,6 +578,14 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     auto [out_out_subblock_h, out_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, vDHt, dst_size, use_streaming_compute ? 2 : UINT32_MAX);
+    // Streaming compute may widen the QKT@V row group beyond the host matmul subblock
+    // height for odd Q chunks. The writer must drain cb_out with the same row-group
+    // cadence that compute pushes, otherwise deferred-save rows can be popped and
+    // reused before the matching grouped write has safely landed.
+    const uint32_t writer_out_row_group_h =
+        use_streaming_compute
+            ? ttnn::transformer::sdpa::streaming_qktv_h(out_out_subblock_h, out_out_subblock_w, dst_size, Sq_chunk_t)
+            : out_out_subblock_h;
 
     const uint32_t out_in0_num_subblocks = Sq_chunk_t / out_out_subblock_h;
     const uint32_t out_in1_num_subblocks = vDHt / out_out_subblock_w;
@@ -696,6 +723,8 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         static_cast<uint32_t>(indexed_kv_cache),
         static_cast<uint32_t>(kv_pad_rotation_enabled),
         active_ring_iter_mask,
+        NHV,
+        static_cast<uint32_t>(v_shares_k_buffer),
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -803,7 +832,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         kernel_is_causal,
         args.is_balanced,
         static_cast<uint32_t>(enable_zigzag_balancing),
-        static_cast<std::uint32_t>(out_out_subblock_h),
+        static_cast<std::uint32_t>(writer_out_row_group_h),
         static_cast<uint32_t>(is_chunked),
         q_chunk_group_tile_count,
         active_ring_iter_mask,
@@ -863,7 +892,8 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         kv_pad_q_mapping.q_post_wrap_start_tile,
         kv_pad_q_mapping.q_valid_tile_count,
         active_ring_iter_mask,
-        last_active_ring_iter};
+        last_active_ring_iter,
+        static_cast<uint32_t>(v_shares_k_buffer)};
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -930,7 +960,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
 
     const uint32_t cb_q_in = allocate_tile_cb(q_tiles, q_tile_size, q_df);
     const uint32_t cb_k_in = allocate_tile_cb(k_tiles, k_tile_size, k_df);
-    const uint32_t cb_v_in = allocate_tile_cb(v_tiles, v_tile_size, v_df);
+    const uint32_t cb_v_in = v_shares_k_buffer ? cb_k_in : allocate_tile_cb(v_tiles, v_tile_size, v_df);
 
     // Lightweight mask CB: holds neginf + optional causal diagonal + optional partial tiles.
     // Used for both causal (ring_iter 0) and padding (ring_iter > 0) masking.
@@ -1554,7 +1584,6 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         reader_compile_time_args[sem_args_offset + 7] = k_mcast_enabled ? 1 : 0;
     }
 
-    log_debug(tt::LogOp, "V chain mode: head ({})", head_mcast_enabled ? "mcast" : "unicast");
     if (k_uses_batch_chain) {
         log_debug(
             tt::LogOp,
@@ -1630,7 +1659,7 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         }
         reader_args.push_back(global_q_start);
         reader_args.push_back(global_q_end);
-        reader_args.push_back(cache_batch_idx);
+        reader_args.push_back(kv_cache_batch_idx);
 
         // Append chain runtime args for store-and-forward
         const auto& head_chain = head_chain_configs.at(i);
@@ -1710,14 +1739,12 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         sdpa_fused_op_signaler->fused_op_receiver_signal_semaphores,
         sdpa_fused_op_signaler->fused_op_signaler_mode);
 
-    std::vector<Tensor> all_gather_input_tensors = {
-        input_tensor_k,
-        input_tensor_v,
-    };
-    std::vector<Tensor> all_gather_output_tensors = {
-        gathered_input_tensor_k,
-        gathered_input_tensor_v,
-    };
+    std::vector<Tensor> all_gather_input_tensors = {input_tensor_k};
+    std::vector<Tensor> all_gather_output_tensors = {gathered_input_tensor_k};
+    if (!v_shares_k_buffer) {
+        all_gather_input_tensors.push_back(input_tensor_v);
+        all_gather_output_tensors.push_back(gathered_input_tensor_v);
+    }
     // Append the all-gather portion to `desc`. The helper assigns sequential
     // semaphore IDs starting at `desc.semaphores.size()` (current count) and
     // returns kernel indices into `desc.kernels`. Runtime args are auto-patched

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -199,7 +199,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     std::optional<float> scale,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
-    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_cache_batch_idx,
     std::optional<uint32_t> kv_actual_isl) {
     auto topology_1d = ttnn::ccl::convert_2d_to_1d_topology(topology);
     auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
@@ -227,12 +227,64 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         scale,
         compute_kernel_config,
         core_allocation_strategy,
-        cache_batch_idx,
+        kv_cache_batch_idx,
         kv_actual_isl);
     return {
         output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
         output_tensors[prim::RING_JOINT_SDPA_JOINT_OUTPUT_IDX],
         output_tensors[prim::RING_JOINT_SDPA_STATS_OUTPUT_IDX]};
+}
+
+std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_kv,
+    ttnn::Tensor& persistent_output_buffer_kv,
+    const uint32_t head_dim_v,
+    std::size_t logical_n,
+    ttnn::operations::transformer::SDPAProgramConfig program_config,
+    const int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    const uint32_t num_links,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    const CoreCoord ccl_core_grid_offset,
+    bool is_balanced,
+    std::optional<float> scale,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    std::optional<uint32_t> kv_cache_batch_idx,
+    std::optional<uint32_t> kv_actual_isl) {
+    auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
+        input_tensor_q,
+        input_tensor_kv,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        persistent_output_buffer_kv,
+        std::nullopt,
+        "rear",
+        logical_n,
+        std::move(program_config),
+        dim,
+        multi_device_global_semaphore,
+        num_links,
+        cluster_axis,
+        mesh_device,
+        topology,
+        ccl_core_grid_offset,
+        subdevice_id,
+        /*is_causal=*/true,
+        is_balanced,
+        scale,
+        compute_kernel_config,
+        core_allocation_strategy,
+        kv_cache_batch_idx,
+        kv_actual_isl,
+        head_dim_v);
+    return {output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX], output_tensors[prim::RING_JOINT_SDPA_STATS_OUTPUT_IDX]};
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteExpRingJointAttention::invoke(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -90,7 +90,29 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     std::optional<float> scale = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
-    std::optional<uint32_t> cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
+    std::optional<uint32_t> kv_actual_isl = std::nullopt);
+
+std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_kv,
+    ttnn::Tensor& persistent_output_buffer_kv,
+    uint32_t head_dim_v,
+    std::size_t logical_n,
+    operations::transformer::SDPAProgramConfig program_config,
+    int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    uint32_t num_links,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    CoreCoord ccl_core_grid_offset,
+    bool is_balanced = false,
+    std::optional<float> scale = std::nullopt,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
+    std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_actual_isl = std::nullopt);
 
 struct ExecuteExpRingJointAttention {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -48,7 +48,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     bool use_column_major_ccl,
     bool is_causal,
     bool is_balanced,
-    std::optional<uint32_t> cache_batch_idx,
+    std::optional<uint32_t> kv_cache_batch_idx,
     std::optional<uint32_t> kv_actual_isl) {
     auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
                                          : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
@@ -78,9 +78,55 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         scale,
         compute_kernel_config,
         strategy,
-        cache_batch_idx,
+        kv_cache_batch_idx,
         kv_actual_isl);
     return outputs;
+}
+
+std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla_wrapper(
+    const ttnn::Tensor& input_tensor_q,
+    const ttnn::Tensor& input_tensor_kv,
+    ttnn::Tensor& persistent_output_buffer_kv,
+    uint32_t head_dim_v,
+    std::size_t logical_n,
+    const SDPAProgramConfig& program_config,
+    std::optional<float> scale,
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    int32_t dim,
+    const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
+    uint32_t num_links,
+    uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    CoreCoord ccl_core_grid_offset,
+    bool use_column_major_ccl,
+    bool is_balanced,
+    std::optional<uint32_t> kv_cache_batch_idx,
+    std::optional<uint32_t> kv_actual_isl) {
+    auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
+                                         : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
+    return ttnn::transformer::ring_mla(
+        input_tensor_q,
+        input_tensor_kv,
+        persistent_output_buffer_kv,
+        head_dim_v,
+        logical_n,
+        program_config,
+        dim,
+        multi_device_global_semaphore,
+        num_links,
+        cluster_axis,
+        mesh_device,
+        topology,
+        subdevice_id,
+        ccl_core_grid_offset,
+        is_balanced,
+        scale,
+        compute_kernel_config,
+        strategy,
+        kv_cache_batch_idx,
+        kv_actual_isl);
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> exp_ring_joint_scaled_dot_product_attention_wrapper(
@@ -399,11 +445,12 @@ void bind_sdpa(nb::module_& mod) {
         Args:
             input_tensor_q (ttnn.Tensor): Original queries  [b x nh x N/num_devices x dh].
             input_tensor_k (ttnn.Tensor): Original keys     [b x nh x N/num_devices x dh].
-            input_tensor_v (ttnn.Tensor): Original values   [b x nh x N/num_devices x dh].
+            input_tensor_v (ttnn.Tensor): Original values [b x nhv x N/num_devices x dv].
 
             joint_tensor_q (ttnn.Tensor, optional): Joint queries     [b x nh x L x dh]. Defaults to None.
             joint_tensor_k (ttnn.Tensor, optional): Joint keys        [b x nh x L x dh]. Defaults to None.
-            joint_tensor_v (ttnn.Tensor, optional): Joint values      [b x nh x L x dh]. Defaults to None.
+            joint_tensor_v (ttnn.Tensor, optional): Joint values [b x nhv x L x dv].
+                Defaults to None when L == 0.
 
         Keyword args:
             persistent_output_buffer_k (ttnn.Tensor): Persistent buffer for gathered K tensor.
@@ -426,7 +473,7 @@ void bind_sdpa(nb::module_& mod) {
                 If False (default), uses row-major allocation. Defaults to False.
             is_causal (bool): Whether to use causal attention masking. Defaults to False.
             is_balanced (bool): Whether to use balanced attention computation. Defaults to False.
-            cache_batch_idx (int, optional): Selects the shared K/V cache batch slot when K and V are full caches.
+            kv_cache_batch_idx (int, optional): Selects the shared K/V cache batch slot when K and V are full caches.
             kv_actual_isl (int, optional): Prior valid global KV length before this fixed-size chunk.
                 When passed, enables KV-pad-aware rotation and derives current valid tokens as
                 logical_n - kv_actual_isl.
@@ -436,16 +483,16 @@ void bind_sdpa(nb::module_& mod) {
         prefix from chunk 0 through the current chunk). The op derives chunk_size and
         the absolute Q-row offset from the shapes plus sp_size — no extra args needed.
         Chunked prefill is mathematically causal; callers must pass is_causal=True.
-        When cache_batch_idx is provided, input_tensor_k and input_tensor_v may be whole caches.
-        The same cache_batch_idx selects the K and V cache slot, and the full K/V sequence
+        When kv_cache_batch_idx is provided, input_tensor_k and input_tensor_v may be whole caches.
+        The same kv_cache_batch_idx selects the K and V cache slot, and the full K/V sequence
         dimension is treated as valid. When kv_actual_isl is provided, the chunked path switches
         to KV-pad-aware rotation: logical_n remains the total valid KV length after this iteration,
         while kv_actual_isl marks the prior valid cache length before the current chunk.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
-              - The attention output for the original Q/K/V shape [b x nh x N/num_devices x dh].
-              - The attention output for the joint Q/K/V shape    [b x nh x L x dh].
+              - The attention output for the original Q/K/V shape [b x nh x N/num_devices x dv].
+              - The attention output for the joint Q/K/V shape    [b x nh x L x dv].
               - The final log-sum-exp of the operation.           [b x nh x (N/num_devices + L) x 1]
         )doc";
 
@@ -478,7 +525,72 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("use_column_major_ccl") = false,
         nb::arg("is_causal").noconvert() = false,
         nb::arg("is_balanced").noconvert() = false,
-        nb::arg("cache_batch_idx").noconvert() = nb::none(),
+        nb::arg("kv_cache_batch_idx").noconvert() = nb::none(),
+        nb::arg("kv_actual_isl").noconvert() = nb::none());
+
+    const auto* const ring_mla_doc = R"doc(
+        Causal Ring MLA attention over a single KV tensor.
+
+        K and V are represented by one tensor. QK uses the full KV head dimension and
+        QKT@V uses the first head_dim_v columns as V. The V dimension must be smaller
+        than K and tile aligned. The KV tensor must have one shared KV head.
+
+        Args:
+            input_tensor_q (ttnn.Tensor): Queries [b x nqh x N/num_devices x dh].
+            input_tensor_kv (ttnn.Tensor): Shared KV tensor [b x nkv x N/num_devices x dh].
+
+        Keyword args:
+            persistent_output_buffer_kv (ttnn.Tensor): Persistent buffer for gathered KV tensor.
+            head_dim_v (int): Tile-aligned V hidden dimension, read from KV's prefix.
+            logical_n (int): Logical global sequence length before sharding.
+            program_config (ttnn.SDPAProgramConfig): Program configuration for the operation.
+            scale (float, optional): Scale factor for QK^T. Defaults to None.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to None.
+            dim (int): Dimension for ring all-gather.
+            multi_device_global_semaphore (List[ttnn.GlobalSemaphore]): Global semaphores for CCL synchronization.
+            num_links (int): Number of CCL links.
+            cluster_axis (int): Mesh axis for all-gather.
+            mesh_device (ttnn.MeshDevice): Multi-device mesh.
+            topology (ttnn.ccl.Topology): Communication topology.
+            subdevice_id (Optional[tt.tt_metal.SubDeviceId]): Sub-device identifier. Defaults to None.
+            ccl_core_grid_offset (ttnn.CoreCoord): Core grid offset for CCL workers.
+            use_column_major_ccl (bool): If true, allocate CCL workers column-major. Defaults to False.
+            is_balanced (bool): Whether to use balanced causal work distribution. Defaults to False.
+            kv_cache_batch_idx (int, optional): Selects one batch slot from an indexed K/V cache. Defaults to None.
+            kv_actual_isl (int, optional): Prior valid global KV length before this fixed-size chunk.
+                When passed, enables KV-pad-aware rotation and derives current valid tokens as
+                logical_n - kv_actual_isl.
+
+        Returns:
+            (ttnn.Tensor, ttnn.Tensor):
+              - Attention output [b x nqh x N/num_devices x head_dim_v].
+              - Streaming statistics scratch [b x nqh x 2*N/num_devices x 1].
+        )doc";
+
+    ttnn::bind_function<"ring_mla", "ttnn.transformer.">(
+        mod,
+        ring_mla_doc,
+        &ring_mla_wrapper,
+        nb::arg("input_tensor_q").noconvert(),
+        nb::arg("input_tensor_kv").noconvert(),
+        nb::kw_only(),
+        nb::arg("persistent_output_buffer_kv").noconvert(),
+        nb::arg("head_dim_v").noconvert(),
+        nb::arg("logical_n"),
+        nb::arg("program_config").noconvert(),
+        nb::arg("scale") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("dim"),
+        nb::arg("multi_device_global_semaphore"),
+        nb::arg("num_links"),
+        nb::arg("cluster_axis"),
+        nb::arg("mesh_device"),
+        nb::arg("topology"),
+        nb::arg("subdevice_id") = nb::none(),
+        nb::arg("ccl_core_grid_offset"),
+        nb::arg("use_column_major_ccl") = false,
+        nb::arg("is_balanced").noconvert() = false,
+        nb::arg("kv_cache_batch_idx").noconvert() = nb::none(),
         nb::arg("kv_actual_isl").noconvert() = nb::none());
 
     const auto* exp_ring_joint_doc = R"doc(


### PR DESCRIPTION
## Summary
- Add ring_mla over a single shared KV tensor, with V read as a tile-aligned prefix of K/KV.
- Teach ring joint SDPA optional-V/latent-V plumbing so the reader all-gathers one KV tensor and materializes compact V from K in L1.
- Support kv_cache_batch_idx, kv_actual_isl, and reusable oversized persistent KV buffers for chunked ring_mla.

## Testing
- Built with `PYTHON_ENV_DIR=/localdev/pjosipovic/tt-metal/python_env ./build_metal.sh --build-dir build_Release --enable-ccache --disable-warnings-as-errors` during cleanup.
- Previously ran full `tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py` successfully before final cleanup/rebase.

### Additional CI
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring_joint_sdpa_optional_latent_v)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring_joint_sdpa_optional_latent_v)

