### PR TITLE
[Bug fix] LLK perf test: pass `legacy_compat` template arg to `rsqrt_init`

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -110,7 +110,7 @@ void call_unary_sfpu_operation_init()
     }
     else if constexpr (OPERATION == SfpuType::rsqrt)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(rsqrt_init<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(rsqrt_init<APPROX_MODE, false /* legacy_compat */>);
     }
     else if constexpr (OPERATION == SfpuType::sqrt)
     {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #46182.

In `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h:113` the perf-test helper calls `rsqrt_init<APPROX_MODE>` with one template argument, but the L4 wrapper introduced by PR #45897 requires two:

```cpp
template <bool APPROXIMATION_MODE, bool legacy_compat>   // no default on legacy_compat
void rsqrt_init();
```

With `legacy_compat` undefaulted, `rsqrt_init<APPROX_MODE>` stays an unresolved function template and template-argument deduction fails when its address is passed to `llk_math_eltwise_unary_sfpu_init`, producing:

```
helpers/include/sfpu_operations.h:113:52: error: no matching function for call to
  'llk_math_eltwise_unary_sfpu_init<SfpuType::rsqrt>(<unresolved overloaded function type>)'
```

This broke every `mathop:Rsqrt` parametrization of `perf_eltwise_unary_sfpu.py::test_perf_eltwise_unary_sfpu` on both Wormhole and Blackhole — see scheduled run [#26995453028](https://github.com/tenstorrent/tt-metal/actions/runs/26995453028) (`llk_perf_wormhole group 1/5`, `llk_perf_blackhole group 1/5`, and the cascading `LLK perf summary` failure).

This PR pass `legacy_compat` explicitly, mirroring:
- the production wrapper `llk_math_eltwise_unary_sfpu_rsqrt.h:15`, which already calls `sfpu::rsqrt_init<APPROXIMATE, legacy_compat>` with both args, and
- the `calculate_rsqrt` call ~200 lines lower in this same file, which already passes `false /* legacy_compat */`.

### Notes for reviewers
- Diff is one line in `tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h`. Nothing else changes.
- Verified locally on Wormhole (n150): 852/852 variants of `perf_eltwise_unary_sfpu.py` pass `--compile-producer -n 10` (90.6s) and `--compile-consumer -n 10` (22.1s) green, with `gw0..gw9` evenly distributed across Tensix tiles.
- Optional follow-up (separate PR, intentionally **not** in this one to keep the fix minimal): give `rsqrt_init`'s `legacy_compat` a `= false` default in both `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h` and the matching Blackhole header, restoring symmetry with `sqrt_init` so this class of breakage cannot recur for any other (non-perf) caller.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_llk_sfpu_perf_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_llk_sfpu_perf_test)