### PR TITLE
[CI Disable] runtime-unit-tests: skip 5 deterministically failing runtime_data_movement tests (#45978)

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/direct_write/test_direct_write.cpp
@@ -347,6 +347,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDirectWriteAddressPatterns) {
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDirectWriteMulticast) {
+    GTEST_SKIP() << "Disabled: see #45978";
     uint32_t test_id = 507;
     unit_tests::dm::direct_write::multicast_test(get_mesh_device(), test_id);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -1194,6 +1194,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedDirect
 
 /* ========== 2x2, non-linked, EXCLUDE_SRC ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x2_2_0) {
+    GTEST_SKIP() << "Disabled: see #45978";
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 10;
 
     auto mesh_device = get_mesh_device();
@@ -1222,6 +1223,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastSemaphore2x2
 
 /* ========== 2x2, linked, INCLUDE_SRC (loopback) ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x2_2_0) {
+    GTEST_SKIP() << "Disabled: see #45978";
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 11;
 
     auto mesh_device = get_mesh_device();
@@ -1250,6 +1252,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 
 /* ========== 5x5, linked, EXCLUDE_SRC ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaphore5x5_2_0) {
+    GTEST_SKIP() << "Disabled: see #45978";
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 12;
 
     auto mesh_device = get_mesh_device();
@@ -1284,6 +1287,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllMulticastLinkedSemaph
 
 /* ========== 2x2 ========== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneToAllUnicastSemaphore2x2_2_0) {
+    GTEST_SKIP() << "Disabled: see #45978";
     uint32_t test_case_id = unit_tests::dm::core_to_all::START_ID_2_0 + 13;
 
     auto mesh_device = get_mesh_device();


### PR DESCRIPTION
Disable 5 GTest cases in `runtime_data_movement` that fail deterministically on both `wh_n150_civ2` and `bh_p150b_civ2` on every `main` run. Tracking issue: #45978

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `GenericMeshDeviceFixture.TensixDirectWriteMulticast [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903173 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDirectWriteMulticast [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903291 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastSemaphore2x2_2_0 [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903173 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastSemaphore2x2_2_0 [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903291 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x2_2_0 [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903173 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphoreLoopback2x2_2_0 [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903291 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphore5x5_2_0 [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903173 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllMulticastLinkedSemaphore5x5_2_0 [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903291 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllUnicastSemaphore2x2_2_0 [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903173 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |
| `GenericMeshDeviceFixture.TensixDataMovementOneToAllUnicastSemaphore2x2_2_0 [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26920844625/job/79422903291 | [5e2561dc](https://github.com/tenstorrent/tt-metal/commit/5e2561dcd5471d9e4a288cb10163f507e1426893) | 2026-06-03 23:59 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-data-movement-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-unit-tests-data-movement-2026-06-03)