### PR TITLE
Relocate named_args_generated.h codegen to the genfiles layer

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_named_runtime_args.cpp
@@ -209,3 +209,45 @@ TEST_F(NamedArgsTest, TensixTestNamedPerCoreArrayRuntimeArgs) {
     EXPECT_EQ(results_core1[0], expected_sum_core1)
         << "Core (1,0): sum should be " << expected_sum_core1 << ", got " << results_core1[0];
 }
+
+// Covers the COMPUTE JIT compile path for the experimental named ct_args:: header.
+// All tests above use DataMovementConfigDescriptor (the BRISC/NCRISC path via
+// jit_build_genfiles_kernel_include); this one uses ComputeConfigDescriptor (the
+// TRISC path via jit_build_genfiles_triscs_src + build_trisc_prolog). Before the
+// genfiles relocation, named_args_generated.h was emitted per-source by build.cpp's
+// compile_one and delivered via `-include` — a non-atomic write on a shared path
+// (racy under multiprocess, and never carried to the remote/JIT-server path). This
+// exercises the relocated, presence-gated prolog #include on the compute path.
+TEST_F(NamedArgsTest, TensixTestNamedCompileTimeArgsComputeKernel) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+
+    CoreCoord core = {0, 0};
+    CoreRangeSet cores = std::set<CoreRange>({CoreRange(core, core)});
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const uint32_t param_a = 42;
+    const uint32_t param_b = 0xBEEF;
+
+    KernelDescriptor kernel = {
+        .kernel_source = "tests/tt_metal/tt_metal/test_kernels/compute/named_compile_time_args_compute_kernel.cpp",
+        .core_ranges = cores,
+        .named_compile_time_args = {{"my_kernel.param_a", param_a}, {"my_kernel.param_b", param_b}},
+        .defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}},
+        .config = ComputeConfigDescriptor{},
+    };
+
+    distributed::MeshWorkload workload;
+    Program program(ProgramDescriptor{.kernels = {kernel}});
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, 2 * sizeof(uint32_t), results);
+
+    EXPECT_EQ(results[0], param_a) << "ct_args::my_kernel::param_a should be 42 (compute path)";
+    EXPECT_EQ(results[1], param_b) << "ct_args::my_kernel::param_b should be 0xBEEF (compute path)";
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/named_compile_time_args_compute_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/named_compile_time_args_compute_kernel.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute-side test kernel for the experimental named ct_args:: feature.
+//
+// Covers the COMPUTE JIT compile path (TRISC_UNPACK / TRISC_MATH / TRISC_PACK)
+// for named_args_generated.h. The data-movement path is covered by
+// named_runtime_args_kernel.cpp. These reach the named-args header through
+// different include chains (api/compute/common.h vs api/dataflow/dataflow_api.h),
+// and the relocated genfiles emit + prolog #include must work in both. Before
+// the relocation, the compute path got the header only via build.cpp's per-source
+// `-include` — a non-atomic write on a shared path (racy under multiprocess, and
+// never carried to the remote/JIT-server path). This kernel exercises the
+// relocated genfiles emit + prolog #include instead.
+//
+// Reads named compile-time args via the ct_args:: namespace and writes them to
+// L1 at WRITE_ADDRESS (PACK only) so the host can verify the values.
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+
+void kernel_main() {
+    // PACK is the only TRISC that populates the result slot; UNPACK/MATH no-op.
+#ifdef TRISC_PACK
+    volatile tt_l1_ptr uint32_t* l1_ptr = (volatile tt_l1_ptr uint32_t*)WRITE_ADDRESS;
+    l1_ptr[0] = ct_args::my_kernel::param_a;
+    l1_ptr[1] = ct_args::my_kernel::param_b;
+#endif
+}

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -19,7 +19,6 @@
 #include <fstream>
 #include <iterator>
 #include <mutex>
-#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -523,83 +522,6 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
                 ss << "\"";
                 defines += ss.str() + " ";
             });
-
-        // Generate named_args_generated.h with a single ct_args:: namespace.
-        // Each prefix becomes a struct containing both CT values (uint32_t) and
-        // RT arg descriptors (rt_args::Arg / rt_args::ArrayArg).  Kernel code
-        // accesses both via the template parameter Args:
-        //   ct_args::my_op::src            — compile-time value
-        //   rt_args::get<Args::field>(i)   — runtime value via descriptor
-
-        // Accumulate RT entries per namespace.
-        std::map<std::string, std::vector<NamedRuntimeArgEntry>> rt_by_ns;
-        settings->process_named_runtime_args([&rt_by_ns](const NamedRuntimeArgNamespaces& namespaces) {
-            for (const auto& [ns, entries] : namespaces) {
-                rt_by_ns[ns].insert(rt_by_ns[ns].end(), entries.begin(), entries.end());
-            }
-        });
-
-        // Accumulate CT entries per namespace.
-        std::map<std::string, std::vector<std::pair<std::string, uint32_t>>> ct_by_ns;
-        settings->process_named_ct_arg_namespaces([&ct_by_ns](const NamedCTArgNamespaces& namespaces) {
-            for (const auto& [ns, entries] : namespaces) {
-                ct_by_ns[ns].insert(ct_by_ns[ns].end(), entries.begin(), entries.end());
-            }
-        });
-
-        // Collect all non-empty namespaces from both CT and RT maps.
-        std::set<std::string> all_ns;
-        for (const auto& [ns, _] : ct_by_ns) {
-            all_ns.insert(ns);
-        }
-        for (const auto& [ns, _] : rt_by_ns) {
-            if (!ns.empty()) {
-                all_ns.insert(ns);
-            }
-        }
-
-        // Emit one struct per namespace containing both CT fields and RT descriptors.
-        std::ostringstream header_ct;
-        for (const auto& ns : all_ns) {
-            if (!ns.empty()) {
-                header_ct << "struct " << ns << " {\n";
-            }
-            // CT fields
-            if (auto it = ct_by_ns.find(ns); it != ct_by_ns.end()) {
-                for (const auto& [field, value] : it->second) {
-                    header_ct << "    static constexpr uint32_t " << field << " = " << value << ";\n";
-                }
-            }
-            // RT descriptors
-            if (auto it = rt_by_ns.find(ns); it != rt_by_ns.end()) {
-                for (const auto& entry : it->second) {
-                    const char* dispatch_str = entry.dispatch == RuntimeArgDispatch::COMMON
-                                                   ? "rt_args::Dispatch::COMMON"
-                                                   : "rt_args::Dispatch::PER_CORE";
-                    if (entry.length > 1) {
-                        header_ct << "    static constexpr rt_args::ArrayArg " << entry.field << " = {" << entry.index
-                                  << ", " << entry.length << ", " << dispatch_str << "};\n";
-                    } else {
-                        header_ct << "    static constexpr rt_args::Arg " << entry.field << " = {" << entry.index
-                                  << ", " << dispatch_str << "};\n";
-                    }
-                }
-            }
-            if (!ns.empty()) {
-                header_ct << "};\n";
-            }
-        }
-
-        auto ct_str = header_ct.str();
-        if (!ct_str.empty()) {
-            std::string header_path = out_dir + "named_args_generated.h";
-            std::ostringstream content;
-            content << "#pragma once\n#include \"api/rt_arg.h\"\n\n";
-            content << "namespace ct_args {\n" << ct_str << "}\n";
-            std::ofstream f(header_path);
-            f << content.str();
-            defines += fmt::format("-include {} ", header_path);
-        }
 
         cmd += fmt::format("-{} ", settings->get_compiler_opt_level());
     } else {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -14,6 +14,8 @@
 #include <filesystem>
 #include <functional>
 #include <iterator>
+#include <map>
+#include <set>
 #include <iostream>
 #include <ostream>
 #include <fstream>
@@ -62,12 +64,16 @@ string get_kernel_source_to_include(const KernelSource& kernel_src) {
 
 // Generates TRISC prolog: #define + includes for JIT-generated headers and defines_generated.h
 // Kernels using Metal 2.0 get additional JIT-generated headers (not included for legacy kernels)
-string build_trisc_prolog(const char* trisc_define, bool is_metal2_kernel) {
+string build_trisc_prolog(const char* trisc_define, bool is_metal2_kernel, bool has_experimental_ct_args) {
     ostringstream prolog;
     prolog << "#define " << trisc_define << "\n";
     if (is_metal2_kernel) {
         prolog << "#include \"kernel_bindings_generated.h\"\n";
         prolog << "#include \"kernel_args_generated.h\"\n";
+    }
+    // EXPERIMENTAL named ct_args::/rt_args:: header — presence-gated, NOT is_metal2-gated.
+    if (has_experimental_ct_args) {
+        prolog << "#include \"named_args_generated.h\"\n";
     }
     prolog << "#include \"defines_generated.h\"\n";
     return prolog.str();
@@ -279,6 +285,85 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     write_file(path, content.str());
 }
 
+// EXPERIMENTAL (blaze leading-edge, NOT Metal 2.0):
+// Emits named_args_generated.h with a single ct_args:: namespace. Each prefix becomes a
+// struct containing both CT values (uint32_t) and RT arg descriptors (rt_args::Arg /
+// rt_args::ArrayArg). Gated on named-arg PRESENCE, NOT on is_metal2_kernel(): named_*_namespaces_
+// are set via setters (program.cpp) independent of the Metal 2.0 fence.
+// Codegen moved verbatim from JitBuildState::compile_one to preserve byte-identical output
+// (the determinism analysis + per-object dephash cache depend on exact bytes).
+// Returns true if a header was written (i.e. the kernel has named args), so callers can
+// decide whether to add the #include.
+bool write_named_args_generated_header(const string& out_dir, const JitBuildSettings& settings) {
+    // Accumulate RT entries per namespace.
+    std::map<std::string, std::vector<NamedRuntimeArgEntry>> rt_by_ns;
+    settings.process_named_runtime_args([&rt_by_ns](const NamedRuntimeArgNamespaces& namespaces) {
+        for (const auto& [ns, entries] : namespaces) {
+            rt_by_ns[ns].insert(rt_by_ns[ns].end(), entries.begin(), entries.end());
+        }
+    });
+
+    // Accumulate CT entries per namespace.
+    std::map<std::string, std::vector<std::pair<std::string, uint32_t>>> ct_by_ns;
+    settings.process_named_ct_arg_namespaces([&ct_by_ns](const NamedCTArgNamespaces& namespaces) {
+        for (const auto& [ns, entries] : namespaces) {
+            ct_by_ns[ns].insert(ct_by_ns[ns].end(), entries.begin(), entries.end());
+        }
+    });
+
+    // Collect all non-empty namespaces from both CT and RT maps.
+    std::set<std::string> all_ns;
+    for (const auto& [ns, _] : ct_by_ns) {
+        all_ns.insert(ns);
+    }
+    for (const auto& [ns, _] : rt_by_ns) {
+        if (!ns.empty()) {
+            all_ns.insert(ns);
+        }
+    }
+
+    // Emit one struct per namespace containing both CT fields and RT descriptors.
+    std::ostringstream header_ct;
+    for (const auto& ns : all_ns) {
+        if (!ns.empty()) {
+            header_ct << "struct " << ns << " {\n";
+        }
+        // CT fields
+        if (auto it = ct_by_ns.find(ns); it != ct_by_ns.end()) {
+            for (const auto& [field, value] : it->second) {
+                header_ct << "    static constexpr uint32_t " << field << " = " << value << ";\n";
+            }
+        }
+        // RT descriptors
+        if (auto it = rt_by_ns.find(ns); it != rt_by_ns.end()) {
+            for (const auto& entry : it->second) {
+                const char* dispatch_str = entry.dispatch == RuntimeArgDispatch::COMMON ? "rt_args::Dispatch::COMMON"
+                                                                                        : "rt_args::Dispatch::PER_CORE";
+                if (entry.length > 1) {
+                    header_ct << "    static constexpr rt_args::ArrayArg " << entry.field << " = {" << entry.index
+                              << ", " << entry.length << ", " << dispatch_str << "};\n";
+                } else {
+                    header_ct << "    static constexpr rt_args::Arg " << entry.field << " = {" << entry.index << ", "
+                              << dispatch_str << "};\n";
+                }
+            }
+        }
+        if (!ns.empty()) {
+            header_ct << "};\n";
+        }
+    }
+
+    auto ct_str = header_ct.str();
+    if (ct_str.empty()) {
+        return false;  // no named args → no header, no #include
+    }
+    std::ostringstream content;
+    content << "#pragma once\n#include \"api/rt_arg.h\"\n\n";
+    content << "namespace ct_args {\n" << ct_str << "}\n";
+    write_file(out_dir + "named_args_generated.h", content.str());
+    return true;
+}
+
 }  // namespace
 
 void jit_build_genfiles_kernel_include(
@@ -297,6 +382,10 @@ void jit_build_genfiles_kernel_include(
         write_kernel_args_generated_header(out_dir, settings);
         kernel_header_content =
             string("#include \"kernel_bindings_generated.h\"\n#include \"kernel_args_generated.h\"\n");
+    }
+    // EXPERIMENTAL named args — presence-gated, independent of is_metal2.
+    if (write_named_args_generated_header(out_dir, settings)) {
+        kernel_header_content += "#include \"named_args_generated.h\"\n";
     }
     kernel_header_content += get_kernel_source_to_include(kernel_src);
 
@@ -317,6 +406,8 @@ void jit_build_genfiles_triscs_src(
         write_kernel_bindings_generated_header(out_dir, settings);
         write_kernel_args_generated_header(out_dir, settings);
     }
+    // EXPERIMENTAL named args — emitted once per kernel here (was build.cpp per-source loop).
+    const bool has_experimental_ct_args = write_named_args_generated_header(out_dir, settings);
 
     const string unpack_cpp = out_dir + "chlkc_unpack.cpp";
     const string math_cpp = out_dir + "chlkc_math.cpp";
@@ -324,10 +415,10 @@ void jit_build_genfiles_triscs_src(
     const string isolate_sfpu_cpp = out_dir + "chlkc_isolate_sfpu.cpp";
 
     // Build prologs for each TRISC
-    const string unpack_prolog = build_trisc_prolog("TRISC_UNPACK", is_metal2);
-    const string math_prolog = build_trisc_prolog("TRISC_MATH", is_metal2);
-    const string pack_prolog = build_trisc_prolog("TRISC_PACK", is_metal2);
-    const string isolate_sfpu_prolog = build_trisc_prolog("TRISC_ISOLATE_SFPU", is_metal2);
+    const string unpack_prolog = build_trisc_prolog("TRISC_UNPACK", is_metal2, has_experimental_ct_args);
+    const string math_prolog = build_trisc_prolog("TRISC_MATH", is_metal2, has_experimental_ct_args);
+    const string pack_prolog = build_trisc_prolog("TRISC_PACK", is_metal2, has_experimental_ct_args);
+    const string isolate_sfpu_prolog = build_trisc_prolog("TRISC_ISOLATE_SFPU", is_metal2, has_experimental_ct_args);
 
     // All TRISCs get the same kernel source (differentiated by TRISC_* defines)
     const string kernel_src_to_include = get_kernel_source_to_include(kernel_src);


### PR DESCRIPTION
## Summary

Relocates generation of the experimental `named_args_generated.h` JIT header (which provides the `ct_args::`/`rt_args::` symbols kernels reference) out of `JitBuildState::compile_one` (`build.cpp`) and into the genfiles layer (`genfiles.cpp`), so it is generated **once per kernel** and written **atomically** via `FileRenamer` — matching the treatment of every other generated kernel header (`kernel_args_generated.h`, `kernel_bindings_generated.h`, `defines_generated.h`).

## Why

The old code wrote `named_args_generated.h` with a bare truncating `std::ofstream` into the shared per-kernel cache dir from `compile_one`, then `-include`d it. `compile_one` runs once per source on a thread pool and the cache dir is shared across processes — so under an MPI multi-host / shared-NFS deployment, N ranks (and the 3 TRISC threads per compute kernel) raced on the same fixed-path file, producing **intermittent torn-read JIT compile failures**. It was the only JIT file write that bypassed the `FileRenamer` atomic temp+rename idiom that every other generated file uses, and the remote/JIT-server path never received the header at all (`export_target_recipe` omits the `-include`).

## What changed

- **`genfiles.cpp`** — new `write_named_args_generated_header()`; the codegen is moved **verbatim** from `build.cpp` to preserve byte-identical output. Called from both `jit_build_genfiles_triscs_src` (compute) and `jit_build_genfiles_kernel_include` (data movement), gated on named-arg **presence**, NOT `is_metal2_kernel()` — this is an experimental feature, not Metal 2.0, and is not coextensive with the Metal-2.0 fence. `build_trisc_prolog` gains a `has_experimental_ct_args` flag that adds the `#include`; the data-movement path appends it to `kernel_includes.hpp`. Both outside the `if (is_metal2)` blocks.
- **`build.cpp`** — delete the per-source codegen block, the `-include`, and the now-orphaned `#include <set>`.

Net effect: the write is atomic and single-writer per kernel (no intra-process or cross-process race), the 3× redundant codegen is gone, and — because genfiles output is shipped via `read_directory_files` — named-arg kernels now also work on the remote/coordinator path.

## Test plan

- [x] `unit_tests_api` builds clean under `-Werror`
- [x] `NamedArgsTest.*` 5/5 (fast dispatch) with genfiles as the sole header source, incl. new `TensixTestNamedCompileTimeArgsComputeKernel` covering the compute (TRISC) path
- [x] `ProgramSpecHWTest.*` 5/5 (slow dispatch) — Metal-2.0 `args::` sibling path unaffected
- [x] `named_args_generated.h` written once per kernel dir

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jchu/fix-jit-compilation-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jchu/fix-jit-compilation-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jchu/fix-jit-compilation-race)