### PR TITLE
[Quasar] Enable CC stack in firmware

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_where.h
@@ -18,18 +18,6 @@ namespace ckernel {
 namespace sfpu {
 
 /**
- * @brief Primes the SFPU CC stack ahead of the first ternary SFPU op.
- *
- * Issues an SFPENCC with mode/imm matching what sfpi emits at every @c v_endif
- * (@c EI_RI / @c IMM12_BOTH, i.e. mode 10 / 0x003) so init and per-iteration
- * cleanup leave the CC stack in identical state. Without this priming, the
- * very first @c v_if AND-s into whatever lane mask the CC stack happened to
- * hold at boot, leaving some lanes pre-disabled in @c v_if and active in
- * @c v_else — manifests as a deterministic mismatch on face 0 of tile 0.
- */
-inline void init_where() { TTI_SFPENCC(sfpi::SFPENCC_IMM12_BOTH, sfpi::SFPENCC_MOD1_EI_RI); }
-
-/**
  * @brief Per-lane ternary select: @c out = (cond == 0) ? false_val : true_val.
  *
  * Loads @c false_val directly into the @c result variable so sfpi aliases

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -14,9 +14,7 @@ namespace ckernel {
 /**
  * @brief Initializes the SFPU for ternary where operations.
  *
- * Programs shared SFPU state (ADDR_MOD_7) via the common ternary init, then
- * calls @c _init_where_() to set up the dest address-mod for per-row
- * advancement and prime the CC stack to a known-empty lane mask.
+ * Programs shared SFPU state (ADDR_MOD_7) via the common ternary init
  *
  * @tparam APPROXIMATE  Unused for where; kept for API parity with other SFPU ops.
  */

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_where.h
@@ -23,7 +23,6 @@ namespace ckernel {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_ternary_sfpu_where_init() {
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
-    sfpu::init_where();
 }
 
 /**

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -114,7 +114,6 @@ void device_setup() {
     // wzeromem
     // invalidate_l1_cache
     // clear_destination_registers
-    // enable_cc_stack
     // set_default_sfpu_constant_register_state
 }
 

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -108,6 +108,12 @@ void init_sync_registers() {
     // }
 }
 
+inline void enable_cc_stack() {
+#if defined(UCK_CHLKC_MATH)
+    TTI_SFPENCC(3, 10);  // Enable all the SPFU lanes
+#endif
+}
+
 extern "C" uint32_t _start1() {
     configure_csr();
     uint32_t hartid = internal_::get_hw_thread_idx();
@@ -129,6 +135,7 @@ extern "C" uint32_t _start1() {
     my_logical_y_ = mailboxes->core_info.absolute_logical_y;
     *trisc_run = RUN_SYNC_MSG_DONE;
     setup_isr_csrs();
+    enable_cc_stack();
     DeviceProfilerInit();
     DPRINT("TRISC-FW: initialized\n");
     while (1) {

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -110,7 +110,9 @@ void init_sync_registers() {
 
 inline void enable_cc_stack() {
 #if defined(UCK_CHLKC_MATH)
-    TTI_SFPENCC(3, 10);  // Enable all the SPFU lanes
+    constexpr uint32_t SFPENCC_IMM12_BOTH = 3;
+    constexpr uint32_t SFPENCC_MOD1_EI_RI = 10;
+    TTI_SFPENCC(SFPENCC_IMM12_BOTH, SFPENCC_MOD1_EI_RI);  // Enable all the SFPU lanes
 #endif
 }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -121,10 +121,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
 
-    // Primes the CC stack
-    // to a known-empty lane mask before the first select op.
-    init_where();
-
     // Runs calculate_where over the faces selected by VECTOR_MODE: cond=tile 0,
     // true_val=tile 1, false_val=tile 2, result written to tile 0. Faces outside
     // the selected set keep whatever the producer wrote into Dest before SFPU ran


### PR DESCRIPTION
Enables all SFPU lanes from the Quasar firmware (from each Compute code) on the Math thread during TRISC initialization. Since the DM core is waiting 4 compute cores to initialize, no TRISC will issue an SFPU instruction until all are initialized. This also removes the need for SFPU ops to enable all lanes themselves inside init functions.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/firmware-enable-cc-stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/firmware-enable-cc-stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/firmware-enable-cc-stack)