### PR TITLE
BugFix: MoE: Fix an issue where `moe_compute` op would fail with more than 1 shared expert

### DIFF
--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -29,6 +29,7 @@ from ttnn.operations.ccl import MoEActivationFunction
 import ttnn
 from models.common.modules.moe.tt_moe_decode import TTMoEDecode
 from models.common.modules.moe.tt_moe_decode_config import TTMoEDecodeConfig
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3.tests.fused_op_unit_tests.moe.test_optimized_moe_decode_block import (
     create_torch_dispatch_input_expert_scores_tensor,
     create_torch_dispatch_input_tensor,
@@ -292,7 +293,6 @@ def _config_id(path: Path) -> str:
 # known failures
 # Note: it would be better to test all of these and let them fail but some cause hard crashes and derail the test
 SKIP_LIST = [
-    "deepseek_ocr.yaml",  # this one is actually unexpected and causes the test to hang (watcher assert)
     "ling_1t.yaml",
     "mistral_large_3.yaml",
     "deepseek_v4_pro.yaml",
@@ -319,7 +319,7 @@ SKIP_LIST = [
         pytest.param(
             (8, 1),
             id="8x1",
-            marks=pytest.mark.skipif(is_mesh_graph_descriptor_set(MESH_GRAPH_DESC_16x1), reason=f"16x1 MGD is set"),
+            marks=pytest.mark.skipif(not is_blackhole(), reason=f"8x1 grid is only for BH testing"),
         ),
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/test_combine_tg.py
+++ b/models/demos/deepseek_v3/tests/test_combine_tg.py
@@ -166,7 +166,6 @@ def run_combine_test(
             batch,
             seq,
             select_experts_k,
-            experts,
             cluster_axis,
             topology=ttnn.Topology.Ring,
             num_links=num_links,

--- a/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/fused_decode.py
@@ -180,7 +180,6 @@ def fused_decode_forward(
         batch_size=total_tokens,
         seq_size=1,
         select_experts_k=K_sel,
-        experts=global_experts,
         cluster_axis=cluster_axis,
         topology=ttnn.Topology.Ring,
         num_links=fused_config.num_links,

--- a/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_all_to_all_dispatch_metadata_6U.py
@@ -747,6 +747,10 @@ def get_shared_expert_to_device_map(routed_experts, devices, mode):
             routed_experts + 1: list(range(1, devices, 2)),
         }
 
+    # 2 shared fully replicated, same as DeepSeek OCR
+    elif mode == "all_shared_x2":
+        return {routed_experts: list(range(devices)), routed_experts + 1: list(range(devices))}
+
     else:
         raise RuntimeError("Invalid shared expert mode")
 
@@ -797,7 +801,7 @@ def get_shared_expert_to_device_map(routed_experts, devices, mode):
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("routed_experts_per_device", [2])
-@pytest.mark.parametrize("shared_expert_mode", ["no_shared", "all_shared", "alternate_shared"])
+@pytest.mark.parametrize("shared_expert_mode", ["no_shared", "all_shared", "all_shared_x2", "alternate_shared"])
 def test_correctness(mesh_device, mesh_shape, cluster_axis, routed_experts_per_device, shared_expert_mode):
     batches_per_device = 32
     routed_experts = routed_experts_per_device * mesh_shape[cluster_axis]

--- a/tests/nightly/tg/ccl/moe/test_selective_combine_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_selective_combine_6U.py
@@ -623,7 +623,6 @@ def _run_test(
                 batch,
                 seq,
                 select_experts_k,
-                experts,
                 cluster_axis,
                 topology=ttnn.Topology.Ring,
                 num_links=num_links,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt_e2e.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt_e2e.py
@@ -1657,7 +1657,6 @@ def run_test_dispatch_compute_combine(mesh_device, tokens_global, hidden_size, s
         batch_size=total_tokens,  # total ring tokens (128); tokens_per_device = 128/4 = 32
         seq_size=1,
         select_experts_k=selected_experts_k,
-        experts=global_experts,  # 128 → experts_per_device = 128/32 = 4 = E
         cluster_axis=cluster_axis,
         topology=ttnn.Topology.Ring,
         num_links=4,
@@ -2184,7 +2183,6 @@ def run_test_moe_gpt_e2e(
         batch_size=M_ring,  # 128; tokens_per_device = 128/4 = 32
         seq_size=1,
         select_experts_k=selected_experts_k,
-        experts=global_experts,
         cluster_axis=cluster_axis,
         topology=ttnn.Topology.Ring,
         num_links=4,
@@ -2244,7 +2242,6 @@ def run_test_moe_gpt_e2e(
                 batch_size=M_ring,  # total ring tokens (128); tokens_per_device = 128/4 = 32
                 seq_size=1,
                 select_experts_k=selected_experts_k,
-                experts=global_experts,  # 128 = experts_total * mesh_cols
                 cluster_axis=cluster_axis,
                 topology=ttnn.Topology.Ring,
                 num_links=4,
@@ -2734,7 +2731,6 @@ def run_test_combine_isolation(mesh_device, tokens_global, hidden_size, selected
             batch_size=total_tokens,
             seq_size=1,
             select_experts_k=selected_experts_k,
-            experts=experts_total,
             cluster_axis=cluster_axis,
             topology=ttnn.Topology.Ring,
             num_links=4,
@@ -3039,7 +3035,6 @@ def run_test_full_pipeline_multi_iter(
             batch_size=total_tokens,
             seq_size=1,
             select_experts_k=selected_experts_k,
-            experts=experts_total,
             cluster_axis=cluster_axis,
             topology=ttnn.Topology.Ring,
             num_links=4,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -19,14 +19,12 @@ void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& token_activations_tensor = tensor_args.dense_activations_tensor;
 
-    const auto num_devices = token_activations_tensor.device()->get_view().num_devices();
-
-    const auto experts = operation_attributes.experts;
     const auto batch_size = operation_attributes.batch_size;
     const auto seq_size = operation_attributes.seq_size;
     const auto total_tokens = batch_size * seq_size;
 
-    const auto experts_per_device = experts / num_devices;
+    // physical experts per device, replicated shared experts are counted per device (matches program factory)
+    const uint32_t experts_per_device = tensor_args.dense_token_maps_tensor.logical_shape()[0];
 
     const uint32_t activations_stride_elm = token_activations_tensor.logical_shape()[-1] / total_tokens;
 
@@ -89,7 +87,6 @@ ttnn::Tensor selective_reduce_combine(
     uint32_t batch_size,
     uint32_t seq_size,
     uint32_t select_experts_k,
-    uint32_t experts,
     uint32_t cluster_axis,
     tt::tt_fabric::Topology topology,
     uint32_t num_links,
@@ -108,7 +105,6 @@ ttnn::Tensor selective_reduce_combine(
             .batch_size = batch_size,
             .seq_size = seq_size,
             .select_experts_k = select_experts_k,
-            .experts = experts,
             .num_links = num_links,
             .axis = cluster_axis,
             .topology = topology,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.cpp
@@ -19,6 +19,11 @@ void SelectiveReduceCombineDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& token_activations_tensor = tensor_args.dense_activations_tensor;
 
+    TT_FATAL(
+        tensor_args.dense_token_maps_tensor.logical_shape().rank() == 2,
+        "dense_token_maps_tensor must be rank 2 ([experts, per-token-stride]); got rank {}",
+        tensor_args.dense_token_maps_tensor.logical_shape().rank());
+
     const auto batch_size = operation_attributes.batch_size;
     const auto seq_size = operation_attributes.seq_size;
     const auto total_tokens = batch_size * seq_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation.hpp
@@ -51,7 +51,6 @@ ttnn::Tensor selective_reduce_combine(
     uint32_t batch_size,
     uint32_t seq_size,
     uint32_t select_experts_k,
-    uint32_t experts,
     uint32_t cluster_axis,
     tt::tt_fabric::Topology topology,
     uint32_t num_links,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
@@ -20,7 +20,6 @@ struct SelectiveReduceCombineParams {
     uint32_t batch_size;
     uint32_t seq_size;
     uint32_t select_experts_k;
-    uint32_t experts;
     uint32_t num_links;
 
     uint32_t axis;
@@ -40,7 +39,6 @@ struct SelectiveReduceCombineParams {
         attrs.emplace_back("batch_size", batch_size);
         attrs.emplace_back("seq_size", seq_size);
         attrs.emplace_back("select_experts_k", select_experts_k);
-        attrs.emplace_back("experts", experts);
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("axis", axis);
         attrs.emplace_back("num_token_parallel_cores", num_token_parallel_cores);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -274,8 +274,6 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const auto hidden_size = operation_attributes.hidden_size;
 
     const auto total_tokens = batch_size * seq_size;
-    // Eventually map number of experts to device
-    const auto experts = operation_attributes.experts;
 
     const auto num_links = operation_attributes.num_links;
     auto topology = operation_attributes.topology;
@@ -291,9 +289,8 @@ SelectiveReduceCombineProgramArtifacts build_selective_reduce_combine_program_ar
     const uint32_t num_devices_total = mesh_view.num_devices();
     const bool double_buffer_source = compute_cores_by_ring_id.has_value();
 
-    // NOTE: shared experts are slightly delicate since they show up as an additional entry in the mapping tensor the
-    // result is fractional experts per device so div_up is required to get the right value here.
-    const uint32_t experts_per_device = tt::div_up(experts, num_devices_total);
+    // physical experts per device, replicated shared experts are counted per device
+    const uint32_t experts_per_device = dense_token_maps_tensor.logical_shape()[0];
 
     const auto input_dtype = input_tensor.dtype();
     const auto& dense_token_maps_tensor_spec = dense_token_maps_tensor.tensor_spec();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/selective_reduce_combine_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/selective_reduce_combine_nanobind.cpp
@@ -91,7 +91,6 @@ void bind_selective_reduce_combine(nb::module_& mod) {
             batch_size (int): B
             seq_size (int): S
             select_experts_k (int): K
-            experts (int) E*D, total experts across all devices
             cluster_axis (int): Mesh axis to cluster along. 0 = column (COLS), 1 = row (ROWS).
             topology (ttnn.Topology): Line or Ring supported
             num_links (int): Number of fabric links to utilize
@@ -122,7 +121,6 @@ void bind_selective_reduce_combine(nb::module_& mod) {
         nb::arg("batch_size"),
         nb::arg("seq_size"),
         nb::arg("select_experts_k"),
-        nb::arg("experts"),
         nb::arg("cluster_axis"),
         nb::arg("topology"),
         nb::arg("num_links"),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -287,6 +287,8 @@ void kernel_main() {
     constexpr uint32_t tokens = get_named_compile_time_arg_val("tokens");
     constexpr uint32_t remote_counts_entry_size = get_named_compile_time_arg_val("remote_counts_entry_size");
     constexpr uint32_t experts = get_named_compile_time_arg_val("experts");
+    constexpr uint32_t experts_per_device = get_named_compile_time_arg_val("experts_per_device");
+
     constexpr uint32_t selected_experts_k = get_named_compile_time_arg_val("selected_experts_k");
 
     // Chunk info
@@ -402,8 +404,6 @@ void kernel_main() {
 
     // Constants
     constexpr uint32_t one_page = 1;
-
-    constexpr uint32_t experts_per_device = (experts + num_devices - 1) / num_devices;
 
     // Size of e_t buffer for all experts (for multicast)
     constexpr uint32_t e_t_buffer_total_size = experts_per_device * (tokens + 1) * e_t_entry_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -122,6 +122,8 @@ void kernel_main() {
     constexpr uint32_t tokens = get_named_compile_time_arg_val("tokens");
     constexpr uint32_t hidden_size = get_named_compile_time_arg_val("hidden_size");
     constexpr uint32_t experts = get_named_compile_time_arg_val("experts");
+    constexpr uint32_t experts_per_device = get_named_compile_time_arg_val("experts_per_device");
+
     constexpr uint32_t selected_experts_k = get_named_compile_time_arg_val("selected_experts_k");
 
     // Chunk info
@@ -206,7 +208,6 @@ void kernel_main() {
     constexpr uint32_t one_page = 1;
     constexpr uint32_t TILE_HEIGHT = 32;
     constexpr uint32_t TILE_WIDTH = 32;
-    constexpr uint32_t experts_per_device = (experts + num_devices - 1) / num_devices;
     constexpr uint32_t element_size = tilize_output_page_size / (TILE_HEIGHT * TILE_WIDTH);
     constexpr uint32_t tile_width_bytes = TILE_WIDTH * element_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -47,6 +47,35 @@ void MoEComputeDeviceOperation::validate_on_program_cache_miss(
         tensor_args.tilize_expert_indices_tensor.dtype() == tt::tt_metal::DataType::UINT16,
         "Indices tensor must be uint16");
 
+    // Input tensor rank guards. Exact ranks are enforced where every caller agrees; lenient
+    // minimum ranks are used for the token/index/score tensors, which legitimately arrive as
+    // rank-3 from some dispatch paths and rank-4 from others (the op only indexes [0]/[1]/[-1]).
+    const auto rank_of = [](const ttnn::Tensor& t) { return t.logical_shape().rank(); };
+    TT_FATAL(
+        rank_of(tensor_args.tilize_input_tensor) >= 3,
+        "tilize_input_tensor must be rank >= 3 ([..., tokens, hidden]); got rank {}",
+        rank_of(tensor_args.tilize_input_tensor));
+    TT_FATAL(
+        rank_of(tensor_args.tilize_expert_indices_tensor) >= 2,
+        "tilize_expert_indices_tensor must be rank >= 2 ([..., tokens, K]); got rank {}",
+        rank_of(tensor_args.tilize_expert_indices_tensor));
+    TT_FATAL(
+        rank_of(tensor_args.tilize_expert_scores_tensor) >= 2,
+        "tilize_expert_scores_tensor must be rank >= 2 ([..., tokens, K]); got rank {}",
+        rank_of(tensor_args.tilize_expert_scores_tensor));
+    TT_FATAL(
+        rank_of(tensor_args.tilize_expert_mapping_tensor) == 2,
+        "tilize_expert_mapping_tensor must be rank 2 ([num_devices, experts]); got rank {}",
+        rank_of(tensor_args.tilize_expert_mapping_tensor));
+    TT_FATAL(
+        rank_of(tensor_args.matmul_w0_w1_tensor) == 6,
+        "matmul_w0_w1_tensor must be rank 6 ([num_cores, L, E, groups_per_core, K, 4*TILE_SIZE]); got rank {}",
+        rank_of(tensor_args.matmul_w0_w1_tensor));
+    TT_FATAL(
+        rank_of(tensor_args.matmul_w2_tensor) == 6,
+        "matmul_w2_tensor must be rank 6 ([num_cores, L, E, groups_per_core, N, 4*TILE_SIZE]); got rank {}",
+        rank_of(tensor_args.matmul_w2_tensor));
+
     // When has_bias=True, dm0 derives per-expert byte strides using ceil((K+1)/W0W1_TXN)*W0W1_TXN and
     // ceil((N+1)/W2_TXN)*W2_TXN. The physical tensors must be padded to those tile counts; if not,
     // dm0 silently reads from wrong expert boundaries after the first expert.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -370,10 +370,8 @@ std::vector<ttnn::Tensor> moe_compute(
     using OperationType = ttnn::experimental::prim::MoEComputeDeviceOperation;
 
     const auto& input_shape = tilize_input_tensor.tensor_spec().logical_shape();
-    const auto& mapping_shape = tilize_expert_mapping_tensor.tensor_spec().logical_shape();
     const auto& indices_shape = tilize_expert_indices_tensor.tensor_spec().logical_shape();
     const uint32_t hidden_size = input_shape[-1];
-    const uint32_t experts = mapping_shape[-1];
     const uint32_t select_experts_k = indices_shape[-1];
     const uint32_t total_tokens = input_shape[0] * input_shape[1];
 
@@ -436,7 +434,6 @@ std::vector<ttnn::Tensor> moe_compute(
             .batch_size = 1,
             .seq_size = total_tokens,
             .select_experts_k = select_experts_k,
-            .experts = experts,
             .num_links = resolved_num_links,
             .axis = cluster_axis.value(),
             .topology = resolved_topology,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -164,17 +164,10 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
 
     const ttnn::Tensor& tilize_input_tensor = tensor_args.tilize_input_tensor;
-    const ttnn::Tensor& tilize_mapping_tensor = tensor_args.tilize_expert_mapping_tensor;
-
     const auto& tilize_input_shape = tilize_input_tensor.tensor_spec().logical_shape();
-    const auto& tilize_mapping_shape = tilize_mapping_tensor.tensor_spec().logical_shape();
-
     auto* mesh_device = tilize_input_tensor.device();
-    const auto& mesh_view = mesh_device->get_view();
-    uint32_t num_devices = mesh_view.num_devices();
 
-    uint32_t experts = tilize_mapping_shape[-1];
-    uint32_t experts_per_device = tt::div_up(experts, num_devices);
+    uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
     uint32_t total_tokens =
         tilize_input_shape[0] *
         tilize_input_shape[1];  // tokens_per_device from input, total tokens across all dispatch devices

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -440,12 +440,12 @@ MoEComputeMeshWorkloadFactory::create_at(
     // General info
     uint32_t tokens = get_num_rows_st(tilize_input_tensor);
     uint32_t hidden_size = tilize_input_shape[-1];
-    uint32_t experts = tilize_mapping_shape[-1];
-    uint32_t selected_experts_k = tilize_indices_shape[-1];
 
-    // NOTE: shared experts are slightly delicate since they show up as an additional entry in the mapping tensor the
-    // result is fractional experts per device so div_up is required to get the right value here.
-    uint32_t experts_per_device = tt::div_up(experts, num_devices);
+    // Logical experts, routed + shared (replicated experts counted as 1)
+    uint32_t experts = tilize_mapping_shape[-1];
+    // physical experts per device, replicated shared experts are counted per device
+    uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
+    uint32_t selected_experts_k = tilize_indices_shape[-1];
 
     // Output/Combine input core dims, for core selection. These are top-level (lifted) so they
     // remain valid even when combine_params is nullopt (ComputeOnly mode).
@@ -969,6 +969,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"hidden_size", hidden_size},
         {"remote_counts_entry_size", remote_counts_entry_size},
         {"experts", experts},
+        {"experts_per_device", experts_per_device},
         {"selected_experts_k", selected_experts_k},
 
         // Chunk info


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/45741
### Summary
- DeepSeek OCR, and other models with more than 1 shared expert, would hang in `moe_compute` on a watcher assert.
- Cleaned up expert accounting to fix this

### Notes for reviewers
- I tweaked the `test_tt_moe_compute` to make some changes added for Blackhole testing work as intended
- NOTE! From to this change, the `experts` parameter in the API for selective_reduce_combine` was made unnecessary so I removed it and modified all of the call sites.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/moe-compute-fix-gt1-shared-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-compute-fix-gt1-shared-expert)