### PR TITLE
ttnn::moe - apply the expert mask 

### DIFF
--- a/models/tt_transformers/tt/mixtral_moe.py
+++ b/models/tt_transformers/tt/mixtral_moe.py
@@ -109,12 +109,11 @@ class TtMoeLayer(LightweightModule):
             core_grid=ttnn.CoreGrid(y=8, x=8),
             dtype=ttnn.bfloat16,
         )
-        # get weights for top-2 experts -- masking out everything except the 8 experts (needed because top-k works with a min input of size 64)
-        gate_logits_1SB8 = ttnn.add(gate_logits_1SB8, self.top8_mask_11B_64)
-
         if mode == Mode.DECODE:
             weights_1SB1 = ttnn.moe(gate_logits_1SB8, self.top8_mask_11B_64, self.top2_mask_11BB, 32)
         else:
+            # get weights for top-2 experts -- masking out everything except the 8 experts (needed because top-k works with a min input of size 64)
+            gate_logits_1SB8 = ttnn.add(gate_logits_1SB8, self.top8_mask_11B_64)
             topk_values, topk_indices = ttnn.topk(gate_logits_1SB8, 32)
             topk_values = ttnn.add(topk_values, self.top2_mask_11BB)
             mask_B2 = ttnn.eqz(topk_indices)

--- a/tests/ttnn/unit_tests/operations/reduce/test_moe.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_moe.py
@@ -22,13 +22,10 @@ def run_moe_test(N, C, H, W, k, E, e, dtype, device):
     expert_mask = torch.zeros([N, C, 1, W], dtype=torch_dtype)
     expert_mask[:, :, :, E:] = float("-inf")
 
-    # TODO: make this addition a part of the moe op
-    input += expert_mask
-
     topE_mask = torch.zeros([N, C, 1, k], dtype=torch_dtype)
     topE_mask[:, :, :, e:] = float("-inf")
 
-    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=-1)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input + expert_mask, k, dim=-1)
     torch_weights_1SB1 = torch.sum(
         (torch.softmax(pyt_topk_values + topE_mask, dim=-1) * (pyt_topk_indices == 0))[:, :, :, :e],
         dim=-1,

--- a/tests/ttnn/unit_tests/operations/reduce/test_moe.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_moe.py
@@ -64,7 +64,10 @@ def run_moe_test(N, C, H, W, k, E, e, dtype, device):
 )
 @pytest.mark.parametrize(
     "N, C, H, W, k, E, e",
-    ((1, 1, 32, 64, 32, 8, 2),),  # Mixtral8x7B
+    [
+        (1, 1, 32, 64, 32, 8, 2),  # Mixtral8x7B decode shape (Wt=2)
+        (1, 1, 32, 256, 32, 8, 2),  # wider expert dim (Wt=8) — exercises the upfront expert-mask load for Wt>4
+    ],
 )
 def test_moe(N, C, H, W, k, E, e, dtype, device):
     run_moe_test(N, C, H, W, k, E, e, dtype, device)

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
@@ -232,6 +232,8 @@ template <
     uint32_t logWt,
     uint32_t logk,
     uint32_t input_cb_index,
+    uint32_t expert_mask_cb_index,
+    uint32_t masked_input_cb_index,
     uint32_t index_cb_index,
     uint32_t input_transposed_cb_index,
     uint32_t index_transposed_cb_index,
@@ -239,7 +241,7 @@ template <
     uint32_t output_ind_cb_index,
     uint32_t tile_width,
     bool first_call>
-void top_k() {
+void mask_and_topk() {
     // dest indices for where to unpack the tiles for the llk
     // the input goes in index 0,1 and the index goes in index 2,3
     constexpr uint32_t input_dest_start = 0;
@@ -249,6 +251,8 @@ void top_k() {
     ckernel::topk_tile_init();
 
     CircularBuffer input_cb(input_cb_index);
+    CircularBuffer expert_mask_cb(expert_mask_cb_index);
+    CircularBuffer masked_input_cb(masked_input_cb_index);
     CircularBuffer index_cb(index_cb_index);
     CircularBuffer input_transposed_cb(input_transposed_cb_index);
     CircularBuffer index_transposed_cb(index_transposed_cb_index);
@@ -258,6 +262,10 @@ void top_k() {
     if (first_call) {
         transpose_wh_init(input_cb_index, input_transposed_cb_index);
     }
+
+    // The expert mask is the same for all rows, so wait for all Wt tiles once before the loop.
+    expert_mask_cb.wait_front(Wt);
+
     for (uint32_t ht = 0; ht < Ht; ++ht) {
         bool ascending = false;
         input_transposed_cb.reserve_back(Wt);
@@ -265,15 +273,33 @@ void top_k() {
 
         // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
         for (uint32_t wt = 0; wt < Wt; wt += 2) {
-            // local sort into k groups
             input_cb.wait_front(2);
             index_cb.wait_front(2);
 
+            // Before transposing, add expert_mask to the two input tiles and store the result in masked_input_cb.
             tile_regs_acquire();
-            reconfig_data_format_srca(input_cb_index);
-            transpose_wh_init_short(input_cb_index);
-            transpose_wh_tile(input_cb_index, 0, 0);
-            transpose_wh_tile(input_cb_index, 1, 1);
+            reconfig_data_format(input_cb_index, expert_mask_cb_index);
+            add_bcast_rows_init_short(input_cb_index, expert_mask_cb_index);
+            add_tiles_bcast_rows(input_cb_index, expert_mask_cb_index, 0, wt, 0);
+            add_tiles_bcast_rows(input_cb_index, expert_mask_cb_index, 1, wt + 1, 1);
+            masked_input_cb.reserve_back(2);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_reconfig_data_format(masked_input_cb_index);
+            pack_tile(0, masked_input_cb_index);
+            pack_tile(1, masked_input_cb_index);
+            masked_input_cb.push_back(2);
+            input_cb.pop_front(2);
+            tile_regs_release();
+
+            // Transpose masked input and index tiles, then locally sort into k groups.
+            tile_regs_acquire();
+            masked_input_cb.wait_front(2);
+            reconfig_data_format_srca(masked_input_cb_index);
+            transpose_wh_init_short(masked_input_cb_index);
+            transpose_wh_tile(masked_input_cb_index, 0, 0);
+            transpose_wh_tile(masked_input_cb_index, 1, 1);
+            masked_input_cb.pop_front(2);
 
             reconfig_data_format_srca(index_cb_index);
             transpose_wh_init_short(index_cb_index);
@@ -285,7 +311,6 @@ void top_k() {
 
             tile_regs_commit();
 
-            input_cb.pop_front(2);
             index_cb.pop_front(2);
 
             tile_regs_wait();
@@ -400,6 +425,7 @@ void top_k() {
         index_transposed_cb.wait_front(Wt);
         index_transposed_cb.pop_front(Wt);
     }
+    expert_mask_cb.pop_front(Wt);
     // sfpu::_init_sfpu_config_reg();
 }
 
@@ -424,21 +450,20 @@ void kernel_main() {
     constexpr uint32_t cb_cur_max = get_compile_time_arg_val(15);
     constexpr uint32_t cb_cur_sum = get_compile_time_arg_val(16);
     constexpr uint32_t tile_width = get_compile_time_arg_val(17);
+    constexpr uint32_t masked_input_cb_index = get_compile_time_arg_val(18);
 
     constexpr uint32_t Kt = K % tile_width == 0 ? K / tile_width : K / tile_width + 1;
 
-    // mask out invalid experts
-    // TODO: fix the bug that makes this give bad results
-    // add_block_bcast_rows_inplace(input_cb_index, expert_mask_cb_index, Ht,Wt, true);
-
-    // top-k
-    top_k<
+    // Apply expert_mask to each input tile pair and run top-k on the masked values.
+    mask_and_topk<
         Ht,
         Wt,
         K,
         logWt,
         logk,
         input_cb_index,
+        expert_mask_cb_index,
+        masked_input_cb_index,
         index_cb_index,
         input_transposed_cb_index,
         index_transposed_cb_index,

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -74,25 +74,22 @@ void kernel_main() {
     CircularBuffer cb_topk(cb_topk_mask);
     CircularBuffer cb_expert(cb_expert_mask);
 
+    // Load all Wt expert mask tiles once, in a single burst, before the input stream loop.
+    // The expert mask row is identical for every input row, so it is read once and the
+    // tiles stay resident in the CB for all Ht rows. Loading the whole row up front gives
+    // the NoC a dedicated window for the expert reads before any input reads begin.
+    cb_expert.reserve_back(Wt);
+    for (uint32_t j = 0; j < Wt; ++j) {
+        noc.async_read(s2, cb_expert, tile_bytes_expert, {.page_id = j}, {.offset_bytes = j * tile_bytes_expert});
+    }
+    noc.async_read_barrier();
+    cb_expert.push_back(Wt);
+
     // Stream in input tensor, buffer has four tiles as we double-buffer to continue streaming while waiting for compute
     // and we need two tiles for the bitonic sort llk We could load in an entire row of tiles at a time but that would
     // require substantially more memory (we would be double buffering four Wt sized CBs)
-
     uint32_t tile_id = 0;
-    uint32_t tile_id_expert = 0;
     for (uint32_t i = 0; i < Ht; ++i) {
-        // Expert mask is not consumed by the compute kernel. Enable back once support is added to the compute kernel.
-        /*
-        cb_expert.reserve_back(Wt);
-        for (uint32_t j = 0; j < Wt; ++j) {
-            noc.async_read(
-                s2, cb_expert, tile_bytes_expert, {.page_id = tile_id_expert}, {.offset_bytes = j * tile_bytes_expert});
-            tile_id_expert++;
-        }
-        noc.async_read_barrier();
-        cb_expert.push_back(Wt);
-        */
-
         // input: stream two tiles at a time (Wt is guaranteed to be a multiple of 2 for this kernel).
         for (uint32_t j = 0; j < Wt; j += 2) {
             cb_in0.reserve_back(2);

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -82,7 +82,7 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
 
     uint32_t expert_mask_cb_index = tt::CBIndex::c_1;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * expert_mask_tile_size,
+        .total_size = Wt * expert_mask_tile_size,
         .core_ranges = core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(expert_mask_cb_index),

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp
@@ -210,6 +210,19 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
         }}},
     });
 
+    // Intermediate buffer for adding input + expert_mask before sorting.
+    // Takes 2 tiles because two tiles are processed and freed before the next two are loaded.
+    uint32_t masked_input_cb_index = tt::CBIndex::c_12;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * input_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(masked_input_cb_index),
+            .data_format = input_cb_data_format,
+            .page_size = input_tile_size,
+        }}},
+    });
+
     std::vector<uint32_t> reader_compile_time_args = {
         input_cb_index, index_cb_index, topk_mask_cb_index, expert_mask_cb_index, Ht, Wt, k};
     tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
@@ -265,7 +278,8 @@ tt::tt_metal::ProgramDescriptor MoeProgramFactory::create_descriptor(
         static_cast<uint32_t>(std::log2(Wt)),
         cb_cur_max_index,
         cb_cur_sum_index,
-        tile_width};
+        tile_width,
+        masked_input_cb_index};
 
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp";


### PR DESCRIPTION
### Summary: 

Resolves #43734.

### Problem Description:

The `ttnn::moe` compute kernel had its expert-mask application disabled since the initial commit (August 2024) with a `TODO: fix the bug that makes this give bad results`. Callers worked around it by manually pre-applying the mask with `ttnn.add` before calling `ttnn.moe`, adding an unnecessary DRAM round trip. This PR fixes the bug and removes the workaround.

### Changes Made: 

**Files modified:**
- `ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp`
- `ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/dataflow/reader_create_index_tensor.cpp`
- `ttnn/cpp/ttnn/operations/reduction/moe/device/moe_program_factory.cpp`
- `models/tt_transformers/tt/mixtral_moe.py`
- `tests/ttnn/unit_tests/operations/reduce/test_moe.py`

**Compute kernel:**

Renamed `top_k` to `mask_and_topk` and fused the expert-mask add into the existing per-tile-pair loop:
- `add_tiles_bcast_rows` adds expert_mask (row-broadcast) to two input tiles.
- Transpose reads from `masked_input_cb` instead of `input_cb`, avoiding the two-producer conflict.
- Top-k sorts the transposed masked values.

`masked_input_cb` stays a constant 2 tiles regardless of Ht since only one tile pair is in-flight at a time; input is read once.

**Reader kernel:**

Moved the expert-mask DRAM read to before the input stream loop. With the old ordering, Ht > 1 deadlocked: `input_cb` holds only 4 tile slots, so the reader blocked filling the 3rd pair while compute blocked on `wait_front(Wt)` for the expert-mask tiles that had not yet been pushed. Loading the mask first lets compute unblock before any input is consumed.

**Program factory:**

Added `masked_input_cb` (c_12, 2 tiles, input format) and passed `masked_input_cb_index` to the compute kernel.

**Caller cleanup:**

Removed the manual `ttnn.add(gate_logits, top8_mask)` pre-masking in `mixtral_moe.py`; the kernel now applies it internally.

**Tests:**

Removed `torch_input = torch_input + expert_mask` which was mutating the reference input before passing it to ttnn. The mask addition is now inlined into the torch reference `torch.topk(torch_input + expert_mask, k, dim=-1)`, keeping `torch_input` clean and matching the kernel behavior of receiving unmasked input and applying the mask internally.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/moe-apply-expert-mask)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/moe-apply-expert-mask)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/moe-apply-expert-mask)