### PR TITLE
remove "packed" from subordinate_map

### DIFF
--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -398,7 +398,7 @@ struct mailboxes_t {
     struct subordinate_sync_msg_t subordinate_sync;
     volatile uint32_t launch_msg_rd_ptr;  // Volatile so this can be manually reset by host. TODO: remove volatile when
                                           // dispatch init moves to one-shot.
-    struct launch_msg_t launch[launch_msg_buffer_num_entries];
+    alignas(16) struct launch_msg_t launch[launch_msg_buffer_num_entries];
     volatile struct go_msg_t go_messages[go_message_num_entries];
     uint64_t link_status_check_timestamp;  // Next timestamp to check link status (active erisc)
     volatile uint32_t go_message_index;    // Index into go_messages to use. Always 0 on unicast cores.

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -398,7 +398,7 @@ struct mailboxes_t {
     struct subordinate_sync_msg_t subordinate_sync;
     volatile uint32_t launch_msg_rd_ptr;  // Volatile so this can be manually reset by host. TODO: remove volatile when
                                           // dispatch init moves to one-shot.
-    alignas(16) struct launch_msg_t launch[launch_msg_buffer_num_entries];
+    alignas(TT_ARCH_MAX_NOC_WRITE_ALIGNMENT) struct launch_msg_t launch[launch_msg_buffer_num_entries];
     volatile struct go_msg_t go_messages[go_message_num_entries];
     uint64_t link_status_check_timestamp;  // Next timestamp to check link status (active erisc)
     volatile uint32_t go_message_index;    // Index into go_messages to use. Always 0 on unicast cores.

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -81,10 +81,9 @@ union subordinate_map_t {
             volatile uint8_t neo3_trisc1;
             volatile uint8_t neo3_trisc2;
             volatile uint8_t neo3_trisc3;
-            uint8_t pad[12];
         };
-    } __attribute__((packed));
-} __attribute__((packed));
+    };
+};
 
 constexpr uint8_t MaxProcessorsPerCoreType = 24;
 constexpr uint8_t MaxProcessorsForThreadingVariables =

--- a/tt_metal/llrt/hal/codegen/codegen.py
+++ b/tt_metal/llrt/hal/codegen/codegen.py
@@ -113,7 +113,7 @@ class CodeGen:
 
     def parse(self):
         while line := self.getline():
-            line = re.sub("alignas\(\d+\)", "", line)
+            line = re.sub(r"\balignas\([^)]*\)\s*", "", line)
             if line.startswith("static_assert"):
                 continue
             if re.match(r"(?:static )?constexpr ", line):
@@ -153,7 +153,7 @@ class CodeGen:
             line = self.getline()
             if not line:
                 self.parse_error("<end of file>", "incomplete struct definition")
-            line = re.sub("alignas\(\d+\) ", "", line)
+            line = re.sub(r"\balignas\([^)]*\)\s*", "", line)
             if re.fullmatch(r"}(?: *__attribute__\(\(\w+\)\))*;", line):
                 level -= 1
                 continue

--- a/tt_metal/llrt/hal/codegen/codegen.py
+++ b/tt_metal/llrt/hal/codegen/codegen.py
@@ -113,6 +113,7 @@ class CodeGen:
 
     def parse(self):
         while line := self.getline():
+            line = re.sub("alignas\(\d+\)", "", line)
             if line.startswith("static_assert"):
                 continue
             if re.match(r"(?:static )?constexpr ", line):
@@ -152,6 +153,7 @@ class CodeGen:
             line = self.getline()
             if not line:
                 self.parse_error("<end of file>", "incomplete struct definition")
+            line = re.sub("alignas\(\d+\) ", "", line)
             if re.fullmatch(r"}(?: *__attribute__\(\(\w+\)\))*;", line):
                 level -= 1
                 continue


### PR DESCRIPTION
### PR Category
cleanup

### Summary
we used `packed` in the definition of `subordinate_map` to make sure the fields will stay together and added padding to make sure following fields align correctly. the use of `packed` led the compiler to check the subordinate fields one byte a time, which increased code size, ran slower and missed the all idea in the definition of the struct. the attribute was removed together with the padding, while `alignas(16)` was added to a filed in the mailbox that needed it. the code generator was updated to ignore the `alignas()` part.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayaacob/fix_subordinate_map)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayaacob/fix_subordinate_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayaacob/fix_subordinate_map)