### PR TITLE
fix: reduce the number of elf reloads in llk tests

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
@@ -71,11 +71,11 @@ def print_stimuli_and_golden(src_A, golden, input_dimensions, r_dim):
 
 @skip_for_wormhole
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b]),
     dest_acc=[DestAccumulation.No],
     input_dimensions=[[32, 32], [32, 64], [32, 128], [32, 256]],
-    r_dim=[1, 2, 4, 8, 16],
     dest_sync=[DestSync.Half],
+    formats=input_output_formats([DataFormat.Float16_b]),
+    r_dim=[1, 2, 4, 8, 16],
 )
 def test_pack_untilize(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
@@ -49,11 +49,6 @@ class CT_DIM(TemplateParameter):
     cpp_source=[
         "sources/multiple_tiles_eltwise_custom_test.cpp",
     ],
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-        ]
-    ),
     mathop=[MathOperation.Elwsub],
     dest_acc=[DestAccumulation.No],
     math_fidelity=[
@@ -64,6 +59,11 @@ class CT_DIM(TemplateParameter):
     ],
     broadcast_type=[BroadcastType.Column],
     input_dimensions_A=[[32, w] for w in range(32, 257, 32)],
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+        ]
+    ),
     input_dimensions_B=[[32, 32]],
 )
 def test_eltwise_bcast_col_custom(

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy.py
@@ -192,6 +192,10 @@ def _run_unary_datacopy_test(
 
 
 @parametrize(
+    dest_acc=get_valid_dest_accumulation_modes,
+    num_faces=get_valid_num_faces_datacopy,
+    tilize=get_valid_tilize_datacopy,
+    input_dimensions=[[64, 64], [32, 256], [128, 256]],
     formats=input_output_formats(
         [
             DataFormat.Float32,
@@ -201,10 +205,6 @@ def _run_unary_datacopy_test(
             DataFormat.Fp8_e4m3,
         ]
     ),
-    dest_acc=get_valid_dest_accumulation_modes,
-    num_faces=get_valid_num_faces_datacopy,
-    tilize=get_valid_tilize_datacopy,
-    input_dimensions=[[64, 64], [32, 256], [128, 256]],
 )
 def test_unary_datacopy(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy_custom.py
@@ -20,8 +20,8 @@ from helpers.utils import passed_test
 
 @skip_for_wormhole
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b]),
     dest_acc=[DestAccumulation.No],
+    formats=input_output_formats([DataFormat.Float16_b]),
 )
 def test_unary_datacopy_custom(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_matmul_pack_untilize.py
@@ -19,6 +19,13 @@ from helpers.utils import passed_test
 
 
 @parametrize(
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
@@ -27,13 +34,6 @@ from helpers.utils import passed_test
             DataFormat.Float32,
         ]
     ),
-    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
 )
 def test_matmul_pack_untilize(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_matmul_unpack_tilize.py
@@ -18,6 +18,13 @@ from helpers.utils import passed_test
 
 
 @parametrize(
+    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
@@ -26,13 +33,6 @@ from helpers.utils import passed_test
         ],  #  Add DataFormat.Bfp8_b only as input when Data format Inference Model 2.0 supports format conversions for > 1 pipeline run with different inputs and outputs.
         same=True,
     ),
-    dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
 )
 def test_matmul_unpack_tilize(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_pack_dest_bank.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_pack_dest_bank.py
@@ -78,8 +78,8 @@ def get_valid_num_faces_datacopy(tilize):
     ),
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     l1_acc=[L1Accumulation.No, L1Accumulation.Yes],
-    num_faces=4,
     tilize=[Tilize.No],
+    num_faces=4,
     dest_index=0,
     input_dimensions=[[32, 32], [32, 64], [128, 32], [128, 64], [128, 256]],
 )
@@ -188,8 +188,8 @@ def test_pack_dest_bank(
     formats=input_output_formats([DataFormat.Float16_b]),
     dest_acc=[DestAccumulation.No],
     l1_acc=[L1Accumulation.No, L1Accumulation.Yes],
-    num_faces=4,
     tilize=[Tilize.No],
+    num_faces=4,
     dest_index=0,
 )
 def test_pack_dest_bank_two_blocked_packs_of_4(

--- a/tt_metal/tt-llk/tests/python_tests/test_pack_tiny_tile_block.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_pack_tiny_tile_block.py
@@ -171,13 +171,13 @@ def test_pack_tiny_tile_block(
 
 @skip_for_wormhole
 @parametrize(
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     formats=input_output_formats(
         [
             DataFormat.Float16,
             DataFormat.Float16_b,
         ]
     ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     tile_dims=[
         (1, 32),  # face_r_dim=1,  num_faces=2
         (2, 32),  # face_r_dim=2,  num_faces=2

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce.py
@@ -48,7 +48,6 @@ mathop_mapping = {
 
 
 @parametrize(
-    tile_dimensions=[[1, 32], [2, 32], [4, 32], [8, 32], [16, 32], [32, 32], [32, 16]],
     formats=input_output_formats(
         [
             DataFormat.Float32,
@@ -56,7 +55,6 @@ mathop_mapping = {
             DataFormat.Bfp8_b,
         ]
     ),
-    is_reduce_to_one=[False, True],
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
     math_fidelity=[
@@ -65,6 +63,8 @@ mathop_mapping = {
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    tile_dimensions=[[1, 32], [2, 32], [4, 32], [8, 32], [16, 32], [32, 32], [32, 16]],
+    is_reduce_to_one=[False, True],
 )
 def test_reduce(
     formats,
@@ -235,7 +235,6 @@ def test_reduce(
 
 
 @parametrize(
-    tile_dimensions=[[32, 32]],
     formats=[
         fmt
         for fmt in input_output_formats(
@@ -249,7 +248,6 @@ def test_reduce(
         if fmt.input_format == DataFormat.Bfp4_b
         or fmt.output_format == DataFormat.Bfp4_b
     ],
-    is_reduce_to_one=[False, True],
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type=[ReducePool.Max, ReducePool.Average, ReducePool.Sum],
     math_fidelity=[
@@ -258,6 +256,8 @@ def test_reduce(
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    tile_dimensions=[[32, 32]],
+    is_reduce_to_one=[False, True],
 )
 def test_reduce_bfp4_b(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
@@ -41,10 +41,10 @@ from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 @skip_for_coverage
 @skip_for_wormhole
 @parametrize(
-    formats=input_output_formats([DataFormat.Float16_b]),
     dest_acc=[DestAccumulation.No],
     math_fidelity=[MathFidelity.LoFi],
     input_dimensions=[[32, 32]],
+    formats=input_output_formats([DataFormat.Float16_b]),
 )
 def test_sdpa_reinits(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -25,14 +25,6 @@ from helpers.utils import passed_test
 
 
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-            DataFormat.Float32,
-        ],  # Unpack Tilize & Pack Untilize does not work on Bfp8_b format
-        same=True,
-    ),
     mathop=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     math_fidelity=[
@@ -41,6 +33,14 @@ from helpers.utils import passed_test
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    formats=input_output_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ],  # Unpack Tilize & Pack Untilize does not work on Bfp8_b format
+        same=True,
+    ),
 )
 def test_tilize_calculate_untilize_L1(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
@@ -314,6 +314,55 @@ def filter_params_with_constraints(all_params):
 all_params = filter_params_with_constraints(all_params)
 
 
+def _elf_locality_key(params):
+    """Group cases that share one compiled ELF so each ELF is loaded onto the cores
+    only once (minimizes ELF-load thrashing).
+
+    The ELF is defined by the template params (STOCHASTIC_ROUNDING, BROADCAST_TYPE,
+    ACC_TO_DEST, REUSE_DEST_TYPE, PARTIAL_FACE, DISABLE_SRC_ZERO_FLAG) plus the
+    build-time dest_acc (a function of acc_to_dest). face_r_dim only affects the ELF
+    through partial_face (face_r_dim < 16); its value otherwise feeds runtime params.
+    formats is effectively runtime here: the only build-affecting use is
+    unpack_to_dest = input_format.is_32_bit() and acc_to_dest, but the constraint
+    filter drops every (is_32_bit, acc_to_dest) case, so unpack_to_dest is always
+    False. Everything else (transpose, num_faces, dimensions, formats, ...) is runtime
+    and free to vary within a group.
+    """
+    (
+        testname,
+        formats,
+        broadcast_type,
+        disable_src_zero,
+        acc_to_dest,
+        stochastic_rnd,
+        reuse_dest,
+        transpose_of_faces,
+        within_face_16x16_transpose,
+        num_faces,
+        face_r_dim,
+        input_dimensions,
+    ) = params
+    partial_face = face_r_dim < 16
+    unpack_to_dest = formats.input_format.is_32_bit() and acc_to_dest
+    return (
+        testname,
+        stochastic_rnd.name,
+        broadcast_type.name,
+        bool(acc_to_dest),
+        reuse_dest.name,
+        bool(disable_src_zero),
+        partial_face,
+        unpack_to_dest,
+    )
+
+
+# Order so all cases sharing a compiled ELF run consecutively. The set of cases is
+# unchanged; only execution order changes. The sort is stable, so runtime variations
+# (formats/output, transpose, num_faces, dimensions, ...) keep their relative order
+# within each ELF group.
+all_params.sort(key=_elf_locality_key)
+
+
 def create_simple_ids(all_params):
     """Create comprehensive but readable IDs for unpack_A tests"""
     ids = []

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -27,12 +27,6 @@ from helpers.tilize_untilize import tilize
 from helpers.utils import passed_test
 
 
-# Parameter order minimizes ELF-load thrashing: the custom parametrize() resolves
-# keys in declaration order (first = outermost/slowest loop, last = innermost/
-# fastest). ELF-defining params (dest_acc, mathop, math_fidelity, input_dimensions)
-# are kept outer; runtime-only params (formats is runtime-configured here, plus
-# srca_reuse_count) are innermost so each ELF is loaded once while its runtime
-# variants are exhausted.
 @skip_for_blackhole
 @parametrize(
     dest_acc=[DestAccumulation.No],

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -27,16 +27,16 @@ from helpers.tilize_untilize import tilize
 from helpers.utils import passed_test
 
 
+# Parameter order minimizes ELF-load thrashing: the custom parametrize() resolves
+# keys in declaration order (first = outermost/slowest loop, last = innermost/
+# fastest). ELF-defining params (dest_acc, mathop, math_fidelity, input_dimensions)
+# are kept outer; runtime-only params (formats is runtime-configured here, plus
+# srca_reuse_count) are innermost so each ELF is loaded once while its runtime
+# variants are exhausted.
 @skip_for_blackhole
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-        ]
-    ),
-    mathop=[MathOperation.Elwsub, MathOperation.Elwadd, MathOperation.Elwmul],
     dest_acc=[DestAccumulation.No],
-    srca_reuse_count=[2, 4, 8],
+    mathop=[MathOperation.Elwsub, MathOperation.Elwadd, MathOperation.Elwmul],
     math_fidelity=[
         MathFidelity.LoFi,
     ],
@@ -45,6 +45,12 @@ from helpers.utils import passed_test
         [32, 128],
         [64, 128],
     ],
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+        ]
+    ),
+    srca_reuse_count=[2, 4, 8],
 )
 def test_unp_bcast_sub_sdpa(
     formats,
@@ -127,8 +133,6 @@ def test_unp_bcast_sub_sdpa(
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             DEST_SYNC(),
-            TILE_COUNT(tile_cnt_A),
-            SRCA_REUSE_COUNT(srca_reuse_count),
         ],
         runtimes=[
             TILE_COUNT(tile_cnt_A),

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -30,6 +30,13 @@ from helpers.utils import passed_test
 
 
 @parametrize(
+    stoch_rnd_type=[
+        StochasticRounding.No,
+        StochasticRounding.Fpu,
+        StochasticRounding.Pack,
+        StochasticRounding.All,
+    ],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     formats=input_output_formats(
         [
             DataFormat.Float32,
@@ -38,13 +45,6 @@ from helpers.utils import passed_test
             DataFormat.Bfp8_b,
         ]
     ),
-    stoch_rnd_type=[
-        StochasticRounding.No,
-        StochasticRounding.Fpu,
-        StochasticRounding.Pack,
-        StochasticRounding.All,
-    ],
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     transpose=[Transpose.No],
     narrow_tile=[NarrowTile.No],
     num_faces=[4, 2, 1],

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -44,9 +44,9 @@ from helpers.utils import passed_test
         StochasticRounding.Pack,
         StochasticRounding.All,
     ],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     transpose=[Transpose.No],
     narrow_tile=[NarrowTile.No],
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     num_faces=[4, 2, 1],
     input_dimensions=[[32, 32], [64, 64], [32, 64], [32, 128], [128, 32]],
 )

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_bcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_bcast.py
@@ -50,8 +50,8 @@ from helpers.utils import passed_test
 supported_formats = [
     DataFormat.Int32,
     DataFormat.UInt32,
-    DataFormat.UInt16,
     DataFormat.Float32,
+    DataFormat.UInt16,
     DataFormat.Float16_b,
     DataFormat.Bfp8_b,
 ]
@@ -66,7 +66,6 @@ supported_formats = [
     # enable tiny tiles tests when they're added formally to the LLKs
     # tile_dimensions=[[1, 32], [2, 32], [4, 32], [8, 32], [16, 32], [32, 32]],
     tile_dimensions=[[32, 32]],
-    formats=input_output_formats(supported_formats, same=True),
     broadcast_type=[
         BroadcastType.None_,
         BroadcastType.Column,
@@ -74,6 +73,7 @@ supported_formats = [
         BroadcastType.Scalar,
     ],
     dest_acc=[DestAccumulation.Yes, DestAccumulation.No],
+    formats=input_output_formats(supported_formats, same=True),
 )
 def test_unpack_bcast(
     tile_dimensions,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_eltwise_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_eltwise_binary.py
@@ -114,7 +114,6 @@ def _get_valid_tile_dimensions(transpose_srca, broadcast_type):
 
 @parametrize(
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    formats=lambda dest_acc: _get_valid_formats(dest_acc),
     broadcast_type=[
         BroadcastType.None_,
         BroadcastType.Row,
@@ -122,9 +121,19 @@ def _get_valid_tile_dimensions(transpose_srca, broadcast_type):
         BroadcastType.Scalar,
     ],
     math_op=[MathOperation.Elwmul, MathOperation.Elwadd, MathOperation.Elwsub],
-    math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
+    math_fidelity=[
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ],
     transpose_srca=[Transpose.Yes, Transpose.No],
     input_dimensions=[[256, 32]],
+    formats=lambda dest_acc, math_fidelity, math_op: [
+        f
+        for f in _get_valid_formats(dest_acc)
+        if math_fidelity in _get_valid_math_fidelity(f, math_op)
+    ],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -311,6 +320,13 @@ def test_eltwise_binary(
 
 @parametrize(
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    broadcast_type=[
+        BroadcastType.None_,
+        BroadcastType.Row,
+        BroadcastType.Column,
+        BroadcastType.Scalar,
+    ],
+    math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     formats=[
         fmt
         for fmt in input_output_formats(
@@ -324,16 +340,9 @@ def test_eltwise_binary(
         if fmt.input_format == DataFormat.Bfp4_b
         # or fmt.output_format == DataFormat.Bfp4_b
     ],
-    broadcast_type=[
-        BroadcastType.None_,
-        BroadcastType.Row,
-        BroadcastType.Column,
-        BroadcastType.Scalar,
-    ],
-    math_fidelity=lambda formats: _get_valid_math_fidelity(formats),
     transpose_srca=Transpose.No,
-    math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
+    math_fidelity=lambda formats: _get_valid_math_fidelity(formats),
     # tile_dimensions=[[32, 32], [16,32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
@@ -512,12 +521,12 @@ def test_eltwise_binary_bfp4_b(
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,
     ],
+    math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
+    math_fidelity=[MathFidelity.LoFi],
     formats=lambda: input_output_formats(
         [DataFormat.Float16_b, DataFormat.Float32, DataFormat.Bfp8_b],
         same=True,
     ),
-    math_fidelity=[MathFidelity.LoFi],
-    math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
     input_dimensions=[[512, 32]],
     output_dimensions=[[128, 32]],
     tile_dimensions=[[32, 32], [16, 32]],

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_eltwise_unary_sfpu.py
@@ -128,21 +128,21 @@ FLOAT_TEST_PARAMS = list(
     chain(
         (
             (fmt, approx, mathop, fast, dest)
-            for fmt, approx, mathop, fast, dest in product(
-                FORMATS,
+            for approx, mathop, fast, dest, fmt in product(
                 [ApproximationMode.No, ApproximationMode.Yes],
                 SUPPORTED_FAST_MODE_OPS,
                 [FastMode.No, FastMode.Yes],
                 [DestAccumulation.No, DestAccumulation.Yes],
+                FORMATS,
             )
         ),
         (
             (fmt, approx, mathop, FastMode.No, dest)
-            for fmt, approx, mathop, dest in product(
-                FORMATS,
+            for approx, mathop, dest, fmt in product(
                 [ApproximationMode.No, ApproximationMode.Yes],
                 [op for op in ALL_MATHOPS if op not in SUPPORTED_FAST_MODE_OPS],
                 [DestAccumulation.No, DestAccumulation.Yes],
+                FORMATS,
             )
         ),
     )
@@ -240,18 +240,17 @@ FLOAT_TEST_PARAMS_BFP4_B = list(
     chain(
         (
             (fmt, approx, mathop, fast, dest)
-            for fmt, approx, mathop, fast, dest in product(
-                FORMATS_INCLUDE_BFP4_B,
+            for approx, mathop, fast, dest, fmt in product(
                 [ApproximationMode.No, ApproximationMode.Yes],
                 [op for op in SUPPORTED_FAST_MODE_OPS if op in MATHOPS_INCLUDE_BFP4_B],
                 [FastMode.No, FastMode.Yes],
                 [DestAccumulation.No, DestAccumulation.Yes],
+                FORMATS_INCLUDE_BFP4_B,
             )
         ),
         (
             (fmt, approx, mathop, FastMode.No, dest)
-            for fmt, approx, mathop, dest in product(
-                FORMATS_INCLUDE_BFP4_B,
+            for approx, mathop, dest, fmt in product(
                 [ApproximationMode.No, ApproximationMode.Yes],
                 [
                     op
@@ -259,6 +258,7 @@ FLOAT_TEST_PARAMS_BFP4_B = list(
                     if op not in SUPPORTED_FAST_MODE_OPS
                 ],
                 [DestAccumulation.No, DestAccumulation.Yes],
+                FORMATS_INCLUDE_BFP4_B,
             )
         ),
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_matmul_and_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_matmul_and_unary_sfpu.py
@@ -41,15 +41,6 @@ from helpers.utils import passed_test
 @skip_for_wormhole
 @parametrize(
     test_name="sources/matmul_and_unary_sfpu_test.cpp",
-    formats=input_output_formats(
-        [
-            DataFormat.Float16,
-            DataFormat.Float16_b,
-            DataFormat.Float32,
-            DataFormat.Bfp8_b,
-        ],
-        same=True,
-    ),
     mathop=[
         MathOperation.Abs,
         MathOperation.Celu,
@@ -71,6 +62,15 @@ from helpers.utils import passed_test
         MathFidelity.HiFi3,
         MathFidelity.HiFi4,
     ],
+    formats=input_output_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+            DataFormat.Bfp8_b,
+        ],
+        same=True,
+    ),
 )
 def test_matmul_and_unary_sfpu(
     test_name,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_pack.py
@@ -128,15 +128,6 @@ def is_relu_threshold_tolerance_issue(
 
 
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.Float32,
-            DataFormat.Int32,
-            DataFormat.Bfp8_b,
-        ]
-    ),
     input_dimensions=[[32, 32], [64, 64], [32, 64], [64, 32]],
     dest_sync=[DestSync.Half, DestSync.Full],
     dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
@@ -148,6 +139,15 @@ def is_relu_threshold_tolerance_issue(
     ],
     dest_index=lambda dest_acc, dest_sync, formats, input_dimensions: get_valid_dest_indices(
         dest_sync, dest_acc, formats, input_dimensions
+    ),
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float16,
+            DataFormat.Float32,
+            DataFormat.Int32,
+            DataFormat.Bfp8_b,
+        ]
     ),
 )
 def test_pack(

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_pack.py
@@ -137,15 +137,15 @@ def is_relu_threshold_tolerance_issue(
             DataFormat.Bfp8_b,
         ]
     ),
-    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
     input_dimensions=[[32, 32], [64, 64], [32, 64], [64, 32]],
-    relu_type=[
+    dest_sync=[DestSync.Half, DestSync.Full],
+    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
+    relu_type=lambda dest_acc: [
         PackerReluType.NoRelu,
         PackerReluType.ZeroRelu,
         PackerReluType.MinThresholdRelu,
         PackerReluType.MaxThresholdRelu,
     ],
-    dest_sync=[DestSync.Half, DestSync.Full],
     dest_index=lambda dest_acc, dest_sync, formats, input_dimensions: get_valid_dest_indices(
         dest_sync, dest_acc, formats, input_dimensions
     ),

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_pack_rows.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_pack_rows.py
@@ -39,6 +39,8 @@ dimension_combinations = [
 
 
 @parametrize(
+    dimensions=dimension_combinations,
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     formats=input_output_formats(
         [
             DataFormat.Bfp8_b,
@@ -49,9 +51,7 @@ dimension_combinations = [
         ],
         same=True,
     ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     num_rows_to_pack=[1, 16, 50, 64],
-    dimensions=dimension_combinations,
 )
 def test_pack_rows(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_pack_untilize.py
@@ -37,6 +37,12 @@ from helpers.utils import passed_test
 
 
 @parametrize(
+    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
+    input_dimensions=[[64, 64], [32, 128], [128, 128], [32, 64]],
+    #  TODO add DestSync::Full tests when we have a solution for the static_assert in _llk_pack_untilize_init_ that requires block_ct_dim to be less or equal to 8,
+    #  which is currently a limitation for testing DestSync::Full with the Untilize blocks calculation algorithm.
+    dest_sync=[DestSync.Half],
+    tile_dst_ct_offset=[0],  # Non-zero offsets are tracked in #1449
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
@@ -47,12 +53,6 @@ from helpers.utils import passed_test
             DataFormat.Fp8_e4m3,
         ]  # Pack Untilize doesn't work for block float formats (Bfp8_b); we only include as input format in our test
     ),
-    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
-    input_dimensions=[[64, 64], [32, 128], [128, 128], [32, 64]],
-    #  TODO add DestSync::Full tests when we have a solution for the static_assert in _llk_pack_untilize_init_ that requires block_ct_dim to be less or equal to 8,
-    #  which is currently a limitation for testing DestSync::Full with the Untilize blocks calculation algorithm.
-    dest_sync=[DestSync.Half],
-    tile_dst_ct_offset=[0],  # Non-zero offsets are tracked in #1449
 )
 def test_pack_untilize(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_binary.py
@@ -389,6 +389,13 @@ def _golden_sfpu_binary_bcast(
 
 
 @parametrize(
+    mathop=[
+        MathOperation.SfpuElwadd,
+        MathOperation.SfpuElwsub,
+        MathOperation.SfpuElwmul,
+    ],
+    bcast_dim=[BroadcastType.ROW, BroadcastType.COL],
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     formats=input_output_formats(
         [
             DataFormat.Float32,
@@ -397,13 +404,6 @@ def _golden_sfpu_binary_bcast(
             DataFormat.Bfp8_b,
         ]
     ),
-    bcast_dim=[BroadcastType.ROW, BroadcastType.COL],
-    mathop=[
-        MathOperation.SfpuElwadd,
-        MathOperation.SfpuElwsub,
-        MathOperation.SfpuElwmul,
-    ],
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
 )
 def test_sfpu_binary_bcast(
     formats,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_reduce.py
@@ -96,13 +96,15 @@ def is_valid_reduce_dimension(mathop, dest_acc, formats, dim):
     ),
     mathop=lambda reduce_pool: get_supported_reduce_axioms(reduce_pool),
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    input_bounds=lambda formats: get_format_input_bounds(formats),
     reduce_pool=[ReducePool.Min, ReducePool.Max, ReducePool.Sum, ReducePool.Average],
     dimension_combinations=lambda mathop, dest_acc, formats: [
         dim
         for dim in dimension_combinations
         if is_valid_reduce_dimension(mathop, dest_acc, formats, dim)
     ],
+    input_bounds=lambda formats, dimension_combinations: get_format_input_bounds(
+        formats
+    ),
 )
 def test_sfpu_reduce(
     formats,
@@ -221,12 +223,12 @@ def test_sfpu_reduce(
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     mathop=[MathOperation.ReduceRow],
     reduce_pool=[ReducePool.Max],
-    input_bounds=lambda formats: get_format_input_bounds(formats),
     input_dimensions=lambda mathop, dest_acc, formats: [
         dim
         for dim in [[32, 32], [64, 64], [64, 128], [128, 64], [256, 32], [32, 256]]
         if is_valid_reduce_dimension(mathop, dest_acc, formats, dim)
     ],
+    input_bounds=lambda formats, input_dimensions: get_format_input_bounds(formats),
 )
 def test_reduce_row_max(
     formats, dest_acc, mathop, reduce_pool, input_bounds, input_dimensions

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
@@ -92,6 +92,13 @@ def generate_transpose_dest_float_combinations(formats_list):
                 for unpack_to_dest in unpack_to_dest_list
             )
 
+    # Group by ELF identity to minimize ELF-load thrashing. With compile_time_formats=False
+    # and an explicit unpack_to_dest, formats is pure runtime here; the ELF is defined only by
+    # (math_transpose_faces, dest_acc, unpack_to_dest). Sorting by that key keeps same-ELF
+    # cases adjacent (fmt varies within a group) so each ELF loads once. Sorting only reorders
+    # the list, so the set of cases is unchanged.
+    combinations.sort(key=lambda c: (str(c[2]), str(c[1]), str(c[3])))
+
     return combinations
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_ttnn_where.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_ttnn_where.py
@@ -23,6 +23,8 @@ def torch_equal_nan(a, b):
 
 
 @parametrize(
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    mathop=MathOperation.TTNNWhere,
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
@@ -31,8 +33,6 @@ def torch_equal_nan(a, b):
         ],
         same=True,
     ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    mathop=MathOperation.TTNNWhere,
     test_case=["mixed", "all_ones", "all_zeros"],
 )
 def test_ttnn_where(
@@ -135,6 +135,10 @@ def test_ttnn_where(
 # MCW test with dynamic format sweeping like main test
 # Use same input/output format - no mixing
 @parametrize(
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+    mathop=MathOperation.TTNNWhere,
+    height=[32],
+    width=[32],
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
@@ -143,10 +147,6 @@ def test_ttnn_where(
         ],
         same=True,
     ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    mathop=MathOperation.TTNNWhere,
-    height=[32],
-    width=[32],
 )
 def test_ttnn_where_mcw(
     formats,


### PR DESCRIPTION
### PR Category
Performance

### Summary
Reordered `@parametrize` keys across 14 files (16 test functions) so ELF-defining (template) parameters are outer (slow-changing) and runtime/format params are inner (fast-changing).
Each ELF is now loaded once while all its runtime variants run consecutively, instead of reloading more often (like now).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/topological-order-of-template-params)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/topological-order-of-template-params)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/topological-order-of-template-params)