### PR TITLE
[skip ci] t3000-unit-tests: skip test_attention_1d_vs_reference Qwen2.5-7B 1x2 decode (#45980)

### DIFF
--- a/models/common/tests/modules/attention/test_attention_1d.py
+++ b/models/common/tests/modules/attention/test_attention_1d.py
@@ -907,7 +907,7 @@ def _list_test_cases() -> list[pytest.param]:
         pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-128-8B"),
         pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-decode-32-8B"),
         pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-decode-32-11B"),
-        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.95, id="1x2-decode-32-Qwen2.5-7B"),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.95, id="1x2-decode-32-Qwen2.5-7B", marks=pytest.mark.skip(reason="Disabled: see #45980")),
         # Multi-device (1x8)
         pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-128-8B"),
         pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-decode-32-8B"),


### PR DESCRIPTION
Disable 2 deterministically failing `test_attention_1d_vs_reference` parametrizations for Qwen2.5-7B with 1x2 mesh in decode mode. Fails on `wh_llmbox` in `t3k_tttv2_fast_unit_tests`. Tracking issue: #45980

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `test_attention_1d_vs_reference[10-standard-1x2-decode-32-Qwen2.5-7B-1x2] [wh_llmbox]` | https://github.com/tenstorrent/tt-metal/actions/runs/26913119973/job/79401375600 | [f0d2341794](https://github.com/tenstorrent/tt-metal/commit/f0d2341794d1674877131d01a6f5ce1e908d2dec) | 2026-06-03 22:25 UTC |
| `test_attention_1d_vs_reference[10-paged-1x2-decode-32-Qwen2.5-7B-1x2] [wh_llmbox]` | https://github.com/tenstorrent/tt-metal/actions/runs/26913119973/job/79401375600 | [f0d2341794](https://github.com/tenstorrent/tt-metal/commit/f0d2341794d1674877131d01a6f5ce1e908d2dec) | 2026-06-03 22:25 UTC |

### Failure details (still failing on `main` as of 2026-06-08)

Both parametrizations fail with:

```
RuntimeError: TT_FATAL @ ttnn/core/tensor/xtensor/partition.cpp:152:
std::unique(sorted_dims.begin(), sorted_dims.end()) == sorted_dims.end()
dims must be unique
```

Raised from `ttnn::distributed::MeshToTensor::compose<bfloat16>` → `concat_ndim`, via `models.common.auto_compose.to_torch_auto_compose`.

Latest failing jobs on `main` (`t3k_tttv2_fast_unit_tests [wh_llmbox]`): [2026-06-08](https://github.com/tenstorrent/tt-metal/actions/runs/27135093370/job/80087551820) · [2026-06-08 earlier](https://github.com/tenstorrent/tt-metal/actions/runs/27129109692/job/80066742642). Full evidence in #45980.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-unit-tests-attention1d-qwen25-2026-06-03)
