### PR TITLE
[CI Disable] blackhole-post-commit: disable test_host_io_decoder_sweep_chunked_trace tests (missing trace data)

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py
@@ -233,6 +233,7 @@ def test_run_host_io_decoder_sweep_multi_slot_stress_config_contract(model_id: s
         assert not config.dump_kv_cache
 
 
+@pytest.mark.skip(reason="Disabled: see #45988")
 @pytest.mark.parametrize(("model_id", "prompt_id"), TRACE_CASES)
 def test_run_host_io_decoder_sweep_chunked_trace_smoke(model_id: str, prompt_id: str) -> None:
     trace_root = _trace_root()
@@ -269,6 +270,7 @@ def test_run_host_io_decoder_sweep_chunked_trace_smoke(model_id: str, prompt_id:
     assert exit_code == 0
 
 
+@pytest.mark.skip(reason="Disabled: see #45988")
 @pytest.mark.parametrize(("model_id", "prompt_id"), TRACE_CASES)
 def test_run_host_io_decoder_sweep_chunked_trace_world_size_4(model_id: str, prompt_id: str) -> None:
     trace_root = _trace_root()
@@ -314,6 +316,7 @@ def test_run_host_io_decoder_sweep_chunked_trace_world_size_4(model_id: str, pro
     assert exit_code == 0
 
 
+@pytest.mark.skip(reason="Disabled: see #45988")
 @pytest.mark.parametrize(("model_id", "prompt_id"), TRACE_CASES)
 def test_run_host_io_decoder_sweep_chunked_trace_multi_slot_stress(model_id: str, prompt_id: str) -> None:
     trace_root = _trace_root()


### PR DESCRIPTION
Disable 3 tests in `blackhole-post-commit` that fail deterministically due to missing model trace file on CI machines.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py::test_run_host_io_decoder_sweep_chunked_trace_smoke[ds-r1-0528-97854ebb-128k]` | https://github.com/tenstorrent/tt-metal/actions/runs/26901984996/job/79361708858 | [5878367](https://github.com/tenstorrent/tt-metal/commit/58783674297daeef3ea1ac72240ea5c8acf72911) | 2026-06-03 18:39 UTC |
| `models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py::test_run_host_io_decoder_sweep_chunked_trace_world_size_4[ds-r1-0528-97854ebb-128k]` | https://github.com/tenstorrent/tt-metal/actions/runs/26901984996/job/79361708858 | [5878367](https://github.com/tenstorrent/tt-metal/commit/58783674297daeef3ea1ac72240ea5c8acf72911) | 2026-06-03 18:39 UTC |
| `models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py::test_run_host_io_decoder_sweep_chunked_trace_multi_slot_stress[ds-r1-0528-97854ebb-128k]` | https://github.com/tenstorrent/tt-metal/actions/runs/26901984996/job/79361708858 | [5878367](https://github.com/tenstorrent/tt-metal/commit/58783674297daeef3ea1ac72240ea5c8acf72911) | 2026-06-03 18:39 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-post-commit-chunked-trace-2026-06-03)