### PR TITLE
adds new testcases for multi-stage reduction for reduce ops (test_generic_ops)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -191,12 +191,31 @@ def _torch_sampling_reference(values, indices, k, p, temp, seed):
     return out_tensor
 
 
+def xfail_test_generic_ops(tensor_shape, dim, keepdim, correction, op, use_legacy):
+    """legacy path std/var failures from test_generic_ops; Created for issue https://github.com/tenstorrent/tt-metal/issues/43994"""
+    if not use_legacy or op not in ("std", "var"):
+        return None
+    is_failing = False
+    if tensor_shape == (2, 4, 8, 32, 64) and dim == 0 and correction:
+        is_failing = True
+    elif tensor_shape == (4, 8, 32, 64) and dim == (0, 2, 3):
+        is_failing = True
+    elif tensor_shape == (3, 6, 40, 63, 20) and dim == (1, 2, 3):
+        is_failing = True
+    elif tensor_shape == (4, 8, 32, 64) and dim == (1, 2, 3) and op == "var":
+        is_failing = True
+    if not is_failing:
+        return None
+    if op == "std":
+        return "ttnn::std PCC failure for multi-dim reduction using legacy path. Issue #46096."
+    return "ttnn::var PCC failure for multi-dim reduction using legacy path. Issue #46073."
+
+
 # Test a 0D, 1D, 1-element, 1 column, 0-volume, and a 5D tensor
 @pytest.mark.parametrize(
-    "tensor_shape",
-    [(), (2,), (1, 1), (32, 1), (6, 0, 32), (3, 6, 40, 63, 20)],
+    "tensor_shape", [(), (2,), (1, 1), (32, 1), (6, 0, 32), (3, 6, 40, 63, 20), (4, 8, 32, 64), (2, 4, 8, 32, 64)]
 )
-@pytest.mark.parametrize("dim", [None, 0, -1, (-2, -1), (0, 2), (0, 2, 4)])
+@pytest.mark.parametrize("dim", [None, 0, -1, (-2, -1), (0, 2), (0, 2, 4), (0, 2, 3), (0, 3, 4), (1, 2, 3)])
 @pytest.mark.parametrize("keepdim", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
@@ -212,6 +231,10 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
     """
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
+
+    xfail_reason = xfail_test_generic_ops(tensor_shape, dim, keepdim, correction, op, use_legacy)
+    if xfail_reason is not None:
+        pytest.xfail(xfail_reason)
 
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -191,26 +191,6 @@ def _torch_sampling_reference(values, indices, k, p, temp, seed):
     return out_tensor
 
 
-def xfail_test_generic_ops(tensor_shape, dim, keepdim, correction, op, use_legacy):
-    """legacy path std/var failures from test_generic_ops; Created for issue https://github.com/tenstorrent/tt-metal/issues/43994"""
-    if not use_legacy or op not in ("std", "var"):
-        return None
-    is_failing = False
-    if tensor_shape == (2, 4, 8, 32, 64) and dim == 0 and correction:
-        is_failing = True
-    elif tensor_shape == (4, 8, 32, 64) and dim == (0, 2, 3):
-        is_failing = True
-    elif tensor_shape == (3, 6, 40, 63, 20) and dim == (1, 2, 3):
-        is_failing = True
-    elif tensor_shape == (4, 8, 32, 64) and dim == (1, 2, 3) and op == "var":
-        is_failing = True
-    if not is_failing:
-        return None
-    if op == "std":
-        return "ttnn::std PCC failure for multi-dim reduction using legacy path. Issue #46096."
-    return "ttnn::var PCC failure for multi-dim reduction using legacy path. Issue #46073."
-
-
 # Test a 0D, 1D, 1-element, 1 column, 0-volume, and a 5D tensor
 @pytest.mark.parametrize(
     "tensor_shape", [(), (2,), (1, 1), (32, 1), (6, 0, 32), (3, 6, 40, 63, 20), (4, 8, 32, 64), (2, 4, 8, 32, 64)]
@@ -231,10 +211,6 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
     """
     if op not in ("var", "std") and correction:
         pytest.skip("PyTorch supports the correction argument only for var and std")
-
-    xfail_reason = xfail_test_generic_ops(tensor_shape, dim, keepdim, correction, op, use_legacy)
-    if xfail_reason is not None:
-        pytest.xfail(xfail_reason)
 
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -274,9 +274,12 @@ def test_prod(device, input_shape, dim, keepdim, force_implicit_pad, dtype):
 @pytest.mark.parametrize("dim_6", [6])
 @pytest.mark.parametrize("dim_7", [7])
 @pytest.mark.parametrize("dim_8", [8, 32, 63])
-@pytest.mark.parametrize("dim", [[3, 7]])
+@pytest.mark.parametrize("dim", [[3, 7], [6, 7]])
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):
+    if dim == [6, 7]:
+        pytest.xfail("Sum op on HW reduction with BF16 input exceeds allclose threshold. Issue #46472")
+
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8), dtype=torch.bfloat16)


### PR DESCRIPTION
### Ticket
Issue: #43994


### Problem description
Multi-stage reductions expose a lower-precision behavior in reduction operations. Although each reduction stage uses FP32 destination accumulation internally, the intermediate output of Stage 1 must still be written back to memory as BF16 tiles, which can introduce precision loss before the final reduction stage.

### Changes added

- Added additional test cases to verify multi-stage reduction in `tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py::test_generic_ops` to capture lower-precision behavior.

- The new test cases are currently marked as xfail.

### What's Observed

**1. std and var op**
- The newly added tests exposed PCC failures in the legacy reduction path (`use_legacy=True`) for **std** and **var** operations on certain tensor shapes and multi-dim reduction cases.

- Few failing cases of std and var op on legacy path

| Shape | Dim | Op | Keepdim | Correction | Use Legacy | Status | PCC |
|---------|---------|---------|---------|---------|---------|---------|---------|
| (4, 8, 32, 64) | (0, 2, 3) | std | False | True | True | FAIL | 0.9201231009113796 |
| (4, 8, 32, 64) | (0, 2, 3) | var | False | True | True | FAIL | 0.9770388815154779 |
| (4, 8, 32, 64) | (1, 2, 3) | var | True | False | True | FAIL | 0.5773502691896258 |
| (3, 6, 40, 63, 20) | (1, 2, 3) | std | False | True | True | FAIL | 0.9682608623256354 |
| (3, 6, 40, 63, 20) | (1, 2, 3) | var | False | True | True | FAIL | 0.9885404143921569 |

- other reduce ops: mean, min and mean were passing on multiple dim reduction testcases.

**2. sum op**
- Additional failing cases were observed on **sum** op on **HW reduction**
     Test: 
`tests/ttnn/unit_tests/operations/reduce/test_reduction.py::test_sum_8d_tensor_dims `

- While running the above test,  **ALLCLOSE** failures were observed for the **sum** operation on **8D** tensors when reducing across the last two dimensions (for example: `dim = (-2,-1) `). 

- Few failing cases of sum op on HW reduction

| Shape | Dim | Keepdim | Status | ATOL | RTOL | PCC |
|---------|---------|---------|---------|---------|---------|---------|
| (1, 2, 3, 4, 4, 6, 7, 8)  | [6, 7] or [-2, -1] | True or False | FAIL | 0.125 | 8.125 | 0.999997 |
| (1, 2, 3, 4, 4, 6, 7, 32) | [6, 7] or [-2, -1] | True or False | FAIL | 0.25 | 2.984375 | 0.999996 |
| (1, 2, 3, 4, 4, 6, 7, 63) | [6, 7] or [-2, -1] | True or False | FAIL | 0.25 | 0.1708984375 | 0.999996 |


### Result

- Issues created 
            - std op: #46096
            - var op: #46073
            - sum op: #46472


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/add_multi_stage_reduction_testcases)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/add_multi_stage_reduction_testcases)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/add_multi_stage_reduction_testcases)