### PR TITLE
[Feature] DRAM-core prefetcher: WaitForCq to fence the prefetcher on a CQ

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_dram_core_large.py
@@ -237,6 +237,8 @@ def test_dram_core_prefetcher_BH_param(
 
     # ---- Run: prefetcher (async) -> matmul (consumes via gcb) -> stop drains ----
     ttnn.experimental.start_dram_core_prefetcher(device)
+    # Fence the prefetcher against the weight write so it never reads stale DRAM.
+    ttnn.experimental.wait_for_cq_on_dram_core_prefetcher(device, 0)
     ttnn.experimental.queue_dram_core_prefetcher_request(device, [(tt_weight, ring_size)], global_cb=gcb)
     tt_out = ttnn.linear(
         tt_act,

--- a/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dram_core_prefetcher.hpp
@@ -102,6 +102,24 @@ void QueueDramCorePrefetcherRequest(
     const std::optional<distributed::MeshCoordinateRangeSet>& device_subset,
     const std::vector<DramCorePrefetcherInput>& input_tensors);
 
+// Fence the prefetcher against command queue `cq_id`: every prefetch request queued
+// after this call waits until all work previously enqueued on `cq_id` has completed
+// on device before it reads DRAM. Use this to guarantee that data written over
+// `cq_id` (e.g. the EnqueueWriteBuffer that populates the weights) has landed before
+// the prefetcher streams it.
+//
+// Call this synchronously on the host thread that issued the data writes — after
+// those writes, and before the QueueDramCorePrefetcherRequest that consumes them.
+//
+//   - `cq_id` selects the command queue to fence against.
+//   - `device_subset` defaults to the full mesh when std::nullopt.
+//
+// Preconditions (TT_FATAL): a prefetcher is active on this mesh device.
+void WaitForCqOnDramCorePrefetcher(
+    distributed::MeshDevice& mesh_device,
+    uint8_t cq_id,
+    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset);
+
 // Block until all previously queued requests have been delivered and the
 // kernels have exited, then release the prefetcher's resources. No-op if no
 // prefetcher is active.

--- a/tt_metal/distributed/dummy_mesh_command_queue.cpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.cpp
@@ -85,6 +85,14 @@ void DummyMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& /*sync_event
     // No-op for inactive rank
 }
 
+void DummyMeshCommandQueue::enqueue_write_dram_core_counter(
+    tt::stl::Span<const DeviceMemoryAddress> /*targets*/,
+    uint32_t /*value*/,
+    bool /*blocking*/,
+    tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
+    // No-op for inactive rank: no local device to signal.
+}
+
 void DummyMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> /*sub_device_ids*/) {
     // No-op for inactive rank
 }

--- a/tt_metal/distributed/dummy_mesh_command_queue.hpp
+++ b/tt_metal/distributed/dummy_mesh_command_queue.hpp
@@ -52,6 +52,11 @@ public:
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
     void enqueue_wait_for_event(const MeshEvent& sync_event) override;
+    void enqueue_write_dram_core_counter(
+        tt::stl::Span<const DeviceMemoryAddress> targets,
+        uint32_t value,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void reset_worker_state(
         bool reset_launch_msg_state,

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -526,9 +526,6 @@ void FDMeshCommandQueue::enqueue_write_dram_core_counter(
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
 
-    // Copied inline into the command region by write_to_core before it returns, so
-    // a local is sufficient.
-    uint32_t v = value;
     for (const auto& target : targets) {
         if (!mesh_device_->impl().is_local(target.device_coord)) {
             continue;
@@ -536,13 +533,14 @@ void FDMeshCommandQueue::enqueue_write_dram_core_counter(
         IDevice* device = mesh_device_->impl().get_device(target.device_coord);
         // target.address is the full device destination (the caller pre-applies the
         // DRAM L1 NOC offset). Use the unchecked write: the DRAM-banked bounds check
-        // in write_to_core rejects programmable DRAM-core (DRISC) L1.
+        // in write_to_core rejects programmable DRAM-core (DRISC) L1. `value` is copied
+        // inline into the command region by write_to_core_unchecked before it returns.
         device_dispatch::write_to_core_unchecked(
             device,
             target.virtual_core_coord,
-            &v,
+            &value,
             target.address,
-            sizeof(v),
+            sizeof(value),
             id_,
             expected_num_workers_completed_,
             sub_device_ids);

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -512,7 +512,9 @@ void FDMeshCommandQueue::enqueue_write_dram_core_counter(
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     ZoneScoped;
 
-    auto lock = lock_api_function_();
+    // No lock_api_function_() here: the caller (DramCorePrefetcherManager) already holds
+    // the MeshDevice api lock across the counter bump + WAIT_CQ enqueue, and that lock is
+    // non-recursive, so re-locking would self-deadlock. See the declaration's contract.
 
     if (this->get_target_device_type() == tt::TargetDevice::Mock ||
         this->get_target_device_type() == tt::TargetDevice::Emule) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -505,6 +505,52 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     }
 }
 
+void FDMeshCommandQueue::enqueue_write_dram_core_counter(
+    tt::stl::Span<const DeviceMemoryAddress> targets,
+    uint32_t value,
+    bool blocking,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    ZoneScoped;
+
+    auto lock = lock_api_function_();
+
+    if (this->get_target_device_type() == tt::TargetDevice::Mock ||
+        this->get_target_device_type() == tt::TargetDevice::Emule) {
+        return;
+    }
+
+    in_use_ = true;
+    TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
+
+    sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
+
+    // Copied inline into the command region by write_to_core before it returns, so
+    // a local is sufficient.
+    uint32_t v = value;
+    for (const auto& target : targets) {
+        if (!mesh_device_->impl().is_local(target.device_coord)) {
+            continue;
+        }
+        IDevice* device = mesh_device_->impl().get_device(target.device_coord);
+        // target.address is the full device destination (the caller pre-applies the
+        // DRAM L1 NOC offset). Use the unchecked write: the DRAM-banked bounds check
+        // in write_to_core rejects programmable DRAM-core (DRISC) L1.
+        device_dispatch::write_to_core_unchecked(
+            device,
+            target.virtual_core_coord,
+            &v,
+            target.address,
+            sizeof(v),
+            id_,
+            expected_num_workers_completed_,
+            sub_device_ids);
+    }
+
+    if (blocking) {
+        this->finish_nolock(sub_device_ids);
+    }
+}
+
 void FDMeshCommandQueue::enqueue_read_shard_from_core(
     DeviceMemoryAddress address,
     void* dst,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -33,12 +33,6 @@ struct MeshCoreDataReadDescriptor;
 using MeshCompletionReaderVariant =
     std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor, MeshCoreDataReadDescriptor>;
 
-struct DeviceMemoryAddress {
-    MeshCoordinate device_coord;
-    CoreCoord virtual_core_coord;
-    DeviceAddr address{};
-};
-
 class FDMeshCommandQueue final : public MeshCommandQueueBase {
 private:
     // This class can now access private members of FDMeshCommandQueue
@@ -237,6 +231,11 @@ public:
         uint32_t size_bytes,
         bool blocking,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+    void enqueue_write_dram_core_counter(
+        tt::stl::Span<const DeviceMemoryAddress> targets,
+        uint32_t value,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
 
     MeshEvent enqueue_record_event(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -138,10 +138,12 @@ public:
 
     // Write `value` (a uint32 counter) to one L1 address on each of `targets`,
     // ordered after prior worker programs / buffer writes on this queue. Each
-    // target's `address` is the FULL device destination (callers writing to DRAM
-    // programmable-core L1 must pre-apply the DRAM L1 NOC offset). Used by the
-    // DRAM-core prefetcher's WaitForCq command. Fast/slow dispatch perform the
-    // write; the dummy (inactive-rank) queue is a no-op.
+    // target's `address` is the full device destination. Must be called with the
+    // MeshDevice api lock already held — unlike the other queue APIs this does NOT
+    // re-lock, so the caller can keep the lock across the surrounding sequence (the
+    // DRAM-core prefetcher's WaitForCq needs the counter bump and the WAIT_CQ enqueue
+    // to be atomic). Fast/slow dispatch perform the write; the dummy (inactive-rank)
+    // queue is a no-op.
     virtual void enqueue_write_dram_core_counter(
         tt::stl::Span<const DeviceMemoryAddress> targets,
         uint32_t value,

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -11,10 +11,20 @@
 #include "tt_metal/impl/threading/thread_pool.hpp"
 #include "tt_target_device.hpp"
 
+#include <tt_stl/assert.hpp>
+
 #include <mutex>
 #include <functional>
 
 namespace tt::tt_metal::distributed {
+
+// Identifies one L1 location on one device of the mesh: (mesh coord, virtual
+// core, device address). Used by per-core enqueue APIs.
+struct DeviceMemoryAddress {
+    MeshCoordinate device_coord;
+    CoreCoord virtual_core_coord;
+    DeviceAddr address{};
+};
 
 class MeshCommandQueueBase : public MeshCommandQueue {
 protected:
@@ -125,6 +135,18 @@ public:
 
     // Returns true if the CQ is in use (has had commands enqueued).
     virtual bool in_use() { return false; }
+
+    // Write `value` (a uint32 counter) to one L1 address on each of `targets`,
+    // ordered after prior worker programs / buffer writes on this queue. Each
+    // target's `address` is the FULL device destination (callers writing to DRAM
+    // programmable-core L1 must pre-apply the DRAM L1 NOC offset). Used by the
+    // DRAM-core prefetcher's WaitForCq command. Fast/slow dispatch perform the
+    // write; the dummy (inactive-rank) queue is a no-op.
+    virtual void enqueue_write_dram_core_counter(
+        tt::stl::Span<const DeviceMemoryAddress> targets,
+        uint32_t value,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -770,6 +770,20 @@ MeshCommandQueue& MeshDeviceImpl::mesh_command_queue(std::optional<uint8_t> cq_i
     return *command_queue;
 }
 
+MeshCommandQueueBase& MeshDeviceImpl::mesh_command_queue_base(std::optional<uint8_t> cq_id) const {
+    auto id = cq_id.value_or(GetCurrentCommandQueueIdForThread());
+
+    // If the mesh device has no local devices, return the dummy mesh command queue.
+    if (this->get_view().get_devices().empty()) {
+        return *mesh_command_queues_[0];
+    }
+
+    TT_FATAL(id < mesh_command_queues_.size(), "cq_id {} is out of range", id);
+    const auto& command_queue = mesh_command_queues_[id];
+    TT_FATAL(id == command_queue->id(), "MeshCommandQueue id mismatch, expected {}, got {}", id, command_queue->id());
+    return *command_queue;
+}
+
 DeviceIds MeshDeviceImpl::get_device_ids() const {
     DeviceIds device_ids;
     for (auto* device : this->get_devices()) {

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -428,6 +428,11 @@ public:
     // If cq_id is not provided, the current command queue is returned from the current thread
     MeshCommandQueue& mesh_command_queue(std::optional<uint8_t> cq_id = std::nullopt) const;
 
+    // Same queue as mesh_command_queue() but returned as the internal
+    // MeshCommandQueueBase, exposing dispatch-implementation methods (e.g.
+    // enqueue_write_dram_core_counter) without a downcast.
+    MeshCommandQueueBase& mesh_command_queue_base(std::optional<uint8_t> cq_id = std::nullopt) const;
+
     // Currently expose users to the dispatch thread pool through the MeshDevice
     void enqueue_to_thread_pool(std::function<void()>&& f);
     void wait_for_thread_pool();

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -313,7 +313,9 @@ void SDMeshCommandQueue::enqueue_write_dram_core_counter(
     if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
-    auto lock = lock_api_function_();
+    // No lock_api_function_() here: the caller (DramCorePrefetcherManager) already holds
+    // the MeshDevice api lock across the counter bump + WAIT_CQ enqueue, and that lock is
+    // non-recursive, so re-locking would self-deadlock. See the declaration's contract.
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
 
     // Slow-dispatch analog of the fast-dispatch leading dispatch wait: ensure any

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -305,6 +305,36 @@ void SDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent&) {
     wait_for_cores_idle();
 }
 
+void SDMeshCommandQueue::enqueue_write_dram_core_counter(
+    tt::stl::Span<const DeviceMemoryAddress> targets,
+    uint32_t value,
+    bool /*blocking*/,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    if (this->get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+    auto lock = lock_api_function_();
+    TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
+
+    // Slow-dispatch analog of the fast-dispatch leading dispatch wait: ensure any
+    // prior program touching this address space (and prior synchronous buffer
+    // writes) is complete before the counter is bumped.
+    wait_for_cores_idle();
+
+    uint32_t v = value;
+    for (const auto& target : targets) {
+        if (!mesh_device_->impl().is_local(target.device_coord)) {
+            continue;
+        }
+        IDevice* device = mesh_device_->impl().get_device(target.device_coord);
+        // target.address is the full device destination (caller pre-applies the
+        // DRAM L1 NOC offset). write_core is synchronous, so `blocking` is moot.
+        tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
+            .get_cluster()
+            .write_core(&v, sizeof(v), tt_cxy_pair(device->id(), target.virtual_core_coord), target.address);
+    }
+}
+
 void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
     if (this->get_target_device_type() == tt::TargetDevice::Mock) {
         return;

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -323,7 +323,6 @@ void SDMeshCommandQueue::enqueue_write_dram_core_counter(
     // writes) is complete before the counter is bumped.
     wait_for_cores_idle();
 
-    uint32_t v = value;
     for (const auto& target : targets) {
         if (!mesh_device_->impl().is_local(target.device_coord)) {
             continue;
@@ -333,7 +332,7 @@ void SDMeshCommandQueue::enqueue_write_dram_core_counter(
         // DRAM L1 NOC offset). write_core is synchronous, so `blocking` is moot.
         tt::tt_metal::MetalContext::instance(mesh_device_->impl().get_context_id())
             .get_cluster()
-            .write_core(&v, sizeof(v), tt_cxy_pair(device->id(), target.virtual_core_coord), target.address);
+            .write_core(&value, sizeof(value), tt_cxy_pair(device->id(), target.virtual_core_coord), target.address);
     }
 }
 

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -59,6 +59,11 @@ public:
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
     void enqueue_wait_for_event(const MeshEvent& sync_event) override;
+    void enqueue_write_dram_core_counter(
+        tt::stl::Span<const DeviceMemoryAddress> targets,
+        uint32_t value,
+        bool blocking,
+        tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void reset_worker_state(
         bool reset_launch_msg_state,

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -493,62 +493,64 @@ void DramCorePrefetcherManager::queue(
 
 void DramCorePrefetcherManager::enqueue_cq_signal_and_wait(
     uint8_t cq_id, const std::optional<MeshCoordinateRangeSet>& device_subset) {
-    uint32_t signal_value = 0;
+    // Hold the API lock across this whole call. Three things must be atomic together:
+    //   1. the counter bump (++cq_signal_counter_[cq_id]),
+    //   2. the dispatcher write that pushes that value to the device, and
+    //   3. the WAIT_CQ enqueue into pending_.
+    // If the lock were dropped between them, two concurrent callers could interleave their
+    // dispatcher writes out of counter order, and stop() could slip its STOP sentinel into
+    // pending_ ahead of this WAIT_CQ request — worker_loop would then try_write() the
+    // WAIT_CQ to a kernel that has already exited and spin forever (try_write has no
+    // stop_requested_ check). queue() and stop() take the lock the same way, so all three
+    // serialize. enqueue_write_dram_core_counter is documented to run under the caller's
+    // api lock and does NOT re-lock, so holding it here does not self-deadlock.
+    auto lock = lock_api_function_();
+    TT_FATAL(active_, "WaitForCqOnDramCorePrefetcher called before StartDramCorePrefetcher");
+    TT_FATAL(
+        cq_id < cq_signal_counter_.size(),
+        "WaitForCqOnDramCorePrefetcher cq_id ({}) out of range [0, {})",
+        cq_id,
+        cq_signal_counter_.size());
+
+    // Monotonic value for this signal; wrap is handled by the kernel's signed compare.
+    const uint32_t signal_value = ++cq_signal_counter_[cq_id];
+
+    // Resolve target device coords (subset if given, else full mesh).
     std::vector<MeshCoordinate> target_devices;
+    MeshCoordinateRangeSet effective_subset = device_subset.has_value() ? *device_subset : full_mesh_subset();
+    for (const auto& range : effective_subset.ranges()) {
+        for (const auto& coord : range) {
+            TT_FATAL(
+                device_index_by_coord_.find(coord) != device_index_by_coord_.end(),
+                "WaitForCqOnDramCorePrefetcher target MeshCoordinate {} is not in the mesh this prefetcher was "
+                "started on",
+                coord);
+            target_devices.push_back(coord);
+        }
+    }
+
+    // Destination of the dispatcher write: the full device address (the kernel's
+    // local slot base plus the programmable-DRAM-core L1 NOC offset), so the
+    // dispatcher must NOT apply a bank offset.
+    const uint64_t dram_l1_noc_offset = MetalContext::instance(mesh_device_->impl().get_context_id())
+                                            .hal()
+                                            .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
+    const uint64_t slot_addr = static_cast<uint64_t>(cq_signal_l1_addr_) +
+                               static_cast<uint64_t>(cq_id) * sizeof(uint32_t) + dram_l1_noc_offset;
+
     std::vector<DeviceMemoryAddress> targets;
-    {
-        // Hold the API lock only for the manager-state snapshot below, then release it
-        // before the dispatcher write. enqueue_write_dram_core_counter takes this same
-        // (non-recursive) api lock itself, so holding it across that call would
-        // self-deadlock; this mirrors the rest of the codebase, which never holds the
-        // api lock while delegating to a command-queue method that re-locks it. Once the
-        // snapshot is captured (target_devices, targets are self-contained value types),
-        // nothing below reads mutable manager state.
-        auto lock = lock_api_function_();
-        TT_FATAL(active_, "WaitForCqOnDramCorePrefetcher called before StartDramCorePrefetcher");
-        TT_FATAL(
-            cq_id < cq_signal_counter_.size(),
-            "WaitForCqOnDramCorePrefetcher cq_id ({}) out of range [0, {})",
-            cq_id,
-            cq_signal_counter_.size());
-
-        // Monotonic value for this signal; wrap is handled by the kernel's signed compare.
-        signal_value = ++cq_signal_counter_[cq_id];
-
-        // Resolve target device coords (subset if given, else full mesh).
-        MeshCoordinateRangeSet effective_subset = device_subset.has_value() ? *device_subset : full_mesh_subset();
-        for (const auto& range : effective_subset.ranges()) {
-            for (const auto& coord : range) {
-                TT_FATAL(
-                    device_index_by_coord_.find(coord) != device_index_by_coord_.end(),
-                    "WaitForCqOnDramCorePrefetcher target MeshCoordinate {} is not in the mesh this prefetcher was "
-                    "started on",
-                    coord);
-                target_devices.push_back(coord);
-            }
+    targets.reserve(target_devices.size() * num_senders_);
+    for (const auto& coord : target_devices) {
+        IDevice* device = devices_[device_index_by_coord_.at(coord)];
+        for (uint32_t s = 0; s < num_senders_; ++s) {
+            const CoreCoord virtual_core =
+                device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
+            targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
         }
+    }
 
-        // Destination of the dispatcher write: the full device address (the kernel's
-        // local slot base plus the programmable-DRAM-core L1 NOC offset), so the
-        // dispatcher must NOT apply a bank offset.
-        const uint64_t dram_l1_noc_offset = MetalContext::instance(mesh_device_->impl().get_context_id())
-                                                .hal()
-                                                .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
-        const uint64_t slot_addr = static_cast<uint64_t>(cq_signal_l1_addr_) +
-                                   static_cast<uint64_t>(cq_id) * sizeof(uint32_t) + dram_l1_noc_offset;
-
-        targets.reserve(target_devices.size() * num_senders_);
-        for (const auto& coord : target_devices) {
-            IDevice* device = devices_[device_index_by_coord_.at(coord)];
-            for (uint32_t s = 0; s < num_senders_; ++s) {
-                const CoreCoord virtual_core =
-                    device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
-                targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
-            }
-        }
-    }  // release the api lock before entering the command-queue path (it re-locks it)
-
-    // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ.
+    // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ. Runs
+    // under the api lock we already hold (the method does not re-lock).
     mesh_device_->impl().mesh_command_queue_base(cq_id).enqueue_write_dram_core_counter(
         tt::stl::Span<const DeviceMemoryAddress>(targets), signal_value, /*blocking=*/false);
 

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -5,6 +5,7 @@
 #include "impl/buffers/dram_core_prefetcher_manager.hpp"
 
 #include "distributed/mesh_device_impl.hpp"
+#include "distributed/mesh_command_queue_base.hpp"
 #include "impl/buffers/drisc_l1_arena.hpp"
 #include "impl/buffers/h2d_socket_internal.hpp"
 
@@ -236,6 +237,7 @@ void DramCorePrefetcherManager::build_and_launch_programs(uint32_t stage_ring_ba
                 stage_ring_size,
                 kRemoteCBId,
                 socket_page_size,
+                cq_signal_l1_addr_,
             };
 
             KernelHandle kernel_id = CreateKernel(
@@ -288,7 +290,12 @@ void DramCorePrefetcherManager::start(const experimental::DramCorePrefetcherConf
     const uint32_t socket_config_bytes = align_up(sizeof(receiver_socket_md), pcie_alignment_for_layout);
     const uint32_t socket_data_bytes = socket_fifo_size_for_layout + pcie_alignment_for_layout;
     const uint32_t kernel_region_base = static_cast<uint32_t>(arena.kernel_working_region_base());
-    socket_config_l1_addr_ = align_up(kernel_region_base, pcie_alignment_for_layout);
+    // Per-CQ signal slots at the front of the region: a small uint32 counter per
+    // command queue, written by the dispatcher for WaitForCqOnDramCorePrefetcher
+    // and polled by the kernel's WAIT_CQ handler.
+    const uint32_t cq_signal_bytes = align_up(kNumCqSignalSlots * sizeof(uint32_t), l1_alignment);
+    cq_signal_l1_addr_ = align_up(kernel_region_base, l1_alignment);
+    socket_config_l1_addr_ = align_up(cq_signal_l1_addr_ + cq_signal_bytes, pcie_alignment_for_layout);
     socket_data_l1_addr_ = align_up(socket_config_l1_addr_ + socket_config_bytes, pcie_alignment_for_layout);
     stage_ring_base_ = align_up(socket_data_l1_addr_ + socket_data_bytes, l1_alignment);
     const uint32_t kernel_region_end = kernel_region_base + kernel_region_size;
@@ -379,9 +386,10 @@ std::vector<std::vector<uint8_t>> DramCorePrefetcherManager::serialize_request_p
     };
     auto finalize_page = [&]() {
         auto* header = reinterpret_cast<DramCorePrefetcherRequestHeader*>(page.data());
-        header->num_entries = num_entries;
-        header->num_layouts = num_layouts;
-        header->gcb_state_addr = gcb_state_addr;
+        header->base.cmd_id = DRAM_PREFETCHER_CMD_PREFETCH;
+        header->prefetch.num_entries = static_cast<uint16_t>(num_entries);
+        header->prefetch.num_layouts = num_layouts;
+        header->prefetch.gcb_state_addr = gcb_state_addr;
         pages.push_back(std::move(page));
     };
 
@@ -483,6 +491,88 @@ void DramCorePrefetcherManager::queue(
     queue_cv_.notify_one();
 }
 
+void DramCorePrefetcherManager::enqueue_cq_signal_and_wait(
+    uint8_t cq_id, const std::optional<MeshCoordinateRangeSet>& device_subset) {
+    uint32_t signal_value = 0;
+    std::vector<MeshCoordinate> target_devices;
+    std::vector<DeviceMemoryAddress> targets;
+    {
+        // Hold the API lock only for the manager-state snapshot below, then release it
+        // before the dispatcher write. enqueue_write_dram_core_counter takes this same
+        // (non-recursive) api lock itself, so holding it across that call would
+        // self-deadlock; this mirrors the rest of the codebase, which never holds the
+        // api lock while delegating to a command-queue method that re-locks it. Once the
+        // snapshot is captured (target_devices, targets are self-contained value types),
+        // nothing below reads mutable manager state.
+        auto lock = lock_api_function_();
+        TT_FATAL(active_, "WaitForCqOnDramCorePrefetcher called before StartDramCorePrefetcher");
+        TT_FATAL(
+            cq_id < cq_signal_counter_.size(),
+            "WaitForCqOnDramCorePrefetcher cq_id ({}) out of range [0, {})",
+            cq_id,
+            cq_signal_counter_.size());
+
+        // Monotonic value for this signal; wrap is handled by the kernel's signed compare.
+        signal_value = ++cq_signal_counter_[cq_id];
+
+        // Resolve target device coords (subset if given, else full mesh).
+        MeshCoordinateRangeSet effective_subset = device_subset.has_value() ? *device_subset : full_mesh_subset();
+        for (const auto& range : effective_subset.ranges()) {
+            for (const auto& coord : range) {
+                TT_FATAL(
+                    device_index_by_coord_.find(coord) != device_index_by_coord_.end(),
+                    "WaitForCqOnDramCorePrefetcher target MeshCoordinate {} is not in the mesh this prefetcher was "
+                    "started on",
+                    coord);
+                target_devices.push_back(coord);
+            }
+        }
+
+        // Destination of the dispatcher write: the full device address (the kernel's
+        // local slot base plus the programmable-DRAM-core L1 NOC offset), so the
+        // dispatcher must NOT apply a bank offset.
+        const uint64_t dram_l1_noc_offset = MetalContext::instance(mesh_device_->impl().get_context_id())
+                                                .hal()
+                                                .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
+        const uint64_t slot_addr = static_cast<uint64_t>(cq_signal_l1_addr_) +
+                                   static_cast<uint64_t>(cq_id) * sizeof(uint32_t) + dram_l1_noc_offset;
+
+        targets.reserve(target_devices.size() * num_senders_);
+        for (const auto& coord : target_devices) {
+            IDevice* device = devices_[device_index_by_coord_.at(coord)];
+            for (uint32_t s = 0; s < num_senders_; ++s) {
+                const CoreCoord virtual_core =
+                    device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
+                targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
+            }
+        }
+    }  // release the api lock before entering the command-queue path (it re-locks it)
+
+    // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ.
+    mesh_device_->impl().mesh_command_queue_base(cq_id).enqueue_write_dram_core_counter(
+        tt::stl::Span<const DeviceMemoryAddress>(targets), signal_value, /*blocking=*/false);
+
+    // (b) Queue a WAIT_CQ request. It rides the same async worker path as prefetch
+    // requests, so it lands in each socket's FIFO ahead of the next prefetch request;
+    // the kernel blocks on it until it observes signal_value.
+    const uint32_t pcie_alignment =
+        MetalContext::instance(mesh_device_->impl().get_context_id()).hal().get_alignment(HalMemType::HOST);
+    const uint32_t page_bytes = align_up(kRequestPageBytes, pcie_alignment);
+    Request req;
+    req.page.assign(page_bytes, 0);
+    auto* header = reinterpret_cast<DramCorePrefetcherRequestHeader*>(req.page.data());
+    header->base.cmd_id = DRAM_PREFETCHER_CMD_WAIT_CQ;
+    header->wait_cq.cq_index = cq_id;
+    header->wait_cq.cq_wait_value = signal_value;
+    req.target_devices = std::move(target_devices);
+
+    {
+        std::lock_guard<std::mutex> lk(queue_mu_);
+        pending_.push_back(std::move(req));
+    }
+    queue_cv_.notify_one();
+}
+
 void DramCorePrefetcherManager::worker_loop() {
     while (true) {
         Request req;
@@ -544,9 +634,10 @@ void DramCorePrefetcherManager::stop() {
     if (!active_) {
         return;
     }
-    // Stop = a zero-filled page (num_entries == 0) broadcast to every device in
-    // the mesh. The kernel exits its request loop on `num_entries == 0`. The
-    // worker_loop returns once pending is drained and stop_requested_ is set.
+    // Stop = a zero-filled page broadcast to every device in the mesh. The leading
+    // command id byte is 0 == DRAM_PREFETCHER_CMD_STOP, so the kernel exits its
+    // request loop on it. The worker_loop returns once pending is drained and
+    // stop_requested_ is set.
     Request sentinel;
     const uint32_t pcie_alignment =
         MetalContext::instance(mesh_device_->impl().get_context_id()).hal().get_alignment(HalMemType::HOST);
@@ -608,6 +699,14 @@ void QueueDramCorePrefetcherRequest(
     const std::vector<DramCorePrefetcherInput>& input_tensors) {
     auto& manager = mesh_device.impl().dram_core_prefetcher(&mesh_device);
     manager.queue(gcb, device_subset, input_tensors);
+}
+
+void WaitForCqOnDramCorePrefetcher(
+    distributed::MeshDevice& mesh_device,
+    uint8_t cq_id,
+    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset) {
+    auto& manager = mesh_device.impl().dram_core_prefetcher(&mesh_device);
+    manager.enqueue_cq_signal_and_wait(cq_id, device_subset);
 }
 
 void StopDramCorePrefetcher(distributed::MeshDevice& mesh_device) {

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -517,7 +517,7 @@ void DramCorePrefetcherManager::enqueue_cq_signal_and_wait(
 
     // Resolve target device coords (subset if given, else full mesh).
     std::vector<MeshCoordinate> target_devices;
-    MeshCoordinateRangeSet effective_subset = device_subset.has_value() ? *device_subset : full_mesh_subset();
+    const MeshCoordinateRangeSet effective_subset = device_subset.has_value() ? *device_subset : full_mesh_subset();
     for (const auto& range : effective_subset.ranges()) {
         for (const auto& coord : range) {
             TT_FATAL(

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.cpp
@@ -521,7 +521,7 @@ void DramCorePrefetcherManager::enqueue_cq_signal_and_wait(
     for (const auto& range : effective_subset.ranges()) {
         for (const auto& coord : range) {
             TT_FATAL(
-                device_index_by_coord_.find(coord) != device_index_by_coord_.end(),
+                device_index_by_coord_.contains(coord),
                 "WaitForCqOnDramCorePrefetcher target MeshCoordinate {} is not in the mesh this prefetcher was "
                 "started on",
                 coord);

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
@@ -143,7 +143,7 @@ private:
     // Host-side monotonic signal counter per command queue. enqueue_cq_signal_and_wait
     // pre-increments cq_signal_counter_[cq_id] and uses it for both the dispatcher
     // write and the WAIT_CQ request value.
-    std::array<uint32_t, 2> cq_signal_counter_{};
+    std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
     // sender_logical_cores_[s] = logical DRAM core for bank s. Picked at start
     // via pick_unused_dram_logical_core(s); GCBs queued must use the same

--- a/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_manager.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
@@ -64,7 +65,9 @@ public:
     // `lock_api_function` grabs the owning MeshDevice's api_mutex_ (bound from
     // MeshDeviceImpl::lock_api). start()/queue()/stop() take it for the duration
     // of the call so prefetcher operations serialize against the rest of the
-    // device API, mirroring MeshCommandQueueBase.
+    // device API, mirroring MeshCommandQueueBase. enqueue_cq_signal_and_wait() also
+    // takes it, but only around its manager-state snapshot — it must release the lock
+    // before the dispatcher write, which re-locks the same (non-recursive) api_mutex_.
     DramCorePrefetcherManager(MeshDevice* mesh_device, std::function<std::lock_guard<std::mutex>()> lock_api_function);
     ~DramCorePrefetcherManager();
 
@@ -79,6 +82,15 @@ public:
         const experimental::GlobalCircularBuffer& gcb,
         const std::optional<MeshCoordinateRangeSet>& device_subset,
         const std::vector<experimental::DramCorePrefetcherInput>& tensors);
+
+    // Make the prefetcher wait until all work currently enqueued on command queue
+    // `cq_id` has landed before it reads DRAM. Bumps a host-side per-CQ counter,
+    // has the dispatcher write the new value into every DRAM core's signal slot
+    // (ordered after prior CQ work), and queues a WAIT_CQ request so each kernel
+    // blocks until that value is observed. Must be called synchronously on the
+    // host thread that enqueues the data writes (after them, before the dependent
+    // prefetch request).
+    void enqueue_cq_signal_and_wait(uint8_t cq_id, const std::optional<MeshCoordinateRangeSet>& device_subset);
 
     void stop();
 
@@ -125,6 +137,13 @@ private:
     // over NOC.
     uint32_t socket_config_l1_addr_ = 0;
     uint32_t socket_data_l1_addr_ = 0;
+    // Base (local DRISC L1) of this prefetcher's per-CQ signal slots; uniform
+    // across all sender cores. Carved at the front of the kernel working region.
+    uint32_t cq_signal_l1_addr_ = 0;
+    // Host-side monotonic signal counter per command queue. enqueue_cq_signal_and_wait
+    // pre-increments cq_signal_counter_[cq_id] and uses it for both the dispatcher
+    // write and the WAIT_CQ request value.
+    std::array<uint32_t, 2> cq_signal_counter_{};
 
     // sender_logical_cores_[s] = logical DRAM core for bank s. Picked at start
     // via pick_unused_dram_logical_core(s); GCBs queued must use the same

--- a/tt_metal/impl/buffers/dram_core_prefetcher_request.hpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_request.hpp
@@ -122,7 +122,15 @@ struct DramCorePrefetcherRequestHeader {
         DramCorePrefetcherPrefetchCmd prefetch;
         DramCorePrefetcherWaitCqCmd wait_cq;
     } __attribute__((packed));
-};
+} __attribute__((packed));
+
+// The host fills this header and the kernel parses it field-by-field, so its layout is a
+// host↔kernel wire contract. Pin the size (and pack the struct above) so a difference in
+// padding/alignment between host and JIT compiler settings can't silently shift cmd_id,
+// the payload union, or the layout-table offsets.
+static_assert(
+    sizeof(DramCorePrefetcherRequestHeader) == 12,
+    "DramCorePrefetcherRequestHeader must be 12 bytes (host↔kernel wire contract)");
 
 // A single tensor must fit in an otherwise-empty PREFETCH page (header + one layout + one entry).
 static_assert(

--- a/tt_metal/impl/buffers/dram_core_prefetcher_request.hpp
+++ b/tt_metal/impl/buffers/dram_core_prefetcher_request.hpp
@@ -7,7 +7,18 @@
 // out of its H2D socket page via the same structs). Keep all structs packed so the
 // L1 byte layout matches on both sides.
 //
-// One request page is a fixed kRequestPageBytes payload region whose two halves grow
+// Every page starts with a DramCorePrefetcherRequestHeader: a one-byte command id
+// (DramCorePrefetcherBaseCmd) followed by a union of the per-command payloads,
+// modeled on the dispatch CQPrefetchCmd / CQDispatchCmd encoding in
+// tt_metal/impl/dispatch/kernels/cq_commands.hpp. The three commands are:
+//   * STOP      — no payload; the kernel exits its request loop. STOP == 0, so an
+//                 all-zero page is a valid stop sentinel.
+//   * PREFETCH  — the rest of the page holds the entry + layout tables described
+//                 below; the kernel streams those tensors into the target GCB.
+//   * WAIT_CQ   — no tables; the kernel spins until its per-CQ signal slot
+//                 [wait_cq.cq_index] reaches wait_cq.cq_wait_value (wrap-safe).
+//
+// For a PREFETCH page the payload region (kRequestPageBytes) has two halves that grow
 // toward each other:
 //
 //   [Header][Entry 0][Entry 1] ... [Entry K-1]  ... free ...  [Layout L-1] ... [Layout 0]
@@ -22,13 +33,13 @@
 //   at byte offset kRequestPageBytes - (i + 1) * sizeof(DramCorePrefetcherTensorLayout)
 //   (i.e. layout 0 is flush against the end of the payload).
 //
-// The kernel walks the entries in order; for each it reads the address from the entry
-// and the geometry from the referenced layout, then runs the per-tensor chunk loop. A
-// header with num_entries == 0 is the stop sentinel.
+// The kernel walks header.prefetch.num_entries entries in order; for each it reads the
+// address from the entry and the geometry from the referenced layout, then runs the
+// per-tensor chunk loop.
 //
 // When one Queue call has more tensors than fit in a single page, the host emits
-// multiple pages (each an independent request); the per-GCB fifo_wr_ptr persists in the
-// sender state block across requests, so the page split is invisible to the receiver.
+// multiple PREFETCH pages (each an independent request); the per-GCB fifo_wr_ptr persists
+// in the sender state block across requests, so the page split is invisible to the receiver.
 
 #pragma once
 
@@ -42,6 +53,11 @@ namespace tt::tt_metal {
 // Larger packs more tensors per page but grows the per-socket DRISC L1 FIFO by
 // kSocketFifoPages × this.
 inline constexpr uint32_t kRequestPageBytes = 1024;
+
+// Number of per-DRAM-core CQ signal slots (one uint32 counter per command queue).
+// WaitForCqOnDramCorePrefetcher writes an incrementing value into slot[cq_id] via
+// the dispatcher; a WAIT_CQ request makes the kernel spin until it is reached.
+constexpr uint32_t kNumCqSignalSlots = 2;
 
 // Address-independent per-tensor geometry handed to the DRAM-core prefetcher kernel.
 // All values are derived from the tensor shape + dtype + GCB ring topology + DRISC L1
@@ -71,14 +87,44 @@ struct DramCorePrefetcherEntry {
     uint32_t layout_index = 0;     // index into the page's DramCorePrefetcherTensorLayout table
 } __attribute__((packed));
 
-// Header at the start of each request page.
-struct DramCorePrefetcherRequestHeader {
-    uint32_t num_entries = 0;     // number of valid DramCorePrefetcherEntry entries; 0 = stop sentinel
-    uint32_t num_layouts = 0;     // number of valid DramCorePrefetcherTensorLayout table entries
-    uint32_t gcb_state_addr = 0;  // DRISC L1 base of the target GCB's sender state block
+// One-byte command id at the front of every request page.
+enum DramCorePrefetcherCmdId : uint8_t {
+    DRAM_PREFETCHER_CMD_STOP = 0,      // exit the request loop (no payload; all-zero page)
+    DRAM_PREFETCHER_CMD_PREFETCH = 1,  // entry + layout tables follow the header
+    DRAM_PREFETCHER_CMD_WAIT_CQ = 2,   // spin until cq slot[cq_index] >= cq_wait_value
+};
+
+struct DramCorePrefetcherBaseCmd {
+    DramCorePrefetcherCmdId cmd_id;  // 1 byte
 } __attribute__((packed));
 
-// A single tensor must fit in an otherwise-empty page (header + one layout + one entry).
+// PREFETCH payload. The leading pad keeps the 32-bit fields 4-byte aligned past the
+// one-byte base (mirrors the pad fields in cq_commands.hpp commands); the resulting
+// 12-byte header then keeps the entry table 4-byte aligned.
+struct DramCorePrefetcherPrefetchCmd {
+    uint8_t pad1;
+    uint16_t num_entries;     // number of valid DramCorePrefetcherEntry entries
+    uint32_t num_layouts;     // number of valid DramCorePrefetcherTensorLayout table entries
+    uint32_t gcb_state_addr;  // DRISC L1 base of the target GCB's sender state block
+} __attribute__((packed));
+
+// WAIT_CQ payload.
+struct DramCorePrefetcherWaitCqCmd {
+    uint8_t cq_index;  // which per-core CQ signal slot to wait on (0/1)
+    uint16_t pad1;
+    uint32_t cq_wait_value;  // wait until slot >= this value (wrap-safe int32 compare)
+} __attribute__((packed));
+
+// Header at the start of each request page: command id + per-command payload union.
+struct DramCorePrefetcherRequestHeader {
+    DramCorePrefetcherBaseCmd base;
+    union {
+        DramCorePrefetcherPrefetchCmd prefetch;
+        DramCorePrefetcherWaitCqCmd wait_cq;
+    } __attribute__((packed));
+};
+
+// A single tensor must fit in an otherwise-empty PREFETCH page (header + one layout + one entry).
 static_assert(
     sizeof(DramCorePrefetcherRequestHeader) + sizeof(DramCorePrefetcherTensorLayout) +
             sizeof(DramCorePrefetcherEntry) <=

--- a/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/dram_core_prefetcher.cpp
@@ -11,13 +11,14 @@
 // fifo_wr_ptr back to L1 so the next request to the same GCB resumes from the right
 // ring offset, and acks the socket page.
 //
-// Request page wire format (one socket page): a DramCorePrefetcherRequestHeader, then
-// a forward-growing table of per-tensor DramCorePrefetcherEntry (address + layout index)
+// Request page wire format (one socket page): a DramCorePrefetcherRequestHeader
+// (one-byte command id + per-command union). The STOP command (all-zero page) exits
+// the request loop; WAIT_CQ blocks on a per-CQ signal slot; PREFETCH is followed by a
+// forward-growing table of per-tensor DramCorePrefetcherEntry (address + layout index)
 // and a backward-growing (from the end of the payload) deduplicated table of
 // DramCorePrefetcherTensorLayout. The kernel walks the entries in order, resolving each
 // entry's geometry from the referenced layout. See
-// tt_metal/impl/buffers/dram_core_prefetcher_request.hpp. A header with
-// num_entries == 0 is the stop sentinel.
+// tt_metal/impl/buffers/dram_core_prefetcher_request.hpp.
 //
 // Per-GCB sender state block layout: see
 // tt_metal/impl/buffers/dram_sender_state_block.hpp.
@@ -36,6 +37,7 @@ using tt::tt_metal::DramCorePrefetcherEntry;
 using tt::tt_metal::DramCorePrefetcherRequestHeader;
 using tt::tt_metal::DramCorePrefetcherTensorLayout;
 using tt::tt_metal::DramSenderStateBlock;
+using tt::tt_metal::kNumCqSignalSlots;
 using tt::tt_metal::kRequestPageBytes;
 
 // DRISC firmware doesn't define cb_interface (no CB infra on DRAM cores).
@@ -163,6 +165,10 @@ void kernel_main() {
     constexpr uint32_t stage_ring_size = get_compile_time_arg_val(1);
     constexpr uint32_t remote_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t socket_page_size = get_compile_time_arg_val(3);
+    // Base of this core's per-CQ signal slots (kNumCqSignalSlots uint32 counters).
+    // WaitForCqOnDramCorePrefetcher writes an incrementing value here from the
+    // dispatcher; a WAIT_CQ request blocks until the requested slot reaches it.
+    constexpr uint32_t cq_signal_l1_base = get_compile_time_arg_val(4);
     constexpr uint32_t ring_half = stage_ring_size / 2;
     constexpr uint32_t stage_slot_a = stage_ring_base;
     constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
@@ -181,14 +187,23 @@ void kernel_main() {
     RemoteSenderCBInterface& iface = get_remote_sender_cb_interface(remote_cb_id);
     bool has_loaded_sender_state = false;
 
+    // Zero the per-CQ signal slots before parking on the socket. Safe to do here
+    // (rather than from the host) because no WaitForCqOnDramCorePrefetcher signal
+    // can be enqueued until StartDramCorePrefetcher returns to the single-threaded
+    // host caller, long after this init runs.
+    volatile tt_l1_ptr uint32_t* cq_signal_slots = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cq_signal_l1_base);
+    for (uint32_t i = 0; i < kNumCqSignalSlots; ++i) {
+        cq_signal_slots[i] = 0;
+    }
+
     // ---- Request loop ----
     while (true) {
         socket_wait_for_pages(socket, 1);
 
         volatile tt_l1_ptr DramCorePrefetcherRequestHeader* req =
             reinterpret_cast<volatile tt_l1_ptr DramCorePrefetcherRequestHeader*>(socket.read_ptr);
-        const uint32_t req_num_entries = req->num_entries;
-        if (req_num_entries == 0) {
+        const uint8_t cmd_id = req->base.cmd_id;
+        if (cmd_id == tt::tt_metal::DRAM_PREFETCHER_CMD_STOP) {
             // Stop sentinel. Receiver pages_acked atomics target DRISC L1 while
             // stream mode is active; wait for the last loaded GCB to drain before
             // exiting the request loop and restoring NoC2AXI mode.
@@ -199,7 +214,21 @@ void kernel_main() {
             socket_notify_sender(socket);
             break;
         }
-        const uint32_t gcb_state_addr = req->gcb_state_addr;
+        if (cmd_id == tt::tt_metal::DRAM_PREFETCHER_CMD_WAIT_CQ) {
+            // Block until the dispatcher has bumped this CQ's signal slot to the
+            // requested value. Wrap-safe: compare the unsigned difference as signed.
+            const uint32_t idx = req->wait_cq.cq_index;
+            const uint32_t target = req->wait_cq.cq_wait_value;
+            while ((int32_t)(cq_signal_slots[idx] - target) < 0) {
+                invalidate_l1_cache();
+            }
+            socket_pop_pages(socket, 1);
+            socket_notify_sender(socket);
+            continue;
+        }
+        // DRAM_PREFETCHER_CMD_PREFETCH
+        const uint32_t req_num_entries = req->prefetch.num_entries;
+        const uint32_t gcb_state_addr = req->prefetch.gcb_state_addr;
         volatile tt_l1_ptr DramSenderStateBlock* state =
             reinterpret_cast<volatile tt_l1_ptr DramSenderStateBlock*>(gcb_state_addr);
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -137,6 +137,41 @@ void write_to_core(
     }
 }
 
+void write_to_core_unchecked(
+    IDevice* device,
+    const CoreCoord& virtual_core,
+    const void* src,
+    DeviceAddr address,
+    uint32_t size_bytes,
+    uint32_t cq_id,
+    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    // Same command sequence as write_to_core, minus the bounds validation and bank
+    // offset: `address` is taken as the full device destination.
+    while (size_bytes > 0) {
+        const CoreType dispatch_core_type =
+            MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+        const uint32_t size_bytes_to_write =
+            std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
+
+        CoreWriteDispatchParams dispatch_params{
+            {virtual_core,
+             address,
+             size_bytes_to_write,
+             device,
+             cq_id,
+             dispatch_core_type,
+             expected_num_workers_completed,
+             sub_device_ids},
+            src};
+        issue_core_write_command_sequence(dispatch_params);
+
+        size_bytes -= size_bytes_to_write;
+        address += size_bytes_to_write;
+        src = (uint8_t*)src + size_bytes_to_write;
+    }
+}
+
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params) {
     const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
     DeviceCommandCalculator calculator;

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -102,7 +102,11 @@ void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_p
     sysmem_manager.fetch_queue_write(cmd_sequence_sizeB, dispatch_params.cq_id);
 }
 
-void write_to_core(
+namespace {
+// Shared body of write_to_core / write_to_core_unchecked: chunk the write across the max
+// prefetch payload size and issue a command sequence per chunk. `address` is used verbatim
+// as the full device destination (no bank/channel translation).
+void write_to_core_impl(
     IDevice* device,
     const CoreCoord& virtual_core,
     const void* src,
@@ -111,8 +115,6 @@ void write_to_core(
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    validate_core_read_write_bounds(device, virtual_core, address, size_bytes);
-
     while (size_bytes > 0) {
         const CoreType dispatch_core_type =
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
@@ -136,6 +138,21 @@ void write_to_core(
         src = (uint8_t*)src + size_bytes_to_write;
     }
 }
+}  // namespace
+
+void write_to_core(
+    IDevice* device,
+    const CoreCoord& virtual_core,
+    const void* src,
+    DeviceAddr address,
+    uint32_t size_bytes,
+    uint32_t cq_id,
+    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    validate_core_read_write_bounds(device, virtual_core, address, size_bytes);
+    write_to_core_impl(
+        device, virtual_core, src, address, size_bytes, cq_id, expected_num_workers_completed, sub_device_ids);
+}
 
 void write_to_core_unchecked(
     IDevice* device,
@@ -146,31 +163,10 @@ void write_to_core_unchecked(
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    // Same command sequence as write_to_core, minus the bounds validation: `address` is
-    // taken as the full device destination verbatim (write_to_core applies no bank offset
-    // either, so there is nothing extra to skip here).
-    while (size_bytes > 0) {
-        const CoreType dispatch_core_type =
-            MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-        const uint32_t size_bytes_to_write =
-            std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
-
-        CoreWriteDispatchParams dispatch_params{
-            {virtual_core,
-             address,
-             size_bytes_to_write,
-             device,
-             cq_id,
-             dispatch_core_type,
-             expected_num_workers_completed,
-             sub_device_ids},
-            src};
-        issue_core_write_command_sequence(dispatch_params);
-
-        size_bytes -= size_bytes_to_write;
-        address += size_bytes_to_write;
-        src = (uint8_t*)src + size_bytes_to_write;
-    }
+    // Same as write_to_core, minus validate_core_read_write_bounds: the DRAM-banked bounds
+    // check would reject programmable DRAM-core (DRISC) L1.
+    write_to_core_impl(
+        device, virtual_core, src, address, size_bytes, cq_id, expected_num_workers_completed, sub_device_ids);
 }
 
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params) {

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -146,8 +146,9 @@ void write_to_core_unchecked(
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    // Same command sequence as write_to_core, minus the bounds validation and bank
-    // offset: `address` is taken as the full device destination.
+    // Same command sequence as write_to_core, minus the bounds validation: `address` is
+    // taken as the full device destination verbatim (write_to_core applies no bank offset
+    // either, so there is nothing extra to skip here).
     while (size_bytes > 0) {
         const CoreType dispatch_core_type =
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -49,6 +49,20 @@ void write_to_core(
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
+// Like write_to_core, but skips validate_core_read_write_bounds and the DRAM-bank
+// offset. `address` must already be the full device destination. Used for writes
+// to programmable DRAM-core (DRISC) L1, which the bounds check (DRAM-banked-memory
+// semantics) would otherwise reject.
+void write_to_core_unchecked(
+    IDevice* device,
+    const CoreCoord& virtual_core,
+    const void* src,
+    DeviceAddr address,
+    uint32_t size_bytes,
+    uint32_t cq_id,
+    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    tt::stl::Span<const SubDeviceId> sub_device_ids = {});
+
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params);
 
 void read_core_data_from_completion_queue(

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -49,10 +49,11 @@ void write_to_core(
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {});
 
-// Like write_to_core, but skips validate_core_read_write_bounds and the DRAM-bank
-// offset. `address` must already be the full device destination. Used for writes
-// to programmable DRAM-core (DRISC) L1, which the bounds check (DRAM-banked-memory
-// semantics) would otherwise reject.
+// Like write_to_core, but skips validate_core_read_write_bounds. That is the only
+// functional difference: as with write_to_core, `address` is used verbatim as the full
+// device destination with no bank/channel translation. Used for writes to programmable
+// DRAM-core (DRISC) L1, which the bounds check (DRAM-banked-memory semantics) would
+// otherwise reject.
 void write_to_core_unchecked(
     IDevice* device,
     const CoreCoord& virtual_core,

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.cpp
@@ -30,6 +30,13 @@ void queue_dram_core_prefetcher_request(
     tt::tt_metal::experimental::QueueDramCorePrefetcherRequest(*mesh_device, global_cb, device_subset, inputs);
 }
 
+void wait_for_cq_on_dram_core_prefetcher(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    uint8_t cq_id,
+    const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset) {
+    tt::tt_metal::experimental::WaitForCqOnDramCorePrefetcher(*mesh_device, cq_id, device_subset);
+}
+
 void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device) {
     tt::tt_metal::experimental::StopDramCorePrefetcher(*mesh_device);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher.hpp
@@ -51,6 +51,15 @@ void queue_dram_core_prefetcher_request(
     const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset = std::nullopt);
 
+// Fence the prefetcher against command queue `cq_id`: every prefetch request queued
+// after this call waits until all work previously enqueued on `cq_id` has completed
+// on device before the prefetcher reads DRAM. Call after the data writes and before
+// the dependent queue_dram_core_prefetcher_request.
+void wait_for_cq_on_dram_core_prefetcher(
+    tt::tt_metal::distributed::MeshDevice* mesh_device,
+    uint8_t cq_id,
+    const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset = std::nullopt);
+
 void stop_dram_core_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dram_core_prefetcher/dram_core_prefetcher_nanobind.cpp
@@ -83,6 +83,33 @@ void bind_dram_core_prefetcher(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("device_subset") = std::nullopt);
 
+    ttnn::bind_function<"wait_for_cq_on_dram_core_prefetcher", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            Fence the DRAM-core prefetcher against work enqueued on a command queue.
+            Every prefetch request queued after this call waits until all work previously
+            enqueued on `cq_id` has completed on device before the prefetcher reads DRAM.
+            Use this to guarantee data written over `cq_id` has landed before the
+            prefetcher streams it.
+
+            Call synchronously on the host thread that issued the data writes — after those
+            writes, and before the queue_dram_core_prefetcher_request that consumes them.
+
+            Args:
+                mesh_device (ttnn.MeshDevice): the mesh device whose prefetcher to fence.
+                cq_id (int): the command queue to fence against.
+                device_subset (Optional[MeshCoordinateRangeSet]): subset of the mesh to
+                    fence. Defaults to the full mesh.
+
+            Returns:
+                None
+        )doc",
+        &wait_for_cq_on_dram_core_prefetcher,
+        nb::arg("mesh_device"),
+        nb::arg("cq_id") = 0,
+        nb::kw_only(),
+        nb::arg("device_subset") = std::nullopt);
+
     ttnn::bind_function<"stop_dram_core_prefetcher", "ttnn.experimental.">(
         mod,
         R"doc(


### PR DESCRIPTION
### PR Category
Feature (part of #45751)

### Summary
Weights are written to DRAM over the fast-dispatch command queue, while the DRAM-core prefetcher request travels an independent H2D socket path. Nothing currently guarantees the weight write has landed before the DRISC kernel DMA-reads that DRAM. This adds an explicit fence.

`WaitForCqOnDramCorePrefetcher(mesh_device, cq_id)` (exposed as `ttnn.experimental.wait_for_cq_on_dram_core_prefetcher`) makes every prefetch request queued after the call wait until all work previously enqueued on `cq_id` has completed on device before the prefetcher reads DRAM.

How it works:
- The dispatcher writes an incrementing value into a per-CQ signal slot on every DRAM core (gated by a per-sub-device dispatch wait, ordered after prior CQ work); a new `WAIT_CQ` DRISC request blocks the kernel until it observes that value (wrap-safe signed compare).
- The request wire format becomes a `cq_commands.hpp`-style base+union (`STOP`/`PREFETCH`/`WAIT_CQ`); the 12-byte header stays 4-byte aligned and `STOP == 0` keeps a zeroed page a valid stop sentinel. The `PREFETCH` payload carries the dedup-layout entry-table fields introduced in #45425.
- `enqueue_write_dram_core_counter` is a new `MeshCommandQueueBase` virtual, implemented for fast dispatch (`write_to_core_unchecked` + dispatch wait) and slow dispatch (`wait_for_cores_idle` + `cluster.write_core`); `MeshDeviceImpl` gains `mesh_command_queue_base()` so the manager avoids a downcast.
- `write_to_core_unchecked` skips `validate_core_read_write_bounds` (which rejects programmable DRAM-core / DRISC L1 by applying DRAM-bank semantics); the caller passes the full 64-bit destination, one `WRITE_LINEAR` per core.

### Notes for reviewers
- The wire-format change in `dram_core_prefetcher_request.hpp` is the main contract surface — host (`serialize_request_pages` / `enqueue_cq_signal_and_wait`) and the DRISC kernel must agree on the base+union layout.
- The DRISC kernel (`kernels/dram_core_prefetcher.cpp`) is JIT-compiled at runtime, so it is exercised by `test_prefetcher_BH_dram_core_large.py` on Blackhole (`TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1`), not by the host build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/driscwait)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/driscwait)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/driscwait)