### PR TITLE
Fix ring-joint MLA SDPA TRISC0 stack overflow

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -75,6 +75,59 @@ struct RingAccumulatorState {
     AccumulatorHalf prev, cur;
 };
 
+// Ring-streaming lightweight-mask context. Field NAMES match LightweightMaskContext so sdpa_ring_v2's
+// generic `lw_mask.<field>` reads work for either type, BUT the 9 compile-time-constant fields are
+// template params (static constexpr → zero per-instance storage), leaving only the 3 per-ring-iter
+// runtime fields on the stack. Shrinks the live lw_mask object ~48 B → ~12 B on kernel_main's frame.
+// Only the ring_joint_sdpa producer uses it; exp_ring keeps the plain LightweightMaskContext —
+// sdpa_ring_v2's MaskCtx template param is deduced per caller.
+template <
+    uint32_t NeginfTileIdx,
+    uint32_t CausalDiagTileIdx,
+    uint32_t LocalNPaddedTiles,
+    uint32_t JointNPaddedTiles,
+    uint32_t GlobalNPartialCol,
+    uint32_t JointLPartialCol,
+    uint32_t GlobalNPartialTileIdx,
+    uint32_t JointLPartialTileIdx,
+    uint32_t StraddleMaskChunkId>
+struct RingStreamingMaskCtx {
+    // Per-ring-iter runtime fields (the only ones needing stack storage):
+    bool is_causal = false;
+    uint32_t global_n_padded_tiles = 0;
+    uint32_t straddle_num_padded_tiles = 0;
+    // Compile-time-constant fields (no per-instance storage):
+    static constexpr uint32_t neginf_tile_idx = NeginfTileIdx;
+    static constexpr uint32_t causal_diag_tile_idx = CausalDiagTileIdx;
+    static constexpr uint32_t local_n_padded_tiles = LocalNPaddedTiles;
+    static constexpr uint32_t joint_n_padded_tiles = JointNPaddedTiles;
+    static constexpr uint32_t global_n_partial_col = GlobalNPartialCol;
+    static constexpr uint32_t joint_l_partial_col = JointLPartialCol;
+    static constexpr uint32_t global_n_partial_tile_idx = GlobalNPartialTileIdx;
+    static constexpr uint32_t joint_l_partial_tile_idx = JointLPartialTileIdx;
+    static constexpr uint32_t straddle_mask_chunk_id = StraddleMaskChunkId;
+
+    // Materialize a full LightweightMaskContext. Only used on the if-constexpr-discarded v1
+    // (sdpa_ring) path so it type-checks; DCE'd on the streaming v2 path (which deduces this type
+    // directly and keeps the compact frame).
+    operator LightweightMaskContext() const {
+        LightweightMaskContext m;
+        m.is_causal = is_causal;
+        m.neginf_tile_idx = neginf_tile_idx;
+        m.causal_diag_tile_idx = causal_diag_tile_idx;
+        m.global_n_padded_tiles = global_n_padded_tiles;
+        m.local_n_padded_tiles = local_n_padded_tiles;
+        m.joint_n_padded_tiles = joint_n_padded_tiles;
+        m.global_n_partial_col = global_n_partial_col;
+        m.joint_l_partial_col = joint_l_partial_col;
+        m.global_n_partial_tile_idx = global_n_partial_tile_idx;
+        m.joint_l_partial_tile_idx = joint_l_partial_tile_idx;
+        m.straddle_num_padded_tiles = straddle_num_padded_tiles;
+        m.straddle_mask_chunk_id = straddle_mask_chunk_id;
+        return m;
+    }
+};
+
 // Sentinel for "no CB" — beyond the valid 0-31 range.
 constexpr uint32_t INVALID_CB = 32;
 // BH benefits from blocked pack at width 4; WH keeps the threshold at 8 because
@@ -214,8 +267,14 @@ ALWI void pack_contiguous_rows(
 /**
  * Blocked subblock matmul with absolute offset packing.
  * Always uses pack_tile<true> at row-major positions in out_cb.
+ *
+ * noinline on Wormhole: keeps sdpa_inner_loop_step's frame off the TR0 stack to stay within budget
+ * for the ring cases (it would otherwise overflow). WH-only to avoid the call overhead elsewhere.
  */
 template <bool transpose, uint32_t in1_stride, uint32_t out_num_cols>
+#if defined(ARCH_WORMHOLE)
+__attribute__((noinline))
+#endif
 void blocked_matmul_and_pack(
     uint32_t in0_cb,
     uint32_t in1_cb,
@@ -1645,7 +1704,8 @@ template <
     bool straddle_mask_enabled = false,
     bool kv_pad_rotation_enabled = false,
     uint32_t v_cb_physical_width_t = vDHt,
-    bool v_shares_k_buffer = false>
+    bool v_shares_k_buffer = false,
+    typename MaskCtx = LightweightMaskContext>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
     const uint32_t global_q_end,
@@ -1664,7 +1724,7 @@ void sdpa_ring_v2(
     RingAccumulatorState& acc_state,
     const bool is_last_ring_iter = false,
     const uint32_t q_per_core = 1,
-    const LightweightMaskContext& lw_mask = {},
+    const MaskCtx& lw_mask = {},
     const bool skip_first_half_q = false,
     const bool use_zigzag_balancing = false,
     const ChunkedContext& chunked = {},

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -211,21 +211,24 @@ void kernel_main() {
         const uint32_t joint_n_mask_chunk_id = L / (Sk_chunk_t * tt::constants::TILE_HEIGHT);
 
         // is_causal: diagonal only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
-        LightweightMaskContext lw_mask;
+        // The 9 compile-time-constant mask fields are template params (static constexpr, no stack
+        // storage); only the 3 per-iter runtime fields are set below.
+        RingStreamingMaskCtx<
+            neginf_tile_idx,
+            causal_diag_tile_idx,
+            local_n_padded_tiles,
+            joint_n_padded_tiles,
+            global_n_partial_col,
+            joint_l_partial_col,
+            global_n_partial_tile_idx,
+            joint_l_partial_tile_idx,
+            straddle_chunk_id>
+            lw_mask;
         lw_mask.is_causal = chunked_enabled || (is_causal && ring_iter == 0);
-        lw_mask.neginf_tile_idx = neginf_tile_idx;
-        lw_mask.causal_diag_tile_idx = causal_diag_tile_idx;
-        lw_mask.local_n_padded_tiles = local_n_padded_tiles;
-        lw_mask.joint_n_padded_tiles = joint_n_padded_tiles;
-        lw_mask.global_n_partial_col = global_n_partial_col;
-        lw_mask.joint_l_partial_col = joint_l_partial_col;
-        lw_mask.global_n_partial_tile_idx = global_n_partial_tile_idx;
-        lw_mask.joint_l_partial_tile_idx = joint_l_partial_tile_idx;
         // Straddle mask fires only on the rix>rid halved-range iters that would otherwise exclude
         // the straddle chunk. Must agree with the K-loop extension condition below.
         const bool ring_iter_needs_straddle_mask = has_straddle && is_causal && is_balanced && (ring_index > ring_id);
         lw_mask.straddle_num_padded_tiles = ring_iter_needs_straddle_mask ? straddle_num_padded_tiles : 0;
-        lw_mask.straddle_mask_chunk_id = straddle_chunk_id;
         if (ring_iter_needs_global_n_mask) {
             // Tile-aligned: valid_tiles == global_nt_within_ring_iter % Sk_chunk_t
             const uint32_t valid_tiles = global_nt_within_ring_iter % Sk_chunk_t;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

**Root cause:** WH B0 ring-joint MLA SDPA hung on `seq100k` (Sq=5 remainder path) due to a TRISC0 (UNPACK thread) stack overflow. The deep co-resident call chain `kernel_main`(336B) → `sdpa_inner_loop_step`(208B) → `normalize_row_streaming`(96B) exhausted the 704B TR0 stack budget exactly (free=0). The 4-byte overflow clobbered `unp_cfg_context` (the last `.bss` word, adjacent to `__stack_base`) with a stack local (`0xa = Sq_chunk_t = 10`), causing the normalize scalar matmul to use the wrong unpack context → hang. Previously masked by a `reset_config_context()` band-aid (commits 8a7cf52, ea1e19d); that band-aid is removed here.

**Two fixes (both in `compute_streaming.hpp` / `ring_joint_sdpa.cpp`):**

1. **`__attribute__((noinline))` on `blocked_matmul_and_pack`** (WH-only, `#if defined(ARCH_WORMHOLE)`): this function was inlined at both the QK and SV matmul sites inside `sdpa_inner_loop_step`, doubling its 32B frame. Out-lining shares one frame, shrinking `sdpa_inner_loop_step` **208→176B** and clearing the overflow. Call overhead is paid at the non-hot normalize path, not the inner matmul loop.

2. **`RingStreamingMaskCtx` template struct**: replaces a `LightweightMaskContext` local on `kernel_main`'s frame. The 9 compile-time-constant mask fields become template parameters (`static constexpr`, zero stack storage); only the 3 per-ring-iteration runtime fields remain as struct members. Shrinks the live mask object **~48→12B** on `kernel_main`'s frame (+32B headroom). Scoped to ring path via a deduced `typename MaskCtx` on `sdpa_ring_v2` (default `LightweightMaskContext`; `exp_ring_joint_sdpa.cpp`, `sdpa.cpp`, and `compute_common.hpp` are unchanged). An `operator LightweightMaskContext()` satisfies the `if constexpr`-discarded v1 path type-check.

**Measured headroom** (in-kernel canary probe — fill TR0 stack `0xBABABABA` at entry, scan from `__stack_base` at exit; same probe in all three builds for exact deltas):

| build | TR0 free (with probe) |
|---|---|
| baseline + band-aid | overflow (probe itself tips it → hang; confirms free≈0) |
| fix 1 (matmul noinline) only | **28B** |
| fix 1 + fix 2 (mask templating) | **60B** |

**Verified no-reset** (band-aid disabled, cache cleared):
- `seq100k` (Sq=5, the failing shape): PASS, PCC 0.9972
- `seq128k` (Sq=4, regression guard): PASS, PCC 0.9969

### Notes for reviewers

- **`exp_ring_joint_sdpa.cpp`** shares `sdpa_ring_v2` and is backward-compatible (it passes `LightweightMaskContext` by default, which is still deduced correctly), but it was **not compiled or run** in this branch. An eager-ring test should confirm.
- **`blocked_matmul_and_pack` noinline call overhead**: this function sits on the hot QK+SV matmul path. The noinline is guarded `#if defined(ARCH_WORMHOLE)` so BH is unaffected, but a silicon perf-bench on WH SDPA would confirm the overhead is acceptable before merge.
- **Diagnosis method**: DPRINT bisection fails on this heisenbug (adding code shifts the stack layout → overflow lands on a different word → band-aid may re-mask it). The reliable non-perturbing tool is `nm -n` on the JIT `trisc0.elf` + `objdump -dl` frame analysis; the in-kernel canary probe gives absolute ground truth.
- **A larger follow-on fix** (separate PR, `pjosipovic/uint8-unpack-format-tables`): changing `genfiles.cpp` to emit `unpack_src_format`/`unpack_dst_format` as `constexpr uint8_t` instead of `constexpr int32_t` saves **+96B TR0** for *every* WH/BH compute kernel (would have prevented this hang outright). That change needs cross-arch regression + LLK sign-off and is not included here.

Repro test: `scripts/run_safe_pytest.sh 'models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla[wormhole_b0-balanced-check_pcc-seq100k-scaled_sl-random-line-2x4]' -s`

### Additional CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/runs/27022827698)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-hang)