### PR TITLE
[Bug fix] align moreh_norm keepdim-false output shape

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -197,6 +197,74 @@ def run_moreh_norm(
     assert passing
 
 
+def run_moreh_norm_output_mode(
+    input_shape,
+    p,
+    dim,
+    rtol,
+    atol,
+    device,
+    *,
+    keepdim=False,
+    compute_kernel_options=None,
+    torch_dtype=torch.float32,
+    ttnn_dtype=ttnn.bfloat16,
+    is_linalg_vector_norm=False,
+    use_provided_output=True,
+):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b is not supported in the kernel")
+
+    torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim, dtype=torch_dtype)
+    expected_output, _ = torch_norm(
+        torch_input,
+        torch_output_grad,
+        p=p,
+        dim=dim,
+        keepdim=keepdim,
+        is_linalg_vector_norm=is_linalg_vector_norm,
+        do_backward=False,
+    )
+
+    ttnn_input = create_ttnn_tilized_tensor(torch_input, device, ttnn_dtype)
+    kwargs = {
+        "p": p,
+        "dim": dim,
+        "keepdim": keepdim,
+        "compute_kernel_config": get_compute_kernel_options(compute_kernel_options),
+    }
+
+    if use_provided_output:
+        _, ttnn_output_shape = compute_output_shape(torch_input.shape, dim, keepdim=keepdim)
+        kwargs["output"] = create_ttnn_tilized_tensor(torch.empty(ttnn_output_shape), device, ttnn_dtype)
+
+    actual_output = ttnn.operations.moreh.norm(ttnn_input, **kwargs)
+    actual_output = ttnn.to_torch(actual_output)
+
+    passing, out = comp_allclose(expected_output, actual_output, rtol=rtol, atol=atol)
+    logger.info(f"output's {out}")
+    assert passing
+
+
+@pytest.mark.parametrize("p", [0.0, float("inf"), float("-inf")])
+@pytest.mark.parametrize("use_provided_output", [True, False], ids=["provide-output", "allocate-output"])
+@pytest.mark.parametrize("is_linalg_vector_norm", [False, True])
+def test_moreh_norm_rank_1_dim_0_keepdim_false_output_modes(p, use_provided_output, device, is_linalg_vector_norm):
+    torch.manual_seed(2024)
+    run_moreh_norm_output_mode(
+        [5],
+        p,
+        0,
+        0.06,
+        0.06,
+        device,
+        keepdim=False,
+        ttnn_dtype=ttnn.bfloat16,
+        is_linalg_vector_norm=is_linalg_vector_norm,
+        use_provided_output=use_provided_output,
+    )
+
+
 def run_moreh_norm_backward(
     input_shape,
     p,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp
@@ -30,72 +30,6 @@ inline void validate_input_tensor_with_dim(const Tensor& input, int64_t dim) {
     TT_FATAL((dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
 }
 
-inline void validate_output_tensor_with_keepdim(const Tensor& input, const Tensor& output, int64_t dim, bool keepdim) {
-    const auto& input_shape = input.padded_shape();
-    const auto& input_shape_wo_padding = input.logical_shape();
-    const auto input_rank = input_shape.rank();
-
-    const auto& output_shape = output.padded_shape();
-    const auto& output_shape_wo_padding = output.logical_shape();
-    const auto output_rank = output_shape.rank();
-
-    const bool is_tile_dim = (dim == input_rank - 1 || dim == input_rank - 2);
-
-    if (keepdim) {
-        TT_FATAL(input_rank == output_rank, "Input and output ranks must be equal when keepdim is true.");
-
-        auto adjusted_input_shape = input_shape;
-        auto adjusted_input_shape_wo_padding = input_shape_wo_padding;
-        adjusted_input_shape[dim] = (is_tile_dim) ? tt::constants::TILE_HEIGHT : 1;
-        adjusted_input_shape_wo_padding[dim] = 1;
-
-        ttnn::SmallVector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        ttnn::SmallVector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-
-        expand_to_max_dim(input_dim, adjusted_input_shape);
-        expand_to_max_dim(output_dim, output_shape);
-        expand_to_max_dim(input_dim_wo_padding, adjusted_input_shape_wo_padding);
-        expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
-
-        for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_dim[i] == output_dim[i], "Input and output dimensions do not match at index {}.", i);
-            TT_FATAL(
-                input_dim_wo_padding[i] == output_dim_wo_padding[i],
-                "Input and output dimensions without padding do not match at index {}.",
-                i);
-        }
-    } else {
-        TT_FATAL(!is_tile_dim, "Dimension {} should not be a tile dimension when keepdim is false.", dim);
-
-        ttnn::SmallVector<uint32_t> expected_output_shape;
-        ttnn::SmallVector<uint32_t> expected_output_shape_wo_padding;
-        for (int i = 0; i < output_rank; ++i) {
-            if (i == dim && !is_tile_dim) {
-                expected_output_shape.push_back(1);
-                expected_output_shape_wo_padding.push_back(1);
-            }
-            expected_output_shape.push_back(output_shape[i]);
-            expected_output_shape_wo_padding.push_back(output_shape_wo_padding[i]);
-        }
-
-        for (int i = 0; i < input_rank; ++i) {
-            if (i == dim) {
-                continue;
-            }
-            TT_FATAL(
-                input_shape[i] == expected_output_shape[i],
-                "Input and expected output shapes do not match at index {}.",
-                i);
-            TT_FATAL(
-                input_shape_wo_padding[i] == expected_output_shape_wo_padding[i],
-                "Input and expected output shapes without padding do not match at index {}.",
-                i);
-        }
-    }
-}
-
 void MorehNormOperation::validate_inputs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
@@ -105,7 +39,7 @@ void MorehNormOperation::validate_inputs(
     check_tensor(output, "moreh_norm", "output");
     validate_input_tensor_with_dim(input, dim);
     if (output.has_value()) {
-        validate_output_tensor_with_keepdim(input, output.value(), dim, operation_attributes.keepdim);
+        validate_output_with_keepdim(input, output.value(), dim, operation_attributes.keepdim);
     }
 }
 
@@ -152,7 +86,7 @@ MorehNormOperation::spec_return_value_t MorehNormOperation::compute_output_specs
         if (is_reduced_dim && !is_tile_dim) {
             continue;
         }
-        shape.push_back(input_shape[i]);
+        shape.push_back((is_reduced_dim && is_tile_dim) ? 1 : input_shape[i]);
     }
     return TensorSpec(
         ttnn::Shape(shape),


### PR DESCRIPTION
PR Category
Bug fix

Summary
1. Align `moreh_norm` provided-output validation with the shared `validate_output_with_keepdim(...)` helper.
2. Align `moreh_norm` `keepdim=False` auto output-shape computation with sibling `moreh_sum` and `moreh_mean` behavior on reduced tile dims.
3. `moreh_norm` previously rejected tile-dim `keepdim=False` when the caller provided an output tensor, while its auto-created output path used a different shape contract.
4. This patch removes that local mismatch and adds a focused regression that exercises both output modes on the skipped edge.
5. Relates to #46048.

Notes for reviewers
1. The functional change is limited to `ttnn/cpp/ttnn/operations/moreh/moreh_norm/device/moreh_norm_device_operation.cpp`.
2. The regression coverage is in `tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py`.
3. The new test bypasses the shared `check_dim(...)` helper because that helper skips `keepdim == false` on last-two-dim reductions.
4. This patch does not change kernel math or program-factory selection.

Test plan
1. `python3 -m py_compile tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py`
2. `git diff --check`
3. Added focused coverage for:
   - `shape=[5]`
   - `dim=0`
   - `keepdim=False`
   - `p in {0.0, inf, -inf}`
   - `is_linalg_vector_norm in {False, True}`
   - `output in {provided, auto-allocated}`
4. Local `pytest --collect-only` could not complete in the available WSL env because the imported `ttnn` package in that env does not expose `ttnn.device`, which blocks `conftest.py` before this test module is collected.
