### PR TITLE
jit_build: emit unpack_src/dst_format as uint8_t (was int32_t)

### DIFF
--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -406,9 +406,11 @@ void emit_unpack_data_formats(
     const std::vector<DataFormat>& src_formats_all_cbs,
     const std::vector<DataFormat>& dst_formats_all_cbs,
     uint32_t max_cbs) {
-    // TODO: we should be emitting "unsigned char", no reason to use up 4B per data format
-    emit_formats_array(out, "constexpr std::int32_t", "unpack_src_format", max_cbs, src_formats_all_cbs);
-    emit_formats_array(out, "constexpr std::int32_t", "unpack_dst_format", max_cbs, dst_formats_all_cbs);
+    // DataFormat values fit in a byte (Invalid==255); emit as uint8_t to save 3B/entry of LDM (the
+    // .data region shares the TRISC's 2KB local memory with the stack). Matches pack_src/dst_format
+    // and the unpack tile-dim arrays, which are already uint8_t. All consumers read+promote to uint32.
+    emit_formats_array(out, "constexpr uint8_t", "unpack_src_format", max_cbs, src_formats_all_cbs);
+    emit_formats_array(out, "constexpr uint8_t", "unpack_dst_format", max_cbs, dst_formats_all_cbs);
 }
 
 std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_pack_data_formats(
@@ -689,7 +691,7 @@ void generate_all_descriptors(const JitBuildEnv& env, const JitBuildOptions& opt
     // if the original input format is 8-bit (Int8, UInt8, Fp8_e4m3, Lf8) since those formats
     // do not require the tilize workaround. This is needed to determine whether to skip the workaround in llk_pack_init.
     out << "#if defined(UCK_CHLKC_PACK)\n";
-    emit_formats_array(out, "constexpr std::int32_t", "unpack_src_format", max_cbs, fmts.unpack_src);
+    emit_formats_array(out, "constexpr uint8_t", "unpack_src_format", max_cbs, fmts.unpack_src);
     out << "#endif\n";   // if pack
     out << "#endif\n\n"; // if not math and not unpack
 


### PR DESCRIPTION
### PR Category

Enhancement

### Summary

`unpack_src_format` / `unpack_dst_format` were emitted into every compute kernel's generated descriptor header as `constexpr std::int32_t[max_cbs]` — 128B each, 256B total of LDM. Because LDM (`.data` + `.bss` + stack) is a shared 2KB budget on every TRISC, this directly cuts into available stack headroom for all WH/BH compute kernels.

`DataFormat` values fit in a byte (`Invalid == 255`). The pack-side tables (`pack_src/dst_format`) and the unpack tile-dim arrays were already `uint8_t`, and there was a standing TODO to do this. Changed the 3 `genfiles.cpp` emit sites to `constexpr uint8_t`.

**Measured on WH (DeepSeek MLA SDPA kernel):** each table 128B → 32B; **+96B of TR0 stack free** (net below the 192B object shrink because the `uint8` tile-dim arrays then co-reside in `.data` and ICF folds identical arrays). PCC unchanged at 0.9972. All consumers read by element and promote to `uint32`, so the storage type is transparent — the pack side already proves this pattern works.

This change frees ~96B for **every** WH/BH compute kernel. It would have prevented the ring-joint MLA SDPA hang (PR #46201) outright: the overflow was only 4 bytes and this frees 96B.

### Notes for reviewers

- Host-side change (`libtt_metal`); requires a full `./build_metal.sh --release` rebuild, not just a JIT cache clear.
- Needs cross-arch (WH/BH/Quasar) compute-kernel regression before merge — sanity and BH post-commit triggered on this branch.
- The 3 changed emit sites: `genfiles.cpp:410-411` (`emit_unpack_data_formats`) + `genfiles.cpp:692` (BH tilize-workaround `UCK_CHLKC_PACK` path).
- Related: PR #46201 (ring-joint MLA SDPA TRISC0 stack overflow fix, WH-only kernel-side workaround that is no longer needed if this lands broadly).

### Additional CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/runs/27022262169)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/runs/27022264323)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/uint8-unpack-format-tables)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/uint8-unpack-format-tables)