### PR TITLE
[API Cleanup] Make Metal 2.0 *Spec identifiers strongly typed

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -624,7 +624,7 @@ void run_concurrent_dfbs_program(
     // erroneously register all N threads as producers for every DFB.
     std::vector<experimental::DataflowBufferSpec> dfb_specs;
     std::vector<experimental::KernelSpec> kernel_specs;
-    std::vector<std::string> kernel_names;
+    std::vector<experimental::KernelSpecName> kernel_names;
     dfb_specs.reserve(num_dfbs);
     kernel_specs.reserve(2 * num_dfbs);
     kernel_names.reserve(2 * num_dfbs);
@@ -810,7 +810,7 @@ void run_concurrent_tensix_dm_dfbs_program(
     // DM concurrent consumers: one 1-thread kernel instance per DFB, each binding
     // its own per-DFB OUT_TENSOR_<i>.
     std::vector<experimental::KernelSpec> kernel_specs;
-    std::vector<std::string> kernel_names;
+    std::vector<experimental::KernelSpecName> kernel_names;
     std::vector<experimental::DataflowBufferSpec> dfb_specs;
     std::vector<experimental::TensorParameter> tensor_parameters;
     kernel_specs.reserve(1 + num_dfbs);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1082,7 +1082,7 @@ inline ProgramRunArgs MakeBorrowedDFBRunArgs() {
 // All cores of a single DFB share the same address (lockstep allocation invariant), so
 // returning the first entry is representative.
 inline uint32_t PeekBorrowedDFBAddress(Program& program, const DFBSpecName& dfb_name) {
-    const uint32_t dfb_id = program.impl().get_dfb_handle(dfb_name);
+    const uint32_t dfb_id = program.impl().get_dfb_handle(dfb_name.get());
     const auto dfb = program.impl().get_dataflow_buffer(dfb_id);
     TT_FATAL(!dfb->groups.empty(), "DFB '{}' has no groups; finalize_dataflow_buffer_configs() not called?", dfb_name);
     TT_FATAL(!dfb->groups[0].l1_by_core.empty(), "DFB '{}' group 0 is empty", dfb_name);
@@ -1340,7 +1340,7 @@ inline MeshTensor AllocateTensorForBinding(distributed::MeshDevice& mesh_device,
 // site shows up as a test failure.
 inline uint32_t ReadBindingAddressFromCRTA(
     const Program& program, const KernelSpecName& kernel_name, const std::string& tensor_parameter_name) {
-    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name);
+    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name.get());
     for (const auto& handle : kernel->tensor_binding_handles()) {
         if (handle.tensor_parameter_name == tensor_parameter_name) {
             const uint32_t word_index = handle.addr_crta_offset / sizeof(uint32_t);
@@ -1679,7 +1679,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_RankMismatchFails) {
 // Returns the [rank] shape words in declaration order.
 inline std::vector<uint32_t> ReadBindingShapeFromCRTA(
     const Program& program, const KernelSpecName& kernel_name, const std::string& tensor_parameter_name) {
-    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name);
+    auto kernel = program.impl().get_kernel_by_spec_name(kernel_name.get());
     for (const auto& handle : kernel->tensor_binding_handles()) {
         if (handle.tensor_parameter_name == tensor_parameter_name) {
             const uint32_t base_word = handle.addr_crta_offset / sizeof(uint32_t);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_semi_strong_type.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_semi_strong_type.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//---------------------------------------------------------------------------------
+// Unit tests for SemiStrongType (metal2_host_api/util/semi_strong_type.hpp).
+//
+// SemiStrongType is a temporary local mirror of ttsl::StrongType that permits
+// IMPLICIT construction from the wrapped value. These tests are deliberately
+// self-contained and free of any Metal-specific dependencies so that they can be
+// lifted into tt_stl's test suite when SemiStrongType is promoted into
+// ttsl::StrongType (as an opt-in implicit mode).
+//
+// The heart of the file is the compile-time block: SemiStrongType's one piece of
+// novel machinery is its constrained forwarding constructor, and its contract
+// ("lenient inbound from the wrapped type, strict across wrapper tags") is a
+// statement about the type system. So we assert it with static_assert; the
+// runtime TESTs then cover the ordinary value-type behaviors.
+//---------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+
+#include <tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp>
+
+namespace tt::tt_metal::experimental {
+namespace {
+
+// Two distinct string-valued wrappers (the ProgramSpec identifier use case) and
+// one numeric wrapper (to confirm the generic template behaves for non-strings).
+using NameA = SemiStrongType<std::string, struct NameATag>;
+using NameB = SemiStrongType<std::string, struct NameBTag>;
+using Count = SemiStrongType<int, struct CountTag>;
+
+// ---- The contract, proven at compile time -------------------------------------
+
+// Lenient inbound: implicitly constructible from the wrapped type and from
+// anything convertible to it in a single hop (notably const char* -> std::string,
+// the literal-authoring case that motivated this type).
+static_assert(std::is_convertible_v<std::string, NameA>);
+static_assert(std::is_convertible_v<const char*, NameA>);
+static_assert(std::is_convertible_v<int, Count>);
+
+// Strict across wrapper tags: distinct tags do not interconvert, cross-assign, or
+// cross-construct. This is the property that makes the type worth having.
+static_assert(!std::is_convertible_v<NameA, NameB>);
+static_assert(!std::is_assignable_v<NameA&, NameB>);
+static_assert(!std::is_constructible_v<NameA, NameB>);
+
+// Strict outbound: no implicit conversion back to the wrapped type (you must
+// dereference / .get()), so a wrapper can't silently decay into a bare string.
+static_assert(!std::is_convertible_v<NameA, std::string>);
+
+// The forwarding ctor's constraint really constrains: a string wrapper is not
+// constructible from something std::string itself can't be built from.
+static_assert(!std::is_constructible_v<NameA, int>);
+
+// The forwarding ctor must not shadow the copy/move special members.
+static_assert(std::is_copy_constructible_v<NameA>);
+static_assert(std::is_move_constructible_v<NameA>);
+static_assert(std::is_copy_assignable_v<NameA>);
+static_assert(std::is_move_assignable_v<NameA>);
+
+// Trait detection.
+static_assert(is_semi_strong_type_v<NameA>);
+static_assert(is_semi_strong_type_v<Count>);
+static_assert(!is_semi_strong_type_v<std::string>);
+
+// ---- Runtime behaviors ---------------------------------------------------------
+
+TEST(SemiStrongTypeTest, ImplicitConstructionAndAccess) {
+    NameA from_literal = "in0";
+    EXPECT_EQ(*from_literal, "in0");
+    EXPECT_EQ(from_literal.get(), "in0");
+
+    std::string owned = "out0";
+    NameA from_string = owned;
+    EXPECT_EQ(*from_string, "out0");
+}
+
+TEST(SemiStrongTypeTest, DefaultConstructsToWrappedDefault) {
+    NameA a;
+    EXPECT_EQ(*a, std::string{});
+    Count c;
+    EXPECT_EQ(*c, 0);
+}
+
+TEST(SemiStrongTypeTest, EqualityAndOrdering) {
+    NameA alpha = "alpha";
+    NameA alpha_again = "alpha";
+    NameA beta = "beta";
+
+    EXPECT_EQ(alpha, alpha_again);
+    EXPECT_NE(alpha, beta);
+    EXPECT_LT(alpha, beta);
+    EXPECT_GT(beta, alpha);
+}
+
+TEST(SemiStrongTypeTest, UsableInUnorderedSet) {
+    std::unordered_set<NameA> names;
+    names.insert(NameA{"x"});
+    names.insert(NameA{"y"});
+    names.insert(NameA{"x"});  // duplicate
+
+    EXPECT_EQ(names.size(), 2u);
+    EXPECT_TRUE(names.contains(NameA{"x"}));
+    EXPECT_FALSE(names.contains(NameA{"z"}));
+}
+
+TEST(SemiStrongTypeTest, UsableAsOrderedMapKey) {
+    std::map<NameA, int> by_name;
+    by_name[NameA{"a"}] = 1;
+    by_name[NameA{"b"}] = 2;
+
+    EXPECT_EQ(by_name.at(NameA{"a"}), 1);
+    EXPECT_EQ(by_name.at(NameA{"b"}), 2);
+}
+
+TEST(SemiStrongTypeTest, Streams) {
+    NameA a = "hello";
+    std::ostringstream oss;
+    oss << a;
+    EXPECT_EQ(oss.str(), "hello");
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -27,6 +27,7 @@ set(UNIT_TESTS_API_SOURCES
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp
     metal2_host_api/test_program_run_args.cpp
+    metal2_host_api/test_semi_strong_type.cpp
     test_kernel_thread_sync.cpp
     tensor/test_tensor_sharding.cpp
     tensor/test_host_tensor.cpp

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -91,7 +91,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
     uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     std::vector<KernelConfig> kernel_configs;
-    std::vector<std::string> work_unit_kernel_names;
+    std::vector<KernelSpecName> work_unit_kernel_names;
 
     if (is_quasar) {
         auto spec = MakeMinimalDMKernel("dm_barrier_kernel", expected_num_threads);

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -203,7 +203,7 @@ std::pair<distributed::MeshWorkload, std::vector<std::string>> initialize_progra
 
     std::vector<std::string> kernel_names(num_kernels);
     std::vector<experimental::KernelSpec> kernel_specs;
-    std::vector<std::string> wu_kernel_names;
+    std::vector<experimental::KernelSpecName> wu_kernel_names;
     kernel_specs.reserve(num_kernels);
     wu_kernel_names.reserve(num_kernels);
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp>
 
 namespace tt::tt_metal::experimental {
 
@@ -33,9 +34,10 @@ namespace tt::tt_metal::experimental {
 //
 // ============================================================================
 
-// Forward-declare *Name typedefs that AdvancedOptions members reference.
-// (Each is also declared in its owning spec header.)
-using DFBSpecName = std::string;
+// Canonical definition of DFBSpecName. It lives in this lower-level header
+// (rather than dataflow_buffer_spec.hpp) because AdvancedOptions members here
+// reference it, and dataflow_buffer_spec.hpp includes this header.
+using DFBSpecName = SemiStrongType<std::string, struct DFBSpecNameTag>;
 
 struct KernelAdvancedOptions {
     ////////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -63,8 +63,8 @@
 
 namespace tt::tt_metal::experimental {
 
-// A name identifying a DataflowBufferSpec within a ProgramSpec.
-using DFBSpecName = std::string;
+// DFBSpecName is defined in advanced_options.hpp (included above) — the lowest
+// header that references it.
 
 //------------------------------------------------
 // DataflowBufferSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
+#include <tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp>
 
 namespace tt::tt_metal::experimental {
 
@@ -60,7 +61,7 @@ namespace tt::tt_metal::experimental {
 // ============================================================================
 
 // A name identifying a KernelSpec within a ProgramSpec.
-using KernelSpecName = std::string;
+using KernelSpecName = SemiStrongType<std::string, struct KernelSpecNameTag>;
 
 //------------------------------------------------
 // KernelSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -44,12 +44,6 @@ namespace tt::tt_metal::experimental {
 //
 // ============================================================================
 
-// A name identifying a ProgramSpec within a MeshWorkload.
-using ProgramSpecName = std::string;
-
-// A name identifying a WorkUnitSpec within a ProgramSpec.
-using WorkUnitSpecName = std::string;
-
 //------------------------------------------------
 // WorkUnitSpec
 //------------------------------------------------
@@ -62,7 +56,7 @@ using WorkUnitSpecName = std::string;
 //
 struct WorkUnitSpec {
     // Human-readable name (debug/messaging only; no uniqueness invariant).
-    WorkUnitSpecName name;
+    std::string name;
 
     // The kernels that run on this WorkUnitSpec's nodes.
     std::vector<KernelSpecName> kernels;
@@ -78,7 +72,7 @@ struct WorkUnitSpec {
 // A ProgramSpec describes a complete Program (its immutable properties).
 struct ProgramSpec {
     // Human-readable name (debug/messaging only; no uniqueness invariant).
-    ProgramSpecName name;
+    std::string name;
 
     // Kernels, DFBs (local + remote), and semaphores that make up the Program
     std::vector<KernelSpec> kernels;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
+#include <tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp>
 
 namespace tt::tt_metal::experimental {
 
@@ -34,7 +35,7 @@ namespace tt::tt_metal::experimental {
 // ============================================================================
 
 // A name identifying a SemaphoreSpec within a ProgramSpec.
-using SemaphoreSpecName = std::string;
+using SemaphoreSpecName = SemiStrongType<std::string, struct SemaphoreSpecNameTag>;
 
 struct SemaphoreSpec {
     // Semaphore identifier: used to reference this Semaphore within the ProgramSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
+#include <tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 
 namespace tt::tt_metal::experimental {
@@ -29,7 +30,7 @@ namespace tt::tt_metal::experimental {
 // ============================================================================
 
 // A name identifying a TensorParameter within a ProgramSpec.
-using TensorParameterName = std::string;
+using TensorParameterName = SemiStrongType<std::string, struct TensorParameterNameTag>;
 
 struct TensorParameter {
     // Tensor identifier: used to reference this Tensor within the ProgramSpec

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp
@@ -7,9 +7,10 @@
 #include <concepts>
 #include <functional>
 #include <ostream>
-#include <tuple>
 #include <type_traits>
 #include <utility>
+
+#include <fmt/format.h>
 
 namespace tt::tt_metal::experimental {
 
@@ -18,7 +19,7 @@ namespace tt::tt_metal::experimental {
 // ============================================================================
 //
 // SemiStrongType is a near-verbatim copy of ttsl::StrongType
-// (tt_stl/tt_stl/strong_type.hpp) that differs in exactly ONE respect: it is
+// (tt_stl/tt_stl/strong_type.hpp) that differs in one essential respect: it is
 // IMPLICITLY constructible from its wrapped value, whereas ttsl::StrongType is
 // explicit-only.
 //
@@ -46,7 +47,7 @@ namespace tt::tt_metal::experimental {
 //   sites are untouched (they only ever reference the `using` aliases).
 //
 //   Keep this type a faithful mirror of ttsl::StrongType so that the upstream
-//   merge stays a minimal, mechanical diff. There are two deliberate deltas:
+//   merge stays a minimal, mechanical diff. There are four deliberate deltas:
 //     1. The constructor is implicit (the whole point of this type).
 //     2. operator<< lives INSIDE this namespace, not at global scope as in
 //        ttsl::StrongType. StrongType's global placement is found only by
@@ -55,6 +56,17 @@ namespace tt::tt_metal::experimental {
 //        operator<< hiding it at the call site. Placing it in the type's own
 //        namespace makes ADL find it unconditionally. This is a robustness fix
 //        that should be carried back into ttsl::StrongType at merge time.
+//     3. A fmt::formatter is provided inline below (dereferencing to the inner
+//        value, so identifiers format as bare strings in TT_FATAL/log messages).
+//        ttsl::StrongType's formatter instead lives in tt_stl/fmt.hpp. This delta
+//        disappears at merge: that existing formatter already covers the type.
+//     4. It deliberately OMITS StrongType's attribute protocol
+//        (attribute_names/attribute_values). That protocol is unused here — no
+//        Metal 2.0 spec struct is a reflection type — and keeping it would make
+//        SemiStrongType match reflection.hpp's attribute-based catch-all fmt
+//        formatter, forcing a carve-out in tt_stl/reflection.hpp and defeating
+//        the purpose of keeping this type self-contained. Re-added trivially at
+//        merge, since ttsl::StrongType already provides it.
 // ============================================================================
 
 template <typename T>
@@ -75,7 +87,7 @@ public:
         requires std::default_initializable<T>
         : value_(T{}) {}
 
-    // IMPLICIT construction — this is the sole intentional difference from
+    // IMPLICIT construction — this is the primary intentional difference from
     // ttsl::StrongType. A constrained forwarding constructor, rather than a plain
     // `SemiStrongType(T)`, so that anything T is constructible from converts in a
     // SINGLE user-defined conversion — notably `const char*` for T = std::string,
@@ -109,9 +121,6 @@ public:
         requires(!HasConstexprThreeWayCompare<T>)
     = default;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("value");
-    constexpr auto attribute_values() const { return std::forward_as_tuple(value_); }
-
 private:
     T value_;
 };
@@ -137,5 +146,19 @@ template <typename T, typename Tag>
 struct std::hash<tt::tt_metal::experimental::SemiStrongType<T, Tag>> {
     std::size_t operator()(const tt::tt_metal::experimental::SemiStrongType<T, Tag>& h) const noexcept {
         return std::hash<T>{}(*h);
+    }
+};
+
+// Format as the bare wrapped value (mirrors ttsl::StrongType's formatter in
+// tt_stl/fmt.hpp), so identifiers render cleanly in TT_FATAL / log messages.
+// Because SemiStrongType has no attribute protocol (see delta 4 above), it does
+// not match reflection.hpp's attribute-based catch-all formatter, so this is the
+// sole matching formatter — no reflection.hpp carve-out required.
+template <typename T, typename Tag>
+struct fmt::formatter<tt::tt_metal::experimental::SemiStrongType<T, Tag>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator { return ctx.end(); }
+    auto format(const tt::tt_metal::experimental::SemiStrongType<T, Tag>& val, fmt::format_context& ctx) const
+        -> fmt::format_context::iterator {
+        return fmt::format_to(ctx.out(), "{}", *val);
     }
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <concepts>
+#include <functional>
+#include <ostream>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace tt::tt_metal::experimental {
+
+// ============================================================================
+//  SemiStrongType  —  a StrongType that permits implicit construction
+// ============================================================================
+//
+// SemiStrongType is a near-verbatim copy of ttsl::StrongType
+// (tt_stl/tt_stl/strong_type.hpp) that differs in exactly ONE respect: it is
+// IMPLICITLY constructible from its wrapped value, whereas ttsl::StrongType is
+// explicit-only.
+//
+// It is "semi"-strong because it is still fully strong on the axis that matters:
+// distinct wrapper types do not interconvert. What it relaxes — deliberately —
+// is construction from the underlying type, so that string-literal authoring of
+// identifiers stays ergonomic:
+//
+//     using DFBSpecName       = SemiStrongType<std::string, struct DFBSpecNameTag>;
+//     using SemaphoreSpecName = SemiStrongType<std::string, struct SemaphoreSpecNameTag>;
+//
+//     DFBSpecName a = "in0";       // OK (implicit) — ttsl::StrongType forbids this
+//     DFBSpecName b = a;           // OK
+//     SemaphoreSpecName s = a;     // DOES NOT COMPILE — different wrapper type
+//
+// WHY THIS EXISTS, AND WHY IT IS TEMPORARY:
+//   ttsl::StrongType's explicit constructor is exactly right for its current
+//   users, which are all numeric IDs (DeviceId, MeshId, QueueId, ...) where
+//   bare-literal construction is undesirable and even bug-prone. The Metal 2.0
+//   ProgramSpec cross-reference identifiers are the first STRING-valued strong
+//   types, and they are authored inline as literals, where explicit construction
+//   is pure friction. Rather than fork permanently, this is a temporary local
+//   mirror: the intended endgame is an opt-in implicit mode on ttsl::StrongType
+//   itself, after which this header collapses to a single alias and the call
+//   sites are untouched (they only ever reference the `using` aliases).
+//
+//   Keep this type a faithful mirror of ttsl::StrongType so that the upstream
+//   merge stays a minimal, mechanical diff. There are two deliberate deltas:
+//     1. The constructor is implicit (the whole point of this type).
+//     2. operator<< lives INSIDE this namespace, not at global scope as in
+//        ttsl::StrongType. StrongType's global placement is found only by
+//        ordinary unqualified lookup (global is never an ADL-associated
+//        namespace for a type in `ttsl`), so it is fragile to a closer
+//        operator<< hiding it at the call site. Placing it in the type's own
+//        namespace makes ADL find it unconditionally. This is a robustness fix
+//        that should be carried back into ttsl::StrongType at merge time.
+// ============================================================================
+
+template <typename T>
+concept HasConstexprThreeWayCompare = requires(T t) {
+    { std::bool_constant<(T{}.operator<=>(T{}), true)>() } -> std::same_as<std::true_type>;
+};
+
+// lambdas are guaranteed to be unique according to the standard,
+// so the default Tag allows each SemiStrongType instantiation
+// to be truly unique
+template <typename T, typename Tag = decltype([]() {})>
+class SemiStrongType {
+public:
+    using value_type = T;
+    using tag_type = Tag;
+
+    constexpr SemiStrongType() noexcept
+        requires std::default_initializable<T>
+        : value_(T{}) {}
+
+    // IMPLICIT construction — this is the sole intentional difference from
+    // ttsl::StrongType. A constrained forwarding constructor, rather than a plain
+    // `SemiStrongType(T)`, so that anything T is constructible from converts in a
+    // SINGLE user-defined conversion — notably `const char*` for T = std::string,
+    // which would otherwise need const char* -> std::string -> wrapper (two hops,
+    // which the language refuses to do implicitly). Self is excluded so the
+    // copy/move constructors below are not shadowed, and types T cannot be built
+    // from (and other wrapper tags) are SFINAE'd out — preserving strength.
+    template <typename U>
+        requires(!std::same_as<std::remove_cvref_t<U>, SemiStrongType> && std::constructible_from<T, U &&>)
+    constexpr SemiStrongType(U&& v) noexcept(std::is_nothrow_constructible_v<T, U&&>) : value_(std::forward<U>(v)) {}
+
+    constexpr SemiStrongType(const SemiStrongType&) = default;
+    constexpr SemiStrongType(SemiStrongType&&) noexcept = default;
+    constexpr SemiStrongType& operator=(const SemiStrongType&) = default;
+    constexpr SemiStrongType& operator=(SemiStrongType&&) noexcept = default;
+
+    constexpr const T& operator*() const { return value_; }
+    constexpr const T& get() const { return value_; }
+
+    // requires() = default on a constexpr function doesn't behave on gcc/clang
+    // so it needed the explicit definition to compile.
+    // We need the separate definition for non/constexpr to accommodate
+    // types that don't have constexpr <=> (eg. std::unique_ptr)
+    constexpr auto operator<=>(const SemiStrongType& rhs) const noexcept
+        requires(HasConstexprThreeWayCompare<T>)
+    {
+        return value_ <=> rhs.value_;
+    }
+
+    auto operator<=>(const SemiStrongType&) const noexcept
+        requires(!HasConstexprThreeWayCompare<T>)
+    = default;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("value");
+    constexpr auto attribute_values() const { return std::forward_as_tuple(value_); }
+
+private:
+    T value_;
+};
+
+// Type trait to detect SemiStrongType instantiations.
+template <typename T>
+struct is_semi_strong_type : std::false_type {};
+template <typename T, typename Tag>
+struct is_semi_strong_type<SemiStrongType<T, Tag>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_semi_strong_type_v = is_semi_strong_type<T>::value;
+
+// operator<< lives inside the namespace so that ADL finds it when the
+// wrapper appears as an operand (callers in any namespace benefit equally).
+template <typename T, typename Tag>
+std::ostream& operator<<(std::ostream& os, const SemiStrongType<T, Tag>& h) {
+    return os << *h;
+}
+
+}  // namespace tt::tt_metal::experimental
+
+template <typename T, typename Tag>
+struct std::hash<tt::tt_metal::experimental::SemiStrongType<T, Tag>> {
+    std::size_t operator()(const tt::tt_metal::experimental::SemiStrongType<T, Tag>& h) const noexcept {
+        return std::hash<T>{}(*h);
+    }
+};

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -55,21 +55,22 @@ void ValidateTensorArgs(const Program& program, std::span<const ProgramRunArgs::
 
     std::unordered_set<std::string> tensor_parameters_with_params;
     for (const auto& tensor_params : tensor_args) {
-        auto [it, inserted] = tensor_parameters_with_params.insert(tensor_params.tensor_parameter_name);
+        auto [it, inserted] = tensor_parameters_with_params.insert(tensor_params.tensor_parameter_name.get());
         TT_FATAL(
             inserted,
             "Duplicate tensor_parameter_name '{}' in tensor_args. Each TensorParameter must appear at most once.",
             tensor_params.tensor_parameter_name);
-        const TensorSpec* expected_spec = program_impl.get_tensor_parameter_layout(tensor_params.tensor_parameter_name);
+        const TensorSpec* expected_spec =
+            program_impl.get_tensor_parameter_layout(tensor_params.tensor_parameter_name.get());
         TT_FATAL(
             expected_spec != nullptr,
             "TensorArgument references unknown TensorParameter '{}'.",
             tensor_params.tensor_parameter_name);
         const TensorSpec& runtime_spec = tensor_params.tensor.get().tensor_spec();
         const bool dyn_shape =
-            program_impl.get_tensor_parameter_dynamic_tensor_shape(tensor_params.tensor_parameter_name);
+            program_impl.get_tensor_parameter_dynamic_tensor_shape(tensor_params.tensor_parameter_name.get());
         const bool padded_only =
-            program_impl.get_tensor_parameter_match_padded_shape_only(tensor_params.tensor_parameter_name);
+            program_impl.get_tensor_parameter_match_padded_shape_only(tensor_params.tensor_parameter_name.get());
         if (dyn_shape) {
             // dynamic_tensor_shape: tensor_layout must match exactly; logical_shape may differ in
             // per-dim values, but rank must still match. (Wins over match_padded_shape_only if both
@@ -147,14 +148,14 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
             kernel_name);
 
         // Check that the kernel exists
-        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_name);
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_name.get());
         TT_FATAL(
             schema != nullptr,
             "Kernel '{}' has no RTA schema registered. Was the Program created from a ProgramSpec?",
             kernel_name);
 
         // Nodes the kernel runs on — the required domain for named-RTA coverage.
-        const std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
+        const std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name.get());
         const std::set<CoreCoord>& kernel_nodes = kernel->logical_cores();
 
         // Validate vararg RTA counts per node
@@ -278,8 +279,8 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
     // by SetProgramRunArgs from the corresponding TensorArgument — and SetProgramRunArgs
     // only walks kernels present in params.kernel_run_args, so a kernel with tensor bindings
     // omitted from kernel_run_args would have its binding CRTAs left uninitialized.
-    std::vector<KernelSpecName> registered_names = program_impl.get_registered_kernel_names();
-    for (const KernelSpecName& name : registered_names) {
+    auto registered_names = program_impl.get_registered_kernel_names();
+    for (const auto& name : registered_names) {
         if (kernels_with_params.contains(name)) {
             continue;
         }
@@ -401,7 +402,7 @@ void AttachBorrowedDFBBuffers(
     std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
     tensor_by_param.reserve(tensor_args.size());
     for (const auto& tensor_params : tensor_args) {
-        tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
+        tensor_by_param.emplace(tensor_params.tensor_parameter_name.get(), &tensor_params.tensor.get());
     }
 
     for (const auto& [dfb_id, tp_name] : borrowed_bindings) {
@@ -471,7 +472,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params) {
     std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
     tensor_by_param.reserve(params.tensor_args.size());
     for (const auto& tensor_params : params.tensor_args) {
-        tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
+        tensor_by_param.emplace(tensor_params.tensor_parameter_name.get(), &tensor_params.tensor.get());
     }
 
     // Process kernel runtime arguments.
@@ -488,8 +489,8 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params) {
     // The device-side get_vararg / get_common_vararg helpers invisibly add the combined named-arg + binding
     // offset, so kernel code indexes varargs from 0.
     for (const auto& kernel_params : params.kernel_run_args) {
-        std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_params.kernel_spec_name);
-        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_params.kernel_spec_name);
+        std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_params.kernel_spec_name.get());
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_params.kernel_spec_name.get());
         TT_FATAL(schema != nullptr, "Kernel '{}' has no RTA schema registered.", kernel_params.kernel_spec_name);
 
         // Build a node -> named-RTA-values-map lookup for serialization.
@@ -623,7 +624,7 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunArgs::TensorAr
     std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
     tensor_by_param.reserve(tensor_args.size());
     for (const auto& tensor_params : tensor_args) {
-        tensor_by_param.emplace(tensor_params.tensor_parameter_name, &tensor_params.tensor.get());
+        tensor_by_param.emplace(tensor_params.tensor_parameter_name.get(), &tensor_params.tensor.get());
     }
 
     // For every kernel with tensor bindings, patch the binding slots in its CRTA buffer in
@@ -633,7 +634,7 @@ void UpdateTensorArgs(Program& program, std::span<const ProgramRunArgs::TensorAr
     // CRTAs, vararg CRTAs) is left untouched and retains the values installed by the most
     // recent SetProgramRunArgs call. The kernel's RTA buffer is also left untouched
     // (tensor binding state lives in CRTAs only).
-    for (const KernelSpecName& kernel_name : program_impl.get_registered_kernel_names()) {
+    for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
         const auto& binding_handles = kernel->tensor_binding_handles();
         if (binding_handles.empty()) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -551,7 +551,7 @@ void ValidateNodeBounds(const ProgramSpec& spec) {
         check_target_nodes(work_unit.target_nodes, "WorkUnitSpec", work_unit.name);
     }
     for (const auto& sem : spec.semaphores) {
-        check_target_nodes(sem.target_nodes, "SemaphoreSpec", sem.unique_id);
+        check_target_nodes(sem.target_nodes, "SemaphoreSpec", sem.unique_id.get());
     }
 }
 
@@ -1517,7 +1517,7 @@ std::pair<DMProcessorMask, DMProcessorMask> ReserveDMProcessors(
     const KernelSpec* kernel_spec,
     std::optional<DMProcessorMask> existing_mask,
     DMProcessorMask cumulative_mask,
-    const WorkUnitSpecName& work_unit_id) {
+    const std::string& work_unit_id) {
     // Was this kernel already assigned a mask from a previous WorkUnitSpec?
     if (existing_mask.has_value()) {
         DMProcessorMask existing = existing_mask.value();
@@ -1659,7 +1659,7 @@ int ConstraintScore(const KernelCouplingGroup* g) {
 
 // Deterministic tiebreaker: sort by the lexicographically-smallest member unique_id.
 // Group::members is canonicalized at construction time so members.front() is the sort key.
-const std::string& group_sort_key(const KernelCouplingGroup* g) { return g->members.front()->unique_id; }
+const std::string& group_sort_key(const KernelCouplingGroup* g) { return g->members.front()->unique_id.get(); }
 
 void SortByConstraint(std::vector<const KernelCouplingGroup*>& groups) {
     std::sort(groups.begin(), groups.end(), [](const KernelCouplingGroup* a, const KernelCouplingGroup* b) {
@@ -2072,7 +2072,7 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
 
         TensorBindingHandle handle;
         handle.accessor_name = binding.accessor_name;
-        handle.tensor_parameter_name = binding.tensor_parameter_name;
+        handle.tensor_parameter_name = binding.tensor_parameter_name.get();
         handle.cta_offset = cta_word_offset;
         handle.addr_crta_offset = static_cast<uint32_t>(crta_word_index * sizeof(uint32_t));
         handle.num_runtime_field_crta_words = resolved.extra_crta_words;
@@ -2551,7 +2551,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape;
         const bool match_padded_only = tensor_parameter.advanced_options.match_padded_shape_only;
         program_impl->register_tensor_parameter(
-            tensor_parameter.unique_id, tensor_parameter.spec, dyn_shape, match_padded_only);
+            tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only);
     }
 
     // Create DataflowBuffers and build name -> ID map.
@@ -2569,14 +2569,14 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // (For borrowed-memory DFBs, config.borrows_memory was set in MakeDataflowBufferConfig;
         // the device-side runtime uses that to skip regular L1 allocation.)
         uint32_t dfb_id = program_impl->add_dataflow_buffer(collected.dfb_node_set.at(dfb_name), config);
-        program_impl->register_dfb_spec_name(dfb_name, dfb_id);
+        program_impl->register_dfb_spec_name(dfb_name.get(), dfb_id);
         dfb_name_to_id[dfb_name] = dfb_id;
 
         // Borrowed-memory DFB: record the dfb_id ↔ TensorParameterName binding so that
         // SetProgramRunArgs / UpdateTensorArgs can resolve and attach the actual L1 Buffer
         // at runtime (analog of dynamic CB's UpdateDynamicCircularBufferAddress).
         if (dfb_spec.borrowed_from.has_value()) {
-            program_impl->register_dfb_borrowed_binding(dfb_id, *dfb_spec.borrowed_from);
+            program_impl->register_dfb_borrowed_binding(dfb_id, dfb_spec.borrowed_from->get());
         }
     }
 
@@ -2615,7 +2615,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         const uint32_t init_value = semaphore_spec.advanced_options.initial_value;
         uint32_t sem_id = program_impl->create_semaphore(
             to_node_range_set(semaphore_spec.target_nodes), init_value, CoreType::WORKER);
-        program_impl->register_semaphore_spec_name(semaphore_name, sem_id);
+        program_impl->register_semaphore_spec_name(semaphore_name.get(), sem_id);
         semaphore_name_to_id[semaphore_name] = sem_id;
     }
 
@@ -2721,7 +2721,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
         // Add the kernel to the ProgramImpl and register the name -> handle mapping
         KernelHandle handle = program_impl->add_kernel(kernel, HalProgrammableCoreType::TENSIX);
-        program_impl->register_kernel_spec_name(kernel_spec.unique_id, handle);
+        program_impl->register_kernel_spec_name(kernel_spec.unique_id.get(), handle);
 
         // Register the RTA+CRTA schema (named lists + vararg counts) with the ProgramImpl.
         // Used by ValidateProgramRunArgs and SetProgramRunArgs to validate and serialize
@@ -2783,7 +2783,7 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
             }
         }
         runtime_schema.num_common_runtime_varargs = num_common_runtime_varargs;
-        program_impl->register_kernel_rta_schema(kernel_spec.unique_id, runtime_schema);
+        program_impl->register_kernel_rta_schema(kernel_spec.unique_id.get(), runtime_schema);
     }
 
     return Program(std::move(program_impl));

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -69,6 +69,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+    api/tt-metalium/experimental/metal2_host_api/util/semi_strong_type.hpp
     api/tt-metalium/experimental/mock_device.hpp
     api/tt-metalium/experimental/noc_estimator/noc_estimator.hpp
     api/tt-metalium/experimental/noc_estimator/types.hpp


### PR DESCRIPTION
## PR Category
API cleanup

## Summary
Previously, the four `ProgramSpec` identifier types (KernelSpecName, DFBSpecName, SemaphoreSpecName, TensorParameterName) were all using `X = std::string` — so the compiler saw them as one interchangeable type. This is gross, since it forgoes compiler type checks and C++ standard semantics. Mixing up (say) a semaphore name and a DFB name would only trigger runtime validation checks.

This makes each a distinct type via a small self-contained wrapper, `SemiStrongType`, so cross-wiring is a compile error — while inline string authoring is unchanged:

```C++
work_unit.kernels = {"reader", "writer"};       // unchanged (implicit from literal)
binding.dfb_spec_name = some_semaphore_name;    // now a compile error (was silent)
```

### New: `SemiStrongType`
For now, `SemiStrongType` lives in `metal2_host_api/util/`. It mirrors `ttsl::StrongType` but allows implicit construction from its value — StrongType's explicit-only stance is right for numeric IDs but friction for string names authored as literals. The rationale for this, and a proposed path to eventually fold this into `ttsl::StrongType`, are in the in-header comment.

### Testing
 - New static_assert-based unit test for the wrapper's contract
 - Since this is a drop-in replacement for the existing `*SpecName` string aliases, we get coverage from the existing Metal 2.0 test suite

### TODO
I want to get rid of the janky `constexpr const char*` convention from early Metal 2.0, which is used across the Metalium test suite. Those are still legal, but now wrong. They should all be replaced with pre-declared `BlahSpecName` types. That change has a wide blast radius, so I'll separate it into a different PR.


## Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/strongly-typed-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/strongly-typed-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/strongly-typed-ids)