### PR TITLE
[Bug fix] use centered variance in batch_norm training

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -891,9 +891,9 @@ def test_batch_norm_training_avoids_variance_cancellation(device):
     eps = 1e-5
 
     torch.manual_seed(0)
-    channel_offsets = torch.where(
-        torch.arange(channels, dtype=torch.float32) % 2 == 0, 5.0, -5.0
-    ).view(1, channels, 1, 1)
+    channel_offsets = torch.where(torch.arange(channels, dtype=torch.float32) % 2 == 0, 5.0, -5.0).view(
+        1, channels, 1, 1
+    )
     in_data = (channel_offsets + 0.1 * torch.randn(input_shape, dtype=torch.float32)).to(torch.bfloat16)
 
     def to_tt(tensor):

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -881,3 +881,54 @@ def test_batch_norm_program_cache_shape_collision(device):
             )
     finally:
         device.disable_and_clear_program_cache()
+
+
+def test_batch_norm_training_avoids_variance_cancellation(device):
+    """Regression test for #45968: avoid bf16 E[x^2] - E[x]^2 cancellation in training mode."""
+
+    input_shape = torch.Size([2, 64, 32, 32])
+    channels = input_shape[1]
+    eps = 1e-5
+
+    torch.manual_seed(0)
+    channel_offsets = torch.where(
+        torch.arange(channels, dtype=torch.float32) % 2 == 0, 5.0, -5.0
+    ).view(1, channels, 1, 1)
+    in_data = (channel_offsets + 0.1 * torch.randn(input_shape, dtype=torch.float32)).to(torch.bfloat16)
+
+    def to_tt(tensor):
+        return ttnn.from_torch(tensor.to(torch.bfloat16), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    input_tensor = to_tt(in_data)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    running_mean_tensor = to_tt(torch.zeros(1, channels, 1, 1))
+    running_var_tensor = to_tt(torch.ones(1, channels, 1, 1))
+    weight_tensor = to_tt(torch.ones(1, channels, 1, 1))
+    bias_tensor = to_tt(torch.zeros(1, channels, 1, 1))
+
+    tt_output_tensor = ttnn.batch_norm(
+        input_tensor,
+        running_mean=running_mean_tensor,
+        running_var=running_var_tensor,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        training=True,
+        eps=eps,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor).float()
+    tt_running_var = ttnn.to_torch(running_var_tensor)
+
+    torch_output = torch.nn.functional.batch_norm(
+        input=in_data.float(),
+        running_mean=None,
+        running_var=None,
+        weight=torch.ones(channels),
+        bias=torch.zeros(channels),
+        training=True,
+        eps=eps,
+    )
+
+    assert torch.isfinite(tt_output).all()
+    assert torch.isfinite(tt_running_var).all()
+    assert_numeric_metrics(torch_output, tt_output, pcc_threshold=0.99, rtol=0.1, atol=4.0, frobenius_threshold=0.15)

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -107,9 +107,13 @@ Tensor batch_norm(
         // propagate the precision requirement here so that the output `batch_mean`/`batch_var` are in
         // higher precision rather than inheriting the `dtype` of input.
         batch_mean = operations::normalization::mean_NHW(input, memory_config, compute_kernel_config);
-        auto mean_sq = operations::normalization::mean_NHW(
-            ttnn::square(input, memory_config), memory_config, compute_kernel_config);
-        batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
+        // Use the centered two-pass form E[(x - mean)^2] instead of E[x^2] - E[x]^2.
+        // The latter suffers catastrophic cancellation when the batch mean is large
+        // relative to the batch variance, which can drive the variance slightly
+        // negative and produce NaNs in the normalization step.
+        auto centered = ttnn::subtract(input, batch_mean, std::nullopt, memory_config);
+        batch_var = operations::normalization::mean_NHW(
+            ttnn::square(centered, memory_config), memory_config, compute_kernel_config);
     } else {
         TT_FATAL(
             (running_mean.has_value() && running_var.has_value()),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Fixes #45968.
2. The training path in `ttnn.batch_norm` computed batch variance as `E[x^2] - E[x]^2`, which loses precision on bf16 large-mean / low-variance inputs and can drive normalization toward NaN or badly scaled output.
3. Switch the training-path variance to the centered two-pass form `E[(x - mean)^2]`.
4. Align the fused batch-norm regression with the issue reproducer: bf16 input, large per-channel offsets, low noise, and default affine / running-stat tensors.

### Notes for reviewers
1. The functional change is limited to the training branch in `ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp`.
2. The new regression in `tests/ttnn/unit_tests/operations/fused/test_batch_norm.py` now exercises the same bf16 failure shape described in #45968 instead of a float32 approximation.
3. This does not change inference mode or the batch_norm device kernels. It only changes how the host computes training-time variance before normalization and running-stat updates.

### Test plan
1. `python3 -m py_compile tests/ttnn/unit_tests/operations/fused/test_batch_norm.py`
2. `git diff --check`
3. I did not complete a hardware-backed rerun in this environment.
