### PR TITLE
Add query_op_constraints_with_initial_state (stateful op-constraint query)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_query_op_constraints_mock_device.cpp
@@ -45,6 +45,11 @@ protected:
         auto mesh_shape = mock_env_->get_system_mesh().shape();
         mock_device_ = mock_env_->create_mesh_device(distributed::MeshDeviceConfig(mesh_shape));
         ASSERT_GT(mock_device_->num_devices(), 0u);
+
+        // Constraint queries run ops in NORMAL mode, which enqueues a MeshWorkload. With the program
+        // cache enabled, a cached workload outlives the sub-devices it references and crashes at
+        // teardown (tenstorrent/tt-metal#45646).
+        mock_device_->disable_and_clear_program_cache();
     }
 
     void TearDown() override {
@@ -348,6 +353,147 @@ TEST_F(QueryOpConstraintsMockDevice, Matmul) {
     EXPECT_GT(query.resource_usage.peak_memory_usage_per_core, 0u);
     ASSERT_TRUE(query.output_tensor_specs.has_value());
     EXPECT_EQ(query.output_tensor_specs->size(), 1u);
+}
+
+// ============================================================================
+// query_op_constraints_with_initial_state — pure state-in / state-out variant
+// ============================================================================
+
+TEST_F(QueryOpConstraintsMockDevice, WithInitialStateReturnsResponseAndNewState) {
+    const auto input_spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+
+    // Start from an empty allocator state.
+    auto initial_state = experimental::extract_mock_allocator_state(*mock_device_);
+    ASSERT_TRUE(initial_state.is_empty(BufferType::L1));
+
+    auto out = ttnn::graph::query_op_constraints_with_initial_state(
+        [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); },
+        mock_device_.get(),
+        initial_state,
+        input_spec,
+        input_spec.tensor_layout().get_memory_config());
+
+    // The embedded response behaves exactly like the existing API.
+    EXPECT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out.response.error_message.value_or("none");
+    EXPECT_GT(out.response.resource_usage.l1_buffers_peak_per_core, 0u);
+    ASSERT_TRUE(out.response.output_tensor_specs.has_value());
+    EXPECT_EQ(out.response.output_tensor_specs->size(), 1u);
+
+    // new_state reflects the op output allocated on top of the (empty) initial state.
+    EXPECT_GT(out.new_state.total_allocated_size(BufferType::L1), 0u);
+}
+
+TEST_F(QueryOpConstraintsMockDevice, WithInitialStateThreadsStateAcrossOps) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty = experimental::extract_mock_allocator_state(*mock_device_);
+
+    // Op 1 from empty state.
+    auto out1 = ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty, spec, mem_cfg);
+    ASSERT_EQ(out1.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out1.response.error_message.value_or("none");
+    const auto after_op1 = out1.new_state.total_allocated_size(BufferType::L1);
+    EXPECT_GT(after_op1, 0u);
+
+    // Op 2 threaded on op1's output state: op1's output is still live, so op2's output
+    // is allocated on top of it — total occupancy strictly grows.
+    auto out2 =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), out1.new_state, spec, mem_cfg);
+    ASSERT_EQ(out2.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out2.response.error_message.value_or("none");
+    EXPECT_GT(out2.new_state.total_allocated_size(BufferType::L1), after_op1);
+}
+
+TEST_F(QueryOpConstraintsMockDevice, WithInitialStateIsPureAcrossCalls) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty = experimental::extract_mock_allocator_state(*mock_device_);
+
+    // Same initial_state + same op => same resulting occupancy, regardless of prior calls.
+    auto a = ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty, spec, mem_cfg);
+    auto b = ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty, spec, mem_cfg);
+    ASSERT_EQ(a.response.status, ttnn::graph::ExecutionStatus::Success);
+    ASSERT_EQ(b.response.status, ttnn::graph::ExecutionStatus::Success);
+    EXPECT_EQ(a.new_state.total_allocated_size(BufferType::L1), b.new_state.total_allocated_size(BufferType::L1));
+
+    // The caller's initial_state is not mutated.
+    EXPECT_TRUE(empty.is_empty(BufferType::L1));
+}
+
+TEST_F(QueryOpConstraintsMockDevice, OptionalStateNulloptRunsStatelessQuery) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    // std::nullopt => dispatch to the stateless query: same response as query_op_constraints,
+    // and an empty new_state (nothing was allocated against a supplied state).
+    auto out =
+        ttnn::graph::query_op_constraints_with_optional_state(relu, mock_device_.get(), std::nullopt, spec, mem_cfg);
+
+    ASSERT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Success)
+        << "Error: " << out.response.error_message.value_or("none");
+    EXPECT_GT(out.response.resource_usage.l1_buffers_peak_per_core, 0u);
+    ASSERT_TRUE(out.response.output_tensor_specs.has_value());
+    EXPECT_EQ(out.response.output_tensor_specs->size(), 1u);
+    EXPECT_TRUE(out.new_state.is_empty(BufferType::L1));
+
+    // The embedded response matches the default stateless API for the same op.
+    auto baseline = ttnn::graph::query_op_constraints(relu, mock_device_.get(), spec, mem_cfg);
+    ASSERT_EQ(baseline.status, ttnn::graph::ExecutionStatus::Success);
+    EXPECT_EQ(out.response.resource_usage.l1_buffers_peak_per_core, baseline.resource_usage.l1_buffers_peak_per_core);
+    EXPECT_EQ(
+        out.response.resource_usage.peak_memory_usage_per_core, baseline.resource_usage.peak_memory_usage_per_core);
+}
+
+TEST_F(QueryOpConstraintsMockDevice, OptionalStateWithValueMatchesStatefulCore) {
+    const auto spec = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 64, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+    const auto mem_cfg = spec.tensor_layout().get_memory_config();
+
+    auto empty = experimental::extract_mock_allocator_state(*mock_device_);
+
+    // With a state present, the dispatcher delegates to the stateful core: same resulting occupancy.
+    auto via_core =
+        ttnn::graph::query_op_constraints_with_initial_state(relu, mock_device_.get(), empty, spec, mem_cfg);
+    auto via_dispatch = ttnn::graph::query_op_constraints_with_optional_state(
+        relu, mock_device_.get(), std::optional<experimental::MockAllocatorState>(empty), spec, mem_cfg);
+
+    ASSERT_EQ(via_core.response.status, ttnn::graph::ExecutionStatus::Success);
+    ASSERT_EQ(via_dispatch.response.status, ttnn::graph::ExecutionStatus::Success);
+    EXPECT_GT(via_dispatch.new_state.total_allocated_size(BufferType::L1), 0u);
+    EXPECT_EQ(
+        via_dispatch.new_state.total_allocated_size(BufferType::L1),
+        via_core.new_state.total_allocated_size(BufferType::L1));
+}
+
+TEST_F(QueryOpConstraintsMockDevice, WithInitialStateReportsOomAsError) {
+    // An L1 output far larger than total L1 cannot be allocated in Phase 2 -> Error.
+    const auto huge = ttnn::TensorSpec(
+        ttnn::Shape(Array4D{1, 1, 16384, 16384}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), ttnn::L1_MEMORY_CONFIG));
+    auto relu = [](auto&&... args) { return ttnn::relu(std::forward<decltype(args)>(args)...); };
+
+    auto empty = experimental::extract_mock_allocator_state(*mock_device_);
+    auto out = ttnn::graph::query_op_constraints_with_initial_state(
+        relu, mock_device_.get(), empty, huge, huge.tensor_layout().get_memory_config());
+
+    EXPECT_EQ(out.response.status, ttnn::graph::ExecutionStatus::Error);
+    EXPECT_TRUE(out.response.error_message.has_value());
 }
 
 // ============================================================================

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -18,6 +19,7 @@
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/experimental/mock_device/mock_allocator.hpp>
 #include <ttnn/distributed/tensor_topology.hpp>
 
 namespace ttnn::graph {
@@ -87,6 +89,41 @@ inline std::vector<Tensor> extract_output_tensors(const std::variant<Ts...>& res
     return tensors;
 }
 
+// Transform a query argument into the value passed to the op: TensorSpec/DistributedTensorSpec
+// (and their optional/vector forms) become device tensors via create_device_tensor; a MeshDevice
+// is wrapped in a reference_wrapper; everything else is forwarded unchanged.
+template <typename Arg>
+auto materialize_arg(tt::tt_metal::distributed::MeshDevice* device, Arg&& arg) {
+    if constexpr (std::is_same_v<std::decay_t<Arg>, DistributedTensorSpec>) {
+        return create_device_tensor(arg.tensor_spec, device, arg.tensor_topology);
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, std::optional<DistributedTensorSpec>>) {
+        return arg ? std::optional<Tensor>(create_device_tensor(arg->tensor_spec, device, arg->tensor_topology))
+                   : std::nullopt;
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, std::vector<DistributedTensorSpec>>) {
+        std::vector<Tensor> result(arg.size());
+        std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {
+            return create_device_tensor(item.tensor_spec, device, item.tensor_topology);
+        });
+        return result;
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, TensorSpec>) {
+        return create_device_tensor(arg, device);
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, std::optional<TensorSpec>>) {
+        return arg ? std::optional<Tensor>(create_device_tensor(*arg, device)) : std::nullopt;
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, std::vector<TensorSpec>>) {
+        std::vector<Tensor> result(arg.size());
+        std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {
+            return create_device_tensor(item, device);
+        });
+        return result;
+    } else if constexpr (std::is_same_v<std::decay_t<Arg>, tt::tt_metal::distributed::MeshDevice>) {
+        // MeshDevice is non-copyable; wrap in reference_wrapper so make_tuple can store it.
+        // reference_wrapper<MeshDevice> implicitly converts to MeshDevice& at the call site.
+        return std::ref(arg);
+    } else {
+        return std::forward<Arg>(arg);
+    }
+}
+
 }  // namespace detail
 
 struct ResourceUsage {
@@ -102,6 +139,53 @@ struct ConstraintQueryResponse {
     std::optional<std::vector<TensorSpec>> output_tensor_specs;
     std::optional<std::string> error_message;
 };
+
+// Result of the pure, state-threading query. `new_state` is the allocator state
+// after the op's outputs are allocated on top of the caller-supplied initial state.
+struct QueryOutput {
+    ConstraintQueryResponse response;
+    tt::tt_metal::experimental::MockAllocatorState new_state;
+};
+
+namespace detail {
+
+// Build a success response from the captured op trace and its output tensors.
+inline ConstraintQueryResponse build_success_response(
+    const nlohmann::json& op_trace, const std::vector<Tensor>& outputs) {
+    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
+        extract_resource_usage_per_core(op_trace);
+
+    size_t l1_output_buffer_per_core = 0;
+    for (const auto& output : outputs) {
+        if (!output.buffer()->is_dram()) {
+            l1_output_buffer_per_core += extract_l1_output_buffer_allocation_size_per_core(output);
+        }
+    }
+
+    std::vector<TensorSpec> output_specs;
+    output_specs.reserve(outputs.size());
+    std::transform(outputs.begin(), outputs.end(), std::back_inserter(output_specs), [](const Tensor& t) {
+        return t.tensor_spec();
+    });
+
+    return ConstraintQueryResponse{
+        ExecutionStatus::Success,
+        {cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core, l1_output_buffer_per_core},
+        std::make_optional(std::move(output_specs))};
+}
+
+inline ConstraintQueryResponse error_response(const std::string& message) {
+    return ConstraintQueryResponse{
+        ExecutionStatus::Error,
+        {.cb_peak_size_per_core = 0,
+         .l1_buffers_peak_per_core = 0,
+         .peak_memory_usage_per_core = 0,
+         .l1_output_buffer_per_core = 0},
+        /* output_tensor_specs= */ std::nullopt,
+        message};
+}
+
+}  // namespace detail
 
 /**
  * @brief Captures the graph operations and extracts resource usage constraints.
@@ -126,39 +210,7 @@ auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, 
     // outer graph capture is to avoid dispatching/allocating dummy input tensors
     {
         auto capture_outer = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
-
-        // helper lambda to transform TensorSpec/DistributedTensorSpec to DeviceTensor
-        auto transform_arg = [device](auto&& arg) {
-            if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, DistributedTensorSpec>) {
-                return create_device_tensor(arg.tensor_spec, device, arg.tensor_topology);
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::optional<DistributedTensorSpec>>) {
-                return arg ? std::optional<Tensor>(create_device_tensor(arg->tensor_spec, device, arg->tensor_topology))
-                           : std::nullopt;
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::vector<DistributedTensorSpec>>) {
-                std::vector<Tensor> result(arg.size());
-                std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {
-                    return create_device_tensor(item.tensor_spec, device, item.tensor_topology);
-                });
-                return result;
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, TensorSpec>) {
-                return create_device_tensor(arg, device);
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::optional<TensorSpec>>) {
-                return arg ? std::optional<Tensor>(create_device_tensor(*arg, device)) : std::nullopt;
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, std::vector<TensorSpec>>) {
-                std::vector<Tensor> result(arg.size());
-                std::transform(arg.begin(), arg.end(), result.begin(), [device](auto&& item) {
-                    return create_device_tensor(item, device);
-                });
-                return result;
-            } else if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, tt::tt_metal::distributed::MeshDevice>) {
-                // MeshDevice is non-copyable; wrap in reference_wrapper so make_tuple can store it.
-                // reference_wrapper<MeshDevice> implicitly converts to MeshDevice& at the call site.
-                return std::ref(arg);
-            } else {
-                return std::forward<decltype(arg)>(arg);
-            }
-        };
-        auto transformed_args = std::make_tuple(transform_arg(std::forward<Args>(args))...);
+        auto transformed_args = std::make_tuple(detail::materialize_arg(device, std::forward<Args>(args))...);
 
         // inner graph capture is to capture the actual op graph trace
         try {
@@ -167,39 +219,112 @@ auto query_op_constraints(Op op, tt::tt_metal::distributed::MeshDevice* device, 
         }  // end of inner graph capture
         catch (const std::exception& e) {
             log_debug(tt::LogOp, "Error during graph capture: {}", e.what());
-            return ConstraintQueryResponse{
-                ExecutionStatus::Error,
-                {.cb_peak_size_per_core = 0,
-                 .l1_buffers_peak_per_core = 0,
-                 .peak_memory_usage_per_core = 0,
-                 .l1_output_buffer_per_core = 0},
-                /* output_tensor_specs= */ std::nullopt,
-                e.what()};
+            return detail::error_response(e.what());
         }
         op_trace = capture_outer.end_graph_capture();
     }  // end of outer graph capture
 
-    // extract memory footprint from the trace
-    const auto& [cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core] =
-        extract_resource_usage_per_core(op_trace);
+    return detail::build_success_response(op_trace, outputs);
+}
 
-    size_t l1_output_buffer_per_core = 0;
-    for (const auto& output : outputs) {
-        if (!output.buffer()->is_dram()) {
-            l1_output_buffer_per_core += extract_l1_output_buffer_allocation_size_per_core(output);
-        }
+/**
+ * @brief Pure, state-threading variant of query_op_constraints.
+ *
+ * The caller supplies an opaque allocator state (`initial_state`); `QueryOutput::new_state` is the
+ * allocator state after the op runs on top of it. Nothing is retained between calls — advancing is
+ * `state = result.new_state`.
+ *
+ * This is the always-stateful core. Callers that may or may not have a state to thread (e.g. a
+ * single op-model entry serving both stateless and stateful queries) should call
+ * `query_op_constraints_with_optional_state`, which dispatches on the optional.
+ *
+ * Mechanism (two *sequential*, non-nested graph captures):
+ *   - Phase 1 (NO_DISPATCH): materialize the input tensors as weightless handles (address=0,
+ *     allocator untouched). Their real footprint is already encoded in `initial_state`, so they must
+ *     not be allocated again here — doing so would double-count and risk a false OOM.
+ *   - Phase 2 (NORMAL, outermost capture): run the op for real. A fresh capture installs the global
+ *     allocation hook with block=false, so the op's outputs (and transiently its intermediates) are
+ *     allocated through the MockAllocator on top of `initial_state`, reproducing real placement and
+ *     fragmentation. `new_state` is snapshotted while the outputs are still alive.
+ *
+ * The captures must be sequential, not nested: the allocation block flag is set once by the
+ * outermost capture, so a NORMAL capture nested inside a NO_DISPATCH one would stay blocked.
+ *
+ * If the op cannot fit (allocation throws), the result is `ExecutionStatus::Error`.
+ *
+ * Requires `device` to be a mock/planning device whose allocator is a MockAllocator. `move` and
+ * `reallocate` are unsupported as direct query targets (they branch on input buffer addresses,
+ * which are 0 for the weightless inputs).
+ *
+ * @tparam Op The type of the operation that will be invoked to capture the graph operations.
+ * @tparam Args The types of the arguments that will be passed to the operation.
+ * @param op The operation that will be invoked to capture the graph operations.
+ * @param device A pointer to a mock MeshDevice used for planning.
+ * @param initial_state The caller-owned allocator state to evaluate the op against.
+ * @param args The arguments that will be passed to the operation.
+ * @return QueryOutput { response, new_state }.
+ */
+template <typename Op, typename... Args>
+QueryOutput query_op_constraints_with_initial_state(
+    Op op,
+    tt::tt_metal::distributed::MeshDevice* device,
+    const tt::tt_metal::experimental::MockAllocatorState& initial_state,
+    Args&&... args) {
+    detail::LogLevelGuard log_guard(spdlog::level::level_enum::off);
+
+    // A stateful query requires a mock device whose allocator supports checkpoint/restore.
+    // override_mock_allocator_state TT_FATALs on a non-mock device; since this is a public API,
+    // surface the misconfiguration as an Error rather than aborting the process.
+    if (tt::tt_metal::experimental::get_mock_allocator(*device) == nullptr) {
+        return QueryOutput{
+            detail::error_response("query_op_constraints_with_initial_state requires a mock device"),
+            tt::tt_metal::experimental::MockAllocatorState{}};
     }
 
-    std::vector<TensorSpec> output_specs;
-    output_specs.reserve(outputs.size());
-    std::transform(outputs.begin(), outputs.end(), std::back_inserter(output_specs), [](const Tensor& t) {
-        return t.tensor_spec();
-    });
+    // Precondition: the caller must run with the device's program cache disabled. Phase 2 enqueues a
+    // real MeshWorkload; a cached workload outlives the sub-devices it references and crashes at
+    // device teardown (tenstorrent/tt-metal#45646).
+    tt::tt_metal::experimental::override_mock_allocator_state(*device, initial_state);
 
-    return ConstraintQueryResponse{
-        ExecutionStatus::Success,
-        {cb_peak_size_per_core, l1_buffers_peak_per_core, peak_memory_usage_per_core, l1_output_buffer_per_core},
-        std::make_optional(std::move(output_specs))};
+    // Phase 1: materialize inputs as weightless handles (address=0, allocator untouched).
+    auto transformed_args = [&] {
+        auto phase1 = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
+        return std::make_tuple(detail::materialize_arg(device, std::forward<Args>(args))...);
+    }();  // phase1 capture ends here -> global hook removed
+
+    // Phase 2: run the op under the outermost NORMAL capture so outputs are allocated for real.
+    auto phase2 = ScopedGraphCapture(GraphProcessor::RunMode::NORMAL);
+    try {
+        auto outputs = detail::extract_output_tensors(detail::invoke_op(op, transformed_args));
+        auto op_trace = phase2.end_graph_capture();
+        // Snapshot while the output buffers are alive (after they are allocated, before they drop).
+        auto new_state = tt::tt_metal::experimental::extract_mock_allocator_state(*device);
+        return QueryOutput{detail::build_success_response(op_trace, outputs), std::move(new_state)};
+    } catch (const std::exception& e) {
+        log_debug(tt::LogOp, "Error during stateful graph capture: {}", e.what());
+        return QueryOutput{
+            detail::error_response(e.what()), tt::tt_metal::experimental::extract_mock_allocator_state(*device)};
+    }
+}
+
+/**
+ * @brief Optional-state dispatcher giving callers a single call shape: std::nullopt runs the
+ * stateless `query_op_constraints` (empty `new_state`); a value delegates to
+ * `query_op_constraints_with_initial_state`.
+ */
+template <typename Op, typename... Args>
+QueryOutput query_op_constraints_with_optional_state(
+    Op op,
+    tt::tt_metal::distributed::MeshDevice* device,
+    const std::optional<tt::tt_metal::experimental::MockAllocatorState>& initial_state,
+    Args&&... args) {
+    if (initial_state.has_value()) {
+        return query_op_constraints_with_initial_state(op, device, *initial_state, std::forward<Args>(args)...);
+    }
+    // query_op_constraints manages its own log level, so no guard is needed here.
+    return QueryOutput{
+        query_op_constraints(op, device, std::forward<Args>(args)...),
+        tt::tt_metal::experimental::MockAllocatorState{}};
 }
 
 }  // namespace ttnn::graph


### PR DESCRIPTION
Adds `query_op_constraints_with_initial_state`, a state-in / state-out variant of `query_op_constraints` for the tt-mlir L1-planning use case: the caller passes an opaque `MockAllocatorState` and gets back `{response, new_state}`, where `new_state` reflects the op's outputs placed by the real allocator on top of the supplied state (faithful occupancy/fragmentation, not a transient peak).

**Mechanism** — two sequential (non-nested) graph captures:
- Phase 1 (NO_DISPATCH): materialize inputs as weightless handles (address 0, allocator untouched) — their footprint is already in `initial_state`.
- Phase 2 (NORMAL): run the op for real so outputs/intermediates allocate through the MockAllocator; snapshot state while outputs are alive. OOM → `Error`.

Also adds `query_op_constraints_with_optional_state`, a thin dispatcher over `std::optional<MockAllocatorState>` (nullopt → stateless query with empty `new_state`; value → stateful core), so a single caller (tt-mlir's op model) can use one call shape for both stateless and stateful queries.

The default `query_op_constraints` is behavior-preserved.

**Caveat:** caller must run with the program cache disabled to avoid a MeshWorkload teardown use-after-free on mock devices (#45646).

**Tests:** response+new_state, cross-op state threading/accumulation, purity across calls, OOM → Error, and the optional-state dispatcher (nullopt → stateless, value → stateful core).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/query-op-constraints-with-initial-state)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/query-op-constraints-with-initial-state)