### PR TITLE
[Bug fix] validate user-provided group_norm masks before launch

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1167,6 +1167,40 @@ def test_group_norm_rejects_host_input_mask(device):
         )
 
 
+def test_group_norm_rejects_host_negative_mask(device):
+    grid_size = ttnn.CoreGrid(y=1, x=1)
+    torch_input_tensor = torch.rand((1, 320, 32, 32), dtype=torch.bfloat16)
+    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(1, 1, 32 * 32, 320)
+    input_tensor = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    input_mask = ttnn.create_group_norm_input_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16)
+    input_mask = ttnn.to_device(input_mask, device)
+    negative_mask = ttnn.create_group_norm_input_negative_mask(320, 32, grid_size.x, ttnn.DataType.BFLOAT16)
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (32 * 32, 320), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor = ttnn.to_memory_config(input_tensor, memory_config=sharded_mem_config)
+
+    with pytest.raises(RuntimeError, match="Negative mask must be on device"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=32,
+            input_mask=input_mask,
+            negative_mask=negative_mask,
+            memory_config=sharded_mem_config,
+            core_grid=grid_size,
+        )
+
+
 @pytest.mark.parametrize("N, C, H, W, num_groups", DRAM_GRID_SIZE_SHAPES)
 @pytest.mark.parametrize("specify_grid", [True])
 def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1153,6 +1153,20 @@ def test_group_norm_negative_tests(
         )
 
 
+def test_group_norm_rejects_host_input_mask(device):
+    input_tensor = ttnn.empty((1, 1, 32, 320), device=device)
+    input_mask = ttnn.create_group_norm_input_mask(320, 32, 1, ttnn.DataType.BFLOAT16)
+
+    with pytest.raises(RuntimeError, match="Input mask must be on device"):
+        ttnn.group_norm(
+            input_tensor,
+            num_groups=32,
+            input_mask=input_mask,
+            core_grid=ttnn.CoreGrid(y=1, x=1),
+            inplace=False,
+        )
+
+
 @pytest.mark.parametrize("N, C, H, W, num_groups", DRAM_GRID_SIZE_SHAPES)
 @pytest.mark.parametrize("specify_grid", [True])
 def test_group_norm_dram_grid_size(device, N, C, H, W, num_groups, specify_grid):

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -156,6 +156,12 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             "Input mask must have TILE layout, got: {}",
             input_mask.value().layout());
         TT_FATAL(
+            input_mask.value().storage_type() == StorageType::DEVICE,
+            "Input mask must be on device, got storage type: {}",
+            input_mask.value().storage_type());
+        TT_FATAL(input_mask.value().buffer() != nullptr, "Input mask must be allocated in buffers on device!");
+        TT_FATAL(a.device() == input_mask.value().device(), "Input and input mask tensors must be on same device");
+        TT_FATAL(
             input_mask.value().padded_shape()[1] == args.num_groups,
             "Input mask dim1 must match number of groups, got: {} vs {}",
             input_mask.value().padded_shape()[1],

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -185,8 +185,16 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
     if (negative_mask.has_value()) {
         TT_FATAL(
             negative_mask.value().layout() == Layout::TILE,
-            "Negative musk must be in TILE layout, but layout is {}",
+            "Negative mask must have TILE layout, got: {}",
             negative_mask.value().layout());
+        TT_FATAL(
+            negative_mask.value().storage_type() == StorageType::DEVICE,
+            "Negative mask must be on device, got storage type: {}",
+            negative_mask.value().storage_type());
+        TT_FATAL(
+            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
+        TT_FATAL(
+            a.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
         TT_FATAL(
             negative_mask.value().padded_shape()[1] == args.num_groups,
             "Negative mask padded shape[1] must be equal to num_groups, but is {} and num_groups is {}",
@@ -313,6 +321,15 @@ Tensor group_norm(
     std::optional<Tensor> input_mask,
     std::optional<Tensor> negative_mask,
     std::optional<Tensor> reciprocals) {
+    if (negative_mask.has_value()) {
+        TT_FATAL(
+            negative_mask.value().storage_type() == StorageType::DEVICE,
+            "Negative mask must be on device, got storage type: {}",
+            negative_mask.value().storage_type());
+        TT_FATAL(
+            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
+        TT_FATAL(input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
+    }
     using OperationType = GroupNormDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
         .eps = eps,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -220,6 +220,14 @@ Tensor group_norm(
         input_tensor.storage_type() == StorageType::DEVICE,
         "Invalid input tensor storage type: Input tensor must be on device. (storage type={})",
         input_tensor.storage_type());
+    if (input_mask.has_value()) {
+        TT_FATAL(
+            input_mask->storage_type() == StorageType::DEVICE,
+            "Input mask must be on device, got storage type: {}",
+            input_mask->storage_type());
+        TT_FATAL(input_mask->buffer() != nullptr, "Input mask must be allocated in buffers on device!");
+        TT_FATAL(input_tensor.device() == input_mask->device(), "Input and input mask tensors must be on same device");
+    }
     const auto arch = input_tensor.device()->arch();
     const auto math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
     const auto approx_mode = true;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Sharded `group_norm` paths assume device-backed optional mask tensors and dereference their buffers during program setup.
2. Host-provided `input_mask` or `negative_mask` could reach the generic device-operation launch checks first and fail with low-level storage errors instead of a `group_norm`-specific contract error.
3. Keep the validator-side checks and add pre-launch device-storage, buffer, and same-device checks before `ttnn::device_operation::launch(...)` so both optional masks fail early with operator-specific errors.
4. Add focused regressions for host `input_mask` and host `negative_mask`.

### Notes for reviewers
1. The highest-risk change is in `ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp`.
2. The pre-launch checks sit at the last operator-owned boundary before `ttnn::device_operation::launch(...)`:
   `input_mask` is checked in `ttnn::group_norm(...)`, while `negative_mask` is checked in `ttnn::prim::group_norm(...)` because the two optional masks reach that launch boundary through slightly different host-side bridges.
3. This patch does not change group_norm kernels, sharding math, or program-factory behavior. It only tightens the host-side contract for optional masks before launch.

### Test plan
1. `python3 -m py_compile tests/ttnn/unit_tests/operations/fused/test_group_norm.py`
2. `git diff --check`
3. `pytest -q tests/ttnn/unit_tests/operations/fused/test_group_norm.py -k "rejects_host_input_mask or rejects_host_negative_mask" -q` in a local WSL mock-device environment.
4. I did not run hardware-backed validation in this environment.
