### PR TITLE
[skip ci] runtime-integration-tests: disable test_indexed_slice D=4 (device hang)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
@@ -30,7 +30,7 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 )
 @pytest.mark.parametrize(
     "D",
-    [4, 16, 1024, 4096],
+    [pytest.param(4, marks=pytest.mark.skip(reason="Disabled: see #45989")), 16, 1024, 4096],
 )
 @pytest.mark.parametrize(
     "tt_dtype",


### PR DESCRIPTION
Disable `test_indexed_slice[DataType.BFLOAT16-4-32-6-0]` (D=4 parametrization) in `runtime-integration-tests` that causes a hardware device hang deterministically across 3+ consecutive main runs.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py::test_indexed_slice[DataType.BFLOAT16-4-32-6-0] [wh_n150_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26868028159/job/79237084600 | [24d9a02](https://github.com/tenstorrent/tt-metal/commit/24d9a02f0d25ae4db9f4c08a87804a7edc5f62b4) | 2026-06-03 07:09 UTC |
| `tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py::test_indexed_slice[DataType.BFLOAT16-4-32-6-0] [bh_p150b_civ2]` | https://github.com/tenstorrent/tt-metal/actions/runs/26868028159/job/79237084610 | [24d9a02](https://github.com/tenstorrent/tt-metal/commit/24d9a02f0d25ae4db9f4c08a87804a7edc5f62b4) | 2026-06-03 07:09 UTC |

### Failure details (still failing on `main` as of 2026-06-08)

`test_indexed_slice[DataType.BFLOAT16-4-32-6-0]` (D=4) hangs the device on both SKUs: NCRISC stuck in `ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_reader.cpp:102`, tripping the 5 s operation/dispatch timeout (`TT_METAL_OPERATION_TIMEOUT_SECONDS=5`) and leaving the device unrecoverable.

Latest failing jobs on `main` (run 27084976012, 2026-06-07): [bh_p150b_civ2](https://github.com/tenstorrent/tt-metal/actions/runs/27084976012/job/79938083215) · [wh_n150_civ2](https://github.com/tenstorrent/tt-metal/actions/runs/27084976012/job/79938083216). Full evidence in #45989.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-integration-tests-indexed-fill-2026-06-03)
