### PR TITLE
ds_prefill :: Fix nightly experimental test failures (uint16 indices + moe_compute validation)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_reduce.py
@@ -72,7 +72,7 @@ class TtReduceModule(LightweightModule):
             weights: Optional gate weights.
                 Shape: [1, dispatch_group_size, seq_len, topk] or [..., topk, 1]
                 If provided, applies fused weighted sum: sum(weights * combine_output, dim=topk)
-            indices: Global expert IDs per token/slot, INT32.
+            indices: Global expert IDs per token/slot, UINT16.
                 Shape: [dispatch_group_size, seq_len, topk]
             expert_dispatch_table: Dispatch table mapping expert ID to chip ID, INT32.
                 Shape: [num_routed_experts] (sharded per dispatch group)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
@@ -52,9 +52,9 @@ def make_indices(num_tokens, num_experts, device):
     """Create indices tensor with random global expert IDs."""
     # Each token routes to num_experts random experts out of NUM_ROUTED_EXPERTS
     indices = torch.stack([torch.randperm(NUM_ROUTED_EXPERTS)[:num_experts] for _ in range(num_tokens)])
-    indices = indices.unsqueeze(0).to(torch.int32)  # [1, num_tokens, num_experts]
+    indices = indices.unsqueeze(0).to(torch.int16)  # [1, num_tokens, num_experts]
     return indices, ttnn.from_torch(
-        indices, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        indices, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.uint16, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
@@ -52,7 +52,7 @@ def make_indices(num_tokens, num_experts, device):
     """Create indices tensor with random global expert IDs."""
     # Each token routes to num_experts random experts out of NUM_ROUTED_EXPERTS
     indices = torch.stack([torch.randperm(NUM_ROUTED_EXPERTS)[:num_experts] for _ in range(num_tokens)])
-    indices = indices.unsqueeze(0).to(torch.int16)  # [1, num_tokens, num_experts]
+    indices = indices.unsqueeze(0).to(torch.uint16)  # [1, num_tokens, num_experts]
     return indices, ttnn.from_torch(
         indices, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.uint16, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -411,6 +411,12 @@ std::vector<ttnn::Tensor> moe_compute(
         "moe_compute: bh_ring_size={} is not supported (must be 8, 12, or 16)",
         ring_n);
 
+    TT_FATAL(
+        !(compute_only && cluster_axis.has_value()),
+        "moe_compute: compute_only=True is incompatible with cluster_axis (got cluster_axis={}). "
+        "compute_only skips the combine path, so cluster_axis has no meaning.",
+        cluster_axis.value_or(0));
+
     std::optional<ttnn::experimental::prim::SelectiveReduceCombineParams> combine_params;
     if (!compute_only) {
         // see #27196 for potential limitations


### PR DESCRIPTION
## Summary
  - Fix `test_deepseek_moe_post_combine_reduce` nightly tests to pass indices as `uint16` instead of `int32`, matching the kernel's dtype requirement added in  #45716                                                                                                                                                         
  - Update stale docstring in `tt_reduce.py` (INT32 -> UINT16)
  - Add missing TT_FATAL in moe_compute to explicitly reject compute_only=True with cluster_axis set. The test expected this validation but it was never implemented, causing a cryptic "Only L1 buffers can have an associated circular buffer" crash instead of a clear error message. Saw it failing after my fix and it looked straightforward to add 

before:
- [Failing `test_deepseek_moe_post_combine_reduce`](https://github.com/tenstorrent/tt-metal/actions/runs/26937615633/job/79512089938#step:6:58)
- [Failing moe_compute to explicitly reject compute_only=True with cluster_axis set](https://github.com/tenstorrent/tt-metal/actions/runs/27008205003/job/79708817612#step:6:2941)

after:
- [Passing ttnn nightly experimental tests P150b](https://github.com/tenstorrent/tt-metal/actions/runs/27011093239/job/79717172034)

Just a heads-up on this one, since it uncovered after my uint16 fix:

The P100 tests fail with - [`moe_compute: expected 12 matmul cores after padding (got 11)`](https://github.com/tenstorrent/tt-metal/actions/runs/27011093239/job/79717171870#step:6:2115)

>FAILED test_moe_compute_single_card.py::test_moe_compute_single_card_deepseek[...-bh_ring_size=12-...]
  >This is in moe_compute_program_factory.cpp:197 — it expects 12 matmul cores (bh_ring_size=12) but the P100 only has 11 available after the compute grid is laid out. The P100 has a smaller compute grid than P150b (likely a harvested row/column), so the bh_ring_size=12 parametrize config doesn't fit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/indices-uint16-nightly-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/indices-uint16-nightly-tests)