### PR TITLE
fix: remove duplicate test parameters

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -124,6 +124,7 @@ def test_unp_bcast_sub_sdpa(
         formats,
         templates=[
             generate_input_dim(input_dimensions, input_dimensions),
+            MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             DEST_SYNC(),
         ],

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -37,9 +37,6 @@ from helpers.utils import passed_test
     mathop=[MathOperation.Elwsub, MathOperation.Elwadd, MathOperation.Elwmul],
     dest_acc=[DestAccumulation.No],
     srca_reuse_count=[2, 4, 8],
-    math_fidelity=[
-        MathFidelity.LoFi,
-    ],
     input_dimensions=[
         [128, 32],
         [32, 128],
@@ -124,11 +121,8 @@ def test_unp_bcast_sub_sdpa(
         formats,
         templates=[
             generate_input_dim(input_dimensions, input_dimensions),
-            MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             DEST_SYNC(),
-            TILE_COUNT(tile_cnt_A),
-            SRCA_REUSE_COUNT(srca_reuse_count),
         ],
         runtimes=[
             TILE_COUNT(tile_cnt_A),

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -37,6 +37,9 @@ from helpers.utils import passed_test
     mathop=[MathOperation.Elwsub, MathOperation.Elwadd, MathOperation.Elwmul],
     dest_acc=[DestAccumulation.No],
     srca_reuse_count=[2, 4, 8],
+    math_fidelity=[
+        MathFidelity.LoFi,
+    ],
     input_dimensions=[
         [128, 32],
         [32, 128],


### PR DESCRIPTION
### PR Category
Test Only

### Summary
There were duplicate runtime and template parameters in the test itself, although these were only runtime parameters, causing more elfs to be generated than are being used later. Removing it should improve our test hygiene and overall test duration time.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT/remove-duplicate-template-and-runtime-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT/remove-duplicate-template-and-runtime-params)