### PR TITLE
#42858: Extend universal input/output support for ttnn::slice

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_universal_io.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_universal_io.py
@@ -1,0 +1,893 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for slice universal input/output support — one case per routing path.
+
+Routing summary (verified below):
+  - TILE + INTERLEAVED in/out                  → SliceTileProgramFactory (native)
+  - TILE + sharded in/out (with spec)          → SliceTileProgramFactory (native)
+  - TILE + sharded out without shard_spec      → composite via L1 interleaved + reshard
+  - RM + HEIGHT-sh in + HEIGHT-sh out, no step → SliceRmShardedProgramFactory (native)
+  - RM + (sharded in or out), no step          → SliceRmProgramFactory (native); irregular B/W
+                                                 composes via L1 interleaved
+  - RM + has step                              → SliceRmStrideProgramFactory (native)
+  - DRAM-sharded                               → to_memory_config-style fallback
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+    ttnn.bfloat8_b: torch.bfloat16,
+}
+
+_TILE_H = 32
+_TILE_W = 32
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+def _round_up(x, m):
+    return ((x + m - 1) // m) * m
+
+
+def _layout_hw_for_shard(shape, layout):
+    """Return (total_height, width). TILE pads last-two dims to a tile each; RM uses logical dims."""
+    if layout == ttnn.TILE_LAYOUT:
+        total_h = 1
+        for d in shape[:-2]:
+            total_h *= d
+        total_h *= _round_up(shape[-2], _TILE_H)
+        return total_h, _round_up(shape[-1], _TILE_W)
+    total_h = 1
+    for d in shape[:-1]:
+        total_h *= d
+    return total_h, shape[-1]
+
+
+def _tile_align(shard_shape, layout):
+    h, w = shard_shape
+    if layout == ttnn.TILE_LAYOUT:
+        return (_round_up(h, _TILE_H), _round_up(w, _TILE_W))
+    return (h, w)
+
+
+def _interleaved_l1(_d):
+    return L1_INTERLEAVED
+
+
+def _interleaved_dram(_d):
+    return DRAM_INTERLEAVED
+
+
+def _sharded_no_spec(layout):
+    return lambda _d: ttnn.MemoryConfig(layout, ttnn.BufferType.L1)
+
+
+def _height_sharded(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, buffer_type=ttnn.BufferType.L1):
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type,
+        ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+
+def _width_sharded(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+
+def _block_sharded(shape, device, layout=ttnn.TILE_LAYOUT):
+    grid = device.compute_with_storage_grid_size()
+    gx = min(2, grid.x)
+    gy = min(2, grid.y)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align(((total_h + gy - 1) // gy, (w + gx - 1) // gx), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))}),
+            shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+
+
+# Explicit shard helpers — caller-controlled grid + shard shape (irregular, uneven, sub-tile).
+
+
+def _explicit_block_shard_config(device, grid_y, grid_x, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for requested {grid_y}x{grid_x}")
+    spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_height_shard_config(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_width_shard_config(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Shared runner
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def _run_slice(
+    shape, begins, ends, step, layout, input_mem_config, output_mem_config, dtype, device, ulp_when_exact=True
+):
+    """Run slice and assert output memory_layout matches request; verifies shard_spec is set when sharded."""
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x = torch.rand(shape, dtype=torch_dtype)
+
+    ttnn_in = ttnn.from_torch(x, layout=layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    slices = tuple(slice(b, e, s) for b, e, s in zip(begins, ends, step))
+    result = ttnn.slice(ttnn_in, begins, ends, step, memory_config=output_mem_config)
+
+    if output_mem_config is not None:
+        actual = result.memory_config()
+        assert (
+            actual.memory_layout == output_mem_config.memory_layout
+        ), f"Expected memory_layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+        if output_mem_config.memory_layout in (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ):
+            assert actual.shard_spec is not None, "Sharded output requested but result has no shard_spec"
+
+    ref = x[slices]
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+
+    # bf16 native → bit-exact; bf8_b/f32 → PCC (quantization or composite bf16 intermediates).
+    if dtype == ttnn.bfloat16 and ulp_when_exact:
+        assert_with_ulp(ref, got, ulp_threshold=0)
+    else:
+        assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group A: TILE — interleaved & sharded in/out (native via SliceTileProgramFactory)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, input_factory, output_factory",
+    [
+        # Baselines: pure interleaved.
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            _interleaved_l1,
+            _interleaved_l1,
+            id="L1_interleaved_baseline",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            _interleaved_dram,
+            _interleaved_dram,
+            id="DRAM_interleaved",
+        ),
+        # TILE sharded in → interleaved (height + block; width is symmetric).
+        pytest.param(
+            (1, 1, 128, 64),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            _interleaved_l1,
+            id="TILE_height_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _block_sharded((1, 1, 128, 128), d),
+            _interleaved_l1,
+            id="TILE_block_to_interleaved",
+        ),
+        # TILE interleaved → sharded (height + block; width is symmetric).
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            _interleaved_l1,
+            lambda d: _height_sharded((1, 1, 64, 64), d, num_cores=2),
+            id="TILE_interleaved_to_height",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            _interleaved_l1,
+            lambda d: _block_sharded((1, 1, 64, 64), d),
+            id="TILE_interleaved_to_block",
+        ),
+        # TILE sharded → sharded (same layout, explicit spec).
+        pytest.param(
+            (1, 1, 128, 64),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            lambda d: _height_sharded((1, 1, 64, 64), d, num_cores=2),
+            id="TILE_height_to_height",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _width_sharded((1, 1, 64, 128), d),
+            lambda d: _width_sharded((1, 1, 64, 64), d, num_cores=2),
+            id="TILE_width_to_width",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _block_sharded((1, 1, 128, 128), d),
+            lambda d: _block_sharded((1, 1, 64, 64), d),
+            id="TILE_block_to_block",
+        ),
+        # TILE sharded → sharded (cross-layout) exercises the spec recomputation block.
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _height_sharded((1, 1, 128, 128), d),
+            lambda d: _width_sharded((1, 1, 64, 64), d, num_cores=2),
+            id="TILE_height_to_width",
+        ),
+        # Implicit inheritance — no memory_config arg, input is sharded (block stands in for all).
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _block_sharded((1, 1, 128, 128), d),
+            None,
+            id="TILE_block_default_output",
+        ),
+    ],
+)
+def test_slice_tile(shape, begins, ends, step, input_factory, output_factory, dtype, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        ttnn.TILE_LAYOUT,
+        input_factory(device),
+        output_factory(device) if output_factory is not None else None,
+        dtype,
+        device,
+        ulp_when_exact=(dtype != ttnn.bfloat8_b),
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group B: TILE — sharded output without explicit shard_spec (composite reshard)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="height"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="block"),
+    ],
+)
+def test_slice_tile_interleaved_to_sharded_no_spec(memory_layout, dtype, device):
+    shape = (1, 1, 128, 128)
+    out_mc = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    _run_slice(
+        shape,
+        (0, 0, 0, 0),
+        (1, 1, 64, 64),
+        (1, 1, 1, 1),
+        ttnn.TILE_LAYOUT,
+        L1_INTERLEAVED,
+        out_mc,
+        dtype,
+        device,
+        ulp_when_exact=False,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group C: RM — interleaved, HEIGHT-sharded fast path, mixed sharded I/O
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, input_factory, output_factory",
+    [
+        # Pure interleaved RM.
+        pytest.param(
+            (1, 1, 64, 64),
+            (0, 0, 0, 0),
+            (1, 1, 32, 32),
+            (1, 1, 1, 1),
+            _interleaved_l1,
+            _interleaved_l1,
+            id="RM_interleaved_baseline",
+        ),
+        # RM HEIGHT-sh in → HEIGHT-sh out (fast path — SliceRmShardedProgramFactory).
+        pytest.param(
+            (1, 1, 128, 64),
+            (0, 0, 0, 0),
+            (1, 1, 96, 64),
+            (1, 1, 1, 1),
+            lambda d: _height_sharded((1, 1, 128, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 96, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_height_to_height_fastpath",
+        ),
+        # RM HEIGHT-sh in → INTERLEAVED out (native via SliceRmProgramFactory).
+        pytest.param(
+            (1, 1, 128, 64),
+            (0, 0, 0, 0),
+            (1, 1, 96, 64),
+            (1, 1, 1, 1),
+            lambda d: _height_sharded((1, 1, 128, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_height_to_interleaved",
+        ),
+        # RM WIDTH-sh in → INTERLEAVED out (native: reader passes shard_W as the page-size override).
+        pytest.param(
+            (1, 1, 32, 128),
+            (0, 0, 0, 0),
+            (1, 1, 32, 64),
+            (1, 1, 1, 1),
+            lambda d: _width_sharded((1, 1, 32, 128), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_width_to_interleaved_native",
+        ),
+        # RM BLOCK-sh in → INTERLEAVED out (native; same mechanism).
+        pytest.param(
+            (1, 1, 64, 64),
+            (0, 0, 0, 0),
+            (1, 1, 32, 32),
+            (1, 1, 1, 1),
+            lambda d: _block_sharded((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_block_to_interleaved_native",
+        ),
+        # RM INTERLEAVED in → BLOCK-sh out (covers interleaved→sharded scale-spec for all 3).
+        pytest.param(
+            (1, 1, 128, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            _interleaved_l1,
+            lambda d: _block_sharded((1, 1, 64, 64), d),
+            id="RM_interleaved_to_block",
+        ),
+        # RM WIDTH-sh in → HEIGHT-sh out (cross-layout; composite path via L1 interleaved).
+        pytest.param(
+            (1, 1, 64, 128),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 1, 1),
+            lambda d: _width_sharded((1, 1, 64, 128), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_width_to_height",
+        ),
+        # Strided + sharded inputs/outputs (native; SliceRmStrideProgramFactory).
+        pytest.param(
+            (1, 1, 64, 64),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 2, 1),
+            lambda d: _height_sharded((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_strided_height_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (0, 0, 0, 0),
+            (1, 1, 64, 64),
+            (1, 1, 2, 2),
+            _interleaved_l1,
+            _interleaved_l1,
+            id="RM_strided_interleaved_baseline",
+        ),
+    ],
+)
+def test_slice_rm(shape, begins, ends, step, input_factory, output_factory, dtype, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        ttnn.ROW_MAJOR_LAYOUT,
+        input_factory(device),
+        output_factory(device) if output_factory is not None else None,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group D: RM — sharded output without explicit shard_spec
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="height"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="block"),
+    ],
+)
+def test_slice_rm_interleaved_to_sharded_no_spec(memory_layout, dtype, device):
+    shape = (1, 1, 64, 64)
+    out_mc = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    _run_slice(
+        shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 32),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        out_mc,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group E: Irregular logical shapes (last-two not tile multiples)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+_IRREGULAR_SHAPES = [
+    # Logical H/W not tile multiples — one shape covers all irregular paths.
+    ((1, 1, 65, 97), (0, 0, 0, 0), (1, 1, 32, 49), (1, 1, 1, 1)),
+]
+
+
+@pytest.mark.parametrize("shape, begins, ends, step", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_slice_irregular_shapes_interleaved(shape, begins, ends, step, layout, device):
+    _run_slice(shape, begins, ends, step, layout, L1_INTERLEAVED, L1_INTERLEAVED, ttnn.bfloat16, device)
+
+
+@pytest.mark.parametrize("shape, begins, ends, step", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize(
+    "shard_factory",
+    [
+        pytest.param(_height_sharded, id="height"),
+        pytest.param(_width_sharded, id="width"),
+        pytest.param(_block_sharded, id="block"),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_slice_irregular_shapes_sharded(shape, begins, ends, step, shard_factory, layout, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        layout,
+        shard_factory(shape, device, layout=layout),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=False,  # composite paths may go through tile-rounded intermediates
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group F: Sharded inputs with explicit grids/shapes — irregular logical dims, uneven splits.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, mc_factory",
+    [
+        # Keep one of each shard layout (height/width/block) with irregular dims.
+        pytest.param(
+            (1, 1, 65, 64),
+            (0, 0, 0, 0),
+            (1, 1, 32, 32),
+            (1, 1, 1, 1),
+            lambda d: _explicit_height_shard_config(d, 3, 32, 64),
+            id="TILE_height_3_irregular_h",
+        ),
+        pytest.param(
+            (1, 1, 32, 97),
+            (0, 0, 0, 0),
+            (1, 1, 32, 49),
+            (1, 1, 1, 1),
+            lambda d: _explicit_width_shard_config(d, 4, 32, 32),
+            id="TILE_width_4_irregular_w",
+        ),
+    ],
+)
+def test_slice_tile_explicit_sharded_inputs(shape, begins, ends, step, mc_factory, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        ttnn.TILE_LAYOUT,
+        mc_factory(device),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group G: Multi-batch / multi-channel sharded inputs (N>1 or C>1)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, layout, mc_factory",
+    [
+        pytest.param(
+            (1, 2, 64, 64),
+            (0, 0, 0, 0),
+            (1, 1, 32, 32),
+            (1, 1, 1, 1),
+            ttnn.TILE_LAYOUT,
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32),
+            id="TILE_C2_block",
+        ),
+        pytest.param(
+            (2, 2, 32, 64),
+            (0, 0, 0, 0),
+            (1, 1, 32, 32),
+            (1, 1, 1, 1),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _explicit_height_shard_config(d, 4, 32, 64),
+            id="RM_N2C2_height",
+        ),
+    ],
+)
+def test_slice_multi_batch_channel(shape, begins, ends, step, layout, mc_factory, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        layout,
+        mc_factory(device),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group H: Sub-tile slices and non-tile-aligned RM HEIGHT shards
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, ncores, shard_shape",
+    [
+        pytest.param((1, 1, 64, 32), (0, 0, 0, 0), (1, 1, 32, 32), (1, 1, 1, 1), 2, (32, 32), id="TILE_64x32_hs2"),
+        pytest.param((2, 1, 64, 32), (0, 0, 0, 0), (1, 1, 32, 32), (1, 1, 1, 1), 4, (32, 32), id="TILE_2x1_64x32_hs4"),
+    ],
+)
+def test_slice_tile_subtile_height_sharded(shape, begins, ends, step, ncores, shard_shape, device):
+    imc = _explicit_height_shard_config(device, ncores, shard_shape[0], shard_shape[1])
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        ttnn.TILE_LAYOUT,
+        imc,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, shard_shape",
+    [
+        pytest.param((1, 1, 52, 64), (0, 0, 0, 0), (1, 1, 26, 64), (1, 1, 1, 1), (13, 64), id="RM_hs_13x64_nontile"),
+    ],
+)
+def test_slice_row_major_height_sharded_nontile_aligned(shape, begins, ends, step, shard_shape, device):
+    imc = _explicit_height_shard_config(device, 4, shard_shape[0], shard_shape[1])
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        ttnn.ROW_MAJOR_LAYOUT,
+        imc,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group I: Higher-rank inputs (rank > 4) — slice supports up to nD
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, layout, input_factory",
+    [
+        pytest.param(
+            (1, 2, 1, 64, 64),
+            (0, 0, 0, 0, 0),
+            (1, 2, 1, 32, 64),
+            (1, 1, 1, 1, 1),
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_sharded((1, 2, 1, 64, 64), d),
+            id="TILE_rank5_height",
+        ),
+        pytest.param(
+            (1, 1, 2, 2, 32, 32),
+            (0, 0, 0, 0, 0, 0),
+            (1, 1, 2, 2, 32, 32),
+            (1, 1, 1, 1, 1, 1),
+            ttnn.TILE_LAYOUT,
+            _interleaved_l1,
+            id="TILE_rank6_interleaved_noop",
+        ),
+    ],
+)
+def test_slice_higher_rank(shape, begins, ends, step, layout, input_factory, dtype, device):
+    _run_slice(
+        shape,
+        begins,
+        ends,
+        step,
+        layout,
+        input_factory(device),
+        L1_INTERLEAVED,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group J: DRAM-sharded fallback — DRAM-sharded inputs route through L1 interleaved.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def test_slice_dram_sharded_fallback(device):
+    shape = (1, 1, 128, 64)
+    dram_sharded = _height_sharded(shape, device, buffer_type=ttnn.BufferType.DRAM)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=dram_sharded
+    )
+    result = ttnn.slice(ttnn_in, (0, 0, 0, 0), (1, 1, 64, 64), (1, 1, 1, 1), memory_config=L1_INTERLEAVED)
+    assert result.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    ref = x[:, :, :64, :]
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group K: Default-memory-config regression guards
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def test_slice_block_sharded_default_mc_no_longer_fatal(device):
+    """BLOCK_SHARDED input + implicit output mc — must produce a rescaled BLOCK_SHARDED output."""
+    shape = (1, 1, 64, 64)
+    in_mc = _block_sharded(shape, device)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.slice(ttnn_in, (0, 0, 0, 0), (1, 1, 32, 32), (1, 1, 1, 1))
+    assert result.memory_config().memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    ref = x[:1, :1, :32, :32]
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+def test_slice_rm_irregular_width_in_bad_fallback(device):
+    """RM WIDTH-sharded input with irregular W=97: needs_rm_composite_input → composite via L1 interleaved."""
+    shape = (1, 1, 64, 97)
+    _run_slice(
+        shape,
+        (0, 0, 0, 0),
+        (1, 1, 64, 49),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        _width_sharded(shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "shard_factory, mem_layout",
+    [
+        pytest.param(_width_sharded, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="width"),
+    ],
+)
+def test_slice_rm_irregular_bw_output_out_bad_fallback(shard_factory, mem_layout, device):
+    """RM interleaved → B/W-sharded output with irregular W=97: needs_rm_composite_output → composite then reshard."""
+    in_shape = (1, 1, 64, 97)
+    out_shape = (1, 1, 64, 49)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        out_shape,
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        shard_factory(out_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+        if shard_factory is _width_sharded
+        else shard_factory(out_shape, device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=False,
+    )
+
+
+def test_slice_rm_sharded_in_sharded_no_spec_out(device):
+    """HEIGHT-sharded in → HEIGHT no-spec out + step>1. Regression: ret_adjustment must not FATAL
+    when the output_mc has no shard_spec."""
+    in_shape = (1, 1, 96, 64)
+    in_mc = _height_sharded(in_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    out_no_spec_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 64, 64),
+        (1, 1, 2, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        out_no_spec_mc,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=False,
+    )
+
+
+def test_slice_tile_same_layout_sharded_no_spec_halving(device):
+    """TILE HEIGHT-sharded → halving slice → HEIGHT no-spec out. Regression: adjust_shard_spec_to_shape
+    must fall back to generate_transpose_shard_spec when the scaled shard would be sub-tile."""
+    in_shape = (1, 1, 64, 64)
+    in_mc = _height_sharded(in_shape, device, num_cores=2, layout=ttnn.TILE_LAYOUT)
+    out_no_spec_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 0),
+        (1, 1, 32, 32),
+        (1, 1, 1, 1),
+        ttnn.TILE_LAYOUT,
+        in_mc,
+        out_no_spec_mc,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "shard_factory",
+    [pytest.param(_width_sharded, id="width")],
+)
+def test_slice_rm_bw_sharded_nonzero_width_begin(shard_factory, device):
+    """RM B/W-sharded input with non-zero width-begin: needs_rm_composite_input must route through
+    L1 interleaved because the native reader can't address non-contiguous shard pages."""
+    in_shape = (1, 1, 64, 128)
+    in_mc = (
+        shard_factory(in_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+        if shard_factory is _width_sharded
+        else shard_factory(in_shape, device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    )
+    _run_slice(
+        in_shape,
+        (0, 0, 0, 32),
+        (1, 1, 64, 96),
+        (1, 1, 1, 1),
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+        ulp_when_exact=True,
+    )
+
+
+# Focused dtype spot-checks on representative paths. The core suites above run bf16 only to keep
+# the file under budget; this hits f32 across TILE+RM paths and bf8b on the TILE-only path.
+@pytest.mark.parametrize(
+    "shape, layout, in_mc_fn, dtype",
+    [
+        pytest.param((1, 1, 128, 128), ttnn.TILE_LAYOUT, _interleaved_l1, ttnn.float32, id="f32_tile_interleaved"),
+        pytest.param(
+            (1, 1, 128, 64),
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            ttnn.float32,
+            id="f32_tile_height_to_interleaved",
+        ),
+        pytest.param((1, 1, 128, 128), ttnn.TILE_LAYOUT, _interleaved_l1, ttnn.bfloat8_b, id="bf8b_tile_interleaved"),
+    ],
+)
+def test_slice_dtype_coverage(shape, layout, in_mc_fn, dtype, device):
+    _run_slice(
+        shape,
+        (0, 0, 0, 0),
+        (1, 1, 64, 64),
+        (1, 1, 1, 1),
+        layout,
+        in_mc_fn(device),
+        L1_INTERLEAVED if in_mc_fn is not _interleaved_dram else DRAM_INTERLEAVED,
+        dtype,
+        device,
+        ulp_when_exact=(dtype != ttnn.bfloat8_b),
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
@@ -43,6 +43,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -151,13 +152,10 @@ void kernel_main() {
                 cb_out.reserve_back(1);
                 uint32_t l1_write_addr = cb_out.get_write_ptr();
 
-                // Read the full input row first
-                noc.async_read(
-                    s0,
-                    cb_out,
-                    input_bytes_per_row,
-                    {.page_id = input_row_idx, .offset_bytes = 0},
-                    {.offset_bytes = 0});
+                // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+                // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+                tt::data_movement::common::noc_async_read_sharded(
+                    l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
                 noc.async_read_barrier();
 
                 // Now slice the row according to width slice parameters

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
@@ -49,6 +49,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -136,9 +137,10 @@ void kernel_main() {
             cb_out.reserve_back(1);
             uint32_t l1_write_addr = cb_out.get_write_ptr();
 
-            // Read the full input row first
-            noc.async_read(
-                s0, cb_out, input_bytes_per_row, {.page_id = input_row_idx, .offset_bytes = 0}, {.offset_bytes = 0});
+            // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+            // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_read_sharded(
+                l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
             noc.async_read_barrier();
 
             // Now slice the row according to width slice parameters (last dimension)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -29,8 +29,8 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<0>();
     uint32_t read_size = unpadded_stick_size + misalignment;
 
-    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
-    // program cache hits.
+    // padded_stick_size = per-shard page size (shard_W on B/W-sharded, full row otherwise);
+    // feeds `noc_async_read_sharded`'s multi-shard split via `get_aligned_page_size()`.
     const auto s0 = TensorAccessor(src_args, src_addr, padded_stick_size);
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -47,8 +47,10 @@ void kernel_main() {
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            CoreLocalMem<uint32_t> dst(src_buffer_l1_addr);
-            noc.async_read(s0, dst, read_size, {.page_id = src_stick_id, .offset_bytes = 0}, {.offset_bytes = 0});
+            // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+            // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_read_sharded(
+                src_buffer_l1_addr, s0, src_stick_id, /*offset=*/0, /*size=*/read_size);
             if (misalignment != 0) {
                 noc.async_read_barrier();
                 tt::data_movement::common::tt_memmove<false, false, false, 0>(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -16,13 +17,14 @@ void kernel_main() {
     uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
     uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
     uint32_t start_id = get_arg_val<uint32_t>(6);
+    // Per-shard page size: shard_W on B/W-sharded outputs, full row otherwise.
+    // Feeds `noc_async_write_sharded`'s multi-shard split via `get_aligned_page_size()`.
+    uint32_t page_size_override = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
     constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    // Third argument page_size from runtime args overrides TensorAccessorArgs::AlignedPageSize, which may be stale on
-    // program cache hits.
-    const auto s0 = TensorAccessor(dst_args, dst_addr, stick_size);
+    const auto s0 = TensorAccessor(dst_args, dst_addr, page_size_override);
 
     Noc noc;
     // Create CircularBuffer for Device 2.0 API
@@ -32,13 +34,15 @@ void kernel_main() {
     uint32_t sticks_read = 0;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
         cb_out0.wait_front(num_read_per_barrier);
-        uint32_t cb_read_offset = 0;
+        uint32_t l1_read_addr = cb_out0.get_read_ptr();
 
         for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
             sticks_read++;
-            noc.async_write(
-                cb_out0, s0, stick_size, {.offset_bytes = cb_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
-            cb_read_offset += stick_size_offset;
+            // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+            // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_write_sharded(
+                l1_read_addr, s0, i_stick, /*offset=*/0, /*size=*/stick_size);
+            l1_read_addr += stick_size_offset;
             i_stick += 1;
         }
         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
@@ -43,6 +43,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -78,13 +79,15 @@ void kernel_main() {
     // Write each row from circular buffer to output tensor at the correct logical position
     for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
         cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
 
         // Calculate global output row index for this local row
         uint32_t global_output_row = start_row_for_this_core + local_row;
 
-        // Write the complete row to output tensor
-        noc.async_write(
-            cb_in, s0, output_bytes_per_row, {.offset_bytes = 0}, {.page_id = global_output_row, .offset_bytes = 0});
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
         noc.async_writes_flushed();
 
         cb_in.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
@@ -48,6 +48,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -85,13 +86,15 @@ void kernel_main() {
     // Write each row from circular buffer to output tensor at the correct logical position
     for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
         cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
 
         // Calculate global output row index for this local row
         uint32_t global_output_row = start_row_for_this_core + local_row;
 
-        // Write the complete row to output tensor
-        noc.async_write(
-            cb_in, s0, output_bytes_per_row, {.offset_bytes = 0}, {.page_id = global_output_row, .offset_bytes = 0});
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
         noc.async_writes_flushed();
 
         cb_in.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 
 #include <tt-metalium/constants.hpp>
 
@@ -143,7 +144,8 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
     if (has_step) {  // if all ones modify before passing in to function
         TT_FATAL(
             tensor_args.input.layout() == Layout::ROW_MAJOR, "Strided slice is only supported for row major layout");
-        TT_FATAL(!tensor_args.input.is_sharded(), "Strided slice is not supported for sharded tensor");
+        // Strided + sharded is natively supported: reader/writer kernels route per-row NOC calls
+        // through noc_async_*_sharded, which handles cross-shard splitting transparently.
         TT_FATAL(
             args.step.size() == args.slice_end.rank(),
             "Number of steps {} must match number of ends/starts {}",
@@ -214,9 +216,39 @@ SliceDeviceOperation::spec_return_value_t SliceDeviceOperation::compute_output_s
         }
     }
     ttnn::Shape output_tensor_shape(std::move(out_shape));
+
+    // Synthesize shard spec for sharded-no-spec output: scale from input spec when layouts match,
+    // else fall back to generate_transpose_shard_spec for a fresh full-grid spec.
+    auto output_mem_config = args.output_mem_config;
+    if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
+        std::optional<tt::tt_metal::ShardSpec> derived;
+        if (input_tensor.is_sharded() && input_tensor.memory_config().shard_spec().has_value() &&
+            input_tensor.memory_config().memory_layout() == output_mem_config.memory_layout() &&
+            input_tensor.logical_shape().rank() == output_tensor_shape.rank()) {
+            auto adjusted = ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape(
+                *input_tensor.memory_config().shard_spec(), input_tensor.logical_shape(), output_tensor_shape);
+            if (adjusted.has_value()) {
+                // TILE factories require tile-aligned shards; sub-tile results from
+                // adjust_shard_spec_to_shape fall through to generate_transpose_shard_spec.
+                const bool tile_layout = input_tensor.layout() == Layout::TILE;
+                const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
+                                          adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
+                if (!tile_layout || tile_aligned) {
+                    derived = std::move(adjusted);
+                }
+            }
+        }
+        if (!derived.has_value()) {
+            derived = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                input_tensor, output_tensor_shape, output_mem_config.memory_layout());
+        }
+        output_mem_config =
+            tt::tt_metal::MemoryConfig(output_mem_config.memory_layout(), output_mem_config.buffer_type(), derived);
+    }
+
     return ttnn::TensorSpec(
         output_tensor_shape,
-        tt::tt_metal::TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), args.output_mem_config));
+        tt::tt_metal::TensorLayout(input_tensor.dtype(), PageConfig(input_tensor.layout()), output_mem_config));
 }
 
 Tensor SliceDeviceOperation::create_output_tensors(
@@ -243,7 +275,14 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     bool has_step = std::any_of(args.step.cbegin(), args.step.cend(), [](uint32_t s) { return s != 1; });
 
     if (input.layout() == Layout::ROW_MAJOR) {
-        if (input.is_sharded()) {
+        // HEIGHT→HEIGHT no-step: fast CB path, no NOC read needed.
+        // WIDTH/BLOCK-sharded RM: SliceRmProgramFactory with per-shard page size via noc_async_*_sharded.
+        const bool height_sharded_in_out_no_step =
+            input.is_sharded() &&
+            input.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED &&
+            args.output_mem_config.is_sharded() &&
+            args.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED && !has_step;
+        if (height_sharded_in_out_no_step) {
             return SliceRmShardedProgramFactory{};
         }
         if (has_step) {
@@ -251,7 +290,7 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
         }
         return SliceRmProgramFactory{};
     }
-    // Layout::TILE
+    // Layout::TILE — TensorAccessor at tile granularity handles all sharded buffer types natively.
     return SliceTileProgramFactory{};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -71,9 +71,22 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
     uint32_t start_addr = input_tensor.buffer()->address();
 
+    // shard_W * elem_size for B/W-sharded (splits row across shards); full row otherwise.
+    // Fallback is padded for the reader tensor, unpadded for the writer tensor.
+    const auto per_shard_page_size_bytes = [&](const Tensor& t, uint32_t row_bytes) -> uint32_t {
+        const auto& mc = t.memory_config();
+        if (mc.is_sharded() && (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+                                mc.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
+            const auto& spec = mc.shard_spec().value();
+            return spec.shape[1] * t.element_size();
+        }
+        return row_bytes;
+    };
+    const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
+
     std::vector<uint32_t> common_reader_kernel_args = {
         start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
-        padded_row_size_bytes,
+        reader_page_size,
         unpadded_row_size_bytes,
         unpadded_row_size_bytes_offset,
         num_dims,
@@ -127,6 +140,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         reader_kernel_args[addr_offset] = num_read_per_barrier;
         reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
+        const uint32_t writer_page_size = per_shard_page_size_bytes(output_tensor, unpadded_row_size_bytes);
         std::vector<uint32_t> writer_kernel_args = {
             output_buffer->address(),
             unpadded_row_size_bytes,
@@ -135,7 +149,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             num_sticks_per_core_read,
             num_read_per_barrier,
             num_sticks_written,
-            0};
+            writer_page_size,
+        };
         num_sticks_written += num_sticks_per_core;
         ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
     }
@@ -166,8 +181,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
     if (misalignment != 0) {
         alignment *= 2;
     }
-    const ttnn::Shape& output_shape = output.padded_shape();
-    const uint32_t unpadded_row_size_bytes = output_shape[-1] * input.element_size();
+    const uint32_t unpadded_row_size_bytes = output.padded_shape()[-1] * input.element_size();
     const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
     const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
     const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
@@ -212,10 +226,8 @@ tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
 
     constexpr uint8_t src0_cb_index = 0;
 
-    // CB sizing depends on slice_start (via misalignment / unpadded_row_size_bytes).
-    // padded_shape is folded into compute_program_hash() so each unique sizing
-    // gets its own cache entry; CB total_size/page_size are not patched on
-    // cache hit — the cached descriptor already carries the correct values.
+    // CB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
+    // unique CB layout gets its own cache entry (total_size/page_size are not patched on cache hit).
     const auto [cb_page_size, num_read_per_barrier, misalignment] = ttnn::operations::data_movement::compute_cb_size(
         input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -5,12 +5,80 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/operations/experimental/reshape/view.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/core/core.hpp"
 
+#include <tt-metalium/constants.hpp>
+
 namespace ttnn {
+
+namespace detail {
+
+inline bool is_rm_bw_sharded(const tt::tt_metal::MemoryConfig& mc) {
+    const auto layout = mc.memory_layout();
+    return mc.is_sharded() && (layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                               layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+}
+
+// RM constraint, not TILE: `noc_async_*_sharded` derives pages_per_row from the padded shape,
+// so non-tile-multiple H/W overshoots.
+inline bool has_nontile_hw(const ttnn::Tensor& input) {
+    const auto& s = input.logical_shape();
+    if (s.rank() < 2) {
+        return false;
+    }
+    return s[-1] % tt::constants::TILE_WIDTH != 0 || s[-2] % tt::constants::TILE_HEIGHT != 0;
+}
+
+// For B/W-sharded buffers the NOC helper splits by W only; irregular H alone is fine natively.
+inline bool has_nontile_w(const ttnn::Tensor& input) {
+    const auto& s = input.logical_shape();
+    return s.rank() >= 1 && s[-1] % tt::constants::TILE_WIDTH != 0;
+}
+
+// Route RM sharded input through composite when native isn't safe: nontile-aligned B/W,
+// B/W with non-zero width-begin, or nontile-aligned HEIGHT outside the sharded fast path.
+inline bool needs_rm_composite_input(
+    const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc, bool no_step, bool width_begin_nonzero) {
+    if (input.layout() != Layout::ROW_MAJOR || !input.is_sharded()) {
+        return false;
+    }
+    if (is_rm_bw_sharded(input.memory_config())) {
+        // Only W misalignment breaks the per-shard page split; irregular H is fine.
+        return has_nontile_w(input) || width_begin_nonzero;
+    }
+    // Require a spec: no-spec HEIGHT output triggers needs_sharded_output_reshard → composite anyway.
+    const bool stays_on_sharded_fast_path =
+        output_mc.is_sharded() && output_mc.shard_spec().has_value() &&
+        output_mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED && no_step;
+    return has_nontile_hw(input) && !stays_on_sharded_fast_path;
+}
+
+// Compose RM B/W-sharded output only on nontile-aligned W (irregular H is fine natively).
+inline bool needs_rm_composite_output(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
+    if (input.layout() != Layout::ROW_MAJOR || !is_rm_bw_sharded(output_mc)) {
+        return false;
+    }
+    return has_nontile_w(input);
+}
+
+// Sharded-no-spec output that can't seed from the input (not sharded, or layout differs);
+// synthesize from the sliced shape.
+inline bool needs_sharded_output_reshard(const ttnn::Tensor& input, const tt::tt_metal::MemoryConfig& output_mc) {
+    if (!output_mc.is_sharded() || output_mc.shard_spec().has_value()) {
+        return false;
+    }
+    if (!input.is_sharded()) {
+        return true;
+    }
+    return input.memory_config().memory_layout() != output_mc.memory_layout();
+}
+
+}  // namespace detail
 
 template <typename T>
 ttnn::Tensor slice(
@@ -54,23 +122,86 @@ ttnn::Tensor slice(
 
     auto memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
                                                             : memory_config_arg.value_or(input_tensor.memory_config());
-    // output_memory_config may be recomputed below for sharded tensors to match the
-    // sliced output dimensions. memory_config stays as the original (input-compatible)
-    // config and is used for input layout conversion (to_layout in the rm_only path).
+    // memory_config: original (input-compatible) config, used by to_layout in the rm_only path.
+    // output_memory_config: may be rescaled below to match the sliced output dims.
     auto output_memory_config = memory_config;
 
-    auto ret_adjustment([&](const ttnn::Tensor& input_tensor) {
-        if (input_tensor.storage_type() == StorageType::DEVICE) {
-            auto tensor = ttnn::to_memory_config(input_tensor, output_memory_config, std::nullopt);
-            tensor = ttnn::to_layout(tensor, input_layout);
-            return tensor;
+    // Fill in a missing shard_spec on a sharded output: reuse source's if layouts match, else
+    // synthesize from the source shape.
+    auto resolve_mc = [&](const ttnn::Tensor& source) {
+        auto resolved_mc = output_memory_config;
+        if (resolved_mc.is_sharded() && !resolved_mc.shard_spec().has_value()) {
+            const auto& in_mc = source.memory_config();
+            if (in_mc.is_sharded() && in_mc.memory_layout() == resolved_mc.memory_layout() &&
+                in_mc.shard_spec().has_value()) {
+                resolved_mc = resolved_mc.with_shard_spec(in_mc.shard_spec());
+            } else {
+                auto spec = operations::data_movement::transpose::generate_transpose_shard_spec(
+                    source, source.padded_shape(), resolved_mc.memory_layout());
+                resolved_mc = resolved_mc.with_shard_spec(spec);
+            }
         }
-        return input_tensor;
+        return resolved_mc;
+    };
+
+    // True when the next to_memory_config can land directly in the preallocated buffer: layouts
+    // must match (prim::copy validates equality) and source must not alias the preallocated.
+    auto can_land_in_preallocated = [&](const ttnn::Tensor& source) {
+        return optional_output_tensor.has_value() && source.storage_type() == StorageType::DEVICE &&
+               source.layout() == optional_output_tensor->layout() &&
+               source.buffer() != optional_output_tensor->buffer();
+    };
+    // Safety net for paths that bypass the device op (composite / no-op / rm_only layout fixup):
+    // short-circuits by buffer identity, falls back to ttnn::copy when result != preallocated.
+    auto finalize_into_preallocated = [&](const ttnn::Tensor& result) -> ttnn::Tensor {
+        if (!optional_output_tensor.has_value() || result.storage_type() != StorageType::DEVICE) {
+            return result;
+        }
+        const auto& dst = optional_output_tensor.value();
+        if (result.buffer() == dst.buffer()) {
+            return result;
+        }
+        return ttnn::copy(result, dst);
+    };
+
+    auto ret_adjustment([&](const ttnn::Tensor& source) {
+        if (source.storage_type() != StorageType::DEVICE) {
+            return source;
+        }
+        // source carries the correct shard spec (input for no-op, prim::slice result otherwise).
+        const auto resolved_mc = resolve_mc(source);
+        const auto target = can_land_in_preallocated(source) ? optional_output_tensor : std::nullopt;
+        auto tensor = ttnn::to_memory_config(source, resolved_mc, std::nullopt, target);
+        tensor = ttnn::to_layout(tensor, input_layout);
+        return tensor;
     });
 
     // No-op check
     if (no_step && starts_zero && ends_max) {
-        return ret_adjustment(input_tensor);
+        return finalize_into_preallocated(ret_adjustment(input_tensor));
+    }
+
+    // Composite hop: unshard to L1 interleaved if needed, slice, then convert to the requested mc.
+    const bool width_begin_nonzero = !begins.empty() && begins.back() != 0;
+    const bool rm_in_bad =
+        detail::needs_rm_composite_input(input_tensor, output_memory_config, no_step, width_begin_nonzero);
+    const bool rm_out_bad = detail::needs_rm_composite_output(input_tensor, output_memory_config);
+    const bool out_no_spec = detail::needs_sharded_output_reshard(input_tensor, output_memory_config);
+    if (rm_in_bad || rm_out_bad || out_no_spec) {
+        const auto interleaved_l1 =
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+        Tensor x = rm_in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
+        // Intermediate lives in L1 interleaved; to_memory_config lands the result in the caller's
+        // buffer. sub_core_grids is threaded through to bound the recursive slice's work split.
+        auto sliced = ttnn::slice<T>(x, begins, ends, step, interleaved_l1, std::nullopt, pad_value, sub_core_grids);
+        // slice preserves layout and to_memory_config doesn't change it — no trailing to_layout needed.
+        // sliced is L1-interleaved so resolve_mc falls through to generate_transpose_shard_spec.
+        const auto final_mc = resolve_mc(sliced);
+        if (sliced.memory_config() == final_mc) {
+            return finalize_into_preallocated(sliced);
+        }
+        const auto target = can_land_in_preallocated(sliced) ? optional_output_tensor : std::nullopt;
+        return finalize_into_preallocated(ttnn::to_memory_config(sliced, final_mc, std::nullopt, target));
     }
 
     // Create modified vectors with wrapped indices and adjust them to match the tensor's rank
@@ -106,31 +237,19 @@ ttnn::Tensor slice(
     bool handled_tile_alignment = one_dimensional ? true : check_handled_tile_alignment();
 
     Tensor input = input_tensor;
-    // Use row-major path if:
-    // 1. Input is NOT in TILE layout, OR
-    // 2. Input is in TILE layout AND any of these conditions apply:
-    //    - Has non-unit steps (strided slice)
-    //    - Is 1D tensor
-    //    - Slice begins are not tile-aligned
-    // The tile path handles any end values (they get padded to tile boundaries
-    // downstream), so only begin alignment matters.
+    // Use the RM path when input isn't TILE, or TILE input has strided/1D/non-tile-aligned begins
+    // (ends are padded downstream, so only begin alignment matters).
     rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
 
-    // When no explicit output memory config is provided and the input is sharded,
-    // recompute the shard spec to match the output dimensions. Without this, the output
-    // tensor inherits the input's shard spec which may be too large for the sliced shape.
-    // (Issue #38016)
+    // Implicit inheritance from a sharded input: rescale the shard spec to the sliced shape so the
+    // output doesn't reuse the input's (oversized) spec. Covers HEIGHT/WIDTH/BLOCK. (Issue #38016)
     if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
         input_rank >= 2) {
         const auto& mem_layout = output_memory_config.memory_layout();
-        TT_FATAL(
-            mem_layout != tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
-            "ttnn::slice does not support implicit memory_config inheritance for BLOCK_SHARDED tensors. "
-            "Please provide an explicit output memory_config.");
         if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
-            mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+            mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED ||
+            mem_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
             const auto& shard_spec_val = output_memory_config.shard_spec().value();
-            uint32_t num_cores = shard_spec_val.num_cores();
 
             // Compute output dimensions, tile-aligned if using TILE path
             ttnn::SmallVector<uint32_t> output_dims(input_rank);
@@ -153,17 +272,37 @@ ttnn::Tensor slice(
 
             std::array<uint32_t, 2> new_shard_shape = shard_spec_val.shape;
             if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED) {
+                uint32_t num_cores = shard_spec_val.num_cores();
                 uint32_t new_shard_h = tt::div_up(output_height, num_cores);
                 if (!rm_only) {
                     new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
                 }
                 new_shard_shape = {new_shard_h, output_width};
-            } else {  // WIDTH_SHARDED
+            } else if (mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED) {
+                uint32_t num_cores = shard_spec_val.num_cores();
                 uint32_t new_shard_w = tt::div_up(output_width, num_cores);
                 if (!rm_only) {
                     new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
                 }
                 new_shard_shape = {output_height, new_shard_w};
+            } else {
+                // BLOCK_SHARDED requires a rectangular grid; bounding_box() is valid only then.
+                const auto bbox = shard_spec_val.grid.bounding_box();
+                const uint32_t grid_h = bbox.end_coord.y - bbox.start_coord.y + 1;
+                const uint32_t grid_w = bbox.end_coord.x - bbox.start_coord.x + 1;
+                TT_FATAL(
+                    shard_spec_val.num_cores() == grid_h * grid_w,
+                    "BLOCK_SHARDED grid must be a full rectangle; got {} cores for {}x{} bounding box",
+                    shard_spec_val.num_cores(),
+                    grid_h,
+                    grid_w);
+                uint32_t new_shard_h = tt::div_up(output_height, grid_h);
+                uint32_t new_shard_w = tt::div_up(output_width, grid_w);
+                if (!rm_only) {
+                    new_shard_h = std::max(tt::round_up(new_shard_h, tile_shape[0]), tile_shape[0]);
+                    new_shard_w = std::max(tt::round_up(new_shard_w, tile_shape[1]), tile_shape[1]);
+                }
+                new_shard_shape = {new_shard_h, new_shard_w};
             }
 
             if (new_shard_shape != shard_spec_val.shape) {
@@ -213,6 +352,9 @@ ttnn::Tensor slice(
     if (empty) {
         TT_FATAL(
             input.storage_type() == StorageType::DEVICE, "Host tensor slice cannot return a scalar or empty tensor");
+        if (optional_output_tensor.has_value()) {
+            return optional_output_tensor.value();
+        }
         return ttnn::empty(
             actual_shape,
             input_tensor.dtype(),
@@ -243,7 +385,8 @@ ttnn::Tensor slice(
         res = ttnn::fill_implicit_tile_padding(res, pad_value.value());
     }
 
-    return ret_adjustment(res);
+    // ret_adjustment may re-allocate (rm_only-from-TILE); finalize guarantees the caller's buffer.
+    return finalize_into_preallocated(ret_adjustment(res));
 }
 
 template <typename T, std::size_t N>

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -51,15 +51,19 @@ void bind_slice(nb::module_& mod) {
         Returns a sliced tensor. If the input tensor is on host, the slice will be performed on host, and if its on device it will be performed on device.
 
         Args:
-            input_tensor: Input Tensor.
-            slice_start: Start indices of input tensor. Values along each dim must be < input_tensor_shape[i].
-            slice_end: End indices of input tensor. Values along each dim must be < input_tensor_shape[i].
-            slice_step: (Optional[List[int[tensor rank]]) Step size for each dim. Default is None, which works out be 1 for each dimension.
+            input_tensor (ttnn.Tensor): Input tensor.
+            slice_start (List[int]): Start indices of input tensor. Values along each dim must be in ``[0, input_tensor_shape[i])``.
+            slice_end (List[int]): End indices of input tensor (exclusive). Values along each dim must be in ``(0, input_tensor_shape[i]]``.
+            slice_step (List[int], optional): Step size for each dim. Defaults to ``None`` (step = 1 for all dims).
 
         Keyword Args:
-            memory_config: Memory Config of the output tensor
-            pad_value: Optional value to fill padding for tiled tensors. Padding values are unmodified (and undefined) by default
-            sub_core_grids: (ttnn.CoreRangeSet, optional): Sub core grids. Defaults to `None`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the output tensor. Defaults to the input tensor's memory config.
+            output_tensor (ttnn.Tensor, optional): Pre-allocated output tensor. Its shape must match the slice output. Defaults to ``None``.
+            pad_value (float, optional): Fill value for implicit tile padding on tiled tensors. Padding is undefined by default.
+            sub_core_grids (ttnn.CoreRangeSet, optional): sub core grids for the operation. Defaults to `None`.
+
+        Note:
+            Strided slicing (``slice_step != 1``) is not supported for ``bfloat8_b`` tensors.
 
         Returns:
             ttnn.Tensor: the output tensor.


### PR DESCRIPTION
### Ticket
Link to Github Issue #42858

### Problem
`ttnn::slice` lacked universal input/output support — block-sharded inputs, width-sharded inputs, RM strided + sharded buffers, and sharded outputs requested without an explicit `shard_spec` would crash (`TT_FATAL`, `bad_optional_access`) or silently corrupt data. Only HEIGHT-sharded in/out with no step had a native fast path; every other sharding configuration hit unsupported code, an invalid `noc_async_*` page-size split, or a downstream `to_memory_config` call that couldn't synthesize a `shard_spec`.

### What this PR does
- **Add composite-fallback predicates in `slice.cpp`** — `needs_rm_composite_input` / `needs_rm_composite_output` route only the cases that can't be served natively (irregular B/W-sharded W, non-zero width-begin on B/W-sharded, irregular HEIGHT off the RM-sharded fast path) through an L1-interleaved hop; `needs_sharded_output_reshard` covers sharded-output-without-spec when the input can't seed one. Regular B/W-sharded and regular HEIGHT-sharded now flow natively.
- **Pass per-shard `page_size_override` to RM reader/writer kernels** — `slice_program_factory_rm.cpp` now computes `shard_W * elem_size` for B/W-sharded buffers (full row width otherwise) and feeds it as the `TensorAccessor` page-size override. This is what makes `noc_async_read_sharded` / `noc_async_write_sharded` split a logical row across `pages_per_row` shards. Before this, the kernel-side override defeated the multi-shard split and corrupted regular-shape B/W I/O.
- **Upgrade strided readers/writers to `noc_async_*_sharded`** — `reader_multicore_slice_4d/_nd.cpp` and `writer_multicore_slice_4d/_nd.cpp` now route per-row NOC calls through `tt::data_movement::common::noc_async_*_sharded`, so strided + B/W-sharded I/O is native (the strided factory reuses the compile-time `TensorAccessorArgs::AlignedPageSize`, which already encodes per-shard page size for sharded buffers).
- **Synthesize output `shard_spec` in `compute_output_specs`** — when the user requests a sharded output without a spec, the device op derives one via `adjust_shard_spec_to_shape` (when the input layout matches and ranks agree) and falls back to `generate_transpose_shard_spec` otherwise, so cross-config requests (`interleaved → sharded`, `rank>4 → sharded`) produce a fully-resolved `MemoryConfig`.
- **Harden `ret_adjustment` against sharded-no-spec output** — when the requested output is sharded but the user didn't supply a `shard_spec`, the host-side conversion reuses the spec the device op has already placed on the result (when layouts match) or synthesizes a fresh full-grid one; previously this path raised `TT_FATAL @ tensor_layout.cpp:205` for inputs whose layout matched the requested sharded output.
- **Expand the implicit-inheritance path to BLOCK_SHARDED** — `slice.cpp`'s "no explicit output mc, input sharded" branch now rescales the input's shard spec for BLOCK in addition to HEIGHT/WIDTH (issue #38016 was the original HEIGHT/WIDTH-only fix), so `slice(block_sharded_in, …)` with no `memory_config_arg` no longer fatals.
- **Drop the strided + sharded TT_FATAL in `validate_on_program_cache_miss`** — strided RM slicing of sharded buffers is now supported via the upgraded kernels above.
- **Add comprehensive test suite (`test_slice_universal_io.py`)** — 51 cases covering: TILE/RM interleaved baselines; TILE sharded in/out with explicit spec, cross-layout, default-output; TILE/RM sharded out without `shard_spec`; RM HEIGHT-sh fast path; RM B/W-sharded native and irregular-shape composite fallback; RM cross-layout WIDTH↔HEIGHT; RM strided + sharded; irregular logical shapes (last-two not tile multiples) across all three sharding types and both layouts; explicit grids / uneven shards / sub-tile shards; multi-batch / multi-channel sharded inputs; non-tile-aligned RM HEIGHT shards; rank-5/rank-6 inputs; DRAM-sharded fallback; default-mc regression guards. The main sharded I/O matrix runs **bf16 only**; `test_slice_dtype_coverage` provides spot-checks for **f32** (TILE interleaved, TILE HEIGHT-sharded) and **bf8_b** (TILE interleaved).

### Tests
All on Wormhole B0 (`tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_universal_io.py`):
- `test_slice_tile` — 11 cases (interleaved baselines, sharded in/out with spec, cross-layout, implicit inheritance × **bf16**) — **PASSED**
- `test_slice_tile_interleaved_to_sharded_no_spec` — 2 cases (HEIGHT/BLOCK × bf16; WIDTH is symmetric to HEIGHT) — **PASSED**
- `test_slice_tile_explicit_sharded_inputs` — 2 cases (explicit height 3-core irregular-H, explicit width 4-core irregular-W) — **PASSED**
- `test_slice_tile_subtile_height_sharded` — 2 cases (sub-tile shards on TILE inputs) — **PASSED**
- `test_slice_tile_same_layout_sharded_no_spec_halving` — 1 case (Fix 1 regression: sub-tile shard spec guard in `adjust_shard_spec_to_shape`) — **PASSED**
- `test_slice_rm` — 9 cases (interleaved, HEIGHT-sh fast path, B/W-sh native, cross-layout WIDTH↔HEIGHT, strided + sharded × **bf16**) — **PASSED**
- `test_slice_rm_interleaved_to_sharded_no_spec` — 2 cases (HEIGHT/BLOCK × bf16; WIDTH is symmetric) — **PASSED**
- `test_slice_rm_bw_sharded_nonzero_width_begin` — 1 case (WIDTH-sharded RM with non-zero width-begin routes composite) — **PASSED**
- `test_slice_irregular_shapes_interleaved` — 2 cases (1 irregular shape × TILE/RM) — **PASSED**
- `test_slice_irregular_shapes_sharded` — 6 cases (1 irregular shape × HEIGHT/WIDTH/BLOCK × TILE/RM) — **PASSED**
- `test_slice_multi_batch_channel` — 2 cases (TILE C>1 block, RM N>1C>1 height) — **PASSED**
- `test_slice_row_major_height_sharded_nontile_aligned` — 1 case (non-tile-aligned RM HEIGHT shards) — **PASSED**
- `test_slice_higher_rank` — 2 cases (rank-5 HEIGHT-sharded, rank-6 interleaved no-op) — **PASSED**
- `test_slice_dram_sharded_fallback` — 1 case (DRAM-sharded → L1 interleaved fallback) — **PASSED**
- `test_slice_block_sharded_default_mc_no_longer_fatal` — 1 case (implicit-inheritance regression guard) — **PASSED**
- `test_slice_rm_irregular_width_in_bad_fallback` — 1 case (`needs_rm_composite_input` for irregular W) — **PASSED**
- `test_slice_rm_irregular_bw_output_out_bad_fallback` — 1 case (`needs_rm_composite_output` for WIDTH-sharded irregular-W out) — **PASSED**
- `test_slice_rm_sharded_in_sharded_no_spec_out` — 1 case (regression guard for `ret_adjustment` on sharded-no-spec output) — **PASSED**
- `test_slice_dtype_coverage` — 3 cases (f32: TILE interleaved, TILE HEIGHT-sharded; bf8_b: TILE interleaved) — **PASSED**

Total: **51 passed in ~10s**.

### Notes for Reviewers
- The full gap analysis, routing tables (before/after FU1), and the corner-case discussion that surfaced the `ret_adjustment` sharded-no-spec bug live on issue #42858 — recommended reading alongside the diff.
- The composite-fallback predicates and the `shard_spec` synthesis helpers (`adjust_shard_spec_to_shape`, `generate_transpose_shard_spec`) are shared with the data-movement op family; no new helpers introduced here.
- Irregular-shape composite (nontile-aligned W on B/W-sharded, nontile-aligned HEIGHT off the fast path) is the only remaining non-native path. Tracked as a kernel-helper follow-up (`noc_async_*_sharded`'s `pages_per_row` reads the padded shape; logical W misalignment overshoots the buffer). Regular B/W and regular HEIGHT are fully native after this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/slice_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/slice_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/slice_fix)