### PR TITLE
ds_prefill(ring_barrier) - add terminating NOC barrier to ring_joint_reader

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -679,4 +679,8 @@ void kernel_main() {
             cb_push_back(cb_v_in, v_cb_entry_tiles);
         }
     }
+
+    // Without this, the kernel could return with chain_link write-ACKs and atomic
+    // responses still in flight, leaving stale state for the next dispatch.
+    noc_async_full_barrier();
 }


### PR DESCRIPTION
## Summary
- Add a terminating `noc_async_full_barrier()` at the end of `ring_joint_reader.cpp::kernel_main`.
- The kernel previously had no terminating NOC barrier. The per-iteration `noc_async_writes_flushed()` only guarantees write *departure*, not landing; the `chain_link::receive` atomics (`noc_semaphore_inc`) are fired with no terminating wait, and `chain_link::forward`'s non-posted writes (`noc_async_write`/`_multicast`) are likewise un-acked at exit.
- As a result the kernel could return with both write-ACKs and atomic responses still in flight, leaving stale state for the next dispatch ("works once then hangs").
- `noc_async_full_barrier()` waits on both outstanding non-posted writes and atomic responses. (The `exp_` sibling only needs `writes_flushed()`+`write_barrier()` because its atomics are part of an explicit request/response handshake that already synchronizes them.)

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)
- T3K `deepseek_prefill` on this branch vs `main` baseline

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2606-ring-atomic-barrier-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2606-ring-atomic-barrier-fix)