### PR TITLE
[skip ci]: fix codeowners bypass self-approval detection + pipeline-select-t3k extra-tag error

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -307,11 +307,9 @@ jobs:
 
           # Pre-flight: detect self-approval (GitHub rejects reviews where the
           # authenticated user is also the PR author).
-          PR_AUTHOR=$(curl -s \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
-            | jq -r '.user.login // empty')
+          # PR author is available from the event payload (issue_comment trigger),
+          # avoiding an extra API call.
+          PR_AUTHOR="${{ github.event.issue.user.login }}"
 
           PAT_USER=$(curl -s \
             -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
@@ -399,8 +397,9 @@ jobs:
               FAIL_DETAIL="GitHub API error: $ERROR_MSG. This might be a temporary issue — try again or contact the infra team."
             fi
 
+            FAIL_BODY=$(printf '❌ **Bypass Approval Failed**\n\n%s' "$FAIL_DETAIL")
             TEMP_FILE=$(mktemp)
-            jq -n --arg body "❌ **Bypass Approval Failed**\n\n$FAIL_DETAIL" '{"body": $body}' > "$TEMP_FILE"
+            jq -n --arg body "$FAIL_BODY" '{"body": $body}' > "$TEMP_FILE"
 
             curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -305,6 +305,56 @@ jobs:
 
           echo "Approving PR #$PR_NUMBER as requested by authorized user: $COMMENT_AUTHOR"
 
+          # Pre-flight: detect self-approval (GitHub rejects reviews where the
+          # authenticated user is also the PR author).
+          PR_AUTHOR=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+            | jq -r '.user.login // empty')
+
+          PAT_USER=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/user" \
+            | jq -r '.login // empty')
+
+          if [ -n "$PAT_USER" ] && [ "$PAT_USER" = "$PR_AUTHOR" ]; then
+            echo "❌ Self-approval detected: PAT belongs to '$PAT_USER' who is also the PR author."
+            echo "GitHub does not allow a user to approve their own pull request."
+
+            SELF_APPROVE_MSG=$(cat <<'EOFMSG'
+          ❌ **Bypass Approval Failed — Self-Approval Not Allowed**
+
+          The bypass PAT (`CODEOWNERS_GROUP_ANALYSIS_PAT`) is authenticated as **@PATUSER**, who is also the author of this PR. GitHub does not permit a user to approve their own pull request.
+
+          **To fix:** A different team member with bypass authority must run `/codeowners bypass`, or the infra team must configure a second PAT belonging to a different account for bypass approvals.
+          EOFMSG
+          )
+            SELF_APPROVE_MSG="${SELF_APPROVE_MSG//PATUSER/$PAT_USER}"
+
+            TEMP_FILE=$(mktemp)
+            jq -n --arg body "$SELF_APPROVE_MSG" '{"body": $body}' > "$TEMP_FILE"
+
+            curl -s -X POST \
+              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              -d @"$TEMP_FILE" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+
+            rm -f "$TEMP_FILE"
+
+            curl -s -X POST \
+              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              -d '{"content": "-1"}' \
+              "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
+
+            exit 1
+          fi
+
           # Create approval
           REVIEW_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews"
 
@@ -324,6 +374,7 @@ jobs:
             "$REVIEW_API")
 
           REVIEW_ID=$(echo "$REVIEW_RESPONSE" | jq -r '.id // empty')
+          ERROR_MSG=$(echo "$REVIEW_RESPONSE" | jq -r '.message // empty')
 
           if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
             echo "✅ Successfully approved PR #$PR_NUMBER (Review ID: $REVIEW_ID)"
@@ -339,13 +390,26 @@ jobs:
             echo "❌ Failed to approve PR #$PR_NUMBER"
             echo "Response: $REVIEW_RESPONSE"
 
-            # Post failure comment with explanation
+            # Build a diagnostic error message
+            if echo "$ERROR_MSG" | grep -qi "can not approve your own"; then
+              FAIL_DETAIL="The PAT user ($PAT_USER) is the PR author — GitHub blocks self-approval. Use a different account's PAT or have another team member run the bypass."
+            elif echo "$ERROR_MSG" | grep -qi "validation failed"; then
+              FAIL_DETAIL="GitHub rejected the review: $ERROR_MSG"
+            else
+              FAIL_DETAIL="GitHub API error: $ERROR_MSG. This might be a temporary issue — try again or contact the infra team."
+            fi
+
+            TEMP_FILE=$(mktemp)
+            jq -n --arg body "❌ **Bypass Approval Failed**\n\n$FAIL_DETAIL" '{"body": $body}' > "$TEMP_FILE"
+
             curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
-              -d "{\"body\": \"❌ **Bypass Approval Failed**\\n\\nFailed to approve PR #$PR_NUMBER. This might be a temporary issue with the GitHub API.\\n\\nPlease try again or contact the infra team if the problem persists.\"}" \
+              -d @"$TEMP_FILE" \
               "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+
+            rm -f "$TEMP_FILE"
 
             # Add failure reaction
             curl -s -X POST \

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -266,7 +266,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
## Summary

Two CI fixes:

### 1. Codeowners bypass self-approval detection

When `/codeowners bypass` is run on a PR authored by the same account that owns `CODEOWNERS_GROUP_ANALYSIS_PAT` (e.g. `tenstorrent-github-bot`), GitHub rejects the self-approval but the error message was generic ("might be a temporary issue"). See [#46056 comment](https://github.com/tenstorrent/tt-metal/pull/46056#issuecomment-4622045247).

**Fix:**
- Pre-flight check compares PAT user against PR author (using event payload, no extra API call)
- Posts a clear diagnostic: explains the self-approval restriction and suggests fixes
- On other API failures, includes the actual GitHub error message

### 2. pipeline-select-t3k extra-tag validation error

`pipeline-select-t3k.yaml` passes `extra-tag` to `t3000-profiler-tests-impl.yaml`, but that workflow doesn't define `extra-tag` as an input → workflow validation failure.

**Failing pipeline:** https://github.com/tenstorrent/tt-metal/actions/runs/26955696395

**Fix:** Remove the undeclared `extra-tag` input from the profiler tests call.

## Test plan
- [ ] Verify `/codeowners bypass` on a bot-authored PR shows the self-approval error
- [ ] Verify `/codeowners bypass` on a human-authored PR still works
- [ ] Verify `pipeline-select-t3k` no longer fails validation

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-codeowners-bypass-self-approval)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-codeowners-bypass-self-approval)