### PR TITLE
Quasar Test Only - Int8 Matmul Testing 

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1250,6 +1250,18 @@ class MatmulGolden(FidelityMasking):
                 dest_acc,
             )
 
+        if data_format.is_integer():
+            return self._matmul_integer(
+                operand1,
+                operand2,
+                data_format,
+                input_A_dimensions,
+                input_B_dimensions,
+                tilize,
+                input_A_format=input_A_format,
+                input_B_format=input_B_format,
+            )
+
         return self._matmul_default(
             operand1,
             operand2,
@@ -1261,6 +1273,42 @@ class MatmulGolden(FidelityMasking):
             input_A_format,
             input_B_format,
         )
+
+    def _matmul_integer(
+        self,
+        operand1,
+        operand2,
+        data_format,
+        input_A_dimensions,
+        input_B_dimensions,
+        tilize: bool,
+        input_A_format: DataFormat = None,
+        input_B_format: DataFormat = None,
+    ):
+        torch_format = format_dict[data_format]
+        operand_a_format = input_A_format or data_format
+        operand_b_format = input_B_format or data_format
+
+        M, K1, K2, N, _ = self._resolve_matmul_dimensions(
+            input_A_dimensions, input_B_dimensions
+        )
+
+        t1 = to_tensor(operand1, operand_a_format).view(M, K1)
+        t2 = to_tensor(operand2, operand_b_format).view(K2, N)
+
+        res = saturate_integer(
+            torch.matmul(t1.to(torch.int64), t2.to(torch.int64)).view(M * N),
+            data_format,
+            torch_format,
+        )
+
+        if tilize:
+            res = tilize_block(
+                res,
+                dimensions=(input_A_dimensions[0], input_B_dimensions[1]),
+                stimuli_format=data_format,
+            ).flatten()
+        return res
 
     def _matmul_default(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1258,8 +1258,8 @@ class MatmulGolden(FidelityMasking):
                 input_A_dimensions,
                 input_B_dimensions,
                 tilize,
-                input_A_format=input_A_format,
-                input_B_format=input_B_format,
+                input_A_format,
+                input_B_format,
             )
 
         return self._matmul_default(
@@ -1286,8 +1286,8 @@ class MatmulGolden(FidelityMasking):
         input_B_format: DataFormat = None,
     ):
         torch_format = format_dict[data_format]
-        operand_a_format = input_A_format or data_format
-        operand_b_format = input_B_format or data_format
+        operand_a_format = input_A_format
+        operand_b_format = input_B_format
 
         M, K1, K2, N, _ = self._resolve_matmul_dimensions(
             input_A_dimensions, input_B_dimensions

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1274,6 +1274,7 @@ class MatmulGolden(FidelityMasking):
             input_B_format,
         )
 
+    # Integer matmul is LoFi-only on Quasar.
     def _matmul_integer(
         self,
         operand1,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1286,15 +1286,13 @@ class MatmulGolden(FidelityMasking):
         input_B_format: DataFormat = None,
     ):
         torch_format = format_dict[data_format]
-        operand_a_format = input_A_format
-        operand_b_format = input_B_format
 
         M, K1, K2, N, _ = self._resolve_matmul_dimensions(
             input_A_dimensions, input_B_dimensions
         )
 
-        t1 = to_tensor(operand1, operand_a_format).view(M, K1)
-        t2 = to_tensor(operand2, operand_b_format).view(K2, N)
+        t1 = to_tensor(operand1, input_A_format).view(M, K1)
+        t2 = to_tensor(operand2, input_B_format).view(K2, N)
 
         res = saturate_integer(
             torch.matmul(t1.to(torch.int64), t2.to(torch.int64)).view(M * N),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -23,7 +23,6 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.matmul_sweep import generate_tile_dims
-from helpers.pack import pack_int8
 from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
     input_output_formats,
@@ -44,7 +43,6 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_FACES,
 )
 from helpers.tilize_untilize import tilize_block, untilize_block
-from helpers.unpack import unpack_int8
 from helpers.utils import passed_test
 
 kt_dims = [1, 2, 4]
@@ -84,17 +82,6 @@ MATMUL_FORMAT = input_output_formats(
         DataFormat.MxInt2,
     ],
 ) + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)]
-
-
-def _int8_operands_after_l1_pack(tilized, dimensions):
-    """Round-trip tilized Int8 through sign-magnitude pack/unpack (same as L1 write)."""
-    packed = pack_int8(tilized)
-    unpacked = torch.tensor(unpack_int8(list(packed)), dtype=torch.int8)
-    return untilize_block(
-        unpacked,
-        dimensions=dimensions,
-        stimuli_format=DataFormat.Int8,
-    )
 
 _ARCH = get_chip_architecture()
 
@@ -181,10 +168,7 @@ def test_matmul(
 
     src_A_golden = src_A
     src_B_golden = src_B
-    if format.input_format == DataFormat.Int8:
-        src_A_golden = _int8_operands_after_l1_pack(tilized_A, input_A_dimensions)
-        src_B_golden = _int8_operands_after_l1_pack(tilized_B, input_B_dimensions)
-    elif format.input_format.is_mx_format():
+    if format.input_format.is_mx_format():
         tilized_A_golden = quantize_mx_tensor_chunked(
             tilized_A.flatten().to(torch.bfloat16), format.input_format
         ).reshape(tilized_A.shape)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -23,7 +23,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.matmul_sweep import generate_tile_dims
-from helpers.pack import pack_int8, pack_int32
+from helpers.pack import pack_int8
 from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
     input_output_formats,
@@ -44,7 +44,7 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_FACES,
 )
 from helpers.tilize_untilize import tilize_block, untilize_block
-from helpers.unpack import unpack_int8, unpack_int32
+from helpers.unpack import unpack_int8
 from helpers.utils import passed_test
 
 kt_dims = [1, 2, 4]
@@ -302,10 +302,6 @@ def test_matmul(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    if format.output_format == DataFormat.Int32:
-        golden_tensor = torch.tensor(
-            unpack_int32(list(pack_int32(golden_tensor))), dtype=torch_format
-        )
     # For MX outputs, model the packer: quantize the golden onto the MX lattice (from the
     # math/pack_src format the result was produced in) so the comparison validates the
     # device's MX output quantization, not just matmul-math-to-MX-precision. The lattice-

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -67,6 +67,7 @@ def matmul_dimensions_dest_sync(dest_acc_modes):
         for kt_dim in kt_dims
     ]
 
+
 # Generate format-aware combinations. MxFp4 is an input-only (L1) format here: the
 # unpacker produces MxFp4_2x_A/B in the src registers, so drop the cross-product
 # entries where MxFp4 would land as an output.

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.data_format_inference import data_formats
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
     TILE_DIM,
     MatmulGolden,
@@ -23,6 +23,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.matmul_sweep import generate_tile_dims
+from helpers.pack import pack_int8, pack_int32
 from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
     input_output_formats,
@@ -43,26 +44,30 @@ from helpers.test_variant_parameters import (
     UNPACK_TRANS_FACES,
 )
 from helpers.tilize_untilize import tilize_block, untilize_block
+from helpers.unpack import unpack_int8, unpack_int32
 from helpers.utils import passed_test
 
 kt_dims = [1, 2, 4]
-matmul_dimensions_dest_sync = [
-    (
-        [mt_dim * TILE_DIM, kt_dim * TILE_DIM],
-        [kt_dim * TILE_DIM, nt_dim * TILE_DIM],
-        dest_acc,
-        dest_sync,
-    )
-    for dest_sync in (DestSync.Half, DestSync.Full)
-    for dest_acc in (DestAccumulation.Yes, DestAccumulation.No)
-    for max_tiles in (
-        DEST_SYNC_TILE_LIMITS[dest_sync]
-        // (2 if dest_acc == DestAccumulation.Yes else 1),
-    )
-    for mt_dim in range(1, max_tiles + 1)
-    for nt_dim in range(1, max_tiles // mt_dim + 1)
-    for kt_dim in kt_dims
-]
+
+
+def matmul_dimensions_dest_sync(dest_acc_modes):
+    return [
+        (
+            [mt_dim * TILE_DIM, kt_dim * TILE_DIM],
+            [kt_dim * TILE_DIM, nt_dim * TILE_DIM],
+            dest_acc,
+            dest_sync,
+        )
+        for dest_sync in (DestSync.Half, DestSync.Full)
+        for dest_acc in dest_acc_modes
+        for max_tiles in (
+            DEST_SYNC_TILE_LIMITS[dest_sync]
+            // (2 if dest_acc == DestAccumulation.Yes else 1),
+        )
+        for mt_dim in range(1, max_tiles + 1)
+        for nt_dim in range(1, max_tiles // mt_dim + 1)
+        for kt_dim in kt_dims
+    ]
 
 # Generate format-aware combinations. MxFp4 is an input-only (L1) format here: the
 # unpacker produces MxFp4_2x_A/B in the src registers, so drop the cross-product
@@ -78,21 +83,40 @@ MATMUL_FORMAT = input_output_formats(
         DataFormat.MxInt4,
         DataFormat.MxInt2,
     ],
-)
+) + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)]
+
+
+def _int8_operands_after_l1_pack(tilized, dimensions):
+    """Round-trip tilized Int8 through sign-magnitude pack/unpack (same as L1 write)."""
+    packed = pack_int8(tilized)
+    unpacked = torch.tensor(unpack_int8(list(packed)), dtype=torch.int8)
+    return untilize_block(
+        unpacked,
+        dimensions=dimensions,
+        stimuli_format=DataFormat.Int8,
+    )
 
 _ARCH = get_chip_architecture()
 
 
 @pytest.mark.quasar
 @parametrize(
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
-    dimensions_dest_acc_dest_sync=matmul_dimensions_dest_sync,
     format=MATMUL_FORMAT,
+    math_fidelity=lambda format: (
+        [MathFidelity.LoFi]
+        if format.input_format == DataFormat.Int8
+        else [
+            MathFidelity.LoFi,
+            MathFidelity.HiFi2,
+            MathFidelity.HiFi3,
+            MathFidelity.HiFi4,
+        ]
+    ),
+    dimensions_dest_acc_dest_sync=lambda format: (
+        matmul_dimensions_dest_sync((DestAccumulation.Yes,))
+        if format.input_format == DataFormat.Int8
+        else matmul_dimensions_dest_sync((DestAccumulation.Yes, DestAccumulation.No))
+    ),
     implied_math_format=lambda format: (
         [ImpliedMathFormat.Yes]
         if format.input_format.is_mx_format()
@@ -134,14 +158,17 @@ def test_matmul(
 
     torch_format = format_dict[format.output_format]
 
-    sfpu_false_spec = StimuliSpec.uniform(low=0.0, high=1.0)
+    if format.input_format == DataFormat.Int8:
+        stimuli_spec = StimuliSpec.uniform(low=-127.0, high=127.0)
+    else:
+        stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=format.input_format,
         input_dimensions_A=input_A_dimensions,
         stimuli_format_B=format.input_format,
         input_dimensions_B=input_B_dimensions,
-        spec_A=sfpu_false_spec,
-        spec_B=sfpu_false_spec,
+        spec_A=stimuli_spec,
+        spec_B=stimuli_spec,
         output_format=format.output_format,
     )
 
@@ -154,7 +181,10 @@ def test_matmul(
 
     src_A_golden = src_A
     src_B_golden = src_B
-    if format.input_format.is_mx_format():
+    if format.input_format == DataFormat.Int8:
+        src_A_golden = _int8_operands_after_l1_pack(tilized_A, input_A_dimensions)
+        src_B_golden = _int8_operands_after_l1_pack(tilized_B, input_B_dimensions)
+    elif format.input_format.is_mx_format():
         tilized_A_golden = quantize_mx_tensor_chunked(
             tilized_A.flatten().to(torch.bfloat16), format.input_format
         ).reshape(tilized_A.shape)
@@ -272,6 +302,10 @@ def test_matmul(
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
+    if format.output_format == DataFormat.Int32:
+        golden_tensor = torch.tensor(
+            unpack_int32(list(pack_int32(golden_tensor))), dtype=torch_format
+        )
     # For MX outputs, model the packer: quantize the golden onto the MX lattice (from the
     # math/pack_src format the result was produced in) so the comparison validates the
     # device's MX output quantization, not just matmul-math-to-MX-precision. The lattice-

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -89,6 +89,7 @@ _ARCH = get_chip_architecture()
 @pytest.mark.quasar
 @parametrize(
     format=MATMUL_FORMAT,
+    # Integer matmul is LoFi-only on Quasar.
     math_fidelity=lambda format: (
         [MathFidelity.LoFi]
         if format.input_format == DataFormat.Int8

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -86,8 +86,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false>(
-        static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.math));
+  
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    if (pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+    }
+    
     // ENABLE_2X_FORMAT enables the 2x-packed FP4 matmul path (8 MVMULs per tile vs 16, K-dim
     // halved per MVMUL via the SrcA 2x sub-datum expansion). Set when SrcA/SrcB are
     // configured as MxFp4_2x_A or MxFp4_2x_B.

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -96,7 +96,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
     }
-    
     // ENABLE_2X_FORMAT enables the 2x-packed FP4 matmul path (8 MVMULs per tile vs 16, K-dim
     // halved per MVMUL via the SrcA 2x sub-datum expansion). Set when SrcA/SrcB are
     // configured as MxFp4_2x_A or MxFp4_2x_B.

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -86,7 +86,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-  
     DataFormat math_format     = static_cast<DataFormat>(formats.math);
     DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
     if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -89,7 +89,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
   
     DataFormat math_format     = static_cast<DataFormat>(formats.math);
     DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (pack_src_format == DataFormat::Int32)
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
     {
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
     }


### PR DESCRIPTION
### PR Category
Test only 

### Summary
Relates to #45777 
Extends `test_matmul_quasar.py` with an `Int8 → Int32` format case
Int8 cases are constrained to `DestAccumulation.Yes` and `MathFidelity.LoFi`

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/int8-testing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/int8-testing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/int8-testing)