### PR TITLE
[Feature] Sampling - Add Int32 Support for Quasar

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sampling.py
@@ -17,12 +17,14 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 from models.common.utility_functions import is_watcher_enabled
 
 
-def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device):
+def check_determinism(
+    input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device, k_dtype=ttnn.uint32
+):
     """
     Check that the sampling operation is deterministic for the same seed.
     """
     # Run the operation twice with the same seed
-    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     p_tensor = ttnn.from_torch(torch.tensor(p), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     temp = ttnn.from_torch(torch.ones(32), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor_1 = ttnn.sampling(
@@ -51,12 +53,12 @@ def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub
     assert torch.allclose(output_1, output_2), "Output is not deterministic for the same seed"
 
 
-def check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device):
+def check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device, k_dtype=ttnn.uint32):
     """
     Check that the sampling operation is random without setting the seed.
     """
     # Run the operation twice with the same seed
-    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     p_tensor = ttnn.from_torch(torch.tensor(p), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     temp = ttnn.from_torch(torch.ones(32), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     output_tensor_1 = ttnn.sampling(
@@ -103,13 +105,15 @@ def validate_statistics(input_values, output, k, p):
             ), f"Output values for user {user_idx} are not within the top-{cutoff_index} values"
 
 
-def run_edge_cases(input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids):
+def run_edge_cases(
+    input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids, k_dtype=ttnn.uint32
+):
     """
     Test edge cases for the sampling operation.
     """
     num_users = len(k)
     k_tensor = ttnn.from_torch(
-        torch.tensor([32] * num_users), device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+        torch.tensor([32] * num_users), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT
     )
     p_tensor = ttnn.from_torch(torch.tensor(p) * 0.0, device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     temp = ttnn.from_torch(torch.ones(32), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -129,13 +133,13 @@ def run_edge_cases(input_values, input_values_tensor, input_indices_tensor, k, p
     ), f"Output for users does not match top-1 value"
 
 
-def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_grids=None):
+def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_grids=None, k_dtype=ttnn.uint32):
     # Convert input tensors to ttnn tensors
     input_values_tensor = ttnn.from_torch(input_values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_indices_tensor = ttnn.from_torch(input_indices, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
 
     temp = ttnn.from_torch(torch.ones(32), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     p_tensor = ttnn.from_torch(torch.tensor(p), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     # Call the sampling operation
     with device.cache_entries_counter.measure():
@@ -153,19 +157,21 @@ def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_
     output = ttnn.to_torch(output_tensor)
 
     # Perform determinism check
-    check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device)
+    check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device, k_dtype=k_dtype)
 
     # Perform randomness check
-    check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device)
+    check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device, k_dtype=k_dtype)
 
     # Perform statistical validation
     validate_statistics(input_values, output, k, p)
 
     # Perform edge case testing
-    run_edge_cases(input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids)
+    run_edge_cases(
+        input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids, k_dtype=k_dtype
+    )
 
 
-def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
+def run_sampling(shape, k, p, seed, device, sub_core_grids=None, k_dtype=ttnn.uint32):
     # Generate random input values and indices
     input_values = torch.randn(shape)
     input_indices = torch.arange(0, shape[-1], dtype=torch.int32).expand(shape)
@@ -179,6 +185,7 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
         seed=seed,
         device=device,
         sub_core_grids=sub_core_grids,
+        k_dtype=k_dtype,
     )
 
 
@@ -192,10 +199,11 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
 @pytest.mark.parametrize("k", [[10, 15, 20, 25, 30] * 6 + [10, 20]])  # Example of per-user k
 @pytest.mark.parametrize("p", [[0.0, 0.3, 0.5, 0.7, 0.9] * 6 + [0.1, 0.8]])  # Example of per-user p
 @pytest.mark.parametrize("seed", [2024, 11, 123])
-def test_sampling_callback(shape, k, p, seed, device):
+@pytest.mark.parametrize("k_dtype", [ttnn.uint32, ttnn.int32])
+def test_sampling_callback(shape, k, p, seed, k_dtype, device):
     torch.manual_seed(seed)
     for i in range(2):
-        run_sampling(shape, k, p, seed, device)
+        run_sampling(shape, k, p, seed, device, k_dtype=k_dtype)
         # Add dummy tensor to make sure that created tensor in 2 iteration don't share the same addr
         tt_dummy_tensor = ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
         if i == 0:
@@ -216,13 +224,14 @@ def test_sampling_callback(shape, k, p, seed, device):
 @pytest.mark.parametrize("k", [[10, 15, 20, 25, 30] * 6 + [10, 20]])  # Example of per-user k
 @pytest.mark.parametrize("p", [[0.0, 0.3, 0.5, 0.7, 0.9] * 6 + [0.1, 0.8]])  # Example of per-user p
 @pytest.mark.parametrize("seed", [2024])
+@pytest.mark.parametrize("k_dtype", [ttnn.uint32, ttnn.int32])
 @pytest.mark.parametrize(
     "sub_core_grids", [ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8 - 1, 4 - 1))})]
 )
-def test_sampling_subcores_callback(shape, k, p, seed, device, sub_core_grids):
+def test_sampling_subcores_callback(shape, k, p, seed, k_dtype, device, sub_core_grids):
     torch.manual_seed(seed)
     for i in range(2):
-        run_sampling(shape, k, p, seed, device, sub_core_grids)
+        run_sampling(shape, k, p, seed, device, sub_core_grids, k_dtype=k_dtype)
         # Add dummy tensor to make sure that created tensor in 2 iteration don't share the same addr
         tt_dummy_tensor = ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
         if i == 0:

--- a/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
@@ -17,9 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 from models.common.utility_functions import is_watcher_enabled
 
 
-def check_determinism(
-    input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device, k_dtype=ttnn.uint32
-):
+def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device, k_dtype):
     """
     Check that the sampling operation is deterministic for the same seed.
     """
@@ -53,7 +51,7 @@ def check_determinism(
     assert torch.allclose(output_1, output_2), "Output is not deterministic for the same seed"
 
 
-def check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device, k_dtype=ttnn.uint32):
+def check_randomness(input_values_tensor, input_indices_tensor, k, p, sub_core_grids, device, k_dtype):
     """
     Check that the sampling operation is random without setting the seed.
     """
@@ -106,7 +104,7 @@ def validate_statistics(input_values, output, k, p):
 
 
 def run_edge_cases(
-    input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids, k_dtype=ttnn.uint32
+    input_values, input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids, k_dtype
 ):
     """
     Test edge cases for the sampling operation.
@@ -133,7 +131,7 @@ def run_edge_cases(
     ), f"Output for users does not match top-1 value"
 
 
-def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_grids=None, k_dtype=ttnn.uint32):
+def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_grids=None, *, k_dtype):
     # Convert input tensors to ttnn tensors
     input_values_tensor = ttnn.from_torch(input_values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     input_indices_tensor = ttnn.from_torch(input_indices, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
@@ -171,7 +169,7 @@ def validate_sampling(input_values, input_indices, k, p, seed, device, sub_core_
     )
 
 
-def run_sampling(shape, k, p, seed, device, sub_core_grids=None, k_dtype=ttnn.uint32):
+def run_sampling(shape, k, p, seed, device, sub_core_grids=None, *, k_dtype):
     # Generate random input values and indices
     input_values = torch.randn(shape)
     input_indices = torch.arange(0, shape[-1], dtype=torch.int32).expand(shape)

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -14,21 +14,33 @@
  * first 32 elements are {0,..31}, then next 32 are {32,..64}
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
  */
+// USE_32BIT == false (WH/BH): pack two 16-bit indices per 32-bit word (UInt16 index tile, LO16
+// dest mode). USE_32BIT == true (Quasar): write one 32-bit index per element (Int32 index tile,
+// INT32 dest mode). The index width must match the top-k LLK's fp32_dest_acc_en setting.
+template <bool USE_32BIT>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // TODO: investigate moving to compile time (binary size is at risk)
     CircularBuffer cb(cb_id);
     cb.reserve_back(1);
     CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
-    uint16_t wt_offset = wt << 5;
+    uint32_t wt_offset = wt << 5;
 
     uint32_t count = 0;
     for (uint32_t i = 0; i < 2; ++i) {
         for (uint32_t j = 0; j < 2; ++j) {
             for (uint32_t k = 0; k < 16; ++k) {
-                for (uint32_t l = 0; l < 16; l += 2) {
-                    uint16_t value = l + 16 * j + wt_offset;
-                    ptr[count] = (value + 1) << 16 | value;
-                    count++;
+                if constexpr (USE_32BIT) {
+                    for (uint32_t l = 0; l < 16; ++l) {
+                        uint32_t value = l + 16 * j + wt_offset;
+                        ptr[count] = value;
+                        count++;
+                    }
+                } else {
+                    for (uint32_t l = 0; l < 16; l += 2) {
+                        uint16_t value = l + 16 * j + wt_offset;
+                        ptr[count] = (value + 1) << 16 | value;
+                        count++;
+                    }
                 }
             }
         }
@@ -48,8 +60,9 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(4);
     constexpr uint32_t input_indices_page_size = get_compile_time_arg_val(5);
     constexpr uint32_t tile_height = get_compile_time_arg_val(6);
+    constexpr bool use_32bit_index = get_compile_time_arg_val(7) == 1;
 
-    constexpr auto s0_args = TensorAccessorArgs<7>();
+    constexpr auto s0_args = TensorAccessorArgs<8>();
     constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
 
     // ublocks size defined in tiles
@@ -73,7 +86,7 @@ void kernel_main() {
             noc.async_read(
                 s0, input_values_cb, tile_bytes_input_values, {.page_id = tile_id_input_values}, {.offset_bytes = 0});
             tile_id_input_values++;
-            generate_index_tile(cb_intermed_index, j);
+            generate_index_tile<use_32bit_index>(cb_intermed_index, j);
             noc.async_read_barrier();
             input_values_cb.push_back(onetile);
         }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include "api/numeric/bfloat16.h"
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
@@ -63,6 +64,9 @@ void kernel_main() {
     constexpr uint32_t core_id = get_compile_time_arg_val(args_base + 13);
     constexpr uint32_t ids_per_batch = get_compile_time_arg_val(args_base + 14);
     constexpr uint32_t num_cores = get_compile_time_arg_val(args_base + 15);
+    // Local sort-index width must match the index CB format / fp32_dest_acc_en chosen by the host:
+    // 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
+    constexpr bool use_32bit_index = get_compile_time_arg_val(args_base + 16) == 1;
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -132,7 +136,8 @@ void kernel_main() {
     // Read producer-written compute outputs from these CBs in L1.
     CoreLocalMem<volatile uint16_t> local_values(cb_local_values.get_read_ptr());
 
-    CoreLocalMem<volatile uint16_t> local_indices(cb_local_indices.get_read_ptr());
+    using local_index_t = std::conditional_t<use_32bit_index, uint32_t, uint16_t>;
+    CoreLocalMem<volatile local_index_t> local_indices(cb_local_indices.get_read_ptr());
 
     CoreLocalMem<volatile uint32_t> final_indices(cb_final_indices.get_read_ptr() + core_id * final_indices_stick_size);
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -12,6 +12,8 @@
 #include "ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
+#include <tt-metalium/tt_backend_api_types.hpp>
+
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -23,6 +25,12 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     const auto& p = tensor_args.p;
     const auto& temp = tensor_args.temp;
     const auto& preallocated_output_tensor = tensor_args.preallocated_output;
+
+    // Quasar lacks UInt16/UInt32 tile (DFB) metadata support, so the index/k/output dtypes must be
+    // INT32 there (the program factory drives the kernels in INT32 mode on Quasar). WH/BH continue
+    // to accept both UINT32 and INT32. Reject UINT32 explicitly on Quasar instead of silently
+    // miscomputing.
+    const bool is_quasar = input_values_tensor.device()->arch() == tt::ARCH::QUASAR;
 
     TT_FATAL(
         input_values_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -38,6 +46,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_indices_tensor.dtype() == DataType::UINT32 || input_indices_tensor.dtype() == DataType::INT32,
         "Only UINT32 & INT32 dtypes are supported for input indices!");
+    TT_FATAL(
+        !is_quasar || input_indices_tensor.dtype() == DataType::INT32,
+        "On Quasar, only INT32 is supported for input indices (UINT32 tile format is unavailable)!");
 
     TT_FATAL(input_indices_tensor.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR is supported for input indices!");
 
@@ -81,6 +92,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
             preallocated_output_tensor.value().dtype() == DataType::UINT32 ||
                 preallocated_output_tensor.value().dtype() == DataType::INT32,
             "Only UINT32 & INT32 dtypes are supported for outputs!");
+        TT_FATAL(
+            !is_quasar || preallocated_output_tensor.value().dtype() == DataType::INT32,
+            "On Quasar, only INT32 is supported for outputs (UINT32 tile format is unavailable)!");
 
         TT_FATAL(
             preallocated_output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -107,6 +121,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         k.dtype() == DataType::UINT32 || k.dtype() == DataType::INT32,
         "Only UINT32 & INT32 dtypes are supported for k!");
+    TT_FATAL(
+        !is_quasar || k.dtype() == DataType::INT32,
+        "On Quasar, only INT32 is supported for k (UINT32 tile format is unavailable)!");
     TT_FATAL(p.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for p!");
     TT_FATAL(temp.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for temp!");
     TT_FATAL(k.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for k!");
@@ -127,9 +144,13 @@ TensorSpec SamplingDeviceOperation::compute_output_specs(
     auto input_shape = input_values_tensor.logical_shape();
     ttnn::Shape output_shape({1, 1, 1, input_shape[2]});
 
+    // Quasar cannot represent a UInt32 tile, so the default (non-preallocated) output must be INT32
+    // there; WH/BH keep the historical UINT32 default.
+    const bool is_quasar = input_values_tensor.device()->arch() == tt::ARCH::QUASAR;
+    const DataType output_dtype = is_quasar ? DataType::INT32 : DataType::UINT32;
+
     return TensorSpec(
-        output_shape,
-        TensorLayout(DataType::UINT32, PageConfig(Layout::ROW_MAJOR), input_values_tensor.memory_config()));
+        output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), input_values_tensor.memory_config()));
 }
 
 Tensor SamplingDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -26,11 +26,12 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     const auto& temp = tensor_args.temp;
     const auto& preallocated_output_tensor = tensor_args.preallocated_output;
 
-    // Quasar lacks UInt16/UInt32 tile (DFB) metadata support, so the index/k/output dtypes must be
-    // INT32 there (the program factory drives the kernels in INT32 mode on Quasar). WH/BH continue
-    // to accept both UINT32 and INT32. Reject UINT32 explicitly on Quasar instead of silently
-    // miscomputing.
-    const bool is_quasar = input_values_tensor.device()->arch() == tt::ARCH::QUASAR;
+    // WH/BH support both UINT32 and INT32 for the index/k/output dtypes. Every other architecture
+    // (e.g. Quasar, which lacks UInt16/UInt32 tile (DFB) metadata support) runs the kernels in the
+    // 32-bit (INT32) path, so UINT32 is not representable and must be rejected instead of silently
+    // miscomputing. Gated on !(WH || BH) so new architectures default to the safe 32-bit path.
+    const auto arch = input_values_tensor.device()->arch();
+    const bool use_32bit_index = !(arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE);
 
     TT_FATAL(
         input_values_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -47,8 +48,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
         input_indices_tensor.dtype() == DataType::UINT32 || input_indices_tensor.dtype() == DataType::INT32,
         "Only UINT32 & INT32 dtypes are supported for input indices!");
     TT_FATAL(
-        !is_quasar || input_indices_tensor.dtype() == DataType::INT32,
-        "On Quasar, only INT32 is supported for input indices (UINT32 tile format is unavailable)!");
+        !use_32bit_index || input_indices_tensor.dtype() == DataType::INT32,
+        "Only INT32 is supported for input indices on this architecture (UINT32 is only available on "
+        "Wormhole/Blackhole)!");
 
     TT_FATAL(input_indices_tensor.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR is supported for input indices!");
 
@@ -93,8 +95,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
                 preallocated_output_tensor.value().dtype() == DataType::INT32,
             "Only UINT32 & INT32 dtypes are supported for outputs!");
         TT_FATAL(
-            !is_quasar || preallocated_output_tensor.value().dtype() == DataType::INT32,
-            "On Quasar, only INT32 is supported for outputs (UINT32 tile format is unavailable)!");
+            !use_32bit_index || preallocated_output_tensor.value().dtype() == DataType::INT32,
+            "Only INT32 is supported for outputs on this architecture (UINT32 is only available on "
+            "Wormhole/Blackhole)!");
 
         TT_FATAL(
             preallocated_output_tensor.value().memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
@@ -122,8 +125,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
         k.dtype() == DataType::UINT32 || k.dtype() == DataType::INT32,
         "Only UINT32 & INT32 dtypes are supported for k!");
     TT_FATAL(
-        !is_quasar || k.dtype() == DataType::INT32,
-        "On Quasar, only INT32 is supported for k (UINT32 tile format is unavailable)!");
+        !use_32bit_index || k.dtype() == DataType::INT32,
+        "Only INT32 is supported for k on this architecture (UINT32 is only available on "
+        "Wormhole/Blackhole)!");
     TT_FATAL(p.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for p!");
     TT_FATAL(temp.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for temp!");
     TT_FATAL(k.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for k!");
@@ -144,10 +148,12 @@ TensorSpec SamplingDeviceOperation::compute_output_specs(
     auto input_shape = input_values_tensor.logical_shape();
     ttnn::Shape output_shape({1, 1, 1, input_shape[2]});
 
-    // Quasar cannot represent a UInt32 tile, so the default (non-preallocated) output must be INT32
-    // there; WH/BH keep the historical UINT32 default.
-    const bool is_quasar = input_values_tensor.device()->arch() == tt::ARCH::QUASAR;
-    const DataType output_dtype = is_quasar ? DataType::INT32 : DataType::UINT32;
+    // WH/BH keep the historical UINT32 default; every other architecture (e.g. Quasar) runs the
+    // 32-bit path and cannot represent a UInt32 tile, so the default (non-preallocated) output must
+    // be INT32 there. Gated on !(WH || BH) so new architectures default to the safe INT32 path.
+    const auto arch = input_values_tensor.device()->arch();
+    const bool use_32bit_index = !(arch == tt::ARCH::WORMHOLE_B0 || arch == tt::ARCH::BLACKHOLE);
+    const DataType output_dtype = use_32bit_index ? DataType::INT32 : DataType::UINT32;
 
     return TensorSpec(
         output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), input_values_tensor.memory_config()));

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -51,6 +51,17 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
         input_shape[3] != 0 && input_shape[3] % 32 == 0,
         "Input inner dim ({}) must be non-zero and divisible by 32, pad if needed!",
         input_shape[3]);
+    // The top-k stage processes the W/32 candidate tiles with a pairwise local sort followed by a
+    // bitonic merge tree whose schedule assumes a power-of-2 tile count. A non-power-of-2 Wt hangs
+    // the device (odd Wt) or silently drops candidate tiles (even non-power-of-2 Wt), so reject it
+    // here instead of timing out. See https://github.com/tenstorrent/tt-metal/issues/44558.
+    const uint32_t Wt = input_shape[3] / 32;
+    TT_FATAL(
+        (Wt & (Wt - 1)) == 0,
+        "Input inner dim ({}) must yield a power-of-2 number of tiles (Wt = W/32 = {}); pad W up to the "
+        "next power-of-2 multiple of 32 (e.g. with -inf values and dummy indices) if needed!",
+        input_shape[3],
+        Wt);
 
     if (args.sub_core_grids.has_value()) {
         ReduceOpDeviceGridValidationOptions sampling_grid_opts;
@@ -93,7 +104,9 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     }
 
     // Check size, layout and dtype of k, p, temp
-    TT_FATAL(k.dtype() == DataType::UINT32, "Only UINT32 dtypes are supported for k!");
+    TT_FATAL(
+        k.dtype() == DataType::UINT32 || k.dtype() == DataType::INT32,
+        "Only UINT32 & INT32 dtypes are supported for k!");
     TT_FATAL(p.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for p!");
     TT_FATAL(temp.dtype() == DataType::BFLOAT16, "Only BFLOAT16 dtypes are supported for temp!");
     TT_FATAL(k.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for k!");

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -48,13 +48,9 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     tt::DataFormat input_indices_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_indices_tensor.dtype());
     tt::DataFormat index_cb_data_format = use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
+    // On the 32-bit path (e.g. Quasar), validation already requires k to be INT32 (UInt32 DFB
+    // metadata is unsupported there), so the dtype-derived format is correct as-is.
     tt::DataFormat k_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
-    // Architectures on the 32-bit path (e.g. Quasar) reject UInt32 DFB metadata; k values are
-    // non-negative and fit in signed 32-bit, so stage k as Int32 there. WH/BH keep the
-    // dtype-derived format unchanged.
-    if (use_32bit_index && k_cb_data_format == tt::DataFormat::UInt32) {
-        k_cb_data_format = tt::DataFormat::Int32;
-    }
     tt::DataFormat p_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(p.dtype());
     tt::DataFormat temp_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(temp.dtype());
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -32,12 +32,27 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
 
     uint32_t random_seed = 0;
 
+    auto* device = &input_values_tensor.mutable_device();
+
+    // The bitonic top-k LLK carries sort indices through the dest register, and the index
+    // load/store width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). Quasar
+    // additionally does not support UInt16/UInt32 tile (DFB) metadata. So on Quasar we use 32-bit
+    // (Int32) index intermediates with fp32 dest accumulation enabled; on WH/BH we keep the
+    // cheaper 16-bit (UInt16) path with fp32 dest accumulation disabled (unchanged behavior)
+    // so that WH/BH does not suffer any restrictions on the dest register
+    const bool use_32bit_index = (device->arch() == tt::ARCH::QUASAR);
+
     tt::DataFormat input_values_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_values_tensor.dtype());
     tt::DataFormat input_indices_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_indices_tensor.dtype());
-    tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+    tt::DataFormat index_cb_data_format = use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
     tt::DataFormat k_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
+    // Quasar rejects UInt32 DFB metadata; k values are non-negative and fit in signed 32-bit, so
+    // stage k as Int32 there. WH/BH keep the dtype-derived format unchanged.
+    if (use_32bit_index && k_cb_data_format == tt::DataFormat::UInt32) {
+        k_cb_data_format = tt::DataFormat::Int32;
+    }
     tt::DataFormat p_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(p.dtype());
     tt::DataFormat temp_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(temp.dtype());
 
@@ -45,8 +60,6 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     uint32_t index_tile_size = tile_size(index_cb_data_format);
 
     const auto& output_mesh = output_tensor.mesh_tensor();
-
-    auto* device = &input_values_tensor.mutable_device();
 
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
@@ -320,7 +333,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         Ht,
         Wt,
         aligned_final_indices_rm_unit_size,
-        tile_height};
+        tile_height,
+        static_cast<uint32_t>(use_32bit_index)};
     tt::tt_metal::TensorAccessorArgs(input_values_tensor).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_compile_time_args);
 
@@ -370,6 +384,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
                 i,
                 tile_width,
                 num_cores,
+                static_cast<uint32_t>(use_32bit_index),
             });
 
         KernelDescriptor writer_desc;
@@ -408,7 +423,11 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
         compute_desc.core_ranges = single_core;
         compute_desc.compile_time_args = compute_args;
-        compute_desc.config = ComputeConfigDescriptor{};
+        // 32-bit (Int32) sort indices require fp32 dest accumulation so the top-k LLK loads/stores
+        // indices in INT32 mode; the 16-bit (UInt16) path uses LO16 mode with fp32 dest acc off.
+        compute_desc.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = use_32bit_index,
+        };
         desc.kernels.push_back(std::move(compute_desc));
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -35,12 +35,13 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     auto* device = &input_values_tensor.mutable_device();
 
     // The bitonic top-k LLK carries sort indices through the dest register, and the index
-    // load/store width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). Quasar
-    // additionally does not support UInt16/UInt32 tile (DFB) metadata. So on Quasar we use 32-bit
-    // (Int32) index intermediates with fp32 dest accumulation enabled; on WH/BH we keep the
-    // cheaper 16-bit (UInt16) path with fp32 dest accumulation disabled (unchanged behavior)
-    // so that WH/BH does not suffer any restrictions on the dest register
-    const bool use_32bit_index = (device->arch() == tt::ARCH::QUASAR);
+    // load/store width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). WH/BH
+    // support the cheaper 16-bit (UInt16) path with fp32 dest accumulation disabled (unchanged
+    // behaviour) so that WH/BH does not suffer any restrictions on the dest register. Every other
+    // architecture (e.g. Quasar, which additionally lacks UInt16/UInt32 tile (DFB) metadata
+    // support) uses 32-bit (Int32) index intermediates with fp32 dest accumulation enabled. This
+    // is gated on !(WH || BH) so new architectures default to the safe 32-bit path.
+    const bool use_32bit_index = !(device->arch() == tt::ARCH::WORMHOLE_B0 || device->arch() == tt::ARCH::BLACKHOLE);
 
     tt::DataFormat input_values_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_values_tensor.dtype());
@@ -48,8 +49,9 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         tt::tt_metal::datatype_to_dataformat_converter(input_indices_tensor.dtype());
     tt::DataFormat index_cb_data_format = use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
     tt::DataFormat k_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
-    // Quasar rejects UInt32 DFB metadata; k values are non-negative and fit in signed 32-bit, so
-    // stage k as Int32 there. WH/BH keep the dtype-derived format unchanged.
+    // Architectures on the 32-bit path (e.g. Quasar) reject UInt32 DFB metadata; k values are
+    // non-negative and fit in signed 32-bit, so stage k as Int32 there. WH/BH keep the
+    // dtype-derived format unchanged.
     if (use_32bit_index && k_cb_data_format == tt::DataFormat::UInt32) {
         k_cb_data_format = tt::DataFormat::Int32;
     }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -88,14 +88,16 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                 output tensor (UINT32/UINT16 tile formats are unavailable). On Wormhole and Blackhole,
                 both UINT32 and INT32 are supported.
 
-            If no :attr:`output_tensor` is provided, the return tensor will be as follows:
+            If no :attr:`output_tensor` is provided, the return tensor will be as follows.
+            The default dtype is architecture-dependent: UINT32 on Wormhole/Blackhole, and INT32 on
+            Quasar (which does not support UINT32 tile formats).
 
             .. list-table:: output_tensor (default)
                 :header-rows: 1
 
                 * - dtype
                   - layout
-                * - UINT32
+                * - UINT32 (Wormhole/Blackhole), INT32 (Quasar)
                   - ROW_MAJOR
 
             If :attr:`output_tensor` is provided, the supported data types and layout are:

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -45,7 +45,7 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
             temp (ttnn.Tensor): Temperature tensor for scaling (1/T).
             seed (int, optional): Seed for sampling randomness. Defaults to `0`.
             sub_core_grids (ttnn.CoreRangeSet, optional): Core range set for multicore execution. Defaults to `None`.
-            optional_output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): Preallocated output tensor. Defaults to `None`.
 
         Note:
             This operations only supports inputs and outputs according to the following data types and layout:
@@ -58,21 +58,12 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                 * - BFLOAT16
                   - TILE
 
-
-            .. list-table:: input_indices_tensor
+            .. list-table:: input_indices_tensor, k
                 :header-rows: 1
 
                 * - dtype
                   - layout
-                * - UINT32, INT32
-                  - ROW_MAJOR
-
-            .. list-table:: k
-                :header-rows: 1
-
-                * - dtype
-                  - layout
-                * - UINT32, INT32
+                * - UINT32 (only on Wormhole/Blackhole), INT32
                   - ROW_MAJOR
 
             .. list-table:: p, temp
@@ -83,52 +74,37 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                 * - BFLOAT16
                   - ROW_MAJOR
 
-            .. note::
-                On Quasar, only INT32 is supported for :attr:`input_indices_tensor`, :attr:`k`, and the
-                output tensor (UINT32/UINT16 tile formats are unavailable). On Wormhole and Blackhole,
-                both UINT32 and INT32 are supported.
-
-            If no :attr:`output_tensor` is provided, the return tensor will be as follows.
-            The default dtype is architecture-dependent: UINT32 on Wormhole/Blackhole, and INT32 on
-            Quasar (which does not support UINT32 tile formats).
-
-            .. list-table:: output_tensor (default)
+            .. list-table:: output_tensor (optional)
                 :header-rows: 1
 
                 * - dtype
                   - layout
-                * - UINT32 (Wormhole/Blackhole), INT32 (Quasar)
+                * - UINT32 (only on Wormhole/Blackhole), INT32
                   - ROW_MAJOR
 
-            If :attr:`output_tensor` is provided, the supported data types and layout are:
+            On Wormhole and Blackhole, both UINT32 and INT32 are supported for
+            :attr:`input_indices_tensor`, :attr:`k`, and the output tensor. Otherwise (e.g. on
+            Quasar, which does not support UINT32/UINT16 tile formats), only INT32 is supported.
 
-            .. list-table:: output_tensor (if provided)
-                :header-rows: 1
+        Returns:
+            ttnn.Tensor: The output tensor containing sampled indices.
 
-                * - dtype
-                  - layout
-                * - INT32, UINT32
-                  - ROW_MAJOR
+        Memory Support:
+            - Interleaved: DRAM and L1
 
-            Returns:
-                ttnn.Tensor: The output tensor containing sampled indices.
-
-            Memory Support:
-                - Interleaved: DRAM and L1
-
-            Limitations:
-                - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
-                - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
-                - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
-                - The number of tiles along the last dimension, ``Wt = W / 32``, must be a power of 2
-                  (i.e. ``W`` must be a power-of-2 multiple of 32: 32, 64, 128, 256, ...). The internal
-                  top-k stage uses a bitonic merge tree that assumes a power-of-2 tile count; a
-                  non-power-of-2 ``Wt`` is rejected. Pad ``W`` up to the next power-of-2 multiple of 32
-                  (e.g. with ``-inf`` values and dummy indices) if needed.
-                - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
-                - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
-                - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
-                - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
+        Limitations:
+            - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
+            - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
+            - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
+            - The number of tiles along the last dimension, ``Wt = W / 32``, must be a power of 2
+              (i.e. ``W`` must be a power-of-2 multiple of 32: 32, 64, 128, 256, ...). The internal
+              top-k stage uses a bitonic merge tree that assumes a power-of-2 tile count; a
+              non-power-of-2 ``Wt`` is rejected. Pad ``W`` up to the next power-of-2 multiple of 32
+              (e.g. with ``-inf`` values and dummy indices) if needed.
+            - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
+            - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
+            - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
+            - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
         )doc";
 
     ttnn::bind_function<"sampling">(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -72,7 +72,7 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
 
                 * - dtype
                   - layout
-                * - UINT32
+                * - UINT32, INT32
                   - ROW_MAJOR
 
             .. list-table:: p, temp
@@ -82,6 +82,11 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                   - layout
                 * - BFLOAT16
                   - ROW_MAJOR
+
+            .. note::
+                On Quasar, only INT32 is supported for :attr:`input_indices_tensor`, :attr:`k`, and the
+                output tensor (UINT32/UINT16 tile formats are unavailable). On Wormhole and Blackhole,
+                both UINT32 and INT32 are supported.
 
             If no :attr:`output_tensor` is provided, the return tensor will be as follows:
 
@@ -113,6 +118,11 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
                 - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
                 - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
                 - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
+                - The number of tiles along the last dimension, ``Wt = W / 32``, must be a power of 2
+                  (i.e. ``W`` must be a power-of-2 multiple of 32: 32, 64, 128, 256, ...). The internal
+                  top-k stage uses a bitonic merge tree that assumes a power-of-2 tile count; a
+                  non-power-of-2 ``Wt`` is rejected. Pad ``W`` up to the next power-of-2 multiple of 32
+                  (e.g. with ``-inf`` values and dummy indices) if needed.
                 - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
                 - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
                 - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -86,6 +86,9 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
             :attr:`input_indices_tensor`, :attr:`k`, and the output tensor. Otherwise (e.g. on
             Quasar, which does not support UINT32/UINT16 tile formats), only INT32 is supported.
 
+            When :attr:`output_tensor` is not provided, the default output dtype is architecture-dependent:
+            UINT32 on Wormhole/Blackhole, and INT32 otherwise.
+
         Returns:
             ttnn.Tensor: The output tensor containing sampled indices.
 


### PR DESCRIPTION
### Summary
#45196 - Quasar does not support uint16 or uint32, whereas Sampling used int16 internally and required 'k' to be int32. This adds support for k to be uint32, and on Quasar, uses int32 internally. Note that the bitonic sort used in sampling puts the index in the dest register, meaning that int32 requires enabling fp32 accumulation. To prevent regressions in WH/BH, int16 is still used internally where possible (int32 only used for Quasar).

Also note that validation is not possible on Quasar currently as LLKs aren't ready, and emulation only has a 1x2 grid, while this op indirectly requires a grid of 32 cores due to its requirements of 32 users. Two assertions ensure this:

1. N\*C\*H == 32: https://github.com/tenstorrent/tt-metal/blob/4f90717932abe7ffe170c843cd76c0b8a7d38490/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp#L49
2. Where a sub core grid is supplied, the num_cores must equal N\*C\*H:  https://github.com/tenstorrent/tt-metal/blob/4f90717932abe7ffe170c843cd76c0b8a7d38490/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp#L65

Issue https://github.com/tenstorrent/tt-metal/issues/46371 is opened to explore non-32 user/core sampling.

PR also adds validation to ensure size of a power of two for https://github.com/tenstorrent/tt-metal/issues/44558

Sampling tests are moved to Reduce directory to reflect op ownership

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/45196/sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/45196/sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/45196/sampling)