### PR TITLE
ci-disable: models-t2-e2e-tests Llama 3.2-90B-Vision test_multimodal_demo_text[batch1-trace] performance regression (see #46016)

### DIFF
--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -269,7 +269,7 @@ def prepare_generator_args(
                 "models/tt_transformers/demo/sample_prompts/vision_input_data.json",
             ),  # input_prompts
         ),  # batch1-notrace
-        (
+        pytest.param(
             0,  # warmup_iters
             True,  # enable_trace
             1,  # max_batch_size
@@ -277,6 +277,7 @@ def prepare_generator_args(
                 "models/tt_transformers/demo/sample_prompts/vision_input_data_trace.json",
                 "models/tt_transformers/demo/sample_prompts/vision_input_data.json",
             ),  # input_prompts
+            marks=pytest.mark.skip(reason="Disabled: see #46016"),
         ),  # batch1-trace
         (
             0,  # warmup_iters


### PR DESCRIPTION
Disable `test_multimodal_demo_text[...-batch1-trace-...]` in `simple_vision_demo.py` — failing deterministically on `wh_llmbox_perf` with performance regression assertion. Tracks issue #46016.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/tt_transformers/demo/simple_vision_demo.py::test_multimodal_demo_text[wormhole_b0-device_params0-1-batch1-trace-normal-mesh_device0]` | https://github.com/tenstorrent/tt-metal/actions/runs/26863952291/job/79224197492 | [bdc8c319d2](https://github.com/tenstorrent/tt-metal/commit/bdc8c319d266cf19a08c3cfcba0fe6eef30c3e3b) | 2026-06-03T09:59 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/models-t2-e2e-tests-vision-batch1-2026-06-03)