### PR TITLE
Fixing rexpert NaN outputs in tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -106,11 +106,17 @@ ttnn::Tensor unified_routed_expert_moe(
     // emb) tensor with rows starting at 0. The FFN kernel always reads/writes
     // from row 0 of its inputs; `ttnn::insert` handles placement into the
     // shared output at expert_region_offsets[global_expert_id].
-    auto expert_outputs = ttnn::empty(
+    // Zero-initialized (not ttnn::empty): only `insert` writes each expert's
+    // valid token rows, so padding rows — tile-aligned slack within a region,
+    // regions of zero-count experts, and the tail of the buffer — would
+    // otherwise keep uninitialized DRAM garbage (incl. NaN/Inf bit patterns).
+    // The torch reference zeros these, and a NaN in padding would corrupt any
+    // downstream masked reduction/combine, so the buffer is zeroed up front.
+    auto expert_outputs = ttnn::zeros(
         dispatched_buffer.logical_shape(),
         dispatched_buffer.dtype(),
         ttnn::TILE_LAYOUT,
-        dispatched_buffer.device(),
+        *dispatched_buffer.device(),
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM});
     for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
         auto tokens = ttnn::extract(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -112,11 +112,17 @@ ttnn::Tensor unified_routed_expert_moe(
     // otherwise keep uninitialized DRAM garbage (incl. NaN/Inf bit patterns).
     // The torch reference zeros these, and a NaN in padding would corrupt any
     // downstream masked reduction/combine, so the buffer is zeroed up front.
-    auto expert_outputs = ttnn::zeros(
-        dispatched_buffer.logical_shape(),
-        dispatched_buffer.dtype(),
-        ttnn::TILE_LAYOUT,
-        *dispatched_buffer.device(),
+    //
+    // zeros_like (not zeros): dispatched_buffer is a TILE device tensor in a
+    // device-fill-eligible dtype (bf8/bf16/fp32), so zeros_like takes the
+    // on-device ttnn::fill path — no host-side std::vector(volume) + H2D copy
+    // (which plain ttnn::zeros would incur for a large dispatch buffer) and no
+    // device-pointer deref here.
+    auto expert_outputs = ttnn::zeros_like(
+        dispatched_buffer,
+        /*dtype=*/std::nullopt,
+        /*layout=*/std::nullopt,
+        /*device=*/std::nullopt,
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM});
     for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
         auto tokens = ttnn::extract(


### PR DESCRIPTION
# Summary
Due to padding, `ttnn::empty` is not enough. Replaced with `ttnn::zeros_like`.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/rexpert_nan_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/rexpert_nan_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/rexpert_nan_fix)