### PR TITLE
Set golden-result comparisons in LLK tests to be block-aware for MX formats.

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -148,6 +148,14 @@ class DataFormat(Enum):
             DataFormat.MxFp4,
         }
 
+    def is_mx_fp_format(self) -> bool:
+        """Checks if the data format is an MX floating-point format."""
+        return self in {
+            DataFormat.MxFp8R,
+            DataFormat.MxFp8P,
+            DataFormat.MxFp4,
+        }
+
     def supports_l1_accumulation(self) -> bool:
         """Checks if the data format supports L1 accumulation"""
         return self in {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -266,6 +266,62 @@ def _bfp_block_aware_compare(
 
 _RECORD_TEST_ORDER: bool = False
 
+# Per-format params for _mxfp_block_aware_compare: (mantissa_bits, max_steps).
+#   mantissa_bits of the SxEyMz element -> local step = 2^(floor(log2|v|) - mantissa_bits).
+#   max_steps = accepted adjacent-representable steps (same role as MxInt's
+#     max_ulp_steps). HW flushes subnormals to 0, so the smallest representable
+#     magnitude is the min normal and the a==0 branch handles flushed values.
+_MXFP_COMPARE_PARAMS = {
+    DataFormat.MxFp4: (1, 2),  # E2M1
+    DataFormat.MxFp8R: (2, 2),  # E5M2
+    DataFormat.MxFp8P: (3, 2),  # E4M3
+}
+
+
+def _mxfp_block_aware_compare(
+    golden: torch.Tensor,
+    result: torch.Tensor,
+    mantissa_bits: int,
+    max_steps: int = 2,
+) -> torch.Tensor:
+    """Compare two MX-float tensors allowing small representable-adjacency diffs.
+
+    Unlike the MxInt formats (uniform integer lattice) and BFP4 (one shared
+    exponent per block -> uniform ULP), MX-float elements (MxFp4 E2M1, MxFp8R
+    E5M2, MxFp8P E4M3) carry their own exponent on top of the block's E8M0
+    scale, so the representable lattice is non-uniform. For an element format
+    with `mantissa_bits` mantissa bits the local step at a value v is exactly
+    2^(floor(log2|v|) - mantissa_bits) -- derivable per element from v's own
+    magnitude, no block scale needed. A position is valid iff |g-r| is within
+    `max_steps` such local steps (golden and HW within `max_steps` adjacent
+    representable values). Sign flips and larger jumps still fail.
+
+    HW flushes subnormals to 0, so a flushed value is 0 on both sides and is
+    caught by the a==0 branch (exact match) -- no separate subnormal handling.
+    """
+    g = golden.float().flatten()
+    r = result.float().flatten()
+    n = g.numel()
+    if n == 0:
+        return torch.ones(0, dtype=torch.bool)
+
+    both_nan = torch.isnan(g) & torch.isnan(r)
+
+    # Per-element local lattice step from the larger magnitude.
+    a = torch.nan_to_num(
+        torch.maximum(g.abs(), r.abs()), nan=0.0, posinf=0.0, neginf=0.0
+    )
+    safe = a > 0
+    exp = torch.zeros_like(a)
+    exp[safe] = torch.floor(torch.log2(a[safe]))
+    local_ulp = torch.where(
+        safe, torch.pow(2.0, exp - mantissa_bits), torch.zeros_like(a)
+    )
+
+    diff = (g - r).abs()
+    is_valid = torch.where(safe, diff <= max_steps * local_ulp + 1e-6, g == r)
+    return is_valid | both_nan
+
 
 def passed_test(
     golden_tensor,
@@ -312,6 +368,18 @@ def passed_test(
         is_valid = _bfp_block_aware_compare(
             golden_tensor, res_tensor, mantissa_bits=1, max_ulp_diff=1
         )
+    elif output_data_format.is_mx_fp_format():
+        # Non-uniform float lattice (E2M1 / E5M2 / E4M3): per-element adjacency
+        # check instead of a fixed ULP. Replaces the loose torch.isclose +
+        # count fallback; per-format (mantissa_bits, max_steps) in
+        # _MXFP_COMPARE_PARAMS.
+        mantissa_bits, max_steps = _MXFP_COMPARE_PARAMS[output_data_format]
+        is_valid = _mxfp_block_aware_compare(
+            golden_tensor,
+            res_tensor,
+            mantissa_bits=mantissa_bits,
+            max_steps=max_steps,
+        )
     else:
         is_close = torch.isclose(
             golden_tensor, res_tensor, rtol=tolerance.rtol, atol=tolerance.atol
@@ -320,6 +388,18 @@ def passed_test(
         is_valid = is_close | is_nan
 
     is_within_tolerance = torch.all(is_valid)
+
+    if output_data_format.is_mx_format():
+        # Every MX low-bit format is judged by its lattice-aware compare
+        # (MxFp* via _mxfp_block_aware_compare on the E2M1/E5M2/E4M3 float
+        # lattices), which accepts disagreements up to a few lattice steps. At
+        # power-of-2 block-max boundaries the golden (fp32 amax) and HW (lower-
+        # precision amax) can pick block exponents one spec-legal step apart
+        # (OCP MX: scale = largest pow2 <= amax) — The per-element lattice
+        # check is the principled correctness criterion here, so trust its
+        # verdict rather than re-gating on PCC (sign flips and gross multi-step
+        # jumps still fail the lattice-aware check).
+        return bool(is_within_tolerance)
 
     if print_errors and not _RECORD_TEST_ORDER:
         try:
@@ -425,8 +505,6 @@ def passed_test(
         target_pcc = (
             0.90  # Bfp2_b has only 1 mantissa bit; precision is severely limited
         )
-    elif output_data_format == DataFormat.MxFp4:
-        target_pcc = 0.95  # MxFp4 E2M1 has very limited precision (only 8 positive and 8 negative representable values)
 
     if custom_pcc_threshold is not None:
         logger.info(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/utils.py
@@ -319,7 +319,12 @@ def _mxfp_block_aware_compare(
     )
 
     diff = (g - r).abs()
-    is_valid = torch.where(safe, diff <= max_steps * local_ulp + 1e-6, g == r)
+    # Relative float32-rounding guard (~1 ULP at the comparison magnitude) instead of a
+    # fixed absolute slack. A constant would dominate `max_steps * local_ulp` for small
+    # magnitudes (tiny block scales) and let sign flips / multi-step jumps pass.
+    is_valid = torch.where(
+        safe, diff <= max_steps * local_ulp + torch.finfo(torch.float32).eps * a, g == r
+    )
     return is_valid | both_nan
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -109,11 +109,6 @@ def test_eltwise_binary_reuse_dest_quasar(
             "Elwmul with MxFp8R or MxFp8P input and reuse_dest has rounding differences; skip to avoid flaky tolerance failures"
         )
 
-    if mathop == MathOperation.Elwmul and formats.output_format == DataFormat.MxFp4:
-        pytest.skip(
-            "Elwmul with MxFp4 output and reuse_dest has rounding differences; skip to avoid flaky tolerance failures"
-        )
-
     # MX formats require implied_math_format=Yes on Quasar; set it and disable_format_inference so golden matches.
     use_mx = formats.input_format.is_mx_format() or formats.output_format.is_mx_format()
     implied_math_format = ImpliedMathFormat.Yes if use_mx else ImpliedMathFormat.No

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -40,7 +40,7 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_FACES,
 )
 from helpers.tilize_untilize import tilize_block, untilize_block
-from helpers.utils import passed_test, tolerances
+from helpers.utils import passed_test
 
 kt_dims = [1, 2, 4]
 matmul_dimensions_dest_sync = [
@@ -66,31 +66,11 @@ MATMUL_FORMAT = input_output_formats(
     [
         DataFormat.Float16,
         DataFormat.Float16_b,
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
         DataFormat.MxFp4,
     ],
 )
-
-
-def _mismatch_ratio_allows_pass(
-    golden_tensor: torch.Tensor,
-    res_tensor: torch.Tensor,
-    output_format: DataFormat,
-    max_mismatch_ratio: float = 0.01,
-) -> tuple[bool, int, int]:
-    tolerance = tolerances[output_format]
-    golden = golden_tensor.type(format_dict[output_format])
-    res = res_tensor.type(format_dict[output_format])
-    is_close = torch.isclose(golden, res, rtol=tolerance.rtol, atol=tolerance.atol)
-    is_nan = torch.isnan(golden) & torch.isnan(res)
-    diff_mask = ~(is_close | is_nan)
-
-    diff_count = int(diff_mask.sum().item())
-    total = int(golden.numel())
-
-    if total == 0:
-        return False, diff_count, total
-
-    return (diff_count / total) <= max_mismatch_ratio, diff_count, total
 
 
 @pytest.mark.quasar
@@ -249,25 +229,10 @@ def test_matmul(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    if format.output_format.is_mx_format():
-        golden_tensor = quantize_mx_tensor_chunked(
-            golden_tensor.to(format_dict[pack_src_format]), format.output_format
-        ).to(torch_format)
-
-    # Don't print errors for mx formats as they are expected to be higher due to quantization,
-    # and we will check them against a relaxed tolerance instead
     test_passed = passed_test(
         golden_tensor,
         res_tensor,
         format.output_format,
-        print_errors=not format.output_format.is_mx_format(),
     )
-
-    if not test_passed and format.output_format.is_mx_format():
-        mismatch_ok, _, _ = _mismatch_ratio_allows_pass(
-            golden_tensor, res_tensor, format.output_format
-        )
-        if mismatch_ok:
-            test_passed = True
 
     assert test_passed, "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -229,10 +229,17 @@ def test_matmul(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    test_passed = passed_test(
+    # For MX outputs, model the packer: quantize the golden onto the MX lattice (from the
+    # math/pack_src format the result was produced in) so the comparison validates the
+    # device's MX output quantization, not just matmul-math-to-MX-precision. The lattice-
+    # aware compare in passed_test then supplies the small HW-vs-reference rounding slack.
+    if format.output_format.is_mx_format():
+        golden_tensor = quantize_mx_tensor_chunked(
+            golden_tensor.to(format_dict[pack_src_format]), format.output_format
+        ).to(torch_format)
+
+    assert passed_test(
         golden_tensor,
         res_tensor,
         format.output_format,
-    )
-
-    assert test_passed, "Assert against golden failed"
+    ), "Assert against golden failed"


### PR DESCRIPTION
### Summary

Mx tiles exist in L1. They are divided into groups of 32 elements where each group has its own scale.
Conversions and rounding happen separately on each group when we have Mx format on output. 
Therefore it makes no sense to use PCC and "continuous-signal" comparison for these cases in utils.py.

We now check each Mx format block separately and discard the rare tie issues and rounding discrepancies between hardware and golden model. This is fine since we are not aiming for a bit accurate model. 
These discrepancies are very small and happen rarely. They are documented and are currently under review.

### Result

Matmul now works fine with Mx.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/mx_formats_block_aware_compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/mx_formats_block_aware_compare)