### PR TITLE
[Cleanup] Remove tile_size params from unpack hw_configure & reconfig_data_format paths (#34495)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -48,10 +48,23 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
+    // fifo_page_size is the per-tile L1 footprint in bytes, recorded on the CB
+    // by the host program. Validate it matches the geometry-derived byte size:
+    // TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM), where
+    // num_faces * face_r_dim * FACE_C_DIM is the datum count and
+    // TILE_SIZE_BYTES scales it to the actual L1 footprint -- including
+    // BFP4/BFP2 sub-byte mantissa packing and the per-face exponent bytes
+    // added by BFP* formats. This is the contract that lets the LLK compute
+    // tile size internally from face geometry + src format; see
+    // tt-metal#34495.
+    LLK_ASSERT(
+        get_local_cb_interface(unpA_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpA_operand_id], unpA_num_faces * unpA_face_r_dim * ckernel::FACE_C_DIM),
+        "unpA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
+    LLK_ASSERT(
+        get_local_cb_interface(unpB_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpB_operand_id], unpB_num_faces * unpB_face_r_dim * ckernel::FACE_C_DIM),
+        "unpB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -61,9 +74,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpB_num_faces);
 }
 
 /**
@@ -94,11 +105,21 @@ llk_unpack_hw_configure(
 
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+    const uint32_t unpA_face_c_dim = ckernel::FACE_C_DIM;
+    const uint32_t unpB_face_c_dim = ckernel::FACE_C_DIM;
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
+    // fifo_page_size is the per-tile L1 footprint in bytes, recorded on the CB
+    // by the host program. Validate it matches the geometry-derived byte size:
+    // TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim). See
+    // the matching comment on the two-operand overload above for details.
+    LLK_ASSERT(
+        get_local_cb_interface(unpA_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpA_operand_id], unpA_num_faces * unpA_face_r_dim * unpA_face_c_dim),
+        "unpA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim)");
+    LLK_ASSERT(
+        get_local_cb_interface(unpB_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpB_operand_id], unpB_num_faces * unpB_face_r_dim * unpB_face_c_dim),
+        "unpB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim)");
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -108,9 +129,7 @@ llk_unpack_hw_configure(
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpB_num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -176,11 +176,15 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
+    // Validate that the host-supplied per-tile L1 footprint (fifo_page_size,
+    // bytes) matches what the LLK now derives from src format + face geometry.
+    // See _llk_unpack_hw_configure_ in cunpack_common.h and #34495.
+    LLK_ASSERT(
+        get_local_cb_interface(srca_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[srca_operand_id], num_faces * face_r_dim * ckernel::FACE_C_DIM),
+        "srcA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
-        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], face_r_dim, num_faces);
 }
 
 /**
@@ -200,11 +204,15 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
+    // Validate that the host-supplied per-tile L1 footprint (fifo_page_size,
+    // bytes) matches what the LLK now derives from src format + face geometry.
+    // See _llk_unpack_hw_configure_ in cunpack_common.h and #34495.
+    LLK_ASSERT(
+        get_local_cb_interface(srcb_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[srcb_operand_id], num_faces * face_r_dim * ckernel::FACE_C_DIM),
+        "srcB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
-        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], face_r_dim, num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -48,10 +48,23 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
+    // fifo_page_size is the per-tile L1 footprint in bytes, recorded on the CB
+    // by the host program. Validate it matches the geometry-derived byte size:
+    // TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM), where
+    // num_faces * face_r_dim * FACE_C_DIM is the datum count and
+    // TILE_SIZE_BYTES scales it to the actual L1 footprint -- including
+    // BFP4/BFP2 sub-byte mantissa packing and the per-face exponent bytes
+    // added by BFP* formats. This is the contract that lets the LLK compute
+    // tile size internally from face geometry + src format; see
+    // tt-metal#34495.
+    LLK_ASSERT(
+        get_local_cb_interface(unpA_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpA_operand_id], unpA_num_faces * unpA_face_r_dim * ckernel::FACE_C_DIM),
+        "unpA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
+    LLK_ASSERT(
+        get_local_cb_interface(unpB_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpB_operand_id], unpB_num_faces * unpB_face_r_dim * ckernel::FACE_C_DIM),
+        "unpB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -61,9 +74,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpB_num_faces);
 }
 
 /**
@@ -94,11 +105,21 @@ llk_unpack_hw_configure(
 
     const uint32_t unpB_num_faces = get_operand_num_faces(unpB_operand_id);
     const uint32_t unpB_face_r_dim = get_operand_face_r_dim(unpB_operand_id);
+    const uint32_t unpA_face_c_dim = ckernel::FACE_C_DIM;
+    const uint32_t unpB_face_c_dim = ckernel::FACE_C_DIM;
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const uint32_t unpA_tile_size = get_local_cb_interface(unpA_operand_id).fifo_page_size;
-    const uint32_t unpB_tile_size = get_local_cb_interface(unpB_operand_id).fifo_page_size;
+    // fifo_page_size is the per-tile L1 footprint in bytes, recorded on the CB
+    // by the host program. Validate it matches the geometry-derived byte size:
+    // TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim). See
+    // the matching comment on the two-operand overload above for details.
+    LLK_ASSERT(
+        get_local_cb_interface(unpA_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpA_operand_id], unpA_num_faces * unpA_face_r_dim * unpA_face_c_dim),
+        "unpA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim)");
+    LLK_ASSERT(
+        get_local_cb_interface(unpB_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[unpB_operand_id], unpB_num_faces * unpB_face_r_dim * unpB_face_c_dim),
+        "unpB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * face_c_dim)");
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en, disable_src_zero_flag>(
         unpack_src_format[unpA_operand_id],
@@ -108,9 +129,7 @@ llk_unpack_hw_configure(
         unpA_face_r_dim,
         unpB_face_r_dim,
         unpA_num_faces,
-        unpB_num_faces,
-        unpA_tile_size,
-        unpB_tile_size);
+        unpB_num_faces);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -176,11 +176,15 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srca_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srca_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const std::uint32_t tile_size = get_local_cb_interface(srca_operand_id).fifo_page_size;
+    // Validate that the host-supplied per-tile L1 footprint (fifo_page_size,
+    // bytes) matches what the LLK now derives from src format + face geometry.
+    // See _llk_unpack_hw_configure_ in cunpack_common.h and #34495.
+    LLK_ASSERT(
+        get_local_cb_interface(srca_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[srca_operand_id], num_faces * face_r_dim * ckernel::FACE_C_DIM),
+        "srcA fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
-        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], tile_size, face_r_dim, num_faces);
+        unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id], face_r_dim, num_faces);
 }
 
 /**
@@ -200,11 +204,15 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
     const std::uint32_t num_faces = get_operand_num_faces(srcb_operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(srcb_operand_id);
 
-    // Currently, there is a constraint that tile size is equal to the fifo page size
-    // TODO NC: tile size should be computed in the LLK instead, as the part of #34495
-    const std::uint32_t tile_size = get_local_cb_interface(srcb_operand_id).fifo_page_size;
+    // Validate that the host-supplied per-tile L1 footprint (fifo_page_size,
+    // bytes) matches what the LLK now derives from src format + face geometry.
+    // See _llk_unpack_hw_configure_ in cunpack_common.h and #34495.
+    LLK_ASSERT(
+        get_local_cb_interface(srcb_operand_id).fifo_page_size ==
+            TILE_SIZE_BYTES(unpack_src_format[srcb_operand_id], num_faces * face_r_dim * ckernel::FACE_C_DIM),
+        "srcB fifo_page_size (bytes) must equal TILE_SIZE_BYTES(src_format, num_faces * face_r_dim * FACE_C_DIM)");
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, dim_stride_target, to_from_int8>(
-        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], tile_size, face_r_dim, num_faces);
+        unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id], face_r_dim, num_faces);
 }
 
 /**

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -237,22 +237,16 @@ class FuserSentinel:
         if srca_changed:
             code += (
                 f"_llk_unpack_reconfig_data_format_srca_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
-                f"    {self._fmt(new_fmt.unpack_A_src)}, {self._fmt(new_fmt.unpack_A_dst)}, {compute_node.src_a.tile_size}\n"
+                f"    {self._fmt(new_fmt.unpack_A_src)}, {self._fmt(new_fmt.unpack_A_dst)}\n"
                 f");\n"
             )
 
         if srcb_changed:
-            srcb_tile_size = (
-                compute_node.src_a.tile_size
-                if compute_node.reuse_dest is EltwiseBinaryReuseDestType.DEST_TO_SRCA
-                else (compute_node.src_b.tile_size if compute_node.src_b else None)
+            code += (
+                f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
+                f"    {self._fmt(new_fmt.unpack_B_src)}, {self._fmt(new_fmt.unpack_B_dst)}\n"
+                f");\n"
             )
-            if srcb_tile_size is not None:
-                code += (
-                    f"_llk_unpack_reconfig_data_format_srcb_impl_<{dest_acc}, p_dim_stride_target::IGNORE, false>(\n"
-                    f"    {self._fmt(new_fmt.unpack_B_src)}, {self._fmt(new_fmt.unpack_B_dst)}, {srcb_tile_size}\n"
-                    f");\n"
-                )
 
         self._unpack_format = new_fmt
         return code

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -48,12 +48,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tensor_shape.face_r_dim,
         tensor_shape.face_r_dim,
         tensor_shape.total_num_faces(),
-        tensor_shape.total_num_faces(),
-        params.TILE_SIZE_UNPACK_A,
-        params.TILE_SIZE_UNPACK_B);
+        tensor_shape.total_num_faces());
 
     // Must come after _llk_unpack_hw_configure_, otherwise the ALU stoch-rnd
-    // bits programmed here are overwritten by configure_unpack_AB().
+    // bits programmed here are overwritten by _llk_unpack_hw_configure_().
     _llk_unpack_configure_stoch_rnd_<StochRndType::None>();
 
     _llk_unpack_AB_init_<BROADCAST_TYPE>(tensor_shape, transpose);

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -51,7 +51,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Start of second unpack kernel to perform unpack matmul on now tilized input data
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
-        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, TILE_SIZE_PACK);
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         0, 0, FACE_R_DIM, 4, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
@@ -27,16 +27,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src,
-        formats.unpack_B_src,
-        formats.unpack_A_dst,
-        formats.unpack_B_dst,
-        FACE_R_DIM,
-        FACE_R_DIM,
-        params.num_faces_A,
-        params.num_faces_B,
-        params.TILE_SIZE_UNPACK_A,
-        params.TILE_SIZE_UNPACK_B);
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces_A, params.num_faces_B);
     _llk_unpack_AB_matmul_init_<>(
         0 /* transpose */,
         params.CT_DIM,

--- a/tt_metal/tt-llk/tests/sources/matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_test.cpp
@@ -28,16 +28,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src,
-        formats.unpack_B_src,
-        formats.unpack_A_dst,
-        formats.unpack_B_dst,
-        FACE_R_DIM,
-        FACE_R_DIM,
-        params.num_faces_A,
-        params.num_faces_B,
-        params.TILE_SIZE_UNPACK_A,
-        params.TILE_SIZE_UNPACK_B);
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces_A, params.num_faces_B);
     _llk_unpack_AB_matmul_init_<>(0, params.CT_DIM, params.RT_DIM, params.KT_DIM, FACE_R_DIM, FACE_R_DIM, 4, 4, false, false);
     for (std::uint32_t j = 0; j < params.KT_DIM; j++)
     {

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -78,12 +78,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Start of second unpack kernel to perform unpack matmul on now tilized input data
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
+    // Reconfigure unpack kernel data formats_array if they change in this run.
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
-        formats_array[run].unpack_A_src,
-        formats_array[run].unpack_A_dst,
-        tile_size); // have to reconfigure unpack kernel data formats_array if they change in this run
+        formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
     _llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
-        formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
+        formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst);
     _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, 4 /* num_faces */, FACE_R_DIM);
     _llk_unpack_AB_matmul_init_<>();
     _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized), 0, 0, tile_size, tile_size);

--- a/tt_metal/tt-llk/tests/sources/reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_test.cpp
@@ -40,9 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         tensor_shape.face_r_dim,
         tensor_shape.face_r_dim,
         tensor_shape.total_num_faces(),
-        tensor_shape.total_num_faces(),
-        params.TILE_SIZE_UNPACK_A,
-        params.TILE_SIZE_UNPACK_B);
+        tensor_shape.total_num_faces());
     _llk_unpack_AB_reduce_init_<POOL_TYPE, REDUCE_DIM>(tensor_shape);
     for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -37,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format0 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format0 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format0 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_hw_configure_<false, false>(unpack_a_src_format0, unpack_b_src_format0, unpack_a_dst_format0, unpack_b_dst_format0, 16, 16, 4, 4, 128, 128);
+    _llk_unpack_hw_configure_<false, false>(unpack_a_src_format0, unpack_b_src_format0, unpack_a_dst_format0, unpack_b_dst_format0, 16, 16, 4, 4);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
         _llk_unpack_AB_matmul_init_<>(false, 1, 1, 1, 16, 16);

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -56,8 +56,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format1 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format1 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format1, unpack_a_dst_format1, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format1, unpack_b_dst_format1, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format1, unpack_a_dst_format1);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format1, unpack_b_dst_format1);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -76,8 +76,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format2 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format2 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format2, unpack_a_dst_format2, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format2, unpack_b_dst_format2, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format2, unpack_a_dst_format2);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format2, unpack_b_dst_format2);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -92,8 +92,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     UNUSED const std::uint32_t unpack_a_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_src_format3 = ckernel::to_underlying(DataFormat::Float16_b);
     UNUSED const std::uint32_t unpack_b_dst_format3 = ckernel::to_underlying(DataFormat::Float16_b);
-    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format3, unpack_a_dst_format3, 128);
-    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format3, unpack_b_dst_format3, 128);
+    _llk_unpack_reconfig_data_format_srca_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_a_src_format3, unpack_a_dst_format3);
+    _llk_unpack_reconfig_data_format_srcb_impl_<false, p_dim_stride_target::IGNORE, false>(unpack_b_src_format3, unpack_b_dst_format3);
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -174,7 +174,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         // We need to use reconfigure API to avoid race condition between hardware configuration in the second stage and unpacking in the first
                         // stage.
                         _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false /* to_from_int8 */>(
-                            unpack_src_format, unpack_dst_format, 16 * 16 * 4 /* tile_size */);
+                            unpack_src_format, unpack_dst_format);
                     }
 
                     // only do face level transpose in the first iteration to turn in into column-wise format.

--- a/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
@@ -32,10 +32,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_B_dst,
         params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM,
         params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
-        params.num_faces_B, // in1
-        params.num_faces_A, // in0
-        params.TILE_SIZE_UNPACK_B,
-        params.TILE_SIZE_UNPACK_A);
+        params.num_faces_B,  // in1
+        params.num_faces_A); // in0
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
     _llk_unpack_AB_matmul_init_<>(
         params.UNPACK_TRANSPOSE_FACES,

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -240,6 +240,41 @@ constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint3
     };
 }
 
+// Returns the per-tile L1 footprint in bytes for `datum_count` datums of `format`.
+// Layered on top of SCALE_DATUM_SIZE, with two BFP-specific corrections:
+//   * Bfp4/Bfp4_b pack 2 mantissa datums per byte, so the mantissa payload is half
+//     of what SCALE_DATUM_SIZE (which is byte-per-datum for sub-byte formats) returns;
+//     Bfp2/Bfp2_b pack 4 datums per byte, so the payload is a quarter.
+//   * All BFP* formats also store one shared exponent byte per 16 datums (one
+//     exp byte per face row) alongside the mantissas.
+// This matches what the host writes into the CB's fifo_page_size, and is what the
+// matching pack-side helper (_llk_pack_output_size_bytes_) computes.
+constexpr static std::uint32_t TILE_SIZE_BYTES(std::uint32_t format, std::uint32_t datum_count)
+{
+    std::uint32_t tile_size_bytes = SCALE_DATUM_SIZE(format, datum_count);
+
+    switch (masked_data_format(format))
+    {
+        case (to_underlying(DataFormat::Bfp4)):
+        case (to_underlying(DataFormat::Bfp4_b)):
+            tile_size_bytes /= 2;
+            break;
+        case (to_underlying(DataFormat::Bfp2)):
+        case (to_underlying(DataFormat::Bfp2_b)):
+            tile_size_bytes /= 4;
+            break;
+        default:
+            break;
+    }
+
+    if (IS_BFP_FORMAT(format))
+    {
+        tile_size_bytes += datum_count / 16;
+    }
+
+    return tile_size_bytes;
+}
+
 #define LOWER_HALFWORD(x) ((x) & 0xFFFF)
 #define UPPER_HALFWORD(x) ((x) >> 16)
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -706,15 +706,14 @@ __attribute__((noinline, optimize("no-jump-tables"))) bool is_unpacker_format_co
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool row_pool = false, bool fpu_srnd_en = false, bool pack_srnd_en = false, bool disable_src_zero_flag = false>
-inline void configure_unpack_AB(
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
+inline void _llk_unpack_hw_configure_(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpB_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_dst_format,
     const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const bool transpose_xy_srca_en     = false,
     const std::uint32_t unpA_num_faces  = 4,
     const std::uint32_t unpB_num_faces  = 4)
 {
@@ -752,7 +751,6 @@ inline void configure_unpack_AB(
                                                                                                              : 1;
     std::uint32_t unpA_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpA_ch1_x_stride;
     std::uint32_t unpB_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpB_ch1_x_stride;
-    std::uint32_t exp_width         = (static_cast<std::uint32_t>(unpA_dst_format_masked) >> 2) & 0x1; // 0=5-bit, 1=8-bit
 
     // Strides for incrementing ch1 address to srcA and srcB
     cfg[UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] =
@@ -789,9 +787,9 @@ inline void configure_unpack_AB(
     static_assert(ALU_ACC_CTRL_Fp32_enabled_ADDR32 == ALU_ACC_CTRL_SFPU_Fp32_enabled_ADDR32);
     constexpr std::uint32_t alu_stoch_rnd_mask =
         ALU_ROUNDING_MODE_Fpu_srnd_en_MASK | ALU_ROUNDING_MODE_Gasket_srnd_en_MASK | ALU_ROUNDING_MODE_Packer_srnd_en_MASK;
-    alu_payload.f.ALU_ROUNDING_MODE_Fpu_srnd_en    = fpu_srnd_en;
-    alu_payload.f.ALU_ROUNDING_MODE_Gasket_srnd_en = pack_srnd_en;
-    alu_payload.f.ALU_ROUNDING_MODE_Packer_srnd_en = pack_srnd_en;
+    alu_payload.f.ALU_ROUNDING_MODE_Fpu_srnd_en    = false;
+    alu_payload.f.ALU_ROUNDING_MODE_Gasket_srnd_en = false;
+    alu_payload.f.ALU_ROUNDING_MODE_Packer_srnd_en = false;
 
     constexpr std::uint32_t alu_mask = alu_format_mask | alu_stoch_rnd_mask;
 
@@ -825,7 +823,7 @@ inline void configure_unpack_AB(
     {
         cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + i] = tile_descriptor.val[i];
     }
-    tile_descriptor.f.in_data_format = row_pool ? to_underlying(DataFormat::Float32) : unpB_src_format_masked;
+    tile_descriptor.f.in_data_format = unpB_src_format_masked;
     tile_descriptor.f.x_dim          = unpB_face_r_dim * FACE_C_DIM;
     tile_descriptor.f.z_dim          = unpB_num_faces;
     for (std::uint32_t i = 0; i < TILE_DESC_SIZE; i++)
@@ -842,7 +840,7 @@ inline void configure_unpack_AB(
     config.f.out_data_format = unpA_dst_format_masked;
     config.f.throttle_mode   = 2;
     config.f.context_count   = 0;
-    config.f.haloize_mode    = transpose_xy_srca_en ? 1 : 0;
+    config.f.haloize_mode    = 0;
     // config.f.upsample_rate   = 0;
     // config.f.upsamle_and_interlave  = 0;
     // config.f.shift_amount = 0;
@@ -855,7 +853,7 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC0_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    config.f.out_data_format = row_pool ? (to_underlying(DataFormat::Float16) | (exp_width << 2)) : unpB_dst_format_masked;
+    config.f.out_data_format = unpB_dst_format_masked;
     config.f.haloize_mode    = 0;
 
     for (std::uint32_t i = 0; i < CONFIG_SIZE; i++)
@@ -895,6 +893,20 @@ inline void configure_unpack_AB(
 
     // Clear context ID
     reset_config_context();
+
+    // TILE_SIZE_A/B GPRs hold the per-tile L1 footprint in bytes; the unpacker
+    // uses them for byte-level address arithmetic (e.g. base_address +
+    // tile_size * tile_index in matmul) and they must agree with the CB's
+    // fifo_page_size, which is also recorded in bytes. Derive the same value
+    // from face geometry: num_faces * face_r_dim * FACE_C_DIM is the datum
+    // count, and TILE_SIZE_BYTES scales it to the actual L1 footprint --
+    // including BFP4/BFP2 sub-byte mantissa packing and the per-face exponent
+    // bytes that BFP* formats add. The matching LLK API assert (#34495)
+    // validates this against fifo_page_size.
+    const std::uint32_t unpA_tile_size = TILE_SIZE_BYTES(unpA_src_format, unpA_num_faces * unpA_face_r_dim * FACE_C_DIM);
+    const std::uint32_t unpB_tile_size = TILE_SIZE_BYTES(unpB_src_format, unpB_num_faces * unpB_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
+    TT_SETDMAREG(0, LOWER_HALFWORD(unpB_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
 }
 
 template <std::uint32_t UNP_SEL = p_setadc::UNP_AB>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -37,30 +37,6 @@ static inline __attribute__((always_inline)) std::uint32_t store_then_load(volat
     return result;
 }
 
-// TODO NC: Remove disable_src_zero_flag parameter from here, configure_unpack_AB and
-// llk_unpack_hw_configure as the part of #966
-template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
-inline void _llk_unpack_hw_configure_(
-    const std::uint32_t unpA_src_format,
-    const std::uint32_t unpB_src_format,
-    const std::uint32_t unpA_dst_format,
-    const std::uint32_t unpB_dst_format,
-    const std::uint32_t unpA_face_r_dim,
-    const std::uint32_t unpB_face_r_dim,
-    const std::uint32_t unpA_num_faces,
-    const std::uint32_t unpB_num_faces,
-    const std::uint32_t unpA_tile_size = 0,
-    const std::uint32_t unpB_tile_size = 0)
-{
-    LLK_ASSERT(unpA_num_faces == 1 || unpA_num_faces == 2 || unpA_num_faces == 4, "unpA_num_faces must be 1, 2, or 4");
-    LLK_ASSERT(unpB_num_faces == 1 || unpB_num_faces == 2 || unpB_num_faces == 4, "unpB_num_faces must be 1, 2, or 4");
-    configure_unpack_AB<is_fp32_dest_acc_en, false, false, false, disable_src_zero_flag>(
-        unpA_src_format, unpB_src_format, unpA_dst_format, unpB_dst_format, unpA_face_r_dim, unpB_face_r_dim, 0, unpA_num_faces, unpB_num_faces);
-
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpB_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
-}
-
 template <StochRndType stoch_rnd_mode>
 inline void _llk_unpack_configure_stoch_rnd_()
 {
@@ -178,7 +154,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 // Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
 //
 // The zero-src flag causes the hardware to substitute 0 for values whose bit
-// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
+// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  _llk_unpack_hw_configure_
 // disables the flag whenever either dest format is uint16, because 0x8000 is a
 // valid uint16 value (32768) that must not be zeroed.  The same adjustment is
 // needed every time formats are reconfigured.

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -56,7 +56,6 @@ template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool 
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t tile_size,
     const std::uint32_t unpack_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpack_num_faces  = 4)
 {
@@ -79,7 +78,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
     cfg_reg_rmw_tensix<THCON_SEC0_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (std::uint32_t)DataFormat::Fp8_e4m3) ? 1 : 0);
 
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
+    // Refresh TILE_SIZE_A GPR with the per-tile L1 footprint in bytes derived
+    // from the new src format and face geometry. Mirrors the calculation in
+    // _llk_unpack_hw_configure_; see TILE_SIZE_BYTES in ckernel_defs.h and #34495.
+    const std::uint32_t tile_size = TILE_SIZE_BYTES(unpack_src_format, unpack_num_faces * unpack_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
@@ -108,7 +111,6 @@ template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool 
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t tile_size,
     const std::uint32_t unpack_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpack_num_faces  = 4)
 {
@@ -131,7 +133,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     cfg_reg_rmw_tensix<THCON_SEC1_REG1_Unp_LF8_4b_exp_RMW>(((unpack_src_format & 0x1F) == (std::uint32_t)DataFormat::Fp8_e4m3) ? 1 : 0);
 
     cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
+    // Refresh TILE_SIZE_B GPR with the per-tile L1 footprint in bytes derived
+    // from the new src format and face geometry. Mirrors the calculation in
+    // _llk_unpack_hw_configure_; see TILE_SIZE_BYTES in ckernel_defs.h and #34495.
+    const std::uint32_t tile_size = TILE_SIZE_BYTES(unpack_src_format, unpack_num_faces * unpack_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -222,6 +222,41 @@ constexpr static std::uint32_t SCALE_DATUM_SIZE(std::uint32_t format, std::uint3
     };
 }
 
+// Returns the per-tile L1 footprint in bytes for `datum_count` datums of `format`.
+// Layered on top of SCALE_DATUM_SIZE, with two BFP-specific corrections:
+//   * Bfp4/Bfp4_b pack 2 mantissa datums per byte, so the mantissa payload is half
+//     of what SCALE_DATUM_SIZE (which is byte-per-datum for sub-byte formats) returns;
+//     Bfp2/Bfp2_b pack 4 datums per byte, so the payload is a quarter.
+//   * All BFP* formats also store one shared exponent byte per 16 datums (one
+//     exp byte per face row) alongside the mantissas.
+// This matches what the host writes into the CB's fifo_page_size, and is what the
+// matching pack-side helper (_llk_pack_output_size_bytes_) computes.
+constexpr static std::uint32_t TILE_SIZE_BYTES(std::uint32_t format, std::uint32_t datum_count)
+{
+    std::uint32_t tile_size_bytes = SCALE_DATUM_SIZE(format, datum_count);
+
+    switch (masked_data_format(format))
+    {
+        case (to_underlying(DataFormat::Bfp4)):
+        case (to_underlying(DataFormat::Bfp4_b)):
+            tile_size_bytes /= 2;
+            break;
+        case (to_underlying(DataFormat::Bfp2)):
+        case (to_underlying(DataFormat::Bfp2_b)):
+            tile_size_bytes /= 4;
+            break;
+        default:
+            break;
+    }
+
+    if (IS_BFP_FORMAT(format))
+    {
+        tile_size_bytes += datum_count / 16;
+    }
+
+    return tile_size_bytes;
+}
+
 #define LOWER_HALFWORD(x) ((x) & 0xFFFF)
 #define UPPER_HALFWORD(x) ((x) >> 16)
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -701,15 +701,14 @@ __attribute__((noinline, optimize("no-jump-tables"))) bool is_unpacker_format_co
     }
 }
 
-template <bool is_fp32_dest_acc_en, bool row_pool = false, bool fpu_srnd_en = false, bool pack_srnd_en = false, bool disable_src_zero_flag = false>
-inline void configure_unpack_AB(
+template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
+inline void _llk_unpack_hw_configure_(
     const std::uint32_t unpA_src_format,
     const std::uint32_t unpB_src_format,
     const std::uint32_t unpA_dst_format,
     const std::uint32_t unpB_dst_format,
     const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const bool transpose_xy_srca_en     = false,
     const std::uint32_t unpA_num_faces  = 4,
     const std::uint32_t unpB_num_faces  = 4)
 {
@@ -742,7 +741,6 @@ inline void configure_unpack_AB(
                                                                                                       : 1;
     std::uint32_t unpA_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpA_ch1_x_stride;
     std::uint32_t unpB_ch1_z_stride = FACE_C_DIM * FACE_R_DIM * unpB_ch1_x_stride;
-    std::uint32_t exp_width         = (unpA_dst_format >> 2) & 0x1; // 0=5-bit, 1=8-bit
 
     // Strides for incrementing ch1 address to srcA and srcB
     cfg[UNP0_ADDR_CTRL_ZW_REG_1_Zstride_ADDR32] =
@@ -779,9 +777,9 @@ inline void configure_unpack_AB(
     static_assert(ALU_ACC_CTRL_Fp32_enabled_ADDR32 == ALU_ACC_CTRL_SFPU_Fp32_enabled_ADDR32);
     constexpr std::uint32_t alu_stoch_rnd_mask =
         ALU_ROUNDING_MODE_Fpu_srnd_en_MASK | ALU_ROUNDING_MODE_Gasket_srnd_en_MASK | ALU_ROUNDING_MODE_Packer_srnd_en_MASK;
-    alu_payload.f.ALU_ROUNDING_MODE_Fpu_srnd_en    = fpu_srnd_en;
-    alu_payload.f.ALU_ROUNDING_MODE_Gasket_srnd_en = pack_srnd_en;
-    alu_payload.f.ALU_ROUNDING_MODE_Packer_srnd_en = pack_srnd_en;
+    alu_payload.f.ALU_ROUNDING_MODE_Fpu_srnd_en    = false;
+    alu_payload.f.ALU_ROUNDING_MODE_Gasket_srnd_en = false;
+    alu_payload.f.ALU_ROUNDING_MODE_Packer_srnd_en = false;
 
     constexpr std::uint32_t alu_mask = alu_format_mask | alu_stoch_rnd_mask;
 
@@ -813,7 +811,7 @@ inline void configure_unpack_AB(
     {
         cfg[THCON_SEC0_REG0_TileDescriptor_ADDR32 + i] = tile_descriptor.val[i];
     }
-    tile_descriptor.f.in_data_format = row_pool ? to_underlying(DataFormat::Float32) : masked_data_format(unpB_src_format);
+    tile_descriptor.f.in_data_format = masked_data_format(unpB_src_format);
     tile_descriptor.f.x_dim          = unpB_face_r_dim * FACE_C_DIM;
     tile_descriptor.f.z_dim          = unpB_num_faces;
     for (std::uint32_t i = 0; i < TILE_DESC_SIZE; i++)
@@ -830,7 +828,7 @@ inline void configure_unpack_AB(
     config.f.out_data_format = masked_data_format(unpA_dst_format);
     config.f.throttle_mode   = 2;
     config.f.context_count   = 0;
-    config.f.haloize_mode    = transpose_xy_srca_en ? 1 : 0;
+    config.f.haloize_mode    = 0;
     // config.f.upsample_rate   = 0;
     // config.f.upsamle_and_interlave  = 0;
     // config.f.shift_amount = 0;
@@ -843,7 +841,7 @@ inline void configure_unpack_AB(
         cfg[THCON_SEC0_REG2_Out_data_format_ADDR32 + i] = config.val[i];
     }
 
-    config.f.out_data_format = row_pool ? (to_underlying(DataFormat::Float16) | (exp_width << 2)) : masked_data_format(unpB_dst_format);
+    config.f.out_data_format = masked_data_format(unpB_dst_format);
     config.f.haloize_mode    = 0;
 
     for (std::uint32_t i = 0; i < CONFIG_SIZE; i++)
@@ -883,6 +881,20 @@ inline void configure_unpack_AB(
 
     // Clear context ID
     reset_config_context();
+
+    // TILE_SIZE_A/B GPRs hold the per-tile L1 footprint in bytes; the unpacker
+    // uses them for byte-level address arithmetic (e.g. base_address +
+    // tile_size * tile_index in matmul) and they must agree with the CB's
+    // fifo_page_size, which is also recorded in bytes. Derive the same value
+    // from face geometry: num_faces * face_r_dim * FACE_C_DIM is the datum
+    // count, and TILE_SIZE_BYTES scales it to the actual L1 footprint --
+    // including BFP4/BFP2 sub-byte mantissa packing and the per-face exponent
+    // bytes that BFP* formats add. The matching LLK API assert (#34495)
+    // validates this against fifo_page_size.
+    const std::uint32_t unpA_tile_size = TILE_SIZE_BYTES(unpA_src_format, unpA_num_faces * unpA_face_r_dim * FACE_C_DIM);
+    const std::uint32_t unpB_tile_size = TILE_SIZE_BYTES(unpB_src_format, unpB_num_faces * unpB_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
+    TT_SETDMAREG(0, LOWER_HALFWORD(unpB_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
 }
 
 template <std::uint32_t UNP_SEL = p_setadc::UNP_AB>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -60,29 +60,14 @@ static __attribute__((noinline, noclone)) void pack_multitile(const std::uint32_
 
 inline std::uint32_t _llk_pack_output_size_bytes_(const std::uint32_t pack_dst_format, const std::uint32_t datum_count)
 {
-    std::uint32_t packed_tile_size_bytes = SCALE_DATUM_SIZE(pack_dst_format, datum_count);
-
-    // SCALE_DATUM_SIZE keeps one-byte-per-datum compatibility for the sub-byte
-    // BFP payload formats. Pack address programming needs the real packed L1
-    // footprint instead: Bfp4 payload is 2 datums/byte, Bfp2 is 4 datums/byte,
-    // and all BFP formats also store one exponent byte per 16 datums
-    // alongside the mantissas.
-    if (pack_dst_format == to_underlying(DataFormat::Bfp4) || pack_dst_format == to_underlying(DataFormat::Bfp4_b))
-    {
-        packed_tile_size_bytes /= 2;
-    }
-    else if (pack_dst_format == to_underlying(DataFormat::Bfp2) || pack_dst_format == to_underlying(DataFormat::Bfp2_b))
-    {
-        packed_tile_size_bytes /= 4;
-    }
-
-    if (IS_BFP_FORMAT(pack_dst_format))
-    {
-        packed_tile_size_bytes += datum_count / 16;
-    }
-
-    return packed_tile_size_bytes;
+    // The "packed L1 footprint of `datum_count` datums of `pack_dst_format`"
+    // is exactly what TILE_SIZE_BYTES computes: SCALE_DATUM_SIZE adjusted for
+    // BFP4/BFP2 sub-byte mantissa packing plus the per-face exponent bytes
+    // that all BFP* formats add. The unpack side derives TILE_SIZE_A/B from
+    // the same helper, keeping pack and unpack in agreement (#34495).
+    return TILE_SIZE_BYTES(pack_dst_format, datum_count);
 }
+
 inline std::uint32_t _llk_pack_output_addr_offset_words_(
     const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -38,30 +38,6 @@ static inline __attribute__((always_inline)) std::uint32_t store_then_load(volat
     return result;
 }
 
-// TODO NC: Remove disable_src_zero_flag parameter from here, configure_unpack_AB and
-// llk_unpack_hw_configure as the part of #966
-template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
-inline void _llk_unpack_hw_configure_(
-    const std::uint32_t unpA_src_format,
-    const std::uint32_t unpB_src_format,
-    const std::uint32_t unpA_dst_format,
-    const std::uint32_t unpB_dst_format,
-    const std::uint32_t unpA_face_r_dim,
-    const std::uint32_t unpB_face_r_dim,
-    const std::uint32_t unpA_num_faces,
-    const std::uint32_t unpB_num_faces,
-    const std::uint32_t unpA_tile_size = 0,
-    const std::uint32_t unpB_tile_size = 0)
-{
-    LLK_ASSERT(unpA_num_faces == 1 || unpA_num_faces == 2 || unpA_num_faces == 4, "unpA_num_faces must be 1, 2, or 4");
-    LLK_ASSERT(unpB_num_faces == 1 || unpB_num_faces == 2 || unpB_num_faces == 4, "unpB_num_faces must be 1, 2, or 4");
-    configure_unpack_AB<is_fp32_dest_acc_en, false, false, false, disable_src_zero_flag>(
-        unpA_src_format, unpB_src_format, unpA_dst_format, unpB_dst_format, unpA_face_r_dim, unpB_face_r_dim, 0, unpA_num_faces, unpB_num_faces);
-
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpA_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
-    TT_SETDMAREG(0, LOWER_HALFWORD(unpB_tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
-}
-
 template <StochRndType stoch_rnd_mode>
 inline void _llk_unpack_configure_stoch_rnd_()
 {
@@ -173,7 +149,7 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 // Update ALU_ACC_CTRL_Zero_Flag_disabled_src after a data-format reconfig.
 //
 // The zero-src flag causes the hardware to substitute 0 for values whose bit
-// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  configure_unpack_AB
+// pattern matches -0.0f in bfloat16 (e.g. 0x8000).  _llk_unpack_hw_configure_
 // disables the flag whenever either dest format is uint16, because 0x8000 is a
 // valid uint16 value (32768) that must not be zeroed.  The same adjustment is
 // needed every time formats are reconfigured.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -57,7 +57,6 @@ template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool 
 inline void _llk_unpack_reconfig_data_format_srca_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t tile_size,
     const std::uint32_t unpack_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpack_num_faces  = 4)
 {
@@ -77,7 +76,11 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(
 
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A)); // update gpr which holds tile size A
+    // Refresh TILE_SIZE_A GPR with the per-tile L1 footprint in bytes derived
+    // from the new src format and face geometry. Mirrors the calculation in
+    // _llk_unpack_hw_configure_; see TILE_SIZE_BYTES in ckernel_defs.h and #34495.
+    const std::uint32_t tile_size = TILE_SIZE_BYTES(unpack_src_format, unpack_num_faces * unpack_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {
@@ -106,7 +109,6 @@ template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool 
 inline void _llk_unpack_reconfig_data_format_srcb_impl_(
     const std::uint32_t unpack_src_format,
     const std::uint32_t unpack_dst_format,
-    const std::uint32_t tile_size,
     const std::uint32_t unpack_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpack_num_faces  = 4)
 {
@@ -126,7 +128,11 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 
     cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);
     cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpack_dst_format);
-    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B)); // update gpr which holds tile size B
+    // Refresh TILE_SIZE_B GPR with the per-tile L1 footprint in bytes derived
+    // from the new src format and face geometry. Mirrors the calculation in
+    // _llk_unpack_hw_configure_; see TILE_SIZE_BYTES in ckernel_defs.h and #34495.
+    const std::uint32_t tile_size = TILE_SIZE_BYTES(unpack_src_format, unpack_num_faces * unpack_face_r_dim * FACE_C_DIM);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_B));
 
     if constexpr (dim_stride_target == p_dim_stride_target::FACE_ROW_MAJOR)
     {


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Closes #34495.

The internal unpack hardware configuration and data-format reconfig functions used to take per-tile `tile_size` byte arguments threaded all the way down from kernel callers, even though the value is fully derivable from `src_format` and face geometry (`num_faces * face_r_dim * FACE_C_DIM`). This PR removes the parameters and derives the per-tile L1 footprint inside the LLK, while validating against the host-supplied `fifo_page_size` at the public LLK API boundary.

What changed:

1. New helper `TILE_SIZE_BYTES(format, datum_count)` in `ckernel_defs.h` (WH + BH) computes the actual per-tile L1 footprint in bytes for **all** formats — including the BFP-specific corrections (Bfp4 = mantissa/2, Bfp2 = mantissa/4, plus 1 exp byte per 16 datums for any BFP\* format). This is what the host writes into `fifo_page_size`, so the assert holds across `Float32`, `Float16(_b)`, `UInt16`, `Int8`/`UInt8`, and `Bfp8(_b)` / `Bfp4(_b)` / `Bfp2(_b)`.
2. `_llk_unpack_hw_configure_` (WH + BH `cunpack_common.h`) now:
   - drops `unpA_tile_size` / `unpB_tile_size` parameters,
   - moves the `TT_SETDMAREG(... TILE_SIZE_A/B ...)` calls inside,
   - simplifies the template signature by dropping always-`false`/`0` template/runtime args (`row_pool`, `fpu_srnd_en`, `pack_srnd_en`, `transpose_xy_srca_en`),
   - and replaces the old per-arch wrapper in `llk_unpack_common.h` (the old wrapper is gone; its `disable_src_zero_flag` `TODO` is preserved).
3. `_llk_unpack_reconfig_data_format_srca_impl_` / `_llk_unpack_reconfig_data_format_srcb_impl_` (WH + BH `llk_unpack_common.h`) drop their `tile_size` parameter and derive it via `TILE_SIZE_BYTES` before refreshing `TILE_SIZE_A/B` GPRs.
4. The public `llk_unpack_hw_configure` API and the `llk_unpack_reconfig_data_format_srca/srcb` API wrappers (WH + BH `llk_unpack_common_api.h`) now `LLK_ASSERT` that the CB's `fifo_page_size` matches the geometry-derived footprint, then delegate to the simplified internal functions. This removes the last \"#34495 TODO: tile size should be computed in the LLK instead\" sites in the codebase.
5. WH `_llk_pack_output_size_bytes_` is refactored to a one-line delegate to `TILE_SIZE_BYTES`, eliminating duplicated BFP correction logic and keeping pack and unpack in agreement.
6. Test kernels that called `_llk_unpack_hw_configure_` or `_llk_unpack_reconfig_data_format_*_impl_` directly (`eltwise_binary_test.cpp`, `reduce_test.cpp`, `matmul_test.cpp`, `matmul_custom_test.cpp`, `unpack_matmul_test.cpp`, `sdpa_reinits_test.cpp`, `topk_test.cpp`, `matmul_and_unary_sfpu_test.cpp`, `matmul_unpack_tilize_test.cpp`) updated to the new signatures, plus the `fuser_sentinel.py` codegen that emits these calls.

Sanity check for a 32x32 tile (`datum_count = 4 * 16 * 16 = 1024`):

| format     | `SCALE_DATUM_SIZE` | sub-byte adj | `+ datum/16` | `TILE_SIZE_BYTES` |
|------------|--------------------|--------------|--------------|-------------------|
| Float32    | 4096               | -            | -            | 4096              |
| Float16(_b)| 2048               | -            | -            | 2048              |
| UInt16     | 2048               | -            | -            | 2048              |
| Int8/UInt8 | 1024               | -            | -            | 1024              |
| Bfp8(_b)   | 1024               | -            | +64          | 1088              |
| Bfp4(_b)   | 1024               | /2 -> 512    | +64          | 576               |
| Bfp2(_b)   | 1024               | /4 -> 256    | +64          | 320               |

All values match what the host program puts into the CB's `fifo_page_size`.

### Notes for reviewers

- `TILE_SIZE_BYTES` was deliberately added as a separate helper rather than folded into `SCALE_DATUM_SIZE`. Reasoning: `SCALE_DATUM_SIZE` is used pervasively for **stride / address arithmetic** (e.g. `bytes_per_face_row`, `block_c_dim`-shifted offsets in `llk_unpack_tilize.h`, `cpack_common.h`, etc.), where folding in BFP exponent bytes (`+ datum_count / 16`) and mantissa-payload divisions would silently corrupt offsets — BFP exponent bytes live in a separate L1 region from mantissa rows, and many call sites pass non-tile-aligned datum counts. Keeping the per-datum byte rate (= `SCALE_DATUM_SIZE`) and the per-tile L1 footprint (= `TILE_SIZE_BYTES`) as two distinct helpers avoids that.
- The deprecated `llk_unpack_hw_configure(unpA_operand, unpB_operand, unpA_face_r_dim, unpA_num_faces)` overload is left in place but its body now uses `TILE_SIZE_BYTES`. It can go away as soon as remaining callers migrate.
- Two test files (`sdpa_reinits_test.cpp`, `topk_test.cpp`) were previously hard-coding tile_size literals (`128`, `16 * 16 * 4`) that didn't match the format/geometry they were configuring; under the new derivation those callers will program the actual L1 footprint instead. Behavior may differ if a test was implicitly relying on a wrong value — please flag if any kernel test starts asserting after this change.
- `LLK_ASSERT` will catch any host-side `CircularBufferConfig` whose `page_size` disagrees with the geometry — please flag any callsite where `fifo_page_size` is intentionally inflated (e.g. for alignment) so we can decide between fixing the host or relaxing the assert.
- Wider \"#34499\" cleanup of the same reconfig family of functions is intentionally out of scope here; only the `tile_size` argument removal (the #34495 portion) is addressed.
- BH does not have an `_llk_pack_output_size_bytes_` equivalent today, so only WH `llk_pack.h` was simplified to delegate. If/when BH grows one, it should call `TILE_SIZE_BYTES` directly.