### PR TITLE
#MINFRA-658: Disable BH Deskbox tests across tt-metal CI

### DIFF
--- a/.github/actions/analyze-workflow-data/owners.json
+++ b/.github/actions/analyze-workflow-data/owners.json
@@ -6,7 +6,6 @@
       { "id": "U08CEGF78ET", "name": "Salar Hosseini Khorasgani" }
     ] },
     { "job-name-component": "vllm-tests / vllm-tests ([WH-T3K] Qwen2.5-VL-72B-Instruct", "owner": { "id": "U07RY6B5FLJ", "name": "Gongyu Wang" } },
-    { "job-name-component": "vllm-tests / vllm-tests ([BH-DB] Llama-3.1-8B-Instruct", "owner": { "id": "U08GELBB1AP", "name": "Ambrose Ling" } },
     { "job-name-component": "vllm-tests / vllm-tests ([BH-QB] Llama-3.1-8B-Instruct", "owner": { "id": "U08CEGF78ET", "name": "Salar Hosseini Khorasgani" } },
     { "job-name-component": "vllm-tests / vllm-tests ([WH-GLX] Llama-3.3-70B-Instruct", "owner": [
       { "id": "U08E1JCDVNX", "name": "Pavle Petrovic" },
@@ -540,7 +539,6 @@
     { "job-name-component": "whisper performance", "owner": { "id": "U05RWH3QUPM", "name": "Salar Hosseini" } },
     { "job-name-component": "llama3-8b performance", "owner": { "id": "U03PUAKE719", "name": "Miguel Tairum" } },
     { "job-name-component": "unet-shallow performance", "owner": { "id": "U06ECNVR0EN", "name": "Evan Smal" } },
-    { "job-name-component": "[BH-DB] Llama-3.1-8B-Instruct", "owner": { "id": "U08GELBB1AP", "name": "Ambrose Ling" } },
     { "job-name-component": "[BH-LB] Llama-3.1-8B-Instruct", "owner": { "id": "U08GELBB1AP", "name": "Ambrose Ling" } },
     { "job-name-component": "[BH-QB] Llama-3.1-8B-Instruct", "owner": { "id": "U08CEGF78ET", "name": "Salar Hosseini Khorasgani" } },
     { "job-name-component": "[WH-GLX] Llama-3.3-70B-Instruct v0 structured-output", "owner": { "id": "U091SNDA4TS", "name": "Tomasz Cheda" } },

--- a/.github/actions/ensure-bh-links-online/action.yml
+++ b/.github/actions/ensure-bh-links-online/action.yml
@@ -1,11 +1,6 @@
 name: "Ensure BH Eth links online"
 description: "Perform smi reset and health check in a loop"
 
-inputs:
-  runner-label:
-    required: true
-    description: "Runner label to determine health check parameters"
-
 runs:
   using: "composite"
   steps:
@@ -18,7 +13,7 @@ runs:
         # https://tenstorrent.atlassian.net/browse/BH-84
         for i in {1..10}; do
           echo "Health check attempt $i"
-          if tt-smi -r >/dev/null 2>&1 && ./build/test/tt_metal/tt_fabric/test_system_health ${{ inputs.runner-label == 'BH-DeskBox' && '--min-connections 4' || '' }}; then
+          if tt-smi -r >/dev/null 2>&1 && ./build/test/tt_metal/tt_fabric/test_system_health; then
             echo "Health checks passed"
             break
           fi

--- a/.github/blackhole_demo_systems.yaml
+++ b/.github/blackhole_demo_systems.yaml
@@ -27,10 +27,6 @@ systems:
     name: "Quietbox (4xP150)"
     weights-cache-mode: local-disk
     num_devices: 4
-  - sku: bh_deskbox
-    name: "DeskBox (2xP150)"
-    weights-cache-mode: cloud-mlperf
-    num_devices: 2
   - sku: bh_loudbox
     name: "LoudBox (8xP150)"
     weights-cache-mode: cloud-mlperf

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -194,12 +194,6 @@ skus:
       - pipeline-perf
       - in-service
 
-  bh_deskbox:
-    runs_on:
-      - BH-DeskBox
-      - pipeline-functional
-      - in-service
-
   bh_loudbox_civ2_viommu:
     runs_on:
       - tt-ubuntu-2204-BH-LoudBox-viommu-stable

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -79,7 +79,6 @@ ttnn:
     wh_galaxy: 90
     bh_galaxy: 70
     bh_p150b_civ2: 55
-    bh_deskbox: 145
     bh_llmbox: 180
     bh_loudbox: 145
     bh_p300: 145
@@ -125,7 +124,6 @@ scaleout:
     bh_spsg: 20 # single galaxy
     bh_sp1: 90
     bh_sp4: 150
-    bh_deskbox: 80
     bh_llmbox: 80
     bh_loudbox: 80
     bh_p300: 80
@@ -182,7 +180,6 @@ models:
     bh_p300: 50
     bh_loudbox: 160
     bh_llmbox: 50
-    bh_deskbox: 13
     bh_quietbox_2: 251
     bh_galaxy: 78
   unit:
@@ -224,7 +221,6 @@ models:
     bh_p150_perf: 420
     bh_p150b_civ2: 250
     bh_p150b_civ2_viommu: 50
-    bh_deskbox: 250
     bh_llmbox: 1200
     bh_loudbox: 1200
 

--- a/.github/time_budgets/pools.yaml
+++ b/.github/time_budgets/pools.yaml
@@ -39,7 +39,6 @@ bh_p300_viommu:              0  # see bh_p300
 bh_quietbox:               347
 bh_quietbox_perf:            5
 bh_quietbox_2:             106
-bh_deskbox:                415
 bh_galaxy:                  38
 bh_galaxy_perf:             15
 bh_galaxy_release:           0

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -143,8 +143,6 @@ jobs:
         # Skip this on single-card systems
         if: ${{ matrix.test-group.sku != 'bh_p150' && matrix.test-group.sku != 'bh_p150_perf' }}
         timeout-minutes: 10
-        with:
-          runner-label: ${{ matrix.test-group.sku == 'bh_deskbox' && 'BH-DeskBox' || '' }}
       - name: Download Llama model weights from LFC
         if: ${{ matrix.test-group['weights-cache-mode'] == 'lfc' && contains(matrix.test-group.name, 'llama') }}
         timeout-minutes: 15

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -31,7 +31,6 @@ on:
           - P150 (1xP150)
           - P150 CIv2 (1xP150)
           - Quietbox (4xP150)
-          - DeskBox (2xP150)
           - LoudBox (8xP150)
           - P300 (1xP300)
           - QuietBox 2 (2xP300)

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -174,8 +174,6 @@ jobs:
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         if: ${{ !startsWith(matrix.test-group.sku, 'bh_p100') && !startsWith(matrix.test-group.sku, 'bh_p150') }}
         timeout-minutes: 10
-        with:
-          runner-label: ${{ matrix.test-group.sku == 'bh_deskbox' && 'BH-DeskBox' || '' }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -12,7 +12,6 @@ on:
           - all
           - P150 CIv2 (1xP150)
           - Quietbox (4xP150)
-          - DeskBox (2xP150)
           - LoudBox (8xP150)
           - P300 (1xP300)
           - QuietBox 2 (2xP300)
@@ -107,7 +106,6 @@ jobs:
           all_systems='[
             {"name": "P150 CIv2 (1xP150)", "sku": "bh_p150b_civ2"},
             {"name": "Quietbox (4xP150)", "sku": "bh_llmbox"},
-            {"name": "DeskBox (2xP150)", "sku": "bh_deskbox"},
             {"name": "LoudBox (8xP150)", "sku": "bh_loudbox"},
             {"name": "P300 (1xP300)", "sku": "bh_p300"},
             {"name": "QuietBox 2 (2xP300)", "sku": "bh_quietbox_2"}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -171,8 +171,6 @@ jobs:
           hang-detection-timeout: ${{ contains(matrix.test-group.name, 'PERF') && '20.0' || '5.0' }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
-        with:
-          runner-label: ${{ inputs.runner-label }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/release-demo-tests-impl.yaml
+++ b/.github/workflows/release-demo-tests-impl.yaml
@@ -175,8 +175,6 @@ jobs:
         if: ${{ contains(matrix.test-group.sku, 'bh_') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
-        with:
-          runner-label: ${{ join(matrix.test-group.runs_on, ' ') }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -41,11 +41,6 @@ on:
         type: boolean
         default: true
         description: "Run tests on BH-LLMBox"
-      bh-runner-deskbox:
-        required: false
-        type: boolean
-        default: true
-        description: "Run tests on BH-DeskBox"
       bh-runner-loudbox:
         required: false
         type: boolean
@@ -268,10 +263,6 @@ jobs:
             runner_items+=('{"name":"LLMBox unit tests","runner-label":"BH-LLMBox"}')
           fi
 
-          if [[ "${{ inputs.bh-runner-deskbox }}" == "true" ]]; then
-            runner_items+=('{"name":"DeskBox unit tests","runner-label":"BH-DeskBox"}')
-          fi
-
           if [[ "${{ inputs.bh-runner-loudbox }}" == "true" ]]; then
             runner_items+=('{"name":"LoudBox unit tests","runner-label":"BH-LoudBox"}')
           fi
@@ -388,11 +379,7 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          if [[ "${{ matrix.test-group.name }}" == "fabric system health tests" && "${{ matrix.runner-group.runner-label }}" == "BH-DeskBox" ]]; then
-            ${{ matrix.test-group.cmd }} --min-connections 4
-          else
-            ${{ matrix.test-group.cmd }}
-          fi
+          ${{ matrix.test-group.cmd }}
       - name: Print tt-smi data on failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -374,8 +374,6 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
-        with:
-          runner-label: ${{ matrix.runner-group.runner-label }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -49,9 +49,9 @@ on:
         default: true
         type: boolean
       bh-runner-deskbox:
-        description: "Run tests on BH-DeskBox"
+        description: "Run tests on BH-DeskBox (disabled per MINFRA-658)"
         required: false
-        default: true
+        default: false
         type: boolean
       bh-runner-loudbox:
         description: "Run tests on BH-LoudBox"
@@ -149,7 +149,7 @@ jobs:
             run_wh_6u="true"
             run_bh="true"
             bh_llmbox="true"
-            bh_deskbox="true"
+            bh_deskbox="false"  # disabled per MINFRA-658
             bh_loudbox="true"
             bh_p300="true"
             bh_quietbox_2="true"

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -48,11 +48,6 @@ on:
         required: false
         default: true
         type: boolean
-      bh-runner-deskbox:
-        description: "Run tests on BH-DeskBox (disabled per MINFRA-658)"
-        required: false
-        default: false
-        type: boolean
       bh-runner-loudbox:
         description: "Run tests on BH-LoudBox"
         required: false
@@ -137,7 +132,6 @@ jobs:
             run_wh_6u="${{ inputs.run-wh-6u-fabric-tests }}"
             run_bh="${{ inputs.run-bh-multi-card-unit-tests }}"
             bh_llmbox="${{ inputs.bh-runner-llmbox }}"
-            bh_deskbox="${{ inputs.bh-runner-deskbox }}"
             bh_loudbox="${{ inputs.bh-runner-loudbox }}"
             bh_p300="${{ inputs.bh-runner-p300 }}"
             bh_quietbox_2="${{ inputs.bh-runner-quietbox-2 }}"
@@ -149,7 +143,6 @@ jobs:
             run_wh_6u="true"
             run_bh="true"
             bh_llmbox="true"
-            bh_deskbox="false"  # disabled per MINFRA-658
             bh_loudbox="true"
             bh_p300="true"
             bh_quietbox_2="true"
@@ -174,19 +167,16 @@ jobs:
           if [[ "$run_bh" == "true" ]]; then
             # Add blackhole test configurations for each selected runner
             if [[ "$bh_llmbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":true,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
-            fi
-            if [[ "$bh_deskbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":true,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":true,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_loudbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":true,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-loudbox":true,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_p300" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":true,"bh-runner-quietbox-2":false}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-loudbox":false,"bh-runner-p300":true,"bh-runner-quietbox-2":false}')
             fi
             if [[ "$bh_quietbox_2" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-deskbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":true}')
+              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-llmbox":false,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":true}')
             fi
           fi
 
@@ -225,7 +215,6 @@ jobs:
       run-wh-6u-fabric-tests: ${{ matrix.test-config.run-wh-6u-fabric-tests }}
       run-bh-multi-card-unit-tests: ${{ matrix.test-config.run-bh-multi-card-unit-tests }}
       bh-runner-llmbox: ${{ matrix.test-config.bh-runner-llmbox || false }}
-      bh-runner-deskbox: ${{ matrix.test-config.bh-runner-deskbox || false }}
       bh-runner-loudbox: ${{ matrix.test-config.bh-runner-loudbox || false }}
       bh-runner-p300: ${{ matrix.test-config.bh-runner-p300 || false }}
       bh-runner-quietbox-2: ${{ matrix.test-config.bh-runner-quietbox-2 || false }}

--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -23,7 +23,6 @@ on:
           - n300-llmbox
           - topology-6u
           - BH-LLMBox
-          - BH-DeskBox
           - BH-LoudBox
         default: "N150"
       load-to-db:

--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -172,7 +172,7 @@ jobs:
         run: |
           RUNNER="$RUNNER_LABEL"
           case "$RUNNER" in
-            P100a|P150b|BH-LLMBox|BH-DeskBox|BH-LoudBox)
+            P100a|P150b|BH-LLMBox|BH-LoudBox)
               ARCH="blackhole"
               ;;
             *)
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
     runs-on: >-
       ${{
-        (inputs.runner-label == 'topology-6u' || inputs.runner-label == 'BH-LLMBox' || inputs.runner-label == 'BH-DeskBox' || inputs.runner-label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
+        (inputs.runner-label == 'topology-6u' || inputs.runner-label == 'BH-LLMBox' || inputs.runner-label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
         || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
       }}
     steps:
@@ -317,7 +317,7 @@ jobs:
           if [[ "$STATUS" != "200" ]]; then
             echo "::error::LFC does not serve ${INPUT_HF_MODEL} (HTTP $STATUS at $URL)."
             echo "::error::Upload the weights to /mldata/model_checkpoints/pytorch/huggingface/${INPUT_HF_MODEL}/,"
-            echo "::error::or re-run this workflow on a CIv1 runner label (topology-6u, BH-LLMBox, BH-DeskBox, BH-LoudBox)"
+            echo "::error::or re-run this workflow on a CIv1 runner label (topology-6u, BH-LLMBox, BH-LoudBox)"
             echo "::error::where /mnt/MLPerf provides the weights."
             exit 1
           fi

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -620,7 +620,6 @@ on:
           - n300-llmbox
           - topology-6u
           - BH-LLMBox
-          - BH-DeskBox
           - BH-LoudBox
         default: "N150"
       log-level:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -879,7 +879,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{
-        (needs.resolve-inputs.outputs.runner-label == 'topology-6u' || needs.resolve-inputs.outputs.runner-label == 'BH-LLMBox' || needs.resolve-inputs.outputs.runner-label == 'BH-DeskBox' || needs.resolve-inputs.outputs.runner-label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', needs.resolve-inputs.outputs.runner-label))
+        (needs.resolve-inputs.outputs.runner-label == 'topology-6u' || needs.resolve-inputs.outputs.runner-label == 'BH-LLMBox' || needs.resolve-inputs.outputs.runner-label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', needs.resolve-inputs.outputs.runner-label))
         || format('tt-ubuntu-2204-{0}-viommu-stable', needs.resolve-inputs.outputs.runner-label)
       }}
     steps:
@@ -1026,7 +1026,7 @@ jobs:
     timeout-minutes: 720
     runs-on: >-
       ${{
-        (matrix.test-group.runner_label == 'topology-6u' || matrix.test-group.runner_label == 'BH-LLMBox' || matrix.test-group.runner_label == 'BH-DeskBox' || matrix.test-group.runner_label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', matrix.test-group.runner_label))
+        (matrix.test-group.runner_label == 'topology-6u' || matrix.test-group.runner_label == 'BH-LLMBox' || matrix.test-group.runner_label == 'BH-LoudBox') && fromJSON(format('["{0}", "in-service", "bare-metal"]', matrix.test-group.runner_label))
         || format('tt-ubuntu-2204-{0}-viommu-stable', matrix.test-group.runner_label)
       }}
     steps:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && fromJSON(format('["{0}", "in-service", "bare-metal"]', inputs.runner-label))
-        || (contains('BH-DeskBox, BH-LLMBox, BH-LoudBox', inputs.runner-label) && fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)))
+        || (contains('BH-LLMBox, BH-LoudBox', inputs.runner-label) && fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)))
         || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
       }}
     container:
@@ -67,8 +67,6 @@ jobs:
         if: ${{ contains(inputs.runner-label, 'BH-') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
-        with:
-          runner-label: ${{ inputs.runner-label }}
 
       - name: Run Stress Tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -239,7 +239,7 @@ jobs:
               "owner_id": "U08GELBB1AP"
             },
             {
-              "name": "[BH-LB] Llama-3.1-8B-Instruct",
+              "name": "[BH-LB] Llama-3.1-8B-Instruct with sampling-tests",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 35,
               "benchmark-timeout": 10,
@@ -249,6 +249,7 @@ jobs:
               "tt-llama-text-ver": "tt_transformers",
               "additional-server-args": "--data_parallel_size 8 --async-scheduling",
               "structured-output": true,
+              "sampling-tests": true,
               "multimodal": false,
               "owner_id": "U08GELBB1AP"
             },

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -224,21 +224,6 @@ jobs:
               "co-owner-2-id": "U08CEGF78ET"
             },
             {
-              "name": "[BH-DB] Llama-3.1-8B-Instruct with sampling-tests",
-              "model": "meta-llama/Llama-3.1-8B-Instruct",
-              "server-timeout": 10,
-              "benchmark-timeout": 5,
-              "runner-label": "BH-DeskBox",
-              "arch": "arch-blackhole",
-              "mesh-device": "P150x2",
-              "tt-llama-text-ver": "tt_transformers",
-              "additional-server-args": "--data_parallel_size 2 --async-scheduling",
-              "structured-output": true,
-              "sampling-tests": true,
-              "multimodal": false,
-              "owner_id": "U08GELBB1AP"
-            },
-            {
               "name": "[BH-QB-2] Llama-3.1-8B-Instruct",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 10,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -435,8 +435,6 @@ jobs:
         if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
-        with:
-          runner-label: ${{ matrix.test-group.runner-label }}
 
       - name: ⬇️ Checkout vLLM
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -86,20 +86,12 @@ test_suite_bh_single_pcie_llama_demo_tests() {
 test_suite_bh_multi_pcie_metal_unit_tests() {
     echo "[upstream-tests] Running BH LLMBox metal unit tests"
 
-    # Sim HW deskbox has 8 connections so we need to pass in the min-connections arg
-    # This changes the connection count assert == 4 to assert >= 4
-    if [[ "$hw_topology" == "blackhole_deskbox" ]]; then
-        local min_connections_arg="--min-connections 4"
-    else
-        local min_connections_arg=""
-    fi
-
     # Health check loop. Needed due to the following issues:
     # https://tenstorrent.atlassian.net/browse/SYS-1634
     # https://tenstorrent.atlassian.net/browse/BH-84
     for i in {1..10}; do
         echo "Health check attempt $i"
-        if tt-smi -r >/dev/null 2>&1 && ./build/test/tt_metal/tt_fabric/test_system_health $min_connections_arg; then
+        if tt-smi -r >/dev/null 2>&1 && ./build/test/tt_metal/tt_fabric/test_system_health; then
             echo "Health checks passed"
             break
         fi
@@ -128,7 +120,7 @@ test_suite_bh_multi_pcie_metal_unit_tests() {
 test_suite_bh_multi_pcie_llama_demo_tests() {
     echo "[upstream-tests] Running BH multi-pcie upstream Llama demo model tests for topology: $hw_topology"
 
-    if [[ "$hw_topology" == "blackhole_deskbox" ]] || [[ "$hw_topology" == "blackhole_p300" ]]; then
+    if [[ "$hw_topology" == "blackhole_p300" ]]; then
         local data_parallel_devices="2"
     elif [[ "$hw_topology" == "blackhole_llmbox" ]] || [[ "$hw_topology" == "blackhole_qb_ge" ]]; then
         local data_parallel_devices="4"
@@ -147,7 +139,7 @@ test_suite_bh_multi_pcie_llama_demo_tests() {
 test_suite_bh_multi_pcie_llama_stress_tests() {
     echo "[upstream-tests] Running BH multi-pcie upstream Llama stress model tests for topology: $hw_topology"
 
-    if [[ "$hw_topology" == "blackhole_deskbox" ]] || [[ "$hw_topology" == "blackhole_p300" ]]; then
+    if [[ "$hw_topology" == "blackhole_p300" ]]; then
         local data_parallel_devices="2"
     elif [[ "$hw_topology" == "blackhole_llmbox" ]] || [[ "$hw_topology" == "blackhole_qb_ge" ]]; then
         local data_parallel_devices="4"
@@ -288,11 +280,6 @@ test_suite_bh_single_pcie_python_unit_tests
 test_suite_bh_single_pcie_metal_unit_tests"
 
 hw_topology_test_suites["blackhole_llmbox"]="
-test_suite_bh_multi_pcie_metal_unit_tests
-test_suite_bh_pcie_didt_tests
-test_suite_bh_multi_pcie_llama_demo_tests"
-
-hw_topology_test_suites["blackhole_deskbox"]="
 test_suite_bh_multi_pcie_metal_unit_tests
 test_suite_bh_pcie_didt_tests
 test_suite_bh_multi_pcie_llama_demo_tests"

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -34,8 +34,6 @@
     TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_at_least_2x2_mesh.yaml
     TT_FABRIC_PROFILE_RX_CH_FWD=1 TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_code_profiling.yaml
   skus:
-    bh_deskbox:
-      timeout: 15
     bh_llmbox:
       timeout: 15
     bh_loudbox:
@@ -51,8 +49,6 @@
   name: ccl nightly tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
   skus:
-    bh_deskbox:
-      timeout: 60
     bh_llmbox:
       timeout: 60
     bh_loudbox:
@@ -69,8 +65,6 @@
   tags: [sdpa]
   cmd: pytest tests/nightly/blackhole/sdpa/ -svv
   skus:
-    bh_deskbox:
-      timeout: 60
     bh_llmbox:
       timeout: 60
     bh_loudbox:
@@ -106,8 +100,6 @@
   cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
   upload_fabric_data: true
   skus:
-    bh_deskbox:
-      timeout: 15
     bh_llmbox:
       timeout: 15
     bh_loudbox:
@@ -129,8 +121,6 @@
     SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
     SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
   skus:
-    bh_deskbox:
-      timeout: 10
     bh_loudbox:
       timeout: 10
     bh_p300:
@@ -147,8 +137,6 @@
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2DUDMModeFixture.*:*ChannelTrimming*"
     ./build/test/ttnn/unit_tests_ttnn_udm
   skus:
-    bh_deskbox:
-      timeout: 20
     bh_llmbox:
       timeout: 20
     bh_loudbox:
@@ -180,8 +168,6 @@
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     TT_METAL_DISABLE_MULTI_AERISC=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
   skus:
-    bh_deskbox:
-      timeout: 15
     bh_llmbox:
       timeout: 15
     bh_loudbox:
@@ -200,8 +186,6 @@
     # Disabled due to issue https://github.com/tenstorrent/tt-metal/issues/41040
     # pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
   skus:
-    bh_deskbox:
-      timeout: 15
     bh_llmbox:
       timeout: 15
     bh_loudbox:
@@ -227,8 +211,6 @@
   name: fabric stability nightly tests
   cmd: TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ./tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_stability_short_running.yaml
   skus:
-    bh_deskbox:
-      timeout: 15
     bh_llmbox:
       timeout: 15
     bh_loudbox:
@@ -348,19 +330,6 @@
   skus:
     bh_p300:
       timeout: 10
-  owner_id: U094PKWHNJ0 # Petar Milojevic
-  team: models
-
-- id: bh-db-deepseek-prefill-op-tests
-  name: bh_db_DeepSeek_PREFILL_OP_TESTS
-  model-name: deepseek_prefill
-  cmd: |
-    exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short || exit_code=$?
-    exit $exit_code
-  skus:
-    bh_deskbox:
-      timeout: 13
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 


### PR DESCRIPTION
The BH Deskbox systems are being decommissioned. 
Remove bh_deskbox SKU entries from CI matrices and dropdowns so nothing dispatches to BH-DeskBox runners. SKU definitions and time budgets are left in place — to be cleaned up once the disable is validated.

Changes:
- tests/pipeline_reorg/blackhole_e2e_tests.yaml: drop bh_deskbox from 9 multi-SKU tests; remove bh-db-deepseek-prefill-op-tests (deskbox-only).
- .github/blackhole_demo_systems.yaml: drop bh_deskbox system entry.
- .github/workflows/blackhole-e2e-tests.yaml: remove DeskBox (2xP150) dropdown option and matrix entry.
- .github/workflows/tm-fabric-tests.yaml: flip bh-runner-deskbox default to false (dispatch input + workflow_call/push branch).
- .github/workflows/ttnn-run-model-trace.yaml, .github/workflows/ttnn-run-sweeps.yaml: remove BH-DeskBox from runner-label dropdowns.
- .github/workflows/vllm-nightly-tests-impl.yaml: remove BH-DeskBox Llama-3.1-8B sampling-tests job.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mchiou/MINFRA-658-disable-bh-deskbox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mchiou/MINFRA-658-disable-bh-deskbox-tests)