### PR TITLE
[Feature][matmul] Accept ND_SHARDED DRAM in1 for 2D-mcast matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3814,14 +3814,12 @@ _ND_IN1_NUM_DRAM_SHARD_CORES = 4
         (512, 512, 512, (4, 4)),
         (256, 1024, 768, (4, 2)),
     ],
-    ids=["square_4x4", "rect_4x2"],
 )
 @pytest.mark.parametrize(
     # (K-splits, N-splits): 8 shards over 4 cores. Either wrapping the N dim
     # round-robin or a 2D K-by-N split keeps the layout genuinely ND_SHARDED.
     "k_splits, n_splits",
     [(1, 8), (2, 4)],
-    ids=["rr_wrap_8n", "nd_2k_4n"],
 )
 def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits):
     """2D-multicast matmul with an ND_SHARDED (NdShardSpec) DRAM in1.

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3801,3 +3801,115 @@ def test_matmul_compute_output_specs_with_allowed_worker_cores(
     )
     output_specs = ttnn.MatmulDeviceOperation.compute_output_specs(attributes, tensor_args)
     assert len(output_specs) >= 1
+
+
+# ND shards spread over this many DRAM cores. Kept below any real device's DRAM
+# bank count so round-robin patterns with more shards genuinely wrap.
+_ND_IN1_NUM_DRAM_SHARD_CORES = 4
+
+
+@pytest.mark.parametrize(
+    "m, k, n, grid_size",
+    [
+        (512, 512, 512, (4, 4)),
+        (256, 1024, 768, (4, 2)),
+    ],
+    ids=["square_4x4", "rect_4x2"],
+)
+@pytest.mark.parametrize(
+    # (K-splits, N-splits): 8 shards over 4 cores. Either wrapping the N dim
+    # round-robin or a 2D K-by-N split keeps the layout genuinely ND_SHARDED.
+    "k_splits, n_splits",
+    [(1, 8), (2, 4)],
+    ids=["rr_wrap_8n", "nd_2k_4n"],
+)
+def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits):
+    """2D-multicast matmul with an ND_SHARDED (NdShardSpec) DRAM in1.
+
+    ND_SHARDED in1 is not handled by the WIDTH/HEIGHT-sharded in1 reader, so the
+    matmul program factory falls through to the generic TensorAccessor path, which
+    addresses the NdShardSpec layout from the accessor args. This exercises the
+    in1-sharded memory-layout validation in MatmulDeviceOperation, which accepts
+    ND_SHARDED only when in1 lives in DRAM.
+
+    A weight is ND_SHARDED (rather than canonicalized to WIDTH/HEIGHT) when its
+    shards don't map one-contiguous-slab-per-core: either more shards than grid
+    cores (round-robin wrap, as in the receiver-contiguous DRAM prefetcher where
+    ring_size > num_banks) or a genuine 2D K-by-N split. Runs the identical matmul
+    with in1 interleaved vs. ND-sharded in DRAM and checks the ND output matches
+    both torch and the interleaved output.
+    """
+    grid_x, grid_y = grid_size
+    if device.dram_grid_size().x < _ND_IN1_NUM_DRAM_SHARD_CORES:
+        pytest.skip("needs at least _ND_IN1_NUM_DRAM_SHARD_CORES DRAM banks")
+    if k % (grid_x * 32) or m % (grid_y * 32) or n % (grid_x * 32):
+        pytest.skip("dims must be tile-aligned to the 2D-mcast grid")
+    if (k // 32) % k_splits or (n // 32) % n_splits:
+        pytest.skip("K/N (in tiles) must be divisible by the shard split")
+
+    in0 = torch.randn([1, 1, m, k]).bfloat16()
+    in1 = torch.randn([1, 1, k, n]).bfloat16()
+    pt_out = (in0.float() @ in1.float())[0, 0]
+
+    in0_t = ttnn.from_torch(
+        in0, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    # in1, interleaved in DRAM (reference path).
+    in1_interleaved = ttnn.from_torch(
+        in1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    # in1, ND-sharded across a fixed set of DRAM cores. With 8 shards over 4 cores
+    # this can't reduce to a one-slab-per-core width/height shard, so it stays ND.
+    dram_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(_ND_IN1_NUM_DRAM_SHARD_CORES - 1, 0))}
+    )
+    nd_shard_spec = ttnn.NdShardSpec(ttnn.Shape([k // k_splits, n // n_splits]), dram_grid)  # default ROUND_ROBIN_1D
+    in1_nd = ttnn.from_torch(
+        in1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.BufferType.DRAM, nd_shard_spec),
+    )
+    assert in1_nd.memory_config().memory_layout == ttnn.TensorMemoryLayout.ND_SHARDED
+
+    per_core_M = m // grid_y // 32
+    per_core_N = n // grid_x // 32
+    out_subblock_h, out_subblock_w, _ = find_max_subblock(per_core_M, per_core_N)
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=k // grid_x // 32,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=False,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+    def run(in1_t):
+        out_t = ttnn.matmul(
+            in0_t,
+            in1_t,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=compute_kernel_config,
+        )
+        return ttnn.to_torch(out_t)[0, 0]
+
+    out_interleaved = run(in1_interleaved)
+    out_nd = run(in1_nd)
+
+    assert_with_pcc(pt_out, out_nd, 0.99)
+    # The ND read must produce the same result as the interleaved read of the same weight.
+    assert_with_pcc(out_interleaved, out_nd, 0.999)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -16,7 +16,7 @@ from models.common.utility_functions import (
     skip_for_blackhole,
     skip_for_slow_dispatch,
 )
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_numeric_metrics, assert_equal
 from ttnn.operations.activations import get_golden_function_for_activation
 
 
@@ -3908,6 +3908,15 @@ def test_matmul_2d_nd_sharded_in1(device, m, k, n, grid_size, k_splits, n_splits
     out_interleaved = run(in1_interleaved)
     out_nd = run(in1_nd)
 
-    assert_with_pcc(pt_out, out_nd, 0.99)
-    # The ND read must produce the same result as the interleaved read of the same weight.
-    assert_with_pcc(out_interleaved, out_nd, 0.999)
+    assert_numeric_metrics(
+        pt_out,
+        out_nd,
+        atol=0.004 * k,
+        rtol=0.227 * k,
+        frobenius_threshold=0.001 * k,
+        pcc_threshold=0.999,
+        check_ulp=False,
+    )
+    # Same weight, same matmul program; only in1's DRAM layout differs, so the ND
+    # read must reproduce the interleaved read bit-for-bit.
+    assert_equal(out_interleaved, out_nd)

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1385,10 +1385,17 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                 if (input_tensor_b.memory_config().is_sharded()) {
                     TT_FATAL(!program_config.transpose_mcast, "Transpose MCAST not supported when input B is sharded");
                     auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout();
+                    // ND_SHARDED in1 in DRAM is read via the generic TensorAccessor path: the program
+                    // factory's in1_is_sharded only covers WIDTH/HEIGHT, so ND falls through to the
+                    // interleaved-style reader, which addresses the NdShardSpec layout from the accessor
+                    // args. The width/height-specific validation below is gated on those layouts, so ND
+                    // DRAM in1 skips it (no shard_spec() access).
+                    const bool in1_is_nd_dram = tensor_b_memory_layout == TensorMemoryLayout::ND_SHARDED &&
+                                                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM;
                     TT_FATAL(
                         tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
-                            tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
-                        "Input B memory layout must be WIDTH_SHARDED or HEIGHT_SHARDED, got: {}",
+                            tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || in1_is_nd_dram,
+                        "Input B memory layout must be WIDTH_SHARDED, HEIGHT_SHARDED, or DRAM ND_SHARDED, got: {}",
                         tensor_b_memory_layout);
                     if (tensor_b_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                         // Height-sharded in1 is only supported for DRAM batched matmuls


### PR DESCRIPTION
### PR Category
Feature

### Summary
`MatmulMultiCoreReuseMultiCast` (2D-mcast) validation required a sharded in1 to be `WIDTH_SHARDED` or `HEIGHT_SHARDED`. `ND_SHARDED` in1 is read via the generic `TensorAccessor` path — the program factory's `in1_is_sharded` only covers WIDTH/HEIGHT, so ND falls through to the interleaved-style reader, which addresses the `NdShardSpec` layout from the accessor args. This change allows `ND_SHARDED` in1 when it lives in DRAM; the width/height-specific checks below are gated on those layouts, so the ND case skips them (no `shard_spec()` access).

Motivation: a weight laid out for the receiver-contiguous DRAM prefetcher (`NdShardSpec`, `ring_size` shards round-robin over the DRAM banks) can feed a 2D-mcast matmul directly, instead of requiring a separately-allocated `WIDTH_SHARDED` copy.

### Notes for reviewers
- The only functional change is the relaxed `TT_FATAL` in `validate_on_program_cache_miss` (the `MatmulMultiCoreReuseMultiCastProgramConfig` branch). It only *adds* an allowed layout, so existing WIDTH/HEIGHT/interleaved paths are unaffected.
- For `ND_SHARDED` DRAM in1, none of the downstream `shard_spec()` accesses are reachable: the HEIGHT_SHARDED branch, the non-DRAM branch, and the WIDTH_SHARDED branch are all gated out by layout/buffer-type.
- New test `test_matmul.py::test_matmul_2d_nd_sharded_in1` runs the identical 2D-mcast matmul with in1 interleaved vs. ND-sharded in DRAM and asserts the ND output matches both torch (PCC ≥ 0.99) and the interleaved output (PCC ≥ 0.999) — so it proves the read is correct, not merely non-fatal.
- The test deliberately uses shard patterns that stay `ND_SHARDED` (more shards than grid cores → round-robin wrap, or a 2D K×N split); a one-slab-per-core `NdShardSpec` canonicalizes to `WIDTH_SHARDED` and wouldn't exercise this path. It asserts `memory_layout == ND_SHARDED` up front to prevent silent regression.
- Validated on a single-card Blackhole P100 (4/4 cases pass).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/matmul-nd-sharded-in1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/matmul-nd-sharded-in1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/matmul-nd-sharded-in1)