### PR TITLE
gpt-oss: fix Blackhole decode hang by inferring nnz at runtime in MoE decode sparse_matmuls

### DIFF
--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -69,7 +69,14 @@ def decode_forward(
         hidden_states,
         weights.gate_proj,
         sparsity=sparsity,
-        nnz=num_experts_per_tok,
+        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
+        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
+        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
+        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
+        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
+        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
+        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
+        nnz=None,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=program_config.get_decode_gate_up_config(
@@ -88,7 +95,14 @@ def decode_forward(
         hidden_states,
         weights.up_proj,
         sparsity=sparsity,
-        nnz=num_experts_per_tok,
+        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
+        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
+        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
+        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
+        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
+        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
+        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
+        nnz=None,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=program_config.get_decode_gate_up_config(
@@ -113,7 +127,14 @@ def decode_forward(
         down_input,
         weights.down_proj,
         sparsity=sparsity,
-        nnz=num_experts_per_tok,
+        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
+        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
+        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
+        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
+        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
+        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
+        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
+        nnz=None,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         is_input_a_sparse=True,


### PR DESCRIPTION
## Summary

Fixes the deterministic **GPT-OSS-120B decode hang on Blackhole** (QuietBox 2 / P300x2, `(1,4)` mesh) by dropping the static `nnz` argument on the three MoE decode `sparse_matmul`s in `experts/decode.py` so the op infers the non-zero count from the `sparsity` tensor at runtime.

- Fixes #45052 (GPT-OSS-120B decode hang on BH-QB2)
- Related: #45943 (`ttnn.sparse_matmul` deadlocks when declared `nnz` > `count_nonzero(sparsity)`)

## Root cause

The decode MoE gate/up/down projections call `ttnn.sparse_matmul(..., nnz=num_experts_per_tok)` (=4). When `nnz` is supplied, the kernels wire up with **mismatched loop counts**:

- the in0-mcast **sender** loops over all experts and multicasts **once per non-zero `sparsity` entry** (it skips zeros), i.e. `count_nonzero(sparsity)` times;
- the in0 **receivers** and **compute** loop a **fixed `nnz`** times, each waiting on the in0 semaphore.

So the op silently requires `count_nonzero(sparsity) == nnz`. The decode `sparsity` is built from the router as `scatter(zeros, top-k indices, softmax(top-k logits))`. On **Blackhole**, the softmax over the top-k logits flushes the smaller weights to **exact `0.0`**, so for many tokens the scattered sparsity has **fewer than `nnz` non-zeros** (measured distribution over decode calls: count = 1 ≈ 60%, 2 ≈ 4%, 3 ≈ 1%, 4 ≈ 36%). Whenever `count < nnz`, the receivers wait on a multicast the sender never issues → device deadlock. Wormhole keeps those small weights non-zero, so the count stays 4 there and the hang did not reproduce — which is why this regressed only once Blackhole was enabled. The op-level defect is tracked in #45943.

## Fix applied

Omit `nnz` (pass `None`) on the three decode `sparse_matmul`s. With no `nnz`, the kernel takes the **runtime-inference path** (`get_batch_from_reader`): sender and receivers both iterate the full expert set and the sender signals per-expert `VALID`/`IGNORE`, so the handshake counts always match regardless of how many experts are actually selected. This is robust to any per-token non-zero count.

```python
gate = ttnn.sparse_matmul(
    hidden_states, weights.gate_proj, sparsity=sparsity,
    nnz=None,  # was: nnz=num_experts_per_tok
    ...
)
```

### Alternatives considered
- **Router-side floor** (force all top-k weights non-zero so `count == nnz`, keep the fast path) — faster, but perturbs routing numerics and is GPT-OSS-specific.
- **Op-level robustness** (make `sparse_matmul` drive the handshake from the actual sparsity even when `nnz` is given) — fixes every caller but is a shared-kernel change requiring a build; tracked separately in #45943.

The model-side `nnz=None` change was chosen as the minimal, correct fix that matches the documented op contract ("if `nnz` is not provided it is inferred from the sparsity tensor at runtime").

## Performance impact

The runtime-inference path loops over the full expert set with a per-expert mcast handshake, instead of looping only `nnz` selected experts. Measured on `(1,4)` BH:

- decode throughput ≈ **21.2 tok/s/user** (vs ≈ 24.6 tok/s/user if the static-`nnz` fast path could be kept) — roughly a **13–16% decode slowdown**.
- This still meets the ≥21 tok/s/user target, and is obviously preferable to the alternative (a hang). The cost is synchronization overhead (extra per-expert NOC semaphore round-trips), not extra matmul work.

## Why no further optimization here

The faster variants (router floor / op-level fast-path) are intentionally **not** pursued in this PR. This per-token, per-layer `sparse_matmul` MoE decode path is slated to be **replaced by the generalized MoE implementation**, so micro-optimizing it now is throwaway work. This change keeps the fix minimal and robust until that replacement lands.

## Testing

- Full demo `text_demo.py::test_gpt_oss_demo[blackhole-1x4-prefill_1k]` (decode trace enabled): previously hung on the first decode token; now runs **200 decode iterations to completion** at ≈21 tok/s/user (`1 passed`).
- The underlying op deadlock has a standalone single-device repro (no mesh/model) attached to #45943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [x] [benchmarks](https://github.com/tenstorrent/tt-shield/actions/runs/26940093315/job/79487397836)
- [x] [e2e demo BH-QB2](https://github.com/tenstorrent/tt-metal/actions/runs/26949245822)
- [x] [e2e demo WH-GLX ](https://github.com/tenstorrent/tt-metal/actions/runs/26949263295)