### PR TITLE
[Bug fix] fix rank-1 moreh_sum global reduction

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
@@ -224,6 +224,20 @@ def test_moreh_sum_non_4d(input_shape, dim, keepdim, use_provide_output, device)
 
 @pytest.mark.parametrize(
     "input_shape",
+    ([5],),
+    ids=["rank-1"],
+)
+@pytest.mark.parametrize("dim", [None], ids=["None"])
+@pytest.mark.parametrize("use_provide_output", [True, False], ids=["provide-output", "allocate-output"])
+def test_moreh_sum_rank_1_global(input_shape, dim, use_provide_output, device):
+    torch.manual_seed(2023)
+
+    passing = moreh_sum(input_shape, dim, False, use_provide_output, False, device)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
     [
         [4, TILE_HEIGHT * 4, TILE_WIDTH * 4],
     ],

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
 namespace ttnn {
 
@@ -16,8 +17,16 @@ Tensor moreh_sum(
     const std::optional<Tensor>& output,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    ttnn::SmallVector<int64_t> dims = operations::get_dim(dim, input.padded_shape().rank());
+    ttnn::SmallVector<int64_t> dims = operations::get_dim(dim, input.logical_shape().rank());
     std::sort(dims.begin(), dims.end());
+
+    if (input.logical_shape().rank() == 1 && dims.size() == 1 && dims.front() == 0) {
+        const auto input_width = input.logical_shape()[0];
+        auto rank_2_input = ttnn::reshape(input, ttnn::Shape({1, input_width}));
+        auto reduced =
+            ttnn::prim::moreh_sum(rank_2_input, /*dim=*/1, keepdim, output, memory_config, compute_kernel_config);
+        return output.has_value() ? reduced : ttnn::reshape(reduced, ttnn::Shape({1}));
+    }
 
     auto temp_input = input;
     for (uint32_t i = dims.size() - 1; i > 0; i--) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Fix rank-1 `moreh_sum` global reductions when `dim=None`.
2. Expand `dim=None` from `logical_shape().rank()` instead of `padded_shape().rank()` so rank-1 tensors do not get interpreted through the padded tile rank.
3. Bridge the rank-1 global-reduction case through a temporary `[1, N]` reshape so it reuses the existing width-reduction path and still returns a scalar-shaped result.
4. Add focused nightly coverage for rank-1 `moreh_sum` with both allocated output and provided output.

### Notes for reviewers
1. The highest-risk change is in `ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp`.
2. This patch keeps the device-side reduction kernels unchanged. It only fixes the entrypoint rank interpretation and the rank-1 full-reduction bridge.
3. This is the path that `moreh_nll_loss(..., reduction="mean")` uses when it sums the rank-1 `step1_result` divisor.
4. I kept earlier local emulation-only compatibility helpers out of this PR so the public diff stays scoped to the rank-1 semantic fix from #45813.

### Test plan
1. `python3 -m py_compile tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py`
2. I validated the rank-1 regression path in a Linux-side emulation setup before rebasing this branch.
3. I did not rerun the rebased branch end-to-end in this clean worktree because the local host emulation setup here is currently blocked by separate build / JIT environment drift outside this two-file patch.
