### PR TITLE
[Bug fix] validate moreh_group_norm_backward stats tensors

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
@@ -546,3 +546,54 @@ def test_moreh_group_norm_backward_callback(
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
     assert num_program_cache_entries_list[0] > 0
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
+
+
+@pytest.mark.parametrize(
+    "are_required_outputs",
+    [
+        (True, False, False),
+        (False, True, False),
+    ],
+    ids=["input_grad", "gamma_grad"],
+)
+def test_moreh_group_norm_backward_rejects_invalid_mean_volume(are_required_outputs, device):
+    torch.manual_seed(2024)
+
+    N, C, H, W = 2, 4, 23, 23
+    num_groups = 2
+    input_shape = (N, C, H, W)
+    mean_rstd_shape = [1, 1, N, num_groups]
+    wrong_mean_shape = [1, 1, N + 1, num_groups]
+    gamma_beta_shape = [1, 1, 1, C]
+
+    cpu_input, _, _, cpu_output_grad = make_input_tensors(input_shape, affine=False, do_backward=True)
+
+    x_view = cpu_input.view(N, num_groups, -1)
+    cpu_rstd = (((x_view - x_view.mean(dim=-1, keepdim=True)) ** 2).mean(dim=-1, keepdim=False) + 1e-5).rsqrt()
+
+    npu_output_grad = to_ttnn(cpu_output_grad, device=device)
+    npu_input = to_ttnn(cpu_input, device=device)
+    npu_mean = to_ttnn(torch.zeros(wrong_mean_shape, dtype=torch.bfloat16), device=device)
+    npu_rstd = to_ttnn(cpu_rstd, device=device, shape=mean_rstd_shape)
+
+    npu_input_grad = None
+    if are_required_outputs[0]:
+        npu_input_grad = to_ttnn(torch.empty(input_shape, dtype=torch.bfloat16), device=device)
+
+    npu_gamma_grad = None
+    if are_required_outputs[1]:
+        npu_gamma_grad = to_ttnn(torch.empty(gamma_beta_shape, dtype=torch.bfloat16), device=device)
+
+    with pytest.raises(RuntimeError, match="mean must have logical volume"):
+        ttnn.operations.moreh.group_norm_backward(
+            npu_output_grad,
+            npu_input,
+            npu_mean,
+            npu_rstd,
+            num_groups,
+            are_required_outputs=are_required_outputs,
+            gamma=None,
+            input_grad=npu_input_grad,
+            gamma_grad=npu_gamma_grad,
+            beta_grad=None,
+        )

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/gamma_beta_grad/moreh_group_norm_backward_gamma_beta_grad_device_operation.cpp
@@ -14,6 +14,14 @@
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
+namespace {
+
+uint64_t expected_mean_rstd_volume_gamma_beta_grad(const Tensor& output_grad, uint32_t num_groups) {
+    return static_cast<uint64_t>(output_grad.logical_shape()[0]) * num_groups;
+}
+
+}  // namespace
+
 void MorehGroupNormBackwardGammaBetaGradOperation::validate_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& output_grad = tensor_args.output_grad;
@@ -53,8 +61,18 @@ void MorehGroupNormBackwardGammaBetaGradOperation::validate_tensors(
 
     // mean (1, 1, N, num_groups)
     TT_FATAL(mean.logical_shape()[-1] == num_groups, "mean_shape[-1] must match num_groups.");
+    TT_FATAL(
+        mean.logical_volume() == expected_mean_rstd_volume_gamma_beta_grad(output_grad, num_groups),
+        "mean must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume_gamma_beta_grad(output_grad, num_groups),
+        mean.logical_volume());
     // rstd (1, 1, N, num_groups)
     TT_FATAL(rstd.logical_shape()[-1] == num_groups, "rstd_shape[-1] must match num_groups.");
+    TT_FATAL(
+        rstd.logical_volume() == expected_mean_rstd_volume_gamma_beta_grad(output_grad, num_groups),
+        "rstd must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume_gamma_beta_grad(output_grad, num_groups),
+        rstd.logical_volume());
 }
 
 void MorehGroupNormBackwardGammaBetaGradOperation::validate_on_program_cache_miss(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_device_operation.cpp
@@ -9,6 +9,14 @@
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 
 namespace ttnn::operations::moreh::moreh_group_norm_backward {
+namespace {
+
+uint64_t expected_mean_rstd_volume_input_grad(const Tensor& output_grad, uint32_t num_groups) {
+    return static_cast<uint64_t>(output_grad.logical_shape()[0]) * num_groups;
+}
+
+}  // namespace
+
 void MorehGroupNormBackwardInputGradOperation::validate_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& output_grad = tensor_args.output_grad;
@@ -50,8 +58,18 @@ void MorehGroupNormBackwardInputGradOperation::validate_tensors(
 
     // mean (1, 1, N, num_groups)
     TT_FATAL(mean.logical_shape()[-1] == num_groups, "mean_shape[-1] must match num_groups.");
+    TT_FATAL(
+        mean.logical_volume() == expected_mean_rstd_volume_input_grad(output_grad, num_groups),
+        "mean must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume_input_grad(output_grad, num_groups),
+        mean.logical_volume());
     // rstd (1, 1, N, num_groups)
     TT_FATAL(rstd.logical_shape()[-1] == num_groups, "rstd_shape[-1] must match num_groups.");
+    TT_FATAL(
+        rstd.logical_volume() == expected_mean_rstd_volume_input_grad(output_grad, num_groups),
+        "rstd must have logical volume {}. Got {}.",
+        expected_mean_rstd_volume_input_grad(output_grad, num_groups),
+        rstd.logical_volume());
 }
 
 void MorehGroupNormBackwardInputGradOperation::validate_on_program_cache_miss(


### PR DESCRIPTION
PR Category
Bug fix

Summary
1. Add missing mean and rstd logical-volume checks to both moreh_group_norm_backward validators.
2. Reject malformed stats tensors before program setup on the input-grad and gamma/beta-grad backward branches.
3. Add one focused nightly negative regression that exercises both active backward output modes.
4. Fixes #46074.

Notes for reviewers
1. This patch stays at the host-side validation boundary. It does not change kernel math or program-factory behavior.
2. The bug is that both validators only checked the last stats dimension against num_groups, so shapes like [1, 1, 3, 2] passed for N=2 and num_groups=2.
3. I used distinct helper names in the two validator files because the moreh build unifies sibling translation units in this area.

Test plan
1. `python3 -m py_compile tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py`
2. `git diff --check`
3. `pytest -q tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py::test_moreh_group_norm_backward_rejects_invalid_mean_volume -q`

Observed result
1. The focused pytest node passes for both parameterizations.
2. The runtime now fails early with:
mean must have logical volume 4. Got 6.
