### PR TITLE
[Feature] TTNN FactoryConcepts for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -33,6 +33,9 @@
 #include <optional>
 #include <type_traits>
 
+#include <tt_stl/concepts.hpp>
+#include <tt_stl/reflection.hpp>
+
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/host_api/temp_quasar_api.hpp"  // for QuasarComputeConfig
@@ -2340,6 +2343,37 @@ static_assert(
 static_assert(
     std::is_aggregate_v<RemoteDataflowBufferSpec>,
     "RemoteDataflowBufferSpec must remain an aggregate to support designated initializers");
+
+// ----------------------------------------------------------------------------
+// Reflection-based hashability — required by TTNN's Option 2 program-cache
+// path (which hashes the immutable ProgramSpec to key the program cache).
+//
+// The ttsl::concepts::Reflectable concept = aggregate + reflect-cpp can walk
+// the type's fields.  For aggregates this is essentially a free check; we
+// state it explicitly so any future addition that defeats reflection (e.g.
+// growing past reflect-cpp's field-count ceiling, or introducing an opaque
+// nested type that can't be reflected through) trips at compile time at the
+// specific type that broke it.
+//
+// The inline function below additionally forces compilation of
+// hash_objects_with_default_seed(ProgramSpec{}), which transitively requires
+// every nested type (KernelSpec, DataflowBufferSpec, SemaphoreSpec,
+// TensorParameter, WorkUnitSpec, Nodes, and everything inside them) to be
+// hashable — either by std::hash, by being a recognized standard container,
+// or by being a Reflectable aggregate of hashable things.  If any nested
+// leaf breaks hashability, the compile error points at it directly.
+static_assert(ttsl::concepts::Reflectable<ProgramSpec>, "ProgramSpec must remain reflection-hashable");
+static_assert(ttsl::concepts::Reflectable<WorkUnitSpec>, "WorkUnitSpec must remain reflection-hashable");
+static_assert(ttsl::concepts::Reflectable<KernelSpec>, "KernelSpec must remain reflection-hashable");
+static_assert(ttsl::concepts::Reflectable<DataflowBufferSpec>, "DataflowBufferSpec must remain reflection-hashable");
+static_assert(
+    ttsl::concepts::Reflectable<RemoteDataflowBufferSpec>, "RemoteDataflowBufferSpec must remain reflection-hashable");
+static_assert(ttsl::concepts::Reflectable<SemaphoreSpec>, "SemaphoreSpec must remain reflection-hashable");
+
+[[maybe_unused]] inline ttsl::hash::hash_t _program_spec_must_stay_hashable() {
+    ProgramSpec spec{};
+    return ttsl::hash::hash_objects_with_default_seed(spec);
+}
 
 // These tests document the intended construction pattern using designated initializers.
 // They serve as living documentation and will fail to compile if aggregate status is broken.

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -124,16 +124,16 @@ struct Option2Factory {
         const TestAttrs&, const TestArgs&, TestReturn&);
 };
 
-// Opt-in via the type marker → routed to Option 1 (UpdateTensorArgs fast path).
+// Opt-in via the strategy declaration → routed to Option 1 (UpdateTensorArgs fast path).
 struct Option1Factory {
-    using fast_cache_hit_path = std::true_type;
+    static constexpr auto caching_strategy = ttnn::device_operation::ProgramCachingStrategy::MinimizeCacheHitCost;
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TestAttrs&, const TestArgs&, TestReturn&);
 };
 
-// Explicit opt-out via false_type — should match Option 2 (the default).
+// Explicit opt-out (declares MaximizeCacheReuse, the default) — should match Option 2.
 struct Option2ExplicitFactory {
-    using fast_cache_hit_path = std::false_type;
+    static constexpr auto caching_strategy = ttnn::device_operation::ProgramCachingStrategy::MaximizeCacheReuse;
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TestAttrs&, const TestArgs&, TestReturn&);
 };
@@ -163,11 +163,11 @@ struct DoubleShapeFactory {
 
 }  // namespace trifecta_test_factories
 
-// HasFastCacheHitPathOptIn detects the marker — absent / false / true.
-static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option2Factory>);
-static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option2ExplicitFactory>);
-static_assert(ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option1Factory>);
-static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::WorkloadFactory>);
+// HasMinimizeCacheHitCostOptIn detects the strategy — absent / MaximizeCacheReuse / MinimizeCacheHitCost.
+static_assert(!ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::Option2ExplicitFactory>);
+static_assert(ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::Option1Factory>);
+static_assert(!ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::WorkloadFactory>);
 
 // WorkloadArtifactConcept matches exactly the create_workload_artifacts shape.
 static_assert(ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::WorkloadFactory>);
@@ -206,7 +206,7 @@ static_assert(
 // Regression guard: dispatch_option2_spec_hash must remain instantiable for an
 // Option 2 factory. The Option 2 path used to reference the Option 1 adapter's
 // nested types (shared_variables_t, cached_mesh_workload_t) for its cache wrapper,
-// but the Option 1 adapter has `requires HasFastCacheHitPathOptIn` — which is
+// but the Option 1 adapter has `requires HasMinimizeCacheHitCostOptIn` — which is
 // false for Option 2 factories by definition. The substitution failure only
 // surfaced when an Option 2 factory was actually wired up. This block forces
 // instantiation now so the regression is caught at compile time.

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -105,6 +105,89 @@ struct NewInfraWorkloadFactory {
 static_assert(ttnn::device_operation::MeshWorkloadFactoryConcept<NewInfraWorkloadFactory>);
 static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFactory>);
 
+// -----------------------------------------------------------------------------
+// Metal 2.0 trifecta — concept-level tests
+//
+// Confirm that ProgramSpecFactoryConcept (umbrella) admits the three intended
+// sub-shapes, the type-level fast-path opt-in marker is detected correctly,
+// and a factory that accidentally exposes two shapes is rejected.
+// -----------------------------------------------------------------------------
+namespace trifecta_test_factories {
+
+struct TestAttrs {};
+struct TestArgs {};
+struct TestReturn {};
+
+// Default — no marker → routed to Option 2 (safe-by-construction full RunArgs re-apply).
+struct Option2Factory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&);
+};
+
+// Opt-in via the type marker → routed to Option 1 (UpdateTensorArgs fast path).
+struct Option1Factory {
+    using fast_cache_hit_path = std::true_type;
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&);
+};
+
+// Explicit opt-out via false_type — should match Option 2 (the default).
+struct Option2ExplicitFactory {
+    using fast_cache_hit_path = std::false_type;
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&);
+};
+
+// Workload-style — single declarative call returning all per-coord programs
+// and workload-scoped resources.
+struct WorkloadFactory {
+    static ttnn::device_operation::MeshWorkloadArtifacts create_workload_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&, const ttnn::MeshCoordinateRangeSet&);
+};
+
+// Advanced (Option 3) — three-method shape; adapter support deferred.
+struct AdvancedFactory {
+    static int extract_immutable_info();
+    static int create_program_spec();
+    static int create_program_run_args();
+};
+
+// Accidentally exposes two shapes — rejected by the sum-equals-1 disambiguation
+// in ProgramSpecFactoryConcept.
+struct DoubleShapeFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&);
+    static ttnn::device_operation::MeshWorkloadArtifacts create_workload_artifacts(
+        const TestAttrs&, const TestArgs&, TestReturn&, const ttnn::MeshCoordinateRangeSet&);
+};
+
+}  // namespace trifecta_test_factories
+
+// HasFastCacheHitPathOptIn detects the marker — absent / false / true.
+static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option2ExplicitFactory>);
+static_assert(ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::Option1Factory>);
+static_assert(!ttnn::device_operation::HasFastCacheHitPathOptIn<trifecta_test_factories::WorkloadFactory>);
+
+// WorkloadArtifactConcept matches exactly the create_workload_artifacts shape.
+static_assert(ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::Option1Factory>);
+static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::AdvancedFactory>);
+
+// AdvancedProgramSpecFactoryConcept matches exactly the three-method shape.
+static_assert(ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+
+// Umbrella concept admits all three sub-shapes — and rejects the double-shape factory.
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option2ExplicitFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option1Factory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::DoubleShapeFactory>);
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -108,9 +108,10 @@ static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFacto
 // -----------------------------------------------------------------------------
 // Metal 2.0 trifecta — concept-level tests
 //
-// Confirm that ProgramSpecFactoryConcept (umbrella) admits the three intended
-// sub-shapes, the type-level fast-path opt-in marker is detected correctly,
-// and a factory that accidentally exposes two shapes is rejected.
+// Confirm that Metal2FactoryConcept (umbrella) admits the four intended
+// leaf sub-shapes, each leaf concept matches exactly its own shape, the
+// type-level fast-path opt-in marker is detected correctly, and a factory that
+// accidentally exposes two shapes is rejected.
 // -----------------------------------------------------------------------------
 namespace trifecta_test_factories {
 
@@ -152,8 +153,15 @@ struct AdvancedFactory {
     static int create_program_run_args();
 };
 
+// Advanced multi-program — workload analog of the three-method shape; stub only.
+struct AdvancedWorkloadFactory {
+    static int extract_workload_immutable_info();
+    static int create_workload_spec();
+    static int create_workload_run_args();
+};
+
 // Accidentally exposes two shapes — rejected by the sum-equals-1 disambiguation
-// in ProgramSpecFactoryConcept.
+// in Metal2FactoryConcept.
 struct DoubleShapeFactory {
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TestAttrs&, const TestArgs&, TestReturn&);
@@ -169,24 +177,45 @@ static_assert(!ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_tes
 static_assert(ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::Option1Factory>);
 static_assert(!ttnn::device_operation::HasMinimizeCacheHitCostOptIn<trifecta_test_factories::WorkloadFactory>);
 
-// WorkloadArtifactConcept matches exactly the create_workload_artifacts shape.
-static_assert(ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::WorkloadFactory>);
-static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::Option2Factory>);
-static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::Option1Factory>);
-static_assert(!ttnn::device_operation::WorkloadArtifactConcept<trifecta_test_factories::AdvancedFactory>);
-
-// AdvancedProgramSpecFactoryConcept matches exactly the three-method shape.
-static_assert(ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
-static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
-static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
-
-// Umbrella concept admits all three sub-shapes — and rejects the double-shape factory.
+// ProgramSpecFactoryConcept (basic single-program leaf) matches exactly the
+// create_program_artifacts shape.
 static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
 static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option2ExplicitFactory>);
 static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::Option1Factory>);
-static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
-static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
-static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::DoubleShapeFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::AdvancedWorkloadFactory>);
+
+// WorkloadSpecFactoryConcept (basic multi-program leaf) matches exactly the
+// create_workload_artifacts shape.
+static_assert(ttnn::device_operation::WorkloadSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(!ttnn::device_operation::WorkloadSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::WorkloadSpecFactoryConcept<trifecta_test_factories::Option1Factory>);
+static_assert(!ttnn::device_operation::WorkloadSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::WorkloadSpecFactoryConcept<trifecta_test_factories::AdvancedWorkloadFactory>);
+
+// AdvancedProgramSpecFactoryConcept matches exactly the single-program three-method shape.
+static_assert(ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::Option2Factory>);
+static_assert(!ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(
+    !ttnn::device_operation::AdvancedProgramSpecFactoryConcept<trifecta_test_factories::AdvancedWorkloadFactory>);
+
+// AdvancedWorkloadSpecFactoryConcept matches exactly the multi-program three-method shape.
+static_assert(
+    ttnn::device_operation::AdvancedWorkloadSpecFactoryConcept<trifecta_test_factories::AdvancedWorkloadFactory>);
+static_assert(!ttnn::device_operation::AdvancedWorkloadSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(!ttnn::device_operation::AdvancedWorkloadSpecFactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(!ttnn::device_operation::AdvancedWorkloadSpecFactoryConcept<trifecta_test_factories::Option1Factory>);
+
+// Umbrella concept admits all four leaf sub-shapes — and rejects the double-shape factory.
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::Option2Factory>);
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::Option2ExplicitFactory>);
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::Option1Factory>);
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::WorkloadFactory>);
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::AdvancedFactory>);
+static_assert(ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::AdvancedWorkloadFactory>);
+static_assert(!ttnn::device_operation::Metal2FactoryConcept<trifecta_test_factories::DoubleShapeFactory>);
 
 // Guard: ProgramSpec must remain reflection-hashable (Metal 2.0 Option 2 spec-hash
 // path depends on this). If a future change to ProgramSpec or any nested type

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -203,6 +203,49 @@ static_assert(
     return ttsl::hash::hash_objects_with_default_seed(spec);
 }
 
+// Regression guard: dispatch_option2_spec_hash must remain instantiable for an
+// Option 2 factory. The Option 2 path used to reference the Option 1 adapter's
+// nested types (shared_variables_t, cached_mesh_workload_t) for its cache wrapper,
+// but the Option 1 adapter has `requires HasFastCacheHitPathOptIn` — which is
+// false for Option 2 factories by definition. The substitution failure only
+// surfaced when an Option 2 factory was actually wired up. This block forces
+// instantiation now so the regression is caught at compile time.
+namespace option2_instantiation_guard {
+
+struct Attrs {};
+struct Args {};
+struct Spec {};
+struct Ret {};
+
+struct Option2Factory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(const Attrs&, const Args&, Ret&) {
+        return {};
+    }
+};
+
+struct FakeDeviceOp {
+    using operation_attributes_t = Attrs;
+    using tensor_args_t = Args;
+    using spec_return_value_t = Spec;
+    using tensor_return_value_t = Ret;
+    using program_factory_t = std::variant<Option2Factory>;
+
+    static void validate_on_program_cache_miss(const Attrs&, const Args&) {}
+    static Ret create_output_tensors(const Attrs&, const Args&) { return {}; }
+    static Spec compute_output_specs(const Attrs&, const Args&) { return {}; }
+    static program_factory_t select_program_factory(const Attrs&, const Args&) { return Option2Factory{}; }
+};
+
+// Taking the address of the function-template specialization forces full
+// instantiation of its body. If dispatch_option2_spec_hash references types
+// that aren't valid for an Option 2 factory, this fails to compile.
+[[maybe_unused]] inline auto _force_option2_dispatch_instantiation() {
+    using Adapter = ttnn::device_operation::MeshDeviceOperationAdapter<FakeDeviceOp>;
+    return &ttnn::device_operation::detail::dispatch_option2_spec_hash<Adapter, Option2Factory>;
+}
+
+}  // namespace option2_instantiation_guard
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -188,6 +188,21 @@ static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_fa
 static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::AdvancedFactory>);
 static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<trifecta_test_factories::DoubleShapeFactory>);
 
+// Guard: ProgramSpec must remain reflection-hashable (Metal 2.0 Option 2 spec-hash
+// path depends on this). If a future change to ProgramSpec or any nested type
+// breaks reflection-hashability, the next assertion or the inline call below
+// trips at compile time, pointing at exactly the offending type.
+static_assert(
+    std::is_aggregate_v<tt::tt_metal::experimental::ProgramSpec>,
+    "ProgramSpec must be an aggregate for reflection-based hashing");
+static_assert(
+    ttsl::concepts::Reflectable<tt::tt_metal::experimental::ProgramSpec>,
+    "ProgramSpec must satisfy ttsl Reflectable concept");
+[[maybe_unused]] inline ttsl::hash::hash_t _program_spec_must_stay_hashable() {
+    tt::tt_metal::experimental::ProgramSpec spec{};
+    return ttsl::hash::hash_objects_with_default_seed(spec);
+}
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -246,9 +246,30 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
             [&]<ProgramSpecFactoryConcept T>(const T&) {
-                using AdaptedMeshWorkloadFactory =
-                    mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
-                fn.template operator()<AdaptedMeshWorkloadFactory>();
+                // ProgramSpecFactoryConcept is an umbrella over three sub-shapes; dispatch
+                // each to its own adapter.  The sub-concepts are mutually exclusive by
+                // construction (sum-equals-1 in the umbrella concept), so the branches
+                // here are exhaustive.
+                if constexpr (WorkloadArtifactConcept<T>) {
+                    using AdaptedMeshWorkloadFactory =
+                        mesh_device_operation_t::template WorkloadArtifactMeshWorkloadAdapter<T>;
+                    fn.template operator()<AdaptedMeshWorkloadFactory>();
+                } else if constexpr (AdvancedProgramSpecFactoryConcept<T>) {
+                    // Option 3 — deferred to a future stage. The umbrella concept admits
+                    // it so factories can be written ahead of adapter support, but the
+                    // adapter is not yet implemented.
+                    static_assert(
+                        ttsl::concepts::always_false_v<T>,
+                        "AdvancedProgramSpecFactoryConcept (Option 3) is not yet supported by "
+                        "the mesh dispatch adapter. Use create_program_artifacts "
+                        "(Options 1 or 2) or create_workload_artifacts in the meantime.");
+                } else {
+                    // create_program_artifacts — Options 1 and 2; the adapter branches
+                    // internally on the HasFastCacheHitPathOptIn marker.
+                    using AdaptedMeshWorkloadFactory =
+                        mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
+                    fn.template operator()<AdaptedMeshWorkloadFactory>();
+                }
             },
             [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {
                 fn.template operator()<WorkloadFactory>();

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -263,13 +263,13 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                         "AdvancedProgramSpecFactoryConcept (Option 3) is not yet supported by "
                         "the mesh dispatch adapter. Use create_program_artifacts "
                         "(Options 1 or 2) or create_workload_artifacts in the meantime.");
-                } else if constexpr (HasFastCacheHitPathOptIn<T>) {
-                    // Option 1: create_program_artifacts + fast_cache_hit_path opt-in.
+                } else if constexpr (HasMinimizeCacheHitCostOptIn<T>) {
+                    // Option 1: create_program_artifacts + MinimizeCacheHitCost opt-in.
                     using AdaptedMeshWorkloadFactory =
                         mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
                     fn.template operator()<AdaptedMeshWorkloadFactory>();
                 } else {
-                    // Option 2 — create_program_artifacts without the fast_cache_hit_path
+                    // Option 2 — create_program_artifacts without the MinimizeCacheHitCost
                     // opt-in. Option 2 is routed by launch_operation_with_adapter through
                     // dispatch_option2_spec_hash BEFORE the cache-hit / cache-miss handlers
                     // that call this function are reached; arriving here means the routing
@@ -277,7 +277,7 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                     static_assert(
                         ttsl::concepts::always_false_v<T>,
                         "Option 2 (ProgramSpecFactoryConcept create_program_artifacts without "
-                        "fast_cache_hit_path) is dispatched via dispatch_option2_spec_hash. "
+                        "MinimizeCacheHitCost) is dispatched via dispatch_option2_spec_hash. "
                         "Reaching this branch means launch_operation_with_adapter's Option 2 "
                         "routing was bypassed.");
                 }
@@ -399,7 +399,7 @@ void create_and_cache_mesh_workload(
 }
 
 // Option 2 (ProgramSpecFactoryConcept create_program_artifacts shape, no
-// fast_cache_hit_path opt-in): the factory runs on every dispatch and the cache
+// MinimizeCacheHitCost opt-in): the factory runs on every dispatch and the cache
 // key is the immutable ProgramSpec — not the op-args. The Option 2 path is
 // structurally different from handle_mesh_adapter_cache_hit /
 // create_and_cache_mesh_workload because it must call the factory BEFORE the
@@ -427,7 +427,7 @@ void dispatch_option2_spec_hash(
     // is just an empty marker satisfying the AdaptedCachedMeshWorkload type
     // slot. (Defining it locally rather than reusing the Option 1 adapter's
     // shared_variables_t keeps this function independent of the Option 1
-    // adapter's `HasFastCacheHitPathOptIn` requires-clause — Option 2
+    // adapter's `HasMinimizeCacheHitCostOptIn` requires-clause — Option 2
     // factories don't satisfy that requirement, so going through the adapter
     // would be a substitution failure here.)
     struct shared_variables_t {};
@@ -541,7 +541,7 @@ void dispatch_option2_spec_hash(
 }
 
 // Detect whether the active factory variant arm is Option 2 (ProgramSpecFactoryConcept
-// create_program_artifacts shape, no fast_cache_hit_path marker, neither Workload nor
+// create_program_artifacts shape, no MinimizeCacheHitCost marker, neither Workload nor
 // the deferred Advanced shape). Returns true and dispatches to dispatch_option2_spec_hash
 // if so; returns false to indicate the caller should use the existing args-hash flow.
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
@@ -559,7 +559,7 @@ bool try_dispatch_option2_spec_hash(
         [&](const auto& factory) {
             using F = std::decay_t<decltype(factory)>;
             if constexpr (
-                ProgramSpecFactoryConcept<F> && !HasFastCacheHitPathOptIn<F> && !WorkloadArtifactConcept<F> &&
+                ProgramSpecFactoryConcept<F> && !HasMinimizeCacheHitCostOptIn<F> && !WorkloadArtifactConcept<F> &&
                 !AdvancedProgramSpecFactoryConcept<F>) {
                 dispatch_option2_spec_hash<mesh_device_operation_t, F>(
                     operation_attributes,

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -231,7 +231,7 @@ void enqueue_mesh_workload(
 }
 
 // Dispatches `fn` to `program_factory` through either the `MeshWorkloadFactoryConcept` directly, or through the adapted
-// path for `ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `ProgramSpecFactoryConcept` factories.
+// path for `ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `Metal2FactoryConcept` factories.
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramFactory, typename Fn>
 void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, const Fn& fn) {
     std::visit(
@@ -245,15 +245,24 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                 using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template DescriptorMeshWorkloadAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
-            [&]<ProgramSpecFactoryConcept T>(const T&) {
-                // ProgramSpecFactoryConcept is an umbrella over three sub-shapes; dispatch
+            [&]<Metal2FactoryConcept T>(const T&) {
+                // Metal2FactoryConcept is an umbrella over four sub-shapes; dispatch
                 // each to its own adapter.  The sub-concepts are mutually exclusive by
                 // construction (sum-equals-1 in the umbrella concept), so the branches
                 // here are exhaustive.
-                if constexpr (WorkloadArtifactConcept<T>) {
+                if constexpr (WorkloadSpecFactoryConcept<T>) {
                     using AdaptedMeshWorkloadFactory =
                         mesh_device_operation_t::template WorkloadArtifactMeshWorkloadAdapter<T>;
                     fn.template operator()<AdaptedMeshWorkloadFactory>();
+                } else if constexpr (AdvancedWorkloadSpecFactoryConcept<T>) {
+                    // Advanced multi-program — stub only. The umbrella concept admits it
+                    // so factories can be written ahead of adapter support, but the
+                    // adapter is not yet implemented.
+                    static_assert(
+                        ttsl::concepts::always_false_v<T>,
+                        "AdvancedWorkloadSpecFactoryConcept is not yet supported by the mesh "
+                        "dispatch adapter. Use create_workload_artifacts or "
+                        "create_program_artifacts in the meantime.");
                 } else if constexpr (AdvancedProgramSpecFactoryConcept<T>) {
                     // Option 3 — deferred to a future stage. The umbrella concept admits
                     // it so factories can be written ahead of adapter support, but the
@@ -459,7 +468,7 @@ void dispatch_option2_spec_hash(
             "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args or "
             "tensor_return_value. Option 2 (create_program_artifacts) does not support "
             "op-owned resource tensors; route through create_workload_artifacts "
-            "(WorkloadArtifactConcept) if you need them.",
+            "(WorkloadSpecFactoryConcept) if you need them.",
             tensor_arg.tensor_parameter_name);
     }
 
@@ -540,10 +549,10 @@ void dispatch_option2_spec_hash(
     }
 }
 
-// Detect whether the active factory variant arm is Option 2 (ProgramSpecFactoryConcept
-// create_program_artifacts shape, no MinimizeCacheHitCost marker, neither Workload nor
-// the deferred Advanced shape). Returns true and dispatches to dispatch_option2_spec_hash
-// if so; returns false to indicate the caller should use the existing args-hash flow.
+// Detect whether the active factory variant arm is Option 2 (basic single-program
+// ProgramSpecFactoryConcept create_program_artifacts shape, no MinimizeCacheHitCost
+// marker). Returns true and dispatches to dispatch_option2_spec_hash if so; returns
+// false to indicate the caller should use the existing args-hash flow.
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 bool try_dispatch_option2_spec_hash(
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
@@ -558,9 +567,10 @@ bool try_dispatch_option2_spec_hash(
     std::visit(
         [&](const auto& factory) {
             using F = std::decay_t<decltype(factory)>;
-            if constexpr (
-                ProgramSpecFactoryConcept<F> && !HasMinimizeCacheHitCostOptIn<F> && !WorkloadArtifactConcept<F> &&
-                !AdvancedProgramSpecFactoryConcept<F>) {
+            // The basic single-program leaf (ProgramSpecFactoryConcept) already
+            // excludes the workload and advanced shapes by construction, so the
+            // marker check is all that distinguishes Option 2 from Option 1.
+            if constexpr (ProgramSpecFactoryConcept<F> && !HasMinimizeCacheHitCostOptIn<F>) {
                 dispatch_option2_spec_hash<mesh_device_operation_t, F>(
                     operation_attributes,
                     tensor_args,

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -451,6 +451,20 @@ void dispatch_option2_spec_hash(
     auto artifacts =
         ProgramSpecFactory::create_program_artifacts(operation_attributes, tensor_args, tensor_return_value);
 
+    // Forbidden cell: op-owned tensors under MaximizeCacheReuse. This strategy
+    // re-runs the factory on every dispatch, so any op-owned mesh_tensors would
+    // be re-allocated each time and the cached Program left referencing freed
+    // device memory (Option 2 stores no shared state to keep them alive — see
+    // the empty shared_variables_t above). Op-owned tensors require
+    // MinimizeCacheHitCost, whose cache-hit path skips the factory and keeps the
+    // miss-time tensors alive.
+    TT_FATAL(
+        artifacts.mesh_tensors.empty(),
+        "create_program_artifacts returned op-owned mesh_tensors under the default MaximizeCacheReuse "
+        "strategy, which re-runs the factory every dispatch and would re-allocate them. Op-owned tensors "
+        "require the MinimizeCacheHitCost strategy: declare `caching_strategy = "
+        "ProgramCachingStrategy::MinimizeCacheHitCost` on the factory.");
+
     // Validate io-tensor reachability inline (op-owned MeshTensors die at
     // factory return and would leave SetProgramRunArgs's copy with freed device
     // addresses; route through create_workload_artifacts if you need op-owned

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -263,12 +263,23 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                         "AdvancedProgramSpecFactoryConcept (Option 3) is not yet supported by "
                         "the mesh dispatch adapter. Use create_program_artifacts "
                         "(Options 1 or 2) or create_workload_artifacts in the meantime.");
-                } else {
-                    // create_program_artifacts — Options 1 and 2; the adapter branches
-                    // internally on the HasFastCacheHitPathOptIn marker.
+                } else if constexpr (HasFastCacheHitPathOptIn<T>) {
+                    // Option 1: create_program_artifacts + fast_cache_hit_path opt-in.
                     using AdaptedMeshWorkloadFactory =
                         mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
                     fn.template operator()<AdaptedMeshWorkloadFactory>();
+                } else {
+                    // Option 2 — create_program_artifacts without the fast_cache_hit_path
+                    // opt-in. Option 2 is routed by launch_operation_with_adapter through
+                    // dispatch_option2_spec_hash BEFORE the cache-hit / cache-miss handlers
+                    // that call this function are reached; arriving here means the routing
+                    // was bypassed and this path can't be served.
+                    static_assert(
+                        ttsl::concepts::always_false_v<T>,
+                        "Option 2 (ProgramSpecFactoryConcept create_program_artifacts without "
+                        "fast_cache_hit_path) is dispatched via dispatch_option2_spec_hash. "
+                        "Reaching this branch means launch_operation_with_adapter's Option 2 "
+                        "routing was bypassed.");
                 }
             },
             [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {
@@ -387,6 +398,162 @@ void create_and_cache_mesh_workload(
         });
 }
 
+// Option 2 (ProgramSpecFactoryConcept create_program_artifacts shape, no
+// fast_cache_hit_path opt-in): the factory runs on every dispatch and the cache
+// key is the immutable ProgramSpec — not the op-args. The Option 2 path is
+// structurally different from handle_mesh_adapter_cache_hit /
+// create_and_cache_mesh_workload because it must call the factory BEFORE the
+// cache lookup (the spec doesn't exist until the factory has run). It's an
+// end-to-end alternative to those two functions, branched away from in
+// launch_operation_with_adapter.
+//
+// Cache-key shape: hash_objects_with_default_seed(type_hash<DeviceOperation>,
+// spec) mixed with mesh coords — exact same shape as compute_mesh_workload_hash
+// (the framework's args-hash entry point), except the second argument is the
+// freshly-built ProgramSpec instead of (attrs, tensor_args). This means two
+// dispatches whose args differ but produce the same compiled Program share a
+// cache entry — the cache-reuse benefit Option 2 was designed for, e.g. when
+// TensorParameter relaxations route shape variation through CRTAs.
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramSpecFactory>
+void dispatch_option2_spec_hash(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device,
+    tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
+    std::size_t program_factory_index) {
+    using Adapter =
+        typename mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<ProgramSpecFactory>;
+    using cached_mesh_workload_t = typename Adapter::cached_mesh_workload_t;
+
+    // Always run cache-miss validation; if cache hit and a separate cache-hit
+    // validator is provided, also run that below.
+    mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+
+    // Defining characteristic of Option 2: factory runs BEFORE the cache lookup
+    // because the cache key is derived from the factory's output.
+    auto artifacts =
+        ProgramSpecFactory::create_program_artifacts(operation_attributes, tensor_args, tensor_return_value);
+
+    // Validate io-tensor reachability (op-owned MeshTensors die at factory
+    // return and would leave SetProgramRunArgs's copy with freed device
+    // addresses). The resolved bindings are discarded — Option 2 doesn't store
+    // them, the factory is re-run every dispatch.
+    auto io_mesh_tensors = Adapter::collect_mesh_tensors(tensor_args, tensor_return_value);
+    (void)Adapter::resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+
+    ttsl::hash::hash_t program_hash = 0;
+    bool program_cache_hit = false;
+    if (program_cache.is_enabled()) {
+        program_hash =
+            ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<mesh_device_operation_t>, artifacts.spec);
+        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+            program_hash = ttsl::hash::hash_objects(program_hash, coord);
+        }
+        program_cache_hit = program_cache.contains(program_hash);
+        if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
+            auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
+            TT_THROW("Device operation \"{}\": program cache miss occurred, but cache misses are forbidden", op_name);
+        }
+    }
+
+    log_operation<mesh_device_operation_t>(
+        mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
+    ttsl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
+
+    if (program_cache_hit) {
+        if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
+            mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+        }
+        // Re-apply the freshly-built ProgramRunArgs to every cached Program.
+        auto& cached_program_factory = program_cache.get(program_hash);
+        auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+        for (auto& [coordinate_range, program] : cached_mesh_workload.workload.get_programs()) {
+            tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+        }
+        enqueue_mesh_workload<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_mesh_workload.workload, true);
+        return;
+    }
+
+    // Cache miss: build Program(s) from the spec, apply RunArgs, optionally cache.
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    if (mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
+        tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device->shape()));
+    } else {
+        log_warning(
+            tt::LogOp,
+            "Tensors that are distributed across mesh device unevenly negatively affect Op dispatch performance.");
+        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+            tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
+        }
+    }
+
+    tt::tt_metal::distributed::MeshWorkload mesh_workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, typename Adapter::shared_variables_t> shared_variables;
+    for (const auto& range : tensor_coords.ranges()) {
+        auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+        tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+        shared_variables.emplace(range, typename Adapter::shared_variables_t{});
+        mesh_workload.add_program(range, std::move(program));
+    }
+    auto cached_workload = cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+
+    // Don't cache during NO_DISPATCH graph capture (mirrors create_and_cache_mesh_workload).
+    bool hook_blocks = false;
+    if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
+        auto* processor_hooks = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get());
+        if (processor_hooks) {
+            hook_blocks = processor_hooks->get_block();
+        }
+    }
+    bool should_cache = program_cache.is_enabled() && !hook_blocks;
+    if (should_cache) {
+        program_cache.insert(program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+        auto& workload = program_cache.get(program_hash).cached_program.template get<cached_mesh_workload_t>().workload;
+        enqueue_mesh_workload<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
+    } else {
+        enqueue_mesh_workload<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_workload.workload);
+    }
+}
+
+// Detect whether the active factory variant arm is Option 2 (ProgramSpecFactoryConcept
+// create_program_artifacts shape, no fast_cache_hit_path marker, neither Workload nor
+// the deferred Advanced shape). Returns true and dispatches to dispatch_option2_spec_hash
+// if so; returns false to indicate the caller should use the existing args-hash flow.
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+bool try_dispatch_option2_spec_hash(
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    ttnn::MeshDevice* mesh_device,
+    tt::tt_metal::program_cache::detail::ProgramCache& program_cache) {
+    auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+    auto program_factory_index = program_factory.index();
+
+    bool handled = false;
+    std::visit(
+        [&](const auto& factory) {
+            using F = std::decay_t<decltype(factory)>;
+            if constexpr (
+                ProgramSpecFactoryConcept<F> && !HasFastCacheHitPathOptIn<F> && !WorkloadArtifactConcept<F> &&
+                !AdvancedProgramSpecFactoryConcept<F>) {
+                dispatch_option2_spec_hash<mesh_device_operation_t, F>(
+                    operation_attributes,
+                    tensor_args,
+                    tensor_return_value,
+                    mesh_device,
+                    program_cache,
+                    program_factory_index);
+                handled = true;
+            }
+        },
+        program_factory);
+    return handled;
+}
+
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void launch_operation_with_adapter(
@@ -402,6 +569,16 @@ void launch_operation_with_adapter(
     }
 
     auto& program_cache = mesh_device->get_program_cache();
+
+    // Option 2 (default ProgramSpecFactoryConcept create_program_artifacts shape) requires the
+    // factory to run before the cache lookup so the immutable ProgramSpec can be the cache key.
+    // Route those calls to the dedicated spec-hash dispatch; everything else stays on the
+    // args-hash flow below.
+    if (try_dispatch_option2_spec_hash<mesh_device_operation_t>(
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache)) {
+        return;
+    }
+
     auto program_hash = 0;
     bool program_cache_hit = false;
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -471,7 +471,7 @@ void dispatch_option2_spec_hash(
     // resources). Bindings aren't stored — Option 2 re-runs the factory on
     // every dispatch — so this is a check-only pass.
     auto io_mesh_tensors = mesh_device_operation_t::collect_io_mesh_tensors(tensor_args, tensor_return_value);
-    for (const auto& tensor_arg : artifacts.run_params.tensor_args) {
+    for (const auto& tensor_arg : artifacts.run_args.tensor_args) {
         const auto* target = &tensor_arg.tensor.get();
         const bool reachable =
             std::any_of(io_mesh_tensors.begin(), io_mesh_tensors.end(), [target](const auto& wrapped) {
@@ -513,7 +513,7 @@ void dispatch_option2_spec_hash(
         auto& cached_program_factory = program_cache.get(program_hash);
         auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
         for (auto& [coordinate_range, program] : cached_mesh_workload.workload.get_programs()) {
-            tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+            tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_args);
         }
         enqueue_mesh_workload<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_mesh_workload.workload, true);
@@ -537,7 +537,7 @@ void dispatch_option2_spec_hash(
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& range : tensor_coords.ranges()) {
         auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-        tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+        tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_args);
         shared_variables.emplace(range, shared_variables_t{});
         mesh_workload.add_program(range, std::move(program));
     }

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -452,15 +452,15 @@ void dispatch_option2_spec_hash(
         ProgramSpecFactory::create_program_artifacts(operation_attributes, tensor_args, tensor_return_value);
 
     // Forbidden cell: op-owned tensors under MaximizeCacheReuse. This strategy
-    // re-runs the factory on every dispatch, so any op-owned mesh_tensors would
+    // re-runs the factory on every dispatch, so any op-owned tensors would
     // be re-allocated each time and the cached Program left referencing freed
     // device memory (Option 2 stores no shared state to keep them alive — see
     // the empty shared_variables_t above). Op-owned tensors require
     // MinimizeCacheHitCost, whose cache-hit path skips the factory and keeps the
     // miss-time tensors alive.
     TT_FATAL(
-        artifacts.mesh_tensors.empty(),
-        "create_program_artifacts returned op-owned mesh_tensors under the default MaximizeCacheReuse "
+        artifacts.op_owned_tensors.empty(),
+        "create_program_artifacts returned op-owned tensors under the default MaximizeCacheReuse "
         "strategy, which re-runs the factory every dispatch and would re-allocate them. Op-owned tensors "
         "require the MinimizeCacheHitCost strategy: declare `caching_strategy = "
         "ProgramCachingStrategy::MinimizeCacheHitCost` on the factory.");

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -422,9 +422,16 @@ void dispatch_option2_spec_hash(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     std::size_t program_factory_index) {
-    using Adapter =
-        typename mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<ProgramSpecFactory>;
-    using cached_mesh_workload_t = typename Adapter::cached_mesh_workload_t;
+    // Option 2 has no cross-dispatch state: the factory runs on every dispatch
+    // and the full ProgramRunArgs is re-applied each time. shared_variables_t
+    // is just an empty marker satisfying the AdaptedCachedMeshWorkload type
+    // slot. (Defining it locally rather than reusing the Option 1 adapter's
+    // shared_variables_t keeps this function independent of the Option 1
+    // adapter's `HasFastCacheHitPathOptIn` requires-clause — Option 2
+    // factories don't satisfy that requirement, so going through the adapter
+    // would be a substitution failure here.)
+    struct shared_variables_t {};
+    using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
     // Always run cache-miss validation; if cache hit and a separate cache-hit
     // validator is provided, also run that below.
@@ -435,12 +442,26 @@ void dispatch_option2_spec_hash(
     auto artifacts =
         ProgramSpecFactory::create_program_artifacts(operation_attributes, tensor_args, tensor_return_value);
 
-    // Validate io-tensor reachability (op-owned MeshTensors die at factory
-    // return and would leave SetProgramRunArgs's copy with freed device
-    // addresses). The resolved bindings are discarded — Option 2 doesn't store
-    // them, the factory is re-run every dispatch.
-    auto io_mesh_tensors = Adapter::collect_mesh_tensors(tensor_args, tensor_return_value);
-    (void)Adapter::resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+    // Validate io-tensor reachability inline (op-owned MeshTensors die at
+    // factory return and would leave SetProgramRunArgs's copy with freed device
+    // addresses; route through create_workload_artifacts if you need op-owned
+    // resources). Bindings aren't stored — Option 2 re-runs the factory on
+    // every dispatch — so this is a check-only pass.
+    auto io_mesh_tensors = mesh_device_operation_t::collect_io_mesh_tensors(tensor_args, tensor_return_value);
+    for (const auto& tensor_arg : artifacts.run_params.tensor_args) {
+        const auto* target = &tensor_arg.tensor.get();
+        const bool reachable =
+            std::any_of(io_mesh_tensors.begin(), io_mesh_tensors.end(), [target](const auto& wrapped) {
+                return &wrapped.get() == target;
+            });
+        TT_FATAL(
+            reachable,
+            "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args or "
+            "tensor_return_value. Option 2 (create_program_artifacts) does not support "
+            "op-owned resource tensors; route through create_workload_artifacts "
+            "(WorkloadArtifactConcept) if you need them.",
+            tensor_arg.tensor_parameter_name);
+    }
 
     ttsl::hash::hash_t program_hash = 0;
     bool program_cache_hit = false;
@@ -490,11 +511,11 @@ void dispatch_option2_spec_hash(
     }
 
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, typename Adapter::shared_variables_t> shared_variables;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
     for (const auto& range : tensor_coords.ranges()) {
         auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
         tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-        shared_variables.emplace(range, typename Adapter::shared_variables_t{});
+        shared_variables.emplace(range, shared_variables_t{});
         mesh_workload.add_program(range, std::move(program));
     }
     auto cached_workload = cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -583,13 +583,10 @@ public:
     //  2. The factory must not declare or supply ANY runtime arguments
     //     (other than its TensorParameters): no schema entries in the
     //     returned ProgramSpec, and no values in the returned ProgramRunArgs.
-    //     Note: this is a TTNN-side restriction specific to
-    //     ProgramSpecFactoryConcept; Metal 2.0 itself supports RTAs in other
-    //     factory shapes.
+    //     NOTE: this is a TTNN-side restriction specific to the basic
+    //     ProgramSpecFactoryConcept, not a Metal 2.0 restriction.
     //  3. The returned ProgramRunArgs must not contain any DFB size overrides.
-    //     Same reason and same TTNN-side restriction as #2. Sizes that vary
-    //     should be set on the ProgramSpec directly (and attr-derived
-    //     variation is naturally specialised via the cache key).
+    //     Same reason and same TTNN-side restriction as #2.
     //
     // Unhandled use cases:
     //  - Ops that need op-owned resources (single-program or multi-program)
@@ -636,14 +633,14 @@ public:
             return result;
         }
 
+        // Disallow runtime arguments for the basic ProgramSpecFactoryConcept.
+        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
+        //
         // A ProgramSpecFactoryConcept factory uses UpdateTensorArgs as its sole
-        // per-dispatch update mechanism — tensor bindings are the only state that
+        // per-dispatch update mechanism — tensor bindings are the ONLY state that
         // mutates between dispatches that share a cache entry. Any runtime argument
         // declared in the returned ProgramSpec is therefore frozen at cache-miss
         // time, and would be silently stale on every subsequent cache hit.
-        //
-        // This is exactly the silent cache-hit corruption bug class this concept exists
-        // to rule out, so we reject any spec that declares one.
         //
         // Factories that genuinely need per-dispatch RTAs belong on a different
         // factory concept (one with explicit per-dispatch mutable state).
@@ -656,63 +653,54 @@ public:
                         adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0 &&
                         adv.num_runtime_varargs_per_node.empty(),
                     "Kernel '{}' declares runtime arguments in its ProgramSpec. "
-                    "ProgramSpecFactoryConcept (a TTNN-side restriction; Metal 2.0 itself "
-                    "supports RTAs) restricts factories using create_program_artifacts to "
-                    "tensor-only per-dispatch mutation. Move constants to compile-time args, "
-                    "route tensor-derived values through TensorParameter bindings, or wait "
-                    "for the future TTNN factory concept with explicit per-dispatch mutable "
-                    "state.",
+                    "TTNN ProgramSpecFactoryConcept restricts factories using the basic "
+                    "create_program_artifacts to tensor-only per-dispatch mutation. "
+                    "Either use compile-time arguments, consider advanced TensorParameters, "
+                    "or upgrade to the version of the factory concept that supports full "
+                    "generality of fast-path mutable ProgramRunArgs.",
                     kernel.unique_id);
             }
         }
 
-        // Same reasoning as assert_no_runtime_args, applied to DFB size overrides.
-        // ProgramRunArgs::dfb_run_overrides lets the factory resize a DFB per
-        // dispatch (entry_size / num_entries). On a Ryan-shaped factory those
-        // overrides would be frozen at cache-miss time and run stale on every
-        // cache hit — the same silent-corruption bug class.
+        // Check that the factory doesn't attempt to supply runtime argument values.
+        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
         //
-        // DFB sizes that depend on attrs are naturally specialised via the cache
-        // key (different attrs → different cache entry → fresh ProgramSpec with
-        // the right sizes). Sizes that need to vary within a single cache entry
-        // require a factory concept with per-dispatch mutable state.
-        static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
-            TT_FATAL(
-                run_args.dfb_run_overrides.empty(),
-                "ProgramRunArgs returned by create_program_artifacts contains {} DFB size "
-                "override entries. ProgramSpecFactoryConcept (a TTNN-side restriction; Metal "
-                "2.0 itself supports DFB size overrides) restricts factories to tensor-only "
-                "per-dispatch mutation. Set DFB sizes directly in the ProgramSpec (attr-derived "
-                "sizes are already specialised via the cache key), or wait for the future TTNN "
-                "factory concept with explicit per-dispatch mutable state.",
-                run_args.dfb_run_overrides.size());
-        }
-
-        // Parallel run-args-side check to assert_no_runtime_args. Catches the
-        // values-without-schema case: a factory that leaves the spec's
-        // RuntimeArgSchema empty (passing assert_no_runtime_args) but populates
-        // ProgramRunArgs::kernel_run_args[k]'s runtime_arg_values anyway.
-        //
-        // Without this check, Metalium's SetProgramRunArgs would still catch the
-        // mismatch — but its error message is framed as a schema/value mismatch,
-        // not as "this TTNN concept doesn't support RTAs." For porters new to the
-        // Metal 2.0 immutable/mutable split, the TTNN-side message is a clearer
-        // first signal about which API restriction they're hitting.
+        // This is a technically redundant check; we've already enforced that the ProgramSpec
+        // schema disallows runtime arguments. To avoid surprises for op authors, also
+        // check that no attempt was made to supply runtime argument values in the ProgramRunArgs.
+        // This check is both for op author ergonomics (the TTNN-side error will be clearer in
+        // context than the Metal 2.0 validation error). It also guards against future changes to
+        // the TTNN infra that may bypass these checks with the power-user Metal 2.0 APIs.
         static void assert_no_runtime_arg_values(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
             for (const auto& kra : run_args.kernel_run_args) {
                 const auto& adv = kra.advanced_options;
                 TT_FATAL(
                     kra.runtime_arg_values.empty() && kra.common_runtime_arg_values.empty() &&
                         adv.runtime_varargs.empty() && adv.common_runtime_varargs.empty(),
-                    "Kernel '{}' in ProgramRunArgs supplies runtime argument values. "
-                    "ProgramSpecFactoryConcept (a TTNN-side restriction; Metal 2.0 itself "
-                    "supports RTAs) restricts factories to tensor-only per-dispatch mutation. "
-                    "Leave runtime_arg_values, common_runtime_arg_values, and advanced_options "
-                    "empty for this kernel (the kernel must still appear in kernel_run_args). "
-                    "The only mutable state supported here is tensor bindings via "
-                    "ProgramRunArgs::tensor_args.",
+                    "Kernel '{}' supplies runtime argument values in ProgramRunArgs. "
+                    "TTNN ProgramSpecFactoryConcept restricts factories using the basic "
+                    "create_program_artifacts to tensor-only per-dispatch mutation. "
+                    "Either use compile-time arguments, consider advanced TensorParameters, "
+                    "or upgrade to the version of the factory concept that supports full "
+                    "generality of fast-path mutable ProgramRunArgs.",
                     kra.kernel_spec_name);
             }
+        }
+
+        // Disallow DFB size overrides for the basic ProgramSpecFactoryConcept.
+        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
+        //
+        // Same reasoning as assert_no_runtime_args above. This factory concept
+        // only updates tensor arguments on the fast path, so any DFB size override
+        // attempted through ProgramRunArgs would not mutate between dispatches.
+        static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
+            TT_FATAL(
+                run_args.dfb_run_overrides.empty(),
+                "ProgramRunArgs returned by create_program_artifacts contains DFB size "
+                "overrides. TTNN ProgramSpecFactoryConcept restricts factories using the "
+                "basic create_program_artifacts to tensor-only per-dispatch mutation. "
+                "Either use fixed DFB sizes, or upgrade to the version of the factory "
+                "concept that supports full generality of fast-path ProgramRunArgs.");
         }
 
         // Match each TensorArgument's MeshTensor reference back to its index in the

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -561,35 +561,39 @@ public:
     // ProgramSpecMeshWorkloadFactoryAdapter
     //
     // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0, single-program /
-    // SPMD-flavored) for mesh dispatch. The op author writes ONLY
-    // create_program_artifacts, returning a single ProgramArtifacts (one ProgramSpec
-    // + ProgramRunArgs). The adapter stamps a Program from that spec onto
-    // each mesh coordinate range covered by the workload — mirroring the
-    // descriptor adapter's per-range build pattern.
+    // SPMD) for mesh dispatch. The op author writes ONLY create_program_artifacts,
+    // returning a single ProgramArtifacts (one ProgramSpec + ProgramRunArgs).
+    // The adapter stamps a Program from that spec onto each mesh coordinate
+    // range covered by the workload.
     //
-    // On cache miss: the adapter calls create_program_artifacts, builds one Program
-    // per coordinate range via experimental::MakeProgramFromSpec, applies
-    // the initial ProgramRunArgs via SetProgramRunArgs, then resolves
-    // each TensorArgument against the io_tensors enumerated from tensor_args /
-    // tensor_return_value (pointer-identity match within the call).
+    // On cache miss: The adapter calls create_program_artifacts, builds one Program
+    // per coordinate range (via experimental::MakeProgramFromSpec), applies
+    // the initial ProgramRunArgs (via experimental::SetProgramRunArgs), then
+    // resolves each TensorArgument against the io_tensors enumerated from
+    // tensor_args / tensor_return_value (pointer-identity match within the call).
     //
     // On cache hit: the adapter enumerates fresh io_tensors, mutates the
     // cached TensorArgument storage in place using the stored index bindings, and
-    // applies via experimental::UpdateTensorArgs — no Program rebuild,
-    // no heap allocation.
+    // applies the new MeshTensors to the existing (cached) Program
+    // (via experimental::UpdateTensorArgs).
     //
-    // Design: every TensorArgument returned by the factory must reference a
-    // MeshTensor reachable from tensor_args or tensor_return_value. The factory
-    // has no path to declare op-owned resource tensors (halo lookup tables, etc.) —
-    // by design, mirroring the descriptor-side split between ProgramDescriptor
-    // (single-program, no workload-scoped resources) and WorkloadDescriptor
-    // (multi-program, with `semaphores` + `buffers` for op-owned resources).
-    // Tensor is a natively mesh-wide memory object and Program is single-device,
-    // so SPMD ops have no natural place to carry workload-scoped resources.
+    // Requirements:
+    //  1. Every TensorArgument returned by the factory must reference a
+    //     MeshTensor reachable from tensor_args or tensor_return_value.
+    //  2. The factory must not declare ANY runtime arguments (other than its
+    //     TensorParameters) in the returned Program Spec. Runtime arguments
+    //     are forbidden because the infrastructure DELIBERATELY excludes
+    //     fast-path patching of non-tensor runtime arguments.
     //
-    // Ops that need op-owned resources (single-program or multi-program) should
-    // route through the future MeshWorkloadSpecFactoryConcept analog of
-    // WorkloadDescriptorConcept, not this concept.
+    // Unhandled use cases:
+    //  - Ops that need op-owned resources (single-program or multi-program)
+    //    should use the (future) MeshWorkloadSpecFactoryConcept analog of
+    //    WorkloadDescriptorConcept, not this concept.
+    //  - Ops that need fast-path patching of non-tensor mutable arguments
+    //    should use the (future) create_program_spec / create_program_run_args
+    //    mechanism.
+    //  - Ops that need different per-device Programs should use the (future)
+    //    MeshWorkloadSpecFactoryConcept.
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
@@ -632,7 +636,7 @@ public:
         // declared in the returned ProgramSpec is therefore frozen at cache-miss
         // time, and would be silently stale on every subsequent cache hit.
         //
-        // This is exactly the silent cache-hit corruption bug class the concept exists
+        // This is exactly the silent cache-hit corruption bug class this concept exists
         // to rule out, so we reject any spec that declares one.
         //
         // Factories that genuinely need per-dispatch RTAs belong on a different
@@ -646,9 +650,9 @@ public:
                         adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0 &&
                         adv.num_runtime_varargs_per_node.empty(),
                     "Kernel '{}' declares runtime arguments, but a ProgramSpecFactoryConcept "
-                    "factory has no per-dispatch update path for them — they would be silently "
-                    "stale on every program-cache hit. Move constants to compile-time args, "
-                    "route tensor-derived values through TensorParameter bindings, or move "
+                    "factory using create_program_artifacts has no per-dispatch update path "
+                    "for non-tensor arguments. Move constants to compile-time args, route "
+                    "tensor-derived values through TensorParameter bindings, or move "
                     "the op to a factory concept with explicit per-dispatch mutable state.",
                     kernel.unique_id);
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -580,15 +580,16 @@ public:
     // Requirements:
     //  1. Every TensorArgument returned by the factory must reference a
     //     MeshTensor reachable from tensor_args or tensor_return_value.
-    //  2. The factory must not declare ANY runtime arguments (other than its
-    //     TensorParameters) in the returned Program Spec. Runtime arguments
-    //     are forbidden because the infrastructure DELIBERATELY excludes
-    //     fast-path patching of non-tensor runtime arguments.
+    //  2. The factory must not declare or supply ANY runtime arguments
+    //     (other than its TensorParameters): no schema entries in the
+    //     returned ProgramSpec, and no values in the returned ProgramRunArgs.
+    //     Note: this is a TTNN-side restriction specific to
+    //     ProgramSpecFactoryConcept; Metal 2.0 itself supports RTAs in other
+    //     factory shapes.
     //  3. The returned ProgramRunArgs must not contain any DFB size overrides.
-    //     Same reason as #2 — fast-path patching of DFB sizes is deliberately
-    //     excluded. Sizes that vary should be set on the ProgramSpec directly
-    //     (and attr-derived variation is naturally specialised via the cache
-    //     key).
+    //     Same reason and same TTNN-side restriction as #2. Sizes that vary
+    //     should be set on the ProgramSpec directly (and attr-derived
+    //     variation is naturally specialised via the cache key).
     //
     // Unhandled use cases:
     //  - Ops that need op-owned resources (single-program or multi-program)
@@ -654,11 +655,13 @@ public:
                     schema.runtime_arg_names.empty() && schema.common_runtime_arg_names.empty() &&
                         adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0 &&
                         adv.num_runtime_varargs_per_node.empty(),
-                    "Kernel '{}' declares runtime arguments, but a ProgramSpecFactoryConcept "
-                    "factory using create_program_artifacts has no per-dispatch update path "
-                    "for non-tensor arguments. Move constants to compile-time args, route "
-                    "tensor-derived values through TensorParameter bindings, or move "
-                    "the op to a factory concept with explicit per-dispatch mutable state.",
+                    "Kernel '{}' declares runtime arguments in its ProgramSpec. "
+                    "ProgramSpecFactoryConcept (a TTNN-side restriction; Metal 2.0 itself "
+                    "supports RTAs) restricts factories using create_program_artifacts to "
+                    "tensor-only per-dispatch mutation. Move constants to compile-time args, "
+                    "route tensor-derived values through TensorParameter bindings, or wait "
+                    "for the future TTNN factory concept with explicit per-dispatch mutable "
+                    "state.",
                     kernel.unique_id);
             }
         }
@@ -677,11 +680,39 @@ public:
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
                 "ProgramRunArgs returned by create_program_artifacts contains {} DFB size "
-                "override entries, but a ProgramSpecFactoryConcept factory has no per-dispatch "
-                "update path for them. Set DFB sizes directly in the ProgramSpec (attr-derived "
-                "sizes are already specialised via the cache key), or move the op to a factory "
-                "concept with explicit per-dispatch mutable state.",
+                "override entries. ProgramSpecFactoryConcept (a TTNN-side restriction; Metal "
+                "2.0 itself supports DFB size overrides) restricts factories to tensor-only "
+                "per-dispatch mutation. Set DFB sizes directly in the ProgramSpec (attr-derived "
+                "sizes are already specialised via the cache key), or wait for the future TTNN "
+                "factory concept with explicit per-dispatch mutable state.",
                 run_args.dfb_run_overrides.size());
+        }
+
+        // Parallel run-args-side check to assert_no_runtime_args. Catches the
+        // values-without-schema case: a factory that leaves the spec's
+        // RuntimeArgSchema empty (passing assert_no_runtime_args) but populates
+        // ProgramRunArgs::kernel_run_args[k]'s runtime_arg_values anyway.
+        //
+        // Without this check, Metalium's SetProgramRunArgs would still catch the
+        // mismatch — but its error message is framed as a schema/value mismatch,
+        // not as "this TTNN concept doesn't support RTAs." For porters new to the
+        // Metal 2.0 immutable/mutable split, the TTNN-side message is a clearer
+        // first signal about which API restriction they're hitting.
+        static void assert_no_runtime_arg_values(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
+            for (const auto& kra : run_args.kernel_run_args) {
+                const auto& adv = kra.advanced_options;
+                TT_FATAL(
+                    kra.runtime_arg_values.empty() && kra.common_runtime_arg_values.empty() &&
+                        adv.runtime_varargs.empty() && adv.common_runtime_varargs.empty(),
+                    "Kernel '{}' in ProgramRunArgs supplies runtime argument values. "
+                    "ProgramSpecFactoryConcept (a TTNN-side restriction; Metal 2.0 itself "
+                    "supports RTAs) restricts factories to tensor-only per-dispatch mutation. "
+                    "Leave runtime_arg_values, common_runtime_arg_values, and advanced_options "
+                    "empty for this kernel (the kernel must still appear in kernel_run_args). "
+                    "The only mutable state supported here is tensor bindings via "
+                    "ProgramRunArgs::tensor_args.",
+                    kra.kernel_spec_name);
+            }
         }
 
         // Match each TensorArgument's MeshTensor reference back to its index in the
@@ -742,6 +773,7 @@ public:
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
             assert_no_runtime_args(artifacts.spec);
+            assert_no_runtime_arg_values(artifacts.run_params);
             assert_no_dfb_size_overrides(artifacts.run_params);
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -584,6 +584,11 @@ public:
     //     TensorParameters) in the returned Program Spec. Runtime arguments
     //     are forbidden because the infrastructure DELIBERATELY excludes
     //     fast-path patching of non-tensor runtime arguments.
+    //  3. The returned ProgramRunArgs must not contain any DFB size overrides.
+    //     Same reason as #2 — fast-path patching of DFB sizes is deliberately
+    //     excluded. Sizes that vary should be set on the ProgramSpec directly
+    //     (and attr-derived variation is naturally specialised via the cache
+    //     key).
     //
     // Unhandled use cases:
     //  - Ops that need op-owned resources (single-program or multi-program)
@@ -658,6 +663,27 @@ public:
             }
         }
 
+        // Same reasoning as assert_no_runtime_args, applied to DFB size overrides.
+        // ProgramRunArgs::dfb_run_overrides lets the factory resize a DFB per
+        // dispatch (entry_size / num_entries). On a Ryan-shaped factory those
+        // overrides would be frozen at cache-miss time and run stale on every
+        // cache hit — the same silent-corruption bug class.
+        //
+        // DFB sizes that depend on attrs are naturally specialised via the cache
+        // key (different attrs → different cache entry → fresh ProgramSpec with
+        // the right sizes). Sizes that need to vary within a single cache entry
+        // require a factory concept with per-dispatch mutable state.
+        static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
+            TT_FATAL(
+                run_args.dfb_run_overrides.empty(),
+                "ProgramRunArgs returned by create_program_artifacts contains {} DFB size "
+                "override entries, but a ProgramSpecFactoryConcept factory has no per-dispatch "
+                "update path for them. Set DFB sizes directly in the ProgramSpec (attr-derived "
+                "sizes are already specialised via the cache key), or move the op to a factory "
+                "concept with explicit per-dispatch mutable state.",
+                run_args.dfb_run_overrides.size());
+        }
+
         // Match each TensorArgument's MeshTensor reference back to its index in the
         // io_tensor enumeration. Cache-miss path only.
         // TT_FATALs on a TensorArgument that doesn't reference an io_tensor — see
@@ -716,6 +742,7 @@ public:
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
             assert_no_runtime_args(artifacts.spec);
+            assert_no_dfb_size_overrides(artifacts.run_params);
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -578,14 +578,18 @@ public:
     // applies via experimental::UpdateTensorArgs — no Program rebuild,
     // no heap allocation.
     //
-    // Limitation: every TensorArgument returned by the factory must reference a
-    // MeshTensor reachable from tensor_args or tensor_return_value.
+    // Design: every TensorArgument returned by the factory must reference a
+    // MeshTensor reachable from tensor_args or tensor_return_value. The factory
+    // has no path to declare op-owned resource tensors (halo lookup tables, etc.) —
+    // by design, mirroring the descriptor-side split between ProgramDescriptor
+    // (single-program, no workload-scoped resources) and WorkloadDescriptor
+    // (multi-program, with `semaphores` + `buffers` for op-owned resources).
+    // Tensor is a natively mesh-wide memory object and Program is single-device,
+    // so SPMD ops have no natural place to carry workload-scoped resources.
     //
-    // TODO: support op-owned resource tensors (the prepare_resources analog
-    // from the descriptor adapter) — will require extending shared_variables_t
-    // and the io_tensor enumeration to include factory-produced tensors.
-    //
-    // TODO: consider replacing with a general MeshWorkloadSpecFactoryAdapter?
+    // Ops that need op-owned resources (single-program or multi-program) should
+    // route through the future MeshWorkloadSpecFactoryConcept analog of
+    // WorkloadDescriptorConcept, not this concept.
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
@@ -652,8 +656,9 @@ public:
 
         // Match each TensorArgument's MeshTensor reference back to its index in the
         // io_tensor enumeration. Cache-miss path only.
-        // TT_FATALs on a TensorArgument that doesn't reference an io_tensor (see
-        // adapter-level TODO on op-owned resource tensor support).
+        // TT_FATALs on a TensorArgument that doesn't reference an io_tensor — see
+        // the adapter-level Design comment on why op-owned resource tensors are
+        // not supported on this concept.
         //
         // NOTE on host perf: the index-based binding scheme is what makes a
         // fast cache-hit path possible, but the current straightforward
@@ -675,7 +680,8 @@ public:
                 TT_FATAL(
                     it != io_mesh_tensors.end(),
                     "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args or "
-                    "tensor_return_value (got non-io_tensor MeshTensor)",
+                    "tensor_return_value. ProgramSpecFactoryConcept does not support op-owned "
+                    "resource tensors; route through the multi-program factory concept if you need them.",
                     tensor_arg.tensor_parameter_name);
                 bindings.push_back(
                     {tensor_arg.tensor_parameter_name,

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -650,8 +650,10 @@ public:
                 const auto& adv = kernel.advanced_options;
                 TT_FATAL(
                     schema.runtime_arg_names.empty() && schema.common_runtime_arg_names.empty() &&
-                        adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0 &&
-                        adv.num_runtime_varargs_per_node.empty(),
+                        adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0,
+                    // technically should also be checking adv.num_runtime_varargs_per_node,
+                    // but it's [[deprecated]] and will cause build spam...
+                    // so catch this corner case in the ProgramRunArgs check below instead.
                     "Kernel '{}' declares runtime arguments in its ProgramSpec. "
                     "TTNN ProgramSpecFactoryConcept restricts factories using the basic "
                     "create_program_artifacts to tensor-only per-dispatch mutation. "

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -580,19 +580,35 @@ public:
     // Requirements:
     //  1. Every TensorArgument returned by the factory must reference a
     //     MeshTensor reachable from tensor_args or tensor_return_value.
-    //  2. The factory must not declare or supply ANY runtime arguments
-    //     (other than its TensorParameters): no schema entries in the
-    //     returned ProgramSpec, and no values in the returned ProgramRunArgs.
-    //     NOTE: this is a TTNN-side restriction specific to the basic
+    //  2. The returned ProgramRunArgs must not contain any DFB size overrides.
+    //     This is a TTNN-side restriction specific to the basic
     //     ProgramSpecFactoryConcept, not a Metal 2.0 restriction.
-    //  3. The returned ProgramRunArgs must not contain any DFB size overrides.
-    //     Same reason and same TTNN-side restriction as #2.
+    //
+    // Runtime arguments — important constraint:
+    // Runtime arguments are supported. They are the standard mechanism for
+    // per-node distribution: the same compiled kernel binary running on N
+    // nodes receives different per-node argument values (slice indices, work
+    // offsets, per-node tensor addresses, etc.). RTA values are set ONCE at
+    // cache-miss time by experimental::SetProgramRunArgs and persist through
+    // every subsequent cache hit (UpdateTensorArgs only refreshes tensor args;
+    // all other ProgramRunArgs are stateful and retained — see the comment on
+    // experimental::UpdateTensorArgs).
+    //
+    // The factory must therefore ensure RTA values are deterministic from
+    // cache-miss-time inputs (operation_attributes, tensor_args, mesh
+    // coordinates). Encoding anything that varies BETWEEN dispatches sharing
+    // a cache entry (e.g., raw tensor addresses, dispatch counters) would
+    // silently produce stale values on cache hits — the bug class the
+    // immutable/mutable contract is built around. For per-dispatch mutable
+    // non-tensor state, use the (future) more general factory concept (see
+    // Unhandled use cases below).
     //
     // Unhandled use cases:
     //  - Ops that need op-owned resources (single-program or multi-program)
     //    should use the (future) MeshWorkloadSpecFactoryConcept analog of
     //    WorkloadDescriptorConcept, not this concept.
     //  - Ops that need fast-path patching of non-tensor mutable arguments
+    //    (RTA values that vary per dispatch, DFB sizes that vary per dispatch)
     //    should use the (future) create_program_spec / create_program_run_args
     //    mechanism.
     //  - Ops that need different per-device Programs should use the (future)
@@ -633,68 +649,18 @@ public:
             return result;
         }
 
-        // Disallow runtime arguments for the basic ProgramSpecFactoryConcept.
-        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
-        //
-        // A ProgramSpecFactoryConcept factory uses UpdateTensorArgs as its sole
-        // per-dispatch update mechanism — tensor bindings are the ONLY state that
-        // mutates between dispatches that share a cache entry. Any runtime argument
-        // declared in the returned ProgramSpec is therefore frozen at cache-miss
-        // time, and would be silently stale on every subsequent cache hit.
-        //
-        // Factories that genuinely need per-dispatch RTAs belong on a different
-        // factory concept (one with explicit per-dispatch mutable state).
-        static void assert_no_runtime_args(const tt::tt_metal::experimental::ProgramSpec& spec) {
-            for (const auto& kernel : spec.kernels) {
-                const auto& schema = kernel.runtime_arg_schema;
-                const auto& adv = kernel.advanced_options;
-                TT_FATAL(
-                    schema.runtime_arg_names.empty() && schema.common_runtime_arg_names.empty() &&
-                        adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0,
-                    // technically should also be checking adv.num_runtime_varargs_per_node,
-                    // but it's [[deprecated]] and will cause build spam...
-                    // so catch this corner case in the ProgramRunArgs check below instead.
-                    "Kernel '{}' declares runtime arguments in its ProgramSpec. "
-                    "TTNN ProgramSpecFactoryConcept restricts factories using the basic "
-                    "create_program_artifacts to tensor-only per-dispatch mutation. "
-                    "Either use compile-time arguments, consider advanced TensorParameters, "
-                    "or upgrade to the version of the factory concept that supports full "
-                    "generality of fast-path mutable ProgramRunArgs.",
-                    kernel.unique_id);
-            }
-        }
-
-        // Check that the factory doesn't attempt to supply runtime argument values.
-        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
-        //
-        // This is a technically redundant check; we've already enforced that the ProgramSpec
-        // schema disallows runtime arguments. To avoid surprises for op authors, also
-        // check that no attempt was made to supply runtime argument values in the ProgramRunArgs.
-        // This check is both for op author ergonomics (the TTNN-side error will be clearer in
-        // context than the Metal 2.0 validation error). It also guards against future changes to
-        // the TTNN infra that may bypass these checks with the power-user Metal 2.0 APIs.
-        static void assert_no_runtime_arg_values(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
-            for (const auto& kra : run_args.kernel_run_args) {
-                const auto& adv = kra.advanced_options;
-                TT_FATAL(
-                    kra.runtime_arg_values.empty() && kra.common_runtime_arg_values.empty() &&
-                        adv.runtime_varargs.empty() && adv.common_runtime_varargs.empty(),
-                    "Kernel '{}' supplies runtime argument values in ProgramRunArgs. "
-                    "TTNN ProgramSpecFactoryConcept restricts factories using the basic "
-                    "create_program_artifacts to tensor-only per-dispatch mutation. "
-                    "Either use compile-time arguments, consider advanced TensorParameters, "
-                    "or upgrade to the version of the factory concept that supports full "
-                    "generality of fast-path mutable ProgramRunArgs.",
-                    kra.kernel_spec_name);
-            }
-        }
-
         // Disallow DFB size overrides for the basic ProgramSpecFactoryConcept.
         // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
         //
-        // Same reasoning as assert_no_runtime_args above. This factory concept
-        // only updates tensor arguments on the fast path, so any DFB size override
-        // attempted through ProgramRunArgs would not mutate between dispatches.
+        // ProgramRunArgs::dfb_run_overrides resize a DFB at dispatch time
+        // (entry_size / num_entries). This concept's cache-hit path runs only
+        // UpdateTensorArgs, which doesn't touch DFB sizes — so any override
+        // set at cache-miss persists, but the factory can't update it between
+        // dispatches that share a cache entry. Unlike RTAs, DFB sizes have no
+        // per-node-distribution use case (a DFB is per-spec, not per-node), so
+        // there is no legitimate reason to use dfb_run_overrides on this
+        // concept: factories should set DFB sizes directly in the ProgramSpec
+        // (attr-derived sizes are naturally specialised via the cache key).
         static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
@@ -762,8 +728,6 @@ public:
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
-            assert_no_runtime_args(artifacts.spec);
-            assert_no_runtime_arg_values(artifacts.run_params);
             assert_no_dfb_size_overrides(artifacts.run_params);
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -622,6 +622,34 @@ public:
             return result;
         }
 
+        // A ProgramSpecFactoryConcept factory uses UpdateTensorArgs as its sole
+        // per-dispatch update mechanism — tensor bindings are the only state that
+        // mutates between dispatches that share a cache entry. Any runtime argument
+        // declared in the returned ProgramSpec is therefore frozen at cache-miss
+        // time, and would be silently stale on every subsequent cache hit.
+        //
+        // This is exactly the silent cache-hit corruption bug class the concept exists
+        // to rule out, so we reject any spec that declares one.
+        //
+        // Factories that genuinely need per-dispatch RTAs belong on a different
+        // factory concept (one with explicit per-dispatch mutable state).
+        static void assert_no_runtime_args(const tt::tt_metal::experimental::ProgramSpec& spec) {
+            for (const auto& kernel : spec.kernels) {
+                const auto& schema = kernel.runtime_arg_schema;
+                const auto& adv = kernel.advanced_options;
+                TT_FATAL(
+                    schema.runtime_arg_names.empty() && schema.common_runtime_arg_names.empty() &&
+                        adv.num_runtime_varargs == 0 && adv.num_common_runtime_varargs == 0 &&
+                        adv.num_runtime_varargs_per_node.empty(),
+                    "Kernel '{}' declares runtime arguments, but a ProgramSpecFactoryConcept "
+                    "factory has no per-dispatch update path for them — they would be silently "
+                    "stale on every program-cache hit. Move constants to compile-time args, "
+                    "route tensor-derived values through TensorParameter bindings, or move "
+                    "the op to a factory concept with explicit per-dispatch mutable state.",
+                    kernel.unique_id);
+            }
+        }
+
         // Match each TensorArgument's MeshTensor reference back to its index in the
         // io_tensor enumeration. Cache-miss path only.
         // TT_FATALs on a TensorArgument that doesn't reference an io_tensor (see
@@ -677,6 +705,7 @@ public:
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+            assert_no_runtime_args(artifacts.spec);
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -562,12 +562,12 @@ public:
     //
     // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0, single-program /
     // SPMD-flavored) for mesh dispatch. The op author writes ONLY
-    // create_program_spec, returning a single ProgramArtifacts (one ProgramSpec
+    // create_program_artifacts, returning a single ProgramArtifacts (one ProgramSpec
     // + ProgramRunArgs). The adapter stamps a Program from that spec onto
     // each mesh coordinate range covered by the workload — mirroring the
     // descriptor adapter's per-range build pattern.
     //
-    // On cache miss: the adapter calls create_program_spec, builds one Program
+    // On cache miss: the adapter calls create_program_artifacts, builds one Program
     // per coordinate range via experimental::MakeProgramFromSpec, applies
     // the initial ProgramRunArgs via SetProgramRunArgs, then resolves
     // each TensorArgument against the io_tensors enumerated from tensor_args /
@@ -704,7 +704,7 @@ public:
             // across all coordinate ranges. Bindings derive from the (single) set of
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
-            auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+            auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
             assert_no_runtime_args(artifacts.spec);
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -276,6 +276,23 @@ public:
         return result;
     }
 
+    // Like collect_io_mesh_tensors, but appends op-owned mesh_tensors AFTER the
+    // io tensors.  Order matters: bindings are recorded against this exact
+    // ordering on cache miss and must match on cache hit.  Shared by the
+    // adapters that support op-owned tensors — single-program ProgramSpec
+    // factories (op-owned mesh_tensors only) and multi-program Workload
+    // factories (mesh_tensors + semaphores).
+    static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_all_mesh_tensors(
+        const tensor_args_t& tensor_args,
+        const tensor_return_value_t& tensor_return_value,
+        const std::vector<tt::tt_metal::MeshTensor>& owned_mesh_tensors) {
+        auto result = collect_io_mesh_tensors(tensor_args, tensor_return_value);
+        for (const auto& t : owned_mesh_tensors) {
+            result.push_back(std::cref(t));
+        }
+        return result;
+    }
+
     // An adapter for creating a factory that abides to `MeshWorkloadFactoryConcept` out of `ProgramFactoryConcept`
     // types.
     template <ProgramFactoryConcept ProgramFactory>
@@ -624,13 +641,17 @@ public:
     //     assert_no_dfb_size_overrides and assert_no_common_runtime_args below
     //     for the per-error guidance.
     //   - Every TensorArgument returned by the factory must reference a
-    //     MeshTensor reachable from tensor_args or tensor_return_value (the
+    //     MeshTensor reachable from tensor_args, tensor_return_value, or the
+    //     op-owned mesh_tensors returned in the same ProgramArtifacts (the
     //     adapter matches by pointer identity within the call). Op-owned
-    //     MeshTensors do not work — they're local to create_program_artifacts
-    //     and are destroyed at return, leaving the cached Program holding
-    //     addresses freed before the asynchronous device dispatch completes.
-    //     Ops that need op-owned mesh resources should use
-    //     create_workload_artifacts (WorkloadSpecFactoryConcept) instead.
+    //     MeshTensors ARE supported on this path: they're moved out of the
+    //     ProgramArtifacts into the cache entry and kept alive for the cached
+    //     workload's lifetime, so the cached Program's references stay valid
+    //     across the asynchronous dispatch and across cache hits. This works
+    //     because MinimizeCacheHitCost runs the factory exactly once (on miss),
+    //     so the tensors are allocated once. (Op-owned GlobalSemaphores are not
+    //     offered here — a semaphore is a cross-program coordination resource;
+    //     ops that need one belong on create_workload_artifacts.)
     //
     // Runtime arguments:
     //   Per-node RTAs are supported. They are the standard mechanism for
@@ -663,20 +684,31 @@ public:
         using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
-        // Stored per range across cache entries: for each TensorArgument in a
-        // program's ProgramRunArgs, which io_tensor (by index into the
-        // deterministic reflection-driven enumeration) it was bound to.
-        // Pointer identity is only valid within a single call; the index is
-        // stable across calls.
+        // For each TensorArgument in the ProgramRunArgs, which entry in the
+        // combined {io tensors, op-owned mesh_tensors} enumeration it was bound
+        // to.  Pointer identity is only valid within a single call; the index
+        // is stable across calls.
         struct ResolvedTensorBinding {
             TensorParameterName tensor_parameter_name;
-            std::size_t io_tensor_idx;
+            std::size_t tensor_idx;
         };
 
         struct shared_variables_t {
+            // Op-owned device tensors moved out of the factory's ProgramArtifacts
+            // and kept alive for the cached workload's lifetime.  MeshTensor is
+            // move-only and owns its device allocation, so it is moved in once
+            // and referenced by index from here on.  (Single-program factories
+            // own tensors only — no GlobalSemaphores; those live on the
+            // multi-program workload concept.)
+            std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+            // The spec is stamped identically across every coordinate range, so
+            // the bindings are identical too — resolved once, applied to every
+            // program on cache hit.
             std::vector<ResolvedTensorBinding> bindings;
         };
-        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+        // Workload-level shared state (single slot, not per-range) so the
+        // move-only mesh_tensors are stored exactly once for the whole workload.
+        using cached_mesh_workload_t = CachedMeshWorkload<shared_variables_t>;
 
         // Disallow DFB size overrides on the Option 1 path.
         // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
@@ -748,38 +780,37 @@ public:
             }
         }
 
-        // Match each TensorArgument's MeshTensor reference back to its index in the
-        // io_tensor enumeration. Cache-miss path only.
-        // TT_FATALs on a TensorArgument that doesn't reference an io_tensor — see
-        // the adapter-level Design comment on why op-owned resource tensors are
-        // not supported on this concept.
+        // Match each TensorArgument's MeshTensor reference back to its index in
+        // the combined {io tensors, op-owned mesh_tensors} enumeration.
+        // Cache-miss path only.  TT_FATALs on a TensorArgument that references
+        // neither an io tensor nor an op-owned tensor.
         //
         // NOTE on host perf: the index-based binding scheme is what makes a
         // fast cache-hit path possible, but the current straightforward
-        // implementation isn't there yet — collect_io_mesh_tensors returns a
+        // implementation isn't there yet — collect_all_mesh_tensors returns a
         // heap std::vector, and apply_descriptor builds a fresh TensorArgument
         // vector each dispatch. Both costs are fixable by mirroring the
         // descriptor adapter's compile-time-unrolled walker + SmallVector +
         // cached TensorArgument storage pattern. Deferred pending profiling.
         static std::vector<ResolvedTensorBinding> resolve_bindings(
             const std::vector<TensorArgument>& factory_tensor_args,
-            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& mesh_tensors) {
             std::vector<ResolvedTensorBinding> bindings;
             bindings.reserve(factory_tensor_args.size());
             for (const auto& tensor_arg : factory_tensor_args) {
                 const auto* target = &tensor_arg.tensor.get();
-                auto it = std::find_if(io_mesh_tensors.begin(), io_mesh_tensors.end(), [target](const auto& wrapped) {
+                auto it = std::find_if(mesh_tensors.begin(), mesh_tensors.end(), [target](const auto& wrapped) {
                     return &wrapped.get() == target;
                 });
                 TT_FATAL(
-                    it != io_mesh_tensors.end(),
-                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args or "
-                    "tensor_return_value. ProgramSpecFactoryConcept does not support op-owned "
-                    "resource tensors; route through the multi-program factory concept if you need them.",
+                    it != mesh_tensors.end(),
+                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args, "
+                    "tensor_return_value, or the op-owned mesh_tensors returned in the same "
+                    "ProgramArtifacts.",
                     tensor_arg.tensor_parameter_name);
                 bindings.push_back(
                     {tensor_arg.tensor_parameter_name,
-                     static_cast<std::size_t>(std::distance(io_mesh_tensors.begin(), it))});
+                     static_cast<std::size_t>(std::distance(mesh_tensors.begin(), it))});
             }
             return bindings;
         }
@@ -800,24 +831,26 @@ public:
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
-            // The factory produces a single ProgramArtifacts; the adapter stamps it
-            // across all coordinate ranges. Validate fast-path-specific constraints
-            // and resolve bindings once; copy the (identical) bindings into each
-            // per-range shared state so they're available on cache hits for
-            // UpdateTensorArgs.
+            // The factory produces a single ProgramArtifacts; the adapter stamps
+            // it across all coordinate ranges. Validate fast-path-specific
+            // constraints, move any op-owned tensors into the cache entry, and
+            // resolve the (identical-across-ranges) bindings once.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
             assert_no_dfb_size_overrides(artifacts.run_params);
             assert_no_common_runtime_args(artifacts.run_params);
-            auto io_mesh_tensors =
-                MeshDeviceOperationAdapter::collect_io_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+
+            // Move op-owned tensors into the cache entry FIRST, then enumerate
+            // against the post-move storage; otherwise the bindings would index
+            // a soon-to-be-moved local.
+            shared_variables_t shared_variables{.mesh_tensors = std::move(artifacts.mesh_tensors), .bindings = {}};
+            const auto mesh_tensors = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
+                tensor_args, tensor_return_value, shared_variables.mesh_tensors);
+            shared_variables.bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
-            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
                 mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
@@ -838,15 +871,18 @@ public:
             const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors =
-                MeshDeviceOperationAdapter::collect_io_mesh_tensors(tensor_args, tensor_return_value);
+            auto& sv = cached_workload.shared_variables;
+            // Combine fresh io tensors with the cached op-owned mesh_tensors
+            // (which are stable across hits) in the same order bindings were
+            // recorded against on cache miss.
+            const auto mesh_tensors =
+                MeshDeviceOperationAdapter::collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
                 std::vector<TensorArgument> fresh_tensor_args;
                 fresh_tensor_args.reserve(sv.bindings.size());
                 for (const auto& b : sv.bindings) {
                     fresh_tensor_args.push_back(TensorArgument{
-                        .tensor_parameter_name = b.tensor_parameter_name, .tensor = io_mesh_tensors[b.io_tensor_idx]});
+                        .tensor_parameter_name = b.tensor_parameter_name, .tensor = mesh_tensors[b.tensor_idx]});
                 }
                 tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
             }
@@ -957,25 +993,6 @@ public:
         };
         using cached_mesh_workload_t = CachedMeshWorkload<shared_variables_t>;
 
-        // Walk io tensors then workload mesh_tensors.  Order matters: bindings
-        // are recorded against this exact ordering on cache miss and must
-        // match on cache hit.
-        static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_all_mesh_tensors(
-            const tensor_args_t& tensor_args,
-            const tensor_return_value_t& tensor_return_value,
-            const std::vector<tt::tt_metal::MeshTensor>& workload_mesh_tensors) {
-            std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
-            const auto visit = [&result](const tt::tt_metal::Tensor& t) {
-                result.push_back(std::cref(t.mesh_tensor()));
-            };
-            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_args);
-            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_return_value);
-            for (const auto& wmt : workload_mesh_tensors) {
-                result.push_back(std::cref(wmt));
-            }
-            return result;
-        }
-
         static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
@@ -1031,8 +1048,8 @@ public:
                 .mesh_tensors = std::move(artifacts.mesh_tensors),
                 .bindings_per_range = {}};
 
-            const auto mesh_tensor_refs =
-                collect_all_mesh_tensors(tensor_args, tensor_return_value, shared_variables.mesh_tensors);
+            const auto mesh_tensor_refs = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
+                tensor_args, tensor_return_value, shared_variables.mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             for (auto& precursor : artifacts.program_precursors) {
@@ -1052,7 +1069,8 @@ public:
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
             auto& sv = cached_workload.shared_variables;
-            const auto mesh_tensor_refs = collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
+            const auto mesh_tensor_refs =
+                MeshDeviceOperationAdapter::collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& bindings = sv.bindings_per_range.at(coordinate_range);
                 std::vector<TensorArgument> fresh_tensor_args;

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -652,6 +652,25 @@ public:
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
         requires requires { &ProgramSpecFactory::create_program_artifacts; }
     struct ProgramSpecMeshWorkloadFactoryAdapter {
+        // ProgramSpecFactoryConcept closes the immutable-side cache-key bug generator by
+        // construction: the framework's automatic hash of (op type + attrs + tensor args
+        // + mesh coords) is the ONLY sanctioned cache key — a custom compute_program_hash
+        // on the DeviceOperation could under-specify (omit args that actually affect the
+        // immutable Program) and silently resurrect the wrong Program on cache hit. Force
+        // the user to choose: trifecta factory (no custom hash) or a legacy factory shape
+        // (custom hash allowed at their own risk).
+        static_assert(
+            !requires(const operation_attributes_t& a, const tensor_args_t& t) {
+                DeviceOperation::compute_program_hash(a, t);
+            },
+            "DeviceOperations using a ProgramSpecFactoryConcept factory (Option 1 or Option 2 — "
+            "create_program_artifacts) cannot also define a custom compute_program_hash. The "
+            "framework's automatic hash is the only sanctioned cache key for these factories; "
+            "it closes the immutable-side bug generator (over-permissive hash → cache hit "
+            "resurrects an incorrect Program) by construction. If you need a custom hash for "
+            "performance reasons, use a legacy ProgramFactory or ProgramDescriptorFactory "
+            "factory shape instead.");
+
         // Option 1 (opt-in via the `fast_cache_hit_path` type marker) restores the
         // narrow-but-cheap UpdateTensorArgs fast path; the default is Option 2's
         // safe-by-construction full re-apply.
@@ -721,6 +740,50 @@ public:
                 "Option 2 path (full ProgramRunArgs re-apply on cache hit).");
         }
 
+        // Disallow common (broadcast-to-every-node) runtime args on the Option 1 path.
+        // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
+        //
+        // The Option 1 cache-hit path runs only UpdateTensorArgs, which does NOT refresh
+        // any RunArgs channel other than tensor args. Per-node RTAs are still legal
+        // (they're the standard mechanism for per-node work distribution: a single
+        // compiled binary takes different per-node values, and as long as those values
+        // are deterministic from the cache key, miss-time SetProgramRunArgs is enough).
+        // Common runtime args are different: by definition they're identical across all
+        // nodes for a single dispatch, so the per-node-distribution rationale doesn't
+        // apply. They fall into one of two cases:
+        //
+        //   - The CRTA value is constant for this Program. Then it belongs as a CTA
+        //     (compile-time arg) in the ProgramSpec — cleaner, and the framework will
+        //     bake it into the compiled kernel binary.
+        //
+        //   - The CRTA value varies between dispatches that share a cache entry. Then
+        //     Option 1 will silently use the stale value set at miss-time — exactly the
+        //     mutable-side bug class the trifecta design is built to avoid. Drop the
+        //     `fast_cache_hit_path` opt-in to use Option 2 (full ProgramRunArgs re-apply
+        //     on every cache hit handles varying CRTAs correctly).
+        //
+        // Note: this check applies only to user-channel CRTAs (KernelRunArgs::
+        // common_runtime_arg_values and AdvancedKernelRunArgs::common_runtime_varargs).
+        // The framework-managed CRTAs that route tensor metadata through TensorParameter
+        // relaxations (dynamic_tensor_shape and friends) live in a typed channel outside
+        // ProgramRunArgs and are correctly handled by UpdateTensorArgs.
+        static void assert_no_common_runtime_args(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
+            for (const auto& kernel : run_args.kernel_run_args) {
+                TT_FATAL(
+                    kernel.common_runtime_arg_values.empty() && kernel.advanced_options.common_runtime_varargs.empty(),
+                    "ProgramRunArgs returned by create_program_artifacts sets common runtime "
+                    "args (kernel '{}'). The Option 1 fast cache-hit path of "
+                    "ProgramSpecFactoryConcept (opted into via `using fast_cache_hit_path = "
+                    "std::true_type;`) restricts factories to tensor-only per-dispatch "
+                    "mutation, and per-node distribution is the only sanctioned use of "
+                    "runtime args on this path. If the CRTA value is constant for this "
+                    "Program, declare it as a CTA on the ProgramSpec instead. If it varies "
+                    "between dispatches, drop the `fast_cache_hit_path` opt-in to use the "
+                    "default Option 2 path (full ProgramRunArgs re-apply on cache hit).",
+                    kernel.kernel_spec_name);
+            }
+        }
+
         // Match each TensorArgument's MeshTensor reference back to its index in the
         // io_tensor enumeration. Cache-miss path only.
         // TT_FATALs on a TensorArgument that doesn't reference an io_tensor — see
@@ -785,6 +848,7 @@ public:
                 // once; copy the (identical) bindings into each per-range shared state so
                 // they're available on cache hits for UpdateTensorArgs.
                 assert_no_dfb_size_overrides(artifacts.run_params);
+                assert_no_common_runtime_args(artifacts.run_params);
                 auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
                 auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
                 for (const auto& range : tensor_coords.ranges()) {
@@ -902,6 +966,19 @@ public:
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
         requires WorkloadArtifactConcept<ProgramSpecFactory>
     struct WorkloadArtifactMeshWorkloadAdapter {
+        // Same immutable-side bug-generator closure as ProgramSpecMeshWorkloadFactoryAdapter:
+        // the framework's auto-hash is the only sanctioned cache key.
+        static_assert(
+            !requires(const operation_attributes_t& a, const tensor_args_t& t) {
+                DeviceOperation::compute_program_hash(a, t);
+            },
+            "DeviceOperations using a WorkloadArtifactConcept factory (create_workload_artifacts) "
+            "cannot also define a custom compute_program_hash. The framework's automatic hash is "
+            "the only sanctioned cache key for these factories; it closes the immutable-side bug "
+            "generator (over-permissive hash → cache hit resurrects an incorrect Program) by "
+            "construction. If you need a custom hash for performance reasons, use a legacy "
+            "ProgramFactory or ProgramDescriptorFactory factory shape instead.");
+
         using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -37,6 +37,9 @@ namespace ttnn::device_operation {
 template <typename T>
 using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
 
+template <typename T>
+using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
+
 // Extracts every Tensor reachable from an aggregate `T` and pushes its buffer()
 // onto `out`.  Generated per-T at compile time so the compiler emits a
 // straight-line walk of T's tensor fields with no runtime reflection visit,
@@ -560,77 +563,121 @@ public:
     // -----------------------------------------------------------------------
     // ProgramSpecMeshWorkloadFactoryAdapter
     //
-    // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0, single-program /
-    // SPMD) for mesh dispatch. The op author writes ONLY create_program_artifacts,
-    // returning a single ProgramArtifacts (one ProgramSpec + ProgramRunArgs).
-    // The adapter stamps a Program from that spec onto each mesh coordinate
-    // range covered by the workload.
+    // Adapts a ProgramSpecFactoryConcept factory that exposes
+    // create_program_artifacts (Metal 2.0, single-program / SPMD) for mesh
+    // dispatch.  The op author writes ONLY create_program_artifacts, returning a
+    // single ProgramArtifacts (one ProgramSpec + ProgramRunArgs).  The adapter
+    // stamps a Program from that spec onto each mesh coordinate range covered by
+    // the workload.
     //
-    // On cache miss: The adapter calls create_program_artifacts, builds one Program
-    // per coordinate range (via experimental::MakeProgramFromSpec), applies
-    // the initial ProgramRunArgs (via experimental::SetProgramRunArgs), then
-    // resolves each TensorArgument against the io_tensors enumerated from
-    // tensor_args / tensor_return_value (pointer-identity match within the call).
+    // The adapter supports TWO cache-hit paths, selected by a type-level marker
+    // on the factory (`using fast_cache_hit_path = std::true_type;` opts into
+    // Option 1).  See the doc block on `HasFastCacheHitPathOptIn` in
+    // operation_concepts.hpp for the design rationale.
     //
-    // On cache hit: the adapter enumerates fresh io_tensors, mutates the
-    // cached TensorArgument storage in place using the stored index bindings, and
-    // applies the new MeshTensors to the existing (cached) Program
-    // (via experimental::UpdateTensorArgs).
+    // -------------------------------------------------------
+    // Option 2 — default, safe by construction
+    // -------------------------------------------------------
+    // On cache miss:
+    //   1. create_program_artifacts is called.
+    //   2. One Program per coordinate range is built via MakeProgramFromSpec.
+    //   3. The initial ProgramRunArgs is applied via SetProgramRunArgs.
     //
-    // Requirements:
-    //  1. Every TensorArgument returned by the factory must reference a
-    //     MeshTensor reachable from tensor_args or tensor_return_value.
-    //  2. The returned ProgramRunArgs must not contain any DFB size overrides.
-    //     This is a TTNN-side restriction specific to the basic
-    //     ProgramSpecFactoryConcept, not a Metal 2.0 restriction.
+    // On cache hit:
+    //   1. create_program_artifacts is called AGAIN.
+    //   2. The full ProgramRunArgs is re-applied via SetProgramRunArgs to every
+    //      cached Program.
     //
-    // Runtime arguments — important constraint:
-    // Runtime arguments are supported. They are the standard mechanism for
-    // per-node distribution: the same compiled kernel binary running on N
-    // nodes receives different per-node argument values (slice indices, work
-    // offsets, per-node tensor addresses, etc.). RTA values are set ONCE at
-    // cache-miss time by experimental::SetProgramRunArgs and persist through
-    // every subsequent cache hit (UpdateTensorArgs only refreshes tensor args;
-    // all other ProgramRunArgs are stateful and retained — see the comment on
-    // experimental::UpdateTensorArgs).
+    // The fast path is "wide-and-flat": full Metalium ProgramRunArgs (RTAs,
+    // CRTAs, DFB size overrides, tensor args) are re-applied each dispatch and
+    // therefore can vary freely between dispatches sharing a cache entry.
+    // Greater per-dispatch host overhead (the factory runs each call), in
+    // exchange for guaranteed correctness — no fast-path-specific code in the
+    // factory.
     //
-    // The factory must therefore ensure RTA values are deterministic from
-    // cache-miss-time inputs (operation_attributes, tensor_args, mesh
-    // coordinates). Encoding anything that varies BETWEEN dispatches sharing
-    // a cache entry (e.g., raw tensor addresses, dispatch counters) would
-    // silently produce stale values on cache hits — the bug class the
-    // immutable/mutable contract is built around. For per-dispatch mutable
-    // non-tensor state, use the (future) more general factory concept (see
-    // Unhandled use cases below).
+    // -------------------------------------------------------
+    // Option 1 — opt-in fast path
+    // -------------------------------------------------------
+    // On cache miss:
+    //   1. create_program_artifacts is called.
+    //   2. One Program per coordinate range is built via MakeProgramFromSpec.
+    //   3. The initial ProgramRunArgs is applied via SetProgramRunArgs.
+    //   4. Each TensorArgument is resolved against the io_tensors enumerated
+    //      from tensor_args / tensor_return_value (pointer-identity match
+    //      within the call) and recorded as an index, stored per range.
     //
-    // Unhandled use cases:
-    //  - Ops that need op-owned resources (single-program or multi-program)
-    //    should use the (future) MeshWorkloadSpecFactoryConcept analog of
-    //    WorkloadDescriptorConcept, not this concept.
-    //  - Ops that need fast-path patching of non-tensor mutable arguments
-    //    (RTA values that vary per dispatch, DFB sizes that vary per dispatch)
-    //    should use the (future) create_program_spec / create_program_run_args
-    //    mechanism.
-    //  - Ops that need different per-device Programs should use the (future)
-    //    MeshWorkloadSpecFactoryConcept.
+    // On cache hit:
+    //   1. Fresh io_tensors are enumerated; for each cached Program, the stored
+    //      index bindings rebuild a TensorArgument vector against the fresh
+    //      tensors and apply it via UpdateTensorArgs.  The factory is NOT
+    //      called.
+    //
+    // The fast path is "narrow-but-cheap": only the tensor portion of the
+    // ProgramRunArgs is refreshed.  All other RunArgs (RTAs, CRTAs, DFB sizes)
+    // are set ONCE at cache-miss time and persist across hits.  The factory
+    // must therefore ensure those values are deterministic from cache-miss-time
+    // inputs — anything varying BETWEEN dispatches sharing a cache entry would
+    // silently produce stale values on hits (the bug class the immutable/
+    // mutable contract is built around).
+    //
+    // Option 1 requirements (in addition to the shared requirement below):
+    //   - The returned ProgramRunArgs must not contain any DFB size overrides
+    //     (UpdateTensorArgs does not touch DFB sizes; a stale override would
+    //     persist).  This is a TTNN-side restriction, not a Metal 2.0
+    //     restriction.
+    //
+    // -------------------------------------------------------
+    // Shared requirement (both options)
+    // -------------------------------------------------------
+    // Every TensorArgument returned by the factory must reference a MeshTensor
+    // reachable from tensor_args or tensor_return_value.  Op-owned MeshTensors
+    // do not work on either path: they are local to create_program_artifacts
+    // and are destroyed at return, leaving the cached Program (Option 1) or the
+    // SetProgramRunArgs copy (Option 2) holding addresses freed before the
+    // asynchronous device dispatch completes.  Ops that need op-owned mesh
+    // resources should use create_workload_artifacts (WorkloadArtifactConcept)
+    // instead, which keeps those resources alive for the cached workload's
+    // lifetime.
+    //
+    // -------------------------------------------------------
+    // Runtime arguments
+    // -------------------------------------------------------
+    // Runtime arguments are supported on both options.  They are the standard
+    // mechanism for per-node distribution: the same compiled kernel binary
+    // running on N nodes receives different per-node argument values (slice
+    // indices, work offsets, per-node tensor addresses, etc.).  See the
+    // per-option description above for what varies / persists between
+    // dispatches.
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
+        requires requires { &ProgramSpecFactory::create_program_artifacts; }
     struct ProgramSpecMeshWorkloadFactoryAdapter {
+        // Option 1 (opt-in via the `fast_cache_hit_path` type marker) restores the
+        // narrow-but-cheap UpdateTensorArgs fast path; the default is Option 2's
+        // safe-by-construction full re-apply.
+        static constexpr bool fast_cache_hit_path = HasFastCacheHitPathOptIn<ProgramSpecFactory>;
+
         using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
-        // Stored across cache entries: for each TensorArgument in a program's
-        // ProgramRunArgs, which io_tensor (by index into the deterministic
-        // reflection-driven enumeration) it was bound to. Pointer identity is
-        // only valid within a single call; the index is stable across calls.
+        // Stored across cache entries on the Option 1 path: for each
+        // TensorArgument in a program's ProgramRunArgs, which io_tensor (by
+        // index into the deterministic reflection-driven enumeration) it was
+        // bound to.  Pointer identity is only valid within a single call; the
+        // index is stable across calls.  Empty on Option 2 (the factory is
+        // re-run on every cache hit, so no cross-dispatch state is needed).
         struct ResolvedTensorBinding {
             TensorParameterName tensor_parameter_name;
             std::size_t io_tensor_idx;
         };
 
-        struct shared_variables_t {
+        struct fast_path_shared_variables_t {
             std::vector<ResolvedTensorBinding> bindings;
         };
+        struct safe_path_shared_variables_t {};
+
+        using shared_variables_t =
+            std::conditional_t<fast_cache_hit_path, fast_path_shared_variables_t, safe_path_shared_variables_t>;
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         // Walk tensor_args and tensor_return_value via reflection, collecting
@@ -649,26 +696,29 @@ public:
             return result;
         }
 
-        // Disallow DFB size overrides for the basic ProgramSpecFactoryConcept.
+        // Disallow DFB size overrides on the Option 1 path.
         // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
         //
         // ProgramRunArgs::dfb_run_overrides resize a DFB at dispatch time
-        // (entry_size / num_entries). This concept's cache-hit path runs only
+        // (entry_size / num_entries). The Option 1 cache-hit path runs only
         // UpdateTensorArgs, which doesn't touch DFB sizes — so any override
         // set at cache-miss persists, but the factory can't update it between
         // dispatches that share a cache entry. Unlike RTAs, DFB sizes have no
         // per-node-distribution use case (a DFB is per-spec, not per-node), so
-        // there is no legitimate reason to use dfb_run_overrides on this
-        // concept: factories should set DFB sizes directly in the ProgramSpec
-        // (attr-derived sizes are naturally specialised via the cache key).
+        // there is no legitimate reason to use dfb_run_overrides on the fast
+        // path: factories should set DFB sizes directly in the ProgramSpec
+        // (attr-derived sizes are naturally specialised via the cache key), or
+        // switch to Option 2 (the default), whose SetProgramRunArgs cache-hit
+        // path applies DFB size overrides correctly.
         static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
                 "ProgramRunArgs returned by create_program_artifacts contains DFB size "
-                "overrides. TTNN ProgramSpecFactoryConcept restricts factories using the "
-                "basic create_program_artifacts to tensor-only per-dispatch mutation. "
-                "Either use fixed DFB sizes, or upgrade to the version of the factory "
-                "concept that supports full generality of fast-path ProgramRunArgs.");
+                "overrides. The Option 1 fast cache-hit path of ProgramSpecFactoryConcept "
+                "(opted into via `using fast_cache_hit_path = std::true_type;`) restricts "
+                "factories to tensor-only per-dispatch mutation. Either use fixed DFB "
+                "sizes, or drop the `fast_cache_hit_path` opt-in to use the default "
+                "Option 2 path (full ProgramRunArgs re-apply on cache hit).");
         }
 
         // Match each TensorArgument's MeshTensor reference back to its index in the
@@ -724,21 +774,39 @@ public:
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
             // The factory produces a single ProgramArtifacts; the adapter stamps it
-            // across all coordinate ranges. Bindings derive from the (single) set of
-            // factory tensor_args and are identical for every stamped program; copy
-            // per range into the cached shared state.
+            // across all coordinate ranges.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
-            assert_no_dfb_size_overrides(artifacts.run_params);
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-            for (const auto& range : tensor_coords.ranges()) {
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
-                mesh_workload.add_program(range, std::move(program));
+
+            if constexpr (fast_cache_hit_path) {
+                // Option 1: validate fast-path-specific constraints and resolve bindings
+                // once; copy the (identical) bindings into each per-range shared state so
+                // they're available on cache hits for UpdateTensorArgs.
+                assert_no_dfb_size_overrides(artifacts.run_params);
+                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+                auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+                for (const auto& range : tensor_coords.ranges()) {
+                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                    shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
+                    mesh_workload.add_program(range, std::move(program));
+                }
+            } else {
+                // Option 2: validate the io-tensor reachability invariant (op-owned
+                // MeshTensors would die at factory return and leave the SetProgramRunArgs
+                // copy holding freed device addresses), but discard the resulting
+                // bindings — the factory is re-run on every cache hit, so no
+                // cross-dispatch state needs to persist.
+                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+                (void)resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+                for (const auto& range : tensor_coords.ranges()) {
+                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                    shared_variables.emplace(range, shared_variables_t{});
+                    mesh_workload.add_program(range, std::move(program));
+                }
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }
@@ -750,17 +818,235 @@ public:
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
+            [[maybe_unused]] const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            if constexpr (fast_cache_hit_path) {
+                // Option 1: rebuild TensorArguments from cached bindings against fresh
+                // io_tensors and refresh only the tensor portion of the ProgramRunArgs.
+                // RTAs, CRTAs, and DFB sizes set at cache-miss persist across hits.
+                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                    std::vector<TensorArgument> fresh_tensor_args;
+                    fresh_tensor_args.reserve(sv.bindings.size());
+                    for (const auto& b : sv.bindings) {
+                        fresh_tensor_args.push_back(TensorArgument{
+                            .tensor_parameter_name = b.tensor_parameter_name,
+                            .tensor = io_mesh_tensors[b.io_tensor_idx]});
+                    }
+                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                }
+            } else {
+                // Option 2: re-run the factory and re-apply the full ProgramRunArgs to
+                // every cached Program. Safe by construction — every field (RTAs,
+                // CRTAs, DFB sizes, tensor args) is freshly built from the new inputs,
+                // so nothing can carry stale state across dispatches.
+                auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+                (void)resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                }
+            }
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // WorkloadArtifactMeshWorkloadAdapter
+    //
+    // Adapts a ProgramSpecFactoryConcept factory that exposes
+    // create_workload_artifacts for mesh dispatch.  The op author returns a
+    // MeshWorkloadArtifacts in one call: workload-scoped resources
+    // (GlobalSemaphores, op-owned MeshTensors) and a sequence of per-coord
+    // ProgramArtifacts (each a ProgramSpec + ProgramRunArgs) covering the
+    // workload.  The adapter builds one Program per per-coord entry and
+    // assembles the MeshWorkload.
+    //
+    // Metal 2.0 analog of DescriptorMeshWorkloadAdapter contract (2): the
+    // declarative single-call shape, with MeshTensors instead of WorkloadBuffer.
+    //
+    // On cache miss:
+    //   1. create_workload_artifacts is called.
+    //   2. The factory's workload-scoped resources are MOVED into shared_variables
+    //      and held there for the cached workload's lifetime — MeshTensors are
+    //      move-only and own their device allocations, GlobalSemaphores keep
+    //      their on-device allocation valid.
+    //   3. For each per-coord ProgramArtifacts, a Program is built via
+    //      MakeProgramFromSpec and the initial ProgramRunArgs is applied via
+    //      SetProgramRunArgs.  TensorArguments are resolved to indices into a
+    //      combined enumeration of {io tensors, workload-owned mesh_tensors};
+    //      the bindings are stored per range.
+    //
+    // On cache hit:
+    //   - Fresh io tensors are enumerated and combined with the cached
+    //     workload-owned mesh_tensors (which are stable across hits).  For
+    //     each cached Program, the stored index bindings rebuild a
+    //     TensorArgument vector and apply it via UpdateTensorArgs.  The
+    //     factory is NOT called.
+    //
+    // Why no Option-2-style cache-hit factory re-run:
+    // Re-running create_workload_artifacts on every hit would allocate fresh
+    // GlobalSemaphores and MeshTensors; the cached Programs already hold
+    // device addresses from the cache-miss allocations.  The new resources
+    // would be immediately destroyed at function return, freeing addresses
+    // the cached Programs still reference.
+    //
+    // Requirements:
+    //  - Every TensorArgument in any per-coord ProgramRunArgs must reference
+    //    a MeshTensor reachable from tensor_args, tensor_return_value, or the
+    //    workload's mesh_tensors.
+    //  - DFB size overrides are forbidden (same UpdateTensorArgs cache-hit
+    //    constraint as Option 1 of the create_program_artifacts adapter).
+    // -----------------------------------------------------------------------
+    template <ProgramSpecFactoryConcept ProgramSpecFactory>
+        requires WorkloadArtifactConcept<ProgramSpecFactory>
+    struct WorkloadArtifactMeshWorkloadAdapter {
+        using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
+        using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
+
+        // Signature-mismatch guard: a factory with a `create_workload_artifacts`
+        // member whose signature/return type doesn't match would otherwise
+        // produce deep template errors at the first call site.  Surface the
+        // problem clearly at concept-check time.
+        static constexpr bool has_create_workload_artifacts = requires(
+            const operation_attributes_t& a,
+            const tensor_args_t& t,
+            tensor_return_value_t& r,
+            const ttnn::MeshCoordinateRangeSet& tc) {
+            { ProgramSpecFactory::create_workload_artifacts(a, t, r, tc) } -> std::same_as<MeshWorkloadArtifacts>;
+        };
+        static_assert(
+            has_create_workload_artifacts,
+            "Factory has create_workload_artifacts but its signature/return type doesn't match. "
+            "Expected: static MeshWorkloadArtifacts create_workload_artifacts("
+            "const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&, "
+            "const ttnn::MeshCoordinateRangeSet&)");
+
+        // For each TensorArgument in a per-coord ProgramRunArgs, the index
+        // into the combined {io tensors, workload mesh_tensors} enumeration.
+        struct ResolvedTensorBinding {
+            TensorParameterName tensor_parameter_name;
+            std::size_t tensor_idx;
+        };
+
+        struct shared_variables_t {
+            // Workload-scoped resources, kept alive for the cached workload's
+            // lifetime.  MeshTensor is move-only and owns its device
+            // allocation, so we MOVE it in once and reference it by index from
+            // here on out.  GlobalSemaphore is copyable but we treat it the
+            // same way for symmetry.
+            std::vector<tt::tt_metal::GlobalSemaphore> semaphores;
+            std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+            // Per-program tensor-arg bindings, keyed by program coordinate
+            // range.  Stored as a map so cache-hit lookup is O(1) per range.
+            std::unordered_map<ttnn::MeshCoordinateRange, std::vector<ResolvedTensorBinding>> bindings_per_range;
+        };
+        using cached_mesh_workload_t = CachedMeshWorkload<shared_variables_t>;
+
+        // Walk io tensors then workload mesh_tensors.  Order matters: bindings
+        // are recorded against this exact ordering on cache miss and must
+        // match on cache hit.
+        static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_all_mesh_tensors(
+            const tensor_args_t& tensor_args,
+            const tensor_return_value_t& tensor_return_value,
+            const std::vector<tt::tt_metal::MeshTensor>& workload_mesh_tensors) {
+            std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
+            const auto visit = [&result](const tt::tt_metal::Tensor& t) {
+                result.push_back(std::cref(t.mesh_tensor()));
+            };
+            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_args);
+            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_return_value);
+            for (const auto& wmt : workload_mesh_tensors) {
+                result.push_back(std::cref(wmt));
+            }
+            return result;
+        }
+
+        static void assert_no_dfb_size_overrides(const tt::tt_metal::experimental::ProgramRunArgs& run_args) {
+            TT_FATAL(
+                run_args.dfb_run_overrides.empty(),
+                "ProgramRunArgs returned by create_workload_artifacts contains DFB size overrides. "
+                "The WorkloadArtifactConcept cache-hit path runs only UpdateTensorArgs, which does "
+                "not touch DFB sizes; set DFB sizes directly in the ProgramSpec instead.");
+        }
+
+        static std::vector<ResolvedTensorBinding> resolve_bindings(
+            const std::vector<TensorArgument>& factory_tensor_args,
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& mesh_tensors) {
+            std::vector<ResolvedTensorBinding> bindings;
+            bindings.reserve(factory_tensor_args.size());
+            for (const auto& tensor_arg : factory_tensor_args) {
+                const auto* target = &tensor_arg.tensor.get();
+                auto it = std::find_if(mesh_tensors.begin(), mesh_tensors.end(), [target](const auto& wrapped) {
+                    return &wrapped.get() == target;
+                });
+                TT_FATAL(
+                    it != mesh_tensors.end(),
+                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args, "
+                    "tensor_return_value, or the workload-owned mesh_tensors returned by "
+                    "create_workload_artifacts.",
+                    tensor_arg.tensor_parameter_name);
+                bindings.push_back(
+                    {tensor_arg.tensor_parameter_name,
+                     static_cast<std::size_t>(std::distance(mesh_tensors.begin(), it))});
+            }
+            return bindings;
+        }
+
+        static auto create_mesh_workload(
+            const operation_attributes_t& attrs,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+            TT_FATAL(
+                first_tensor.has_value(),
+                "WorkloadArtifact factory adapter requires at least one Tensor in tensor_args to source the "
+                "MeshDevice");
+            auto* mesh_device = first_tensor.value().device();
+            TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
+
+            auto artifacts =
+                ProgramSpecFactory::create_workload_artifacts(attrs, tensor_args, tensor_return_value, tensor_coords);
+
+            // Move resources into shared_variables FIRST, then collect references off the
+            // post-move storage; otherwise the references would dangle when the local
+            // `artifacts.mesh_tensors` is moved later.
+            shared_variables_t shared_variables{
+                .semaphores = std::move(artifacts.semaphores),
+                .mesh_tensors = std::move(artifacts.mesh_tensors),
+                .bindings_per_range = {}};
+
+            const auto mesh_tensor_refs =
+                collect_all_mesh_tensors(tensor_args, tensor_return_value, shared_variables.mesh_tensors);
+
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            for (auto& precursor : artifacts.program_precursors) {
+                assert_no_dfb_size_overrides(precursor.artifacts.run_params);
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, precursor.artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, precursor.artifacts.run_params);
+                auto bindings = resolve_bindings(precursor.artifacts.run_params.tensor_args, mesh_tensor_refs);
+                shared_variables.bindings_per_range.emplace(precursor.range, std::move(bindings));
+                mesh_workload.add_program(precursor.range, std::move(program));
+            }
+            return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        static void apply_descriptor(
+            cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto& sv = cached_workload.shared_variables;
+            const auto mesh_tensor_refs = collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                const auto& bindings = sv.bindings_per_range.at(coordinate_range);
                 std::vector<TensorArgument> fresh_tensor_args;
-                fresh_tensor_args.reserve(sv.bindings.size());
-                for (const auto& b : sv.bindings) {
+                fresh_tensor_args.reserve(bindings.size());
+                for (const auto& b : bindings) {
                     fresh_tensor_args.push_back(TensorArgument{
-                        .tensor_parameter_name = b.tensor_parameter_name, .tensor = io_mesh_tensors[b.io_tensor_idx]});
+                        .tensor_parameter_name = b.tensor_parameter_name, .tensor = mesh_tensor_refs[b.tensor_idx]});
                 }
                 tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -561,43 +561,22 @@ public:
     };
 
     // -----------------------------------------------------------------------
-    // ProgramSpecMeshWorkloadFactoryAdapter
+    // ProgramSpecMeshWorkloadFactoryAdapter — Option 1 only
     //
     // Adapts a ProgramSpecFactoryConcept factory that exposes
-    // create_program_artifacts (Metal 2.0, single-program / SPMD) for mesh
-    // dispatch.  The op author writes ONLY create_program_artifacts, returning a
-    // single ProgramArtifacts (one ProgramSpec + ProgramRunArgs).  The adapter
-    // stamps a Program from that spec onto each mesh coordinate range covered by
-    // the workload.
+    // create_program_artifacts AND opts into Option 1 via
+    // `using fast_cache_hit_path = std::true_type;` (HasFastCacheHitPathOptIn).
+    // The factory returns a single ProgramArtifacts (one ProgramSpec +
+    // ProgramRunArgs); the adapter stamps a Program from that spec onto each
+    // mesh coordinate range covered by the workload.
     //
-    // The adapter supports TWO cache-hit paths, selected by a type-level marker
-    // on the factory (`using fast_cache_hit_path = std::true_type;` opts into
-    // Option 1).  See the doc block on `HasFastCacheHitPathOptIn` in
-    // operation_concepts.hpp for the design rationale.
+    // Note: Option 2 (default, no opt-in marker) does NOT use this adapter.
+    // It's structurally different: the factory must run before the cache lookup
+    // because the cache key is the ProgramSpec itself, not the op args. That
+    // path is dispatch_option2_spec_hash in device_operation.hpp,
+    // branched away from in launch_operation_with_adapter before reaching the
+    // existing cache-hit / cache-miss handlers.
     //
-    // -------------------------------------------------------
-    // Option 2 — default, safe by construction
-    // -------------------------------------------------------
-    // On cache miss:
-    //   1. create_program_artifacts is called.
-    //   2. One Program per coordinate range is built via MakeProgramFromSpec.
-    //   3. The initial ProgramRunArgs is applied via SetProgramRunArgs.
-    //
-    // On cache hit:
-    //   1. create_program_artifacts is called AGAIN.
-    //   2. The full ProgramRunArgs is re-applied via SetProgramRunArgs to every
-    //      cached Program.
-    //
-    // The fast path is "wide-and-flat": full Metalium ProgramRunArgs (RTAs,
-    // CRTAs, DFB size overrides, tensor args) are re-applied each dispatch and
-    // therefore can vary freely between dispatches sharing a cache entry.
-    // Greater per-dispatch host overhead (the factory runs each call), in
-    // exchange for guaranteed correctness — no fast-path-specific code in the
-    // factory.
-    //
-    // -------------------------------------------------------
-    // Option 1 — opt-in fast path
-    // -------------------------------------------------------
     // On cache miss:
     //   1. create_program_artifacts is called.
     //   2. One Program per coordinate range is built via MakeProgramFromSpec.
@@ -612,7 +591,7 @@ public:
     //      tensors and apply it via UpdateTensorArgs.  The factory is NOT
     //      called.
     //
-    // The fast path is "narrow-but-cheap": only the tensor portion of the
+    // The cache-hit path is "narrow-but-cheap": only the tensor portion of the
     // ProgramRunArgs is refreshed.  All other RunArgs (RTAs, CRTAs, DFB sizes)
     // are set ONCE at cache-miss time and persist across hits.  The factory
     // must therefore ensure those values are deterministic from cache-miss-time
@@ -620,37 +599,30 @@ public:
     // silently produce stale values on hits (the bug class the immutable/
     // mutable contract is built around).
     //
-    // Option 1 requirements (in addition to the shared requirement below):
+    // Requirements:
     //   - The returned ProgramRunArgs must not contain any DFB size overrides
-    //     (UpdateTensorArgs does not touch DFB sizes; a stale override would
-    //     persist).  This is a TTNN-side restriction, not a Metal 2.0
-    //     restriction.
+    //     or common runtime args (CRTAs); both would be set at cache miss and
+    //     silently persist past dispatches that intended to change them. See
+    //     assert_no_dfb_size_overrides and assert_no_common_runtime_args below
+    //     for the per-error guidance.
+    //   - Every TensorArgument returned by the factory must reference a
+    //     MeshTensor reachable from tensor_args or tensor_return_value (the
+    //     adapter matches by pointer identity within the call). Op-owned
+    //     MeshTensors do not work — they're local to create_program_artifacts
+    //     and are destroyed at return, leaving the cached Program holding
+    //     addresses freed before the asynchronous device dispatch completes.
+    //     Ops that need op-owned mesh resources should use
+    //     create_workload_artifacts (WorkloadArtifactConcept) instead.
     //
-    // -------------------------------------------------------
-    // Shared requirement (both options)
-    // -------------------------------------------------------
-    // Every TensorArgument returned by the factory must reference a MeshTensor
-    // reachable from tensor_args or tensor_return_value.  Op-owned MeshTensors
-    // do not work on either path: they are local to create_program_artifacts
-    // and are destroyed at return, leaving the cached Program (Option 1) or the
-    // SetProgramRunArgs copy (Option 2) holding addresses freed before the
-    // asynchronous device dispatch completes.  Ops that need op-owned mesh
-    // resources should use create_workload_artifacts (WorkloadArtifactConcept)
-    // instead, which keeps those resources alive for the cached workload's
-    // lifetime.
-    //
-    // -------------------------------------------------------
-    // Runtime arguments
-    // -------------------------------------------------------
-    // Runtime arguments are supported on both options.  They are the standard
-    // mechanism for per-node distribution: the same compiled kernel binary
-    // running on N nodes receives different per-node argument values (slice
-    // indices, work offsets, per-node tensor addresses, etc.).  See the
-    // per-option description above for what varies / persists between
-    // dispatches.
+    // Runtime arguments:
+    //   Per-node RTAs are supported. They are the standard mechanism for
+    //   per-node work distribution: the same compiled kernel binary running on
+    //   N nodes receives different per-node argument values. They must be
+    //   deterministic from cache-miss-time inputs (see above).
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
-        requires requires { &ProgramSpecFactory::create_program_artifacts; }
+        requires requires { &ProgramSpecFactory::create_program_artifacts; } &&
+                 HasFastCacheHitPathOptIn<ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
         // ProgramSpecFactoryConcept closes the immutable-side cache-key bug generator by
         // construction: the framework's automatic hash of (op type + attrs + tensor args
@@ -671,32 +643,22 @@ public:
             "performance reasons, use a legacy ProgramFactory or ProgramDescriptorFactory "
             "factory shape instead.");
 
-        // Option 1 (opt-in via the `fast_cache_hit_path` type marker) restores the
-        // narrow-but-cheap UpdateTensorArgs fast path; the default is Option 2's
-        // safe-by-construction full re-apply.
-        static constexpr bool fast_cache_hit_path = HasFastCacheHitPathOptIn<ProgramSpecFactory>;
-
         using TensorParameterName = tt::tt_metal::experimental::TensorParameterName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
-        // Stored across cache entries on the Option 1 path: for each
-        // TensorArgument in a program's ProgramRunArgs, which io_tensor (by
-        // index into the deterministic reflection-driven enumeration) it was
-        // bound to.  Pointer identity is only valid within a single call; the
-        // index is stable across calls.  Empty on Option 2 (the factory is
-        // re-run on every cache hit, so no cross-dispatch state is needed).
+        // Stored per range across cache entries: for each TensorArgument in a
+        // program's ProgramRunArgs, which io_tensor (by index into the
+        // deterministic reflection-driven enumeration) it was bound to.
+        // Pointer identity is only valid within a single call; the index is
+        // stable across calls.
         struct ResolvedTensorBinding {
             TensorParameterName tensor_parameter_name;
             std::size_t io_tensor_idx;
         };
 
-        struct fast_path_shared_variables_t {
+        struct shared_variables_t {
             std::vector<ResolvedTensorBinding> bindings;
         };
-        struct safe_path_shared_variables_t {};
-
-        using shared_variables_t =
-            std::conditional_t<fast_cache_hit_path, fast_path_shared_variables_t, safe_path_shared_variables_t>;
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         // Walk tensor_args and tensor_return_value via reflection, collecting
@@ -837,40 +799,23 @@ public:
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
             // The factory produces a single ProgramArtifacts; the adapter stamps it
-            // across all coordinate ranges.
+            // across all coordinate ranges. Validate fast-path-specific constraints
+            // and resolve bindings once; copy the (identical) bindings into each
+            // per-range shared state so they're available on cache hits for
+            // UpdateTensorArgs.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+            assert_no_dfb_size_overrides(artifacts.run_params);
+            assert_no_common_runtime_args(artifacts.run_params);
+            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-
-            if constexpr (fast_cache_hit_path) {
-                // Option 1: validate fast-path-specific constraints and resolve bindings
-                // once; copy the (identical) bindings into each per-range shared state so
-                // they're available on cache hits for UpdateTensorArgs.
-                assert_no_dfb_size_overrides(artifacts.run_params);
-                assert_no_common_runtime_args(artifacts.run_params);
-                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-                auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
-                for (const auto& range : tensor_coords.ranges()) {
-                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                    shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
-                    mesh_workload.add_program(range, std::move(program));
-                }
-            } else {
-                // Option 2: validate the io-tensor reachability invariant (op-owned
-                // MeshTensors would die at factory return and leave the SetProgramRunArgs
-                // copy holding freed device addresses), but discard the resulting
-                // bindings — the factory is re-run on every cache hit, so no
-                // cross-dispatch state needs to persist.
-                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-                (void)resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
-                for (const auto& range : tensor_coords.ranges()) {
-                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                    shared_variables.emplace(range, shared_variables_t{});
-                    mesh_workload.add_program(range, std::move(program));
-                }
+            for (const auto& range : tensor_coords.ranges()) {
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
+                mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }
@@ -880,38 +825,26 @@ public:
         // `override_runtime_arguments` when both exist. We adopt the name to
         // slot into that hook directly — the "descriptor" word here is the
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
+        //
+        // Rebuild TensorArguments from cached bindings against fresh io_tensors
+        // and refresh only the tensor portion of the ProgramRunArgs. RTAs and
+        // DFB sizes set at cache-miss persist across hits (CRTAs are forbidden;
+        // see assert_no_common_runtime_args).
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
-            [[maybe_unused]] const operation_attributes_t& attrs,
+            const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            if constexpr (fast_cache_hit_path) {
-                // Option 1: rebuild TensorArguments from cached bindings against fresh
-                // io_tensors and refresh only the tensor portion of the ProgramRunArgs.
-                // RTAs, CRTAs, and DFB sizes set at cache-miss persist across hits.
-                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-                    std::vector<TensorArgument> fresh_tensor_args;
-                    fresh_tensor_args.reserve(sv.bindings.size());
-                    for (const auto& b : sv.bindings) {
-                        fresh_tensor_args.push_back(TensorArgument{
-                            .tensor_parameter_name = b.tensor_parameter_name,
-                            .tensor = io_mesh_tensors[b.io_tensor_idx]});
-                    }
-                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                std::vector<TensorArgument> fresh_tensor_args;
+                fresh_tensor_args.reserve(sv.bindings.size());
+                for (const auto& b : sv.bindings) {
+                    fresh_tensor_args.push_back(TensorArgument{
+                        .tensor_parameter_name = b.tensor_parameter_name, .tensor = io_mesh_tensors[b.io_tensor_idx]});
                 }
-            } else {
-                // Option 2: re-run the factory and re-apply the full ProgramRunArgs to
-                // every cached Program. Safe by construction — every field (RTAs,
-                // CRTAs, DFB sizes, tensor args) is freshly built from the new inputs,
-                // so nothing can carry stale state across dispatches.
-                auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
-                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-                (void)resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
-                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                }
+                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -836,8 +836,8 @@ public:
             // constraints, move any op-owned tensors into the cache entry, and
             // resolve the (identical-across-ranges) bindings once.
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
-            assert_no_dfb_size_overrides(artifacts.run_params);
-            assert_no_common_runtime_args(artifacts.run_params);
+            assert_no_dfb_size_overrides(artifacts.run_args);
+            assert_no_common_runtime_args(artifacts.run_args);
 
             // Move op-owned tensors into the cache entry FIRST, then enumerate
             // against the post-move storage; otherwise the bindings would index
@@ -845,12 +845,12 @@ public:
             shared_variables_t shared_variables{.mesh_tensors = std::move(artifacts.mesh_tensors), .bindings = {}};
             const auto mesh_tensors = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
                 tensor_args, tensor_return_value, shared_variables.mesh_tensors);
-            shared_variables.bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors);
+            shared_variables.bindings = resolve_bindings(artifacts.run_args.tensor_args, mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_args);
                 mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
@@ -1053,10 +1053,10 @@ public:
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             for (auto& precursor : artifacts.program_precursors) {
-                assert_no_dfb_size_overrides(precursor.artifacts.run_params);
+                assert_no_dfb_size_overrides(precursor.artifacts.run_args);
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, precursor.artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, precursor.artifacts.run_params);
-                auto bindings = resolve_bindings(precursor.artifacts.run_params.tensor_args, mesh_tensor_refs);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, precursor.artifacts.run_args);
+                auto bindings = resolve_bindings(precursor.artifacts.run_args.tensor_args, mesh_tensor_refs);
                 shared_variables.bindings_per_range.emplace(precursor.range, std::move(bindings));
                 mesh_workload.add_program(precursor.range, std::move(program));
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -266,7 +266,7 @@ public:
     // adapter) so it can be used by code paths that don't share the inner
     // adapter's template parameters or constraints — in particular by
     // dispatch_option2_spec_hash, which handles factories that don't satisfy
-    // the Option 1 adapter's `HasFastCacheHitPathOptIn` requirement.
+    // the Option 1 adapter's `HasMinimizeCacheHitCostOptIn` requirement.
     static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_io_mesh_tensors(
         const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
         std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
@@ -583,7 +583,7 @@ public:
     //
     // Adapts a ProgramSpecFactoryConcept factory that exposes
     // create_program_artifacts AND opts into Option 1 via
-    // `using fast_cache_hit_path = std::true_type;` (HasFastCacheHitPathOptIn).
+    // `caching_strategy = ProgramCachingStrategy::MinimizeCacheHitCost` (HasMinimizeCacheHitCostOptIn).
     // The factory returns a single ProgramArtifacts (one ProgramSpec +
     // ProgramRunArgs); the adapter stamps a Program from that spec onto each
     // mesh coordinate range covered by the workload.
@@ -640,7 +640,7 @@ public:
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
         requires requires { &ProgramSpecFactory::create_program_artifacts; } &&
-                 HasFastCacheHitPathOptIn<ProgramSpecFactory>
+                 HasMinimizeCacheHitCostOptIn<ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
         // ProgramSpecFactoryConcept closes the immutable-side cache-key bug generator by
         // construction: the framework's automatic hash of (op type + attrs + tensor args
@@ -697,11 +697,11 @@ public:
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
                 "ProgramRunArgs returned by create_program_artifacts contains DFB size "
-                "overrides. The Option 1 fast cache-hit path of ProgramSpecFactoryConcept "
-                "(opted into via `using fast_cache_hit_path = std::true_type;`) restricts "
-                "factories to tensor-only per-dispatch mutation. Either use fixed DFB "
-                "sizes, or drop the `fast_cache_hit_path` opt-in to use the default "
-                "Option 2 path (full ProgramRunArgs re-apply on cache hit).");
+                "overrides. The MinimizeCacheHitCost cache-hit path of ProgramSpecFactoryConcept "
+                "(opted into via `caching_strategy = ProgramCachingStrategy::MinimizeCacheHitCost`) "
+                "restricts factories to tensor-only per-dispatch mutation. Either use fixed DFB "
+                "sizes, or drop the opt-in to use the default MaximizeCacheReuse path "
+                "(full ProgramRunArgs re-apply on cache hit).");
         }
 
         // Disallow common (broadcast-to-every-node) runtime args on the Option 1 path.
@@ -721,10 +721,11 @@ public:
         //     bake it into the compiled kernel binary.
         //
         //   - The CRTA value varies between dispatches that share a cache entry. Then
-        //     Option 1 will silently use the stale value set at miss-time — exactly the
-        //     mutable-side bug class the trifecta design is built to avoid. Drop the
-        //     `fast_cache_hit_path` opt-in to use Option 2 (full ProgramRunArgs re-apply
-        //     on every cache hit handles varying CRTAs correctly).
+        //     the MinimizeCacheHitCost path will silently use the stale value set at
+        //     miss-time — exactly the mutable-side bug class the trifecta design is
+        //     built to avoid. Drop the opt-in to use the default MaximizeCacheReuse
+        //     path (full ProgramRunArgs re-apply on every cache hit handles varying
+        //     CRTAs correctly).
         //
         // Note: this check applies only to user-channel CRTAs (KernelRunArgs::
         // common_runtime_arg_values and AdvancedKernelRunArgs::common_runtime_varargs).
@@ -736,14 +737,14 @@ public:
                 TT_FATAL(
                     kernel.common_runtime_arg_values.empty() && kernel.advanced_options.common_runtime_varargs.empty(),
                     "ProgramRunArgs returned by create_program_artifacts sets common runtime "
-                    "args (kernel '{}'). The Option 1 fast cache-hit path of "
-                    "ProgramSpecFactoryConcept (opted into via `using fast_cache_hit_path = "
-                    "std::true_type;`) restricts factories to tensor-only per-dispatch "
-                    "mutation, and per-node distribution is the only sanctioned use of "
-                    "runtime args on this path. If the CRTA value is constant for this "
-                    "Program, declare it as a CTA on the ProgramSpec instead. If it varies "
-                    "between dispatches, drop the `fast_cache_hit_path` opt-in to use the "
-                    "default Option 2 path (full ProgramRunArgs re-apply on cache hit).",
+                    "args (kernel '{}'). The MinimizeCacheHitCost cache-hit path of "
+                    "ProgramSpecFactoryConcept (opted into via `caching_strategy = "
+                    "ProgramCachingStrategy::MinimizeCacheHitCost`) restricts factories to "
+                    "tensor-only per-dispatch mutation, and per-node distribution is the only "
+                    "sanctioned use of runtime args on this path. If the CRTA value is constant "
+                    "for this Program, declare it as a CTA on the ProgramSpec instead. If it "
+                    "varies between dispatches, drop the opt-in to use the default "
+                    "MaximizeCacheReuse path (full ProgramRunArgs re-apply on cache hit).",
                     kernel.kernel_spec_name);
             }
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -630,7 +630,7 @@ public:
     //     and are destroyed at return, leaving the cached Program holding
     //     addresses freed before the asynchronous device dispatch completes.
     //     Ops that need op-owned mesh resources should use
-    //     create_workload_artifacts (WorkloadArtifactConcept) instead.
+    //     create_workload_artifacts (WorkloadSpecFactoryConcept) instead.
     //
     // Runtime arguments:
     //   Per-node RTAs are supported. They are the standard mechanism for
@@ -639,8 +639,7 @@ public:
     //   deterministic from cache-miss-time inputs (see above).
     // -----------------------------------------------------------------------
     template <ProgramSpecFactoryConcept ProgramSpecFactory>
-        requires requires { &ProgramSpecFactory::create_program_artifacts; } &&
-                 HasMinimizeCacheHitCostOptIn<ProgramSpecFactory>
+        requires HasMinimizeCacheHitCostOptIn<ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
         // ProgramSpecFactoryConcept closes the immutable-side cache-key bug generator by
         // construction: the framework's automatic hash of (op type + attrs + tensor args
@@ -857,7 +856,7 @@ public:
     // -----------------------------------------------------------------------
     // WorkloadArtifactMeshWorkloadAdapter
     //
-    // Adapts a ProgramSpecFactoryConcept factory that exposes
+    // Adapts a WorkloadSpecFactoryConcept factory that exposes
     // create_workload_artifacts for mesh dispatch.  The op author returns a
     // MeshWorkloadArtifacts in one call: workload-scoped resources
     // (GlobalSemaphores, op-owned MeshTensors) and a sequence of per-coord
@@ -901,8 +900,7 @@ public:
     //  - DFB size overrides are forbidden (same UpdateTensorArgs cache-hit
     //    constraint as Option 1 of the create_program_artifacts adapter).
     // -----------------------------------------------------------------------
-    template <ProgramSpecFactoryConcept ProgramSpecFactory>
-        requires WorkloadArtifactConcept<ProgramSpecFactory>
+    template <WorkloadSpecFactoryConcept WorkloadSpecFactory>
     struct WorkloadArtifactMeshWorkloadAdapter {
         // Same immutable-side bug-generator closure as ProgramSpecMeshWorkloadFactoryAdapter:
         // the framework's auto-hash is the only sanctioned cache key.
@@ -910,7 +908,7 @@ public:
             !requires(const operation_attributes_t& a, const tensor_args_t& t) {
                 DeviceOperation::compute_program_hash(a, t);
             },
-            "DeviceOperations using a WorkloadArtifactConcept factory (create_workload_artifacts) "
+            "DeviceOperations using a WorkloadSpecFactoryConcept factory (create_workload_artifacts) "
             "cannot also define a custom compute_program_hash. The framework's automatic hash is "
             "the only sanctioned cache key for these factories; it closes the immutable-side bug "
             "generator (over-permissive hash → cache hit resurrects an incorrect Program) by "
@@ -929,7 +927,7 @@ public:
             const tensor_args_t& t,
             tensor_return_value_t& r,
             const ttnn::MeshCoordinateRangeSet& tc) {
-            { ProgramSpecFactory::create_workload_artifacts(a, t, r, tc) } -> std::same_as<MeshWorkloadArtifacts>;
+            { WorkloadSpecFactory::create_workload_artifacts(a, t, r, tc) } -> std::same_as<MeshWorkloadArtifacts>;
         };
         static_assert(
             has_create_workload_artifacts,
@@ -982,7 +980,7 @@ public:
             TT_FATAL(
                 run_args.dfb_run_overrides.empty(),
                 "ProgramRunArgs returned by create_workload_artifacts contains DFB size overrides. "
-                "The WorkloadArtifactConcept cache-hit path runs only UpdateTensorArgs, which does "
+                "The WorkloadSpecFactoryConcept cache-hit path runs only UpdateTensorArgs, which does "
                 "not touch DFB sizes; set DFB sizes directly in the ProgramSpec instead.");
         }
 
@@ -1023,7 +1021,7 @@ public:
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
             auto artifacts =
-                ProgramSpecFactory::create_workload_artifacts(attrs, tensor_args, tensor_return_value, tensor_coords);
+                WorkloadSpecFactory::create_workload_artifacts(attrs, tensor_args, tensor_return_value, tensor_coords);
 
             // Move resources into shared_variables FIRST, then collect references off the
             // post-move storage; otherwise the references would dangle when the local

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -285,9 +285,9 @@ public:
     static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_all_mesh_tensors(
         const tensor_args_t& tensor_args,
         const tensor_return_value_t& tensor_return_value,
-        const std::vector<tt::tt_metal::MeshTensor>& owned_mesh_tensors) {
+        const std::vector<tt::tt_metal::MeshTensor>& op_owned_tensors) {
         auto result = collect_io_mesh_tensors(tensor_args, tensor_return_value);
-        for (const auto& t : owned_mesh_tensors) {
+        for (const auto& t : op_owned_tensors) {
             result.push_back(std::cref(t));
         }
         return result;
@@ -642,7 +642,7 @@ public:
     //     for the per-error guidance.
     //   - Every TensorArgument returned by the factory must reference a
     //     MeshTensor reachable from tensor_args, tensor_return_value, or the
-    //     op-owned mesh_tensors returned in the same ProgramArtifacts (the
+    //     op-owned tensors returned in the same ProgramArtifacts (the
     //     adapter matches by pointer identity within the call). Op-owned
     //     MeshTensors ARE supported on this path: they're moved out of the
     //     ProgramArtifacts into the cache entry and kept alive for the cached
@@ -700,7 +700,7 @@ public:
             // and referenced by index from here on.  (Single-program factories
             // own tensors only — no GlobalSemaphores; those live on the
             // multi-program workload concept.)
-            std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+            std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
             // The spec is stamped identically across every coordinate range, so
             // the bindings are identical too — resolved once, applied to every
             // program on cache hit.
@@ -805,7 +805,7 @@ public:
                 TT_FATAL(
                     it != mesh_tensors.end(),
                     "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args, "
-                    "tensor_return_value, or the op-owned mesh_tensors returned in the same "
+                    "tensor_return_value, or the op-owned tensors returned in the same "
                     "ProgramArtifacts.",
                     tensor_arg.tensor_parameter_name);
                 bindings.push_back(
@@ -842,9 +842,10 @@ public:
             // Move op-owned tensors into the cache entry FIRST, then enumerate
             // against the post-move storage; otherwise the bindings would index
             // a soon-to-be-moved local.
-            shared_variables_t shared_variables{.mesh_tensors = std::move(artifacts.mesh_tensors), .bindings = {}};
+            shared_variables_t shared_variables{
+                .op_owned_tensors = std::move(artifacts.op_owned_tensors), .bindings = {}};
             const auto mesh_tensors = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
-                tensor_args, tensor_return_value, shared_variables.mesh_tensors);
+                tensor_args, tensor_return_value, shared_variables.op_owned_tensors);
             shared_variables.bindings = resolve_bindings(artifacts.run_args.tensor_args, mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
@@ -875,8 +876,8 @@ public:
             // Combine fresh io tensors with the cached op-owned mesh_tensors
             // (which are stable across hits) in the same order bindings were
             // recorded against on cache miss.
-            const auto mesh_tensors =
-                MeshDeviceOperationAdapter::collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
+            const auto mesh_tensors = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
+                tensor_args, tensor_return_value, sv.op_owned_tensors);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 std::vector<TensorArgument> fresh_tensor_args;
                 fresh_tensor_args.reserve(sv.bindings.size());
@@ -985,8 +986,8 @@ public:
             // allocation, so we MOVE it in once and reference it by index from
             // here on out.  GlobalSemaphore is copyable but we treat it the
             // same way for symmetry.
-            std::vector<tt::tt_metal::GlobalSemaphore> semaphores;
-            std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+            std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
+            std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
             // Per-program tensor-arg bindings, keyed by program coordinate
             // range.  Stored as a map so cache-hit lookup is O(1) per range.
             std::unordered_map<ttnn::MeshCoordinateRange, std::vector<ResolvedTensorBinding>> bindings_per_range;
@@ -1014,7 +1015,7 @@ public:
                 TT_FATAL(
                     it != mesh_tensors.end(),
                     "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args, "
-                    "tensor_return_value, or the workload-owned mesh_tensors returned by "
+                    "tensor_return_value, or the workload's op-owned tensors returned by "
                     "create_workload_artifacts.",
                     tensor_arg.tensor_parameter_name);
                 bindings.push_back(
@@ -1042,21 +1043,21 @@ public:
 
             // Move resources into shared_variables FIRST, then collect references off the
             // post-move storage; otherwise the references would dangle when the local
-            // `artifacts.mesh_tensors` is moved later.
+            // `artifacts.op_owned_tensors` is moved later.
             shared_variables_t shared_variables{
-                .semaphores = std::move(artifacts.semaphores),
-                .mesh_tensors = std::move(artifacts.mesh_tensors),
+                .global_semaphores = std::move(artifacts.global_semaphores),
+                .op_owned_tensors = std::move(artifacts.op_owned_tensors),
                 .bindings_per_range = {}};
 
             const auto mesh_tensor_refs = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
-                tensor_args, tensor_return_value, shared_variables.mesh_tensors);
+                tensor_args, tensor_return_value, shared_variables.op_owned_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             for (auto& precursor : artifacts.program_precursors) {
-                assert_no_dfb_size_overrides(precursor.artifacts.run_args);
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, precursor.artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, precursor.artifacts.run_args);
-                auto bindings = resolve_bindings(precursor.artifacts.run_args.tensor_args, mesh_tensor_refs);
+                assert_no_dfb_size_overrides(precursor.run_args);
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, precursor.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, precursor.run_args);
+                auto bindings = resolve_bindings(precursor.run_args.tensor_args, mesh_tensor_refs);
                 shared_variables.bindings_per_range.emplace(precursor.range, std::move(bindings));
                 mesh_workload.add_program(precursor.range, std::move(program));
             }
@@ -1069,8 +1070,8 @@ public:
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
             auto& sv = cached_workload.shared_variables;
-            const auto mesh_tensor_refs =
-                MeshDeviceOperationAdapter::collect_all_mesh_tensors(tensor_args, tensor_return_value, sv.mesh_tensors);
+            const auto mesh_tensor_refs = MeshDeviceOperationAdapter::collect_all_mesh_tensors(
+                tensor_args, tensor_return_value, sv.op_owned_tensors);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& bindings = sv.bindings_per_range.at(coordinate_range);
                 std::vector<TensorArgument> fresh_tensor_args;

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -258,6 +258,24 @@ public:
         }
     }
 
+    // Walk tensor_args and tensor_return_value via reflection, collecting the
+    // MeshTensor of every Tensor leaf. Deterministic, stable across calls
+    // (reflection order is field-declaration order). Available to every
+    // factory adapter that needs to validate or bind against the io tensors;
+    // sits at MeshDeviceOperationAdapter scope (rather than nested in an
+    // adapter) so it can be used by code paths that don't share the inner
+    // adapter's template parameters or constraints — in particular by
+    // dispatch_option2_spec_hash, which handles factories that don't satisfy
+    // the Option 1 adapter's `HasFastCacheHitPathOptIn` requirement.
+    static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_io_mesh_tensors(
+        const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
+        std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
+        const auto visit = [&result](const tt::tt_metal::Tensor& t) { result.push_back(std::cref(t.mesh_tensor())); };
+        ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_args);
+        ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_return_value);
+        return result;
+    }
+
     // An adapter for creating a factory that abides to `MeshWorkloadFactoryConcept` out of `ProgramFactoryConcept`
     // types.
     template <ProgramFactoryConcept ProgramFactory>
@@ -661,22 +679,6 @@ public:
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
-        // Walk tensor_args and tensor_return_value via reflection, collecting
-        // the MeshTensor of every Tensor leaf. The walk order is deterministic
-        // (reflection-driven, stable across calls), so the resulting indices
-        // are stable across calls. Metal 2.0 analog of the descriptor adapter's
-        // collect_tensor_buffers, at the MeshTensor level instead of Buffer*.
-        static std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> collect_mesh_tensors(
-            const tensor_args_t& tensor_args, const tensor_return_value_t& tensor_return_value) {
-            std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>> result;
-            const auto visit = [&result](const tt::tt_metal::Tensor& t) {
-                result.push_back(std::cref(t.mesh_tensor()));
-            };
-            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_args);
-            ttsl::reflection::visit_object_of_type<tt::tt_metal::Tensor>(visit, tensor_return_value);
-            return result;
-        }
-
         // Disallow DFB size overrides on the Option 1 path.
         // (This is a TTNN-side restriction, not a Metal 2.0 restriction)
         //
@@ -754,7 +756,7 @@ public:
         //
         // NOTE on host perf: the index-based binding scheme is what makes a
         // fast cache-hit path possible, but the current straightforward
-        // implementation isn't there yet — collect_mesh_tensors returns a
+        // implementation isn't there yet — collect_io_mesh_tensors returns a
         // heap std::vector, and apply_descriptor builds a fresh TensorArgument
         // vector each dispatch. Both costs are fixable by mirroring the
         // descriptor adapter's compile-time-unrolled walker + SmallVector +
@@ -806,7 +808,8 @@ public:
             auto artifacts = ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
             assert_no_dfb_size_overrides(artifacts.run_params);
             assert_no_common_runtime_args(artifacts.run_params);
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto io_mesh_tensors =
+                MeshDeviceOperationAdapter::collect_io_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
@@ -835,7 +838,8 @@ public:
             const operation_attributes_t& /*attrs*/,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            auto io_mesh_tensors =
+                MeshDeviceOperationAdapter::collect_io_mesh_tensors(tensor_args, tensor_return_value);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& sv = cached_workload.shared_variables.at(coordinate_range);
                 std::vector<TensorArgument> fresh_tensor_args;

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -4,21 +4,72 @@
 
 #pragma once
 
+#include <vector>
+
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace ttnn::device_operation {
 
-// Build product of a Metal 2.0 op factory: the immutable ProgramSpec plus the
-// mutable ProgramRunArgs. Returned by a ProgramSpecFactoryConcept factory's
-// create_program_artifacts method; the framework adapter stamps a Program out of
-// this artifact onto each mesh coordinate range of the workload.
-//
-// A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
-// artifact type for ops whose programs vary across the mesh.
+// This file contains TTNN-specific data structures.
+// These use Metalium's Metal 2.0 descriptor structs to create higher-level
+// data structures, specific to the needs of TTNN ops.
+
+/**
+ * Declarative description of a single-device Program.
+ * (Metal 2.0 equivalent to the legacy ProgramDescriptor.)
+ *
+ * ProgramSpec describes the immutable properties of a Program.
+ * These are the Program properties that cannot be changed after Program construction.
+ * The ProgramSpec is analogous to the signature and body of a "whole device function",
+ * which Program construction compiles into an executable device object.
+ *
+ * ProgramRunArgs describes the mutable properties of a Program.
+ * These are the Program properties that CAN be changed after Program construction.
+ * The ProgramRunArgs are analogous to the arguments passed to the "function" above.
+ * Fresh ProgramRunArgs are provided with each execution (enqueue) of the Program.
+ *
+ */
 struct ProgramArtifacts {
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;
+};
+
+/**
+ * Declarative description of a mesh-scoped workload.
+ *
+ * A MeshWorkloadArtifacts pairs the per-coord ProgramArtifacts that make up
+ * the workload with the workload-scoped resources the ProgramSpecs reference.
+ * The framework realises it into a MeshWorkload on cache miss and keeps the
+ * artifacts alive for the cached workload's lifetime so that:
+ *   - GlobalSemaphores keep their device-side allocations valid, and
+ *   - MeshTensors keep their device-side allocations valid.
+ *     (Note: MeshTensor is an RAII mesh device memory object with unique
+ *      ownership semantics.)
+ *
+ * Layout choices:
+ *   - `programs` is range-keyed rather than coord-keyed so that ops with a
+ *     single program replicated across the whole mesh emit just one entry.
+ *   - Resources are flat vectors (not named slots) so factories with N
+ *     semaphores or N buffers can grow without changing the schema.
+ */
+struct MeshWorkloadArtifacts {
+    // Workload-scoped resources, allocated by the factory during workload
+    // build and kept alive for the lifetime of the cached MeshWorkload.
+    std::vector<tt::tt_metal::GlobalSemaphore> semaphores;
+    std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+
+    // Per-coord program descriptors.  Each entry covers a contiguous
+    // MeshCoordinateRange and is materialised into one Program added to the
+    // resulting MeshWorkload.
+    struct PerCoordProgramArtifacts {
+        tt::tt_metal::distributed::MeshCoordinateRange range;
+        ProgramArtifacts artifacts;
+    };
+    std::vector<PerCoordProgramArtifacts> program_precursors;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -11,7 +11,7 @@ namespace ttnn::device_operation {
 
 // Build product of a Metal 2.0 op factory: the immutable ProgramSpec plus the
 // mutable ProgramRunArgs. Returned by a ProgramSpecFactoryConcept factory's
-// create_program_spec method; the framework adapter stamps a Program out of
+// create_program_artifacts method; the framework adapter stamps a Program out of
 // this artifact onto each mesh coordinate range of the workload.
 //
 // A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -44,14 +44,14 @@ struct ProgramArtifacts {
     // Only meaningful under the MinimizeCacheHitCost strategy: that path runs
     // the factory exactly once (on cache miss), so the tensors are allocated
     // once.  The default MaximizeCacheReuse path re-runs the factory on every
-    // dispatch and would re-allocate them, so non-empty mesh_tensors are
+    // dispatch and would re-allocate them, so a non-empty op_owned_tensors is
     // rejected there (see dispatch_option2_spec_hash).
     //
     // GlobalSemaphores are intentionally NOT offered here: a semaphore is a
     // cross-program / cross-device coordination resource, which makes no sense
     // on a single Program.  Ops that need op-owned semaphores belong on the
     // multi-program workload concept (MeshWorkloadArtifacts).
-    std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
 
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_args;
@@ -60,35 +60,41 @@ struct ProgramArtifacts {
 /**
  * Declarative description of a mesh-scoped workload.
  *
- * A MeshWorkloadArtifacts pairs the per-coord ProgramArtifacts that make up
- * the workload with the workload-scoped resources the ProgramSpecs reference.
+ * A MeshWorkloadArtifacts pairs the per-coord programs that make up the
+ * workload with the workload-scoped resources the ProgramSpecs reference.
  * The framework realises it into a MeshWorkload on cache miss and keeps the
- * artifacts alive for the cached workload's lifetime so that:
+ * resources alive for the cached workload's lifetime so that:
  *   - GlobalSemaphores keep their device-side allocations valid, and
  *   - MeshTensors keep their device-side allocations valid.
  *     (Note: MeshTensor is an RAII mesh device memory object with unique
  *      ownership semantics.)
  *
  * Layout choices:
- *   - `programs` is range-keyed rather than coord-keyed so that ops with a
- *     single program replicated across the whole mesh emit just one entry.
+ *   - `program_precursors` is range-keyed rather than coord-keyed so that ops
+ *     with a single program replicated across the whole mesh emit just one
+ *     entry.
  *   - Resources are flat vectors (not named slots) so factories with N
- *     semaphores or N buffers can grow without changing the schema.
+ *     semaphores or N tensors can grow without changing the schema.
  */
 struct MeshWorkloadArtifacts {
-    // Workload-scoped resources, allocated by the factory during workload
-    // build and kept alive for the lifetime of the cached MeshWorkload.
-    std::vector<tt::tt_metal::GlobalSemaphore> semaphores;
-    std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+    // Workload-scoped op-owned resources, allocated by the factory during
+    // workload build and kept alive for the lifetime of the cached MeshWorkload.
+    // These live at the workload level, NOT on the per-coord programs: a
+    // workload's resources are shared across its programs, and the per-coord
+    // unit is deliberately resource-free (storing spec + run_args directly
+    // rather than a ProgramArtifacts, which would carry its own op_owned_tensors
+    // and shadow these).
+    std::vector<tt::tt_metal::GlobalSemaphore> global_semaphores;
+    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
 
-    // Per-coord program descriptors.  Each entry covers a contiguous
-    // MeshCoordinateRange and is materialised into one Program added to the
-    // resulting MeshWorkload.
-    struct PerCoordProgramArtifacts {
+    // Per-coord programs.  Each entry covers a contiguous MeshCoordinateRange
+    // and is materialised into one Program added to the resulting MeshWorkload.
+    struct PerCoordProgram {
         tt::tt_metal::distributed::MeshCoordinateRange range;
-        ProgramArtifacts artifacts;
+        tt::tt_metal::experimental::ProgramSpec spec;
+        tt::tt_metal::experimental::ProgramRunArgs run_args;
     };
-    std::vector<PerCoordProgramArtifacts> program_precursors;
+    std::vector<PerCoordProgram> program_precursors;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -34,6 +34,25 @@ namespace ttnn::device_operation {
  *
  */
 struct ProgramArtifacts {
+    // Op-owned device tensors (config / lookup / scratch) allocated by the
+    // factory and kept alive for the lifetime of the cached Program(s).
+    // MeshTensor is an RAII mesh device-memory object with unique ownership;
+    // the framework moves these into the cache entry so their device
+    // allocations outlive the (asynchronous) dispatch and stay valid across
+    // cache hits.  Empty for the common case of an op that owns no resources.
+    //
+    // Only meaningful under the MinimizeCacheHitCost strategy: that path runs
+    // the factory exactly once (on cache miss), so the tensors are allocated
+    // once.  The default MaximizeCacheReuse path re-runs the factory on every
+    // dispatch and would re-allocate them, so non-empty mesh_tensors are
+    // rejected there (see dispatch_option2_spec_hash).
+    //
+    // GlobalSemaphores are intentionally NOT offered here: a semaphore is a
+    // cross-program / cross-device coordination resource, which makes no sense
+    // on a single Program.  Ops that need op-owned semaphores belong on the
+    // multi-program workload concept (MeshWorkloadArtifacts).
+    std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
+
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;
 };

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -54,7 +54,7 @@ struct ProgramArtifacts {
     std::vector<tt::tt_metal::MeshTensor> mesh_tensors;
 
     tt::tt_metal::experimental::ProgramSpec spec;
-    tt::tt_metal::experimental::ProgramRunArgs run_params;
+    tt::tt_metal::experimental::ProgramRunArgs run_args;
 };
 
 /**

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -72,42 +72,96 @@ template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
-// Metal 2.0 factory concept: factories that return ProgramArtifacts (a ProgramSpec +
-// ProgramRunArgs) from create_program_artifacts. The framework adapter stamps a Program
-// from the spec onto each mesh coordinate range on cache miss, and patches TensorArgs
-// via experimental::UpdateTensorArgs on cache hit.
+// Metal 2.0 factory concept:
+// Factories that return EITHER:
+//  - ProgramArtifacts (a ProgramSpec + ProgramRunArgs) from create_program_artifacts, or
+//  - A separate ProgramSpec from create_program_spec, ProgramRunArgs from create_program_run_args,
+//    and a minimal struct of extracted data from the input args, chained into create_program_spec.
+//
+//-----------------------------------------------------------------------------------
+// "Option 1" (via create_program_artifacts):
+//
+// The framework adapter stamps a Program from the spec onto each mesh coordinate range on
+// cache miss, and patches ONLY the tensor arguments on cache hit.
+//
+// The ProgramCache hash key is automatically computed by the TTNN infrastructure based on
+// the op's type and arguments (taking into account any TensorParameter relaxations).
+// The factory author writes NO fast-path-specific code.
+//
+// The factory-provided create_program_artifacts is only called on cache miss.
 //
 // NOTE: Each TensorArgument.tensor in ProgramRunArgs MUST reference a MeshTensor reachable
-// from the factory's `tensor_args` / `tensor_return_value` parameters — the adapter
-// matches by pointer identity. Constructing or copying a MeshTensor and referencing the
-// copy will TT_FATAL at runtime.
+//   from the factory's `tensor_args` / `tensor_return_value` parameters — the adapter
+//   matches by pointer identity.
 //
-// NOTE: A separate MeshWorkloadSpecFactoryConcept is planned for ops whose programs vary
-// across the mesh (CCL-style); that one will require a multi-program artifact.
-// Alternatively, we could have only a single, common MeshWorkloadSpecFactoryConcept.
-// (Should follow whatever style ProgramDescriptor port ends up using.)
+// CAUTION: Do not pass raw tensor addresses through runtime arguments!
+//   If a raw address is passed as a user-defined runtime argument, only the first dispatch
+//   succeeds; every subsequent program-cache hit then silently uses a stale address.
+//   A Metal 2.0 program factory should NEVER take the address of any tensor or buffer.
+//   Instead, declare a TensorParameter on the ProgramSpec and pass MeshTensor arguments
+//   directly through the ProgramRunArgs. The Metal 2.0 runtime infrastructure implicitly
+//   captures the pointer (and other tensor properties), which the kernel retrieves via
+//   TensorAccessor.
 //
-// ANTI-PATTERN — do not pass raw tensor addresses through runtime arguments:
+//-----------------------------------------------------------------------------------
+// "Option 2" (ALSO via create_program_artifacts):
 //
-//   uint32_t addr = input.buffer()->address();  // WRONG
-//   // ...stuff `addr` into kernel_run_args.runtime_arg_values...
+// The framework adapter stamps a Program from the spec onto each mesh coordinate range on
+// cache miss, and applies the FULL ProgramRunArgs on cache hit.
 //
-// The first dispatch succeeds; every subsequent program-cache hit then
-// silently uses a stale address. The cached Program's RTA was frozen at the
-// previous cache miss, but the next dispatch's tensor may live at a different
-// device address. Memory corruption follows.
+// The ProgramCache hash key is automatically computed by the TTNN infrastructure by hashing
+// the immutable ProgramSpec struct. The factory author writes NO fast-path-specific code.
 //
-// CORRECT: declare a TensorParameter on the ProgramSpec and bind it via a
-// TensorArgument on the ProgramRunArgs. The framework rebinds the device
-// address on every dispatch through the typed channel; kernels read the
-// binding through TensorAccessor.
+// The factory-provided create_program_artifacts is always called (both cache miss and hit).
 //
-// General rule: any value derived from a tensor's mutable state (address,
-// device, allocation) routes through TensorParameter, never through an RTA.
-// See ProgramSpecMeshWorkloadFactoryAdapter for the full RTA constraint.
+// NOTE: Compared to Option 1, Option 2:
+//   - Exposes all of Metalium's ProgramRunArgs (not limited to tensor arguments) for maximum
+//     fast path flexibility.
+//   - Is always safe. The cache key and mutable Program update are guaranteed to be correct
+//     by construction.
+//   - Has greater host overhead on cache hit; create_program_artifacts is always invoked.
+//
+//-----------------------------------------------------------------------------------
+// "Option 3" (AdvancedProgramSpecFactoryConcept):
+//
+// The framework adapter:
+//  - Calls extract_immutable_info and computes the hash key from the returned struct.
+//  - On cache miss, create_program_spec is called using the returned immutable info struct.
+//    The resulting Program is cached; create_program_run_args is then called to generate
+//    the ProgramRunArgs to run the Program.
+//  - On cache hit, ONLY create_program_run_args is called.
+//
+// For the most efficient fast path, minimize the logic in extract_immutable_info.
+//
+// NOTE: Compared to Options 1 and 2:
+//  - Option 3 is the most complex factory to implement.
+//  - Like Option 2, it is always safe (guaranteed to be correct by construction).
+//  - It provides the greatest fast-path flexibility of all options. The factory author
+//    can leverage the full Program mutability, and can also minimize fast-path host
+//    overhead.
+//
 template <typename T>
-concept ProgramSpecFactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
-                                    !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+concept WorkloadArtifactConcept = requires { &T::create_workload_artifacts; };
+
+template <typename T>
+concept AdvancedProgramSpecFactoryConcept = requires {
+    &T::create_program_spec;
+    &T::create_program_run_args;
+    &T::extract_immutable_info;
+};
+
+// TODO: Define how the "switch" to select between Option 1 and 2 works.
+//
+// "Exactly one of the three forms is satisfied" is enforced by sum-equals-1
+// (the same pattern Diego uses for outer-factory disambiguation in
+// AllFactoriesValid below). A factory that accidentally exposes two shapes
+// is rejected at the concept level rather than silently picked apart by
+// adapter precedent order.
+template <typename T>
+concept ProgramSpecFactoryConcept =
+    ((requires { &T::create_program_artifacts; } + AdvancedProgramSpecFactoryConcept<T> + WorkloadArtifactConcept<T>) ==
+     1) &&
+    !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -86,6 +86,25 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // across the mesh (CCL-style); that one will require a multi-program artifact.
 // Alternatively, we could have only a single, common MeshWorkloadSpecFactoryConcept.
 // (Should follow whatever style ProgramDescriptor port ends up using.)
+//
+// ANTI-PATTERN — do not pass raw tensor addresses through runtime arguments:
+//
+//   uint32_t addr = input.buffer()->address();  // WRONG
+//   // ...stuff `addr` into kernel_run_args.runtime_arg_values...
+//
+// The first dispatch succeeds; every subsequent program-cache hit then
+// silently uses a stale address. The cached Program's RTA was frozen at the
+// previous cache miss, but the next dispatch's tensor may live at a different
+// device address. Memory corruption follows.
+//
+// CORRECT: declare a TensorParameter on the ProgramSpec and bind it via a
+// TensorArgument on the ProgramRunArgs. The framework rebinds the device
+// address on every dispatch through the typed channel; kernels read the
+// binding through TensorAccessor.
+//
+// General rule: any value derived from a tensor's mutable state (address,
+// device, allocation) routes through TensorParameter, never through an RTA.
+// See ProgramSpecMeshWorkloadFactoryAdapter for the full RTA constraint.
 template <typename T>
 concept ProgramSpecFactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
                                     !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -73,7 +73,7 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
 // Metal 2.0 factory concept: factories that return ProgramArtifacts (a ProgramSpec +
-// ProgramRunArgs) from create_program_spec. The framework adapter stamps a Program
+// ProgramRunArgs) from create_program_artifacts. The framework adapter stamps a Program
 // from the spec onto each mesh coordinate range on cache miss, and patches TensorArgs
 // via experimental::UpdateTensorArgs on cache hit.
 //
@@ -87,7 +87,7 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // Alternatively, we could have only a single, common MeshWorkloadSpecFactoryConcept.
 // (Should follow whatever style ProgramDescriptor port ends up using.)
 template <typename T>
-concept ProgramSpecFactoryConcept = requires { &T::create_program_spec; } && !ProgramFactoryConcept<T> &&
+concept ProgramSpecFactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
                                     !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -72,73 +72,102 @@ template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
-// Metal 2.0 factory concept:
-// Factories that return EITHER:
-//  - ProgramArtifacts (a ProgramSpec + ProgramRunArgs) from create_program_artifacts, or
-//  - A separate ProgramSpec from create_program_spec, ProgramRunArgs from create_program_run_args,
-//    and a minimal struct of extracted data from the input args, chained into create_program_spec.
+// Metal 2.0 factory concept.
 //
-//-----------------------------------------------------------------------------------
-// "Option 1" (via create_program_artifacts):
+// ============================================================================
+// What this concept is protecting against
+// ============================================================================
 //
-// The framework adapter stamps a Program from the spec onto each mesh coordinate range on
-// cache miss, and patches ONLY the tensor arguments on cache hit.
+// The legacy TTNN op infrastructure had TWO independent bug generators around the
+// ProgramCache, and any successor design has to close both:
 //
-// The ProgramCache hash key is automatically computed by the TTNN infrastructure based on
-// the op's type and arguments (taking into account any TensorParameter relaxations).
-// The factory author writes NO fast-path-specific code.
+//  (A) Immutable-side bug generator — over-permissive hash.
+//      An op author who supplies a custom hash function may accidentally OMIT an
+//      attribute that actually affects the immutable Program. The first dispatch
+//      builds and caches the correct Program. Subsequent dispatches that vary
+//      ONLY the omitted attribute generate the same hash, hit the cache, and
+//      silently resurrect the WRONG Program — the device performs the wrong
+//      computation. The author's only feedback is a wrong answer.
 //
-// The factory-provided create_program_artifacts is only called on cache miss.
+//  (B) Mutable-side bug generator — stale runtime args.
+//      The fast cache-hit path updates some subset of the Program's runtime
+//      state. If the author's update logic misses a field that varies between
+//      dispatches sharing a cache entry, every hit silently uses the stale
+//      value from the previous dispatch. Same failure mode: wrong answer.
 //
-// NOTE: Each TensorArgument.tensor in ProgramRunArgs MUST reference a MeshTensor reachable
-//   from the factory's `tensor_args` / `tensor_return_value` parameters — the adapter
-//   matches by pointer identity.
+// The three factory shapes below sit at different points on the
+// simplicity / cache-hit-perf / safety-by-construction trade-off triangle,
+// but ALL of them close both bug generators by construction.
 //
-// CAUTION: Do not pass raw tensor addresses through runtime arguments!
-//   If a raw address is passed as a user-defined runtime argument, only the first dispatch
-//   succeeds; every subsequent program-cache hit then silently uses a stale address.
-//   A Metal 2.0 program factory should NEVER take the address of any tensor or buffer.
-//   Instead, declare a TensorParameter on the ProgramSpec and pass MeshTensor arguments
-//   directly through the ProgramRunArgs. The Metal 2.0 runtime infrastructure implicitly
-//   captures the pointer (and other tensor properties), which the kernel retrieves via
-//   TensorAccessor.
+// ----------------------------------------------------------------------------
+// "Option 1" (via create_program_artifacts, with `using fast_cache_hit_path = std::true_type;`):
 //
-//-----------------------------------------------------------------------------------
-// "Option 2" (ALSO via create_program_artifacts):
+// On cache miss:    factory called, full ProgramRunArgs set on every Program.
+// On cache hit:     ONLY tensor args refreshed via UpdateTensorArgs; factory NOT called.
 //
-// The framework adapter stamps a Program from the spec onto each mesh coordinate range on
-// cache miss, and applies the FULL ProgramRunArgs on cache hit.
+// Closes (A) by FORBIDDING a custom compute_program_hash on the DeviceOperation.
+// The framework's automatic hash of (op type + attrs + tensor args + mesh coords)
+// is the only sanctioned cache key. The author can't omit anything because they
+// can't write a hash function at all. The trifecta adapter rejects the
+// combination at compile time.
 //
-// The ProgramCache hash key is automatically computed by the TTNN infrastructure by hashing
-// the immutable ProgramSpec struct. The factory author writes NO fast-path-specific code.
+// Closes (B) by FORBIDDING any non-tensor mutation in ProgramRunArgs that varies
+// across dispatches sharing a cache entry. Concretely, the adapter rejects DFB
+// size overrides and common (broadcast) runtime args; per-node RTAs are still
+// legal because they're the standard mechanism for per-node work distribution
+// AND must be deterministic from the cache key (the hash hashes the args those
+// values are derived from).
 //
-// The factory-provided create_program_artifacts is always called (both cache miss and hit).
+// The one residual unsafety is the "raw-address-smuggling" anti-pattern:
+// if a factory bypasses TensorParameter and stuffs a raw tensor base pointer
+// into a per-node RTA, the address is set ONCE at cache-miss and persists on
+// every hit — even when the underlying tensor's allocation changes. This is a
+// hand-crafted backdoor, not something a typed factory accidentally does.
+// See the anti-pattern block at the concept definition below.
 //
-// NOTE: Compared to Option 1, Option 2:
-//   - Exposes all of Metalium's ProgramRunArgs (not limited to tensor arguments) for maximum
-//     fast path flexibility.
-//   - Is always safe. The cache key and mutable Program update are guaranteed to be correct
-//     by construction.
-//   - Has greater host overhead on cache hit; create_program_artifacts is always invoked.
+// ----------------------------------------------------------------------------
+// "Option 2" (default, via create_program_artifacts, no marker):
 //
-//-----------------------------------------------------------------------------------
-// "Option 3" (AdvancedProgramSpecFactoryConcept):
+// On cache miss:    factory called, full ProgramRunArgs set on every Program.
+// On cache hit:     factory called AGAIN, full ProgramRunArgs re-applied via
+//                   SetProgramRunArgs. The factory pays its full cost every dispatch.
 //
-// The framework adapter:
-//  - Calls extract_immutable_info and computes the hash key from the returned struct.
-//  - On cache miss, create_program_spec is called using the returned immutable info struct.
-//    The resulting Program is cached; create_program_run_args is then called to generate
-//    the ProgramRunArgs to run the Program.
-//  - On cache hit, ONLY create_program_run_args is called.
+// Closes (A) the same way Option 1 does (no custom hash allowed). The design
+// intent is that Option 2's hash key be the immutable ProgramSpec struct itself
+// (since the spec captures everything pertinent to the immutable Program by
+// definition); the current implementation falls back to the same auto-hash over
+// op args that Option 1 uses, which is conservative-correct (over-keys
+// occasionally but never under-keys). Spec-hashing is deferred as a perf
+// optimization; correctness does not depend on it.
 //
-// For the most efficient fast path, minimize the logic in extract_immutable_info.
+// Closes (B) by re-running the factory on every cache hit and re-applying the
+// FULL ProgramRunArgs. Every mutable field is built fresh from the current
+// dispatch's inputs, so nothing can carry stale state. Any ProgramRunArgs
+// channel is legal (RTAs, CRTAs, DFB size overrides — all of it).
 //
-// NOTE: Compared to Options 1 and 2:
-//  - Option 3 is the most complex factory to implement.
-//  - Like Option 2, it is always safe (guaranteed to be correct by construction).
-//  - It provides the greatest fast-path flexibility of all options. The factory author
-//    can leverage the full Program mutability, and can also minimize fast-path host
-//    overhead.
+// Greater host overhead than Option 1, in exchange for "I don't need to think
+// about cache-hit semantics" as the factory author's contract.
+//
+// ----------------------------------------------------------------------------
+// "Option 3" (AdvancedProgramSpecFactoryConcept) — not yet implemented:
+//
+// The factory is split into three pieces:
+//   1. extract_immutable_info(op_args) → ImmutableInfo
+//   2. create_program_spec(const ImmutableInfo&) → ProgramSpec  [cache-miss only]
+//   3. create_program_run_args(op_args) → ProgramRunArgs        [every dispatch]
+//
+// Closes (A) by hashing ImmutableInfo as the cache key AND by feeding ONLY the
+// ImmutableInfo (not the raw op_args) into create_program_spec. The factory
+// physically can't depend on a field it didn't declare in ImmutableInfo,
+// because it doesn't have access to anything else. This is a structural
+// guarantee, not a discipline.
+//
+// Closes (B) by calling create_program_run_args fresh on every dispatch.
+//
+// Combines Option 1's fast cache-hit path (the spec isn't rebuilt) with Option
+// 2's safety (the mutable side is fresh every dispatch), at the cost of
+// authoring complexity: the split forces the factory to be explicit about which
+// inputs affect the spec.
 //
 template <typename T>
 concept WorkloadArtifactConcept = requires { &T::create_workload_artifacts; };
@@ -152,19 +181,31 @@ concept AdvancedProgramSpecFactoryConcept = requires {
 
 // Option 1 vs Option 2 selector.
 //
-// Both options expose the same factory signature (create_program_artifacts), so the
-// adapter cannot tell them apart by shape alone. The factory opts into the Ryan-fast
-// Option 1 path explicitly via a type-level marker:
+// Both options expose the same factory signature (create_program_artifacts) and
+// both close both bug generators (see comment block above). The difference is
+// how restrictive the factory contract is:
+//
+//   - Option 2 (default) — no constraints on the ProgramRunArgs returned by the
+//     factory. Anything mutable per dispatch is fine: per-node RTAs, CRTAs, DFB
+//     size overrides. Cost: factory re-runs on every cache hit.
+//
+//   - Option 1 (opt-in) — restricts the factory to per-node RTAs and tensor
+//     args only (no CRTAs, no DFB size overrides). The cache-hit path skips the
+//     factory and refreshes only tensor args. Cheap, but the author has to live
+//     within the restrictions.
+//
+// Opt-in to Option 1 via a type-level marker:
 //
 //   struct MyFactory {
 //       using fast_cache_hit_path = std::true_type;  // opt into Option 1
 //       static ttnn::device_operation::ProgramArtifacts create_program_artifacts(...);
 //   };
 //
-// The default is Option 2 (safe by construction): the factory is re-run on every
-// cache hit and the full ProgramRunArgs is re-applied via SetProgramRunArgs. Porters
-// who don't know about the distinction get correct behavior automatically; opting
-// into Option 1 is "I know what I'm doing, run the fast path".
+// The default-to-Option-2 choice matches the path of least surprise: a porter
+// who writes the factory without knowing about the distinction lands on the
+// less-restrictive contract and their code compiles. Opting into Option 1 is
+// the explicit "I've checked that my factory only varies tensor args between
+// dispatches, please give me the fast path."
 template <typename T>
 concept HasFastCacheHitPathOptIn = requires {
     typename T::fast_cache_hit_path;

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -150,8 +150,27 @@ concept AdvancedProgramSpecFactoryConcept = requires {
     &T::extract_immutable_info;
 };
 
-// TODO: Define how the "switch" to select between Option 1 and 2 works.
+// Option 1 vs Option 2 selector.
 //
+// Both options expose the same factory signature (create_program_artifacts), so the
+// adapter cannot tell them apart by shape alone. The factory opts into the Ryan-fast
+// Option 1 path explicitly via a type-level marker:
+//
+//   struct MyFactory {
+//       using fast_cache_hit_path = std::true_type;  // opt into Option 1
+//       static ttnn::device_operation::ProgramArtifacts create_program_artifacts(...);
+//   };
+//
+// The default is Option 2 (safe by construction): the factory is re-run on every
+// cache hit and the full ProgramRunArgs is re-applied via SetProgramRunArgs. Porters
+// who don't know about the distinction get correct behavior automatically; opting
+// into Option 1 is "I know what I'm doing, run the fast path".
+template <typename T>
+concept HasFastCacheHitPathOptIn = requires {
+    typename T::fast_cache_hit_path;
+    requires T::fast_cache_hit_path::value;
+};
+
 // "Exactly one of the three forms is satisfied" is enforced by sum-equals-1
 // (the same pattern Diego uses for outer-factory disambiguation in
 // AllFactoriesValid below). A factory that accidentally exposes two shapes

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -201,11 +201,11 @@ concept AdvancedProgramSpecFactoryConcept = requires {
 //       static ttnn::device_operation::ProgramArtifacts create_program_artifacts(...);
 //   };
 //
-// The default-to-Option-2 choice matches the path of least surprise: a porter
-// who writes the factory without knowing about the distinction lands on the
-// less-restrictive contract and their code compiles. Opting into Option 1 is
-// the explicit "I've checked that my factory only varies tensor args between
-// dispatches, please give me the fast path."
+// The default-to-Option-2 choice matches the path of least surprise: an op
+// author who writes the factory without knowing about the distinction lands
+// on the less-restrictive contract and their code compiles. Opting into
+// Option 1 is the explicit "I've checked that my factory only varies tensor
+// args between dispatches, please give me the fast path."
 template <typename T>
 concept HasFastCacheHitPathOptIn = requires {
     typename T::fast_cache_hit_path;

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -132,13 +132,15 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // On cache hit:     factory called AGAIN, full ProgramRunArgs re-applied via
 //                   SetProgramRunArgs. The factory pays its full cost every dispatch.
 //
-// Closes (A) the same way Option 1 does (no custom hash allowed). The design
-// intent is that Option 2's hash key be the immutable ProgramSpec struct itself
-// (since the spec captures everything pertinent to the immutable Program by
-// definition); the current implementation falls back to the same auto-hash over
-// op args that Option 1 uses, which is conservative-correct (over-keys
-// occasionally but never under-keys). Spec-hashing is deferred as a perf
-// optimization; correctness does not depend on it.
+// Closes (A) by FORBIDDING custom compute_program_hash (same as Option 1) AND by
+// keying the cache off the immutable ProgramSpec itself — not the op args. The
+// spec captures everything pertinent to the immutable Program by definition, so
+// any two dispatches whose factories produce equal specs map to the same cache
+// entry (cache reuse across arg variations the spec doesn't distinguish, e.g.
+// TensorParameter relaxations that route shape variation through CRTAs). The
+// factory has to run BEFORE the cache lookup to produce the spec — that's the
+// structural cost Option 2 pays for safety-by-construction plus this cache-reuse
+// breadth.
 //
 // Closes (B) by re-running the factory on every cache hit and re-applying the
 // FULL ProgramRunArgs. Every mutable field is built fresh from the current

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -171,14 +171,40 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // authoring complexity: the split forces the factory to be explicit about which
 // inputs affect the spec.
 //
-template <typename T>
-concept WorkloadArtifactConcept = requires { &T::create_workload_artifacts; };
+// The four Metal 2.0 factory leaf concepts — the cells of the
+// {Basic, Advanced} x {single-program, multi-program} matrix. Each is a plain
+// shape check on the factory's method surface; the leaves are mutually
+// exclusive by construction (disjoint method sets), and Metal2FactoryConcept
+// (below) is the umbrella that admits exactly one of them.
 
+// Basic, single-program: one combined call returning spec + run args bundled.
+template <typename T>
+concept ProgramSpecFactoryConcept = requires { &T::create_program_artifacts; };
+
+// Advanced, single-program: the immutable-extraction / spec / run-args split.
 template <typename T>
 concept AdvancedProgramSpecFactoryConcept = requires {
     &T::create_program_spec;
     &T::create_program_run_args;
     &T::extract_immutable_info;
+};
+
+// Basic, multi-program: one combined call returning all per-coord programs and
+// workload-scoped resources.
+template <typename T>
+concept WorkloadSpecFactoryConcept = requires { &T::create_workload_artifacts; };
+
+// Advanced, multi-program: the workload analog of the three-method split.
+// NOTE: stub only — no adapter support yet, and the method names below are
+// deliberately workload-distinct placeholders (the final names are an open
+// design question, see ttnn-factory-design-space). Keeping them disjoint from
+// the single-program advanced names means the eventual rename is a clean
+// find-replace that won't sweep up AdvancedProgramSpecFactoryConcept.
+template <typename T>
+concept AdvancedWorkloadSpecFactoryConcept = requires {
+    &T::create_workload_spec;
+    &T::create_workload_run_args;
+    &T::extract_workload_immutable_info;
 };
 
 // Program caching strategy — the op-author-facing choice between two
@@ -240,15 +266,15 @@ concept HasMinimizeCacheHitCostOptIn = requires {
     requires T::caching_strategy == ProgramCachingStrategy::MinimizeCacheHitCost;
 };
 
-// "Exactly one of the three forms is satisfied" is enforced by sum-equals-1
-// (the same pattern Diego uses for outer-factory disambiguation in
-// AllFactoriesValid below). A factory that accidentally exposes two shapes
-// is rejected at the concept level rather than silently picked apart by
-// adapter precedent order.
+// Umbrella over the four Metal 2.0 factory leaves. "Exactly one of the four
+// forms is satisfied" is enforced by sum-equals-1 (the same pattern Diego uses
+// for outer-factory disambiguation in AllFactoriesValid below). A factory that
+// accidentally exposes two shapes is rejected at the concept level rather than
+// silently picked apart by adapter precedent order.
 template <typename T>
-concept ProgramSpecFactoryConcept =
-    ((requires { &T::create_program_artifacts; } + AdvancedProgramSpecFactoryConcept<T> + WorkloadArtifactConcept<T>) ==
-     1) &&
+concept Metal2FactoryConcept =
+    ((ProgramSpecFactoryConcept<T> + AdvancedProgramSpecFactoryConcept<T> + WorkloadSpecFactoryConcept<T> +
+      AdvancedWorkloadSpecFactoryConcept<T>) == 1) &&
     !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
@@ -288,7 +314,7 @@ concept HasSelectProgramFactory = requires(
 
 // Validate that all variant alternatives in a program_factory_t satisfy exactly one of
 // ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// or ProgramSpecFactoryConcept.
+// or Metal2FactoryConcept.
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -296,7 +322,7 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
         ((ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          Metal2FactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -256,7 +256,7 @@ enum class ProgramCachingStrategy {
 // path actually matters for this op's workload — the factory body stays the
 // same, only the declaration (and the framework's dispatch path) changes.
 //
-// (The longer-term API direction is to make this a runtime choice — the
+// (The longer-term API direction could even make this a runtime choice — the
 // optimal strategy is more a property of the workload than of the op — but
 // the compile-time form is the right starting point and doesn't paint into
 // a corner that would prevent the runtime version later.)
@@ -267,10 +267,7 @@ concept HasMinimizeCacheHitCostOptIn = requires {
 };
 
 // Umbrella over the four Metal 2.0 factory leaves. "Exactly one of the four
-// forms is satisfied" is enforced by sum-equals-1 (the same pattern Diego uses
-// for outer-factory disambiguation in AllFactoriesValid below). A factory that
-// accidentally exposes two shapes is rejected at the concept level rather than
-// silently picked apart by adapter precedent order.
+// forms is satisfied" is enforced by sum-equals-1.
 template <typename T>
 concept Metal2FactoryConcept =
     ((ProgramSpecFactoryConcept<T> + AdvancedProgramSpecFactoryConcept<T> + WorkloadSpecFactoryConcept<T> +

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -100,7 +100,7 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // but ALL of them close both bug generators by construction.
 //
 // ----------------------------------------------------------------------------
-// "Option 1" (via create_program_artifacts, with `using fast_cache_hit_path = std::true_type;`):
+// "Option 1" (via create_program_artifacts, with `caching_strategy = ProgramCachingStrategy::MinimizeCacheHitCost`):
 //
 // On cache miss:    factory called, full ProgramRunArgs set on every Program.
 // On cache hit:     ONLY tensor args refreshed via UpdateTensorArgs; factory NOT called.
@@ -181,44 +181,63 @@ concept AdvancedProgramSpecFactoryConcept = requires {
     &T::extract_immutable_info;
 };
 
-// Option 1 vs Option 2 selector.
+// Program caching strategy — the op-author-facing choice between two
+// behaviorally-distinct dispatch paths through the framework, both correct by
+// construction.
 //
-// Both options expose the same factory signature (create_program_artifacts) and
-// both close both bug generators (see comment block above). The difference is
-// how restrictive the factory contract is:
+//   - MaximizeCacheReuse (default) — no constraints on the ProgramRunArgs
+//     returned by the factory. Anything mutable per dispatch is fine: per-node
+//     RTAs, CRTAs, DFB size overrides. The framework hashes the immutable
+//     ProgramSpec (broader cache equivalence — different op-args that produce
+//     the same spec share a cache entry). Factory runs on every dispatch; the
+//     full ProgramRunArgs is re-applied on cache hit via SetProgramRunArgs.
 //
-//   - Option 2 (default) — no constraints on the ProgramRunArgs returned by the
-//     factory. Anything mutable per dispatch is fine: per-node RTAs, CRTAs, DFB
-//     size overrides. Cost: factory re-runs on every cache hit.
+//   - MinimizeCacheHitCost (opt-in) — restricts the factory to per-node RTAs
+//     and tensor args only (no CRTAs, no DFB size overrides). The framework
+//     hashes op-args (narrower cache equivalence). The cache-hit path skips
+//     the factory entirely and refreshes only tensor args via UpdateTensorArgs
+//     against stored index bindings. Cheap per-hit, but the author has to
+//     live within the restrictions.
 //
-//   - Option 1 (opt-in) — restricts the factory to per-node RTAs and tensor
-//     args only (no CRTAs, no DFB size overrides). The cache-hit path skips the
-//     factory and refreshes only tensor args. Cheap, but the author has to live
-//     within the restrictions.
-//
-// Opt-in to Option 1 via a type-level marker:
+// Verbal symmetry of the min/max naming is deliberate — it signals that these
+// are paired choices on a trade-off curve, with each name unambiguously
+// identifying the objective (cost per cache hit vs. breadth of cache
+// equivalence).
+enum class ProgramCachingStrategy {
+    MaximizeCacheReuse,
+    MinimizeCacheHitCost,
+};
+
+// Opt into MinimizeCacheHitCost via a static constexpr declaration on the factory:
 //
 //   struct MyFactory {
-//       using fast_cache_hit_path = std::true_type;  // opt into Option 1
+//       static constexpr auto caching_strategy =
+//           ProgramCachingStrategy::MinimizeCacheHitCost;
 //       static ttnn::device_operation::ProgramArtifacts create_program_artifacts(...);
 //   };
 //
-// The default-to-Option-2 choice matches the path of least surprise: an op
-// author who writes the factory without knowing about the distinction lands
-// on the less-restrictive contract and their code compiles. Opting into
-// Option 1 is the explicit "I've checked that my factory only varies tensor
-// args between dispatches, please give me the fast path."
+// The default-to-MaximizeCacheReuse choice matches the path of least surprise:
+// an op author who writes the factory without knowing about the distinction
+// lands on the less-restrictive contract and their code compiles. Opting in
+// to MinimizeCacheHitCost is the explicit "I've checked that my factory only
+// varies tensor args between dispatches, please give me the fast cache-hit
+// path."
 //
-// Note that because both options expose the same factory signature, the
-// marker is a cheap perf experiment: an op author can prototype with the
-// default (Option 2) and flip `fast_cache_hit_path` on once the factory is
-// otherwise stable to A/B-test whether the fast cache-hit path actually
-// matters for this op's workload — the factory body stays the same, only
-// the marker (and the framework's dispatch path) changes.
+// Because both strategies expose the same factory signature, the opt-in is
+// a cheap perf experiment: an op author can prototype with the default
+// (MaximizeCacheReuse) and flip the declaration to MinimizeCacheHitCost once
+// the factory is otherwise stable to A/B-test whether the fast cache-hit
+// path actually matters for this op's workload — the factory body stays the
+// same, only the declaration (and the framework's dispatch path) changes.
+//
+// (The longer-term API direction is to make this a runtime choice — the
+// optimal strategy is more a property of the workload than of the op — but
+// the compile-time form is the right starting point and doesn't paint into
+// a corner that would prevent the runtime version later.)
 template <typename T>
-concept HasFastCacheHitPathOptIn = requires {
-    typename T::fast_cache_hit_path;
-    requires T::fast_cache_hit_path::value;
+concept HasMinimizeCacheHitCostOptIn = requires {
+    { T::caching_strategy } -> std::convertible_to<ProgramCachingStrategy>;
+    requires T::caching_strategy == ProgramCachingStrategy::MinimizeCacheHitCost;
 };
 
 // "Exactly one of the three forms is satisfied" is enforced by sum-equals-1

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -208,6 +208,13 @@ concept AdvancedProgramSpecFactoryConcept = requires {
 // on the less-restrictive contract and their code compiles. Opting into
 // Option 1 is the explicit "I've checked that my factory only varies tensor
 // args between dispatches, please give me the fast path."
+//
+// Note that because both options expose the same factory signature, the
+// marker is a cheap perf experiment: an op author can prototype with the
+// default (Option 2) and flip `fast_cache_hit_path` on once the factory is
+// otherwise stable to A/B-test whether the fast cache-hit path actually
+// matters for this op's workload — the factory body stays the same, only
+// the marker (and the framework's dispatch path) changes.
 template <typename T>
 concept HasFastCacheHitPathOptIn = requires {
     typename T::fast_cache_hit_path;


### PR DESCRIPTION
### PR Category
Feature

### Summary
TTNN op infra for Metal 2.0 has evolved into a two-tiered `ProgramSpecFactoryConcept`. The new infrastructure will make custom hash and runtime arguments patching bugs _structurally impossible_.

 - **Basic**. The op author supplies `create_program_artifacts`. This is the simplest way to write an op, but it is somewhat restrictive. The op author must choose between two TTNN caching strategies:
     -  _Option 1_: The TTNN infrastructure strictly limits the the generality of what the op author can update on their `Program` on the cache hit fast path. _Only_ tensor arguments are updated. The infrastructure applies these automatically updates automatically. 
     - _Option 2_: The op author can exploit the full generality of Metalium mutable `Program` parameters. However, the entire `ProgramArtifacts` struct (Metal 2.0 `ProgramSpec` + `ProgramRunArgs`) are recomputed on the fast path.

 - **Advanced**. The op author can access the full generality of mutable `Program` updates supported by Metalium (tensor args, runtime args, common runtime args, DFB size, etc), and avoids superfluous computation on the fast path. However, the op is more complex to construct. The op author must provide the following methods:
        - `create_program_spec` 
        - `create_program_run_args`
        - `extract_immutable_info` (this needs a better name)

TTNN additionally provides a `WorkloadSpecFactoryConcept` for those ops that:
 - Need to place different `Programs` on different devices in the Mesh
 - Need to declare mesh-global resources (`GlobalSemaphore`, `GlobalDataflowBuffer, op-defined `MeshTensor`)


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/ttnn-metal2concept-improvements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/ttnn-metal2concept-improvements)