### PR TITLE
[Feature] TTNN ComputeKernelConfig to a Metal 2.0 ComputeHardwareConfig helper

### DIFF
--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "compute_kernel_config.hpp"
 #include "ttnn/device.hpp"
@@ -103,6 +104,15 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
         compute_kernel_config.fp32_dest_acc_en,
         compute_kernel_config.packer_l1_acc,
         compute_kernel_config.dst_full_sync_en);
+}
+
+tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(const ComputeKernelConfig& config) {
+    return tt::tt_metal::experimental::ComputeHardwareConfig{
+        .math_fidelity = config.math_fidelity,
+        .fp32_dest_acc_en = config.fp32_dest_acc_en,
+        .dst_full_sync_en = config.dst_full_sync_en,
+        .math_approx_mode = config.math_approx_mode,
+    };
 }
 
 uint32_t get_dest_reg_count(

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -12,6 +12,10 @@
 #include <tt-metalium/base_types.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
 
+namespace tt::tt_metal::experimental {
+struct ComputeHardwareConfig;
+}
+
 namespace ttnn {
 
 // Unified compute kernel configuration for all supported architectures.
@@ -59,6 +63,13 @@ ttnn::operations::compute_throttle_utils::ThrottleLevel get_throttle_level(
 
 std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kernel_config_args(
     tt::ARCH arch, DeviceComputeKernelConfig compute_kernel_config);
+
+// Maps the four hardware knobs (math_fidelity, math_approx_mode, fp32_dest_acc_en,
+// dst_full_sync_en) to a Metal 2.0 ComputeHardwareConfig.
+// packer_l1_acc and throttle_level are op-side concerns, not translated.
+// The result's per-DFB unpack_to_dest_mode is left default for the program factory to set.
+// (As is bfp8_pack_precise, but that is rarely to never set non-default.)
+tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(const ComputeKernelConfig& config);
 
 uint32_t get_dest_reg_count(
     const DeviceComputeKernelConfig& compute_kernel_config,


### PR DESCRIPTION
### PR Category
Feature

### Summary
Ops use TTNN's ComputeKernelConfig. To save boilerplate, provide a trivial helper to convert this into a Metal 2.0 ComputeHardwareConfig. 

The helper maps four compute hardware knobs 1:1: 
 - math_fidelity, 
 - math_approx_mode, 
 - fp32_dest_acc_en, 
 - dst_full_sync_en.

The op-specific fields in the TTNN struct are ignored. Metalium fields `unpack_to_dest_mode` (which matters) and `bfp8_pack_precise` (which nobody uses) are left as default. The ProgramFactory must configure these separately if required.

### Notes for reviewers
Seemed far too trivial to unit test; neighboring helpers aren't.
