### PR TITLE
[skip ci] Prewarm harbor diabled on call by default

### DIFF
--- a/.github/workflows/build-all-docker-images.yaml
+++ b/.github/workflows/build-all-docker-images.yaml
@@ -29,6 +29,11 @@ on:
         type: boolean
         default: false
         description: "Force rebuild of all Docker images even if they exist in registry"
+      prewarm-harbor:
+        required: false
+        type: boolean
+        default: false
+        description: "Prewarm built images into Harbor from GHCR"
     outputs:
       # Ubuntu 22.04 images (from build-docker-artifact platform=Ubuntu 22.04)
       ubuntu-2204-ci-build-tag:
@@ -88,6 +93,11 @@ on:
         type: boolean
         default: false
         description: "Force rebuild of all Docker images even if they exist in registry"
+      prewarm-harbor:
+        required: false
+        type: boolean
+        default: true
+        description: "Prewarm built images into Harbor from GHCR"
 
 permissions:
   contents: read
@@ -266,8 +276,8 @@ jobs:
   prewarm-cache:
     name: "Prewarm cache from GHCR via HARBOR"
     needs: [preflight, build-tools, build-llk, build-2204, build-2404]
-    if: always() && !failure() && !cancelled() && needs.preflight.outputs.harbor-prefix != ''
-    runs-on: tt-ubuntu-2204-large-stable
+    if: always() && !failure() && !cancelled() && inputs.prewarm-harbor && needs.preflight.outputs.harbor-prefix != ''
+    runs-on: tt-ubuntu-2204-medium-stable
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

CI Infra

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

* prewarm harbor is a checkbox enabled on dispatch by default
* prewarm harbor is disabled on call by default
* medium runner for prewarming (need disk space)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-dont-prewarm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-dont-prewarm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-dont-prewarm)