### PR TITLE
[Test Only]Replace PCC with elementwise check for integer tests in `test_run_eltwise_typecast_op`

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -21,6 +21,33 @@ cpu_layout = ttnn.Layout.ROW_MAJOR
 npu_layout = ttnn.Layout.TILE
 
 
+def _typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):
+    """Out-of-range inputs for integer typecast: clamp (→uint16), wrap (→uint8).
+
+    int32 inputs may be negative; uint16/uint32 inputs stay >= 0 to avoid reinterpretation
+    on device (e.g. -1 as uint32 → 4294967295) that would mismatch clamp-aware golden.
+    """
+    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.int32:
+        return -1000, 80000  # signed: negatives clamp to 0, >65535 clamp to 65535
+    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.uint32:
+        return 0, 80000  # unsigned: no negatives; >65535 values will be clamped
+    if tt_output_dtype == ttnn.uint32 and tt_input_dtype == ttnn.int32:
+        return -1000, 80000
+    if tt_output_dtype == ttnn.uint8 and tt_input_dtype == ttnn.int32:
+        return -512, 512  # wrap/truncate to uint8 (not clamp); wide range ensures out-of-[0,255] values
+    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in (ttnn.uint16, ttnn.uint32):
+        return 0, 512  # values >255 exercise truncation; wide enough to guarantee hits
+    return 0, 100
+
+
+def _make_typecast_test_input(shape, pt_input_dtype, in_low, in_high):
+    if pt_input_dtype == torch.uint8:
+        return torch.randint(0, 256, shape, dtype=torch.uint8)
+    if pt_input_dtype in (torch.int, torch.int32):
+        return torch.randint(in_low, in_high + 1, shape, dtype=torch.int32)
+    return (torch.rand(shape) * (in_high - in_low) + in_low).to(pt_input_dtype)
+
+
 @pytest.mark.parametrize(
     "pt_input_dtype, tt_input_dtype, tt_output_dtype",
     (
@@ -110,13 +137,9 @@ class TestTypecast:
     ):
         if tt_input_dtype == tt_output_dtype:
             pytest.skip("Same I/O data types. Skip.")
-        in_low = 0
-        in_high = 100
-        if tt_output_dtype == ttnn.uint8:
-            in_low = -257
-            in_high = 257
+        in_low, in_high = _typecast_test_input_bounds(tt_input_dtype, tt_output_dtype)
         shape = input_shapes[0]
-        torch_input = (torch.rand(shape) * (in_high - in_low) + in_low).to(pt_input_dtype)
+        torch_input = _make_typecast_test_input(shape, pt_input_dtype, in_low, in_high)
 
         tt_input = ttnn.from_torch(
             torch_input, dtype=tt_input_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_mem_config

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -126,8 +126,13 @@ class TestTypecast:
 
         torch_golden = eltwise_typecast(torch_input, tt_input_dtype=tt_input_dtype, tt_output_dtype=tt_output_dtype)
 
-        if tt_output_dtype == ttnn.float32 or tt_output_dtype == ttnn.bfloat16:
+        if tt_output_dtype in (ttnn.float32, ttnn.bfloat16):
             assert_equal(torch_golden, torch_output)
+        # Integer outputs (and uint16 from integer inputs): compare elementwise via assert_equal.
+        elif tt_output_dtype in (ttnn.int32, ttnn.uint32, ttnn.uint8) or (
+            tt_output_dtype == ttnn.uint16 and tt_input_dtype in (ttnn.int32, ttnn.uint16, ttnn.uint32, ttnn.uint8)
+        ):
+            assert_equal(torch_golden.to(torch.int64), torch_output.to(torch.int64))
         else:
             pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
             assert_with_pcc(torch_golden, torch_output, pcc=pcc)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/46035

### PR Category
Test Only.

## Summary

Fixes #46035 (test-only).

- Replace PCC with assert_equal for integer typecast outputs in test_run_eltwise_typecast_op. Widen inputs so clamp/saturation is exercised; golden remains clamp-aware via eltwise_typecast.
- In `test_run_eltwise_typecast_op`, split assertions by output dtype:
  - **float32 / bfloat16:** `assert_equal` (unchanged behavior; cleaner `in (...)` check)
  - **int32 / uint32 / uint8**, and **uint16 from integer inputs** (uint8, int32, uint16, uint32): `assert_equal` on tensors cast to int64 (replaces PCC)
  - **All other combinations** (e.g. bf16/fp32/bf8_b/bf4_b → uint16, → bfp8_b, → bfp4_b): keep existing PCC thresholds (unchanged from main)

**Scope:** Only `TestTypecast::test_run_eltwise_typecast_op`. Other typecast tests will be modified in following PRs

### Pipeline Updates

- [x] (Runtime) Sanity test - Passed
- [x] Sanity test - Passed as in main
- [x] BH Post commit - Passed as in main
- [x] Nightly - Passed as in main

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/typecast_test_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/typecast_test_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/typecast_test_fix)