### PR TITLE
[tt-triage] Change op window suppression

### DIFF
--- a/tools/triage/dump_op_window.py
+++ b/tools/triage/dump_op_window.py
@@ -38,7 +38,7 @@ from triage import (
     ScriptConfig,
     ScriptPriority,
     collection_serializer,
-    log_check,
+    log_warning,
     run_script,
     triage_field,
 )
@@ -86,7 +86,7 @@ def run(args, context: Context):
         window = 0
 
     if window <= 0:
-        log_check(False, f"Op-id window suppressed: --op-window={window} (must be > 0).")
+        log_warning(f"Op-id window suppressed: --op-window={window} (must be > 0).")
         return None
 
     bundle = get_operation_provider(args, context)
@@ -94,14 +94,12 @@ def run(args, context: Context):
     runtime_id_to_operation = bundle.runtime_id_to_operation
 
     if not aggregations:
-        log_check(False, "Op-id window suppressed: no running ops found in dispatcher mailboxes.")
         return None
 
     raw_to_devices = _build_raw_id_to_devices(aggregations, runtime_id_to_operation)
     running_raw_ids = set(raw_to_devices.keys())
     if not running_raw_ids:
-        log_check(
-            False,
+        log_warning(
             "Op-id window suppressed: no running host_assigned_id resolved to a known Inspector "
             "runtime id (Inspector data may be empty / out of sync).",
         )
@@ -114,7 +112,7 @@ def run(args, context: Context):
         (raw_id, op_info) for raw_id, op_info in runtime_id_to_operation.items() if min_id <= raw_id <= max_id
     )
     if not entries:
-        log_check(False, f"Op-id window suppressed: no Inspector entries in range [{min_id}, {max_id}].")
+        log_warning(f"Op-id window suppressed: no Inspector entries in range [{min_id}, {max_id}].")
         return None
 
     rows: list[OpWindowRow] = []


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
When there are no ops dispatched to the device, `dump_running_ops` will show nothing, `dump_op_mesh` will say all devices are idle, but due to a miss, `dump_op_mesh` will report script failure which is wrong behavior. This aligns all three scripts by fixing the bug in `dump_op_window` 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/op-window-supress)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/op-window-supress)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/op-window-supress)