### PR TITLE
[WH][LLK] Fix fp32 dest-reuse ZEROACC zero-flag addressing

### DIFF
--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NoC_tile_transfer)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfpu_eltwise_chain)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_sfpi_add)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_sfpi_smoothstep)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wh_alias_dest_reuse_repro)
 
 add_custom_target(
     programming_examples

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/CMakeLists.txt
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22...4.2)
+project(wh_alias_dest_reuse_repro)
+
+add_executable(wh_alias_dest_reuse_repro)
+target_sources(wh_alias_dest_reuse_repro PRIVATE wh_alias_dest_reuse_repro.cpp)
+
+if(NOT TARGET TT::Metalium)
+    find_package(TT-Metalium REQUIRED)
+endif()
+target_link_libraries(wh_alias_dest_reuse_repro PUBLIC TT::Metalium)
+if(TARGET TT::CommonPCH)
+    tt_reuse_precompile_headers(wh_alias_dest_reuse_repro TT::CommonPCH)
+endif()

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/README.md
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/README.md
@@ -1,0 +1,121 @@
+# WH dest-reuse ELWMUL bug repro (after UnpackToDest fp32 read)
+
+Minimal standalone reproducer for a Wormhole-B0-only LLK bug: any compute kernel that
+performs an UnpackToDest fp32 read followed by `binary_dest_reuse_tiles<ELWMUL,
+DEST_TO_SRCB>` with `fp32_dest_acc_en=true` produces structurally wrong output. The
+identical sequence runs correctly on Blackhole.
+
+## Trigger conditions (all required)
+
+1. `fp32_dest_acc_en = true` in compute kernel config.
+2. `DstSync::SyncHalf` (the default).
+3. At least one CB has `unpack_to_dest_mode = UnpackToDestFp32` AND the kernel
+   actually performs an UnpackToDest fp32 read of it (e.g. `copy_tile(cb, 0, dst)`
+   where the LLK takes the UnpackToDest path because both src and unpack_dst are
+   Float32).
+4. After that read, the kernel does `sub_tiles_bcast_cols(primary_cb, bcast_a, ...)`
+   followed by `binary_dest_reuse_tiles<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+   bcast_b, 0, i)` within the same `tile_regs_acquire/commit` window on a CB
+   carrying Float32 data.
+
+**Multi-buffer-index CB aliasing is NOT required.** The test demonstrates this by
+running two cases:
+- **Case A**: the UnpackToDest cb and the dest-reuse-ELWMUL cb have separate L1
+  allocations.
+- **Case B**: they share an L1 allocation via the multi-buffer-index pattern.
+
+Both fail with the identical pattern on WH.
+
+## Observed failure pattern on WH
+
+Per 4-tile `SyncHalf` block (`block_size = 4` with fp32 dest acc):
+
+```
+Block N (even index): tile 0 correct, tiles 1-3 zero
+Block N (odd index):  all 4 tiles scaled by (1 + bcast_b) / bcast_b
+```
+
+The over-scaling is exactly the accumulation signature `dst = dst + dst*srcA`
+instead of `dst = dst*srcA`. With `bcast_b = 0.7` the ratio is ~2.4286 (= 17/7).
+
+## Files
+
+- [wh_alias_dest_reuse_repro.cpp](wh_alias_dest_reuse_repro.cpp) — host driver.
+  Runs Case A then Case B, prints per-tile expected/actual/ratio, classifies tiles
+  into "correct", "zero", "over-scaled", and reports pass/fail.
+- [kernels/compute/alias_dest_reuse.cpp](kernels/compute/alias_dest_reuse.cpp) —
+  compute kernel. Does `copy_tile(cb_alias, 0, 0)` (UnpackToDest fp32 path), then
+  per-block: `sub_tiles_bcast_cols(cb_primary, cb_bcast_a, i, 0, i)` for i in 0..3,
+  then `binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCB>(cb_bcast_b, 0, i)` for i in
+  0..3, then pack.
+- [kernels/dataflow/reader.cpp](kernels/dataflow/reader.cpp) — pushes x / bcast_a
+  / bcast_b tiles. Handles both Case A (writes data to alias's own L1) and Case B
+  (alias shares L1; reader just pushes the alias semaphore).
+- [kernels/dataflow/writer.cpp](kernels/dataflow/writer.cpp) — drains the output
+  CB to DRAM.
+
+## Build and run
+
+```
+./build_metal.sh -e --enable-fake-kernels-target --build-programming-examples
+build_Release/programming_examples/wh_alias_dest_reuse_repro
+```
+
+## Expected results
+
+| Arch | Case A | Case B |
+|------|--------|--------|
+| WH   | FAIL (striped pattern: 5 zero-output tiles, 8 over-scaled tiles) | FAIL (same striped pattern) |
+| BH   | PASS (ratio ≈ 0.9989 throughout — TF32 SrcA rounding only) | PASS (same) |
+
+Cases A and B fail identically on WH — **multi-buffer-index aliasing is NOT
+required** to trigger the bug. They produce identical correct output on BH
+(modulo TF32 SrcA rounding on the dest-reuse mul).
+
+PASS/FAIL is decided purely by structural metrics:
+- `num_zero_tiles == 0` (tiles whose output is ~0 but expected is non-trivial)
+- `num_overscaled_tiles == 0` (tiles where actual/expected > 2)
+
+Per-element diffs that exceed a small absolute threshold (~1e-3) are still
+printed as `mismatch (informational, not part of verdict)` lines so anyone
+reading the output can see the magnitude of any precision deviation, but they
+do not influence the verdict. The structural metrics are what reliably
+distinguish "bug triggered" from "correct output with TF32 rounding" on
+architectures where the dest-reuse mul reads its operand through the SrcA
+TF32 path.
+
+### Empirical BH output for comparison
+
+On Blackhole, every tile prints a ratio of ~0.9989 (a ~0.1% TF32 rounding loss
+because `cb_bcast_b` is read via SrcA in the dest-reuse mul). No zero-output
+tiles, no over-scaling. Both cases pass.
+
+On Wormhole-B0, the per-block ratio pattern is:
+```
+Block N (even index): tile 0 correct, tiles 1-3 zero
+Block N (odd index):  all 4 tiles scaled by (1 + bcast_b) / bcast_b ≈ 2.4286
+```
+
+## Suspected root cause
+
+The bug appears to be in WH-specific cleanup after `_llk_unpack_A_` runs with
+`unpack_to_dest=true`. The function `unpack_to_dest_tile_done` in
+[`tt_llk_wormhole_b0/common/inc/cunpack_common.h:920-941`](../../tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h)
+includes a WH-only TEN-3868 hardware-bug workaround that performs a dummy
+`TT_UNPACR(SrcA, ...)` after every UnpackToDest read. BH's variant of the same
+function lacks this workaround. The dummy unpack may leave residual SrcA / cfg
+state that corrupts the subsequent dest-reuse ELWMUL path
+(`_llk_math_eltwise_binary_with_dest_reuse_` in
+[`tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h:451-523`](../../tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h))
+specifically when both ZEROACC and `move_d2b_fixed_face` are involved.
+
+## Background
+
+Originally found while debugging fp32 + Welford layernorm on the
+`fplavec_43673_welford` branch (PCC ≈ 0.6 on
+`test_large_layer_norm[dtype=torch.float32-use_welford=True-w=3200-h=2080]`). The
+fix in that branch is a kernel-side workaround that avoids `binary_dest_reuse_tiles<
+ELWMUL, DEST_TO_SRCB>` and instead packs `(x - mean)` to an intermediate CB then
+re-reads it with `mul_tiles_bcast_cols` (the pattern used by `layernorm_welford.cpp`,
+which works on WH). This repro strips away the layernorm-specific machinery to give
+the LLK team a tight, layernorm-free starting point.

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/compute/alias_dest_reuse.cpp
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/compute/alias_dest_reuse.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal repro for a Wormhole-B0-only LLK bug seen with:
+//   - fp32_dest_acc_en = true
+//   - DstSync::SyncHalf (block_size = 4 with fp32 dest acc)
+//   - An UnpackToDest fp32 copy_tile (from any CB in UnpackToDestFp32 mode)
+//     followed by sub_tiles_bcast_cols + binary_dest_reuse_tiles<ELWMUL,
+//     DEST_TO_SRCB> on a CB whose primary buffer index is in Default (Tf32)
+//     unpack mode.
+//
+// The kernel intentionally does the same compute sequence in both Case A
+// (cb_primary and cb_alias have SEPARATE L1 allocations) and Case B
+// (cb_primary and cb_alias share ONE L1 allocation via two CBFormatDescriptors).
+// Both cases fail identically on WH and pass identically on BH, which
+// proves multi-buffer-index CB aliasing is NOT a required trigger condition.
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/reconfig_data_format.h"
+
+using namespace ckernel;
+
+void kernel_main() {
+    // Compile-time args:
+    //   0: n_blocks (each block is block_size tiles, DstSync::SyncHalf alternates parity)
+    //   1: block_size (number of tiles per dst-half block; 4 for fp32 dest acc on WH)
+    constexpr uint32_t n_blocks = get_compile_time_arg_val(0);
+    constexpr uint32_t block_size = get_compile_time_arg_val(1);
+
+    // CB layout: cb_primary (Tf32, Default unpack mode) holds x. cb_alias is the
+    // second buffer-index view of the SAME (Case B) or a SEPARATE (Case A) L1
+    // allocation, in UnpackToDestFp32 mode. The host writes the same x bytes
+    // into both views. cb_bcast_a and cb_bcast_b are column-broadcast tiles
+    // (only the first column is meaningful) used by the sub and mul ops.
+    constexpr uint32_t cb_primary = tt::CBIndex::c_0;  // x, Default Tf32 unpack mode
+    constexpr uint32_t cb_alias = tt::CBIndex::c_29;   // alias of cb_primary, UnpackToDestFp32
+    constexpr uint32_t cb_bcast_a = tt::CBIndex::c_2;  // column-broadcast 'a' (subtrahend)
+    constexpr uint32_t cb_bcast_b = tt::CBIndex::c_3;  // column-broadcast 'b' (multiplier)
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;     // output
+
+    compute_kernel_hw_startup(cb_primary, cb_bcast_a, cb_out);
+
+    // Wait once for the bcast operand tiles; reader pushes them up front and they
+    // are read repeatedly. (One tile each suffices because we use them as broadcasts.)
+    cb_wait_front(cb_bcast_a, 1);
+    cb_wait_front(cb_bcast_b, 1);
+
+    for (uint32_t block = 0; block < n_blocks; ++block) {
+        // Wait for one block's worth of x tiles in cb_primary (and equivalently
+        // cb_alias, which aliases the same allocation or has a separate semaphore).
+        cb_wait_front(cb_primary, block_size);
+        cb_wait_front(cb_alias, block_size);
+
+        tile_regs_acquire();
+
+        // Step 1: copy_tile from the ALIAS index. With unpack_to_dest_mode=
+        // UnpackToDestFp32 on the alias index and Float32 data, the LLK takes
+        // the UnpackToDest fp32 path. We discard the result by overwriting the
+        // same dst slot below; the side effects on unpacker state are what
+        // matters.
+        reconfig_data_format_srca(cb_primary, cb_alias);
+        copy_tile_init(cb_alias);
+        copy_tile(cb_alias, 0, 0);
+
+        // Step 2: sub_tiles_bcast_cols on the PRIMARY index. Produces (x - a) in
+        // dst[i] for each i in [0, block_size).
+        reconfig_data_format_srca(cb_alias, cb_primary);
+        sub_bcast_cols_init_short(cb_primary, cb_bcast_a);
+        for (uint32_t i = 0; i < block_size; ++i) {
+            sub_tiles_bcast_cols(cb_primary, cb_bcast_a, i, 0, i);
+        }
+
+        // Step 3: dest-reuse ELWMUL with cb_bcast_b. Reads dst[i] back via SrcB,
+        // multiplies by cb_bcast_b[0], writes (x - a) * b into dst[i].
+        binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_bcast_b);
+        for (uint32_t i = 0; i < block_size; ++i) {
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                cb_bcast_b, 0, i);
+        }
+
+        tile_regs_commit();
+
+        // Pack out the block.
+        cb_reserve_back(cb_out, block_size);
+        tile_regs_wait();
+        pack_reconfig_data_format(cb_out);
+        for (uint32_t i = 0; i < block_size; ++i) {
+            pack_tile(i, cb_out);
+        }
+        tile_regs_release();
+        cb_push_back(cb_out, block_size);
+
+        cb_pop_front(cb_primary, block_size);
+        cb_pop_front(cb_alias, block_size);
+    }
+
+    cb_pop_front(cb_bcast_a, 1);
+    cb_pop_front(cb_bcast_b, 1);
+}

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/dataflow/reader.cpp
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/dataflow/reader.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reader for the alias-dest-reuse repro.
+//
+// Pushes:
+//   - cb_bcast_a: 1 tile, once
+//   - cb_bcast_b: 1 tile, once
+//   - cb_primary: block_size tiles per block, n_blocks blocks
+//   - cb_alias:   pushed alongside cb_primary. In Case B (single shared L1
+//                 allocation) the host-side reservation of cb_alias is on the
+//                 same memory, but the alias has its own front/back pointers,
+//                 so we still must reserve/push it to satisfy compute's
+//                 cb_wait_front(cb_alias, ...). In Case A (separate allocation)
+//                 we copy the same x bytes a second time into cb_alias.
+//
+// Runtime args (in order):
+//   0: x_addr           (DRAM addr of x tiles, n_blocks * block_size tiles)
+//   1: bcast_a_addr     (DRAM addr of bcast_a, 1 tile)
+//   2: bcast_b_addr     (DRAM addr of bcast_b, 1 tile)
+//   3: n_blocks
+//   4: block_size
+//   5: write_alias_separately  (1 = Case A: also async_read into cb_alias's L1;
+//                                0 = Case B: cb_alias shares cb_primary's L1)
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t x_addr = get_arg_val<uint32_t>(0);
+    uint32_t bcast_a_addr = get_arg_val<uint32_t>(1);
+    uint32_t bcast_b_addr = get_arg_val<uint32_t>(2);
+    uint32_t n_blocks = get_arg_val<uint32_t>(3);
+    uint32_t block_size = get_arg_val<uint32_t>(4);
+    uint32_t write_alias_separately = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_primary = tt::CBIndex::c_0;
+    constexpr uint32_t cb_alias = tt::CBIndex::c_29;
+    constexpr uint32_t cb_bcast_a = tt::CBIndex::c_2;
+    constexpr uint32_t cb_bcast_b = tt::CBIndex::c_3;
+
+    const uint32_t tile_size_x = get_tile_size(cb_primary);
+    const uint32_t tile_size_a = get_tile_size(cb_bcast_a);
+    const uint32_t tile_size_b = get_tile_size(cb_bcast_b);
+
+    constexpr auto x_args = TensorAccessorArgs<0>();
+    constexpr auto a_args = TensorAccessorArgs<x_args.next_compile_time_args_offset()>();
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
+    const auto x_acc = TensorAccessor(x_args, x_addr, tile_size_x);
+    const auto a_acc = TensorAccessor(a_args, bcast_a_addr, tile_size_a);
+    const auto b_acc = TensorAccessor(b_args, bcast_b_addr, tile_size_b);
+
+    // Push bcast operands once.
+    cb_reserve_back(cb_bcast_a, 1);
+    uint32_t a_l1 = get_write_ptr(cb_bcast_a);
+    noc_async_read_tile(0, a_acc, a_l1);
+    noc_async_read_barrier();
+    cb_push_back(cb_bcast_a, 1);
+
+    cb_reserve_back(cb_bcast_b, 1);
+    uint32_t b_l1 = get_write_ptr(cb_bcast_b);
+    noc_async_read_tile(0, b_acc, b_l1);
+    noc_async_read_barrier();
+    cb_push_back(cb_bcast_b, 1);
+
+    // Stream x tiles block by block.
+    uint32_t tile_id = 0;
+    for (uint32_t blk = 0; blk < n_blocks; ++blk) {
+        cb_reserve_back(cb_primary, block_size);
+        if (write_alias_separately) {
+            cb_reserve_back(cb_alias, block_size);
+        }
+
+        uint32_t primary_l1 = get_write_ptr(cb_primary);
+        uint32_t alias_l1 = 0;
+        if (write_alias_separately) {
+            alias_l1 = get_write_ptr(cb_alias);
+        }
+
+        for (uint32_t i = 0; i < block_size; ++i) {
+            noc_async_read_tile(tile_id + i, x_acc, primary_l1 + i * tile_size_x);
+            if (write_alias_separately) {
+                noc_async_read_tile(tile_id + i, x_acc, alias_l1 + i * tile_size_x);
+            }
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_primary, block_size);
+        if (write_alias_separately) {
+            cb_push_back(cb_alias, block_size);
+        } else {
+            // Case B: cb_alias shares cb_primary's L1, but the alias still has
+            // its own reservation/front counters. Reserve and push without
+            // touching memory (already populated via cb_primary above).
+            cb_reserve_back(cb_alias, block_size);
+            cb_push_back(cb_alias, block_size);
+        }
+        tile_id += block_size;
+    }
+}

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/dataflow/writer.cpp
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/kernels/dataflow/writer.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t out_addr = get_arg_val<uint32_t>(0);
+    uint32_t n_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_out = tt::CBIndex::c_16;
+    const uint32_t tile_size_bytes = get_tile_size(cb_out);
+
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto out_acc = TensorAccessor(out_args, out_addr, tile_size_bytes);
+
+    for (uint32_t i = 0; i < n_tiles; ++i) {
+        cb_wait_front(cb_out, 1);
+        uint32_t l1_read = get_read_ptr(cb_out);
+        noc_async_write_tile(i, out_acc, l1_read);
+        noc_async_write_barrier();
+        cb_pop_front(cb_out, 1);
+    }
+}

--- a/tt_metal/programming_examples/wh_alias_dest_reuse_repro/wh_alias_dest_reuse_repro.cpp
+++ b/tt_metal/programming_examples/wh_alias_dest_reuse_repro/wh_alias_dest_reuse_repro.cpp
@@ -1,0 +1,605 @@
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal standalone repro for a Wormhole-B0-only LLK bug uncovered in the
+// fused-Welford fp32 layernorm path.
+//
+// The bug: when fp32_dest_acc_en=true and DstSync::SyncHalf is used (block
+// size = 4 tiles in dst), the sequence (UnpackToDestFp32 read; e.g.
+// copy_tile of a Float32 CB whose unpack_to_dest_mode is UnpackToDestFp32)
+// -> (sub_tiles_bcast_cols populating dst[i]) -> (binary_dest_reuse_tiles
+// <ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>) silently produces
+// wrong output. On Blackhole the same sequence is correct.
+//
+// This test runs the same compute kernel twice with the same data and the
+// same expected math, differing only in the CB layout:
+//
+//   Case A: cb_primary and cb_alias have SEPARATE L1 allocations.
+//   Case B: cb_primary and cb_alias share ONE L1 allocation via two
+//           CBFormatDescriptors on a single CBDescriptor.
+//
+// On WH both cases fail identically (striped pattern described below).
+// On BH both cases pass identically (small TF32 SrcA rounding only).
+// The Case A vs Case B contrast empirically proves that multi-buffer-index
+// CB aliasing is NOT a required trigger condition.
+//
+// Observed failure shape on WH (both cases): output stripes by SyncHalf
+// block (block_size=4 with fp32_dest_acc):
+//   - even-indexed blocks: tile 0 has correct output; tiles 1-3 are zero.
+//   - odd-indexed blocks:  all four tiles over-scaled by ~(1+b)/b.
+//     With b=0.7 used here, the over-scale ratio is ~2.4286.
+//
+// The over-scaling matches dst = dst + b*dst (i.e. a missed ZEROACC on
+// dst[i] which was holding (x - bcast_a) from sub_tiles_bcast_cols, then
+// the math op accumulated b*dst onto it instead of overwriting). The
+// zeroed half is consistent with move_d2b reading dst[i] AFTER ZEROACC
+// ran, so SrcB=0 and math writes b*0=0. The two manifestations alternate
+// with the SyncHalf DST half-ping-pong; whether one or the other or both
+// occur per half is what the LLK fix needs to disentangle.
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/constants.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+using namespace tt::tt_metal;
+
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
+
+namespace {
+
+constexpr uint32_t TILE_H = tt::constants::TILE_HEIGHT;
+constexpr uint32_t TILE_W = tt::constants::TILE_WIDTH;
+constexpr uint32_t TILE_HW = TILE_H * TILE_W;
+constexpr uint32_t FP32_TILE_BYTES = TILE_HW * 4;
+
+// Test parameters: block_size = 4 (forced by fp32_dest_acc on WH); n_blocks=4
+// gives us two even and two odd SyncHalf blocks so the alternating-block
+// pattern is unambiguous.
+constexpr uint32_t kBlockSize = 4;
+constexpr uint32_t kNBlocks = 4;
+constexpr uint32_t kNTiles = kBlockSize * kNBlocks;
+
+// Build a tile (row-major within the 32x32 logical tile) filled with the
+// per-element function fn(row, col). Output is in physical tile layout
+// (4 16x16 faces row-major within tile, row-major within face).
+std::vector<float> make_tile(const std::function<float(uint32_t, uint32_t)>& fn) {
+    std::vector<float> tile(TILE_HW, 0.0f);
+    // Physical tile layout: face[fy][fx] occupies a 16x16 block. Row-major
+    // face order: (0,0), (0,1), (1,0), (1,1). Within face: row-major.
+    constexpr uint32_t FACE = 16;
+    for (uint32_t fy = 0; fy < 2; ++fy) {
+        for (uint32_t fx = 0; fx < 2; ++fx) {
+            uint32_t face_base = (fy * 2 + fx) * FACE * FACE;
+            for (uint32_t r = 0; r < FACE; ++r) {
+                for (uint32_t c = 0; c < FACE; ++c) {
+                    uint32_t logical_row = fy * FACE + r;
+                    uint32_t logical_col = fx * FACE + c;
+                    tile[face_base + r * FACE + c] = fn(logical_row, logical_col);
+                }
+            }
+        }
+    }
+    return tile;
+}
+
+// Concatenate n tile buffers into one flat fp32 buffer.
+std::vector<float> concat_tiles(const std::vector<std::vector<float>>& tiles) {
+    std::vector<float> out;
+    out.reserve(tiles.size() * TILE_HW);
+    for (const auto& t : tiles) {
+        out.insert(out.end(), t.begin(), t.end());
+    }
+    return out;
+}
+
+// Run one case. Returns true if the output matches expected within tol.
+// `case_name` is "A" or "B". `alias_shares_allocation` controls whether the
+// alias buffer index sits on the primary's CBDescriptor (Case B, shared) or
+// on its own CBDescriptor (Case A, separate).
+bool run_case(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshCommandQueue& cq,
+    const std::string& case_name,
+    bool alias_shares_allocation) {
+    fmt::print(
+        "\n==== Case {} ({}) ====\n",
+        case_name,
+        alias_shares_allocation ? "multi-buffer-index alias on shared L1" : "no aliasing, separate L1 allocations");
+
+    // ------------------------------------------------------------------
+    // Inputs
+    // ------------------------------------------------------------------
+    // x[t](r, c) = (t + 1) + 0.01 * r + 0.1 * c  — distinct per tile,
+    // row, and column so any cross-tile / cross-block leakage is visible.
+    std::vector<std::vector<float>> x_tiles;
+    x_tiles.reserve(kNTiles);
+    for (uint32_t t = 0; t < kNTiles; ++t) {
+        x_tiles.push_back(make_tile([t](uint32_t r, uint32_t c) {
+            return static_cast<float>(t + 1) + 0.01f * static_cast<float>(r) + 0.1f * static_cast<float>(c);
+        }));
+    }
+    auto x_data = concat_tiles(x_tiles);
+
+    // bcast_a column-broadcast: column 0 holds the value; other columns
+    // ignored by sub_tiles_bcast_cols.
+    auto bcast_a_tile = make_tile([](uint32_t r, uint32_t /*c*/) { return 2.0f + 0.001f * static_cast<float>(r); });
+
+    // bcast_b column-broadcast: pick a value clearly distinguishable from 1 so
+    // the (1+b)/b vs. 1 ratio between buggy and correct output stands out.
+    // b = 0.7 gives ratio (1+0.7)/0.7 = 2.4286 in the buggy case.
+    auto bcast_b_tile = make_tile([](uint32_t r, uint32_t /*c*/) { return 0.7f + 0.001f * static_cast<float>(r); });
+
+    // ------------------------------------------------------------------
+    // Buffers
+    // ------------------------------------------------------------------
+    distributed::DeviceLocalBufferConfig dram_cfg{
+        .page_size = FP32_TILE_BYTES,
+        .buffer_type = BufferType::DRAM,
+    };
+    distributed::ReplicatedBufferConfig x_buf_cfg{.size = FP32_TILE_BYTES * kNTiles};
+    distributed::ReplicatedBufferConfig tile_buf_cfg{.size = FP32_TILE_BYTES};
+
+    auto x_buffer = distributed::MeshBuffer::create(x_buf_cfg, dram_cfg, mesh_device.get());
+    auto a_buffer = distributed::MeshBuffer::create(tile_buf_cfg, dram_cfg, mesh_device.get());
+    auto b_buffer = distributed::MeshBuffer::create(tile_buf_cfg, dram_cfg, mesh_device.get());
+    auto out_buffer = distributed::MeshBuffer::create(x_buf_cfg, dram_cfg, mesh_device.get());
+
+    distributed::EnqueueWriteMeshBuffer(cq, x_buffer, x_data, false);
+    distributed::EnqueueWriteMeshBuffer(cq, a_buffer, bcast_a_tile, false);
+    distributed::EnqueueWriteMeshBuffer(cq, b_buffer, bcast_b_tile, false);
+
+    // ------------------------------------------------------------------
+    // ProgramDescriptor
+    // ------------------------------------------------------------------
+    constexpr CoreCoord core = {0, 0};
+    CoreRangeSet core_set{CoreRange{core}};
+
+    ProgramDescriptor pd;
+
+    // CB 0: cb_primary (Float32, Default unpack mode). Holds block_size tiles
+    // double-buffered (2 * block_size total) so reader/compute can overlap.
+    {
+        CBDescriptor cb;
+        cb.total_size = 2 * kBlockSize * FP32_TILE_BYTES;
+        cb.core_ranges = core_set;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_0,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = FP32_TILE_BYTES,
+        });
+        if (alias_shares_allocation) {
+            // Case B: the alias index sits on the SAME CBDescriptor as the
+            // primary. The two buffer indices share one L1 allocation but
+            // have distinct producer/consumer counters.
+            cb.format_descriptors.push_back(CBFormatDescriptor{
+                .buffer_index = tt::CBIndex::c_29,
+                .data_format = tt::DataFormat::Float32,
+                .page_size = FP32_TILE_BYTES,
+            });
+        }
+        pd.cbs.push_back(std::move(cb));
+    }
+
+    // CB 29: cb_alias as a SEPARATE allocation. Only for Case A.
+    if (!alias_shares_allocation) {
+        CBDescriptor cb;
+        cb.total_size = 2 * kBlockSize * FP32_TILE_BYTES;
+        cb.core_ranges = core_set;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_29,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = FP32_TILE_BYTES,
+        });
+        pd.cbs.push_back(std::move(cb));
+    }
+
+    // CB 2: bcast_a
+    {
+        CBDescriptor cb;
+        cb.total_size = FP32_TILE_BYTES;
+        cb.core_ranges = core_set;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_2,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = FP32_TILE_BYTES,
+        });
+        pd.cbs.push_back(std::move(cb));
+    }
+
+    // CB 3: bcast_b
+    {
+        CBDescriptor cb;
+        cb.total_size = FP32_TILE_BYTES;
+        cb.core_ranges = core_set;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_3,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = FP32_TILE_BYTES,
+        });
+        pd.cbs.push_back(std::move(cb));
+    }
+
+    // CB 16: cb_out
+    {
+        CBDescriptor cb;
+        cb.total_size = 2 * kBlockSize * FP32_TILE_BYTES;
+        cb.core_ranges = core_set;
+        cb.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_16,
+            .data_format = tt::DataFormat::Float32,
+            .page_size = FP32_TILE_BYTES,
+        });
+        pd.cbs.push_back(std::move(cb));
+    }
+
+    // ------------------------------------------------------------------
+    // Kernels
+    // ------------------------------------------------------------------
+    // Reader compile-time args: three TensorAccessorArgs (x, a, b).
+    std::vector<uint32_t> reader_cta;
+    TensorAccessorArgs(*x_buffer).append_to(reader_cta);
+    TensorAccessorArgs(*a_buffer).append_to(reader_cta);
+    TensorAccessorArgs(*b_buffer).append_to(reader_cta);
+
+    std::vector<uint32_t> writer_cta;
+    TensorAccessorArgs(*out_buffer).append_to(writer_cta);
+
+    KernelDescriptor reader_kd;
+    reader_kd.kernel_source = OVERRIDE_KERNEL_PREFIX "wh_alias_dest_reuse_repro/kernels/dataflow/reader.cpp";
+    reader_kd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kd.core_ranges = core_set;
+    reader_kd.compile_time_args = reader_cta;
+    reader_kd.config = ReaderConfigDescriptor{};
+    reader_kd.runtime_args.emplace_back(
+        core,
+        std::vector<uint32_t>{
+            static_cast<uint32_t>(x_buffer->address()),
+            static_cast<uint32_t>(a_buffer->address()),
+            static_cast<uint32_t>(b_buffer->address()),
+            kNBlocks,
+            kBlockSize,
+            alias_shares_allocation ? 0u : 1u,
+        });
+    pd.kernels.push_back(std::move(reader_kd));
+
+    KernelDescriptor writer_kd;
+    writer_kd.kernel_source = OVERRIDE_KERNEL_PREFIX "wh_alias_dest_reuse_repro/kernels/dataflow/writer.cpp";
+    writer_kd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kd.core_ranges = core_set;
+    writer_kd.compile_time_args = writer_cta;
+    writer_kd.config = WriterConfigDescriptor{};
+    writer_kd.runtime_args.emplace_back(
+        core,
+        std::vector<uint32_t>{
+            static_cast<uint32_t>(out_buffer->address()),
+            kNTiles,
+        });
+    pd.kernels.push_back(std::move(writer_kd));
+
+    // Compute kernel with the targeted UnpackToDestMode configuration.
+    // unpack_to_dest_mode[c_0] = Default, unpack_to_dest_mode[c_29] = UnpackToDestFp32.
+    std::vector<UnpackToDestMode> unpack_modes(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    unpack_modes[static_cast<uint32_t>(tt::CBIndex::c_29)] = UnpackToDestMode::UnpackToDestFp32;
+
+    KernelDescriptor compute_kd;
+    compute_kd.kernel_source = OVERRIDE_KERNEL_PREFIX "wh_alias_dest_reuse_repro/kernels/compute/alias_dest_reuse.cpp";
+    compute_kd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_kd.core_ranges = core_set;
+    compute_kd.compile_time_args = std::vector<uint32_t>{kNBlocks, kBlockSize};
+    compute_kd.config = ComputeConfigDescriptor{
+        .math_fidelity = MathFidelity::HiFi4,
+        .fp32_dest_acc_en = true,
+        .dst_full_sync_en = false,  // SyncHalf
+        .unpack_to_dest_mode = std::move(unpack_modes),
+        .math_approx_mode = false,
+    };
+    compute_kd.runtime_args.emplace_back(core, std::vector<uint32_t>{});
+    pd.kernels.push_back(std::move(compute_kd));
+
+    // ------------------------------------------------------------------
+    // Build, enqueue, read back
+    // ------------------------------------------------------------------
+    Program program{pd};
+
+    distributed::MeshWorkload workload;
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    std::vector<float> result;
+    distributed::EnqueueReadMeshBuffer(cq, result, out_buffer, true);
+
+    // ------------------------------------------------------------------
+    // Verify
+    // ------------------------------------------------------------------
+    // Expected: out[t](r, c) = (x[t](r, c) - bcast_a(r, 0)) * bcast_b(r, 0)
+    // (column 0 of the bcast tiles is what sub_/mul_tiles_bcast_cols uses).
+    auto val_at = [](const std::vector<float>& flat, uint32_t tile_idx, uint32_t logical_row, uint32_t logical_col) {
+        constexpr uint32_t FACE = 16;
+        uint32_t fy = logical_row / FACE;
+        uint32_t fx = logical_col / FACE;
+        uint32_t r = logical_row % FACE;
+        uint32_t c = logical_col % FACE;
+        uint32_t face_base = (fy * 2 + fx) * FACE * FACE;
+        return flat[tile_idx * TILE_HW + face_base + r * FACE + c];
+    };
+
+    // Per-element diffs are reported below for diagnostic visibility, but they are
+    // NOT used to decide PASS/FAIL. On a correct arch the dest-reuse ELWMUL reads
+    // cb_bcast_b via SrcA (TF32-quantized), and the preceding sub_tiles_bcast_cols
+    // does the same for cb_in / cb_bcast_a. Both stages accumulate ~0.1% relative
+    // rounding noise that, when (x - a) gets close to zero, can produce diffs of a
+    // few milli-units on otherwise correct output. Those are not bug signatures.
+    // The bug we're after produces structural failures: tiles that go to zero, or
+    // tiles that come out 2x+ over-scaled (the accumulation signature). Both are
+    // counted below and drive the verdict.
+    constexpr float mismatch_print_tol = 1e-3f;
+    uint32_t printed_mismatches = 0;
+
+    // Per-tile ratio summary: pick the element at (row=0, col=0) of each tile
+    // (face 0) and report actual/expected. On WH (both cases) we expect:
+    //   - even-indexed blocks (block 0, 2): tile 0 ratio ~= 1 (correct);
+    //                                       tiles 1-3 actual ~= 0
+    //   - odd-indexed blocks  (block 1, 3): all four tiles ratio ~= (1+b)/b
+    //                                       = ~2.4286 with b=0.7
+    fmt::print("Per-tile sample (row=0,col=0): expected vs actual (ratio = actual/expected)\n");
+    fmt::print("  tile | block | expected | actual    | ratio\n");
+    fmt::print("  -----+-------+----------+-----------+-------\n");
+
+    uint32_t num_zero_tiles = 0;
+    uint32_t num_overscaled_tiles = 0;
+    for (uint32_t t = 0; t < kNTiles; ++t) {
+        uint32_t block = t / kBlockSize;
+        float x00 = static_cast<float>(t + 1);  // x[t](0, 0)
+        float a00 = 2.0f;                       // bcast_a column 0 at row 0
+        float b00 = 0.7f;                       // bcast_b column 0 at row 0
+        float expected = (x00 - a00) * b00;
+        float actual = val_at(result, t, 0, 0);
+        float ratio = (std::abs(expected) > 1e-12f) ? (actual / expected) : 0.0f;
+        fmt::print("  {:>4} | {:>5} | {:>+8.4f} | {:>+9.4f} | {:>+6.4f}\n", t, block, expected, actual, ratio);
+
+        if (std::abs(actual) < 1e-4f && std::abs(expected) > 0.1f) {
+            ++num_zero_tiles;
+        }
+        if (std::abs(expected) > 0.1f && ratio > 2.0f) {
+            ++num_overscaled_tiles;
+        }
+    }
+
+    // Full-element check.
+    for (uint32_t t = 0; t < kNTiles; ++t) {
+        for (uint32_t r = 0; r < TILE_H; ++r) {
+            for (uint32_t c = 0; c < TILE_W; ++c) {
+                float x_v = static_cast<float>(t + 1) + 0.01f * static_cast<float>(r) + 0.1f * static_cast<float>(c);
+                float a_v = 2.0f + 0.001f * static_cast<float>(r);
+                float b_v = 0.7f + 0.001f * static_cast<float>(r);
+                float expected = (x_v - a_v) * b_v;
+                float actual = val_at(result, t, r, c);
+                if (std::abs(expected - actual) > mismatch_print_tol && printed_mismatches < 8) {
+                    fmt::print(
+                        "  mismatch (informational, not part of verdict): tile={} row={} col={} expected={:.6f} "
+                        "actual={:.6f}\n",
+                        t,
+                        r,
+                        c,
+                        expected,
+                        actual);
+                    ++printed_mismatches;
+                }
+            }
+        }
+    }
+
+    fmt::print(
+        "Summary: zero-output tiles={}, over-scaled (>2x) tiles={}, total={}\n",
+        num_zero_tiles,
+        num_overscaled_tiles,
+        kNTiles);
+
+    // Verdict is driven purely by the structural metrics. Per-element diffs above
+    // are reported for diagnostic visibility but excluded from the verdict because
+    // a correct arch still produces ~0.1-0.3% TF32 rounding (the dest-reuse mul
+    // reads cb_bcast_b via SrcA, masking fp32 to TF32). The bug we're after
+    // produces zero-output tiles and ~2.4x over-scaled tiles -- both structural.
+    bool structural_pass = (num_zero_tiles == 0) && (num_overscaled_tiles == 0);
+    fmt::print("Case {} result: {}\n", case_name, structural_pass ? "PASS" : "FAIL");
+
+    // On failure, dump comprehensive diagnostics so we don't need a re-run to see
+    // what happened.
+    if (!structural_pass) {
+        fmt::print("\n--- FAILURE DIAGNOSTICS (Case {}) ---\n", case_name);
+
+        // Per-tile classification of the (0,0) element. Helps spot the alternating
+        // block pattern characteristic of the WH bug: even-indexed blocks have
+        // tile 0 correct and tiles 1-3 zeroed; odd-indexed blocks have all four
+        // tiles over-scaled by ~(1+b)/b.
+        fmt::print("Per-tile classification at (row=0, col=0):\n");
+        fmt::print("  tile | block | expected | actual    | ratio    | class\n");
+        fmt::print("  -----+-------+----------+-----------+----------+------------\n");
+        for (uint32_t t = 0; t < kNTiles; ++t) {
+            uint32_t block = t / kBlockSize;
+            float x00 = static_cast<float>(t + 1);
+            float a00 = 2.0f;
+            float b00 = 0.7f;
+            float expected = (x00 - a00) * b00;
+            float actual = val_at(result, t, 0, 0);
+            float ratio = (std::abs(expected) > 1e-12f) ? (actual / expected) : 0.0f;
+            const char* cls = "ok";
+            if (std::abs(actual) < 1e-4f && std::abs(expected) > 0.1f) {
+                cls = "ZERO";
+            } else if (std::abs(expected) > 0.1f && ratio > 2.0f) {
+                cls = "OVER-SCALED";
+            } else if (std::abs(expected) > 0.1f && ratio < 0.5f && ratio > -0.5f) {
+                cls = "UNDER-SCALED";
+            } else if (std::abs(expected) > 0.1f && (ratio < 0.95f || ratio > 1.05f)) {
+                cls = "off";
+            }
+            fmt::print(
+                "  {:>4} | {:>5} | {:>+8.4f} | {:>+9.4f} | {:>+8.4f} | {}\n", t, block, expected, actual, ratio, cls);
+        }
+
+        // Full-block statistics: how many ZERO and OVER-SCALED across all elements,
+        // grouped by SyncHalf block (block_size=4 with fp32_dest_acc on WH).
+        fmt::print("\nPer-block element-level statistics:\n");
+        fmt::print("  block | zero-elem | over-scaled-elem | total-bad / total-elem\n");
+        fmt::print("  ------+-----------+------------------+-----------------------\n");
+        uint32_t total_zero_elem = 0;
+        uint32_t total_over_elem = 0;
+        for (uint32_t blk = 0; blk < kNTiles / kBlockSize; ++blk) {
+            uint32_t zero_elem = 0;
+            uint32_t over_elem = 0;
+            uint32_t total_elem = 0;
+            for (uint32_t t = blk * kBlockSize; t < (blk + 1) * kBlockSize; ++t) {
+                for (uint32_t r = 0; r < TILE_H; ++r) {
+                    for (uint32_t c = 0; c < TILE_W; ++c) {
+                        float x_v =
+                            static_cast<float>(t + 1) + 0.01f * static_cast<float>(r) + 0.1f * static_cast<float>(c);
+                        float a_v = 2.0f + 0.001f * static_cast<float>(r);
+                        float b_v = 0.7f + 0.001f * static_cast<float>(r);
+                        float expected = (x_v - a_v) * b_v;
+                        float actual = val_at(result, t, r, c);
+                        if (std::abs(expected) < 0.1f) {
+                            continue;
+                        }
+                        ++total_elem;
+                        float ratio = actual / expected;
+                        if (std::abs(actual) < 1e-4f) {
+                            ++zero_elem;
+                        } else if (ratio > 2.0f) {
+                            ++over_elem;
+                        }
+                    }
+                }
+            }
+            total_zero_elem += zero_elem;
+            total_over_elem += over_elem;
+            fmt::print(
+                "  {:>5} | {:>9} | {:>16} | {:>8} / {:>8}\n",
+                blk,
+                zero_elem,
+                over_elem,
+                zero_elem + over_elem,
+                total_elem);
+        }
+        fmt::print(
+            "  total |   {:>7} |     {:>12} |   {:>6} / {:>8}\n",
+            total_zero_elem,
+            total_over_elem,
+            total_zero_elem + total_over_elem,
+            kNTiles * TILE_HW);
+
+        // Ratio histogram across all non-trivial expected elements. Helps see the
+        // dominant ratio modes ("clusters near 2.4x and near 0" = striped bug;
+        // "single cluster near 1" = correct).
+        fmt::print("\nRatio histogram (only elements with |expected| > 0.1):\n");
+        constexpr int kNBins = 9;
+        const std::array<float, kNBins + 1> bin_edges = {
+            -10.0f, -0.1f, 0.001f, 0.5f, 0.95f, 1.05f, 1.5f, 2.0f, 3.0f, 100.0f};
+        const std::array<const char*, kNBins> bin_labels = {
+            "<-0.1   ",
+            "-0.1..0 ",
+            "0..0.5  ",
+            "0.5..0.95",
+            "0.95..1.05",
+            "1.05..1.5",
+            "1.5..2.0",
+            "2.0..3.0",
+            ">3.0    "};
+        std::array<uint32_t, kNBins> hist{};
+        for (uint32_t t = 0; t < kNTiles; ++t) {
+            for (uint32_t r = 0; r < TILE_H; ++r) {
+                for (uint32_t c = 0; c < TILE_W; ++c) {
+                    float x_v =
+                        static_cast<float>(t + 1) + 0.01f * static_cast<float>(r) + 0.1f * static_cast<float>(c);
+                    float a_v = 2.0f + 0.001f * static_cast<float>(r);
+                    float b_v = 0.7f + 0.001f * static_cast<float>(r);
+                    float expected = (x_v - a_v) * b_v;
+                    if (std::abs(expected) < 0.1f) {
+                        continue;
+                    }
+                    float actual = val_at(result, t, r, c);
+                    float ratio = actual / expected;
+                    for (int b = 0; b < kNBins; ++b) {
+                        if (ratio >= bin_edges[b] && ratio < bin_edges[b + 1]) {
+                            ++hist[b];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        for (int b = 0; b < kNBins; ++b) {
+            fmt::print("  ratio in [{}]: {} elements\n", bin_labels[b], hist[b]);
+        }
+        fmt::print("--- end FAILURE DIAGNOSTICS (Case {}) ---\n\n", case_name);
+    }
+
+    return structural_pass;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+    constexpr int device_id = 0;
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+    auto& cq = mesh_device->mesh_command_queue();
+
+    bool case_a_pass = false;
+    bool case_b_pass = false;
+    try {
+        case_a_pass = run_case(mesh_device, cq, "A", /*alias_shares_allocation=*/false);
+        case_b_pass = run_case(mesh_device, cq, "B", /*alias_shares_allocation=*/true);
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Exception: {}\n", e.what());
+        mesh_device->close();
+        return 2;
+    }
+
+    mesh_device->close();
+
+    fmt::print("\n===== Overall =====\n");
+    fmt::print("  Case A (no aliasing, separate L1 allocs): {}\n", case_a_pass ? "PASS" : "FAIL");
+    fmt::print("  Case B (multi-buffer-index alias, shared L1): {}\n", case_b_pass ? "PASS" : "FAIL");
+    if (!case_a_pass && !case_b_pass) {
+        fmt::print(
+            "\nBoth cases fail with the same striped pattern -- aliasing is NOT a required\n"
+            "trigger condition. The bug is purely about the UnpackToDest-fp32-read +\n"
+            "binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCB> + fp32_dest_acc_en=true sequence.\n"
+            "Expected on Wormhole-B0. On Blackhole both cases should pass.\n");
+    } else if (case_a_pass && case_b_pass) {
+        fmt::print(
+            "\nBoth cases pass. This is the expected outcome on Blackhole and on any arch\n"
+            "where the bug has been fixed. On Wormhole-B0 a PASS here would mean the\n"
+            "repro no longer triggers -- check that fp32_dest_acc_en=true is plumbed\n"
+            "correctly into the compute kernel config.\n");
+    } else if (case_a_pass && !case_b_pass) {
+        fmt::print(
+            "\nOnly Case B fails. This would mean multi-buffer-index aliasing IS a required\n"
+            "trigger condition on this arch -- different from what we observed on WH.\n");
+    } else {
+        fmt::print(
+            "\nOnly Case A fails. Unusual -- aliasing somehow masks the bug. See per-tile\n"
+            "output above.\n");
+    }
+    return (case_a_pass && case_b_pass) ? 0 : 1;
+}

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -433,16 +433,27 @@ inline void eltwise_binary_run_with_dest_reuse(
     {
         eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
 
-        // Clear DEST face-by-face when reusing dest as source
-        auto base_address = (get_dest_buffer_base() >> 4) + (dst_index << ((is_fp32_dest_acc_en && clear_fp32_dst_acc) ? 3 : 2));
+        // Set DEST zero flags face-by-face when reusing dest as source.
         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
         {
-            const std::uint32_t face_offset_fp32 = face_offset * 2;
-            TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset_fp32 + n * 2));
-            TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset_fp32 + ((n * 2) + 1)));
+            // fp32 DEST stores each datum across two physical rows (hi16 + mantissa16) in
+            // the 32-bit Adj32 layout. The dest-reuse MOVD2B/ELWMUL operate in that 32-bit
+            // layout (UseDst32b from ALU_ACC_CTRL_Fp32_enabled), so the zero-flag set must
+            // also be issued in 32-bit mode, otherwise it flags the wrong physical rows and
+            // ELWMUL accumulates onto stale (x - a) data (the (1+b)/b over-scale on WH).
+            // WH p_zeroacc has no named CLR_16 32-bit variant, so raw-encode
+            // (UseDst32b << 2) | CLR_16 == 0b101. Imm10 is in fp32-face units (one CLR_16
+            // call = one 32-physical-row fp32 face), and must be < 32:
+            //   (get_dest_buffer_base() >> 5) selects the SyncHalf (0 or 16),
+            //   (dst_index << 2)            = 4 faces per fp32 tile,
+            //   (face_offset + n)           = the face within the tile.
+            constexpr std::uint32_t ZERO_ACC_MODE_32B = (1u << 2) | p_zeroacc::CLR_16; // 0b101
+            const std::uint32_t base_face             = (get_dest_buffer_base() >> 5) + (dst_index << 2);
+            TT_ZEROACC(ZERO_ACC_MODE_32B, ADDR_MOD_1, base_face + face_offset + n);
         }
         else
         {
+            const std::uint32_t base_address = (get_dest_buffer_base() >> 4) + (dst_index << 2);
             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset + n));
         }
 


### PR DESCRIPTION
## What

Fix the Wormhole-B0 `binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCB>` corruption that appears with `fp32_dest_acc_en=true` + `DstSync::SyncHalf` after an UnpackToDest fp32 read (e.g. `copy_tile` of a `UnpackToDestFp32` CB), plus a standalone programming-example reproducer.

## Root cause

In `eltwise_binary_run_with_dest_reuse` (`tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h`), the per-face `ZEROACC` set DEST **zero flags** using a 16-bit `CLR_16` (`UseDst32b=0`). But in fp32 dest-acc mode the DEST data — and the dest-reuse `MOVD2B`/`ELWMUL` that read it back — operate in the 32-bit (`Adj32`-interleaved) layout. The zero-flag set therefore landed on the wrong physical rows:

- **Odd SyncHalf:** flags never set on the real data rows → `ELWMUL` (`Dst += SrcA*SrcB`) accumulated onto the leftover `(x-a)` → output over-scaled by `(1+b)/b`.
- **Even SyncHalf:** flags set on the wrong rows → some tiles read as undefined (zero) → zeroed output tiles.

## Fix

Issue the zero-flag set in 32-bit mode (raw-encode `0b101` = `UseDst32b | CLR_16`) with `Imm10` in fp32-face units, so the flags match where the fp32 data / `MOVD2B` / `ELWMUL` operate. This mirrors what Blackhole already does (its 5-arg `TT_ZEROACC` passes `use_32_bit_mode`).

## Evidence (WH-B0 hardware)

Verified via DEST register dumps (`dprint_tensix_dest_reg_row_float32`) reading DEST immediately before/after the dest-reuse multiply:

| | before fix | after fix |
|---|---|---|
| odd-half tile0 AFTER_SUB (x−a) | 3.0042 | 3.0042 |
| odd-half tile0 AFTER_MUL | **5.0986** (accumulate) | **2.0944** (overwrite, = 3.0042×0.7) |

The standalone repro (`tt_metal/programming_examples/wh_alias_dest_reuse_repro`) goes from FAIL → PASS for both Case A (separate L1) and Case B (aliased L1).

## Testing

- Standalone repro PASS on WH-B0.
- Sanity tests: triggered via workflow_dispatch on this branch (regression check for other `binary_dest_reuse` users: softmax/layernorm large-tensor, tanhshrink, etc.).
- TODO: re-run the original failing op test (`test_large_layer_norm` fp32 welford) to confirm the real model.

> Draft — intentionally not linked to issue #45216 yet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix)