### PR TITLE
[CI Disable] runtime-unit-tests: skip DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState (see #46022)

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -257,6 +257,7 @@ TEST_F(DispatchTelemetryReadApiTest, PrefetchCommandCountAdvancesForEveryEnqueue
 }
 
 TEST_F(DispatchTelemetryHostL1WaitTest, WorkerWaitReportsUpstreamBlockedState) {
+    GTEST_SKIP() << "Disabled: see #46022";
     IDevice* device = this->device();
     auto& cq = devices_.at(0)->mesh_command_queue();
 


### PR DESCRIPTION
Disable `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` in `runtime_sd_debug_tools_device_dispatch` job — failing deterministically on all 4 SKUs with NOC error mismatch. Tracking issue: #46022

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` [wh_n150_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26866206838/job/79231037111 | [15806d0d564](https://github.com/tenstorrent/tt-metal/commit/15806d0d564eff581a6eb21bea8c56f0b35867d5) | 2026-06-03 05:45 UTC |
| `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` [wh_n300_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26866206838/job/79231037124 | [15806d0d564](https://github.com/tenstorrent/tt-metal/commit/15806d0d564eff581a6eb21bea8c56f0b35867d5) | 2026-06-03 05:45 UTC |
| `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` [bh_p150b_civ2] | https://github.com/tenstorrent/tt-metal/actions/runs/26866206838/job/79231037073 | [15806d0d564](https://github.com/tenstorrent/tt-metal/commit/15806d0d564eff581a6eb21bea8c56f0b35867d5) | 2026-06-03 05:45 UTC |
| `DispatchTelemetryHostL1WaitTest.WorkerWaitReportsUpstreamBlockedState` [bh_p100a_civ2_viommu] | https://github.com/tenstorrent/tt-metal/actions/runs/26866206838/job/79231037125 | [15806d0d564](https://github.com/tenstorrent/tt-metal/commit/15806d0d564eff581a6eb21bea8c56f0b35867d5) | 2026-06-03 05:45 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/runtime-unit-tests-dispatch-telemetry-2026-06-03)