### PR TITLE
[Bug fix] Skip pinning/transfers to non-local chips in tensor write APIs

### DIFF
--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
+#include "tt_metal/distributed/mesh_device_view_impl.hpp"
 #include <tt_stl/concepts.hpp>
 #include <tt_stl/small_vector.hpp>
 
@@ -169,13 +170,25 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
 
     if (use_pinned) {
         auto* mesh_device = mesh_buffer->device();
+        const auto& view = mesh_device->get_view();
         std::vector<distributed::ShardDataTransfer> transfers;
         transfers.reserve(distributed_host_buffer.shard_coords().size());
         bool any_pinned = false;
 
         for (const auto& coord : distributed_host_buffer.shard_coords()) {
+            // get_shard yields a buffer only for shards owned by this host, so remote chips are
+            // never pinned or added to the transfer list -- the transfer is a no-op for them here.
             auto buf = distributed_host_buffer.get_shard(coord);
             if (buf) {
+                // The host buffer's distribution must agree with the device's: host memory can only
+                // be pinned to MMIO devices local to this process, so a populated shard for a coord
+                // the device owns on another host must never reach try_pin (which would fault while
+                // resolving the remote device).
+                TT_FATAL(
+                    view.impl().is_local(coord),
+                    "Host buffer holds a shard for device coordinate {}, but that device is not local "
+                    "to this host; host memory can only be pinned to MMIO devices owned by this process.",
+                    coord);
                 auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
                 HostBuffer pinned_buf(*buf);
                 auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(
@@ -345,15 +358,28 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         ::tt::tt_metal::CMAKE_UNIQUE_NAMESPACE::should_use_pinned_write_path(*mesh_device, data_to_write.size());
 
     if (use_pinned) {
-        auto full_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(mesh_device->shape()));
+        // Replication fans a single 1x1 host shard out to the whole mesh, but only the chips owned
+        // by this host can be pinned/written; restrict the pin and the transfers to those so the
+        // remote coordinates are a complete no-op here.
+        const auto& view = mesh_device->get_view();
+        std::vector<distributed::MeshCoordinate> local_coords;
+        distributed::MeshCoordinateRangeSet local_range;
+        for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+            if (view.impl().is_local(coord)) {
+                local_coords.push_back(coord);
+                local_range.merge(distributed::MeshCoordinateRange(coord, coord));
+            }
+        }
+
         HostBuffer pinned_buffer(*host_buffer);
-        auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(
-            *mesh_device, full_range, pinned_buffer, /*map_to_noc=*/true);
+        auto pinned_memory = local_coords.empty() ? nullptr
+                                                  : experimental::PinnedMemoryCache::instance().try_pin(
+                                                        *mesh_device, local_range, pinned_buffer, /*map_to_noc=*/true);
 
         if (pinned_memory) {
             std::vector<distributed::ShardDataTransfer> transfers;
-            transfers.reserve(mesh_device->shape().mesh_size());
-            for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+            transfers.reserve(local_coords.size());
+            for (const auto& coord : local_coords) {
                 auto xfer = distributed::ShardDataTransfer{coord}
                                 .host_data(const_cast<void*>(static_cast<const void*>(data_to_write.data())))
                                 .region(BufferRegion(0, data_to_write.size()));
@@ -414,13 +440,25 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 
     if (use_pinned) {
         auto* mesh_device = mesh_buffer->device();
+        const auto& view = mesh_device->get_view();
         std::vector<distributed::ShardDataTransfer> transfers;
         transfers.reserve(distributed_host_buffer.shard_coords().size());
         bool any_pinned = false;
 
         for (const auto& coord : distributed_host_buffer.shard_coords()) {
+            // get_shard yields a buffer only for shards owned by this host, so remote chips are
+            // never pinned or added to the transfer list -- the transfer is a no-op for them here.
             auto buf = distributed_host_buffer.get_shard(coord);
             if (buf) {
+                // The host buffer's distribution must agree with the device's: host memory can only
+                // be pinned to MMIO devices local to this process, so a populated shard for a coord
+                // the device owns on another host must never reach try_pin (which would fault while
+                // resolving the remote device).
+                TT_FATAL(
+                    view.impl().is_local(coord),
+                    "Host buffer holds a shard for device coordinate {}, but that device is not local "
+                    "to this host; host memory can only be pinned to MMIO devices owned by this process.",
+                    coord);
                 auto coord_range = distributed::MeshCoordinateRangeSet(distributed::MeshCoordinateRange(coord, coord));
                 HostBuffer pinned_buf(*buf);
                 auto pinned_memory = experimental::PinnedMemoryCache::instance().try_pin(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #46116 (Bug 1).

On a multi-host mesh the device view spans coordinates owned by other hosts. Host memory can only be pinned to MMIO devices local to this process, so transfers targeting remote chips must be a complete no-op.

The 1×1 replicate path in `non_uniform_data_movement::enqueue_write_tensor` — reached when a plain, non-mesh-mapped host tensor (e.g. `ttnn.from_torch(t)` with no mesh mapper, `(1,1)` storage) is sent to a multi-host mesh via `to_device` — fanned the single host shard across the **entire** mesh range and pinned the full range. On a host that does not own `(0,0)`, `try_pin → compute_device_ids → get_device(remote_coord)` then `TT_FATAL`s:

```
Cannot get device for remote device at coordinate MeshCoordinate([0, 0])
  --- MeshDeviceViewImpl::get_device(...)
  --- PinnedMemoryCache::compute_device_ids(...)
  --- PinnedMemoryCache::try_pin(...)
  --- non_uniform_data_movement::enqueue_write_tensor(...)
  --- to_device(...) [via ttnn.from_torch]
```

This restricts the pin range and the transfer list to the host's local coordinates instead, so remote chips are a complete no-op. Locality is queried per coordinate via `MeshDeviceViewImpl::is_local()` (the non-deprecated impl accessor, reached through `view.impl()` — the same pattern `PinnedMemoryCache::compute_device_ids` already uses for `get_device`), which reflects device ownership rather than the source buffer's distribution.

The uniform / non-uniform distributed write loops already no-op on remote shards (`get_shard` returns `nullopt` for shards not owned by this host). A `TT_FATAL` is added there that checks device locality, so a host buffer whose distribution diverges from the device's fails fast with an actionable message instead of faulting deep inside `try_pin`.

### Notes for reviewers
- Single-host behavior is unchanged by construction: every coordinate is local, so the replicate pin range / transfer list are identical to before and the new `TT_FATAL`s never fire. This is why the regression only surfaced on the multi-host (4-host BH Galaxy) mesh in #46116.
- New include of the internal `tt_metal/distributed/mesh_device_view_impl.hpp` from `tt_metal/impl/tensor/tensor_apis.cpp` to reach `view.impl().is_local(coord)`; `pinned_memory_cache.cpp` (already a dependency of this file) includes the same header for the analogous `view.impl().get_device(coord)`.
- This is Bug 1 of #46116 only; the remaining items in that issue (readback helper, trace_region_size, encoder perf budget) are out of scope here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/no-pin-remote-chips-46116)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/no-pin-remote-chips-46116)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/no-pin-remote-chips-46116)