### PR TITLE
DS Prefill :: Add needed fp32_dest_acc_en for fp8 path in dispatch + update perf targets

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -177,7 +177,7 @@ models:
     wh_n150: 100
     wh_n300: 15
     wh_galaxy_perf: 120
-    bh_p150b_civ2: 63
+    bh_p150b_civ2: 75
     bh_p150: 60
     bh_p300: 50
     bh_loudbox: 160

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -24,7 +24,7 @@ def test_deepseek_v3_mla_perf_loudbox():
     """
     run_mla_perf_with_approximation(
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=8_952_745,
+        expected_ns_2x4=8_255_885,
         model_name_2x4="deepseek_v3_mla_lb_2x4",
         subdir="deepseek_v3_mla",
         margin=0.03,
@@ -38,7 +38,7 @@ def test_deepseek_v3_mla_perf_galaxy():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
-        expected_device_perf_ns_per_iteration=15_427_562,
+        expected_device_perf_ns_per_iteration=14_719_306,
         subdir="deepseek_v3_mla",
         model_name="deepseek_v3_mla_glx_8x4",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -39,10 +39,10 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        expected_ns_8x1=102_298_878,
+        expected_ns_8x1=29_185_788,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=94_929_326,
+        expected_ns_2x4=39_194_517,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -31,7 +31,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
     [
         (
             f"pytest {_TEST_PATH} -k 'mesh-8x4 and layer0 and gate_device and no_ref and isl_25k'",
-            20_680_586,
+            19_803_247,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer0_dense",
             1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -51,7 +51,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            107_554_551,
+            61_188_063,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -330,7 +330,7 @@
     exit $exit_code
   skus:
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 20
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
@@ -343,7 +343,7 @@
     exit $exit_code
   skus:
     bh_p300:
-      timeout: 10
+      timeout: 20
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
@@ -369,6 +369,6 @@
     exit $exit_code
   skus:
     bh_quietbox_2:
-      timeout: 20
+      timeout: 30
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -740,7 +740,17 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             (uint32_t)hidden_size,
             read_batch_size,
         };
-        idle_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
+        idle_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = MathFidelity::HiFi4,
+            // Blackhole requires the DEST register in 32-bit mode whenever any CB on the core uses
+            // an 8-bit float format (Fp8_e4m3). The FP8 dispatch path reinterprets UINT8 CBs as
+            // Fp8_e4m3, so fp32_dest_acc_en must be enabled there.
+            .fp32_dest_acc_en = operation_attributes.use_fp8_dispatch,
+            // 32-bit DEST halves pack_untilize block capacity: half-sync 32-bit allows only 4
+            // tiles, but pack_untilize_block uses block_ct_dim=8. Full-sync 32-bit restores the
+            // 8-tile budget so the block still fits. Only needed on the FP8 (32-bit) path.
+            .dst_full_sync_en = operation_attributes.use_fp8_dispatch,
+        };
         desc.kernels.push_back(std::move(idle_compute_kd));
     }
 
@@ -759,7 +769,15 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             (uint32_t)hidden_size,
             read_batch_size,
         };
-        sender_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{.math_fidelity = MathFidelity::HiFi4};
+        sender_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = MathFidelity::HiFi4,
+            // Sender self-untilize writes into c_18, which the FP8 path reinterprets as Fp8_e4m3.
+            // Blackhole requires the DEST register in 32-bit mode whenever an 8-bit float CB is on
+            // the core, so fp32_dest_acc_en must be enabled here too (mirrors the idle compute kernel).
+            .fp32_dest_acc_en = operation_attributes.use_fp8_dispatch,
+            // Full-sync 32-bit restores pack_untilize's 8-tile block budget on the FP8 path.
+            .dst_full_sync_en = operation_attributes.use_fp8_dispatch,
+        };
         desc.kernels.push_back(std::move(sender_compute_kd));
     }
 


### PR DESCRIPTION
- A constraint has been added in main where `fp32_dest_acc_en` needs to be enabled when having 8 bit format's in the kernel
- update perf targets due to MLA perf improvements

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### Deepseek CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nostojic/disp_ci_fix)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/disp_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/disp_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/disp_ci_fix)