### PR TITLE
fix(ttnn): rename ttnn::experimental::disaggregation to avoid unity-build namespace collision

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/disaggregation.cpp
@@ -195,7 +195,7 @@ void bind_disaggregation_api(nb::module_& mod) {
     mod.def(
         "tensor_from_bfp8_bytes",
         [](const nb::bytes& raw_bytes, const std::vector<uint32_t>& shape) {
-            return ttnn::experimental::disaggregation::tensor_from_bfp8_bytes(
+            return ttnn::experimental_disaggregation::tensor_from_bfp8_bytes(
                 std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(raw_bytes.c_str()), raw_bytes.size()), shape);
         },
         nb::arg("raw_bytes"),

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.cpp
@@ -17,7 +17,7 @@
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
 
-namespace ttnn::experimental::disaggregation {
+namespace ttnn::experimental_disaggregation {
 
 ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape) {
     TT_FATAL(
@@ -40,4 +40,4 @@ ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const st
     return ttnn::Tensor(std::move(host_buffer), std::move(spec));
 }
 
-}  // namespace ttnn::experimental::disaggregation
+}  // namespace ttnn::experimental_disaggregation

--- a/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
+++ b/ttnn/cpp/ttnn/experimental/disaggregation/tensor_helpers.hpp
@@ -10,11 +10,11 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
-namespace ttnn::experimental::disaggregation {
+namespace ttnn::experimental_disaggregation {
 
 // Wrap raw bfp8-packed bytes (uint32-aligned, TILE layout) as a host-side
 // ttnn::Tensor with the given shape — no quantization round-trip.
 // Used to compare KV-table reads against the live KV cache byte-for-byte.
 ttnn::Tensor tensor_from_bfp8_bytes(std::span<const uint8_t> raw_bytes, const std::vector<uint32_t>& shape);
 
-}  // namespace ttnn::experimental::disaggregation
+}  // namespace ttnn::experimental_disaggregation


### PR DESCRIPTION
## What

Renames the ttnn-side disaggregation helper namespace
`ttnn::experimental::disaggregation` → `ttnn::experimental_disaggregation`
so it no longer introduces a `ttnn::experimental` namespace.

3 files, 5 lines — `tensor_helpers.{hpp,cpp}` (the namespace) and `disaggregation.cpp` (one call site). No functional change.

## Why — the bug this causes

`ttnn/cpp/ttnn-nanobind/pytensor.cpp` does `using namespace tt::tt_metal;` inside `namespace ttnn::tensor`, then refers to the **unqualified** `experimental::per_core_allocation::…`:

```cpp
using namespace tt::tt_metal;          // line 63
namespace ttnn::tensor {               // line 65
  ...
  experimental::per_core_allocation::is_per_core_allocation(...)   // expects tt::tt_metal::experimental
```

That `experimental` is *meant* to resolve, via the using-directive, to `tt::tt_metal::experimental::per_core_allocation`. C++ name lookup for the unqualified `experimental` walks the enclosing namespaces (`ttnn::tensor` → `ttnn` → global). A using-directive only contributes names if nothing is found by ordinary lookup in those scopes first. So **if any `namespace ttnn::experimental` declaration is visible in the translation unit**, `ttnn::experimental` (a real member of the enclosing `ttnn`) is found by ordinary lookup and **shadows** the using-directive. `experimental` then binds to `ttnn::experimental`, which has no `per_core_allocation`, and the build fails:

```
error: no member named 'per_core_allocation' in namespace 'ttnn::experimental';
       did you mean 'tt::tt_metal::experimental::per_core_allocation'?
```

`tensor_helpers.{hpp,cpp}` declared `namespace ttnn::experimental::disaggregation`, which creates exactly that `ttnn::experimental`.

## Why it only shows up sometimes (unity builds)

In a normal (one-file) translation unit, `pytensor.cpp` never sees `ttnn::experimental::disaggregation`, so the bug stays **latent**.

Under **unity / jumbo builds** the `ttnn` target concatenates many `.cpp` files into batched translation units (`unity_NN_cxx.cxx`). The bug surfaces whenever the batching groups `tensor_helpers.cpp` (or any other `ttnn::experimental`-declaring source) **ahead of** `pytensor.cpp` in the same batch. Batch boundaries are a function of the ordered source list, so they shift as unrelated source files are added or removed elsewhere in `ttnn`. The result: the failure lands on whatever PR happens to *tip the batch boundary*, not on the code that introduced the fragile namespace — which makes it look spurious and PR-specific when it is neither.

## Why fix it here, not in pytensor.cpp

Fixing the shadowing namespace at its source (rather than qualifying `pytensor.cpp`) follows the precedent in **#38969**, which renamed `tt::tt_metal::experimental::distributed` → `…::blitz` for the identical class of unity-build collision. Renaming the culprit removes the latent landmine for *every* future batch arrangement, instead of patching one victim.

## Verification

Reproduced the exact failure on a real build: configured the `ttnn` target with python bindings + unity, found the `unity_NN` batch containing `pytensor.cpp`, and compiled just that object.

- **Before** the rename: that batch fails with the `per_core_allocation` error above.
- **After** the rename: the same batch (and the batch containing the `disaggregation.cpp` call site) compiles cleanly (exit 0).

No Python-facing change — the `ttnn.disaggregation` bindings module is unaffected (its module namespace is already `ttnn::disaggregation`, not under `experimental`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix-disaggregation-unity-namespace-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix-disaggregation-unity-namespace-collision)