### PR TITLE
Craq-sim Multichip Support (squashed)

### DIFF
--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -87,4 +87,8 @@ if(USE_MPI)
     target_compile_definitions(distributed PRIVATE OPEN_MPI="1")
 endif()
 
+if(TT_UMD_BUILD_SIMULATION)
+    target_compile_definitions(distributed PRIVATE TT_UMD_BUILD_SIMULATION)
+endif()
+
 target_include_directories(distributed SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -10,11 +10,11 @@
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
-#include <cstring>
 #include <functional>
 #include <optional>
 #include <type_traits>
@@ -55,6 +55,9 @@
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
 #include "dispatch/simple_trace_allocator.hpp"
+#if defined(TT_UMD_BUILD_SIMULATION)
+#include "buffers/simulator_direct_write.hpp"
+#endif
 
 namespace tt::tt_metal {
 struct ProgramCommandSequence;
@@ -591,12 +594,24 @@ bool FDMeshCommandQueue::write_shard_to_device(
         return false;
     }
 
-    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture. trace id: {}", trace_id_.value());
 
     auto* device_buffer = buffer.get_device_buffer(device_coord);
-    auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
+    auto region_value = region.value_or(BufferRegion(0, device_buffer->size()));
+    auto shard_view = device_buffer->view(region_value);
 
+#if defined(TT_UMD_BUILD_SIMULATION)
+    const tt_sim::DirectWriteGuard tt_sim_direct_write_guard{
+        .target = this->get_target_device_type(),
+        .cq_idle = !in_use_.load(std::memory_order_acquire),
+        .rtoptions = &MetalContext::instance(mesh_device_->impl().get_context_id()).rtoptions(),
+    };
+    if (tt_sim::try_direct_write(tt_sim_direct_write_guard, *shard_view, src, region_value, logical_core_filter)) {
+        return false;
+    }
+#endif
+
+    in_use_ = true;
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     return buffer_dispatch::write_to_device_buffer(
         src,

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -137,6 +137,22 @@ RealtimeProfilerEligibility evaluate_realtime_profiler_eligibility(IDevice* devi
         return {};
     }
 
+    // ttsim: the simulator's D2H socket exists but its device kernels run many orders of
+    // magnitude slower than real silicon, so the 2 s WriteToDeviceL1/sync poll deadline
+    // in run_sync() always trips before the profiler core can respond. That burns ~30 s
+    // per chip during MeshDevice bring-up, and on WH (where the 64-bit-PCIe gate below
+    // does NOT fire) it deadlocks downstream waiters that depend on first_unthrottled
+    // finish_sync. Skip the profiler entirely on Simulator targets; performance traces
+    // are not interesting on the sim anyway.
+    if (cluster.get_target_device_type() == tt::TargetDevice::Simulator) {
+        log_debug(
+            tt::LogMetal,
+            "Real-time profiler disabled on device {}: target is Simulator; D2H sync polls "
+            "cannot meet real-time deadlines against ttsim's emulated PCIe.",
+            device_id);
+        return {};
+    }
+
     if (!device->is_mmio_capable()) {
         log_debug(
             tt::LogMetal,

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -80,6 +80,9 @@ void FabricBuilder::discover_channels() {
 }
 
 void FabricBuilder::create_routers() {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
     // Create router builders
     for (const auto& [direction, eth_channels] : channels_by_direction_) {
         const auto& neighbor_node = chip_neighbors_.at(direction);
@@ -93,6 +96,9 @@ void FabricBuilder::create_routers() {
                 .direction = direction,
                 .is_dispatch_link = is_dispatch,
             };
+
+            cluster.register_sim_fabric_endpoint_direction(
+                device_->id(), eth_chan, control_plane.routing_direction_to_eth_direction(direction));
 
             auto router_builder = FabricRouterBuilder::create(device_, program_, local_node_, location);
             routers_.insert({eth_chan, std::move(router_builder)});

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(sources.cmake)
 
+if(TT_UMD_BUILD_SIMULATION)
+    list(APPEND IMPL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/buffers/simulator_direct_write.cpp)
+endif()
+
 # Include helper functions and generate headers from flatbuffer schemas
 include(flatbuffers)
 
@@ -123,6 +127,10 @@ target_include_directories(impl SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/experi
 
 # Set KJ_NO_EXCEPTIONS=0 to enable exceptions in Cap'n Proto code due to a detection bug with g++-12.
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast PRIVATE -DKJ_NO_EXCEPTIONS=0)
+
+if(TT_UMD_BUILD_SIMULATION)
+    target_compile_definitions(impl PRIVATE TT_UMD_BUILD_SIMULATION)
+endif()
 
 if(TT_METAL_USE_EMULE)
     get_target_property(_EMULE_JIT_DIR tt_emule_headers TT_EMULE_JIT_INCLUDE_DIR)

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -86,7 +86,8 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
     auto mesh_buffer = buffer_.get_mesh_buffer();
     bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-    if (using_fast_dispatch) {
+    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+    if (using_fast_dispatch && !using_simulator) {
         distributed::EnqueueWriteMeshBuffer(
             mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
     } else {

--- a/tt_metal/impl/buffers/simulator_direct_write.cpp
+++ b/tt_metal/impl/buffers/simulator_direct_write.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "buffers/simulator_direct_write.hpp"
+
+#if defined(TT_UMD_BUILD_SIMULATION)
+
+#include "llrt/rtoptions.hpp"
+#include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt_stl/span.hpp>
+
+namespace tt::tt_metal::tt_sim {
+
+bool is_direct_write_enabled(const DirectWriteGuard& guard, const void* src, const BufferRegion& region) {
+    if (guard.target != tt::TargetDevice::Simulator) {
+        return false;
+    }
+    if (!guard.cq_idle) {
+        return false;
+    }
+    if (guard.rtoptions == nullptr || !guard.rtoptions->get_simulator_direct_tensor_writes()) {
+        return false;
+    }
+    if (src == nullptr) {
+        return false;
+    }
+    if (region.offset != 0) {
+        return false;
+    }
+    return true;
+}
+
+void write_shard(
+    Buffer& shard_view, const void* src, const BufferRegion& region, const CoreRangeSet* logical_core_filter) {
+    auto payload = tt::stl::Span<const uint8_t>(static_cast<const uint8_t*>(src), static_cast<size_t>(region.size));
+    if (logical_core_filter != nullptr) {
+        experimental::core_subset_write::WriteToBuffer(shard_view, payload, *logical_core_filter);
+    } else {
+        detail::WriteToBuffer(shard_view, payload);
+    }
+}
+
+bool try_direct_write(
+    const DirectWriteGuard& guard,
+    Buffer& shard_view,
+    const void* src,
+    const BufferRegion& region,
+    const CoreRangeSet* logical_core_filter) {
+    if (!is_direct_write_enabled(guard, src, region)) {
+        return false;
+    }
+    write_shard(shard_view, src, region, logical_core_filter);
+    return true;
+}
+
+}  // namespace tt::tt_metal::tt_sim
+
+#endif  // defined(TT_UMD_BUILD_SIMULATION)

--- a/tt_metal/impl/buffers/simulator_direct_write.hpp
+++ b/tt_metal/impl/buffers/simulator_direct_write.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include "llrt/tt_target_device.hpp"
+
+namespace tt::llrt {
+class RunTimeOptions;
+}  // namespace tt::llrt
+
+namespace tt::tt_metal::tt_sim {
+
+// Inputs required to evaluate the tt-sim direct H2D write guard for fast-dispatch mesh uploads.
+// CQ idle state and trace policy remain owned by the mesh command queue caller.
+struct DirectWriteGuard {
+    tt::TargetDevice target = tt::TargetDevice::Invalid;
+    bool cq_idle = false;
+    const tt::llrt::RunTimeOptions* rtoptions = nullptr;
+};
+
+#if defined(TT_UMD_BUILD_SIMULATION)
+
+// True when tt-sim may bypass simulated CQ payload copies for this shard write.
+bool is_direct_write_enabled(const DirectWriteGuard& guard, const void* src, const BufferRegion& region);
+
+// Synchronous host-to-device shard write used by the tt-sim fast path.
+void write_shard(
+    Buffer& shard_view, const void* src, const BufferRegion& region, const CoreRangeSet* logical_core_filter);
+
+// Returns true when the tt-sim guard fired and the write completed synchronously.
+bool try_direct_write(
+    const DirectWriteGuard& guard,
+    Buffer& shard_view,
+    const void* src,
+    const BufferRegion& region,
+    const CoreRangeSet* logical_core_filter);
+
+#else
+
+inline bool try_direct_write(
+    const DirectWriteGuard& /*guard*/,
+    Buffer& /*shard_view*/,
+    const void* /*src*/,
+    const BufferRegion& /*region*/,
+    const CoreRangeSet* /*logical_core_filter*/) {
+    return false;
+}
+
+#endif
+
+}  // namespace tt::tt_metal::tt_sim

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -215,8 +215,18 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
 
                 if (this->sysmem_manager_->is_dram_backed()) {
+                    // With DRAM-backed CQs, each device stores its command queue in its own DRAM. The CQ
+                    // pointers for a serviced device must therefore be written into that device's DRAM, not
+                    // the MMIO device's DRAM. Writing to this->id() left non-MMIO devices with an uninitialized
+                    // (zero) completion write pointer, causing completion_queue_wait_front to return spuriously.
+                    const uint32_t dram_channel =
+                        this->allocator_impl()->get_dram_channel_from_bank_id(this->sysmem_manager_->get_dram_region_bank_id());
                     MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
-                        pointers.data(), pointers.size() * sizeof(uint32_t), this->id(), 0, cq_offset);
+                        pointers.data(),
+                        pointers.size() * sizeof(uint32_t),
+                        serviced_device_id,
+                        dram_channel,
+                        cq_offset);
                 } else {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                         pointers.data(),

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -239,7 +239,11 @@ void DispatchKernelInitializer::wait_for_dispatch_cores() const {
         // This allows the device handles to be properly released, enabling subsequent
         // device opens and tt-smi resets to succeed.
         try {
-            tt::llrt::internal_::wait_until_cores_done(dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
+            const auto teardown_timeout_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(rtoptions_.get_timeout_duration_for_operations())
+                    .count();
+            tt::llrt::internal_::wait_until_cores_done(
+                dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, static_cast<int>(teardown_timeout_ms));
         } catch (const std::exception& e) {
             log_warning(
                 LogMetal,

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -286,6 +286,20 @@ void FabricFirmwareInitializer::init(
 
     if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
         log_info(tt::LogMetal, "Initializing Fabric");
+#if defined(TT_UMD_BUILD_SIMULATION)
+        if (rtoptions_.get_simulator_enabled()) {
+            for (auto* dev : devices_) {
+                const auto fabric_node_id = control_plane_.get_fabric_node_id_from_physical_chip_id(dev->id());
+                cluster_.get_driver()->register_sim_fabric_node_id(
+                    dev->id(), uint32_t(fabric_node_id.mesh_id.get()), uint32_t(fabric_node_id.chip_id));
+                for (const auto& [eth_chan, direction] :
+                     control_plane_.get_active_fabric_eth_channels(fabric_node_id)) {
+                    cluster_.get_driver()->register_sim_fabric_endpoint_direction(
+                        dev->id(), uint32_t(eth_chan), uint32_t(direction));
+                }
+            }
+        }
+#endif
         control_plane_.write_routing_tables_to_all_chips();
         compile_and_configure_fabric();
         log_info(tt::LogMetal, "Fabric Initialized with config {}", fabric_config);
@@ -492,10 +506,10 @@ void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms)
 }
 
 uint32_t FabricFirmwareInitializer::get_fabric_router_sync_timeout_ms() const {
-    if (rtoptions_.get_simulator_enabled()) {
-        return 15000;
-    }
     auto timeout = rtoptions_.get_fabric_router_sync_timeout_ms();
+    if (rtoptions_.get_simulator_enabled()) {
+        return timeout.value_or(15000);
+    }
     return timeout.value_or(10000);
 }
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -58,6 +58,16 @@ bool mock_firmware_sources_available_for(tt::ARCH arch) {
     }
 }
 
+int firmware_wait_timeout_ms() {
+    const auto& rtoptions = MetalContext::instance().rtoptions();
+    // RTL sim directory backends are event-driven and much slower than functional ttsim (.so).
+    // llrt treats timeout_ms==0 on sim as infinite wait.
+    if (rtoptions.get_simulator_enabled() && rtoptions.get_simulator_path().extension() != ".so") {
+        return 0;
+    }
+    return 10000;
+}
+
 }  // namespace
 
 RiscFirmwareInitializer::RiscFirmwareInitializer(
@@ -451,7 +461,7 @@ void RiscFirmwareInitializer::reset_cores(tt::ChipId device_id) {
     }
 
     for (auto& id_and_cores : device_to_early_exit_cores) {
-        const int timeout_ms = 10000;
+        const int timeout_ms = firmware_wait_timeout_ms();
         if (!id_and_cores.second.empty()) {
             try {
                 llrt::internal_::wait_until_cores_done(
@@ -1385,7 +1395,7 @@ void RiscFirmwareInitializer::initialize_and_launch_firmware(tt::ChipId device_i
     }
 
     log_debug(LogDevice, "Waiting for firmware init complete");
-    const int timeout_ms = 10000;
+    const int timeout_ms = firmware_wait_timeout_ms();
     try {
         llrt::internal_::wait_until_cores_done(device_id, dev_msgs::RUN_MSG_INIT, not_done_cores, timeout_ms);
     } catch (std::runtime_error&) {

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -22,6 +22,9 @@ uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id 
 uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
 
 uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t base) {
+    if (base != 0) {
+        return base + get_relative_cq_offset(cq_id, cq_size);
+    }
     return base + (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -151,10 +151,29 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         this->cq_size = dram_backed_command_queues_size / num_hw_cqs;
         TT_ASSERT((this->cq_size % ctx.hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
-        TT_FATAL(device->is_mmio_capable(), "Device {} is not an MMIO device", this->device_id);
+        TT_FATAL(
+            device->is_mmio_capable() || ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Simulator,
+            "Device {} is not an MMIO device",
+            this->device_id);
+        // Host mirror of the DRAM-backed CQ sysmem region: the host edits this buffer and
+        // write_dram_vec/read_dram_vec sync it to each chip's DRAM (no PCIe hugepage).
         this->dram_region_staging_buffer = std::make_unique<char[]>(dram_backed_command_queues_size);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
         this->channel_offset = 0;
+
+        // Carve out the hugepage "auxiliary" tail (same layout as the MMIO path below).
+        // Per HW CQ we reserve two TRANSFER_PAGE_SIZE (4 KiB) pages outside the issue/completion
+        // fifo layout; they are pooled after all CQ slots in free_region_* and allocated via
+        // allocate_region() when host code needs extra device-visible sysmem (e.g. D2H socket
+        // hugepage fallback for fifo data and bytes-sent counters).
+        static constexpr uint32_t AUX_PAGES_PER_CQ_SIM = 2;
+        uint32_t per_cq_reduction_sim = AUX_PAGES_PER_CQ_SIM * DispatchSettings::TRANSFER_PAGE_SIZE;
+        this->cq_size -= per_cq_reduction_sim;
+        uint32_t total_cq_space_sim = static_cast<uint32_t>(num_hw_cqs) * this->cq_size;
+        this->free_region_start_ = this->channel_offset + total_cq_space_sim;
+        this->free_region_size_ = static_cast<uint32_t>(num_hw_cqs) * per_cq_reduction_sim;
+        this->free_region_host_ptr_ = this->cq_sysmem_start + total_cq_space_sim;
+        this->free_region_bump_ = 0;
         this->init_dispatch_core_interfaces(num_hw_cqs, 0);
         return;
     }
@@ -182,6 +201,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
+    // Two TRANSFER_PAGE_SIZE pages per HW CQ reserved for free_region_* (see DRAM-backed path above).
     static constexpr uint32_t AUX_PAGES_PER_CQ = 2;
     uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
     this->cq_size -= per_cq_reduction;
@@ -732,7 +752,6 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     // Handler for the timeout
     auto on_timeout = [this, &exit_condition]() {
         exit_condition.store(true);
-
         tt::tt_metal::MetalContext::instance(this->context_id).on_dispatch_timeout_detected();
 
         TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");

--- a/tt_metal/impl/dispatch/system_memory_manager.hpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.hpp
@@ -137,6 +137,8 @@ private:
 
     std::unique_ptr<char[]> dram_region_staging_buffer;
 
+    // Bump-allocated tail of CQ sysmem (after all per-CQ issue/completion buffers). Device and host
+    // addresses are returned together by allocate_region() for PCIe/D2H consumers.
     uint32_t free_region_start_ = 0;
     uint32_t free_region_size_ = 0;
     uint32_t free_region_bump_ = 0;

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -516,35 +516,59 @@ void WriteToDeviceSharded(
     const size_t remainder_bytes = page_size - aligned_bytes;
     TT_ASSERT(buffer.aligned_page_size() >= page_size);  // Check that we don't write to the end of the buffer
     const auto& buffer_page_mapping = *buffer.get_buffer_page_mapping();
-    for (auto mapped_page : buffer_page_mapping) {
-        auto core = buffer_page_mapping.all_cores[mapped_page.core_id];
+    const bool can_write_page_ranges = buffer.aligned_page_size() == page_size;
+
+    auto write_pages = [&](uint32_t core_id, uint32_t device_page, uint32_t host_page, uint32_t num_pages) {
+        if (num_pages == 0) {
+            return;
+        }
+        auto core = buffer_page_mapping.all_cores[core_id];
         if (logical_core_filter != nullptr && !logical_core_filter->contains(core)) {
-            continue;
+            return;
         }
         auto bank_id = allocator->get_bank_ids_from_logical_core(buffer.buffer_type(), core)[0];
         auto bank_offset = allocator->get_bank_offset(buffer.buffer_type(), bank_id);
-        auto data_index = mapped_page.host_page * page_size;
-        auto write_chunk = [&](size_t offset, size_t size_in_bytes) {
+        size_t data_index = static_cast<size_t>(host_page) * page_size;
+        auto write_chunk = [&](uint32_t write_device_page, size_t offset, size_t size_in_bytes) {
             if (size_in_bytes == 0) {
                 return;
             }
             std::span<const std::uint8_t> page(host_buffer.data() + data_index + offset, size_in_bytes);
             if (buffer.is_l1()) {
                 auto absolute_address =
-                    buffer.address() + bank_offset + (mapped_page.device_page * buffer.aligned_page_size()) + offset;
+                    buffer.address() + bank_offset + (write_device_page * buffer.aligned_page_size()) + offset;
                 auto core_coordinates =
                     device->worker_core_from_logical_core(buffer.allocator()->get_logical_core_from_bank_id(bank_id));
                 MetalContext::instance().get_cluster().write_core(
                     device->id(), core_coordinates, page, absolute_address);
             } else {
-                auto bank_local_address =
-                    buffer.address() + (mapped_page.device_page * buffer.aligned_page_size()) + offset;
+                auto bank_local_address = buffer.address() + (write_device_page * buffer.aligned_page_size()) + offset;
                 WriteToDeviceDRAMChannel(device, bank_id, bank_local_address, page);
             }
         };
 
-        write_chunk(0, aligned_bytes);
-        write_chunk(aligned_bytes, remainder_bytes);
+        if (can_write_page_ranges) {
+            write_chunk(device_page, 0, static_cast<size_t>(num_pages) * page_size);
+            return;
+        }
+
+        for (uint32_t page = 0; page < num_pages; page++) {
+            data_index = static_cast<size_t>(host_page + page) * page_size;
+            write_chunk(device_page + page, 0, aligned_bytes);
+            write_chunk(device_page + page, aligned_bytes, remainder_bytes);
+        }
+    };
+
+    for (uint32_t core_id = 0; core_id < buffer_page_mapping.all_cores.size(); core_id++) {
+        for (const auto& core_page_mapping : buffer_page_mapping.core_page_mappings[core_id]) {
+            for (const auto& host_range : core_page_mapping.host_ranges) {
+                write_pages(
+                    core_id,
+                    core_page_mapping.device_start_page + host_range.device_page_offset,
+                    host_range.host_page_start,
+                    host_range.num_pages);
+            }
+        }
     }
 }
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -351,11 +351,9 @@ void wait_until_cores_done(
     auto start = std::chrono::high_resolution_clock::now();
     const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     bool is_simulator = rtoptions.get_simulator_enabled();
-    // For simulators, always disable timeout (infinite wait). For non-simulators, a 0
-    // timeout means: use the configured timeout for operations.
-    if (is_simulator) {
-        timeout_ms = 0;
-    } else if (timeout_ms == 0) {
+    // timeout_ms == 0 means infinite wait on sim; on silicon it means use configured operation timeout.
+    // Callers that need a bounded wait on sim (e.g. dispatch-core teardown) pass an explicit timeout_ms > 0.
+    if (timeout_ms == 0 && !is_simulator) {
         timeout_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(rtoptions.get_timeout_duration_for_operations())
                 .count();

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -114,6 +114,7 @@ enum class EnvVarID {
     TT_METAL_FORCE_JIT_COMPILE,                         // Force JIT compilation
     TT_METAL_DISABLE_SFPLOADMACRO,                      // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                            // Store command queues in device DRAM
+    TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,            // Simulator tensor preload bypasses FD CQ copies
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Enable Blackhole DRAM programmable cores
 
     // ========================================
@@ -779,6 +780,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (use hugepages)
         // Usage: export TT_METAL_DRAM_BACKED_CQ=1
         case EnvVarID::TT_METAL_DRAM_BACKED_CQ: this->dram_backed_cq = is_env_enabled(value); break;
+
+        // TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES
+        // Use synchronous direct buffer writes for simulator tensor preloads instead of FD CQ copies.
+        // Default: false
+        // Usage: export TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1
+        case EnvVarID::TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES:
+            this->simulator_direct_tensor_writes = is_env_enabled(value);
+            break;
 
         // ========================================
         // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -332,6 +332,9 @@ class RunTimeOptions {
     // Store command queues in device DRAM
     bool dram_backed_cq = false;
 
+    // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
+    bool simulator_direct_tensor_writes = false;
+
     // To be used for NUMA node based thread binding
     bool numa_based_affinity = false;
 
@@ -789,6 +792,8 @@ public:
     bool get_numa_based_affinity() const { return numa_based_affinity; }
 
     bool get_dram_backed_cq() const { return dram_backed_cq; }
+
+    bool get_simulator_direct_tensor_writes() const { return simulator_direct_tensor_writes; }
 
     std::optional<uint32_t> get_fabric_router_sync_timeout_ms() const { return fabric_router_sync_timeout_ms; }
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -55,7 +55,11 @@ uint64_t get_static_tlb_size() { return 4ULL * (1ULL << 30); }
 }  // namespace quasar
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs) {
     using get_static_tlb_size_ptr = uint64_t (*)();
     get_static_tlb_size_ptr get_static_tlb_size;
 
@@ -87,7 +91,8 @@ void configure_static_tlbs(
         device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
 
-    if (arch == tt::ARCH::BLACKHOLE && sdesc.get_num_dram_channels() == blackhole::NUM_DRAM_CHANNELS) {
+    if (arch == tt::ARCH::BLACKHOLE && sdesc.get_num_dram_channels() == blackhole::NUM_DRAM_CHANNELS &&
+        include_dram_tlbs) {
         uint32_t dram_addr = 0;
         for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {
             tt::umd::CoreCoord dram_core =

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -16,6 +16,10 @@ struct metal_SocDescriptor;
 namespace ll_api {
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver);
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs = true);
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -12,6 +12,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include <algorithm>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -86,7 +87,9 @@ namespace tt {
 
 tt::tt_metal::ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const umd::ClusterDescriptor* cluster_desc) {
-    if (rtoptions.get_simulator_enabled() && !rtoptions.get_mock_enabled()) {
+    // When ttsim is active, derive cluster type from the simulator soc descriptor even if a mock
+    // cluster descriptor is also configured (tt-run MP sweeps set both).
+    if (rtoptions.get_simulator_enabled()) {
         auto soc_desc =
             tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(rtoptions.get_simulator_path());
         auto arch = tt::umd::SocDescriptor::get_arch_from_soc_descriptor_path(soc_desc);
@@ -483,8 +486,18 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
 
         for (const auto& mmio_device_id : mmio_device_ids) {
             futures.emplace_back(tt_metal::detail::async([this, mmio_device_id]() {
+                bool include_dram_tlbs = (this->target_type_ == TargetDevice::Silicon);
+                if (this->target_type_ == TargetDevice::Simulator && rtoptions_.get_simulator_enabled()) {
+                    // Functional ttsim (libttsim.so) does not model BH DRAM TLBs and crashes if they
+                    // are configured. RTL sim uses a directory simulator path and still needs them.
+                    include_dram_tlbs = (rtoptions_.get_simulator_path().extension() != ".so");
+                }
                 ll_api::configure_static_tlbs(
-                    this->arch_, mmio_device_id, this->get_soc_desc(mmio_device_id), *this->driver_);
+                    this->arch_,
+                    mmio_device_id,
+                    this->get_soc_desc(mmio_device_id),
+                    *this->driver_,
+                    include_dram_tlbs);
             }));
         }
 
@@ -722,7 +735,15 @@ std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(ChipId chi
     return worker_logical_to_virtual_y;
 }
 
-int Cluster::get_device_aiclk(const ChipId& chip_id) const { return this->driver_->get_chip(chip_id)->get_clock(); }
+int Cluster::get_device_aiclk(const ChipId& chip_id) const {
+    // Functional ttsim (.so) clock queries are unreliable; RTL sim uses a directory path and
+    // metal/umd unit tests expect a non-zero AICLK (see test_dram_kernels, watcher tests).
+    if (this->target_type_ == TargetDevice::Simulator && rtoptions_.get_simulator_enabled() &&
+        rtoptions_.get_simulator_path().extension() == ".so") {
+        return 0;
+    }
+    return this->driver_->get_chip(chip_id)->get_clock();
+}
 
 uint16_t Cluster::get_bus_id(ChipId chip) const { return this->get_cluster_desc()->get_bus_id(chip); }
 
@@ -1549,6 +1570,26 @@ bool Cluster::supports_ethernet_link_retraining() const {
         return this->get_ethernet_firmware_version() >= tt::umd::semver_t(1, 9, 0);
     }
     return false;
+}
+
+void Cluster::register_sim_fabric_endpoint_direction(
+    ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const {
+    if (std::getenv("TTSIM_FABRIC_TERMINAL_TRACE")) {
+        std::fprintf(
+            stderr,
+            "[ttsim-fabric-terminal] tt-metal-register-direction chip=%d chan=%u dir=%u target=%u\n",
+            chip_id,
+            static_cast<uint32_t>(eth_chan_id),
+            static_cast<uint32_t>(direction),
+            static_cast<uint32_t>(this->target_type_));
+    }
+    if (this->target_type_ != tt::TargetDevice::Simulator) {
+        return;
+    }
+#if defined(TT_UMD_BUILD_SIMULATION)
+    this->get_driver()->register_sim_fabric_endpoint_direction(
+        chip_id, static_cast<uint32_t>(eth_chan_id), static_cast<uint32_t>(direction));
+#endif
 }
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -233,6 +233,10 @@ public:
     }
 
     std::uint32_t get_numa_node_for_device(uint32_t device_id) const {
+        // Simulation/mock/emule chips do not have host NUMA affinity; UMD throws if queried.
+        if (this->target_type_ != tt::TargetDevice::Silicon) {
+            return 0;
+        }
         uint32_t mmio_device_id = this->get_associated_mmio_device(device_id);
         return driver_->get_numa_node_for_pcie_device(mmio_device_id);
     }
@@ -365,6 +369,9 @@ public:
     bool is_mock_or_emulated() const {
         return this->target_type_ == tt::TargetDevice::Mock || this->target_type_ == tt::TargetDevice::Emule;
     }
+
+    void register_sim_fabric_endpoint_direction(
+        ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const;
 
     bool is_base_routing_fw_enabled() const;
 


### PR DESCRIPTION
## Summary

Single-commit squash of #45419 for easier review. Contains all functional simulator-compatibility fixes for multichip TTSim cherry-picked onto current `main`.

Part of #44889 (multichip TTSim).

**Root causes fixed:**
1. `write_dram_vec` hardcoded DRAM channel `0` — now derives channel from allocator bank ID
2. `get_absolute_cq_offset` applied hugepage arithmetic on non-zero `base` — early-return when `base` is already absolute
3. DRAM-backed CQ NOC write accounting split incorrectly — unified completion-queue write counting
4. Blackhole DRAM TLBs configured for `.so` ttsim targets — gated behind target type (RTL sim unchanged)
5. Fabric router endpoint directions never communicated to ttsim — `register_sim_fabric_endpoint_direction` per eth channel
6. `global_semaphore.cpp` used FD `EnqueueWriteMeshBuffer` during fabric bring-up — skip when simulator enabled
7. Fabric-router sync timeout ignored `TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS` — now honored
8. Real-time profiler engaged on Simulator targets — disabled (avoids multi-minute hang on ttsim)
9. NUMA / AICLK probes on simulation chips — skipped for non-silicon targets
10. Opt-in direct H2D tensor writes for FD mesh uploads (`TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1`, ~5.5× sweep speedup)
11. Scoped ttsim vs RTL sim directory CI behavior for core-wait timeouts and DRAM TLB setup

**23 files changed, 353 insertions, 33 deletions** — one commit on top of current `main`.

Replaces the 21-commit history in #45419.

## Notes for reviewers

- `register_sim_fabric_endpoint_direction` is a no-op on silicon.
- `include_dram_tlbs` defaults to `true` — existing silicon callers unaffected.
- DRAM-backed CQ fixes apply to silicon correctness too, not just ttsim.
- No UMD submodule bump in this squash (same as branch tip of #45419 vs current main).

## Test plan

Same as #45419:
- [ ] Merge gate (build + fast dispatch unit tests)
- [ ] TTSim C++ tests (WH + BH)
- [ ] Fabric unit tests on ttsim (1x2 mesh)
- [ ] Multichip mock-fabric / parity sweep on Galaxy compute node

Supersedes #45419.

Made with [Cursor](https://cursor.com)