### PR TITLE
gemma4: declare supports_sample_on_device=True in vLLM bridge

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -129,7 +129,7 @@ jobs:
             {
               "name": "[WH-T3K] Gemma4-26B-A4B",
               "model": "google/gemma-4-26B-A4B-it",
-              "server-timeout": 10,
+              "server-timeout": 30,
               "benchmark-timeout": 5,
               "runner-label": "config-t3000",
               "arch": "arch-wormhole_b0",
@@ -142,7 +142,7 @@ jobs:
             {
               "name": "[BH-QB-2] Gemma4-26B-A4B",
               "model": "google/gemma-4-26B-A4B-it",
-              "server-timeout": 15,
+              "server-timeout": 30,
               "benchmark-timeout": 5,
               "runner-label": "BH-Quietbox-2",
               "arch": "arch-blackhole",

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -45,6 +45,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,
+        "supports_sample_on_device": True,
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

- Adds `"supports_sample_on_device": True` to the `model_capabilities` dict on `Gemma4ForCausalLM` in `models/demos/gemma4/tt/generator_vllm.py`.
- Bumps `server-timeout` to **30** on both `[WH-T3K] Gemma4-26B-A4B` and `[BH-QB-2] Gemma4-26B-A4B` vLLM nightly matrix entries (was 10 and 15 respectively) — device-side sampling adds compile/trace time on first launch.

## Why

PR #45747 ("Declare device sampling capability on model side.") moved the sample-on-device opt-in to a per-model `model_capabilities` dict in the vLLM bridge. Gemma4 supports device-side sampling — the decode trace already returns sampled tokens directly (see `enable_split_sampling = False` immediately below the dict) — so the bridge needs to advertise this so vLLM actually exercises that path. Without the declaration, vLLM falls back to host-side sampling.

## CI

vLLM nightly dispatched on this branch filtered to `google/gemma-4`:
- Initial run (pre-timeout-bump, server-timeout=10/15): https://github.com/tenstorrent/tt-metal/actions/runs/26886257663
- **Current run (server-timeout=30): https://github.com/tenstorrent/tt-metal/actions/runs/26888819455**

## Test plan
- [ ] vLLM nightly (linked above) passes on all three active gemma-4 matrix entries (`[WH-N150] Gemma4-E2B`, `[WH-T3K] Gemma4-26B-A4B`, `[BH-QB-2] Gemma4-26B-A4B`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)