### PR TITLE
[Perf] DeepSeek MLA loudbox: recenter 2x4 perf baseline to 8.25M ns

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -24,7 +24,7 @@ def test_deepseek_v3_mla_perf_loudbox():
     """
     run_mla_perf_with_approximation(
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=8_952_745,
+        expected_ns_2x4=8_251_664,
         model_name_2x4="deepseek_v3_mla_lb_2x4",
         subdir="deepseek_v3_mla",
         margin=0.03,


### PR DESCRIPTION
Recenter `test_deepseek_v3_mla_perf_loudbox` baseline `expected_ns_2x4` from `8_952_745` → `8_251_664` ns.

  ## Why
  The test checks a ±3% window around `expected_ns_2x4`. The MLA device kernel duration improved to a stable ~8.25M ns and now consistently trips the old baseline's lower bound, failing
  `bh_lb_DeepSeek_PREFILL_PERF` every run.

  Measured `AVG DEVICE KERNEL DURATION [ns]` across 10 CI runs (2026-06-04 → 06-05): min 8,223,831 / max 8,279,939 / mean 8,251,664 (~0.7% spread — stable, not a flake). New ±3% window [8,004,114,
  8,499,214] covers all observed values.
  
  Example failure fixed:
  `AVG DEVICE KERNEL DURATION [ns] 8279938.875 is outside of expected range (8684162.65, 9221327.35)`

### CI Status
https://github.com/tenstorrent/tt-metal/actions/runs/27008975646