### PR TITLE
[Bug fix, Test Only] Update stale test kernels to NocOptions API

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_sem_2_0.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
     Semaphore<> sender_valid_sem(sender_valid_sem_id);
     Semaphore<> receiver_sem(receiver_sem_id);
 
-    constexpr Noc::McastMode mcast_mode = loopback ? Noc::McastMode::INCLUDE_SRC : Noc::McastMode::EXCLUDE_SRC;
+    constexpr NocOptions mcast_mode = loopback ? NocOptions::MCAST_INCL_SRC : NocOptions::DEFAULT;
 
     {
         DeviceZoneScopedN("RISCV0");

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -139,9 +139,9 @@ void kernel_main() {
         // Exercises DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE, which must reconstruct the
         // destination from NOC_RET_ADDR (not the sender's own coordinate in NOC_TARG_ADDR). buffer_size is kept
         // <= NOC_MAX_BURST_SIZE by the host so this takes the one-packet path with a deterministic length.
-        noc.set_async_write_state<Noc::ResponseMode::NON_POSTED, NOC_MAX_BURST_SIZE>(
+        noc.set_async_write_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
             dst_unicast_endpoint, buffer_size, {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
-        noc.async_write_with_state<Noc::ResponseMode::NON_POSTED, NOC_MAX_BURST_SIZE>(
+        noc.async_write_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
             local_buffer,
             dst_unicast_endpoint,
             buffer_size,


### PR DESCRIPTION
### PR Category
Bug fix, Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes #46005 
Migrate the two test kernels missed by PR #45509 to the new NocOptions API.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/stale-46005)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/stale-46005)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/stale-46005)