### PR TITLE
[Cleanup] Shrink DRISC local-init scratch + kernel-config to grow L1 working region

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -334,13 +334,27 @@
 #define MEM_DRISC_FIRMWARE_SIZE (24 * 1024)
 #define MEM_DRISC_MAP_END (MEM_DRISC_FIRMWARE_BASE + MEM_DRISC_FIRMWARE_SIZE)
 #define MEM_DRISC_INIT_LOCAL_L1_BASE_SCRATCH MEM_DRISC_MAP_END
-#define MEM_DRISC_BANK_TO_NOC_SCRATCH (MEM_DRISC_INIT_LOCAL_L1_BASE_SCRATCH + MEM_DRISC_LOCAL_SIZE)
+// L1 staging area for the firmware's initialized local .data image, copied into the
+// 8KB private RAM by do_crt1. Only sizeof(.data) is staged here: .bss/.tbss are zeroed
+// in place in local RAM (not copied), and a kernel's local data is staged inside its
+// own binary (__kernel_data_lma), not here. The DRISC firmware currently has 0 bytes of
+// initialized local .data, so 1KB is ample headroom while freeing L1 for the
+// programmable-DRAM-core kernel working region. NOTE: distinct from MEM_DRISC_LOCAL_SIZE,
+// which is the private-RAM *window* size (linker DATA_SIZE in main.ld) and must stay 8KB.
+#define MEM_DRISC_INIT_LOCAL_L1_SCRATCH_SIZE (1 * 1024)
+#define MEM_DRISC_BANK_TO_NOC_SCRATCH (MEM_DRISC_INIT_LOCAL_L1_BASE_SCRATCH + MEM_DRISC_INIT_LOCAL_L1_SCRATCH_SIZE)
 #define MEM_DRISC_BANK_TO_NOC_SIZE (MEM_BANK_TO_NOC_XY_SIZE + MEM_BANK_OFFSET_SIZE)
 #define MEM_DRISC_STACK_MIN_SIZE 256
 #define MEM_DRISC_L1_BASE 0x0
 #define MEM_DRISC_L1_SIZE (128 * 1024)
 #define MEM_DRISC_KERNEL_CONFIG_BASE (MEM_DRISC_BANK_TO_NOC_SCRATCH + MEM_DRISC_BANK_TO_NOC_SIZE)
-#define MEM_DRISC_KERNEL_CONFIG_SIZE (10 * 1024)
+// Per-program RTAs/semaphores ring buffer. DRAM cores do not support CBs and their
+// kernel *text* loads directly into the firmware window (DRAM is the false branch of
+// get_core_kernel_stored_in_config_buffer), so kernel text consumes 0 bytes here. The
+// prefetcher kernel uses 2 RTAs (~tens of bytes); 2KB is generous for any DRISC program.
+// Shrunk from 10KB to free L1 for the kernel working region. finalize_program_offsets
+// TT_FATALs ("Program size too large for kernel config buffer") if a program exceeds it.
+#define MEM_DRISC_KERNEL_CONFIG_SIZE (2 * 1024)
 #define DRISC_RESET_PC (MEM_LOCAL_BASE | 0x14000)
 
 /////////////


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
The DRAM-core prefetcher's stage ring lives in the DRISC `UNRESERVED` region of Blackhole L1. Two regions below it were over-reserved, and this PR right-sizes them so the reclaimed space lands in `UNRESERVED`:

- **Local-init L1 scratch** was sized at `MEM_DRISC_LOCAL_SIZE` (8KB), mirroring the private-RAM window. But that scratch only stages the firmware's initialized local `.data` image (`do_crt1` copies `__ldm_data_end - __ldm_data_start`), which is **0 bytes** (verified, including watcher builds). It's now decoupled from `MEM_DRISC_LOCAL_SIZE` (still 8KB for the linker `DATA_SIZE`) via a dedicated 1KB `MEM_DRISC_INIT_LOCAL_L1_SCRATCH_SIZE`.
- **Kernel-config buffer** was 10KB. DRAM cores don't support CBs and load kernel *text* directly into the firmware window (DRAM is the false branch of `get_core_kernel_stored_in_config_buffer`), so kernel text consumes **0 bytes** here; the region holds only RTAs/semaphores. The prefetcher uses 2 RTAs. Shrunk to 2KB.

Net: DRISC `UNRESERVED` grows 73088 → 88448 B (+15KB), all of which lands in the prefetcher stage ring. The firmware window (24KB) and the 8KB private-RAM window are unchanged; firmware `.data` stays 0 and the kernel still loads at `__fw_export_text_end` well inside the firmware window, with and without watcher.

Single-file change to `tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h`.

### Notes for reviewers
- The two shrunk regions were verified empty/over-reserved at runtime; the key invariant is that the firmware window and private-RAM window are byte-for-byte unchanged.
- Verified on Blackhole p100a: `unit_tests_api *DramSenderGCB*` (4/4 pass, slow dispatch) and `test_prefetcher_BH_validator` `dram_sender bench_default` (PCC).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/drisc-l1-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/drisc-l1-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/drisc-l1-shrink)