### PR TITLE
[tt-train ] Disable flaky tt-train tests

### DIFF
--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -126,7 +126,8 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Batch) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
-TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Batch) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(CrossEntropyForwardTest, DISABLED_CrossEntropyForward_Large_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 1017U, W = 1018U;

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -53,7 +53,8 @@ bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, 
     return all_equals;
 }
 
-TEST_F(LinearOpTest, TTNNBackwardGoodShape) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(LinearOpTest, DISABLED_TTNNBackwardGoodShape) {
     auto tensor = ttml::autograd::create_tensor();
     ttml::init::uniform_init(tensor, ttnn::Shape({64, 1, 256, 64}), ttml::init::UniformRange{-0.1F, 0.1F});
     tensor->set_requires_grad(true);

--- a/tt-train/tests/ops/sdpa_bw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_bw_op_test.cpp
@@ -692,7 +692,8 @@ void run_sdpa_backward_test(const SDPABackwardTestConfig& config) {
 
 // ========== Test Cases ==========
 
-TEST_F(SDPABackwardTest, SmallBatch) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_SmallBatch) {
     SDPABackwardTestConfig config{
         .batch_size = 2U,
         .sequence_length = 128U,
@@ -737,7 +738,8 @@ TEST_F(SDPABackwardTest, NIGHTLY_LargerSequence) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, GroupedQueryAttention) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_GroupedQueryAttention) {
     // Test GQA: more query heads than kv heads
     SDPABackwardTestConfig config{
         .batch_size = 2U,
@@ -753,7 +755,8 @@ TEST_F(SDPABackwardTest, GroupedQueryAttention) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, TinyLlamaConfig) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_TinyLlamaConfig) {
     // Match TinyLlama training config from configs/training_shakespeare_tinyllama.yaml
     // num_heads: 32, num_groups: 4, embedding_dim: 2048, max_sequence_length: 2048
     // head_dim = 2048 / 32 = 64
@@ -779,7 +782,8 @@ TEST_F(SDPABackwardTest, TinyLlamaConfig) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, CausalMask_MHA) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_CausalMask_MHA) {
     // Test causal mask with Multi-Head Attention
     // Both sdpa_bw_q and sdpa_bw_kv support on-the-fly causal mask generation
     SDPABackwardTestConfig config{
@@ -797,7 +801,8 @@ TEST_F(SDPABackwardTest, CausalMask_MHA) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, CausalMask_GQA) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_CausalMask_GQA) {
     SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Test causal mask with Grouped Query Attention
     // Both sdpa_bw_q and sdpa_bw_kv support on-the-fly causal mask generation
@@ -851,7 +856,8 @@ TEST_F(SDPABackwardTest, NIGHTLY_CausalMask_LargerSequence) {
 
 // ========== Different V Dimension Tests (qE == kE != vE) ==========
 
-TEST_F(SDPABackwardTest, DiffVDim_Causal_SmallV) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_DiffVDim_Causal_SmallV) {
     SDPABackwardTestConfig config{
         .batch_size = 2U,
         .sequence_length = 128U,
@@ -868,7 +874,8 @@ TEST_F(SDPABackwardTest, DiffVDim_Causal_SmallV) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, DiffVDim_Causal_LargeV) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_DiffVDim_Causal_LargeV) {
     SDPABackwardTestConfig config{
         .batch_size = 2U,
         .sequence_length = 128U,
@@ -885,7 +892,8 @@ TEST_F(SDPABackwardTest, DiffVDim_Causal_LargeV) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, DiffVDim_ArbitraryMask) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_DiffVDim_ArbitraryMask) {
     SDPABackwardTestConfig config{
         .batch_size = 2U,
         .sequence_length = 128U,
@@ -902,7 +910,8 @@ TEST_F(SDPABackwardTest, DiffVDim_ArbitraryMask) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, DiffVDim_GQA_Causal) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_DiffVDim_GQA_Causal) {
     SDPABackwardTestConfig config{
         .batch_size = 2U,
         .sequence_length = 128U,
@@ -936,7 +945,8 @@ TEST_F(SDPABackwardTest, DiffVDim_SingleTile) {
     run_sdpa_backward_test(config);
 }
 
-TEST_F(SDPABackwardTest, DiffVDim_MultiBatch) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPABackwardTest, DISABLED_DiffVDim_MultiBatch) {
     SDPABackwardTestConfig config{
         .batch_size = 4U,
         .sequence_length = 128U,

--- a/tt-train/tests/ops/sdpa_fw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_fw_op_test.cpp
@@ -657,7 +657,8 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_SingleTile) {
     run_sdpa_test(config);
 }
 
-TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_MHA_Batch4_Seq256) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPAForwardTest, DISABLED_SDPAForwardTest_CausalMask_MHA_Batch4_Seq256) {
     SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Multi-head attention with equal query and KV heads (standard MHA)
     // batch=4, seq=256 (8 tile rows), 6 heads with 128 dim per head
@@ -673,7 +674,8 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_MHA_Batch4_Seq256) {
     run_sdpa_test(config);
 }
 
-TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_GQA_Batch16_Seq512) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPAForwardTest, DISABLED_SDPAForwardTest_CausalMask_GQA_Batch16_Seq512) {
     SKIP_FOR_LLK_ASSERTS("Skip due to too large code size when assert is enabled.");
     // Grouped Query Attention with different query and KV heads
     // batch=16, seq=512 (16 tile rows), 8 query heads, 4 KV heads (2:1 ratio)
@@ -732,7 +734,8 @@ TEST_F(SDPAForwardTest, NIGHTLY_SDPAForwardTest_Batch_12Heads_6Group) {
 // VALIDATION TESTS - Testing Error Conditions and Edge Cases
 // =============================================================================
 
-TEST_F(SDPAForwardTest, ValidationTest_EdgeCaseDimensions) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPAForwardTest, DISABLED_ValidationTest_EdgeCaseDimensions) {
     using namespace ttml;
 
     // Test Case 1: Minimum viable dimensions
@@ -954,7 +957,8 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_DifferentVDim_SingleTile) {
     run_sdpa_test(config);
 }
 
-TEST_F(SDPAForwardTest, SDPAForwardTest_DifferentVDim_MultiBatch) {
+// Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+TEST_F(SDPAForwardTest, DISABLED_SDPAForwardTest_DifferentVDim_MultiBatch) {
     // Multi-batch with different V dim
     SDPATestConfig config{
         .batch_size = 4U,

--- a/tt-train/tests/optimizers/adamw_full_precision_test.cpp
+++ b/tt-train/tests/optimizers/adamw_full_precision_test.cpp
@@ -325,8 +325,8 @@ INSTANTIATE_TEST_SUITE_P(
 static const AdamWFullPrecisionCase kAMSGradCases[] = {
     // Standard AMSGrad
     {{1, 1, 1, 65'536}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f, true, "Standard"},
-    // AMSGrad with weight decay
-    {{1, 4, 64, 256}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.01f, true, "WeightDecay_0p01"},
+    // Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+    // {{1, 4, 64, 256}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.01f, true, "WeightDecay_0p01"},
     // AMSGrad with different shape
     {{2, 8, 64, 512}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f, true, "NIGHTLY_Large_4D"},
 };

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -313,8 +313,8 @@ INSTANTIATE_TEST_SUITE_P(AdamWWeightDecay, AdamWComparisonTest, ::testing::Value
 static const AdamWCase kAMSGradCases[] = {
     // Standard AMSGrad
     {{1, 1, 1, 65'536}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f, true, "Standard"},
-    // AMSGrad with weight decay
-    {{1, 4, 64, 256}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.01f, true, "WeightDecay_0p01"},
+    // Disabled: non-deterministic accuracy failures — https://github.com/tenstorrent/tt-metal/issues/46121
+    // {{1, 4, 64, 256}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.01f, true, "WeightDecay_0p01"},
     // AMSGrad with different shape
     {{2, 8, 64, 512}, 1e-3f, 0.9f, 0.999f, 1e-8f, 0.0f, true, "NIGHTLY_Large_4D"},
 };


### PR DESCRIPTION
### PR Category
Tests

### Summary
A set of tt-train tests are intermittently showing accuracy issues. Since they have a chance of blocking merge gate, they will be disabled for now. The accompanying ticket: https://github.com/tenstorrent/tt-metal/issues/46121

This PR disables the following test:
- CrossEntropyForwardTest.CrossEntropyForward_Large_Batch
- LinearOpTest.TTNNBackwardGoodShape
- SDPAForwardTest.SDPAForwardTest_CausalMask_MHA_Batch4_Seq256
- SDPAForwardTest.SDPAForwardTest_CausalMask_GQA_Batch16_Seq512
- SDPAForwardTest.ValidationTest_EdgeCaseDimensions
- SDPAForwardTest.SDPAForwardTest_DifferentVDim_MultiBatch
- SDPABackwardTest.SmallBatch
- SDPABackwardTest.GroupedQueryAttention
- SDPABackwardTest.TinyLlamaConfig
- SDPABackwardTest.CausalMask_MHA
- SDPABackwardTest.CausalMask_GQA
- SDPABackwardTest.DiffVDim_Causal_SmallV
- SDPABackwardTest.DiffVDim_Causal_LargeV
- SDPABackwardTest.DiffVDim_ArbitraryMask
- SDPABackwardTest.DiffVDim_GQA_Causal
- SDPABackwardTest.DiffVDim_MultiBatch
- AdamWAMSGrad/AdamWComparisonTest.CompareImplementations/WeightDecay_0p01_B1H4S64C256
- AdamWFullPrecisionAMSGrad/AdamWFullPrecisionComparisonTest.CompareWithCPU/WeightDecay_0p01_B1H4S64C256

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/disable-tt-train-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/disable-tt-train-tests)