### PR TITLE
kernel_lib/binary_op_helpers: complete rebase fix for scoped EltwiseBinaryType + init rename

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/binary_op_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/binary_op_helpers.inl
@@ -82,7 +82,9 @@ ALWI void assert_binary_output_cb_size(uint32_t cb, uint32_t chunk_size, uint32_
 
 template <BinaryOpType op_type>
 constexpr EltwiseBinaryType map_to_eltwise_type() {
-    return op_type == BinaryOpType::ADD ? ELWADD : op_type == BinaryOpType::SUB ? ELWSUB : ELWMUL;
+    return op_type == BinaryOpType::ADD   ? EltwiseBinaryType::ELWADD
+           : op_type == BinaryOpType::SUB ? EltwiseBinaryType::ELWSUB
+                                          : EltwiseBinaryType::ELWMUL;
 }
 
 template <BroadcastDim bcast_dim>
@@ -131,9 +133,9 @@ ALWI void binary_init(uint32_t icb_a, uint32_t icb_b) {
 
     // MUL/SQUARE use configured MATH_FIDELITY; ADD/SUB always use LoFi (matches eltwise_binary.h)
     if constexpr (uses_fpu_mul<op_type>()) {
-        MATH((llk_math_eltwise_binary_init_with_operands<elt_type, bcast_type, MATH_FIDELITY>(icb_a, icb_b)));
+        MATH((llk_math_eltwise_binary_init<elt_type, bcast_type, MATH_FIDELITY>(icb_a, icb_b)));
     } else {
-        MATH((llk_math_eltwise_binary_init_with_operands<elt_type, bcast_type, MathFidelity::LoFi>(icb_a, icb_b)));
+        MATH((llk_math_eltwise_binary_init<elt_type, bcast_type, MathFidelity::LoFi>(icb_a, icb_b)));
     }
     UNPACK((llk_unpack_AB_init<bcast_type>(icb_a, icb_b)));
 }


### PR DESCRIPTION
## What

Two API-drift breakages in `binary_op_helpers.inl` that were missed by the earlier `d7b74a98d10 "rebase fix"`. They broke compilation of **every** compute kernel that includes this helper (`toy_variance`, `toy_binary_in_place`, …):

1. **Scoped enum.** `EltwiseBinaryType` is now an `enum class` upstream, so the bare `ELWADD/ELWSUB/ELWMUL` enumerators in `map_to_eltwise_type()` must be qualified as `EltwiseBinaryType::ELW*`.
2. **Init rename.** `llk_math_eltwise_binary_init_with_operands` was renamed to `llk_math_eltwise_binary_init` (the 2-arg call still works; `acc_to_dest` defaults to `0`).

`binary_exec` already matched the current API — no change needed there.

## Symptoms before the fix

- Compile error: `'ELWADD' was not declared in this scope` → cascading `'constexpr' call flows off the end` and `'llk_math_eltwise_binary_init_with_operands' was not declared`.
- A downstream segfault on a partial-tile variant (resolved once the kernel compiles).

## Verification

Applied identically on `mstaletovic/agent_eval` (built on top of this branch) and run on hardware:
- `toy_variance` — 20/20 passed
- `toy_binary_in_place` — 144/144 passed

Opened as **draft** pending review / CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_binary_op_helpers_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_binary_op_helpers_fix)