### PR TITLE
[skip ci] blackhole-demo-tests: disable mistral-small-3.1-24b vision pipeline tests

### DIFF
--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
@@ -393,6 +393,7 @@ def validate_e2e_outputs(results, expected_min_tokens=1):
     return True
 
 
+@pytest.mark.skip(reason="Disabled: see #45992")
 @torch.no_grad()
 @run_for_wormhole_b0_or_blackhole()
 @pytest.mark.timeout(1800)

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_vision_model.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_vision_model.py
@@ -26,6 +26,7 @@ def get_image_features(vision_tower, projector, input_tensor, image_sizes):
     return image_features
 
 
+@pytest.mark.skip(reason="Disabled: see #45992")
 @run_for_wormhole_b0_or_blackhole()
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_vision_tower.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_vision_tower.py
@@ -17,6 +17,7 @@ from models.experimental.mistral_24b.tt.pipeline.mistral_vision_tower import Mis
 from models.common.utility_functions import comp_allclose, comp_pcc, run_for_wormhole_b0_or_blackhole
 
 
+@pytest.mark.skip(reason="Disabled: see #45992")
 @run_for_wormhole_b0_or_blackhole()
 @pytest.mark.parametrize(
     "mesh_device",


### PR DESCRIPTION
Disable 3 mistral-small-3.1-24b vision pipeline tests that fail deterministically across 3+ consecutive main runs in `(Blackhole) Demo tests` (bh_loudbox job).

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py::test_e2e_vision_text_pipeline[blackhole-mesh_device0-device_params0-accuracy-8192-1-page_params0-paged_attention-full]` | https://github.com/tenstorrent/tt-metal/actions/runs/26865834917/job/79230013581 | [b7f9f3b](https://github.com/tenstorrent/tt-metal/commit/b7f9f3b5bc0ae4d7680cbf70a70ccd4abb58385a) | 2026-06-03 06:27 UTC |
| `models/experimental/mistral_24b/tests/pipeline_tests/test_vision_model.py::test_mistral_vision_model[blackhole-device_params0-mesh_device0]` | https://github.com/tenstorrent/tt-metal/actions/runs/26865834917/job/79230013581 | [b7f9f3b](https://github.com/tenstorrent/tt-metal/commit/b7f9f3b5bc0ae4d7680cbf70a70ccd4abb58385a) | 2026-06-03 06:27 UTC |
| `models/experimental/mistral_24b/tests/pipeline_tests/test_vision_tower.py::test_mistral_vision_tower[blackhole-device_params0-mesh_device0]` | https://github.com/tenstorrent/tt-metal/actions/runs/26865834917/job/79230013581 | [b7f9f3b](https://github.com/tenstorrent/tt-metal/commit/b7f9f3b5bc0ae4d7680cbf70a70ccd4abb58385a) | 2026-06-03 06:27 UTC |

### Failure details (still failing on `main` as of 2026-06-08)

| Disabled test | Error |
|---|---|
| `test_e2e_vision_text_pipeline[...]` | `IndexError: tuple index out of range` @ `models/tt_transformers/tt/generator.py:317` (`warmup_model_prefill`) |
| `test_mistral_vision_model[...]` | `RuntimeError: Input type (torch.FloatTensor) and weight type (CPUBFloat16Type) should be the same` (torch `conv.py:548`) |
| `test_mistral_vision_tower[...]` | same `RuntimeError` dtype mismatch |

Latest failing jobs on `main`: [2026-06-08](https://github.com/tenstorrent/tt-metal/actions/runs/27117989562/job/80029376389) · [2026-06-07](https://github.com/tenstorrent/tt-metal/actions/runs/27083801540/job/79934672089). Full evidence in #45992.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mistral-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-demo-tests-mistral-2026-06-03)
