### PR TITLE
Fix sanity debug build artifact permissions

### DIFF
--- a/.github/workflows/sanity-tests-debug.yaml
+++ b/.github/workflows/sanity-tests-debug.yaml
@@ -73,6 +73,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || inputs.run-wormhole-tests || inputs.run-blackhole-tests }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
+      contents: read
       packages: write
     secrets: inherit
     with:
@@ -91,6 +92,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || inputs.run-wormhole-tests || inputs.run-blackhole-tests }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
+      contents: read
       packages: write
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
- Add `contents: read` to the sanity debug build-artifact reusable workflow calls.
- Match the permissions required by `.github/workflows/build-artifact.yaml`.
- Fix `sanity-tests-debug.yaml` workflow_dispatch startup failures.

## Regression
Regression was introduced by `d918fafe87b7` / `#36878` (`Optimize docker layer caching and harbor fallback`). That change made `build-artifact.yaml` require `contents: read` and `packages: write`, then wired `sanity-tests-debug.yaml` through `check-harbor` / `harbor-prefix`, but the sanity debug build-artifact caller jobs still granted only `packages: write`.

GitHub rejects reusable workflows before jobs are created when caller permissions do not cover callee requirements. L2 continued to start because `tt-metal-l2-nightly.yaml` already grants both permissions for the same reusable build workflow call.

## Fix
Add `contents: read` to both sanity debug build-artifact calls:
- `build-artifacts-ubuntu-22`
- `build-artifacts-ubuntu-24`

## Verification
- Dispatched a smoke `sanity-tests-debug.yaml` run on this branch with both test legs disabled; it no longer failed at startup and reached `Determine debug flags` / `check-harbor`, with build/test legs skipped as expected.
- `npx --yes github-actionlint .github/workflows/sanity-tests-debug.yaml`

Smoke run: https://github.com/tenstorrent/tt-metal/actions/runs/26957629711

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-sanity-debug-build-artifact-permissions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-sanity-debug-build-artifact-permissions)