### PR TITLE
[Bug fix] validate moreh_layer_norm_backward tensor contracts

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -692,6 +692,75 @@ def test_moreh_layer_norm_backward_callback(input_shape_normalized_dims, element
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
+def test_moreh_layer_norm_backward_rejects_invalid_mean_volume(device):
+    torch.manual_seed(2023)
+    input_shape = [2, 32, 64]
+    normalized_dims = 1
+    eps = 1e-5
+
+    cpu_input, _, _, cpu_output_grad = make_input_tensors(
+        input_shape, normalized_dims, elementwise_affine=False, do_backward=True
+    )
+
+    mean_rstd_dims = list(range(-normalized_dims, 0))
+    mean = cpu_input.clone().mean(dim=mean_rstd_dims, keepdim=True)
+    var = ((cpu_input.clone() - mean) ** 2).mean(dim=mean_rstd_dims, keepdim=True)
+    rstd = (var + eps).rsqrt()
+
+    wrong_mean_shape = [input_shape[0], input_shape[1] + 1]
+
+    npu_output_grad = to_ttnn(cpu_output_grad, device=device, dtype=ttnn.bfloat16)
+    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
+    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+    npu_rstd = to_ttnn(rstd, device=device, dtype=ttnn.bfloat16, shape=input_shape[:-normalized_dims])
+    npu_input_grad = to_ttnn(torch.empty(input_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
+        ttnn.operations.moreh.layer_norm_backward(
+            npu_output_grad,
+            npu_input,
+            npu_mean,
+            npu_rstd,
+            normalized_dims,
+            input_grad=npu_input_grad,
+        )
+
+
+def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device):
+    torch.manual_seed(2023)
+    input_shape = [2, 32, 64]
+    normalized_dims = 1
+    eps = 1e-5
+
+    cpu_input, _, _, cpu_output_grad = make_input_tensors(
+        input_shape, normalized_dims, elementwise_affine=False, do_backward=True
+    )
+
+    mean_rstd_dims = list(range(-normalized_dims, 0))
+    mean = cpu_input.clone().mean(dim=mean_rstd_dims, keepdim=True)
+    var = ((cpu_input.clone() - mean) ** 2).mean(dim=mean_rstd_dims, keepdim=True)
+    rstd = (var + eps).rsqrt()
+
+    valid_mean_shape = input_shape[:-normalized_dims]
+    wrong_mean_shape = [1, valid_mean_shape[0] * valid_mean_shape[1]]
+
+    npu_output_grad = to_ttnn(cpu_output_grad, device=device, dtype=ttnn.bfloat16)
+    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
+    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+    npu_rstd = to_ttnn(rstd, device=device, dtype=ttnn.bfloat16, shape=valid_mean_shape)
+    npu_input_grad = to_ttnn(torch.empty(input_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
+        ttnn.operations.moreh.layer_norm_backward(
+            npu_output_grad,
+            npu_input,
+            npu_mean,
+            npu_rstd,
+            normalized_dims,
+            input_grad=npu_input_grad,
+        )
+
+
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
 @pytest.mark.parametrize(
     "dtype",
@@ -761,59 +830,3 @@ def test_moreh_layer_norm_rstd_only_mean_none(device):
     pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=0.09, atol=0.06)
     logger.debug(f"rstd's {out_rstd}")
     assert pass_rstd
-
-
-def test_moreh_layer_norm_rejects_invalid_mean_volume(device):
-    torch.manual_seed(2023)
-    input_shape = [2, 32, 64]
-    normalized_dims = 1
-    eps = 1e-5
-    mean_rstd_shape = input_shape[:-normalized_dims]
-    wrong_mean_shape = [input_shape[0], input_shape[1] + 1]
-
-    cpu_input, _, _, _ = make_input_tensors(input_shape, normalized_dims, elementwise_affine=False)
-
-    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
-    npu_output = to_ttnn(torch.empty_like(cpu_input), device=device, dtype=ttnn.bfloat16)
-    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
-    npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
-
-    with pytest.raises(RuntimeError, match="mean must have logical shape"):
-        ttnn.operations.moreh.layer_norm(
-            npu_input,
-            normalized_dims,
-            eps,
-            None,
-            None,
-            output=npu_output,
-            mean=npu_mean,
-            rstd=npu_rstd,
-        )
-
-
-def test_moreh_layer_norm_rejects_same_volume_wrong_mean_shape(device):
-    torch.manual_seed(2023)
-    input_shape = [2, 32, 64]
-    normalized_dims = 1
-    eps = 1e-5
-    mean_rstd_shape = input_shape[:-normalized_dims]
-    wrong_mean_shape = [1, 64]
-
-    cpu_input, _, _, _ = make_input_tensors(input_shape, normalized_dims, elementwise_affine=False)
-
-    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
-    npu_output = to_ttnn(torch.empty_like(cpu_input), device=device, dtype=ttnn.bfloat16)
-    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
-    npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
-
-    with pytest.raises(RuntimeError, match="mean must have logical shape"):
-        ttnn.operations.moreh.layer_norm(
-            npu_input,
-            normalized_dims,
-            eps,
-            None,
-            None,
-            output=npu_output,
-            mean=npu_mean,
-            rstd=npu_rstd,
-        )

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -4,11 +4,107 @@
 
 #include "moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
+
+namespace {
+
+ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
+    auto logical_shape = tensor.logical_shape();
+    const auto padded_rank = tensor.padded_shape().rank();
+    if (logical_shape.rank() < padded_rank) {
+        logical_shape = logical_shape.to_rank(padded_rank);
+    }
+    return logical_shape;
+}
+
+uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
+    uint64_t volume = 1;
+    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
+        volume *= shape[i];
+    }
+    return volume;
+}
+
+uint64_t compute_suffix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
+    uint64_t volume = 1;
+    for (uint32_t i = shape.rank() - normalized_dims; i < shape.rank(); ++i) {
+        volume *= shape[i];
+    }
+    return volume;
+}
+
+}  // namespace
+
 void MorehLayerNormBackwardGammaBetaGradOperation::validate_inputs(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_grad = tensor_args.output_grad;
+    const auto& input = tensor_args.input;
+    const auto& mean = tensor_args.mean;
+    const auto& rstd = tensor_args.rstd;
+    const auto& gamma_grad = tensor_args.gamma_grad;
+    const auto& beta_grad = tensor_args.beta_grad;
+
+    constexpr auto* op_name = "moreh_layer_norm_backward_gamma_beta_grad";
+
+    check_tensor(output_grad, op_name, "output_grad");
+    check_tensor(input, op_name, "input");
+    check_tensor(mean, op_name, "mean");
+    check_tensor(rstd, op_name, "rstd");
+    check_tensor(gamma_grad, op_name, "gamma_grad");
+    check_tensor(beta_grad, op_name, "beta_grad");
+
+    TT_FATAL(output_grad.device() == input.device(), "output_grad and input should be on the same device.");
+    TT_FATAL(mean.device() == input.device(), "mean and input should be on the same device.");
+    TT_FATAL(rstd.device() == input.device(), "rstd and input should be on the same device.");
+
+    const auto normalized_dims = operation_attributes.normalized_dims;
+    const auto input_rank = input.padded_shape().rank();
+    TT_FATAL(normalized_dims > 0, "normalized_dims should > 0. Got {}", normalized_dims);
+    TT_FATAL(
+        normalized_dims <= input_rank,
+        "normalized_dims should <= input rank ({}). Got: {}",
+        input_rank,
+        normalized_dims);
+
+    TT_FATAL(is_same_shape(output_grad, input), "output_grad and input should have the same logical shape.");
+    TT_FATAL(gamma_grad.has_value() || beta_grad.has_value(), "gamma_grad and beta_grad must have values");
+
+    const auto promoted_input_shape = get_promoted_logical_shape(input);
+    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
+    const auto expected_gamma_beta_volume = compute_suffix_volume(promoted_input_shape, normalized_dims);
+
+    TT_FATAL(
+        mean.logical_volume() == expected_mean_rstd_volume,
+        "mean must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume,
+        mean.logical_volume());
+    TT_FATAL(
+        rstd.logical_volume() == expected_mean_rstd_volume,
+        "rstd must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume,
+        rstd.logical_volume());
+
+    if (gamma_grad.has_value()) {
+        TT_FATAL(gamma_grad->device() == input.device(), "gamma_grad and input should be on the same device.");
+        TT_FATAL(
+            gamma_grad->logical_volume() == expected_gamma_beta_volume,
+            "gamma_grad must have logical volume {}. Got {}.",
+            expected_gamma_beta_volume,
+            gamma_grad->logical_volume());
+    }
+
+    if (beta_grad.has_value()) {
+        TT_FATAL(beta_grad->device() == input.device(), "beta_grad and input should be on the same device.");
+        TT_FATAL(
+            beta_grad->logical_volume() == expected_gamma_beta_volume,
+            "beta_grad must have logical volume {}. Got {}.",
+            expected_gamma_beta_volume,
+            beta_grad->logical_volume());
+    }
+}
 void MorehLayerNormBackwardGammaBetaGradOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     validate_inputs(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -4,6 +4,10 @@
 
 #include "moreh_layer_norm_backward_gamma_beta_grad_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+
+#include <algorithm>
+#include <vector>
+
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -11,29 +15,40 @@ namespace ttnn::operations::moreh::moreh_layer_norm_backward_gamma_beta_grad {
 
 namespace {
 
-ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
-    auto logical_shape = tensor.logical_shape();
-    const auto padded_rank = tensor.padded_shape().rank();
-    if (logical_shape.rank() < padded_rank) {
-        logical_shape = logical_shape.to_rank(padded_rank);
+ttnn::Shape canonicalize_shape_for_validation(const ttnn::Shape& shape) {
+    if (shape.rank() == 0) {
+        return ttnn::Shape({1, 1});
     }
-    return logical_shape;
+    if (shape.rank() == 1) {
+        return ttnn::Shape({1, shape[0]});
+    }
+    return shape;
 }
 
-uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
-    uint64_t volume = 1;
-    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
-        volume *= shape[i];
+ttnn::Shape compute_expected_stats_shape(const Tensor& input, uint32_t normalized_dims) {
+    const auto& input_shape = input.logical_shape();
+    const auto input_rank = input_shape.rank();
+    const auto effective_normalized_dims = std::min<uint32_t>(normalized_dims, input_rank);
+
+    std::vector<uint32_t> dims;
+    dims.reserve(input_rank - effective_normalized_dims);
+    for (uint32_t i = 0; i < input_rank - effective_normalized_dims; ++i) {
+        dims.push_back(input_shape[i]);
     }
-    return volume;
+    return canonicalize_shape_for_validation(ttnn::Shape(std::move(dims)));
 }
 
-uint64_t compute_suffix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
-    uint64_t volume = 1;
-    for (uint32_t i = shape.rank() - normalized_dims; i < shape.rank(); ++i) {
-        volume *= shape[i];
+ttnn::Shape compute_expected_gamma_beta_shape(const Tensor& input, uint32_t normalized_dims) {
+    const auto& input_shape = input.logical_shape();
+    const auto input_rank = input_shape.rank();
+    const auto effective_normalized_dims = std::min<uint32_t>(normalized_dims, input_rank);
+
+    std::vector<uint32_t> dims;
+    dims.reserve(effective_normalized_dims);
+    for (uint32_t i = input_rank - effective_normalized_dims; i < input_rank; ++i) {
+        dims.push_back(input_shape[i]);
     }
-    return volume;
+    return canonicalize_shape_for_validation(ttnn::Shape(std::move(dims)));
 }
 
 }  // namespace
@@ -72,37 +87,36 @@ void MorehLayerNormBackwardGammaBetaGradOperation::validate_inputs(
     TT_FATAL(is_same_shape(output_grad, input), "output_grad and input should have the same logical shape.");
     TT_FATAL(gamma_grad.has_value() || beta_grad.has_value(), "gamma_grad and beta_grad must have values");
 
-    const auto promoted_input_shape = get_promoted_logical_shape(input);
-    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
-    const auto expected_gamma_beta_volume = compute_suffix_volume(promoted_input_shape, normalized_dims);
+    const auto expected_mean_rstd_shape = compute_expected_stats_shape(input, normalized_dims);
+    const auto expected_gamma_beta_shape = compute_expected_gamma_beta_shape(input, normalized_dims);
 
     TT_FATAL(
-        mean.logical_volume() == expected_mean_rstd_volume,
-        "mean must have logical volume {}. Got {}.",
-        expected_mean_rstd_volume,
-        mean.logical_volume());
+        canonicalize_shape_for_validation(mean.logical_shape()) == expected_mean_rstd_shape,
+        "mean must have logical shape {}. Got {}.",
+        expected_mean_rstd_shape,
+        mean.logical_shape());
     TT_FATAL(
-        rstd.logical_volume() == expected_mean_rstd_volume,
-        "rstd must have logical volume {}. Got {}.",
-        expected_mean_rstd_volume,
-        rstd.logical_volume());
+        canonicalize_shape_for_validation(rstd.logical_shape()) == expected_mean_rstd_shape,
+        "rstd must have logical shape {}. Got {}.",
+        expected_mean_rstd_shape,
+        rstd.logical_shape());
 
     if (gamma_grad.has_value()) {
         TT_FATAL(gamma_grad->device() == input.device(), "gamma_grad and input should be on the same device.");
         TT_FATAL(
-            gamma_grad->logical_volume() == expected_gamma_beta_volume,
-            "gamma_grad must have logical volume {}. Got {}.",
-            expected_gamma_beta_volume,
-            gamma_grad->logical_volume());
+            canonicalize_shape_for_validation(gamma_grad->logical_shape()) == expected_gamma_beta_shape,
+            "gamma_grad must have logical shape {}. Got {}.",
+            expected_gamma_beta_shape,
+            gamma_grad->logical_shape());
     }
 
     if (beta_grad.has_value()) {
         TT_FATAL(beta_grad->device() == input.device(), "beta_grad and input should be on the same device.");
         TT_FATAL(
-            beta_grad->logical_volume() == expected_gamma_beta_volume,
-            "beta_grad must have logical volume {}. Got {}.",
-            expected_gamma_beta_volume,
-            beta_grad->logical_volume());
+            canonicalize_shape_for_validation(beta_grad->logical_shape()) == expected_gamma_beta_shape,
+            "beta_grad must have logical shape {}. Got {}.",
+            expected_gamma_beta_shape,
+            beta_grad->logical_shape());
     }
 }
 void MorehLayerNormBackwardGammaBetaGradOperation::validate_on_program_cache_miss(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
@@ -10,8 +10,98 @@
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {
+
+namespace {
+
+ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
+    auto logical_shape = tensor.logical_shape();
+    const auto padded_rank = tensor.padded_shape().rank();
+    if (logical_shape.rank() < padded_rank) {
+        logical_shape = logical_shape.to_rank(padded_rank);
+    }
+    return logical_shape;
+}
+
+uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
+    uint64_t volume = 1;
+    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
+        volume *= shape[i];
+    }
+    return volume;
+}
+
+uint64_t compute_suffix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
+    uint64_t volume = 1;
+    for (uint32_t i = shape.rank() - normalized_dims; i < shape.rank(); ++i) {
+        volume *= shape[i];
+    }
+    return volume;
+}
+
+}  // namespace
+
 void MorehLayerNormBackwardInputGradOperation::validate_inputs(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& output_grad = tensor_args.output_grad;
+    const auto& input = tensor_args.input;
+    const auto& mean = tensor_args.mean;
+    const auto& rstd = tensor_args.rstd;
+    const auto& input_grad = tensor_args.input_grad;
+    const auto& gamma = tensor_args.gamma;
+
+    constexpr auto* op_name = "moreh_layer_norm_backward_input_grad";
+
+    check_tensor(output_grad, op_name, "output_grad");
+    check_tensor(input, op_name, "input");
+    check_tensor(mean, op_name, "mean");
+    check_tensor(rstd, op_name, "rstd");
+    check_tensor(input_grad, op_name, "input_grad");
+    check_tensor(gamma, op_name, "gamma");
+
+    TT_FATAL(output_grad.device() == input.device(), "output_grad and input should be on the same device.");
+    TT_FATAL(mean.device() == input.device(), "mean and input should be on the same device.");
+    TT_FATAL(rstd.device() == input.device(), "rstd and input should be on the same device.");
+
+    const auto normalized_dims = operation_attributes.normalized_dims;
+    const auto input_rank = input.padded_shape().rank();
+    TT_FATAL(normalized_dims > 0, "normalized_dims should > 0. Got {}", normalized_dims);
+    TT_FATAL(
+        normalized_dims <= input_rank,
+        "normalized_dims should <= input rank ({}). Got: {}",
+        input_rank,
+        normalized_dims);
+
+    TT_FATAL(is_same_shape(output_grad, input), "output_grad and input should have the same logical shape.");
+
+    const auto promoted_input_shape = get_promoted_logical_shape(input);
+    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
+    const auto expected_gamma_volume = compute_suffix_volume(promoted_input_shape, normalized_dims);
+
+    TT_FATAL(
+        mean.logical_volume() == expected_mean_rstd_volume,
+        "mean must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume,
+        mean.logical_volume());
+    TT_FATAL(
+        rstd.logical_volume() == expected_mean_rstd_volume,
+        "rstd must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume,
+        rstd.logical_volume());
+
+    if (input_grad.has_value()) {
+        TT_FATAL(input_grad->device() == input.device(), "input_grad and input should be on the same device.");
+        TT_FATAL(is_same_shape(input_grad.value(), input), "input_grad and input should have the same logical shape.");
+    }
+
+    if (gamma.has_value()) {
+        TT_FATAL(gamma->device() == input.device(), "gamma and input should be on the same device.");
+        TT_FATAL(
+            gamma->logical_volume() == expected_gamma_volume,
+            "gamma must have logical volume {}. Got {}.",
+            expected_gamma_volume,
+            gamma->logical_volume());
+    }
+}
 void MorehLayerNormBackwardInputGradOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     validate_inputs(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp
@@ -6,6 +6,9 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 
+#include <algorithm>
+#include <vector>
+
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
@@ -13,29 +16,40 @@ namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad {
 
 namespace {
 
-ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
-    auto logical_shape = tensor.logical_shape();
-    const auto padded_rank = tensor.padded_shape().rank();
-    if (logical_shape.rank() < padded_rank) {
-        logical_shape = logical_shape.to_rank(padded_rank);
+ttnn::Shape canonicalize_shape_for_validation(const ttnn::Shape& shape) {
+    if (shape.rank() == 0) {
+        return ttnn::Shape({1, 1});
     }
-    return logical_shape;
+    if (shape.rank() == 1) {
+        return ttnn::Shape({1, shape[0]});
+    }
+    return shape;
 }
 
-uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
-    uint64_t volume = 1;
-    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
-        volume *= shape[i];
+ttnn::Shape compute_expected_stats_shape(const Tensor& input, uint32_t normalized_dims) {
+    const auto& input_shape = input.logical_shape();
+    const auto input_rank = input_shape.rank();
+    const auto effective_normalized_dims = std::min<uint32_t>(normalized_dims, input_rank);
+
+    std::vector<uint32_t> dims;
+    dims.reserve(input_rank - effective_normalized_dims);
+    for (uint32_t i = 0; i < input_rank - effective_normalized_dims; ++i) {
+        dims.push_back(input_shape[i]);
     }
-    return volume;
+    return canonicalize_shape_for_validation(ttnn::Shape(std::move(dims)));
 }
 
-uint64_t compute_suffix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
-    uint64_t volume = 1;
-    for (uint32_t i = shape.rank() - normalized_dims; i < shape.rank(); ++i) {
-        volume *= shape[i];
+ttnn::Shape compute_expected_gamma_shape(const Tensor& input, uint32_t normalized_dims) {
+    const auto& input_shape = input.logical_shape();
+    const auto input_rank = input_shape.rank();
+    const auto effective_normalized_dims = std::min<uint32_t>(normalized_dims, input_rank);
+
+    std::vector<uint32_t> dims;
+    dims.reserve(effective_normalized_dims);
+    for (uint32_t i = input_rank - effective_normalized_dims; i < input_rank; ++i) {
+        dims.push_back(input_shape[i]);
     }
-    return volume;
+    return canonicalize_shape_for_validation(ttnn::Shape(std::move(dims)));
 }
 
 }  // namespace
@@ -73,20 +87,19 @@ void MorehLayerNormBackwardInputGradOperation::validate_inputs(
 
     TT_FATAL(is_same_shape(output_grad, input), "output_grad and input should have the same logical shape.");
 
-    const auto promoted_input_shape = get_promoted_logical_shape(input);
-    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
-    const auto expected_gamma_volume = compute_suffix_volume(promoted_input_shape, normalized_dims);
+    const auto expected_mean_rstd_shape = compute_expected_stats_shape(input, normalized_dims);
+    const auto expected_gamma_shape = compute_expected_gamma_shape(input, normalized_dims);
 
     TT_FATAL(
-        mean.logical_volume() == expected_mean_rstd_volume,
-        "mean must have logical volume {}. Got {}.",
-        expected_mean_rstd_volume,
-        mean.logical_volume());
+        canonicalize_shape_for_validation(mean.logical_shape()) == expected_mean_rstd_shape,
+        "mean must have logical shape {}. Got {}.",
+        expected_mean_rstd_shape,
+        mean.logical_shape());
     TT_FATAL(
-        rstd.logical_volume() == expected_mean_rstd_volume,
-        "rstd must have logical volume {}. Got {}.",
-        expected_mean_rstd_volume,
-        rstd.logical_volume());
+        canonicalize_shape_for_validation(rstd.logical_shape()) == expected_mean_rstd_shape,
+        "rstd must have logical shape {}. Got {}.",
+        expected_mean_rstd_shape,
+        rstd.logical_shape());
 
     if (input_grad.has_value()) {
         TT_FATAL(input_grad->device() == input.device(), "input_grad and input should be on the same device.");
@@ -96,10 +109,10 @@ void MorehLayerNormBackwardInputGradOperation::validate_inputs(
     if (gamma.has_value()) {
         TT_FATAL(gamma->device() == input.device(), "gamma and input should be on the same device.");
         TT_FATAL(
-            gamma->logical_volume() == expected_gamma_volume,
-            "gamma must have logical volume {}. Got {}.",
-            expected_gamma_volume,
-            gamma->logical_volume());
+            canonicalize_shape_for_validation(gamma->logical_shape()) == expected_gamma_shape,
+            "gamma must have logical shape {}. Got {}.",
+            expected_gamma_shape,
+            gamma->logical_shape());
     }
 }
 void MorehLayerNormBackwardInputGradOperation::validate_on_program_cache_miss(


### PR DESCRIPTION
PR Category
Bug fix

Summary

1. Fixes #46060.
2. Fill the empty host-side validators for the `moreh_layer_norm_backward` input-grad and gamma/beta-grad device ops.
3. Reject malformed `mean`, `rstd`, `gamma`, `gamma_grad`, `beta_grad`, and optional `input_grad` tensors before the program factories consume them.
4. Tighten the backward stats and grad-output checks from volume-only validation to canonical logical-shape validation.
5. Add a focused nightly regression for an invalid `mean` shape, including a same-volume wrong-shape case that previously slipped past host-side checks.

Notes for reviewers

1. Before this patch, both `validate_inputs(...)` implementations were empty in:
   - `ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.cpp`
   - `ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_gamma_beta_grad_device_operation.cpp`
2. The downstream program factories already assume structured backward stats contracts, not just matching volume:
   - both paths read `mean.logical_shape()[-2]` and `mean.logical_shape()[-1]`,
   - the gamma/beta path already requires at least one of `gamma_grad` or `beta_grad`.
3. This patch keeps kernel math and output-spec behavior unchanged. It only tightens host-side contract checks.
4. The input-grad path now validates:
   - `output_grad` and `input` logical shape parity,
   - canonical `mean` and `rstd` logical shape,
   - optional `gamma` logical shape,
   - optional `input_grad` shape and device parity.
5. The gamma/beta-grad path now validates:
   - the same canonical stats shape,
   - canonical optional `gamma_grad` / `beta_grad` logical shape,
   - and the non-empty `gamma_grad` / `beta_grad` requirement before program setup.

Test plan

1. `python3 -m py_compile tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py`
2. `python -m pytest -q tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py::test_moreh_layer_norm_backward_rejects_invalid_mean_volume -q`
3. `python -m pytest -q tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py::test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape -q`
4. In a Linux-side mock-cluster run, both negative regressions now fail early with explicit host-side shape errors and pass under pytest.
