### PR TITLE
fix: don't use hardcoded Tensix location in fast untilize test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
@@ -255,7 +255,7 @@ def test_fast_untilize_overflow_guard(
     last_guard_addr = (
         stim.buf_res_addr + (tile_count + guard_tiles - 1) * stim.buf_res_tile_size
     )
-    raw = read_from_device("0,0", last_guard_addr, num_bytes=10)
+    raw = read_from_device(TestConfig.TENSIX_LOCATION, last_guard_addr, num_bytes=10)
     marker = struct.unpack_from("<H", raw, 0)[0]
     assert marker == 0x4680, f"Sentinel marker missing; got 0x{marker:04x}"
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This was discovered when trying to parallelize test execution on multiple cores at the same time.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT/dont-use-hardcoded-tensix-location)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT/dont-use-hardcoded-tensix-location)