### PR TITLE
kernel_lib/reduce_helpers: add partial-tile (non-tile-aligned) reduce

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -146,6 +146,42 @@ struct ReduceInputBlockShape {
 };
 
 /**
+ * @brief Partial-scaler descriptor for non-tile-aligned reduce dimensions
+ *
+ * When the reduce dimension is not a multiple of TILE_DIM, the reader emits
+ * TWO scaler tiles into scaler_cb: tile 0 has the full scaler (all positions
+ * filled), and tile 1 has the partial scaler (only the valid positions filled,
+ * the rest zeroed). The compute kernel must use tile 1 for the *last* tile
+ * along the reduce dimension and tile 0 for every other tile.
+ *
+ * This struct selects which scaler-tile index to use on the last reduce-dim
+ * iteration. The default (`none()`) keeps the legacy behavior of using tile 0
+ * everywhere. Use `last_tile_at(1)` (or any non-zero idx) to switch to the
+ * partial scaler on the last tile.
+ *
+ * Pair with dataflow_kernel_lib::prepare_partial_reduce_scalers (or
+ * calculate_and_prepare_partial_reduce_scalers) on the reader side.
+ *
+ * REDUCE_SCALAR does not support partial scalers — it applies the scaler
+ * twice (row then col), which a single partial tile cannot encode. The
+ * runtime asserts that REDUCE_SCALAR callers pass none().
+ *
+ * Usage:
+ *   constexpr auto partial = has_partial
+ *       ? ReducePartialScaler::last_tile_at(1)
+ *       : ReducePartialScaler::none();
+ *   reduce<SUM, REDUCE_ROW>(cb_in, cb_scaler, cb_out, shape, ..., partial);
+ */
+struct ReducePartialScaler {
+    // Scaler-tile index to use for the LAST reduce-dim iteration. 0 = no
+    // partial (use tile 0 everywhere); >0 = index of the partial scaler tile.
+    uint32_t last_tile_scaler_idx = 0;
+
+    static constexpr ReducePartialScaler none() { return {0}; }
+    static constexpr ReducePartialScaler last_tile_at(uint32_t idx = 1) { return {idx}; }
+};
+
+/**
  * @brief Configuration for accumulation-style reductions
  *
  * Holds the static configuration for accumulation (CB and DST index).
@@ -304,6 +340,11 @@ struct NoOp {
  * is NoWaitNoPop or WaitUpfrontNoPop.
  * @param accumulate Accumulation configuration (default: NoAccumulation)
  * @param post_reduce_op Callback after each reduction (default: NoOp)
+ * @param partial_scaler Partial-scaler selector for non-tile-aligned reduce
+ *        dimensions (default: ReducePartialScaler::none()). When set to
+ *        last_tile_at(idx), the helper waits for `idx + 1` scaler tiles and
+ *        uses scaler tile `idx` for the last reduce-dim iteration. Pair with
+ *        dataflow_kernel_lib::prepare_partial_reduce_scalers on the reader.
  *
  * @example
  *   // Reduce entire HxW grid to single tile (REDUCE_SCALAR)
@@ -383,7 +424,8 @@ ALWI void reduce(
     ReduceInputBlockShape input_block_shape,
     ReduceInputMemoryLayout input_memory_layout = ReduceInputMemoryLayout::contiguous(),
     AccumulateT accumulate = AccumulateT{},
-    PostReduceOp post_reduce_op = PostReduceOp{});
+    PostReduceOp post_reduce_op = PostReduceOp{},
+    ReducePartialScaler partial_scaler = ReducePartialScaler::none());
 
 }  // namespace compute_kernel_lib
 

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -181,7 +181,8 @@ ALWI void reduce(
     ReduceInputBlockShape input_block_shape,
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
-    PostReduceOp post_reduce_op) {
+    PostReduceOp post_reduce_op,
+    ReducePartialScaler partial_scaler) {
     // =============================================================================
     // Static Assertions (compile-time validation)
     // =============================================================================
@@ -260,7 +261,12 @@ ALWI void reduce(
     } else {
         reduce_init<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, output_dfb_id);
     }
-    scaler_dfb.wait_front(1);  // Wait for scaler tile
+    // Partial scaler: REDUCE_SCALAR can't use it (applies the scaler twice).
+    // Other reduce dims may add a partial-fill tile at index >0; wait for both.
+    if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
+        ASSERT(partial_scaler.last_tile_scaler_idx == 0);
+    }
+    scaler_dfb.wait_front(partial_scaler.last_tile_scaler_idx + 1);
 
     constexpr uint32_t onetile = 1;
 
@@ -387,29 +393,32 @@ ALWI void reduce(
 
                 const uint32_t dst_idx = get_dst_index(accumulate);
                 for (uint32_t wt = 0; wt < Wt; ++wt) {
+                    // Last W-tile picks up the partial scaler when one was prepared by the reader.
+                    const uint32_t scaler_idx = (wt == Wt - 1) ? partial_scaler.last_tile_scaler_idx : 0;
                     if constexpr (waits_per_tile(input_policy)) {
                         // One-at-a-time: wait/pop per tile
                         input_dfb.wait_front(onetile);
                         if constexpr (use_matmul) {
-                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, 0, scaler_idx, dst_idx);
                         } else {
-                            reduce_tile<reduce_type, reduce_dim>(input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                            reduce_tile<reduce_type, reduce_dim>(
+                                input_dfb_id, scaler_dfb_id, 0, scaler_idx, dst_idx);
                         }
                         input_dfb.pop_front(onetile);
                     } else if constexpr (waits_bulk(input_policy)) {
                         // BulkWaitBulkPop: use indexed access
                         if constexpr (use_matmul) {
-                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt, 0, dst_idx);
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt, scaler_idx, dst_idx);
                         } else {
                             reduce_tile<reduce_type, reduce_dim>(
-                                input_dfb_id, scaler_dfb_id, wt, 0, dst_idx);
+                                input_dfb_id, scaler_dfb_id, wt, scaler_idx, dst_idx);
                         }
                     } else {  // PreloadedPolicy or PersistentPolicy: indexed access
                         if constexpr (use_matmul) {
-                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
+                            reduce_matmul_tiles(input_dfb_id, scaler_dfb_id, wt + index_offset, scaler_idx, dst_idx);
                         } else {
                             reduce_tile<reduce_type, reduce_dim>(
-                                input_dfb_id, scaler_dfb_id, wt + index_offset, 0, dst_idx);
+                                input_dfb_id, scaler_dfb_id, wt + index_offset, scaler_idx, dst_idx);
                         }
                     }
                 }
@@ -495,22 +504,24 @@ ALWI void reduce(
                 for (uint32_t ht = 0; ht < Ht; ++ht) {
                     // Base dst_index: from accumulation config or 0 for multi-column output
                     uint32_t dst_idx = get_dst_index(accumulate);
+                    // Last H-tile picks up the partial scaler when one was prepared by the reader.
+                    const uint32_t scaler_idx = (ht == Ht - 1) ? partial_scaler.last_tile_scaler_idx : 0;
                     for (uint32_t i = wt; i < chunk_end; ++i) {
                         if constexpr (waits_per_tile(input_policy)) {
                             // One-at-a-time: wait/pop per tile
                             input_dfb.wait_front(onetile);
                             reduce_tile<reduce_type, reduce_dim>(
-                                input_dfb_id, scaler_dfb_id, 0, 0, dst_idx);
+                                input_dfb_id, scaler_dfb_id, 0, scaler_idx, dst_idx);
                             input_dfb.pop_front(onetile);
                         } else if constexpr (waits_bulk(input_policy)) {
                             // BulkWaitBulkPop: use indexed access
                             uint32_t tile_idx = ht * current_chunk + (i - wt);
                             reduce_tile<reduce_type, reduce_dim>(
-                                input_dfb_id, scaler_dfb_id, tile_idx, 0, dst_idx);
+                                input_dfb_id, scaler_dfb_id, tile_idx, scaler_idx, dst_idx);
                         } else {  // PreloadedPolicy or PersistentPolicy: indexed access
                             uint32_t tile_idx = batch_offset + ht * stride + i;
                             reduce_tile<reduce_type, reduce_dim>(
-                                input_dfb_id, scaler_dfb_id, tile_idx, 0, dst_idx);
+                                input_dfb_id, scaler_dfb_id, tile_idx, scaler_idx, dst_idx);
                         }
                         ++dst_idx;
                     }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
@@ -100,6 +100,70 @@ template <
 FORCE_INLINE void calculate_and_prepare_reduce_scaler(
     uint32_t valid_reduce_dim_elements_in_tile = tt::constants::TILE_WIDTH);
 
+// =============================================================================
+// Partial-scaler convenience: emit a full + partial scaler tile pair
+//
+// When the reduce dimension is not tile-aligned, the compute kernel needs the
+// full scaler for all but the last reduce-dim iteration, and a partial scaler
+// (only `partial_positions` elements filled, the rest zeroed) for the last.
+//
+// These helpers emit two scaler tiles into the CB in that order:
+//   tile 0 → full scaler
+//   tile 1 → partial scaler
+//
+// Pair with compute_kernel_lib::ReducePartialScaler::last_tile_at(1) on the
+// compute side. REDUCE_SCALAR is not supported (scaler is applied twice).
+// =============================================================================
+
+/**
+ * @brief Emit two scaler tiles for non-tile-aligned reduce dimensions
+ *
+ * Writes a full-fill scaler tile followed by a partial-fill scaler tile to
+ * `cb_id`. Each tile is computed with the same caller-provided float scaler;
+ * only the number of valid positions differs.
+ *
+ * @tparam cb_id Circular buffer ID to write the tiles to (must be constexpr)
+ * @tparam pool_type Type of pooling operation (SUM, AVG, MAX)
+ * @tparam reduce_dim Reduction dimension. REDUCE_SCALAR is rejected at compile time.
+ * @tparam partial_positions Number of valid elements along the reduce axis in the
+ *         partial tile. Must be in [1, tile_dim - 1]; if you'd pass tile_dim use
+ *         prepare_reduce_scaler with the single-tile path instead.
+ * @tparam compute_uses_reduce_tile When true, forces row-0 fill (reduce LLK layout)
+ *         even for SUM/AVG + REDUCE_ROW combinations that would normally use col-0
+ *         fill (matmul layout). See prepare_reduce_scaler for full description.
+ * @param scaler_f Float scaler value to fill both tiles with
+ */
+template <
+    uint32_t cb_id,
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t partial_positions,
+    bool compute_uses_reduce_tile = false>
+FORCE_INLINE void prepare_partial_reduce_scalers(float scaler_f);
+
+/**
+ * @brief calculate-and-fill variant of prepare_partial_reduce_scalers
+ *
+ * Computes the standard reduce scaler from pool type, reduce dimension, and
+ * reduce factor (1/N for AVG REDUCE_ROW/REDUCE_COL; 1.0 for SUM/MAX), then
+ * emits the full + partial scaler tile pair via prepare_partial_reduce_scalers.
+ *
+ * @tparam cb_id Circular buffer ID
+ * @tparam pool_type Pool type
+ * @tparam reduce_dim Reduction dimension (REDUCE_SCALAR is rejected)
+ * @tparam partial_positions Valid elements in the partial tile, in [1, tile_dim - 1]
+ * @tparam reduce_factor Number of elements being reduced (used by AVG only)
+ * @tparam compute_uses_reduce_tile See prepare_reduce_scaler for description
+ */
+template <
+    uint32_t cb_id,
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t partial_positions,
+    uint32_t reduce_factor = SUM_AND_MAX_REDUCE_FACTOR,
+    bool compute_uses_reduce_tile = false>
+FORCE_INLINE void calculate_and_prepare_partial_reduce_scalers();
+
 }  // namespace dataflow_kernel_lib
 
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl"

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
@@ -340,4 +340,64 @@ FORCE_INLINE void calculate_and_prepare_reduce_scaler(uint32_t valid_reduce_dim_
     prepare_reduce_scaler<dfb_id, pool_type, reduce_dim, compute_uses_reduce_tile>(scaler_f, valid_reduce_dim_elements_in_tile);
 }
 
+// =============================================================================
+// Partial-scaler tile pair: full scaler followed by partial scaler
+// =============================================================================
+
+template <
+    uint32_t cb_id,
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t partial_positions,
+    bool compute_uses_reduce_tile>
+FORCE_INLINE void prepare_partial_reduce_scalers(float scaler_f) {
+    static_assert(
+        reduce_dim != ReduceDim::REDUCE_SCALAR,
+        "Partial scalers are not supported for REDUCE_SCALAR. "
+        "REDUCE_SCALAR applies the scaler twice (row then col) so a single partial tile cannot encode both axes.");
+
+    // Reduce-axis dim of the tile bound to cb_id.
+    constexpr uint32_t full_dim =
+        (reduce_dim == ReduceDim::REDUCE_COL) ? get_tile_r_dim<cb_id>() : get_tile_c_dim<cb_id>();
+    static_assert(
+        partial_positions > 0 && partial_positions < full_dim,
+        "partial_positions must be in [1, tile reduce-axis dim - 1]. "
+        "If the reduce dimension is tile-aligned, use prepare_reduce_scaler with "
+        "valid_reduce_dim_elements_in_tile = full_dim instead.");
+
+    // Tile 0: full fill (every position holds the scaler).
+    prepare_reduce_scaler<cb_id, pool_type, reduce_dim, compute_uses_reduce_tile>(scaler_f, full_dim);
+    // Tile 1: partial fill (only the first `partial_positions` of the reduce axis hold the scaler).
+    prepare_reduce_scaler<cb_id, pool_type, reduce_dim, compute_uses_reduce_tile>(scaler_f, partial_positions);
+}
+
+// =============================================================================
+// calculate-and-fill variant of prepare_partial_reduce_scalers
+// =============================================================================
+
+template <
+    uint32_t cb_id,
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    uint32_t partial_positions,
+    uint32_t reduce_factor,
+    bool compute_uses_reduce_tile>
+FORCE_INLINE void calculate_and_prepare_partial_reduce_scalers() {
+    static_assert(
+        reduce_dim != ReduceDim::REDUCE_SCALAR,
+        "Partial scalers are not supported for REDUCE_SCALAR.");
+
+    // Compute the standard reduce scaler value (1/N for AVG REDUCE_ROW/COL; 1.0 for SUM/MAX).
+    // REDUCE_SCALAR is rejected above, so the 1/sqrt(N) branch is unreachable here.
+    float scaler_f;
+    if constexpr (pool_type == PoolType::AVG) {
+        static_assert(reduce_factor > 0, "reduce_factor must be greater than 0");
+        scaler_f = 1.0f / static_cast<float>(reduce_factor);
+    } else {
+        scaler_f = 1.0f;
+    }
+
+    prepare_partial_reduce_scalers<cb_id, pool_type, reduce_dim, partial_positions, compute_uses_reduce_tile>(scaler_f);
+}
+
 }  // namespace dataflow_kernel_lib


### PR DESCRIPTION
## Summary

Adds the **partial-tile (non-tile-aligned) reduce** path to the `kernel_lib` reduce helpers on `main`. Cherry-pick of `b6c46deac6d` (provenance recorded via `-x`).

4 files changed, +189/−12. Scope limited to the reduce helpers — main's `accumulate_reduce` implementation is untouched and no new shared headers are introduced.

## What it adds

For reduce dimensions not a multiple of `TILE_DIM` (W % TILE_WIDTH != 0 for REDUCE_ROW, H % TILE_HEIGHT != 0 for REDUCE_COL):
- **Compute** (`reduce_helpers_compute.{hpp,inl}`): `struct ReducePartialScaler` (`none()` / `last_tile_at(idx=1)`) + a new trailing `ReducePartialScaler partial_scaler = none()` param on `reduce<>()`, defaulted so existing call sites are unaffected. The last reduce-axis iteration uses the partial scaler tile. `REDUCE_SCALAR` rejects partial scalers via runtime ASSERT.
- **Dataflow** (`reduce_helpers_dataflow.{hpp,inl}`): `prepare_partial_reduce_scalers<...>()` and `calculate_and_prepare_partial_reduce_scalers()` — emit the full + partial scaler-tile pair (tile 0 full, tile 1 partial).

## Deliberately NOT included
- **`accumulate_reduce<MAX, REDUCE_ROW>`** — already on `main` (implemented via the within-16x16-face transpose reload); not re-touched.
- **`common_types.hpp`** — `NoAccumulation`/`NoOp` stay inline in `reduce_helpers_compute.hpp` as on `main`. The `llk_helper_library` extraction into a shared header only pays off once `binary_op_helpers` (the other consumer) is also on `main`.

## Notes / why draft
- Device-side header-only helpers compiled into kernels at JIT/CI time — `build_metal.sh` does not exercise them. CI kernel builds + reduce unit tests are the real validation.
