### PR TITLE
sim: fast-dispatch + fabric simulator enablement (craq-sim multichip)

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -10,10 +10,12 @@
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <optional>
@@ -63,6 +65,18 @@ struct ProgramCommandSequence;
 namespace tt::tt_metal::distributed {
 
 namespace {
+
+bool simulator_direct_tensor_writes_enabled() {
+    static const bool enabled = [] {
+        const char* env = std::getenv("TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES");
+        if (env == nullptr) {
+            return false;
+        }
+        return std::strcmp(env, "0") != 0 && std::strcmp(env, "false") != 0 && std::strcmp(env, "FALSE") != 0 &&
+               std::strcmp(env, "off") != 0 && std::strcmp(env, "OFF") != 0;
+    }();
+    return enabled;
+}
 
 // Don't use std::forward since we are in a loop.
 // NOLINTBEGIN(cppcoreguidelines-missing-std-forward)
@@ -586,12 +600,28 @@ bool FDMeshCommandQueue::write_shard_to_device(
         return false;
     }
 
-    in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture. trace id: {}", trace_id_.value());
 
     auto* device_buffer = buffer.get_device_buffer(device_coord);
-    auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
+    auto region_value = region.value_or(BufferRegion(0, device_buffer->size()));
+    auto shard_view = device_buffer->view(region_value);
 
+    // Simulator preload shortcut: direct synchronous writes avoid simulating CQ payload copies.
+    // Only takes effect while the CQ is idle; once any FD work has been enqueued on this CQ we
+    // fall back to the FD path so that ordering against in-flight programs is preserved.
+    if (!in_use_ && this->get_target_device_type() == tt::TargetDevice::Simulator &&
+        simulator_direct_tensor_writes_enabled() && src != nullptr && region_value.offset == 0) {
+        auto payload =
+            tt::stl::Span<const uint8_t>(static_cast<const uint8_t*>(src), static_cast<size_t>(region_value.size));
+        if (logical_core_filter != nullptr) {
+            tt::tt_metal::experimental::core_subset_write::WriteToBuffer(*shard_view, payload, *logical_core_filter);
+        } else {
+            tt::tt_metal::detail::WriteToBuffer(*shard_view, payload);
+        }
+        return false;
+    }
+
+    in_use_ = true;
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
     return buffer_dispatch::write_to_device_buffer(
         src,

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -80,6 +80,9 @@ void FabricBuilder::discover_channels() {
 }
 
 void FabricBuilder::create_routers() {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+
     // Create router builders
     for (const auto& [direction, eth_channels] : channels_by_direction_) {
         const auto& neighbor_node = chip_neighbors_.at(direction);
@@ -93,6 +96,9 @@ void FabricBuilder::create_routers() {
                 .direction = direction,
                 .is_dispatch_link = is_dispatch,
             };
+
+            cluster.register_sim_fabric_endpoint_direction(
+                device_->id(), eth_chan, control_plane.routing_direction_to_eth_direction(direction));
 
             auto router_builder = FabricRouterBuilder::create(device_, program_, local_node_, location);
             routers_.insert({eth_chan, std::move(router_builder)});

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -86,7 +86,8 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
     std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
     auto mesh_buffer = buffer_.get_mesh_buffer();
     bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-    if (using_fast_dispatch) {
+    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+    if (using_fast_dispatch && !using_simulator) {
         distributed::EnqueueWriteMeshBuffer(
             mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
     } else {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -215,8 +215,10 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
 
                 if (this->sysmem_manager_->is_dram_backed()) {
+                    const uint32_t dram_channel =
+                        this->allocator_impl()->get_dram_channel_from_bank_id(this->sysmem_manager_->get_dram_region_bank_id());
                     MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
-                        pointers.data(), pointers.size() * sizeof(uint32_t), this->id(), 0, cq_offset);
+                        pointers.data(), pointers.size() * sizeof(uint32_t), this->id(), dram_channel, cq_offset);
                 } else {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                         pointers.data(),

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -286,6 +286,16 @@ void FabricFirmwareInitializer::init(
 
     if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
         log_info(tt::LogMetal, "Initializing Fabric");
+        if (rtoptions_.get_simulator_enabled()) {
+            for (auto* dev : devices_) {
+                const auto fabric_node_id = control_plane_.get_fabric_node_id_from_physical_chip_id(dev->id());
+                for (const auto& [eth_chan, direction] :
+                     control_plane_.get_active_fabric_eth_channels(fabric_node_id)) {
+                    cluster_.get_driver()->register_sim_fabric_endpoint_direction(
+                        dev->id(), uint32_t(eth_chan), uint32_t(direction));
+                }
+            }
+        }
         control_plane_.write_routing_tables_to_all_chips();
         compile_and_configure_fabric();
         log_info(tt::LogMetal, "Fabric Initialized with config {}", fabric_config);

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -504,10 +504,10 @@ void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms)
 }
 
 uint32_t FabricFirmwareInitializer::get_fabric_router_sync_timeout_ms() const {
-    if (rtoptions_.get_simulator_enabled()) {
-        return 15000;
-    }
     auto timeout = rtoptions_.get_fabric_router_sync_timeout_ms();
+    if (rtoptions_.get_simulator_enabled()) {
+        return timeout.value_or(15000);
+    }
     return timeout.value_or(10000);
 }
 

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -289,6 +289,8 @@ void FabricFirmwareInitializer::init(
         if (rtoptions_.get_simulator_enabled()) {
             for (auto* dev : devices_) {
                 const auto fabric_node_id = control_plane_.get_fabric_node_id_from_physical_chip_id(dev->id());
+                cluster_.get_driver()->register_sim_fabric_node_id(
+                    dev->id(), uint32_t(fabric_node_id.mesh_id.get()), uint32_t(fabric_node_id.chip_id));
                 for (const auto& [eth_chan, direction] :
                      control_plane_.get_active_fabric_eth_channels(fabric_node_id)) {
                     cluster_.get_driver()->register_sim_fabric_endpoint_direction(

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -22,6 +22,9 @@ uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) { return cq_id 
 uint16_t get_umd_channel(uint16_t channel) { return channel & 0x3; }
 
 uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size, uint32_t base) {
+    if (base != 0) {
+        return base + get_relative_cq_offset(cq_id, cq_size);
+    }
     return base + (DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel)) +
            ((channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE) + get_relative_cq_offset(cq_id, cq_size);
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -358,16 +358,27 @@ void process_write_host_h() {
             noc_async_write(data_ptr, pcie_noc_xy | completion_queue_write_addr, xfer_size);
 #else
             cq_noc_async_write_with_state_any_len(data_ptr, completion_queue_write_addr, xfer_size);
+#if defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+            uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE);
+            noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
+            noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
+            noc_async_writes_flushed();
+#else
             // completion_queue_push_back below will do a write to host, so we add 1 to the number of data packets
             // written
             uint32_t num_noc_packets_written = div_up(xfer_size, NOC_MAX_BURST_SIZE) + 1;
             noc_nonposted_writes_num_issued[noc_index] += num_noc_packets_written;
             noc_nonposted_writes_acked[noc_index] += num_noc_packets_written;
 #endif
+#endif
 
             // This will update the write ptr on device and host
             // We flush to ensure the ptr has been read out of l1 before we update it again
             completion_queue_push_back(npages);
+#if !defined(FABRIC_RELAY) && defined(IS_CQ_DRAM_BACKED) && IS_CQ_DRAM_BACKED == 1
+            noc_nonposted_writes_num_issued[noc_index] += 1;
+            noc_nonposted_writes_acked[noc_index] += 1;
+#endif
 
             length -= xfer_size;
             data_ptr += xfer_size;

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -59,6 +59,21 @@ void* open_ttsim_handle() {
     return handle;
 }
 
+bool dram_backed_cq_dirty_flush_enabled() {
+    static const bool enabled = [] {
+        const char* env = std::getenv("TT_METAL_DRAM_BACKED_CQ_DIRTY_FLUSH");
+        if (env == nullptr) {
+            return false;
+        }
+        const std::string value(env);
+        if (value == "auto") {
+            return std::getenv("TT_METAL_SIMULATOR") != nullptr || std::getenv("TT_UMD_SIMULATOR") != nullptr;
+        }
+        return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
+    }();
+    return enabled;
+}
+
 TTSimClockAllDevicesFn get_ttsim_clock_all_devices() {
     static TTSimClockAllDevicesFn fn = [] {
         void* handle = open_ttsim_handle();

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -59,21 +59,6 @@ void* open_ttsim_handle() {
     return handle;
 }
 
-bool dram_backed_cq_dirty_flush_enabled() {
-    static const bool enabled = [] {
-        const char* env = std::getenv("TT_METAL_DRAM_BACKED_CQ_DIRTY_FLUSH");
-        if (env == nullptr) {
-            return false;
-        }
-        const std::string value(env);
-        if (value == "auto") {
-            return std::getenv("TT_METAL_SIMULATOR") != nullptr || std::getenv("TT_UMD_SIMULATOR") != nullptr;
-        }
-        return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
-    }();
-    return enabled;
-}
-
 TTSimClockAllDevicesFn get_ttsim_clock_all_devices() {
     static TTSimClockAllDevicesFn fn = [] {
         void* handle = open_ttsim_handle();

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -6,6 +6,7 @@
 #include "impl/context/metal_context.hpp"
 #include "system_memory_manager.hpp"
 #include <tt-metalium/tt_align.hpp>
+#include <dlfcn.h>
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -42,6 +43,49 @@ namespace tt::tt_metal {
 void on_dispatch_timeout_detected();
 
 namespace {
+
+using TTSimClockAllDevicesFn = void (*)(uint32_t);
+
+void* open_ttsim_handle() {
+    void* handle = nullptr;
+    if (const char* sim_path = std::getenv("TT_METAL_SIMULATOR")) {
+#ifdef RTLD_NOLOAD
+        handle = dlopen(sim_path, RTLD_NOW | RTLD_NOLOAD);
+#endif
+    }
+    if (handle == nullptr) {
+        handle = RTLD_DEFAULT;
+    }
+    return handle;
+}
+
+TTSimClockAllDevicesFn get_ttsim_clock_all_devices() {
+    static TTSimClockAllDevicesFn fn = [] {
+        void* handle = open_ttsim_handle();
+        return reinterpret_cast<TTSimClockAllDevicesFn>(dlsym(handle, "libttsim_clock_all_devices"));
+    }();
+    return fn;
+}
+
+uint32_t get_ttsim_cq_wait_clock_cycles() {
+    static uint32_t cycles = [] {
+        if (const char* env = std::getenv("TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS")) {
+            return static_cast<uint32_t>(std::stoul(env));
+        }
+        return 1000u;
+    }();
+    return cycles;
+}
+
+void pump_ttsim_clock_if_enabled(ContextId context_id) {
+    auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
+    if (!ctx.rtoptions().get_simulator_enabled()) {
+        return;
+    }
+    if (auto* clock_all_devices = get_ttsim_clock_all_devices()) {
+        clock_all_devices(get_ttsim_cq_wait_clock_cycles());
+    }
+}
 
 bool wrap_ge(uint32_t a, uint32_t b) {
     // Signed Diff uses 2's Complement to handle wrap
@@ -667,6 +711,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         auto fetch_operation_body = [&]() {
             ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
+            pump_ttsim_clock_if_enabled(this->context_id);
         };
 
         // Condition to check if should continue waiting
@@ -717,6 +762,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
+        pump_ttsim_clock_if_enabled(this->context_id);
     };
 
     // Condition to check if the operation should continue
@@ -728,7 +774,6 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     // Handler for the timeout
     auto on_timeout = [this, &exit_condition]() {
         exit_condition.store(true);
-
         tt::tt_metal::MetalContext::instance(this->context_id).on_dispatch_timeout_detected();
 
         TT_THROW("TIMEOUT: device timeout, potential hang detected, the device is unrecoverable");

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -55,7 +55,11 @@ uint64_t get_static_tlb_size() { return 4ULL * (1ULL << 30); }
 }  // namespace quasar
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver) {
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs) {
     using get_static_tlb_size_ptr = uint64_t (*)();
     get_static_tlb_size_ptr get_static_tlb_size;
 
@@ -87,7 +91,7 @@ void configure_static_tlbs(
         device_driver.configure_tlb(mmio_device_id, core, get_static_tlb_size(), address, tt::umd::tlb_data::Strict);
     }
 
-    if (arch == tt::ARCH::BLACKHOLE) {
+    if (arch == tt::ARCH::BLACKHOLE && include_dram_tlbs) {
         // Setup static 4GB tlbs for DRAM cores.
         uint32_t dram_addr = 0;
         for (std::uint32_t dram_channel = 0; dram_channel < blackhole::NUM_DRAM_CHANNELS; dram_channel++) {

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -16,6 +16,10 @@ struct metal_SocDescriptor;
 namespace ll_api {
 
 void configure_static_tlbs(
-    tt::ARCH arch, tt::ChipId mmio_device_id, const metal_SocDescriptor& sdesc, tt::umd::Cluster& device_driver);
+    tt::ARCH arch,
+    tt::ChipId mmio_device_id,
+    const metal_SocDescriptor& sdesc,
+    tt::umd::Cluster& device_driver,
+    bool include_dram_tlbs = true);
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -12,6 +12,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include <algorithm>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -1520,6 +1521,24 @@ umd::ClusterDescriptor* Cluster::get_cluster_desc() const {
 const std::unique_ptr<tt::umd::Cluster>& Cluster::get_driver() const {
     TT_FATAL(driver_ != nullptr, "UMD driver is not initialized.");
     return driver_;
+}
+
+void Cluster::register_sim_fabric_endpoint_direction(
+    ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const {
+    if (std::getenv("TTSIM_FABRIC_TERMINAL_TRACE")) {
+        std::fprintf(
+            stderr,
+            "[ttsim-fabric-terminal] tt-metal-register-direction chip=%d chan=%u dir=%u target=%u\n",
+            chip_id,
+            static_cast<uint32_t>(eth_chan_id),
+            static_cast<uint32_t>(direction),
+            static_cast<uint32_t>(this->target_type_));
+    }
+    if (this->target_type_ != tt::TargetDevice::Simulator) {
+        return;
+    }
+    this->get_driver()->register_sim_fabric_endpoint_direction(
+        chip_id, static_cast<uint32_t>(eth_chan_id), static_cast<uint32_t>(direction));
 }
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -472,8 +472,7 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
     // May block waiting for other processes to release the device.
     this->driver_->start_device(device_params);
 
-    if ((this->target_type_ == TargetDevice::Silicon ||
-         (this->target_type_ == TargetDevice::Simulator && this->arch_ == tt::ARCH::QUASAR)) &&
+    if ((this->target_type_ == TargetDevice::Silicon || this->target_type_ == TargetDevice::Simulator) &&
         device_params.init_device) {
         // Configure TLBs on all MMIO devices in parallel
         std::vector<std::shared_future<void>> futures;
@@ -483,7 +482,11 @@ void Cluster::start_driver(umd::DeviceParams& device_params) const {
         for (const auto& mmio_device_id : mmio_device_ids) {
             futures.emplace_back(tt_metal::detail::async([this, mmio_device_id]() {
                 ll_api::configure_static_tlbs(
-                    this->arch_, mmio_device_id, this->get_soc_desc(mmio_device_id), *this->driver_);
+                    this->arch_,
+                    mmio_device_id,
+                    this->get_soc_desc(mmio_device_id),
+                    *this->driver_,
+                    this->target_type_ == TargetDevice::Silicon);
             }));
         }
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -361,6 +361,9 @@ public:
         return this->target_type_ == tt::TargetDevice::Mock || this->target_type_ == tt::TargetDevice::Emule;
     }
 
+    void register_sim_fabric_endpoint_direction(
+        ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const;
+
     bool is_base_routing_fw_enabled() const;
 
     // Get all fabric ethernet cores

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -528,35 +528,59 @@ void WriteToDeviceSharded(
     const size_t remainder_bytes = page_size - aligned_bytes;
     TT_ASSERT(buffer.aligned_page_size() >= page_size);  // Check that we don't write to the end of the buffer
     const auto& buffer_page_mapping = *buffer.get_buffer_page_mapping();
-    for (auto mapped_page : buffer_page_mapping) {
-        auto core = buffer_page_mapping.all_cores[mapped_page.core_id];
+    const bool can_write_page_ranges = buffer.aligned_page_size() == page_size;
+
+    auto write_pages = [&](uint32_t core_id, uint32_t device_page, uint32_t host_page, uint32_t num_pages) {
+        if (num_pages == 0) {
+            return;
+        }
+        auto core = buffer_page_mapping.all_cores[core_id];
         if (logical_core_filter != nullptr && !logical_core_filter->contains(core)) {
-            continue;
+            return;
         }
         auto bank_id = allocator->get_bank_ids_from_logical_core(buffer.buffer_type(), core)[0];
         auto bank_offset = allocator->get_bank_offset(buffer.buffer_type(), bank_id);
-        auto data_index = mapped_page.host_page * page_size;
-        auto write_chunk = [&](size_t offset, size_t size_in_bytes) {
+        size_t data_index = static_cast<size_t>(host_page) * page_size;
+        auto write_chunk = [&](uint32_t write_device_page, size_t offset, size_t size_in_bytes) {
             if (size_in_bytes == 0) {
                 return;
             }
             std::span<const std::uint8_t> page(host_buffer.data() + data_index + offset, size_in_bytes);
             if (buffer.is_l1()) {
                 auto absolute_address =
-                    buffer.address() + bank_offset + (mapped_page.device_page * buffer.aligned_page_size()) + offset;
+                    buffer.address() + bank_offset + (write_device_page * buffer.aligned_page_size()) + offset;
                 auto core_coordinates =
                     device->worker_core_from_logical_core(buffer.allocator()->get_logical_core_from_bank_id(bank_id));
                 MetalContext::instance().get_cluster().write_core(
                     device->id(), core_coordinates, page, absolute_address);
             } else {
-                auto bank_local_address =
-                    buffer.address() + (mapped_page.device_page * buffer.aligned_page_size()) + offset;
+                auto bank_local_address = buffer.address() + (write_device_page * buffer.aligned_page_size()) + offset;
                 WriteToDeviceDRAMChannel(device, bank_id, bank_local_address, page);
             }
         };
 
-        write_chunk(0, aligned_bytes);
-        write_chunk(aligned_bytes, remainder_bytes);
+        if (can_write_page_ranges) {
+            write_chunk(device_page, 0, static_cast<size_t>(num_pages) * page_size);
+            return;
+        }
+
+        for (uint32_t page = 0; page < num_pages; page++) {
+            data_index = static_cast<size_t>(host_page + page) * page_size;
+            write_chunk(device_page + page, 0, aligned_bytes);
+            write_chunk(device_page + page, aligned_bytes, remainder_bytes);
+        }
+    };
+
+    for (uint32_t core_id = 0; core_id < buffer_page_mapping.all_cores.size(); core_id++) {
+        for (const auto& core_page_mapping : buffer_page_mapping.core_page_mappings[core_id]) {
+            for (const auto& host_range : core_page_mapping.host_ranges) {
+                write_pages(
+                    core_id,
+                    core_page_mapping.device_start_page + host_range.device_page_offset,
+                    host_range.host_page_start,
+                    host_range.num_pages);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Brings the craq-sim **fast-dispatch + fabric simulator enablement** (Nachiket Kapre's `nkapre/sim-fast-h2d-write`) onto `blaze-metal-main`. With these changes the simulator (ttsim) can stand up an 8-chip Blackhole mesh and run the multi-chip craq-sim S-ladder in **fast dispatch** (DRAM-backed CQ + CCL over fabric). Without them, fast dispatch fails the 8-chip preflight with `RuntimeError: TLB window for core (X, Y) not found` during firmware init, and the lane only works in slow dispatch.

These are the 9 core simulator commits from `nkapre/sim-fast-h2d-write`, cherry-picked with `-x`. (The branch's UMD submodule pin and a CI `safe.directory` build tweak are intentionally **excluded** here and handled separately.)

## What changed
**Fast-dispatch on the simulator**
- `fix(sim): enable fast-dispatch CCL on TTSim` — flips the sim gating from `Silicon || (Sim && QUASAR)` to `Silicon || Simulator`, adds an `include_dram_tlbs` parameter controlling DRAM TLB inclusion (`llrt/tlb_config.*`), routes DRAM-backed-CQ pointer writes through the correct DRAM channel (`device.cpp`), adds sim CQ-wait clocking via `libttsim_clock_all_devices` (`system_memory_manager.cpp`), and fixes `cq_dispatch` completion-queue accounting for the DRAM-backed path.
- `perf(sim): dirty-flush DRAM-backed CQ pushes` — helpers to flush only dirtied CQ regions.

**Fabric / multi-chip bring-up on the simulator**
- `fix(sim): register fabric endpoint directions (cluster + builder)` and `(fw initializer)` — tell the simulator which eth cores are fabric endpoints and their routing direction (`tt_cluster.*`, `fabric_builder.cpp`, `fabric_firmware_initializer.cpp`) so firmware init can map them.
- `fix(sim): pass fabric node ids to simulator` — provide fabric node IDs so cross-chip routing resolves.
- `fix(sim): reset global semaphores without fast dispatch` — make global-semaphore reset work in the sim init path (`global_semaphore.cpp`).
- `fix(sim): honor fabric sync timeout override`.

**Host→device upload fast path**
- `sim: add opt-in direct H2D writes for FD mesh uploads` — gated behind `TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1`; bypasses simulated CQ payload copies for idle-CQ host→device tensor writes and batches per-core writes (`fd_mesh_command_queue.cpp`, `tt_metal.cpp`). Reported ~5.5× S-ladder speedup. Default behavior unchanged for silicon/mock/default-sim.
- `fix(sim): remove unused dram_backed_cq_dirty_flush_enabled helper` — cleanup.

## Why
Required for the `craq-sim multi-chip S-ladder` CI lane (and local sweeps) to validate the multi-chip simulator path in **fast dispatch**, which is the configuration it's meant to prove.

## Testing
The equivalent content (this branch's tip) was validated green by the `craq-sim multi-chip S-ladder` run on `craq-sim-multichip-ci` (metal-branch `nkapre/sim-fast-h2d-write`, `rungs=all-no-s10`), which stood up the 8-chip mesh and ran the ladder. S10* rungs are excluded there due to runner-memory limits, not correctness.

## Notes
- Excludes the source branch's UMD submodule pin (`tenstorrent/tt-umd:nkapre/multichip`) and a CI `safe.directory` kissat build fix — those are tracked separately.
- An upstream port of this work to `main` is a larger effort (main's simulator gating has diverged); being pursued separately.

Original author: Nachiket Kapre (`nkapre@tenstorrent.com`). Commits cherry-picked with `-x` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/sim-fast-h2d-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/sim-fast-h2d-blaze-metal-main)

## Status
Standalone upstreaming of Nachiket's fast-dispatch sim enablement onto `blaze-metal-main` (independent of any tt-blaze repin). Note: the tt-blaze S-ladder is currently validated via **slow dispatch** on the #45419 tt-metal pin (#1081), so this fast-dispatch enablement is not on tt-blaze's critical path right now — but remains the clean way to land fast-dispatch craq-sim on `blaze-metal-main`.
