### PR TITLE
#45701: Workaround: remove shared_expert/dispatch overlap

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -321,6 +321,8 @@ class TtPrefillBlock(LightweightModule):
             gate_fallback_mode=gate_fallback_mode,
             weight_cache_path=weight_cache_path,
             layer_idx=layer_idx,
+            # 45701 workaround: disable shared-expert/dispatch sub-device overlap.
+            overlap_shared_expert_with_dispatch=False,
         )
 
     def forward(


### PR DESCRIPTION
### PR Category
Bug fix
### Summary
#45701 
Remove shared expert / dispatch overlap as it is a workaround for the underlying ND issue. Verified locally.

CI:
https://github.com/tenstorrent/tt-metal/actions/runs/26896978199



