### PR TITLE
#46059: CI: bump Blackhole llk_perf job timeout 107 -> 120

### DIFF
--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -127,7 +127,7 @@
     junitparser merge pytest-report-blackhole-1-compile.xml pytest-report-blackhole-1-run.xml pytest-report-blackhole-1.xml
   skus:
     bh_p150b_civ2:
-      timeout: 107
+      timeout: 120
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_blackhole group 2/5
@@ -148,7 +148,7 @@
     junitparser merge pytest-report-blackhole-2-compile.xml pytest-report-blackhole-2-run.xml pytest-report-blackhole-2.xml
   skus:
     bh_p150b_civ2:
-      timeout: 107
+      timeout: 120
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_blackhole group 3/5
@@ -169,7 +169,7 @@
     junitparser merge pytest-report-blackhole-3-compile.xml pytest-report-blackhole-3-run.xml pytest-report-blackhole-3.xml
   skus:
     bh_p150b_civ2:
-      timeout: 107
+      timeout: 120
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_blackhole group 4/5
@@ -190,7 +190,7 @@
     junitparser merge pytest-report-blackhole-4-compile.xml pytest-report-blackhole-4-run.xml pytest-report-blackhole-4.xml
   skus:
     bh_p150b_civ2:
-      timeout: 107
+      timeout: 120
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_blackhole group 5/5
@@ -211,5 +211,5 @@
     junitparser merge pytest-report-blackhole-5-compile.xml pytest-report-blackhole-5-run.xml pytest-report-blackhole-5.xml
   skus:
     bh_p150b_civ2:
-      timeout: 107
+      timeout: 120
   owner_id: U07J3K6KS1K


### PR DESCRIPTION
llk_perf_blackhole compile groups 2/5 and 4/5 have been hitting the 107-min
per-job timeout (Jun 3 nightly bdc8c31 cancelled 2/4; Jun 4 ce8a071 cancelled 2).
The cost is in the compile-producer phase, which is now ~97-102 min wall on the
heavy groups (vs ~90 min on the last green run, Jun 2).

This is two compounding increases of comparable size, not one bad commit:
  1. ~May 29: a +6.85% test-count step (7098 -> 7584 configs/group) raised the
     compile wall ~84 -> ~91 min (per-test cost flat) and ate most of the headroom.
  2. Jun 3 (bdc8c31): a real +8-11% per-test compile slowdown (test count flat)
     added another ~+6-11 min (g2 89.7->97.3, g4 89.6->101.1) - as large or larger
     than the count step - which is what pushed the heavy groups over 107.

The Jun 3 regression is real in CI but is contention/HW-sensitive: it does not
reproduce on a 12-core dev box (the green-vs-bad delta sign-flips run-to-run, even
under -n24 oversubscription), so an automated local bisect of the 49-commit range
is not trustworthy. Leading unconfirmed hypothesis from the CI per-fidelity bucket
analysis is header/include bloat (#45594, #45509).

Bump the timeout 107 -> 120 to restore a green nightly while we track compile
timings over the next several days and decide on a structural fix (split-group
rebalancing / matrix trimming / more compile-producer parallelism). Note 120 only
restores ~10 min of headroom (Jun 3/4 compile already hit ~101-102 min), so this is
a stopgap, not the fix.


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
CI Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Temp fix for #46059  

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
This is temp fix for increased compile time, we need to understand why compile time is increased, I was not able to repro it on lab machine, in order to provide more robust fix

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrsmanovic/bump-bh-llk-perf-timeout-120)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrsmanovic/bump-bh-llk-perf-timeout-120)