### PR TITLE
[Bug fix] validate moreh_layer_norm forward stats tensors

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -761,3 +761,31 @@ def test_moreh_layer_norm_rstd_only_mean_none(device):
     pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=0.09, atol=0.06)
     logger.debug(f"rstd's {out_rstd}")
     assert pass_rstd
+
+
+def test_moreh_layer_norm_rejects_invalid_mean_volume(device):
+    torch.manual_seed(2023)
+    input_shape = [2, 32, 64]
+    normalized_dims = 1
+    eps = 1e-5
+    mean_rstd_shape = input_shape[:-normalized_dims]
+    wrong_mean_shape = [input_shape[0], input_shape[1] + 1]
+
+    cpu_input, _, _, _ = make_input_tensors(input_shape, normalized_dims, elementwise_affine=False)
+
+    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
+    npu_output = to_ttnn(torch.empty_like(cpu_input), device=device, dtype=ttnn.bfloat16)
+    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+    npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+
+    with pytest.raises(RuntimeError, match="mean must have logical volume"):
+        ttnn.operations.moreh.layer_norm(
+            npu_input,
+            normalized_dims,
+            eps,
+            None,
+            None,
+            output=npu_output,
+            mean=npu_mean,
+            rstd=npu_rstd,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -778,7 +778,35 @@ def test_moreh_layer_norm_rejects_invalid_mean_volume(device):
     npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
     npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
 
-    with pytest.raises(RuntimeError, match="mean must have logical volume"):
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
+        ttnn.operations.moreh.layer_norm(
+            npu_input,
+            normalized_dims,
+            eps,
+            None,
+            None,
+            output=npu_output,
+            mean=npu_mean,
+            rstd=npu_rstd,
+        )
+
+
+def test_moreh_layer_norm_rejects_same_volume_wrong_mean_shape(device):
+    torch.manual_seed(2023)
+    input_shape = [2, 32, 64]
+    normalized_dims = 1
+    eps = 1e-5
+    mean_rstd_shape = input_shape[:-normalized_dims]
+    wrong_mean_shape = [1, 64]
+
+    cpu_input, _, _, _ = make_input_tensors(input_shape, normalized_dims, elementwise_affine=False)
+
+    npu_input = to_ttnn(cpu_input, device=device, dtype=ttnn.bfloat16)
+    npu_output = to_ttnn(torch.empty_like(cpu_input), device=device, dtype=ttnn.bfloat16)
+    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+    npu_rstd = to_ttnn(torch.zeros(mean_rstd_shape, dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16)
+
+    with pytest.raises(RuntimeError, match="mean must have logical shape"):
         ttnn.operations.moreh.layer_norm(
             npu_input,
             normalized_dims,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -23,6 +23,23 @@ inline void check_tensor(const Tensor& tensor, const std::string& op_name) {
         tensor.storage_type());
     TT_FATAL(tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
 }
+
+ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
+    auto logical_shape = tensor.logical_shape();
+    const auto padded_rank = tensor.padded_shape().rank();
+    if (logical_shape.rank() < padded_rank) {
+        logical_shape = logical_shape.to_rank(padded_rank);
+    }
+    return logical_shape;
+}
+
+uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
+    uint64_t volume = 1;
+    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
+        volume *= shape[i];
+    }
+    return volume;
+}
 }  // namespace
 
 void MorehLayerNormOperation::validate_inputs(
@@ -55,14 +72,29 @@ void MorehLayerNormOperation::validate_inputs(
 
     const auto& mean = tensor_args.mean;
     const auto& rstd = tensor_args.rstd;
+    const auto promoted_input_shape = get_promoted_logical_shape(input);
+    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
 
     if (mean.has_value()) {
         check_tensor(mean.value(), "moreh_layer_norm");
+        TT_FATAL(input.device() == mean.value().device(), "input and mean should be on the same device.");
+        TT_FATAL(
+            mean->logical_volume() == expected_mean_rstd_volume,
+            "mean must have logical volume {}. Got {}.",
+            expected_mean_rstd_volume,
+            mean->logical_volume());
     }
 
     if (rstd.has_value()) {
         check_tensor(rstd.value(), "moreh_layer_norm");
+        TT_FATAL(input.device() == rstd.value().device(), "input and rstd should be on the same device.");
+        TT_FATAL(
+            rstd->logical_volume() == expected_mean_rstd_volume,
+            "rstd must have logical volume {}. Got {}.",
+            expected_mean_rstd_volume,
+            rstd->logical_volume());
     }
+
 }
 
 void MorehLayerNormOperation::validate_on_program_cache_miss(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_device_operation.cpp
@@ -6,6 +6,8 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 
+#include <vector>
+
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -24,21 +26,29 @@ inline void check_tensor(const Tensor& tensor, const std::string& op_name) {
     TT_FATAL(tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
 }
 
-ttnn::Shape get_promoted_logical_shape(const Tensor& tensor) {
-    auto logical_shape = tensor.logical_shape();
-    const auto padded_rank = tensor.padded_shape().rank();
+ttnn::Shape canonicalize_shape_for_validation(const ttnn::Shape& shape) {
+    if (shape.rank() == 0) {
+        return ttnn::Shape({1, 1});
+    }
+    if (shape.rank() == 1) {
+        return ttnn::Shape({1, shape[0]});
+    }
+    return shape;
+}
+
+ttnn::Shape compute_expected_stats_shape(const Tensor& input, uint32_t normalized_dims) {
+    auto logical_shape = input.logical_shape();
+    const auto padded_rank = input.padded_shape().rank();
     if (logical_shape.rank() < padded_rank) {
         logical_shape = logical_shape.to_rank(padded_rank);
     }
-    return logical_shape;
-}
 
-uint64_t compute_prefix_volume(const ttnn::Shape& shape, uint32_t normalized_dims) {
-    uint64_t volume = 1;
-    for (uint32_t i = 0; i < shape.rank() - normalized_dims; ++i) {
-        volume *= shape[i];
+    std::vector<uint32_t> dims;
+    dims.reserve(logical_shape.rank() - normalized_dims);
+    for (uint32_t i = 0; i < logical_shape.rank() - normalized_dims; ++i) {
+        dims.push_back(logical_shape[i]);
     }
-    return volume;
+    return canonicalize_shape_for_validation(ttnn::Shape(std::move(dims)));
 }
 }  // namespace
 
@@ -72,27 +82,26 @@ void MorehLayerNormOperation::validate_inputs(
 
     const auto& mean = tensor_args.mean;
     const auto& rstd = tensor_args.rstd;
-    const auto promoted_input_shape = get_promoted_logical_shape(input);
-    const auto expected_mean_rstd_volume = compute_prefix_volume(promoted_input_shape, normalized_dims);
+    const auto expected_mean_rstd_shape = compute_expected_stats_shape(input, normalized_dims);
 
     if (mean.has_value()) {
         check_tensor(mean.value(), "moreh_layer_norm");
         TT_FATAL(input.device() == mean.value().device(), "input and mean should be on the same device.");
         TT_FATAL(
-            mean->logical_volume() == expected_mean_rstd_volume,
-            "mean must have logical volume {}. Got {}.",
-            expected_mean_rstd_volume,
-            mean->logical_volume());
+            canonicalize_shape_for_validation(mean->logical_shape()) == expected_mean_rstd_shape,
+            "mean must have logical shape {}. Got {}.",
+            expected_mean_rstd_shape,
+            mean->logical_shape());
     }
 
     if (rstd.has_value()) {
         check_tensor(rstd.value(), "moreh_layer_norm");
         TT_FATAL(input.device() == rstd.value().device(), "input and rstd should be on the same device.");
         TT_FATAL(
-            rstd->logical_volume() == expected_mean_rstd_volume,
-            "rstd must have logical volume {}. Got {}.",
-            expected_mean_rstd_volume,
-            rstd->logical_volume());
+            canonicalize_shape_for_validation(rstd->logical_shape()) == expected_mean_rstd_shape,
+            "rstd must have logical shape {}. Got {}.",
+            expected_mean_rstd_shape,
+            rstd->logical_shape());
     }
 
 }


### PR DESCRIPTION
PR Category
Bug fix

Summary

1. Fixes #46066.
2. Reject malformed forward `mean` and `rstd` tensors in `moreh_layer_norm` before the program factory consumes their shape fields.
3. Validate provided forward stats tensors by canonical logical shape, not by volume only.
4. Add focused nightly regressions for both a malformed-volume `mean` and a same-volume wrong-shape `mean`.

Notes for reviewers

1. Before this patch, `moreh_layer_norm::validate_inputs(...)` checked the input tensor, optional `gamma` and `beta`, and `normalized_dims`, but it left the forward stats shape contract unchecked.
2. The forward program factory already reads `mean.logical_shape()[-2]` and `mean.logical_shape()[-1]`, or the equivalent `rstd` shape, when those tensors are present.
3. This patch keeps the scope narrow:
   - no kernel math changes
   - no program-factory changes
   - only host-side validation plus focused negative regressions
4. The validator now derives the expected unreduced-prefix stats shape from the promoted logical input shape and rejects provided `mean` or `rstd` tensors that do not match it.

Test plan

1. `python3 -m py_compile tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py`
2. `python -m pytest -q tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py::test_moreh_layer_norm_rejects_invalid_mean_volume -q`
3. `python -m pytest -q tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py::test_moreh_layer_norm_rejects_same_volume_wrong_mean_shape -q`
4. In a Linux-side mock-cluster run, the focused regressions now fail early with:
   - `TT_FATAL: mean must have logical shape Shape([2, 32]). Got Shape([2, 33]).`
   - `TT_FATAL: mean must have logical shape Shape([2, 32]). Got Shape([1, 64]).`
