### PR TITLE
kernel_lib helpers + dev-script/sim tooling improvements (consolidated)

### DIFF
--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -45,11 +45,11 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DISPATCH_TIMEOUT=5
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
 WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
-TRIAGE_JSON_DIR="${REPO_DIR}/generated/tt-triage"
+TRIAGE_OUT_DIR="${REPO_DIR}/generated/tt-triage"
 LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/safe-pytest-triage-$$.log"
-TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
+TRIAGE_REPORT="${TRIAGE_OUT_DIR}/triage.txt"
 
 # --- Device-lock contention profiling ---
 # When $TT_DEVICE_TIMING_LOG is set, on EXIT we append one JSON line:
@@ -248,11 +248,11 @@ fi
 # zero overhead for passing tests. On sim there is no hang detection because
 # wall-clock timeouts are meaningless at kHz clock speeds.
 rm -f "$TRIAGE_LOG"
-# Also clear any stale triage JSON from a previous run. Downstream consumers
-# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# Also clear any stale triage report from a previous run. Downstream consumers
+# (hooks, CI) treat the report's presence as the hang signal — leaving a stale
 # file around causes false-positive "hang detected" classification on the
 # next ordinary test failure.
-rm -f "$TRIAGE_JSON"
+rm -f "$TRIAGE_REPORT"
 MISSING_TTEXALENS=false
 if [[ "$SIM_MODE" == false ]]; then
     export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
@@ -262,8 +262,8 @@ if [[ "$SIM_MODE" == false ]]; then
     if ! python3 -c "import ttexalens" 2>/dev/null; then
         MISSING_TTEXALENS=true
     fi
-    mkdir -p "${TRIAGE_JSON_DIR}"
-    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --json-path=${TRIAGE_JSON} > ${TRIAGE_LOG} 2>&1"
+    mkdir -p "${TRIAGE_OUT_DIR}"
+    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --llm-output --llm-output-path=${TRIAGE_REPORT} > ${TRIAGE_LOG} 2>&1"
 fi
 
 emit_missing_ttexalens_warning() {
@@ -449,9 +449,9 @@ if [[ "$IS_HANG" == true ]]; then
         echo ""
     fi
 
-    # Print the JSON triage path as the last line so machine-readers can find it.
-    if [[ -f "$TRIAGE_JSON" ]]; then
-        echo "SAFE_PYTEST: JSON triage: ${TRIAGE_JSON}"
+    # Print the triage report path as the last line so machine-readers can find it.
+    if [[ -f "$TRIAGE_REPORT" ]]; then
+        echo "SAFE_PYTEST: triage report: ${TRIAGE_REPORT}"
     fi
 
     rm -f "$TRIAGE_LOG"

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -9,17 +9,25 @@
 #
 # Simulator mode (TT_METAL_SIMULATOR set):
 #   Exports TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_DISABLE_SFPLOADMACRO=1.
-#   Skips flock, device resets, and triage (these require real hardware).
-#   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
+#   Skips flock, device resets, and HW dispatch-timeout triage (these require
+#   real hardware).
+#   Enables the libttsim hang watchdog via TTSIM_HANG_WATCHDOG_CLOCKS (default
+#   50000; pre-existing env wins). On hang the watchdog _Exit(1)'s the child;
+#   we classify that as HANG and dump the watchdog message.
 #
-# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]
+# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] [--sim-workers N] <test_path> [extra_pytest_args...]
 #
 # Options:
-#   --dev       Enables polling watcher (NoC sanitizer, waypoints, CB
-#               sanitization), lightweight ebreak asserts, and auto-triage
-#               on hang with full triage + watcher log dump.
-#   --run-all   Run all tests instead of stopping on first failure (-x).
-#               Useful for eval scoring where you need full pass/fail counts.
+#   --dev            Enables polling watcher (NoC sanitizer, waypoints, CB
+#                    sanitization), lightweight ebreak asserts, and auto-triage
+#                    on hang with full triage + watcher log dump.
+#   --run-all        Run all tests instead of stopping on first failure (-x).
+#                    Useful for eval scoring where you need full pass/fail counts.
+#   --sim-workers N  Sim only: pytest-xdist worker count. Each worker dlopens
+#                    its own libttsim (no shared device state). Default is 16.
+#                    Pass 1 to serialize (e.g. when DPRINT ordering matters or
+#                    you suspect cross-worker contention). Errors out if used
+#                    outside sim mode.
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
@@ -48,8 +56,9 @@ TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
 #   {source, pid, started_at_ms, wait_ms, run_ms, test_path, exit_code}
 # wait_ms = script entry → flock acquired (contention)
 # run_ms  = flock acquired → script exit  (device occupied)
-# Skipped on sim mode (no flock contention) and when the script exits before
-# acquiring the lock (TT_TIMING_LOCK_ACQUIRED_MS stays 0).
+# On sim, flock is skipped so we seed TT_TIMING_LOCK_ACQUIRED_MS=entry below;
+# wait_ms is 0 and run_ms is the full pytest wall-clock. Skipped only when the
+# script exits before that seed runs.
 TT_TIMING_ENTRY_MS=$(date +%s%3N)
 TT_TIMING_LOCK_ACQUIRED_MS=0
 TT_TIMING_SOURCE="run_safe_pytest"
@@ -81,11 +90,21 @@ if [[ -n "${TT_METAL_SIMULATOR:-}" ]]; then
     SIM_MODE=true
     export TT_METAL_SLOW_DISPATCH_MODE=1
     export TT_METAL_DISABLE_SFPLOADMACRO=1
+    # libttsim's own hang watchdog (clocks of no RISC-V / Tensix progress with
+    # pending work before the sim _Exit(1)'s). User-set env wins.
+    : "${TTSIM_HANG_WATCHDOG_CLOCKS:=50000}"
+    export TTSIM_HANG_WATCHDOG_CLOCKS
+    # No flock on sim, but we still want device_timings: seed the marker so the
+    # exit trap emits with wait_ms=0 and run_ms=full wall-clock.
+    TT_TIMING_LOCK_ACQUIRED_MS=$TT_TIMING_ENTRY_MS
 fi
+PYTEST_STDOUT_LOG="/tmp/safe-pytest-stdout-$$.log"
 
 # --- Parse flags ---
 DEV_MODE=false
 FAIL_FAST=true
+SIM_WORKERS=""
+SIM_WORKERS_GIVEN=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dev)
@@ -96,11 +115,37 @@ while [[ $# -gt 0 ]]; do
             FAIL_FAST=false
             shift
             ;;
+        --sim-workers)
+            if [[ $# -lt 2 ]]; then
+                echo "SAFE_PYTEST_ERROR: --sim-workers requires an integer argument"
+                exit 3
+            fi
+            SIM_WORKERS="$2"
+            SIM_WORKERS_GIVEN=true
+            shift 2
+            ;;
         *)
             break
             ;;
     esac
 done
+
+# --- Validate --sim-workers ---
+if [[ "$SIM_WORKERS_GIVEN" == true ]]; then
+    if [[ "$SIM_MODE" == false ]]; then
+        echo "SAFE_PYTEST_ERROR: --sim-workers is only valid when TT_METAL_SIMULATOR is set"
+        exit 3
+    fi
+    if ! [[ "$SIM_WORKERS" =~ ^[1-9][0-9]*$ ]]; then
+        echo "SAFE_PYTEST_ERROR: --sim-workers must be a positive integer (got: $SIM_WORKERS)"
+        exit 3
+    fi
+fi
+
+# --- Default sim worker count: 16 ---
+if [[ "$SIM_MODE" == true && -z "$SIM_WORKERS" ]]; then
+    SIM_WORKERS=16
+fi
 
 # --- Argument validation ---
 if [[ $# -eq 0 ]]; then
@@ -188,6 +233,16 @@ else
     echo "SAFE_PYTEST: WARNING: python_env not found; using system Python"
 fi
 
+# --- Pre-flight: pytest-xdist required for sim parallelism (SIM_WORKERS > 1) ---
+if [[ "$SIM_MODE" == true && "$SIM_WORKERS" -gt 1 ]]; then
+    if ! python3 -c "import xdist" 2>/dev/null; then
+        echo "SAFE_PYTEST_ERROR: --sim-workers=${SIM_WORKERS} requires pytest-xdist."
+        echo "                   Install with: pip install pytest-xdist"
+        echo "                   Or pass --sim-workers 1 to run serially."
+        exit 3
+    fi
+fi
+
 # --- Hang detection setup (hardware only) ---
 # On timeout, the dispatch layer runs tt-triage. Fires only on actual hang —
 # zero overhead for passing tests. On sim there is no hang detection because
@@ -247,12 +302,16 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
 
     if [[ "$SIM_MODE" == true ]]; then
-        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)"
+        # NoC sanitizer is intentionally disabled on sim — the sanitizer is
+        # tuned for HW behavior and hits false positives under libttsim.
+        # (Mirrors tt-probe.sh.)
+        export TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1
+        echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling(noc_sanitize=OFF) watchdog=${TTSIM_HANG_WATCHDOG_CLOCKS} clocks workers=${SIM_WORKERS}"
     else
         echo "SAFE_PYTEST: [dev] asserts=ebreak llk_asserts=ON watcher=polling triage=ON timeout=${DISPATCH_TIMEOUT}s"
     fi
 elif [[ "$SIM_MODE" == true ]]; then
-    echo "SAFE_PYTEST: [sim] no hang detection"
+    echo "SAFE_PYTEST: [sim] watchdog=${TTSIM_HANG_WATCHDOG_CLOCKS} clocks workers=${SIM_WORKERS}"
 else
     echo "SAFE_PYTEST: dispatch_timeout=${DISPATCH_TIMEOUT}s"
 fi
@@ -273,6 +332,12 @@ fi
 PYTEST_CMD=(pytest "${TEST_PATH}")
 if [[ "$FAIL_FAST" == true ]]; then
     PYTEST_CMD+=(-x)
+fi
+# Sim parallelism via pytest-xdist. Each worker dlopens its own libttsim;
+# DRAM is MAP_PRIVATE per-process so workers don't interfere. Skip when
+# workers=1 to avoid xdist setup overhead.
+if [[ "$SIM_MODE" == true && "$SIM_WORKERS" -gt 1 ]]; then
+    PYTEST_CMD+=(-n "$SIM_WORKERS")
 fi
 PYTEST_CMD+=("$@")
 
@@ -299,10 +364,15 @@ trap '_signal_cleanup INT'  SIGINT
 
 # Run pytest in background so `wait` can be interrupted by a signal. Bash
 # blocks signal delivery while a synchronous foreground command is running.
-"${PYTEST_CMD[@]}" &
+# Mirror stdout/stderr to PYTEST_STDOUT_LOG via process substitution so we can
+# grep for the libttsim watchdog message after a sim hang. Process substitution
+# leaves $! pointing at pytest itself (not tee), so the signal trap still kills
+# the right process tree.
+"${PYTEST_CMD[@]}" > >(tee "$PYTEST_STDOUT_LOG") 2>&1 &
 CHILD_PID=$!
 wait "$CHILD_PID"
 EXIT_CODE=$?
+wait 2>/dev/null  # let tee flush before we grep
 CHILD_PID=
 
 echo "========================================"
@@ -311,6 +381,7 @@ echo "========================================"
 if [[ $EXIT_CODE -eq 0 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
+    rm -f "$PYTEST_STDOUT_LOG"
     echo "SAFE_PYTEST_RESULT: PASS"
     exit 0
 fi
@@ -321,6 +392,7 @@ fi
 if [[ $EXIT_CODE -eq 4 || $EXIT_CODE -eq 5 ]]; then
     rm -f "$DIRTY_FLAG"
     rm -f "$TRIAGE_LOG"
+    rm -f "$PYTEST_STDOUT_LOG"
     if [[ $EXIT_CODE -eq 4 ]]; then
         echo "SAFE_PYTEST_ERROR: Pytest usage error (invalid path or arguments)"
     else
@@ -333,24 +405,31 @@ fi
 pkill -9 -P $$ 2>/dev/null || true
 
 # Determine if this was a hang:
-#   Triage log non-empty = dispatch timeout handler ran tt-triage (definitive hang signal)
-# On sim there is no hang detection, so IS_HANG always stays false.
+#   HW:  Triage log non-empty = dispatch timeout handler ran tt-triage.
+#   Sim: pytest stdout contains "hang watchdog fired" = libttsim watchdog _Exit(1)'d.
+# In the sim case we stage the watchdog message into TRIAGE_LOG so the HANG
+# branch below dumps it identically to a HW triage report.
 IS_HANG=false
 if [[ -s "$TRIAGE_LOG" ]]; then
     IS_HANG=true
+elif [[ "$SIM_MODE" == true ]] && grep -q "hang watchdog fired" "$PYTEST_STDOUT_LOG" 2>/dev/null; then
+    IS_HANG=true
+    grep -A4 "hang watchdog fired" "$PYTEST_STDOUT_LOG" > "$TRIAGE_LOG"
 fi
 
 # Only reset device when the failure might have left it dirty.
 # Hangs and crashes corrupt device state. Normal test failures (PCC mismatch,
 # assertion errors) and collection errors don't touch the device.
 if [[ "$IS_HANG" == true ]]; then
-    echo "SAFE_PYTEST: Resetting device..."
-    if tt-smi -r; then
-        sleep 2
-        rm -f "$DIRTY_FLAG"
-        echo "SAFE_PYTEST: Device reset complete"
-    else
-        echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty"
+    if [[ "$SIM_MODE" == false ]]; then
+        echo "SAFE_PYTEST: Resetting device..."
+        if tt-smi -r; then
+            sleep 2
+            rm -f "$DIRTY_FLAG"
+            echo "SAFE_PYTEST: Device reset complete"
+        else
+            echo "SAFE_PYTEST: Device reset FAILED; leaving device marked dirty"
+        fi
     fi
 
     echo "SAFE_PYTEST_RESULT: HANG (exit code: $EXIT_CODE)"
@@ -376,11 +455,13 @@ if [[ "$IS_HANG" == true ]]; then
     fi
 
     rm -f "$TRIAGE_LOG"
+    rm -f "$PYTEST_STDOUT_LOG"
     exit 2
 fi
 
 rm -f "$DIRTY_FLAG"
 rm -f "$TRIAGE_LOG"
+rm -f "$PYTEST_STDOUT_LOG"
 # Note: $EXIT_CODE here is pytest's internal exit code (e.g. 1 = test failure,
 # 2 = collection error / user interrupt). The wrapper's own exit code is
 # always 1 for this branch — exit 2 is reserved for real dispatch-timeout

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -273,7 +273,7 @@ emit_missing_ttexalens_warning() {
         echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
-trap emit_missing_ttexalens_warning EXIT
+trap '_emit_device_timing; emit_missing_ttexalens_warning' EXIT
 
 if [[ "$DEV_MODE" == true ]]; then
     # Lightweight asserts: compiles ASSERT() as ebreak, halting the core at the

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -130,7 +130,12 @@ if [[ -n "${TT_METAL_SIMULATOR:-}" ]]; then
     SIM_MODE=true
     export TT_METAL_SLOW_DISPATCH_MODE=1
     export TT_METAL_DISABLE_SFPLOADMACRO=1
+    # libttsim's own hang watchdog (clocks of no RISC-V / Tensix progress with
+    # pending work before the sim _Exit(1)'s). User-set env wins.
+    : "${TTSIM_HANG_WATCHDOG_CLOCKS:=50000}"
+    export TTSIM_HANG_WATCHDOG_CLOCKS
 fi
+PROBE_STDOUT_LOG="/tmp/tt-probe-stdout-$$.log"
 
 # --- Timeout config ---
 DISPATCH_TIMEOUT=5
@@ -149,9 +154,10 @@ rm -f "$TRIAGE_LOG"
 # next ordinary probe failure.
 rm -f "$TRIAGE_JSON"
 MISSING_TTEXALENS=false
-if [[ "$SIM_MODE" == true ]]; then
-    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="echo HANG > ${TRIAGE_LOG}"
-else
+# On sim, TT_METAL_OPERATION_TIMEOUT_SECONDS is unset, so the dispatch-timeout
+# command never fires — sim hangs are caught by the libttsim watchdog below,
+# not this hook.
+if [[ "$SIM_MODE" == false ]]; then
     if python3 -c "import ttexalens" 2>/dev/null; then
         mkdir -p "${TRIAGE_JSON_DIR}"
         export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --json-path=${TRIAGE_JSON} > ${TRIAGE_LOG} 2>&1"
@@ -182,8 +188,11 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
 
     if [[ "$SIM_MODE" == true ]]; then
+        # NoC sanitizer is intentionally disabled on sim — see comment in
+        # safe_pytest.sh for symmetry. (Kept off here because sim hits false
+        # positives the sanitizer is tuned for HW behavior on.)
         export TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1
-        echo "TT_PROBE: [sim+dev] watcher=polling(+assert,noc_sanitize=OFF) triage=OFF"
+        echo "TT_PROBE: [sim+dev] watcher=polling(+assert,noc_sanitize=OFF) watchdog=${TTSIM_HANG_WATCHDOG_CLOCKS} clocks"
     else
         # Lightweight asserts: compile ASSERT() as ebreak so the core halts at
         # the exact instruction. The dispatch timeout then fires triage, which
@@ -254,10 +263,14 @@ trap '_signal_cleanup INT'  SIGINT
 
 # Run in background + wait so the trap can fire on signal (bash blocks
 # signal delivery during synchronous foreground commands).
-python3 "$PROBE_FILE" &
+# Mirror stdout/stderr to PROBE_STDOUT_LOG via process substitution so we can
+# grep for the libttsim watchdog message after a sim hang. Process substitution
+# leaves $! pointing at python3 itself (not tee).
+python3 "$PROBE_FILE" > >(tee "$PROBE_STDOUT_LOG") 2>&1 &
 CHILD_PID=$!
 wait "$CHILD_PID"
 EXIT_CODE=$?
+wait 2>/dev/null  # let tee flush before we grep
 CHILD_PID=
 
 echo "========================================"
@@ -283,19 +296,25 @@ if [[ "$SIM_MODE" == false ]]; then
 fi
 
 # --- Detect hang ---
+# HW:  dispatch-timeout handler populated TRIAGE_LOG with tt-triage output.
+# Sim: libttsim watchdog _Exit(1)'d the child; stage its message into
+#      TRIAGE_LOG so the dump below treats it uniformly.
+if [[ "$SIM_MODE" == true ]] && grep -q "hang watchdog fired" "$PROBE_STDOUT_LOG" 2>/dev/null; then
+    grep -A4 "hang watchdog fired" "$PROBE_STDOUT_LOG" > "$TRIAGE_LOG"
+fi
 if [[ -s "$TRIAGE_LOG" ]]; then
     echo "TT_PROBE: HANG DETECTED"
-    if [[ "$SIM_MODE" == false ]]; then
-        cat "$TRIAGE_LOG"
-        if [[ -s "$TRIAGE_JSON" ]]; then
-            echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}"
-        fi
+    cat "$TRIAGE_LOG"
+    if [[ "$SIM_MODE" == false && -s "$TRIAGE_JSON" ]]; then
+        echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}"
     fi
     rm -f "$TRIAGE_LOG"
+    rm -f "$PROBE_STDOUT_LOG"
     echo "TT_PROBE_RESULT: HANG (probe: ${PROBE_REL})"
     exit 2
 fi
 rm -f "$TRIAGE_LOG"
+rm -f "$PROBE_STDOUT_LOG"
 
 # --- Result ---
 # Reserve wrapper exit 2 for the HANG case above. For any other non-zero

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -176,7 +176,7 @@ emit_missing_ttexalens_warning() {
         echo "TT_PROBE: Install with: uv pip install -r tools/triage/requirements.txt"
     fi
 }
-trap emit_missing_ttexalens_warning EXIT
+trap '_emit_device_timing; emit_missing_ttexalens_warning' EXIT
 
 # --- Dev-mode instrumentation ---
 # Mirrors run_safe_pytest.sh --dev. On hardware this enables ebreak ASSERTs and

--- a/scripts/tt-probe.sh
+++ b/scripts/tt-probe.sh
@@ -15,8 +15,8 @@
 #
 # Flags:
 #   --dev   Enables polling watcher (NoC sanitizer, waypoints, CB sanitization),
-#           lightweight ebreak asserts (ASSERT + LLK_ASSERT), and JSON triage
-#           to generated/tt-triage/triage.json. Same semantics as run_safe_pytest.sh --dev.
+#           lightweight ebreak asserts (ASSERT + LLK_ASSERT), and an llm-friendly triage report
+#           to generated/tt-triage/triage.txt. Same semantics as run_safe_pytest.sh --dev.
 #
 # With DPRINT:
 #   TT_METAL_DPRINT_CORES=0,0 TT_METAL_DPRINT_RISCVS=TR0 \
@@ -28,7 +28,7 @@
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
-#   --dev    - Debug mode: watcher + lightweight asserts + JSON triage on hang.
+#   --dev    - Debug mode: watcher + lightweight asserts + llm-friendly triage on hang.
 #              Probes a suspected hang or bad kernel state, letting ASSERT()/
 #              LLK_ASSERT() halt at the exact failing instruction for triage.
 #
@@ -42,8 +42,8 @@ set -o pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
-TRIAGE_JSON_DIR="${REPO_DIR}/generated/tt-triage"
-TRIAGE_JSON="${TRIAGE_JSON_DIR}/triage.json"
+TRIAGE_OUT_DIR="${REPO_DIR}/generated/tt-triage"
+TRIAGE_REPORT="${TRIAGE_OUT_DIR}/triage.txt"
 LOCK_FILE="/tmp/tt-device.lock"
 DIRTY_FLAG="/tmp/tt-device.dirty"
 TRIAGE_LOG="/tmp/tt-probe-triage-$$.log"
@@ -144,23 +144,23 @@ if [[ "$SIM_MODE" == false ]]; then
 fi
 
 # --- Hang detection setup ---
-# Triage writes JSON to generated/tt-triage/triage.json for machine-readable
-# inspection (same location run_safe_pytest.sh uses), plus a text log for the
-# stderr dump. Grep targets are documented in CLAUDE.md § "Hang triage".
+# Triage writes an llm-friendly report to generated/tt-triage/triage.txt for
+# machine-readable inspection (same location run_safe_pytest.sh uses), plus a
+# text log for the stderr dump. Grep targets are documented in CLAUDE.md § "Hang triage".
 rm -f "$TRIAGE_LOG"
-# Also clear any stale triage JSON from a previous run. Downstream consumers
-# (hooks, CI) treat the JSON's presence as the hang signal — leaving a stale
+# Also clear any stale triage report from a previous run. Downstream consumers
+# (hooks, CI) treat the report's presence as the hang signal — leaving a stale
 # file around causes false-positive "hang detected" classification on the
 # next ordinary probe failure.
-rm -f "$TRIAGE_JSON"
+rm -f "$TRIAGE_REPORT"
 MISSING_TTEXALENS=false
 # On sim, TT_METAL_OPERATION_TIMEOUT_SECONDS is unset, so the dispatch-timeout
 # command never fires — sim hangs are caught by the libttsim watchdog below,
 # not this hook.
 if [[ "$SIM_MODE" == false ]]; then
     if python3 -c "import ttexalens" 2>/dev/null; then
-        mkdir -p "${TRIAGE_JSON_DIR}"
-        export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --json-path=${TRIAGE_JSON} > ${TRIAGE_LOG} 2>&1"
+        mkdir -p "${TRIAGE_OUT_DIR}"
+        export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress --skip-version-check --llm-output --llm-output-path=${TRIAGE_REPORT} > ${TRIAGE_LOG} 2>&1"
     else
         # Defer the missing-tool warning to EXIT via trap — otherwise it gets
         # buried in probe output and users never see it.
@@ -305,8 +305,8 @@ fi
 if [[ -s "$TRIAGE_LOG" ]]; then
     echo "TT_PROBE: HANG DETECTED"
     cat "$TRIAGE_LOG"
-    if [[ "$SIM_MODE" == false && -s "$TRIAGE_JSON" ]]; then
-        echo "TT_PROBE: JSON triage: ${TRIAGE_JSON}"
+    if [[ "$SIM_MODE" == false && -s "$TRIAGE_REPORT" ]]; then
+        echo "TT_PROBE: triage report: ${TRIAGE_REPORT}"
     fi
     rm -f "$TRIAGE_LOG"
     rm -f "$PROBE_STDOUT_LOG"

--- a/tests/ttnn/unit_tests/operations/intentional_hang/__init__.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/ttnn/unit_tests/operations/intentional_hang/intentional_hang_op.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/intentional_hang_op.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+intentional_hang — a test-only op whose writer blocks forever waiting
+for a tile that is never produced. Used to validate that the eval
+hang_plugin detects real device hangs and skips subsequent
+parametrizations of the same test function.
+
+Not exported through ttnn.operations. Import directly:
+    from tests.ttnn.unit_tests.operations.intentional_hang.intentional_hang_op import intentional_hang
+"""
+
+import ttnn
+
+from .program_descriptor import create_program_descriptor
+
+
+def intentional_hang(input_tensor: ttnn.Tensor) -> ttnn.Tensor:
+    device = input_tensor.device()
+    output_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(list(input_tensor.shape)),
+        input_tensor.dtype,
+        input_tensor.layout,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    program_descriptor = create_program_descriptor(input_tensor, output_tensor)
+    return ttnn.generic_op([input_tensor, output_tensor], program_descriptor)

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/compute_noop.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/compute_noop.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op compute for intentional_hang. Produces no output tiles.
+
+#include "api/compute/compute_kernel_api.h"
+
+void kernel_main() {
+    // intentionally empty — never pushes to cb_out
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/reader_noop.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/reader_noop.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op reader for intentional_hang. Pushes zero tiles into cb_input.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    // intentionally empty — leaves cb_out empty so writer hangs on cb_wait_front
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/kernels/writer_hang.cpp
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/kernels/writer_hang.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer for intentional_hang. Blocks forever on cb_wait_front since
+// the compute kernel never pushes any tile into cb_out. This produces
+// a deterministic device-side hang that surfaces to the host as a
+// dispatch/operation timeout from system_memory_manager.cpp.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_out = 16;
+    cb_wait_front(cb_out, 1);  // deadlock — compute never pushes
+}

--- a/tests/ttnn/unit_tests/operations/intentional_hang/program_descriptor.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/program_descriptor.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program descriptor for the intentional_hang test op.
+
+Wires up a no-op reader, no-op compute, and a writer that blocks on
+cb_wait_front for a tile that never arrives — guaranteed device hang.
+"""
+
+from pathlib import Path
+import ttnn
+
+KERNEL_DIR = Path(__file__).parent / "kernels"
+
+
+def create_program_descriptor(
+    input_tensor: ttnn.Tensor,
+    output_tensor: ttnn.Tensor,
+) -> ttnn.ProgramDescriptor:
+    input_page_size = input_tensor.buffer_page_size()
+    output_page_size = output_tensor.buffer_page_size()
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+
+    CB_INPUT = 0
+    CB_OUTPUT = 16
+
+    cb_input_descriptor = ttnn.CBDescriptor(
+        total_size=2 * input_page_size,
+        core_ranges=core_grid,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=CB_INPUT,
+                data_format=input_tensor.dtype,
+                page_size=input_page_size,
+            )
+        ],
+    )
+    cb_output_descriptor = ttnn.CBDescriptor(
+        total_size=2 * output_page_size,
+        core_ranges=core_grid,
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=CB_OUTPUT,
+                data_format=output_tensor.dtype,
+                page_size=output_page_size,
+            )
+        ],
+    )
+
+    reader_ct_args = list(ttnn.TensorAccessorArgs(input_tensor).get_compile_time_args())
+    reader_rt_args = ttnn.RuntimeArgs()
+    reader_rt_args[core.x][core.y] = [input_tensor.buffer_address()]
+    reader_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "reader_noop.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=reader_ct_args,
+        runtime_args=reader_rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+    writer_ct_args = list(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args())
+    writer_rt_args = ttnn.RuntimeArgs()
+    writer_rt_args[core.x][core.y] = [output_tensor.buffer_address()]
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "writer_hang.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=writer_ct_args,
+        runtime_args=writer_rt_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    compute_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "compute_noop.cpp"),
+        core_ranges=core_grid,
+        compile_time_args=[],
+        runtime_args=[],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+
+    return ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel, compute_kernel],
+        semaphores=[],
+        cbs=[cb_input_descriptor, cb_output_descriptor],
+    )

--- a/tests/ttnn/unit_tests/operations/intentional_hang/test_intentional_hang.py
+++ b/tests/ttnn/unit_tests/operations/intentional_hang/test_intentional_hang.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Inner test for the hang_plugin device validation. NOT meant to be run
+directly under normal CI — it always hangs and costs a device reset.
+
+The outer test at .claude/eval/tests/test_hang_plugin_device.py invokes
+this as a subprocess to validate that hang_plugin.py:
+  1. Detects the device timeout from the first parametrization.
+  2. Skips the remaining parametrizations with "previous parametrization
+     of test_intentional_hang hung".
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import ttnn
+
+# Allow `from tests....` imports when invoked from the repo root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")))
+
+from tests.ttnn.unit_tests.operations.intentional_hang.intentional_hang_op import (  # noqa: E402
+    intentional_hang,
+)
+
+
+@pytest.mark.parametrize("shape", [(32, 32), (32, 64), (32, 96)])
+def test_intentional_hang(shape, device):
+    torch_in = torch.ones(shape, dtype=torch.bfloat16)
+    tt_in = ttnn.from_torch(
+        torch_in,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = intentional_hang(tt_in)
+    # Force a synchronous read-back so the device-side deadlock manifests
+    # as a Python exception during the call phase, not during teardown.
+    ttnn.to_torch(tt_out)

--- a/ttnn/cpp/ttnn/kernel_lib/binary_op_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/binary_op_helpers.inl
@@ -82,7 +82,9 @@ ALWI void assert_binary_output_cb_size(uint32_t cb, uint32_t chunk_size, uint32_
 
 template <BinaryOpType op_type>
 constexpr EltwiseBinaryType map_to_eltwise_type() {
-    return op_type == BinaryOpType::ADD ? ELWADD : op_type == BinaryOpType::SUB ? ELWSUB : ELWMUL;
+    return op_type == BinaryOpType::ADD   ? EltwiseBinaryType::ELWADD
+           : op_type == BinaryOpType::SUB ? EltwiseBinaryType::ELWSUB
+                                          : EltwiseBinaryType::ELWMUL;
 }
 
 template <BroadcastDim bcast_dim>
@@ -131,9 +133,9 @@ ALWI void binary_init(uint32_t icb_a, uint32_t icb_b) {
 
     // MUL/SQUARE use configured MATH_FIDELITY; ADD/SUB always use LoFi (matches eltwise_binary.h)
     if constexpr (uses_fpu_mul<op_type>()) {
-        MATH((llk_math_eltwise_binary_init_with_operands<elt_type, bcast_type, MATH_FIDELITY>(icb_a, icb_b)));
+        MATH((llk_math_eltwise_binary_init<elt_type, bcast_type, MATH_FIDELITY>(icb_a, icb_b)));
     } else {
-        MATH((llk_math_eltwise_binary_init_with_operands<elt_type, bcast_type, MathFidelity::LoFi>(icb_a, icb_b)));
+        MATH((llk_math_eltwise_binary_init<elt_type, bcast_type, MathFidelity::LoFi>(icb_a, icb_b)));
     }
     UNPACK((llk_unpack_AB_init<bcast_type>(icb_a, icb_b)));
 }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -6,6 +6,7 @@
 // Do not include directly - include reduce_helpers_compute.hpp instead
 
 #include "api/compute/matmul.h"
+#include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/pack.h"
 #include "api/debug/assert.h"
@@ -107,7 +108,26 @@ ALWI void reload_accumulator_if_needed(
             constexpr uint32_t onetile = 1;
             accum_dfb.wait_front(onetile);
             const uint32_t prev_srca_dfb = use_matmul ? scaler_dfb_id : input_dfb_id;
-            copy_tile_to_dst_init_short_with_dt(prev_srca_dfb, accumulate.config.cb_accumulator);
+            // For MAX + REDUCE_ROW, the LLK runs reduce_row_perform_transpose after GMPOOL to
+            // convert the natural DST-row-0 result into DST-col-0 output layout. A vanilla
+            // copy_tile reload would therefore land the running max at DST col 0, but the
+            // next GMPOOL chain accumulates into DST row 0 — so the running max would be
+            // silently dropped. We undo the LLK's transpose on reload by setting the
+            // unpacker into within-face-16x16-transpose mode, which puts col 0 of each face
+            // back at row 0 of that face (the layout GMPOOL expects as its accumulator).
+            //
+            // CRITICAL: transpose_of_faces must stay 0 (per-face transpose only). A full
+            // 32x32 transpose would also swap face positions BL<->TR, moving the running
+            // max for global rows 16-31 (stored in BL col 0) into TR — where the LLK's
+            // second-phase BL/BR GMPOOL chain never reads it.
+            constexpr bool reload_within_face_transpose =
+                (reduce_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW);
+
+            reconfig_data_format_srca(prev_srca_dfb, accumulate.config.cb_accumulator);
+            copy_tile_to_dst_init_short(
+                accumulate.config.cb_accumulator,
+                /*transpose_of_faces=*/0,
+                /*transpose_within_16x16_face=*/reload_within_face_transpose ? 1u : 0u);
             copy_tile(accumulate.config.cb_accumulator, 0, accumulate.config.dst_index);
             accum_dfb.pop_front(onetile);
 
@@ -177,10 +197,10 @@ ALWI void reduce(
         is_post_reduce_op_v<PostReduceOp>,
         "PostReduceOp must be callable with a uint32_t argument");
     static_assert(
-        !is_accumulate_v<AccumulateT> || reduce_type != PoolType::MAX || reduce_dim == ReduceDim::REDUCE_COL,
-        "Accumulate::at with PoolType::MAX only works for REDUCE_COL. For REDUCE_ROW / REDUCE_SCALAR "
-        "the pack reduce edge mask drops the face-row-0 spread that GMPOOL needs as its running "
-        "accumulator on the reload pass, so the previous MAX is lost.");
+        !is_accumulate_v<AccumulateT> || reduce_type != PoolType::MAX || reduce_dim != ReduceDim::REDUCE_SCALAR,
+        "Accumulate::at with PoolType::MAX is not supported for REDUCE_SCALAR. The LLK transposes the "
+        "scalar position post-GMPOOL via MOVD2B/TRNSPSRCB, which does not have a symmetric reload "
+        "remedy like REDUCE_ROW does (DST-only transpose via transpose_wh_dest).");
 
     // =============================================================================
     // Runtime Assertions (parameter validation)

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp
@@ -45,11 +45,29 @@ enum class WaitMode : uint8_t {
 };
 
 // Controls whether fast tilize is used for Float32 data.
-// Fast tilize truncates fp32 to tf32 precision during tilization (lossy).
-// Use Lossless when exact fp32 preservation is required.
+//
+// You almost never want Lossless, even in "max-precision" kernels. Fast tilize
+// truncates fp32 → tf32 on the way into Dest, but every FPU consumer downstream
+// (matmul, FPU reduce, FPU binary eltwise) re-reads the tiled output through
+// SrcA/SrcB, which is tf32-only. So the precision Lossless "preserves" is
+// destroyed by the very next FPU op, and the only cost is a slower tilize path.
+//
+// Lossless is correct ONLY when ALL of these hold:
+//   1. The tiled output is consumed exclusively by SFPU ops reading directly
+//      from Dest (e.g. SFPU eltwise via copy_tile / Dest-resident SFPU chains).
+//      Any FPU op anywhere in the consumer chain — even one matmul or one
+//      add_tiles — invalidates the use case.
+//   2. fp32_dest_acc_en = true in the ComputeConfig.
+//   3. The input CB is configured with UnpackToDestMode::UnpackToDestFp32.
+// If any one is missing, prefer Fast.
 enum class Fp32Mode : uint8_t {
-    Fast,     // Default — uses fast_tilize for fp32 (lossy, truncates to tf32 precision)
-    Lossless  // Forces standard tilize path for fp32 data (exact, no truncation)
+    Fast,     // Default — uses fast_tilize for fp32 (truncates to tf32 precision).
+              // This matches what FPU ops downstream would do anyway, so it is the
+              // right default even when the surrounding kernel is "max precision".
+    Lossless  // Forces standard tilize path for fp32 data. Rarely useful — see
+              // enum comment above. Do not pick this just because the kernel is
+              // "max precision"; pick it only when the SFPU-only consumer chain
+              // and the two CB/ComputeConfig prerequisites are actually in place.
 };
 
 // Controls whether BH fast tilize configures DEST remap during init.
@@ -83,8 +101,17 @@ enum class RemapMode : uint8_t {
  *   wait_mode        — How to synchronize on input data (default: WaitBlock).
  *   reconfig_mode     — Register datatype reconfiguration (default: UnpackAndPackReconfigure).
  *   fp32_mode        — Float32 precision control (default: Fast).
- *                       Fast: uses fast_tilize when possible (lossy for fp32 — truncates to tf32 precision).
- *                       Lossless: forces standard tilize path, preserving exact fp32 values.
+ *                       Fast: uses fast_tilize when possible (truncates fp32 → tf32 in Dest).
+ *                             This is the right default — every FPU op downstream
+ *                             (matmul, FPU reduce, FPU binary eltwise) re-reads through
+ *                             SrcA/SrcB and truncates to tf32 anyway. "Max precision"
+ *                             kernels still want Fast unless the tiled output flows
+ *                             exclusively to SFPU via Dest.
+ *                       Lossless: forces standard tilize path. RARELY USEFUL. Only helps
+ *                             when ALL of: (a) the tiled output is consumed exclusively
+ *                             by SFPU ops reading from Dest (any FPU consumer voids it),
+ *                             (b) fp32_dest_acc_en=true, (c) the input CB uses
+ *                             UnpackToDestFp32. See the Fp32Mode enum comment.
  *   remap_mode       — BH DEST remap setup control (default: Configure).
  *                       Configure: helper configures remap when the selected tilize path needs it.
  *                       AssumeConfigured: caller already enabled BH DEST remap and no intervening code changes it.
@@ -143,7 +170,14 @@ enum class RemapMode : uint8_t {
  *   compute_kernel_lib::tilize<w, dfb_in, dfb_out, tilize_config::InitUninitMode::Neither>(blocks);    // middle
  *   compute_kernel_lib::tilize<w, dfb_in, dfb_out, tilize_config::InitUninitMode::UninitOnly>(blocks); // last
  *
- *   // 7. Lossless fp32 tilize — exact fp32 preservation (no truncation to tf32)
+ *   // 7. Lossless fp32 tilize — RARELY USEFUL. Only correct when the tiled
+ *   //    output is consumed exclusively by SFPU ops reading from Dest, AND
+ *   //    fp32_dest_acc_en=true, AND the input CB uses UnpackToDestFp32. Any
+ *   //    FPU consumer (matmul, FPU reduce, FPU binary eltwise) re-truncates
+ *   //    fp32 → tf32 on the way back through SrcA/SrcB — so Lossless gains
+ *   //    nothing precision-wise and only costs you a slower tilize path.
+ *   //    Default (Fast) is the right choice for almost every kernel, including
+ *   //    ones prompted to use "max precision" defaults.
  *   compute_kernel_lib::tilize<block_w, dfb_in, dfb_out,
  *          tilize_config::InitUninitMode::InitAndUninit,
  *          tilize_config::WaitMode::WaitBlock,

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.hpp
@@ -69,14 +69,28 @@ enum class TilizeGranularity : uint8_t {
  * @tparam Accessor TensorAccessor type (deduced)
  * @param accessor TensorAccessor for the source tensor (stick-indexed)
  * @param total_num_rows Total number of sticks to read
- * @param row_bytes Actual bytes per stick (may be non-tile-aligned)
+ * @param row_bytes Actual bytes per stick to read (may be non-tile-aligned).
+ *        Combined with byte_offset_within_page this selects a chunk along W:
+ *        each stick contributes `row_bytes` bytes starting at byte
+ *        `byte_offset_within_page` of its source page.
  * @param start_page Starting page/stick index in the accessor (default 0).
  *        For multi-core work distribution, pass the per-core start_row offset
  *        so the accessor reads from the correct tensor slice.
+ * @param byte_offset_within_page Byte offset inside each source page where
+ *        reading begins (default 0). Used for wide-W chunking: wrap this
+ *        helper in a chunk-outer loop and pass
+ *        `byte_offset_within_page = chunk_id * row_bytes` so each call reads a
+ *        different W-chunk of the same set of sticks. CB sizing (per call)
+ *        then scales with `row_bytes` (the chunk width), not the full row,
+ *        bounding L1 footprint regardless of total W.
  */
 template <uint32_t cb_id, TilizeGranularity granularity = TilizeGranularity::TILE, typename Accessor>
 FORCE_INLINE void read_sticks_for_tilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page = 0);
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page = 0,
+    uint32_t byte_offset_within_page = 0);
 
 /**
  * @brief Write untilized sticks from a CB to DRAM
@@ -99,14 +113,26 @@ FORCE_INLINE void read_sticks_for_tilize(
  * @tparam Accessor TensorAccessor type (deduced)
  * @param accessor TensorAccessor for the destination tensor (stick-indexed)
  * @param total_num_rows Total number of sticks to write
- * @param row_bytes Actual bytes per stick to write (may be non-tile-aligned)
+ * @param row_bytes Actual bytes per stick to write (may be non-tile-aligned).
+ *        Combined with byte_offset_within_page this selects a chunk along W:
+ *        each stick writes `row_bytes` bytes starting at byte
+ *        `byte_offset_within_page` of its destination page.
  * @param start_page Starting page/stick index in the accessor (default 0).
  *        For multi-core work distribution, pass the per-core start_row offset
  *        so the accessor writes to the correct tensor slice.
+ * @param byte_offset_within_page Byte offset inside each destination page
+ *        where writing begins (default 0). Symmetric to the read helper's
+ *        parameter: wrap this helper in a chunk-outer loop and pass
+ *        `byte_offset_within_page = chunk_id * row_bytes` so each call writes
+ *        a different W-chunk of the same set of sticks.
  */
 template <uint32_t cb_id, typename Accessor>
 FORCE_INLINE void write_sticks_after_untilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page = 0);
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page = 0,
+    uint32_t byte_offset_within_page = 0);
 
 }  // namespace dataflow_kernel_lib
 

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers_dataflow.inl
@@ -66,7 +66,11 @@ constexpr uint32_t div_up(uint32_t a, uint32_t b) {
 //
 template <uint32_t cb_id, TilizeGranularity granularity, typename Accessor>
 FORCE_INLINE void read_sticks_for_tilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page) {
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page,
+    uint32_t byte_offset_within_page) {
     // Derive tile geometry from CB configuration (all constexpr)
     constexpr uint32_t tile_h = unpack_tile_r_dim[cb_id];
     constexpr uint32_t tile_w = unpack_tile_c_dim[cb_id];
@@ -114,7 +118,7 @@ FORCE_INLINE void read_sticks_for_tilize(
             uint32_t l1_addr = get_write_ptr(cb_id);
 
             for (uint32_t row = 0; row < rows_this_block; row++) {
-                uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row);
+                uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row, byte_offset_within_page);
                 noc_async_read(noc_addr, l1_addr, row_bytes);
                 l1_addr += padded_row_bytes;
             }
@@ -145,7 +149,7 @@ FORCE_INLINE void read_sticks_for_tilize(
             cb_reserve_back(cb_id, 1);
             uint32_t l1_addr = get_write_ptr(cb_id);
 
-            uint64_t noc_addr = accessor.get_noc_addr(start_page + row);
+            uint64_t noc_addr = accessor.get_noc_addr(start_page + row, byte_offset_within_page);
             noc_async_read(noc_addr, l1_addr, row_bytes);
 
             noc_async_read_barrier();
@@ -180,7 +184,11 @@ FORCE_INLINE void read_sticks_for_tilize(
 //
 template <uint32_t cb_id, typename Accessor>
 FORCE_INLINE void write_sticks_after_untilize(
-    const Accessor& accessor, uint32_t total_num_rows, uint32_t row_bytes, uint32_t start_page) {
+    const Accessor& accessor,
+    uint32_t total_num_rows,
+    uint32_t row_bytes,
+    uint32_t start_page,
+    uint32_t byte_offset_within_page) {
     // Derive tile geometry from CB configuration (all constexpr)
     constexpr uint32_t tile_h = unpack_tile_r_dim[cb_id];
     constexpr uint32_t tile_w = unpack_tile_c_dim[cb_id];
@@ -222,7 +230,7 @@ FORCE_INLINE void write_sticks_after_untilize(
         uint32_t l1_addr = get_read_ptr(cb_id);
 
         for (uint32_t row = 0; row < rows_this_block; row++) {
-            uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row);
+            uint64_t noc_addr = accessor.get_noc_addr(start_page + block_row + row, byte_offset_within_page);
             noc_async_write(l1_addr, noc_addr, row_bytes);
             l1_addr += padded_row_bytes;
         }


### PR DESCRIPTION
## Summary

Consolidates branch-agnostic kernel_lib + dev-tooling improvements (developed on `mstaletovic/agent_eval`) into a single contribution to `llk_helper_library`. **No** agent-eval-specific changes are included — no nuked ops, no eval-submodule bumps, no registry-model migration, no submodule pointer changes.

Based on the current `llk_helper_library` tip. 14 files changed, +468/-81.

## Changes

### kernel_lib helpers
- **binary_op_helpers**: complete rebase fix for scoped `EltwiseBinaryType` + init rename
- **reduce_helpers**: support `accumulate_reduce<MAX, REDUCE_ROW>` via per-face reload transpose
- **tilize/untilize dataflow helpers**: add `byte_offset_within_page`
- **tilize_helpers docs**: warn against `Fp32Mode::Lossless` in the public docs

### dev scripts (`run_safe_pytest.sh` / `tt-probe.sh`)
- hang triage now uses `tt-triage --llm-output` instead of `--json-path` (matches the upstream `tt-triage` interface)
- preserve device timing in the EXIT trap chain
- bring sim tooling from the sim_agents branch (sim-mode hang detection via the libttsim watchdog)

### test infra
- add `intentional_hang` generic_op for hang_plugin device validation

## Notes
- The `tt-probe.sh` hang-detection block is a **semantic merge** of the sim-tooling and triage-`--llm-output` changes: `cat "$TRIAGE_LOG"` runs unconditionally (the sim watchdog stages its message there), while the report-path echo stays guarded by `SIM_MODE == false`. Taking either side verbatim would have been wrong.

Opening as **draft** for review of scope/contents.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/llk_helper_library_consolidated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/llk_helper_library_consolidated)