### PR TITLE
[WH][LLK] Fix fp32 dest-reuse ZEROACC zero-flag addressing (fix-only)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -433,16 +433,27 @@ inline void eltwise_binary_run_with_dest_reuse(
     {
         eltwise_binary_reuse_dest_as_src<binary_reuse_dest>();
 
-        // Clear DEST face-by-face when reusing dest as source
-        auto base_address = (get_dest_buffer_base() >> 4) + (dst_index << ((is_fp32_dest_acc_en && clear_fp32_dst_acc) ? 3 : 2));
+        // Set DEST zero flags face-by-face when reusing dest as source.
         if (is_fp32_dest_acc_en && clear_fp32_dst_acc)
         {
-            const std::uint32_t face_offset_fp32 = face_offset * 2;
-            TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset_fp32 + n * 2));
-            TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset_fp32 + ((n * 2) + 1)));
+            // fp32 DEST stores each datum across two physical rows (hi16 + mantissa16) in
+            // the 32-bit Adj32 layout. The dest-reuse MOVD2B/ELWMUL operate in that 32-bit
+            // layout (UseDst32b from ALU_ACC_CTRL_Fp32_enabled), so the zero-flag set must
+            // also be issued in 32-bit mode, otherwise it flags the wrong physical rows and
+            // ELWMUL accumulates onto stale (x - a) data (the (1+b)/b over-scale on WH).
+            // WH p_zeroacc has no named CLR_16 32-bit variant, so raw-encode
+            // (UseDst32b << 2) | CLR_16 == 0b101. Imm10 is in fp32-face units (one CLR_16
+            // call = one 32-physical-row fp32 face), and must be < 32:
+            //   (get_dest_buffer_base() >> 5) selects the SyncHalf (0 or 16),
+            //   (dst_index << 2)            = 4 faces per fp32 tile,
+            //   (face_offset + n)           = the face within the tile.
+            constexpr std::uint32_t ZERO_ACC_MODE_32B = (1u << 2) | p_zeroacc::CLR_16; // 0b101
+            const std::uint32_t base_face             = (get_dest_buffer_base() >> 5) + (dst_index << 2);
+            TT_ZEROACC(ZERO_ACC_MODE_32B, ADDR_MOD_1, base_face + face_offset + n);
         }
         else
         {
+            const std::uint32_t base_address = (get_dest_buffer_base() >> 4) + (dst_index << 2);
             TT_ZEROACC(ZERO_ACC_MODE, ADDR_MOD_1, base_address + (face_offset + n));
         }
 


### PR DESCRIPTION
## What

Fix-only PR (off latest main) for the Wormhole-B0 `binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCB>` corruption with `fp32_dest_acc_en=true` + `DstSync::SyncHalf` after an UnpackToDest fp32 read.

This is the PR intended to **merge** (fix + regression tests). Test development happens in the companion repro PR and will be moved here once we're confident.

- Companion repro / test-dev PR: #46223
- Issue: #45216

## Root cause

`eltwise_binary_run_with_dest_reuse` (`tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h`) set DEST **zero flags** with a 16-bit `CLR_16` (`UseDst32b=0`). In fp32 dest-acc mode the DEST data — and the dest-reuse `MOVD2B`/`ELWMUL` reading it back — operate in the 32-bit `Adj32`-interleaved layout, so the flags landed on the wrong physical rows:

- **Odd SyncHalf:** flags never set on the real rows → `ELWMUL` accumulated onto leftover `(x-a)` → output ×`(1+b)/b`.
- **Even SyncHalf:** flags set on wrong rows → tiles read as undefined (zero) → zeroed output tiles.

## Fix

Issue the zero-flag set in 32-bit mode (raw `0b101` = `UseDst32b | CLR_16`) with `Imm10` in fp32-face units, matching where the fp32 data / `MOVD2B` / `ELWMUL` operate. Mirrors what Blackhole already does (its 5-arg `TT_ZEROACC` passes `use_32_bit_mode`).

## Verification (WH-B0)

- DEST register dump: odd-half tile0 AFTER_MUL goes `5.0986` (accumulate) → `2.0944` (overwrite = `(x-a)·b`).
- Standalone repro (#46223): FAIL → PASS, both cases.
- **Real op:** `layer_norm` fp32 + welford large-tensor path, `w=3200, h=2080` (the original issue case) → **PASS**.

## Still TODO before un-drafting
- Regression tests (large-tensor fp32 welford layer_norm + others) — developed in #46223, then moved here.
- Sanity pipeline green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/wh_fp32_dest_reuse_zeroacc_fix_only)