### PR TITLE
test: expect_error fixture wraps pytest.raises

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
       args: ["--style=file"]
 - repo: local
   hooks:
+    - id: prefer-expect-error
+      name: "tests: use the expect_error fixture instead of pytest.raises"
+      language: pygrep
+      files: (^|/)tests/.*\.py$
+      entry: '(?<!allow-)pytest\.raises(?!.*allow-pytest\.raises)'
+      # Override on the same line:  with pytest.raises(...):  # allow-pytest.raises: <why>
+- repo: local
+  hooks:
     - id: check-large-files
       name: check for large files (>500 KB)
       entry: python3 scripts/check_file_size.py

--- a/conftest.py
+++ b/conftest.py
@@ -858,6 +858,29 @@ def tracy_profile():
     profiler.disable()
 
 
+@pytest.fixture
+def expect_error():
+    """Use instead of pytest.raises. Adds info to the logs that these errors are expected,
+    which helps automated CI log triaging. message must appear in the real device error
+    text (the TT_FATAL line), since that's what the triager matches.
+
+        with expect_error(RuntimeError, "Out of Memory"):
+            ...
+    """
+
+    @contextlib.contextmanager
+    def expect_error_(error, message):
+        names = ", ".join(e.__name__ for e in (error if isinstance(error, tuple) else (error,)))
+        logger.info(f'[EXPECTED_ERROR BEGIN] {names} message="{message}"')
+        try:
+            with pytest.raises(error, match=message) as exc_info:
+                yield exc_info
+        finally:
+            logger.info(f'[EXPECTED_ERROR END] {names} message="{message}"')
+
+    return expect_error_
+
+
 ###############################
 # Modifying pytest hooks
 ###############################

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -218,7 +218,7 @@ def run_combine_op(
 )
 @pytest.mark.parametrize("ccl_op", ["dispatch", "combine"])
 @pytest.mark.parametrize("use_l1_small", [False, True], ids=["l1_default", "l1_small"])
-def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op, use_l1_small):
+def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op, use_l1_small, expect_error):
     """Test that dispatch/combine semaphores can be placed in L1_SMALL to prevent L1 fragmentation."""
 
     compute_grid = mesh_device.compute_with_storage_grid_size()
@@ -302,7 +302,7 @@ def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op
     logger.info(f"Tensor C: shape [1, 1, 32, {tensor_c_cols}], {tensor_c_bytes} bytes total")
 
     if not use_l1_small:
-        with pytest.raises(RuntimeError):
+        with expect_error(RuntimeError, "Out of Memory"):
             ttnn.from_torch(
                 torch.randn(1, 1, 32, tensor_c_cols),
                 dtype=ttnn.bfloat16,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
@@ -109,29 +109,27 @@ def test_valid_inputs_2d_index_first_dim_one(device):
 # ---------------------------------------------------------------------------
 
 
-def test_global_tensor_wrong_dtype(device):
-    # The op accepts BFLOAT8_B and BFLOAT16 (bf16 is used by the PCC test path);
-    # float32 is a genuinely-invalid global_tensor dtype that must be rejected.
+def test_global_tensor_wrong_dtype(device, expect_error):
     g = _make_global(device, dtype=ttnn.float32)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be BFLOAT8_B or BFLOAT16"):
         _run(g, s, c)
 
 
-def test_global_tensor_must_be_2d(device):
+def test_global_tensor_must_be_2d(device, expect_error):
     g = _make_global(device, shape=(1, GLOBAL_ROWS, HIDDEN_DIM))
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be 2D"):
         _run(g, s, c)
 
 
-def test_global_tensor_must_be_dram_interleaved(device):
+def test_global_tensor_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device, memory_config=ttnn.L1_MEMORY_CONFIG)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be DRAM interleaved"):
         _run(g, s, c)
 
 
@@ -140,35 +138,35 @@ def test_global_tensor_must_be_dram_interleaved(device):
 # ---------------------------------------------------------------------------
 
 
-def test_start_wrong_dtype(device):
+def test_start_wrong_dtype(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, dtype=ttnn.uint16)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be UINT32"):
         _run(g, s, c)
 
 
-def test_start_must_be_dram_interleaved(device):
+def test_start_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be DRAM interleaved"):
         _run(g, s, c)
 
 
-def test_start_2d_first_dim_not_one(device):
+def test_start_2d_first_dim_not_one(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(2, NUM_EXPERTS))
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be 1D or 2D with first dimension == 1"):
         _run(g, s, c)
 
 
-def test_start_3d_rejected(device):
+def test_start_3d_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(1, 1, NUM_EXPERTS))
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be 1D or 2D with first dimension == 1"):
         _run(g, s, c)
 
 
@@ -177,35 +175,35 @@ def test_start_3d_rejected(device):
 # ---------------------------------------------------------------------------
 
 
-def test_counts_wrong_dtype(device):
+def test_counts_wrong_dtype(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device, dtype=ttnn.uint16)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be UINT32"):
         _run(g, s, c)
 
 
-def test_counts_must_be_dram_interleaved(device):
+def test_counts_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be DRAM interleaved"):
         _run(g, s, c)
 
 
-def test_counts_2d_first_dim_not_one(device):
+def test_counts_2d_first_dim_not_one(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device, shape=(2, NUM_EXPERTS))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be 1D or 2D with first dimension == 1"):
         _run(g, s, c)
 
 
-def test_counts_3d_rejected(device):
+def test_counts_3d_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device, shape=(1, 1, NUM_EXPERTS))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be 1D or 2D with first dimension == 1"):
         _run(g, s, c)
 
 
@@ -214,43 +212,43 @@ def test_counts_3d_rejected(device):
 # ---------------------------------------------------------------------------
 
 
-def test_start_and_counts_last_dim_mismatch_1d(device):
+def test_start_and_counts_last_dim_mismatch_1d(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS + 1,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, s, c)
 
 
-def test_start_and_counts_last_dim_mismatch_2d(device):
+def test_start_and_counts_last_dim_mismatch_2d(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(1, NUM_EXPERTS))
     c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, s, c)
 
 
-def test_start_and_counts_last_dim_mismatch_mixed_rank(device):
+def test_start_and_counts_last_dim_mismatch_mixed_rank(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, s, c)
 
 
-def test_global_expert_id_equal_to_last_dim_rejected(device):
+def test_global_expert_id_equal_to_last_dim_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_expert_id .* must be in the range"):
         _run(g, s, c, global_expert_id=NUM_EXPERTS)
 
 
-def test_global_expert_id_beyond_last_dim_rejected(device):
+def test_global_expert_id_beyond_last_dim_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_expert_id .* must be in the range"):
         _run(g, s, c, global_expert_id=NUM_EXPERTS + 5)
 
 
@@ -267,19 +265,19 @@ def test_global_expert_id_max_valid_accepted(device):
 # ---------------------------------------------------------------------------
 
 
-def test_max_tokens_zero_rejected(device):
+def test_max_tokens_zero_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "max_dispatched_tokens_per_expert must be > 0"):
         _run(g, s, c, max_tokens=0)
 
 
-def test_max_tokens_not_tile_aligned_rejected(device):
+def test_max_tokens_not_tile_aligned_rejected(device, expect_error):
     g = _make_global(device)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "max_dispatched_tokens_per_expert .* must be a multiple of TILE_HEIGHT"):
         _run(g, s, c, max_tokens=17)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
@@ -124,30 +124,30 @@ def test_valid_inputs_2d_index_first_dim_one(device):
 # ---------------------------------------------------------------------------
 
 
-def test_global_tensor_wrong_dtype(device):
-    g = _make_global(device, dtype=ttnn.bfloat16)
+def test_global_tensor_wrong_dtype(device, expect_error):
+    g = _make_global(device, dtype=ttnn.float32)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be BFLOAT8_B or BFLOAT16"):
         _run(g, l, s, c)
 
 
-def test_global_tensor_must_be_2d(device):
+def test_global_tensor_must_be_2d(device, expect_error):
     g = _make_global(device, shape=(1, GLOBAL_ROWS, HIDDEN_DIM))
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be 2D"):
         _run(g, l, s, c)
 
 
-def test_global_tensor_must_be_dram_interleaved(device):
+def test_global_tensor_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device, memory_config=ttnn.L1_MEMORY_CONFIG)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "global_tensor must be DRAM interleaved"):
         _run(g, l, s, c)
 
 
@@ -156,39 +156,39 @@ def test_global_tensor_must_be_dram_interleaved(device):
 # ---------------------------------------------------------------------------
 
 
-def test_local_tensor_wrong_dtype(device):
+def test_local_tensor_wrong_dtype(device, expect_error):
     g = _make_global(device)
-    l = _make_local(device, dtype=ttnn.bfloat16)
+    l = _make_local(device, dtype=ttnn.float32)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_tensor must be BFLOAT8_B or BFLOAT16"):
         _run(g, l, s, c)
 
 
-def test_local_tensor_must_be_2d(device):
+def test_local_tensor_must_be_2d(device, expect_error):
     g = _make_global(device)
     l = _make_local(device, shape=(1, LOCAL_ROWS, HIDDEN_DIM))
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_tensor must be 2D"):
         _run(g, l, s, c)
 
 
-def test_local_tensor_must_be_dram_interleaved(device):
+def test_local_tensor_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device)
     l = _make_local(device, memory_config=ttnn.L1_MEMORY_CONFIG)
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_tensor must be DRAM interleaved"):
         _run(g, l, s, c)
 
 
-def test_local_tensor_hidden_dim_must_match_global(device):
+def test_local_tensor_hidden_dim_must_match_global(device, expect_error):
     g = _make_global(device, shape=(GLOBAL_ROWS, HIDDEN_DIM))
     l = _make_local(device, shape=(LOCAL_ROWS, HIDDEN_DIM * 2))
     s = _make_index(device)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_tensor hidden_dim .* must match global_tensor hidden_dim"):
         _run(g, l, s, c)
 
 
@@ -197,39 +197,39 @@ def test_local_tensor_hidden_dim_must_match_global(device):
 # ---------------------------------------------------------------------------
 
 
-def test_start_wrong_dtype(device):
+def test_start_wrong_dtype(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, dtype=ttnn.uint16)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be UINT32"):
         _run(g, l, s, c)
 
 
-def test_start_must_be_dram_interleaved(device):
+def test_start_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be DRAM interleaved"):
         _run(g, l, s, c)
 
 
-def test_start_2d_first_dim_not_one(device):
+def test_start_2d_first_dim_not_one(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(2, NUM_EXPERTS))
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be 1D or 2D with first dimension == 1"):
         _run(g, l, s, c)
 
 
-def test_start_3d_rejected(device):
+def test_start_3d_rejected(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(1, 1, NUM_EXPERTS))
     c = _make_index(device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start must be 1D or 2D with first dimension == 1"):
         _run(g, l, s, c)
 
 
@@ -238,39 +238,39 @@ def test_start_3d_rejected(device):
 # ---------------------------------------------------------------------------
 
 
-def test_counts_wrong_dtype(device):
+def test_counts_wrong_dtype(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device, dtype=ttnn.uint16)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be UINT32"):
         _run(g, l, s, c)
 
 
-def test_counts_must_be_dram_interleaved(device):
+def test_counts_must_be_dram_interleaved(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device, memory_config=ttnn.L1_MEMORY_CONFIG)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be DRAM interleaved"):
         _run(g, l, s, c)
 
 
-def test_counts_2d_first_dim_not_one(device):
+def test_counts_2d_first_dim_not_one(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device, shape=(2, NUM_EXPERTS))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be 1D or 2D with first dimension == 1"):
         _run(g, l, s, c)
 
 
-def test_counts_3d_rejected(device):
+def test_counts_3d_rejected(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device)
     c = _make_index(device, shape=(1, 1, NUM_EXPERTS))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "counts must be 1D or 2D with first dimension == 1"):
         _run(g, l, s, c)
 
 
@@ -279,48 +279,48 @@ def test_counts_3d_rejected(device):
 # ---------------------------------------------------------------------------
 
 
-def test_start_and_counts_last_dim_mismatch_1d(device):
+def test_start_and_counts_last_dim_mismatch_1d(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS + 1,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, l, s, c)
 
 
-def test_start_and_counts_last_dim_mismatch_2d(device):
+def test_start_and_counts_last_dim_mismatch_2d(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(1, NUM_EXPERTS))
     c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, l, s, c)
 
 
-def test_start_and_counts_last_dim_mismatch_mixed_rank(device):
+def test_start_and_counts_last_dim_mismatch_mixed_rank(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(1, NUM_EXPERTS + 1))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "start and counts must have the same last dimension"):
         _run(g, l, s, c)
 
 
-def test_global_expert_id_equal_to_last_dim_rejected(device):
+def test_global_expert_id_equal_to_last_dim_rejected(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_expert_id .* must be in the range"):
         _run(g, l, s, c, global_expert_id=NUM_EXPERTS)
 
 
-def test_global_expert_id_beyond_last_dim_rejected(device):
+def test_global_expert_id_beyond_last_dim_rejected(device, expect_error):
     g = _make_global(device)
     l = _make_local(device)
     s = _make_index(device, shape=(NUM_EXPERTS,))
     c = _make_index(device, shape=(NUM_EXPERTS,))
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "local_expert_id .* must be in the range"):
         _run(g, l, s, c, global_expert_id=NUM_EXPERTS + 5)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -290,13 +290,13 @@ def test_indexer_score_compute_kernel_config(device, math_fidelity):
     assert_indexer_match(out, ref, sq, t, check_neg=True)
 
 
-def test_indexer_score_rejects_fp32_dest_acc(device):
+def test_indexer_score_rejects_fp32_dest_acc(device, expect_error):
     """fp32_dest_acc_en=True is not supported by the custom LLK -> validate must reject it."""
     heads, dim, sq, t = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"]
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
     ckc = ttnn.init_device_compute_kernel_config(device.arch(), fp32_dest_acc_en=True)
     q, k, w = make_inputs(heads, dim, sq, t)
-    with pytest.raises(RuntimeError, match="fp32_dest_acc_en=false"):
+    with expect_error(RuntimeError, "fp32_dest_acc_en=false"):
         run_indexer(q, k, w, 128, device, program_config=cfg, compute_kernel_config=ckc)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul_split.py
@@ -199,9 +199,9 @@ def test_linear_split_core_grid(device, core_grid):
 
 
 # Constraint validation tests
-def test_invalid_chunks(device):
+def test_invalid_chunks(device, expect_error):
     """Should fail: chunks < 1"""
-    with pytest.raises((RuntimeError, ValueError)):
+    with expect_error((RuntimeError, ValueError), "minimal_matmul_split requires chunks >= 1"):
         M, K, N = 256, 256, 512
         torch_input = torch.randn((M, K), dtype=torch.float32)
         weight_input = torch.randn((K, N), dtype=torch.float32)
@@ -210,9 +210,9 @@ def test_invalid_chunks(device):
         ttnn.experimental.minimal_matmul_split(tt_input, tt_weight, chunks=0, dim=-1)
 
 
-def test_invalid_dim(device):
+def test_invalid_dim(device, expect_error):
     """Should fail: dim != -1"""
-    with pytest.raises((RuntimeError, ValueError)):
+    with expect_error((RuntimeError, ValueError), "minimal_matmul_split currently only supports dim=-1"):
         M, K, N = 256, 256, 768
         torch_input = torch.randn((M, K), dtype=torch.float32)
         weight_input = torch.randn((K, N), dtype=torch.float32)
@@ -221,9 +221,9 @@ def test_invalid_dim(device):
         ttnn.experimental.minimal_matmul_split(tt_input, tt_weight, chunks=3, dim=0)
 
 
-def test_non_divisible_n(device):
+def test_non_divisible_n(device, expect_error):
     """Should fail: N not divisible by 3"""
-    with pytest.raises((RuntimeError, ValueError)):
+    with expect_error((RuntimeError, ValueError), "must be divisible by chunks"):
         M, K, N = 256, 256, 256  # 256 not divisible by 3
         torch_input = torch.randn((M, K), dtype=torch.float32)
         weight_input = torch.randn((K, N), dtype=torch.float32)
@@ -232,9 +232,9 @@ def test_non_divisible_n(device):
         ttnn.experimental.minimal_matmul_split(tt_input, tt_weight, chunks=3, dim=-1)
 
 
-def test_non_tile_aligned_chunk(device):
+def test_non_tile_aligned_chunk(device, expect_error):
     """Should fail: N/chunks not tile-aligned"""
-    with pytest.raises((RuntimeError, ValueError)):
+    with expect_error((RuntimeError, ValueError), "must be a multiple of TILE_WIDTH"):
         M, K, N = 256, 256, 99  # 99/3 = 33, not tile-aligned (not multiple of 32)
         torch_input = torch.randn((M, K), dtype=torch.float32)
         weight_input = torch.randn((K, N), dtype=torch.float32)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -576,7 +576,7 @@ def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, bh_ring_size):
 
 # Minimal sanity check that compute_only=True with conflicting CCL kwargs is rejected.
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
-def test_moe_compute_compute_only_rejects_cluster_axis(mesh_device, mesh_shape):
+def test_moe_compute_compute_only_rejects_cluster_axis(mesh_device, mesh_shape, expect_error):
     """compute_only=True with cluster_axis set must raise (loud rejection per spec)."""
     # Build minimal valid input shapes; we do NOT need the op to actually run --
     # validation must reject the bad arg combination before kernel launch.
@@ -636,7 +636,7 @@ def test_moe_compute_compute_only_rejects_cluster_axis(mesh_device, mesh_shape):
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
-    with pytest.raises(RuntimeError, match=r"compute_only.*cluster_axis"):
+    with expect_error(RuntimeError, r"compute_only.*cluster_axis"):
         ttnn.experimental.moe_compute(
             tt_sparse,
             tt_indices,


### PR DESCRIPTION
`expect_error` fixture wraps `pytest.raises` so that in logs it's more obvious that errors were expected.
currently we see `TT_FATAL` followed by `PASSED`, which might be confusing, especially for an agent analyzing the logs.

an example in ci:
https://github.com/tenstorrent/tt-metal/actions/runs/27831440968/job/82385599954#step:6:114

CI status same as on `main`.
I ran only the jobs that contain the impacted tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/expect-error-deepseek)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/expect-error-deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/expect-error-deepseek)