### PR TITLE
Skip host_io decoder sweep chunked-trace tests when 128K trace is missing

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io_decoder_sweep_chunked_trace.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
@@ -47,7 +48,8 @@ def _require_host_io_sweep_env() -> None:
 def _assert_chunked_trace_is_readable(trace_root: Path, model_id: str, prompt_id: str) -> None:
     trace_dir = _trace_dir(trace_root, model_id, prompt_id)
     if not (trace_dir / "index.json").is_file():
-        pytest.fail(f"chunked 128K trace is not present: {trace_dir}")
+        logger.warning(f"chunked 128K trace is not present: {trace_dir}; this test can only be run on exabox machines")
+        pytest.skip(f"chunked 128K trace is not present: {trace_dir} (only available on exabox machines)")
 
     reader = ChunkedTraceReader(trace_dir)
     assert reader.index["layout"] == "chunked_group_a_v1"


### PR DESCRIPTION
## Summary
- `test_run_host_io_decoder_sweep_chunked_trace_smoke` and `..._world_size_4` hard-failed on non-exabox runners (e.g. `blackhole-post-commit` / `ops-unit-tests (P150b)`) because the shared `_assert_chunked_trace_is_readable` helper called `pytest.fail` when the 128K debug trace was absent.
- The trace under `/mnt/models/ref_data/debug_traces/ds_r1_0528/vllm-97854ebb-128000tok` only exists on exabox machines, so these runners can never satisfy it.
- Switched the helper to `pytest.skip` (with a `logger.warning` noting the exabox-only requirement), matching the skip behavior already used by the sibling tests in the same file (`test_load_reference_kv_cache_chunked_trace_layout`, `test_run_host_io_decoder_sweep_rank_parallel_config_contract`). Both tests route through this one helper, so the single change fixes both.

Fixes the failure seen in run [#26821635135](https://github.com/tenstorrent/tt-metal/actions/runs/26821635135/job/79110218666):
```
FAILED .../test_host_io_decoder_sweep_chunked_trace.py::test_run_host_io_decoder_sweep_chunked_trace_smoke[ds-r1-0528-97854ebb-128k]
Failed: chunked 128K trace is not present: /mnt/models/ref_data/debug_traces/ds_r1_0528/vllm-97854ebb-128000tok
```

## Test plan
- [x] On a machine without the trace: both tests now report `SKIPPED (only available on exabox machines)` instead of `FAILED` (verified the skip control-flow in isolation).
- [x] On an exabox machine where the trace is present: tests still run the full validation as before (unchanged path).

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-host-io-decoder-sweep-skip-missing-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-host-io-decoder-sweep-skip-missing-trace)