### PR TITLE
Fix for top k 1 issue on Qwen inference server (bug fix)

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -50,21 +50,28 @@ class TTSampling(LightweightModule):
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
 
-        When every user in the batch has k=1 (top-1), top-p and temperature
-        cannot change the selected token, so we can skip the full top-k / top-p /
+        When every user in the batch has k=1 (top-1), p=1.0 (no top-p filter),
+        and temp=1.0 (no temperature scaling), we can skip the full top-k / top-p /
         temperature / RNG pipeline and use a single all-gather + argmax instead.
         This is significantly faster because argmax needs only one all-gather of the
         full logits tensor vs. three gathers (values, indices, sampled tokens) in the
         normal path.
 
-        This is not just a performance optimization: explicit top-1 sampling leaves
-        no random choice for the sampler, so it must behave as argmax regardless of
-        whether top_p was supplied explicitly or inherited from generation config.
+        Note: p=1.0 here is the *caller's* convention ("keep all tokens"), distinct
+        from the internal device default of p=0 which also means "no filtering."
+        The model config must also set allow_force_argmax=True for this to activate.
 
         Changing this state between decode steps invalidates captured traces, so
         SamplingGenerator maintains separate trace slots keyed by force_argmax.
         """
-        return is_default_value(k, 1)
+        return (
+            is_default_value(k, 1)
+            or (
+                self._allow_force_argmax_sampling
+                and is_default_value(p, 1.0)
+                and is_default_value(temp, 1.0)
+            )
+        )
 
     def _select_topk_indices_dtype(self, per_device_vocab_size: int, multi_step_reduction: bool):
         # if vocab is larger than uint16 max, return uint32 for indices

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -50,26 +50,21 @@ class TTSampling(LightweightModule):
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
 
-        When every user in the batch has k=1 (top-1), p=1.0 (no top-p filter),
-        and temp=1.0 (no temperature scaling), we can skip the full top-k / top-p /
+        When every user in the batch has k=1 (top-1), top-p and temperature
+        cannot change the selected token, so we can skip the full top-k / top-p /
         temperature / RNG pipeline and use a single all-gather + argmax instead.
         This is significantly faster because argmax needs only one all-gather of the
         full logits tensor vs. three gathers (values, indices, sampled tokens) in the
         normal path.
 
-        Note: p=1.0 here is the *caller's* convention ("keep all tokens"), distinct
-        from the internal device default of p=0 which also means "no filtering."
-        The model config must also set allow_force_argmax=True for this to activate.
+        This is not just a performance optimization: explicit top-1 sampling leaves
+        no random choice for the sampler, so it must behave as argmax regardless of
+        whether top_p was supplied explicitly or inherited from generation config.
 
         Changing this state between decode steps invalidates captured traces, so
         SamplingGenerator maintains separate trace slots keyed by force_argmax.
         """
-        return (
-            self._allow_force_argmax_sampling
-            and is_default_value(k, 1)
-            and is_default_value(p, 1.0)
-            and is_default_value(temp, 1.0)
-        )
+        return is_default_value(k, 1)
 
     def _select_topk_indices_dtype(self, per_device_vocab_size: int, multi_step_reduction: bool):
         # if vocab is larger than uint16 max, return uint32 for indices


### PR DESCRIPTION
### Summary
This is simple top K sampling fix for this issue: https://github.com/tenstorrent/tt-inference-server/issues/4004
We override greedy path on top K explicitly now.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:top_k_fix_qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=top_k_fix_qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:top_k_fix_qwen)