### PR TITLE
[Bug Fix] Fix output granularity mismatch when running compute_sdpa_recip path in flash_mla

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_bcast_col_srca_srcb_reuse.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_sdpa_bcast_col_srca_srcb_reuse.h
@@ -90,7 +90,8 @@ template <
     MathFidelity math_fidelity,
     bool clear_dest = false,
     bool skip_signalling = false,
-    bool fused_signalling = false>
+    bool fused_signalling = false,
+    std::uint32_t output_granularity>
 inline void _llk_math_sdpa_bcast_col_srca_srcb_reuse_(uint dst_index) {
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
@@ -105,9 +106,10 @@ inline void _llk_math_sdpa_bcast_col_srca_srcb_reuse_(uint dst_index) {
             }
         }
     } else {
-        for (std::uint32_t tile_num = 0; tile_num < num_tiles; tile_num += 2) {
-            ckernel_template::run();
-            ckernel_template::run();
+        for (std::uint32_t tile_num = 0; tile_num < num_tiles; tile_num += output_granularity) {
+            for (std::uint32_t g = 0; g < output_granularity; g++) {
+                ckernel_template::run();
+            }
             if constexpr (!skip_signalling) {
                 t6_semaphore_post<p_stall::MATH>(semaphore::FPU_SFPU);
             }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_bcast_col_srca_srcb_reuse_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_sdpa_bcast_col_srca_srcb_reuse_api.h
@@ -32,7 +32,8 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool skip_signalling = false,
-    bool fused_signalling = false>
+    bool fused_signalling = false,
+    std::uint32_t output_granularity>
 inline void llk_math_sdpa_bcast_col_srca_srcb_reuse(const std::uint32_t dst_index) {
     _llk_math_sdpa_bcast_col_srca_srcb_reuse_<
         eltwise_binary_type,
@@ -42,5 +43,6 @@ inline void llk_math_sdpa_bcast_col_srca_srcb_reuse(const std::uint32_t dst_inde
         math_fidelity,
         false,
         skip_signalling,
-        fused_signalling>(dst_index);
+        fused_signalling,
+        output_granularity>(dst_index);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h
@@ -85,7 +85,8 @@ template <
     EltwiseBinaryType eltwise_binary_type = EltwiseBinaryType::ELWADD,
     uint32_t num_tiles,
     bool skip_signalling = false,
-    bool fused_signalling = false>
+    bool fused_signalling = false,
+    uint32_t output_granularity>
 ALWI void sdpa_bcast_col_srca_srcb_reuse_tiles(uint32_t dst_tile_index) {
     MATH((llk_math_sdpa_bcast_col_srca_srcb_reuse<
           eltwise_binary_type,
@@ -93,7 +94,8 @@ ALWI void sdpa_bcast_col_srca_srcb_reuse_tiles(uint32_t dst_tile_index) {
           DST_ACCUM_MODE,
           MATH_FIDELITY,
           skip_signalling,
-          fused_signalling>(dst_tile_index)));
+          fused_signalling,
+          output_granularity>(dst_tile_index)));
 }
 
 template <uint32_t num_tiles>
@@ -101,10 +103,14 @@ ALWI void sdpa_sub_bcast_col_srca_srcb_reuse_tiles_init(uint32_t icb0) {
     sdpa_bcast_col_srca_srcb_reuse_tiles_init<EltwiseBinaryType::ELWSUB, num_tiles>(icb0);
 }
 
-template <uint32_t num_tiles, bool skip_signalling = false, bool fused_signalling = false>
+template <uint32_t num_tiles, bool skip_signalling = false, bool fused_signalling = false, uint32_t output_granularity>
 ALWI void sdpa_sub_bcast_col_srca_srcb_reuse_tiles(uint32_t dst_tile_index) {
-    sdpa_bcast_col_srca_srcb_reuse_tiles<EltwiseBinaryType::ELWSUB, num_tiles, skip_signalling, fused_signalling>(
-        dst_tile_index);
+    sdpa_bcast_col_srca_srcb_reuse_tiles<
+        EltwiseBinaryType::ELWSUB,
+        num_tiles,
+        skip_signalling,
+        fused_signalling,
+        output_granularity>(dst_tile_index);
 }
 
 template <uint32_t num_tiles>
@@ -112,10 +118,14 @@ ALWI void sdpa_mul_bcast_col_srca_srcb_reuse_tiles_init(uint32_t icb0) {
     sdpa_bcast_col_srca_srcb_reuse_tiles_init<EltwiseBinaryType::ELWMUL, num_tiles>(icb0);
 }
 
-template <uint32_t num_tiles, bool skip_signalling = false, bool fused_signalling = false>
+template <uint32_t num_tiles, bool skip_signalling = false, bool fused_signalling = false, uint32_t output_granularity>
 ALWI void sdpa_mul_bcast_col_srca_srcb_reuse_tiles(uint32_t dst_tile_index) {
-    sdpa_bcast_col_srca_srcb_reuse_tiles<EltwiseBinaryType::ELWMUL, num_tiles, skip_signalling, fused_signalling>(
-        dst_tile_index);
+    sdpa_bcast_col_srca_srcb_reuse_tiles<
+        EltwiseBinaryType::ELWMUL,
+        num_tiles,
+        skip_signalling,
+        fused_signalling,
+        output_granularity>(dst_tile_index);
 }
 
 template <DataFormat format>
@@ -279,7 +289,7 @@ void compute_sdpa_chunk(
     sdpa_sub_bcast_col_srca_srcb_reuse_tiles_init<chunk_size>(cb_q);  // For tile shape
     MATH((t6_semaphore_wait_on_max<p_stall::STALL_MATH>(semaphore::FPU_SFPU)));
     sdpa_bcast_col_srca_srcb_reuse_preamble(max_dst_offset);
-    sdpa_sub_bcast_col_srca_srcb_reuse_tiles<chunk_size, false>(mm1_dst_offset);
+    sdpa_sub_bcast_col_srca_srcb_reuse_tiles<chunk_size, false, false, 1>(mm1_dst_offset);
     if (!first_chunk) {
         // Exp Sub (SFPU)
         // Signal FPU that tile is ready
@@ -291,7 +301,7 @@ void compute_sdpa_chunk(
         sdpa_mul_bcast_col_srca_srcb_reuse_tiles_init<num_tiles_v>(cb_q);
         MATH((t6_semaphore_wait_on_zero<p_stall::STALL_MATH>(SFPU_FPU)));
         sdpa_bcast_col_srca_srcb_reuse_preamble(corr_exp_dst_offset);
-        sdpa_mul_bcast_col_srca_srcb_reuse_tiles<num_tiles_v, true>(mm2_dst_offset);
+        sdpa_mul_bcast_col_srca_srcb_reuse_tiles<num_tiles_v, true, false, 1>(mm2_dst_offset);
         // FPU has consumed the tile
         MATH((t6_semaphore_post<p_stall::MATH>(semaphore::FPU_SFPU)));
         // Reset to 0
@@ -339,14 +349,14 @@ void compute_sdpa_chunk(
     cb_pop_front(cb_k, num_tiles_k * chunk_size);
 }
 
-template <uint32_t num_tiles_v, bool exp_approx_mode, uint16_t scale_bf16>
+template <uint32_t num_tiles_v, bool exp_approx_mode, uint16_t scale_bf16, uint32_t output_granularity>
 void compute_sdpa_recip(uint32_t cb_q, uint32_t sum_dst_offset, uint32_t recip_dst_offset, uint32_t mm2_dst_offset) {
     PACK((recip_sum<exp_approx_mode, scale_bf16>(sum_dst_offset, recip_dst_offset)));
     PACK((t6_semaphore_post<p_stall::WAIT_SFPU>(SFPU_FPU)));
     sdpa_mul_bcast_col_srca_srcb_reuse_tiles_init<num_tiles_v>(cb_q);
     MATH((t6_semaphore_wait_on_zero<p_stall::STALL_MATH>(SFPU_FPU)));
     sdpa_bcast_col_srca_srcb_reuse_preamble(recip_dst_offset);
-    sdpa_mul_bcast_col_srca_srcb_reuse_tiles<num_tiles_v, false, true>(mm2_dst_offset);
+    sdpa_mul_bcast_col_srca_srcb_reuse_tiles<num_tiles_v, false, true, output_granularity>(mm2_dst_offset);
     MATH((t6_semaphore_get<p_stall::MATH>(SFPU_FPU)));
 }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -840,7 +840,7 @@ struct FlashMLADecode {
                 pack_block_contiguous(max_dst_tile_offset, sdpa_ms_cb, 1);
                 cb_push_back(sdpa_ms_cb, Sq_chunk_t);
             } else {
-                compute_sdpa_recip<out_chunk_tiles, exp_approx_mode, scale_bf16>(
+                compute_sdpa_recip<out_chunk_tiles, exp_approx_mode, scale_bf16, output_granularity>(
                     cb_q_in, sum_dst_offset, corr_exp_dst_offset, mm2_dst_offset);
             }
             for (uint32_t i = 0; i < out_chunk_tiles; i += output_granularity) {


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
When output granularity support was added into flash_mla instead of being hardcoded to 2, the compute_sdpa_recip was not updated, so hitting this path could mismatch with the set granularity since it's hardcoded to 2. Add output_granularity support into compute_sdpa_recip.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/og)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/og)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/og)