### PR TITLE
Remove dependency on debug bit 11 for typecast

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -31,80 +31,101 @@ constexpr std::uint32_t ROWS_PER_LOAD = 4;
 constexpr std::uint32_t AVG_SHIFT_AMOUNT = 5;    // 2^5 = 32
 constexpr std::uint32_t AVG_SHIFT_MASK = 0xfff;  // Mask for shift instruction encoding
 
-// FP16B representation of 1/32 = 0.03125
-constexpr std::uint32_t FP16B_ONE_OVER_32_HIGH = 0x3D00;
-constexpr std::uint32_t FP16B_ONE_OVER_32_LOW = 0x0000;
-
 // Constants for MAX reduction
 constexpr std::uint32_t ROWS_PER_TILE = 64;
 constexpr std::uint32_t ROWS_PER_FACE = 16;
 
+// Register holding the 0x0000FFFF mask used to clear garbage high bits when loading UInt16 data
+// from a 32-bit (fp32 dest accumulation) dest word. Maps to sfpi::vConstIntPrgm0 on Blackhole.
+constexpr std::uint32_t CLEAR_REG = p_sfpu::LREG12;
+
+template <bool clear_high_bits>
+inline void load_and_clear_high_bits(
+    const std::uint32_t lreg_ind,
+    const InstrModLoadStore instr_mod0,
+    const std::uint32_t sfpu_addr_mode,
+    const std::uint32_t dest_reg_addr) {
+    TT_SFPLOAD(lreg_ind, instr_mod0, sfpu_addr_mode, dest_reg_addr);
+    if constexpr (clear_high_bits) {
+        TT_SFPAND(0, CLEAR_REG, lreg_ind, 0);
+    }
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
-/**
- * @brief Apply sign magnitude conversion to four LREGs
- *
- * Assume you loaded 4 LREGs into p_sfpu::LREG0-3 and want to convert them to sign magnitude and store in
- * p_sfpu::LREG4-7.
- *
- * @tparam INSTR_MOD_CAST: The instruction mode for cast operations
- */
-template <InstrModCast INSTR_MOD_CAST>
-inline void convert_to_sign_magnitude_x4_lregs() {
-    apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG4, INSTR_MOD_CAST);
-    apply_sign_magnitude_conversion(p_sfpu::LREG1, p_sfpu::LREG5, INSTR_MOD_CAST);
-    apply_sign_magnitude_conversion(p_sfpu::LREG2, p_sfpu::LREG6, INSTR_MOD_CAST);
-    apply_sign_magnitude_conversion(p_sfpu::LREG3, p_sfpu::LREG7, INSTR_MOD_CAST);
+
+// Int32 SUM/AVG keep their data in dest as sign-magnitude (matching the MAX/MIN path and the packer),
+// but SFPIADD is a two's-complement adder. Wormhole bridges this with the INT32_2S_COMP load/store mode,
+// which converts sign-magnitude<->two's-complement in hardware; on Blackhole that conversion is a no-op
+// (tenstorrent/tt-llk-bh#16), so we must do it explicitly: convert each operand to two's-complement right
+// after load, and convert results back to sign-magnitude right before store.
+//
+// We use the same SFPCAST+SFPSETSGN primitive as the proven element-wise int kernels (see _add_int_): it is
+// direction-neutral (the same cast mode converts both ways) and, crucially, uses no condition codes, so it is
+// robust regardless of SFPABS/cc interaction. It requires one free GPR (LREG0-7) as scratch; LREG8-15 are
+// constant/config registers that SFPCAST cannot write.
+// "Representation swap": converts an integer between its sign-magnitude and two's-complement representations.
+constexpr InstrModCast REDUCE_INT_REPRESENTATION_SWAP_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+
+// Convert one int operand between sign-magnitude and two's-complement, in place. `scratch_gpr` must be a free
+// GPR (LREG0-7) distinct from `reg`; it is clobbered. The result is left in `reg`.
+inline void convert_int_representation_inplace(std::uint32_t reg, std::uint32_t scratch_gpr) {
+    apply_sign_magnitude_conversion(reg, scratch_gpr, REDUCE_INT_REPRESENTATION_SWAP_CAST);
 }
 
 /**
  * @brief Load data from face into LREG0-3
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for load operations
- * @param face_addr: Base address of face
- * @param column_offset: Column offset for the current iteration, load all rows for even columns (0) or odd columns (2)
+ * @tparam INSTRUCTION_MODE The instruction mode for load operations
+ * @param face_addr Base address of face
+ * @param column_offset Column offset for the current iteration, load all rows for even columns (0) or odd columns (2)
  * of the face
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, std::uint32_t DST_LREG_BASE = p_sfpu::LREG0>
 inline void load_face_data(std::uint32_t face_addr, std::uint32_t column_offset) {
-    TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset);                  // rows 0-3
-    TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
-    TT_SFPLOAD(
-        p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
-    TT_SFPLOAD(
-        p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + 3 * ROWS_PER_LOAD);  // rows 12-15
+    // Load the 4 row-groups into DST_LREG_BASE..DST_LREG_BASE+3. DST_LREG_BASE defaults to LREG0, but
+    // callers can target LREG4 to feed a recorded swap buffer that operates on LREG4-7 directly, avoiding
+    // a redundant LREG0-3 -> LREG4-7 shuffle.
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 0, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 1, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 2, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 3, INSTRUCTION_MODE, ADDR_MOD_7, face_addr + column_offset + 3 * ROWS_PER_LOAD);  // rows 12-15
 }
 
 /**
  * @brief Load data from upper and lower faces into LREG0-7
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for load operations
- * @param upper_face_addr: Base address of upper face (Face 0 or Face 1)
- * @param lower_face_addr: Base address of lower face (Face 2 or Face 3)
- * @param column_offset: Column offset for the current iteration
+ * @tparam INSTRUCTION_MODE The instruction mode for load operations
+ * @param upper_face_addr Base address of upper face (Face 0 or Face 1)
+ * @param lower_face_addr Base address of lower face (Face 2 or Face 3)
+ * @param column_offset Column offset for the current iteration
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
 inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_face_addr, std::uint32_t column_offset) {
     // Load upper face data (Face 0 or Face 1) into LREG0-3
-    TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset);  // rows 0-3
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
+        p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG3,
         INSTRUCTION_MODE,
         ADDR_MOD_7,
         upper_face_addr + column_offset + 3 * ROWS_PER_LOAD);  // rows 12-15
 
     // Load lower face data (Face 2 or Face 3) into LREG4-7
-    TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, lower_face_addr + column_offset);  // rows 0-3
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
+        p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, lower_face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, lower_face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, lower_face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG7,
         INSTRUCTION_MODE,
         ADDR_MOD_7,
@@ -113,14 +134,13 @@ inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_fa
 
 /**
  * @brief Perform integer averaging with proper handling of negative numbers
+ * @tparam INSTRUCTION_MODE The instruction mode (determines signed vs unsigned)
  *
  * For integer formats, we need to handle negative numbers properly for division by 32.
  * Since Blackhole only supports logical shift (not arithmetic), we need to:
  * 1. Check if the number is negative using condition codes (only for signed formats)
  * 2. If negative, negate it, shift right by 5 bits, then negate back
  * 3. If positive, just shift right by 5 bits
- *
- * @tparam INSTRUCTION_MODE: The instruction mode (determines signed vs unsigned)
  */
 template <InstrModLoadStore INSTRUCTION_MODE>
 inline void perform_int_average() {
@@ -140,28 +160,46 @@ inline void perform_int_average() {
         TTI_SFPCOMPC(0, 0, 0, 0);              // Invert condition code (now true if original was negative)
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // Negate LREG0 if condition is true
         TTI_SFPENCC(0, 0, 0, 0);                             // Clear condition codes
+    } else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+        // Two's-complement signed divide-by-32 (round toward zero). SFPABS clears the sign bit and is
+        // only correct for sign-magnitude, so for 2's-complement we take the magnitude via a conditional
+        // negate (0 - x), logical-shift, then restore the sign with a second conditional negate.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);      // Save original (2's-complement) value for sign check
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 4);                // cc if sign bit == 0 (non-negative)
+        TTI_SFPCOMPC(0, 0, 0, 0);                            // Invert -> cc if negative
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // LREG0 = -LREG0 (magnitude) when negative
+        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSHFT(-AVG_SHIFT_AMOUNT & AVG_SHIFT_MASK, p_sfpu::LREG0, p_sfpu::LREG0, 0b01);  // |x| >> 5 (divide by 32)
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, 4);                // cc if original sign bit == 0 (non-negative)
+        TTI_SFPCOMPC(0, 0, 0, 0);                            // Invert -> cc if original was negative
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // Restore sign (2's-complement negate) when negative
+        TTI_SFPENCC(0, 0, 0, 0);
     } else {
         // For unsigned formats (UInt32), just use logical shift directly since they can't be negative
         TTI_SFPSHFT(-AVG_SHIFT_AMOUNT & AVG_SHIFT_MASK, p_sfpu::LREG0, p_sfpu::LREG0, 0b01);
     }
 }
 
+// Programmable float constant register holding 1/32 (0.03125) for float AVG. Preloaded once by
+// init_reduce_sum_avg (only when pool_type == AVG and the format is float), so perform_float_average
+// avoids rebuilding the constant via two SFPLOADI on every column group. Maps to LREG12 on Blackhole
+// (sfpi::vConstFloatPrgm0); the float reduce path does not use the UInt16 high-bit mask, so this
+// register is free to hold the constant across the whole reduce.
+constexpr std::uint32_t AVG_RECIP_REG = p_sfpu::LREG12;
+
 /**
  * @brief Perform floating-point averaging (multiply by 1/32)
  *
  * For a 32x32 tile, each column sum represents the sum of exactly 32 values (one per row).
- * This function divides by 32 by multiplying by the constant 1/32 (0.03125).
+ * This function divides by 32 by multiplying by the constant 1/32 (0.03125), which
+ * init_reduce_sum_avg() preloaded into AVG_RECIP_REG (sfpi::vConstFloatPrgm0).
  */
 inline void perform_float_average() {
-    // Load 1/32 constant (0.03125) into LREG1 for float division
-    TTI_SFPLOADI(p_sfpu::LREG1, 8, FP16B_ONE_OVER_32_HIGH);  // Load 0.03125 as FP16B high part
-    TTI_SFPLOADI(p_sfpu::LREG1, 10, FP16B_ONE_OVER_32_LOW);  // Load 0.03125 as FP16B low part
-
-    // Multiply by 1/32 (divide by 32) - works for both float and integer formats
-    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    // Multiply by 1/32 (divide by 32) using the preloaded constant register.
+    TTI_SFPMUL(p_sfpu::LREG0, AVG_RECIP_REG, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
 }
 
-template <PoolType pool_type, InstrModLoadStore INSTRUCTION_MODE>
+template <PoolType pool_type, InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_col_sum_avg() {
     // Determine if integer or float mode at compile time
     constexpr bool is_integer_mode =
@@ -181,12 +219,54 @@ inline void perform_reduce_col_sum_avg() {
         const std::uint32_t upper_face_addr = UPPER_FACE_ADDRS[i];
         const std::uint32_t lower_face_addr = LOWER_FACE_ADDRS[i];
         const std::uint32_t column_offset = COLUMN_OFFSETS[i];
-        load_face_data<INSTRUCTION_MODE>(upper_face_addr, lower_face_addr, column_offset);
 
         // Step 1: Tree-reduce across registers (LREG0-3→LREG0, LREG4-7→LREG4) without transpose.
         // After this, each of the 4 positions in LREG0 holds the sum of rows at that position
         // across all 4 loaded LREGs (e.g., LREG0[i] = sum of row[i], row[i+4], row[i+8], row[i+12]).
-        lltt::replay(0, 6);
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            // Int32: dest holds sign-magnitude but SFPIADD is a two's-complement adder, and converting in place
+            // needs a free GPR scratch. With all 8 operands live no scratch is free, so we process the upper and
+            // lower faces in sequence: convert+reduce the upper face into LREG0 (freeing LREG1-3), then use those
+            // freed registers as scratch to convert+reduce the lower face into LREG4. This reproduces the
+            // LREG0=sum(LREG0-3), LREG4=sum(LREG4-7) result of replay(0,6).
+            const std::uint32_t upper_base = upper_face_addr + column_offset;
+            const std::uint32_t lower_base = lower_face_addr + column_offset;
+
+            // Upper face -> LREG0-3, scratch from the still-free LREG4-7
+            load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, upper_base);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, upper_base + ROWS_PER_LOAD);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, upper_base + 2 * ROWS_PER_LOAD);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, upper_base + 3 * ROWS_PER_LOAD);
+            convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG4);
+            convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG5);
+            convert_int_representation_inplace(p_sfpu::LREG2, p_sfpu::LREG6);
+            convert_int_representation_inplace(p_sfpu::LREG3, p_sfpu::LREG7);
+            TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG2, 4);  // LREG2 += LREG3
+            TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG1, 4);  // LREG1 += LREG2
+            TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);  // LREG0 = sum of upper face; LREG1-3 now free
+
+            // Lower face -> LREG4-7, scratch from the now-free LREG1-3
+            load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, lower_base);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, lower_base + ROWS_PER_LOAD);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, lower_base + 2 * ROWS_PER_LOAD);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, lower_base + 3 * ROWS_PER_LOAD);
+            convert_int_representation_inplace(p_sfpu::LREG4, p_sfpu::LREG1);
+            convert_int_representation_inplace(p_sfpu::LREG5, p_sfpu::LREG2);
+            convert_int_representation_inplace(p_sfpu::LREG6, p_sfpu::LREG3);
+            convert_int_representation_inplace(p_sfpu::LREG7, p_sfpu::LREG1);
+            TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG6, 4);  // LREG6 += LREG7
+            TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG5, 4);  // LREG5 += LREG6
+            TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, 4);  // LREG4 = sum of lower face
+        } else {
+            load_face_data<INSTRUCTION_MODE, clear_high_bits>(upper_face_addr, lower_face_addr, column_offset);
+            lltt::replay(0, 6);
+        }
 
         // Step 2: Cross-face addition. Unlike the old approach where only position 0 of the
         // cross-face sum was meaningful, here ALL 4 positions carry useful partial sums.
@@ -213,13 +293,27 @@ inline void perform_reduce_col_sum_avg() {
                 perform_float_average();
             }
         }
-        // Store the final column sum/average to the first row
-        TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, upper_face_addr + column_offset);
+        // Store the final column sum/average to the first row.
+        // Mode 9 (SFPSTORE_MOD0_FMT_LO16) is only needed when the packer-visible OUTPUT is UInt16 in a
+        // 32-bit dest: there the reduced value sits in the low 16 bits but the packer reads the high 16,
+        // so we move low->high. When the output is a full 32-bit format (e.g. UInt32) the packer reads
+        // the whole dest word, so we use the plain INSTRUCTION_MODE store even for UInt16 input.
+        // Int32: convert the two's-complement result back to sign-magnitude before storing to dest.
+        // LREG1-7 are free here (only LREG0 holds the result), so LREG1 is a safe GPR scratch.
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG1);
+        }
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        // Use the runtime-address store (TT_ not TTI_): the Int32 two's-complement path makes this loop body
+        // large enough that GCC no longer unrolls it, so the face address is not a compile-time constant.
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, upper_face_addr + column_offset);
     }
 }
 
 /**
- * @brief Performs two horizontal reductions in parallel (LREG0/LREG1 and LREG4/LREG5), interleaving instructions to hide SFPSHFT2 latency.
+ * @brief Performs two horizontal reductions in parallel (LREG0/LREG1 and LREG4/LREG5), interleaving
+ *        instructions to hide SFPSHFT2 latency.
  *
  * SFPU hardware operates on 8 column slices in parallel but independently; column slices cannot
  * directly communicate. SFPSHFT2 is the only instruction that moves data across columns.
@@ -238,7 +332,7 @@ inline void perform_reduce_col_sum_avg() {
  *   Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
  *   Phase 4: Rotate right by 1  -> move the single sum from col 7 to col 0.
  *
- * @tparam is_integer_mode: True for integer types (uses SFPIADD), false for float (uses SFPADD)
+ * @tparam is_integer_mode True for integer types (uses SFPIADD), false for float (uses SFPADD)
  */
 template <bool is_integer_mode>
 inline void horizontal_reduce() {
@@ -345,8 +439,7 @@ inline void record_horizontal_reduce_max() {
 
 /**
  * @brief Executes horizontal max reduction: phase 1 inline, phases 2-4 via replay buffer.
- *
- * @pre @ref record_horizontal_reduce_max must be called once before first use.
+ *        record_horizontal_reduce_max() must have been called before first use.
  */
 inline void horizontal_reduce_max() {
     // Phase 1 (inline): Shift by 4 and max -> 8 values become 4 maxes (cols 4-7).
@@ -382,11 +475,11 @@ inline void horizontal_reduce_max() {
  * 4. Use horizontal_reduce_max to consolidate 8 SFPU columns into column 0
  * 5. Store the per-row max into column 0
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
- * @param tile_row_offset: Base row offset for this tile in the dest register
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
+ * @param tile_row_offset Base row offset for this tile in the dest register
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
-inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
+inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset, std::uint32_t result_store_mode) {
 #pragma GCC unroll 2
     for (std::uint32_t face_pair = 0; face_pair < 2; face_pair++) {
         std::uint32_t face_pair_base = face_pair * 2 * ROWS_PER_FACE;
@@ -396,31 +489,31 @@ inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
             std::uint32_t row_offset_first = row_group * 8;
             std::uint32_t row_offset_second = row_offset_first + 4;
 
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG2,
                 INSTRUCTION_MODE,
                 ADDR_MOD_7,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG3,
                 INSTRUCTION_MODE,
                 ADDR_MOD_7,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first + 2);
 
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG6,
                 INSTRUCTION_MODE,
                 ADDR_MOD_7,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG7,
                 INSTRUCTION_MODE,
                 ADDR_MOD_7,
@@ -436,10 +529,13 @@ inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
 
             horizontal_reduce_max();
 
+            // result_store_mode is mode 9 (SFPSTORE_MOD0_FMT_LO16) only when this per-tile store is the
+            // final, packer-visible result (single column tile); otherwise it is intermediate and stays
+            // in the low 16 bits.
             TT_SFPSTORE(
-                p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
+                p_sfpu::LREG0, result_store_mode, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
             TT_SFPSTORE(
-                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
+                p_sfpu::LREG4, result_store_mode, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
         }
     }
 }
@@ -452,12 +548,13 @@ inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
  * comparator; sign-magnitude integers have the same ordering as IEEE floats for MAX, so
  * no conversion to 2's complement is needed — we operate directly on sign-magnitude data.
  *
- * @param tile_row_offset: Base row offset for this tile in the dest register
+ * @param tile_row_offset Base row offset for this tile in the dest register
  */
-inline void perform_reduce_row_max_int32_tile(std::uint32_t tile_row_offset) {
+template <bool clear_high_bits = false>
+inline void perform_reduce_row_max_int32_tile(std::uint32_t tile_row_offset, std::uint32_t result_store_mode) {
     constexpr InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32;
 
-    perform_reduce_row_max_tile<INSTRUCTION_MODE>(tile_row_offset);
+    perform_reduce_row_max_tile<INSTRUCTION_MODE, clear_high_bits>(tile_row_offset, result_store_mode);
 }
 
 /**
@@ -465,29 +562,37 @@ inline void perform_reduce_row_max_int32_tile(std::uint32_t tile_row_offset) {
  *
  * Mirrors sum_first_columns_across_tiles but uses SFPSWAP instead of SFPADD.
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
- * @param tile_row_base: Base address of the first tile in this row of tiles
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
+ * @param tile_row_base Base address of the first tile in this row of tiles
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void max_first_columns_across_tiles(std::uint32_t tile_row_base, std::uint32_t block_ct_dim) {
     constexpr std::uint32_t RESULT_ROWS[8] = {0, 4, 8, 12, 32, 36, 40, 44};
 
     for (std::uint32_t batch = 0; batch < 2; batch++) {
         std::uint32_t base_idx = batch * 4;
 
-        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPLOAD(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPLOAD(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
 
         for (std::uint32_t t = 1; t < block_ct_dim; t++) {
             std::uint32_t tile_offset = tile_row_base + t * ROWS_PER_TILE;
 
-            TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 0]);
-            TT_SFPLOAD(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 1]);
-            TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 2]);
-            TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 3]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 0]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 1]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 2]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 3]);
 
             TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, 1);
             TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG5, 1);
@@ -495,10 +600,14 @@ inline void max_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
             TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG7, 1);
         }
 
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPSTORE(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPSTORE(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        // Final, packer-visible store: use mode 9 (SFPSTORE_MOD0_FMT_LO16) only when the OUTPUT is
+        // UInt16 in a 32-bit dest (pack_low16); a 32-bit output keeps the plain INSTRUCTION_MODE store.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        TT_SFPSTORE(p_sfpu::LREG2, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        TT_SFPSTORE(p_sfpu::LREG3, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
     }
 }
 
@@ -508,11 +617,12 @@ inline void max_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
  * Sign-magnitude integers have the same ordering as IEEE floats for MAX comparison,
  * so we reuse the FP32 variant directly — no 2's complement conversion needed.
  *
- * @param tile_row_base: Base address of the first tile in this row of tiles
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
+ * @param tile_row_base Base address of the first tile in this row of tiles
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
  */
+template <bool clear_high_bits = false, bool pack_low16 = false>
 inline void max_first_columns_across_tiles_int32(std::uint32_t tile_row_base, std::uint32_t block_ct_dim) {
-    max_first_columns_across_tiles<InstrModLoadStore::INT32>(tile_row_base, block_ct_dim);
+    max_first_columns_across_tiles<InstrModLoadStore::INT32, clear_high_bits, pack_low16>(tile_row_base, block_ct_dim);
 }
 
 /**
@@ -522,22 +632,28 @@ inline void max_first_columns_across_tiles_int32(std::uint32_t tile_row_base, st
  * accumulates the per-tile column-0 maxima across tiles using compare-and-swap into
  * tile 0's column 0.
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
- * @param block_rt_dim: Number of tiles along y axis of tensor (row tiles)
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
+ * @param block_rt_dim Number of tiles along y axis of tensor (row tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_row_max(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
     constexpr bool is_int32 = (INSTRUCTION_MODE == InstrModLoadStore::INT32);
 
-    // The column-reduce Int32 init (init_reduce_max_min_int32) sets SFPCONFIG bit 8,
-    // which changes the SFPSWAP comparison direction. Row-reduce needs the default MAX
-    // direction (bit 8 = 0), so reset the SFPU config register here.
-    // This is needed for both Int32 and FP32 paths to ensure consistent behavior
-    // regardless of which init was called.
-    _init_sfpu_config_reg();
+    // Row-reduce needs the default MAX SFPSWAP direction (SFPCONFIG bit 8 = 0). That default is already
+    // established once by the paired init (init_reduce -> init_reduce_max_min for the MAX pool type,
+    // which calls _init_sfpu_config_reg() and does not set bit 8), so we no longer reset the config
+    // register on every row-max call here. The only init that flips bit 8 is the column MIN / Int32
+    // (sign-magnitude) MAX/MIN path, which is never the init paired with a row-MAX calculate.
 
     record_horizontal_reduce_max();
+
+    // Single column tile => per-tile store is the final packer-visible result, which uses mode 9 only
+    // when the OUTPUT is UInt16 in a 32-bit dest (pack_low16); otherwise it is intermediate and stays
+    // in the low 16 bits via INSTRUCTION_MODE.
+    const std::uint32_t tile_store_mode = (pack_low16 && block_ct_dim == 1)
+                                              ? 9u /* SFPSTORE_MOD0_FMT_LO16 */
+                                              : static_cast<std::uint32_t>(INSTRUCTION_MODE);
 
     for (std::uint32_t i = 0; i < block_rt_dim; i++) {
         std::uint32_t tile_row_offset = ROWS_PER_TILE * block_ct_dim * i;
@@ -545,24 +661,25 @@ inline void perform_reduce_row_max(std::uint32_t block_ct_dim, std::uint32_t blo
         for (std::uint32_t j = 0; j < block_ct_dim; j++) {
             std::uint32_t tile_offset = tile_row_offset + (ROWS_PER_TILE * j);
             if constexpr (is_int32) {
-                perform_reduce_row_max_int32_tile(tile_offset);
+                perform_reduce_row_max_int32_tile(tile_offset, tile_store_mode);
             } else {
-                perform_reduce_row_max_tile<INSTRUCTION_MODE>(tile_offset);
+                perform_reduce_row_max_tile<INSTRUCTION_MODE, clear_high_bits>(tile_offset, tile_store_mode);
             }
         }
 
         if (block_ct_dim > 1) {
             if constexpr (is_int32) {
-                max_first_columns_across_tiles_int32(tile_row_offset, block_ct_dim);
+                max_first_columns_across_tiles_int32<clear_high_bits, pack_low16>(tile_row_offset, block_ct_dim);
             } else {
-                max_first_columns_across_tiles<INSTRUCTION_MODE>(tile_row_offset, block_ct_dim);
+                max_first_columns_across_tiles<INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+                    tile_row_offset, block_ct_dim);
             }
         }
     }
 }
 
-template <InstrModLoadStore INSTRUCTION_MODE>
-inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
+inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset, std::uint32_t result_store_mode) {
     // Determine if integer or float mode at compile time
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
@@ -581,49 +698,88 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
             std::uint32_t row_offset_first = row_group * 8;          // 0 or 8
             std::uint32_t row_offset_second = row_offset_first + 4;  // 4 or 12
 
-            // Load 4 rows from face 0 (or 2) and face 1 (or 3)
-            TT_SFPLOAD(
-                p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
-            TT_SFPLOAD(
-                p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first + 2);
-            TT_SFPLOAD(
-                p_sfpu::LREG2,
-                INSTRUCTION_MODE,
-                ADDR_MOD_7,
-                tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first);
-            TT_SFPLOAD(
-                p_sfpu::LREG3,
-                INSTRUCTION_MODE,
-                ADDR_MOD_7,
-                tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first + 2);
+            const std::uint32_t group_a_base = tile_row_offset + face_pair_base + row_offset_first;
+            const std::uint32_t group_b_base = tile_row_offset + face_pair_base + row_offset_second;
 
-            // Load next 4 rows from face 0 (or 2) and face 1 (or 3)
-            TT_SFPLOAD(
-                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
-            TT_SFPLOAD(
-                p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second + 2);
-            TT_SFPLOAD(
-                p_sfpu::LREG6,
-                INSTRUCTION_MODE,
-                ADDR_MOD_7,
-                tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
-            TT_SFPLOAD(
-                p_sfpu::LREG7,
-                INSTRUCTION_MODE,
-                ADDR_MOD_7,
-                tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second + 2);
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+                // Int32: dest holds sign-magnitude but SFPIADD is a two's-complement adder, and converting in
+                // place needs a free GPR scratch. With all 8 operands live no scratch is free, so we process the
+                // two independent 4-row groups in sequence: convert+reduce group A into LREG0 (freeing LREG1-3),
+                // then use those freed registers as scratch to convert+reduce group B into LREG4. This mirrors
+                // the LREG0=sum(LREG0-3), LREG4=sum(LREG4-7) result of replay(0,6).
 
-            // Perform vertical sum of loaded rows via replay buffer
-            // After this: LREG0 contains sum of first 4 rows, LREG4 contains sum of next 4 rows
-            lltt::replay(0, 6);
+                // Group A (first 4 rows) -> LREG0-3, scratch from the still-free LREG4-7
+                load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + 2);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + ROWS_PER_FACE);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + ROWS_PER_FACE + 2);
+                convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG4);
+                convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG5);
+                convert_int_representation_inplace(p_sfpu::LREG2, p_sfpu::LREG6);
+                convert_int_representation_inplace(p_sfpu::LREG3, p_sfpu::LREG7);
+                TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG2, 4);  // LREG2 += LREG3
+                TTI_SFPIADD(0, p_sfpu::LREG2, p_sfpu::LREG1, 4);  // LREG1 += LREG2
+                TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);  // LREG0 = sum of group A; LREG1-3 now free
+
+                // Group B (next 4 rows) -> LREG4-7, scratch from the now-free LREG1-3
+                load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + 2);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + ROWS_PER_FACE);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + ROWS_PER_FACE + 2);
+                convert_int_representation_inplace(p_sfpu::LREG4, p_sfpu::LREG1);
+                convert_int_representation_inplace(p_sfpu::LREG5, p_sfpu::LREG2);
+                convert_int_representation_inplace(p_sfpu::LREG6, p_sfpu::LREG3);
+                convert_int_representation_inplace(p_sfpu::LREG7, p_sfpu::LREG1);
+                TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG6, 4);  // LREG6 += LREG7
+                TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG5, 4);  // LREG5 += LREG6
+                TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, 4);  // LREG4 = sum of group B
+            } else {
+                // Load 4 rows from face 0 (or 2) and face 1 (or 3)
+                load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + 2);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + ROWS_PER_FACE);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, group_a_base + ROWS_PER_FACE + 2);
+
+                // Load next 4 rows from face 0 (or 2) and face 1 (or 3)
+                load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + 2);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + ROWS_PER_FACE);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, group_b_base + ROWS_PER_FACE + 2);
+
+                // Perform vertical sum of loaded rows via replay buffer
+                // After this: LREG0 contains sum of first 4 rows, LREG4 contains sum of next 4 rows
+                lltt::replay(0, 6);
+            }
 
             // Horizontal reduction: consolidate all 8 SFPU columns into column 0 (interleaved for latency hiding)
             horizontal_reduce<is_integer_mode>();
 
+            // Int32: convert the two's-complement partial sums back to sign-magnitude before storing.
+            // Only LREG0 and LREG4 hold results, so LREG1/LREG5 are free GPR scratch.
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+                convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG1);
+                convert_int_representation_inplace(p_sfpu::LREG4, p_sfpu::LREG5);
+            }
+
+            // result_store_mode is mode 9 (SFPSTORE_MOD0_FMT_LO16) only when this per-tile store is the
+            // final, packer-visible result (single column tile); otherwise it is an intermediate store
+            // re-loaded by the cross-tile accumulation and must stay in the low 16 bits.
             TT_SFPSTORE(
-                p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
+                p_sfpu::LREG0, result_store_mode, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_first);
             TT_SFPSTORE(
-                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
+                p_sfpu::LREG4, result_store_mode, ADDR_MOD_7, tile_row_offset + face_pair_base + row_offset_second);
         }
     }
 }
@@ -643,11 +799,11 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
  * - Store LREG0-3 back to tile 0.
  * LREG4-7 hold the other tiles' data so loads and adds can be pipelined without NOPs.
  *
- * @tparam INSTRUCTION_MODE: The load/store instruction mode
- * @param tile_row_base: Base address of the first tile in this row of tiles
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
+ * @tparam INSTRUCTION_MODE The load/store instruction mode
+ * @param tile_row_base Base address of the first tile in this row of tiles
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uint32_t block_ct_dim) {
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
@@ -660,64 +816,116 @@ inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
         std::uint32_t base_idx = batch * 4;
 
         // Load tile 0's four LREGs at this batch's offsets (0,4,8,12 or 32,36,40,44) into LREG0-3
-        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPLOAD(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPLOAD(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
+
+        // Int32: dest holds sign-magnitude; convert tile 0's partial sums to two's-complement so the
+        // cross-tile SFPIADD accumulation below is correct (Blackhole INT32_2S_COMP load is a no-op).
+        // LREG4-7 are free here, so they serve as GPR scratch for the four casts.
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG4);
+            convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG5);
+            convert_int_representation_inplace(p_sfpu::LREG2, p_sfpu::LREG6);
+            convert_int_representation_inplace(p_sfpu::LREG3, p_sfpu::LREG7);
+        }
 
         // Accumulate from remaining tiles
         for (std::uint32_t t = 1; t < block_ct_dim; t++) {
             std::uint32_t tile_offset = tile_row_base + t * ROWS_PER_TILE;
 
-            // Load tile t's four LREGs at the same offsets into LREG4-7
-            TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 0]);
-            TT_SFPLOAD(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 1]);
-            TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 2]);
-            TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 3]);
-
-            // Add LREG4-7 into LREG0-3
-            if constexpr (is_integer_mode) {
-                TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4);
-                TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG1, 4);
-                TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG2, 4);
-                TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG3, 4);
+            if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+                // The four accumulators (LREG0-3) are live and converting in place needs a free GPR scratch,
+                // so we cannot keep four freshly-loaded operands resident simultaneously. Process one column at
+                // a time: load into LREG4, convert to two's-complement (scratch LREG5), then add into its
+                // accumulator. LREG5-7 stay free for scratch.
+                for (std::uint32_t j = 0; j < 4; j++) {
+                    load_and_clear_high_bits<clear_high_bits>(
+                        p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + j]);
+                    convert_int_representation_inplace(p_sfpu::LREG4, p_sfpu::LREG5);
+                    TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0 + j, 4);  // LREG(j) += LREG4
+                }
             } else {
-                TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0);
-                TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG1, 0);
-                TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG2, 0);
-                TTI_SFPADD(p_sfpu::LREG3, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG3, 0);
+                // Load tile t's four LREGs at the same offsets into LREG4-7
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 0]);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 1]);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 2]);
+                load_and_clear_high_bits<clear_high_bits>(
+                    p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, tile_offset + RESULT_ROWS[base_idx + 3]);
+
+                // Add LREG4-7 into LREG0-3
+                if constexpr (is_integer_mode) {
+                    TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG0, 4);
+                    TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG1, 4);
+                    TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG2, 4);
+                    TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG3, 4);
+                } else {
+                    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+                    TTI_SFPADD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG5, p_sfpu::LREG1, 0);
+                    TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG6, p_sfpu::LREG2, 0);
+                    TTI_SFPADD(p_sfpu::LREG3, p_sfpu::LCONST_1, p_sfpu::LREG7, p_sfpu::LREG3, 0);
+                }
             }
         }
 
-        // Store LREG0-3 back to tile 0
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPSTORE(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPSTORE(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        // Int32: convert the two's-complement accumulated sums back to sign-magnitude before storing.
+        // LREG4-7 are free after the accumulation loop, so they serve as GPR scratch for the four casts.
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            convert_int_representation_inplace(p_sfpu::LREG0, p_sfpu::LREG4);
+            convert_int_representation_inplace(p_sfpu::LREG1, p_sfpu::LREG5);
+            convert_int_representation_inplace(p_sfpu::LREG2, p_sfpu::LREG6);
+            convert_int_representation_inplace(p_sfpu::LREG3, p_sfpu::LREG7);
+        }
+
+        // Store LREG0-3 back to tile 0. This is the final, packer-visible result, so it uses mode 9
+        // (SFPSTORE_MOD0_FMT_LO16) only when the OUTPUT is UInt16 in a 32-bit dest (packer reads the
+        // high 16 bits); a 32-bit output (e.g. UInt32) is stored with the plain INSTRUCTION_MODE.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        TT_SFPSTORE(p_sfpu::LREG2, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        TT_SFPSTORE(p_sfpu::LREG3, STORE_MODE, ADDR_MOD_7, tile_row_base + RESULT_ROWS[base_idx + 3]);
     }
 }
 
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_row_sum(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
+    // When there is a single column tile, the per-tile store is the final packer-visible result and must
+    // use mode 9 only when the OUTPUT is UInt16 in a 32-bit dest (pack_low16). With multiple column tiles
+    // the per-tile store is intermediate (re-loaded by sum_first_columns_across_tiles) and must stay in the
+    // low 16 bits via INSTRUCTION_MODE; the final mode-9 (if any) is applied by the cross-tile store.
+    const std::uint32_t tile_store_mode = (pack_low16 && block_ct_dim == 1)
+                                              ? 9u /* SFPSTORE_MOD0_FMT_LO16 */
+                                              : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+
     for (std::uint32_t i = 0; i < block_rt_dim; i++) {
         std::uint32_t tile_row_offset = ROWS_PER_TILE * block_ct_dim * i;
 
         // Step 1: Reduce each tile individually (horizontal reduction within each tile)
         for (std::uint32_t j = 0; j < block_ct_dim; j++) {
             std::uint32_t tile_offset = tile_row_offset + (ROWS_PER_TILE * j);
-            perform_reduce_row_sum_tile<INSTRUCTION_MODE>(tile_offset);
+            perform_reduce_row_sum_tile<INSTRUCTION_MODE, clear_high_bits>(tile_offset, tile_store_mode);
         }
 
         // Step 2: Sum column 0 from all tiles in this row into tile 0's column 0
         if (block_ct_dim > 1) {
-            sum_first_columns_across_tiles<INSTRUCTION_MODE>(tile_row_offset, block_ct_dim);
+            sum_first_columns_across_tiles<INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+                tile_row_offset, block_ct_dim);
         }
     }
 }
 
 /**
  * @brief Runtime validation helper for supported data formats for reduce sfpu kernel
- *
  */
 constexpr bool is_supported_reduce_format(DataFormat format) {
     return format == DataFormat::Int32 || format == DataFormat::UInt32 || format == DataFormat::Float32 ||
@@ -726,8 +934,7 @@ constexpr bool is_supported_reduce_format(DataFormat format) {
 
 /**
  * @brief Configure address mode for SFPU reduce Max/Min kernel.
- *
- * @param num_cols: The number of columns in the tensor block of multiple tiles
+ * @param num_cols The number of columns in the tensor block of multiple tiles
  * @note One tile is 64 rows in dest
  */
 inline void configure_addrmod_max_min(std::uint32_t num_cols) {
@@ -761,16 +968,13 @@ inline void configure_addrmod_max_min(std::uint32_t num_cols) {
 // ============================================================================
 
 /**
- * @brief Initialization for SFPU reduce MAX/MIN kernel on 32x32 tile for Int32 format.
- *
- * Due to a Blackhole RTL bug, INT32_2S_COMP LOAD/STORE has no effect. Must cast to
- * INT_SIGN_MAGN_TO_INT32_2S_COMP before swapping. Since CAST and SWAP are both SIMPLE instructions,
- * they cannot be integrated together in a LOADMACRO sequence. Therefore, the kernel is initialized
- * with manual loads and stores to perform the CAST and SWAP operations.
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @brief Initialization for SFPU reduce MAX/MIN kernel on 32x32 tile for Int32 format. Due to RTL bug INT32_2S_COMP
+ * LOAD/STORE has no effect. Must cast to INT_SIGN_MAGN_TO_INT32_2S_COMP before swapping. Since CAST and SWAP are both
+ * SIMPLE instructions, cannot be integrated together in LOADMACRO sequence. Therefore, we need to initialize the kernel
+ * with manual loads and stores in order to perform the CAST and SWAP operations.
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
- * @tparam pool_type: The pool type (MAX or MIN) to determine swap direction
+ * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type>
 inline void init_reduce_max_min_int32() {
@@ -790,17 +994,16 @@ inline void init_reduce_max_min_int32() {
 
 /**
  * @brief Initialization for SFPU reduce MAX/MIN kernel.
+ *        Sets up LOADMACRO sequences for compare-and-swap operations, configures address modifiers,
+ *        and records replay buffers for efficient column-wise maximum/minimum reduction.
  *
- * Sets up LOADMACRO sequences for compare-and-swap operations, configures address modifiers,
- * and records replay buffers for efficient column-wise maximum/minimum reduction.
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
- * @tparam pool_type: The pool type (MAX or MIN) to determine swap direction
- * @param num_cols: The number of columns to process (typically 32 for a single tile, or multiple of 32 for block
+ * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
+ * @param num_cols The number of columns to process (typically 32 for a single tile, or multiple of 32 for block
  * operations)
  */
-template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type>
+template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
     _init_sfpu_config_reg();
@@ -826,8 +1029,12 @@ inline void init_reduce_max_min(std::uint32_t num_cols) {
 
     configure_addrmod_max_min(num_cols);
 
-    // Record replay buffer for compare-and-swap operations
-    lltt::record<lltt::NoExec>(0, 11);
+    // Record replay buffer for compare-and-swap operations.
+    // Note: this LOADMACRO-based path is only used for float/UInt32 formats. UInt16 in 32-bit dest
+    // cannot use it because the fused load+swap leaves no place to mask the garbage high bits, so it
+    // is routed to the manual calculate_reduce_max_min_uint16() path instead.
+    constexpr std::uint32_t buffer_len = 11;
+    lltt::record<lltt::NoExec>(0, buffer_len);
     TTI_INCRWC(0, 4, 0, 0);
     TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_7, 2);
     TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 16);
@@ -845,16 +1052,15 @@ inline void init_reduce_max_min(std::uint32_t num_cols) {
 
 /**
  * @brief Initialization for SFPU reduce SUM and AVG kernels.
+ *        Records replay buffers for column-wise summation using tree reduction.
+ *        Two buffers are recorded:
+ *        - Positions 0-5: Full tree reduce for both LREG groups (used by both col and row reduce)
+ *        - Positions 6-8: Half tree reduce for LREG0-3 only (used by optimized col reduce)
  *
- * Records replay buffers for column-wise summation using tree reduction.
- * Two buffers are recorded:
- * - Positions 0-5: Full tree reduce for both LREG groups (used by both col and row reduce)
- * - Positions 6-8: Half tree reduce for LREG0-3 only (used by optimized col reduce)
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type>
 inline void init_reduce_sum_avg() {
     _init_sfpu_config_reg();
 
@@ -862,6 +1068,15 @@ inline void init_reduce_sum_avg() {
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
          INSTRUCTION_MODE == InstrModLoadStore::LO16);
+
+    // Float AVG divides by 32 by multiplying by 1/32. Preload that constant once here (only when it is
+    // actually needed: float AVG) into the programmable float const register AVG_RECIP_REG so
+    // perform_float_average() collapses to a single SFPMUL instead of rebuilding the constant with two
+    // SFPLOADI on every column group. Integer AVG uses perform_int_average (shift) and pays nothing; SUM
+    // never averages, so it pays nothing either.
+    if constexpr (pool_type == PoolType::AVG && !is_integer_mode) {
+        sfpi::vConstFloatPrgm0 = 0.03125f;
+    }
 
     // Record two replay buffers:
     // Positions 0-5: Full tree reduce (both LREG groups, interleaved for latency hiding)
@@ -907,20 +1122,43 @@ inline void init_reduce_sum_avg() {
 // ============================================================================
 
 /**
- * @brief Column-wise maximum/minimum reduction kernel for SFPU reduce MAX/MIN operation on 32x32 tile for Int32 format.
+ * @brief Column-wise maximum/minimum reduction kernel for UInt16 stored in a 32-bit (fp32 dest acc) dest.
  *
- * Due to RTL bug INT32_2S_COMP LOAD/STORE has no effect. Must cast to INT_SIGN_MAGN_TO_INT32_2S_COMP before swapping.
- * Since CAST and SWAP are both SIMPLE instructions, cannot be integrated together in SAME LOADMACRO sequence.
- * Therefore, we need to calculate the kernel with manual loads and stores in order to perform the CAST and SWAP
- * operations after loads.
+ * UInt16 datums live in the low 16 bits of a 32-bit dest word and carry garbage in the high 16 bits,
+ * so every value must be masked (AND 0x0000FFFF) before it participates in a compare-and-swap. The
+ * float/UInt16 LOADMACRO pipeline used by calculate_reduce_max_min() fuses the load and the swap into
+ * a single macro, leaving no place to clear the high bits in between; the garbage then dominates the
+ * integer comparison and produces wrong minima/maxima for any non-constant input.
  *
- * @tparam INSTRUCTION_MODE: The instruction mode (INT32_2S_COMP for Int32 with MAX/MIN)
- * @tparam pool_type: The pool type (MAX or MIN) to determine swap direction
- * @tparam reduce_dim: The reduction dimension (currently only REDUCE_COL is supported)
+ * Instead we use the same manual load/mask/swap structure as the Int32 path (which exists for the
+ * analogous reason that CAST and SWAP cannot share a LOADMACRO). The sign-magnitude casts of the
+ * Int32 path are unnecessary here: masked UInt16 values are always non-negative, so a plain integer
+ * SFPSWAP orders them correctly and the cast would be the identity. We therefore replace the casts
+ * with plain moves (LREG0-3 -> LREG4-7) that feed the recorded swap buffer. Final, packer-visible
+ * results are written with SFPSTORE mode 9 (SFPSTORE_MOD0_FMT_LO16) so the packer reads the low bits.
+ *
+ * The reduction reuses init_reduce_max_min_int32()'s 3-swap replay buffer and swap-direction config.
+ * Only a single 32x32 tile is processed per call (block height 1), matching the column-reduce driver
+ * which invokes the kernel once per tile.
+ *
+ * @tparam INSTRUCTION_MODE The instruction mode (INT32 for UInt16 in 32-bit dest)
+ * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam clear_high_bits Whether to mask the garbage high bits on load (true for UInt16 in 32-bit dest)
+ * @tparam pack_low16 Whether the final packer-visible store uses mode 9 (true for UInt16 OUTPUT in 32-bit dest)
  */
-template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, ReduceDim reduce_dim>
-inline void calculate_reduce_max_min_int32() {
-    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
+inline void calculate_reduce_max_min_uint16() {
+    static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+    static_assert(
+        pool_type == PoolType::MAX || pool_type == PoolType::MIN,
+        "Only MAX and MIN pool types are supported for this function");
+
     constexpr std::uint32_t ODD_COLUMNS = 2;
     constexpr std::uint32_t COLUMN_OFFSETS[4] = {0, 2, 0, 2};  // even, odd, even, odd
     constexpr std::uint32_t FACE_ADDRS[2][4] = {
@@ -932,87 +1170,95 @@ inline void calculate_reduce_max_min_int32() {
         {16, 48}  // j=1: Face 1 and Face 3
     };
 
+    // The intermediate stores below land in non-row-0 dest slots that we reload, so they use the
+    // plain (full 32-bit) instruction mode. Only the final row-0 stores are packer-visible and use
+    // mode 9 (SFPSTORE_MOD0_FMT_LO16) when the OUTPUT is UInt16 in a 32-bit dest (pack_low16), so the
+    // packer reads the low 16 bits of the dest word.
+    constexpr std::uint32_t STORE_MODE =
+        pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+
     for (std::uint32_t j = 0; j < 2; j++) {
         std::uint32_t top_face_addr = FINAL_REDUCE_ADDRS[j][0];     // face 0 & 1 dst indices
         std::uint32_t bottom_face_addr = FINAL_REDUCE_ADDRS[j][1];  // face 2 & 3 dst indices
 
-        // After this loop executes vertically adjacent faces (f0 & f2 first iteration of outer loop, f1 & f3 second
-        // iteration) are processed and store max/min values in top 4 rows of their faces
+        // Reduce each of the four vertically adjacent faces (f0,f2 then f1,f3) within itself; the
+        // max/min of its 16 rows is left in the top 4 rows.
         for (std::uint32_t i = 0; i < NUM_FACES; i++) {
-            load_face_data<INSTRUCTION_MODE>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
-            convert_to_sign_magnitude_x4_lregs<INSTR_MOD_CAST>();
-            lltt::replay(0, 3);
+            // Masked load straight into LREG4-7, where the recorded swap buffer reduces them. Loading
+            // directly into the target registers eliminates the four LREG0-3 -> LREG4-7 moves (and the
+            // post-reduce LREG4 -> LREG0 move) that the previous LREG0-3 load required.
+            load_face_data<INSTRUCTION_MODE, clear_high_bits, p_sfpu::LREG4>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
 
-            apply_sign_magnitude_conversion(
-                p_sfpu::LREG4,
-                p_sfpu::LREG0,
-                INSTR_MOD_CAST);  // Convert back from two's complement to sign-magnitude before storing
-            TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
+            lltt::replay(0, 3);  // compare-and-swap reduce LREG4-7 -> LREG4
+
+            TT_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
         }
 
-        // Load data from top 4 rows of processed vertically adjacent faces into LREG0-3
-        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
-        TT_SFPLOAD(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
-        TT_SFPLOAD(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + ODD_COLUMNS);
+        // Load the partial max/min (top 4 rows) of the two vertically adjacent faces into LREG0-3.
+        load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
+        load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_7, bottom_face_addr + ODD_COLUMNS);
 
-        convert_to_sign_magnitude_x4_lregs<INSTR_MOD_CAST>();  // Store lregs 0-3 in sign-magnitude format in lregs 4-7
+        // Move into LREG4-7 for the transpose + cross-row reduction.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
 
-        // Transpose to find absolutes max/min of top 4 rows of each face
+        // Transpose so the 4 partial results of each column sit in one register, reduce, transpose back.
         TTI_SFPTRANSP(0, 0, 0, 0);
         lltt::replay(0, 3);
         TTI_SFPTRANSP(0, 0, 0, 0);
 
-        // Swap to find max/min of vertically adjacent faces
-        TTI_SFPSWAP(
-            0,
-            p_sfpu::LREG7,
-            p_sfpu::LREG6,
-            1);  // Max/Min of odd columns of face 0 and 2 (first iteration) or face 1 and 3 (second iteration)
-        TTI_SFPSWAP(
-            0,
-            p_sfpu::LREG5,
-            p_sfpu::LREG4,
-            1);  // Max/Min of even columns of face 0 and 2 (first iteration) or face 1 and 3 (second iteration)
+        // Swap to combine the two vertically adjacent faces (even and odd columns).
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, 1);  // odd columns of face pair
+        TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG4, 1);  // even columns of face pair
 
-        // Convert back from two's complement to sign-magnitude before storing
-        apply_sign_magnitude_conversion(p_sfpu::LREG4, p_sfpu::LREG0, INSTR_MOD_CAST);
-        apply_sign_magnitude_conversion(p_sfpu::LREG6, p_sfpu::LREG1, INSTR_MOD_CAST);
+        TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG6, p_sfpu::LREG1, 0);
 
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr);
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_7, top_face_addr);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_7, top_face_addr + ODD_COLUMNS);
     }
 }
 
 /**
  * @brief Column-wise maximum/minimum reduction kernel for SFPU reduce MAX/MIN operation.
- *
- * Processes a block of tiles vertically (block_height tiles stacked) and computes the maximum or minimum value
- * for each of the columns across all rows in the block. The maximum/minimum values are placed into
- * the first row of the output tile (row 0 of faces 0 and 1) in tilized format for each tile in the top row of
+ *        Processes a block of tiles vertically (block_height tiles stacked) and computes the maximum or minimum value
+ *        for each of the columns across all rows in the block. The maximum/minimum values are placed into
+ *        the first row of the output tile (row 0 of faces 0 and 1) in tilized format for each tile in the top row of
  * tiles in the block.
  *
- * Algorithm:
- * - Initializes LREG4-7 with the first face pair's data (even/odd columns from faces 0 and 1)
- * - For each tile in the block, performs compare-and-swap operations using replay buffers to find maxima/minima
- * - Uses SFPSWAP instruction for comparisons to determine maximum/minimum between two lregs storing column data
- * - Transposes and sorts results to align maxima/minima correctly across LREG4-7
- * - Stores final maximum/minimum values to row 0 (32 datums across faces 0 and 1)
+ *        Algorithm:
+ *        - Initializes LREG4-7 with the first face pair's data (even/odd columns from faces 0 and 1)
+ *        - For each tile in the block, performs compare-and-swap operations using replay buffers to find maxima/minima
+ *        - Uses SFPSWAP instruction for comparisons to determine maximum/minimum between two lregs storing column data
+ *        - Transposes and sorts results to align maxima/minima correctly across LREG4-7
+ *        - Stores final maximum/minimum values to row 0 (32 datums across faces 0 and 1)
  *
- * @tparam pool_type: The pool type (MAX or MIN)
- * @tparam reduce_dim: The reduction dimension (currently only REDUCE_COL is supported)
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam pool_type The pool type (MAX or MIN)
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
- * @param block_height: The number of tiles in the vertical block to reduce (default is 1 for single tile).
+ * @param block_height The number of tiles in the vertical block to reduce (default is 1 for single tile).
  *                     For example, block_height=4 means reduce across 4 vertically stacked tiles (128 rows total).
  */
-template <PoolType pool_type, ReduceDim reduce_dim, InstrModLoadStore INSTRUCTION_MODE>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
 inline void calculate_reduce_max_min(const std::uint32_t block_height) {
     static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
     static_assert(
         pool_type == PoolType::MAX || pool_type == PoolType::MIN,
         "Only MAX and MIN pool types are supported for this function");
 
+    // Per-face-pair replay window and the dummy-load tail in the recorded LOADMACRO buffer.
     constexpr std::uint32_t replay_buffer_offset = 9;
     constexpr std::uint32_t replay_buffer_next_face = 10;
 
@@ -1055,32 +1301,41 @@ inline void calculate_reduce_max_min(const std::uint32_t block_height) {
     TTI_SFPSWAP(0 /*unused*/, p_sfpu::LREG4 /*lreg_src_c*/, p_sfpu::LREG5 /*lreg_dest*/, 1 /*instr_mod1*/);
     TTI_SFPTRANSP(0, 0, 0, 0);
 
-    // Store results to first row
-    TTI_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_7, 0);
-    TTI_SFPSTORE(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_7, 2);
-    TTI_SFPSTORE(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_7, 16);
-    TTI_SFPSTORE(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_7, 18);
+    // Store results to first row.
+    // For UInt16 OUTPUT in a 32-bit dest the reduced value lives in the low 16 bits of the LREG, but
+    // the packer reads the high 16 bits of the dest word. SFPSTORE mode 9 (SFPSTORE_MOD0_FMT_LO16)
+    // writes the low 16 bits into the half the packer consumes; a 32-bit output keeps the plain store.
+    constexpr std::uint32_t STORE_MODE =
+        pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+    TTI_SFPSTORE(p_sfpu::LREG4, STORE_MODE, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, STORE_MODE, ADDR_MOD_7, 2);
+    TTI_SFPSTORE(p_sfpu::LREG6, STORE_MODE, ADDR_MOD_7, 16);
+    TTI_SFPSTORE(p_sfpu::LREG7, STORE_MODE, ADDR_MOD_7, 18);
 }
 
 /**
  * @brief Column-wise sum/average reduction kernel for SFPU reduce SUM and AVG operations.
+ *        Computes the sum or average of each column, placing the 32 output values into the first row
+ *        of the output tile (row 0 of faces 0 and 1).
  *
- * Computes the sum or average of each column, placing the 32 output values into the first row
- * of the output tile (row 0 of faces 0 and 1).
+ *        Uses a 4-iteration approach that processes vertically aligned face pairs (0+2, 1+3) to optimize
+ *        column operations and minimize load/store operations. Each iteration handles 8 columns using
+ *        transpose operations and replay buffers for tree reduction.
  *
- * Uses a 4-iteration approach that processes vertically aligned face pairs (0+2, 1+3) to optimize
- * column operations and minimize load/store operations. Each iteration handles 8 columns using
- * transpose operations and replay buffers for tree reduction.
+ *        For AVG mode: Integer formats use arithmetic shift with condition codes to handle negative numbers;
+ *        float formats multiply by 1/32 constant.
  *
- * For AVG mode: Integer formats use arithmetic shift with condition codes to handle negative numbers;
- * float formats multiply by 1/32 constant.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG)
- * @tparam reduce_dim: The reduction dimension (currently only REDUCE_COL is supported)
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG)
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
  */
-template <PoolType pool_type, ReduceDim reduce_dim, InstrModLoadStore INSTRUCTION_MODE>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
 inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
     // Compile-time assertions to restrict to currently supported operations
     static_assert(
@@ -1099,10 +1354,10 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
         is_supported_reduce_instr_mode, "INSTRUCTION_MODE must be one of: INT32, INT32_2S_COMP, LO16, FP32, FP16B");
 
     if constexpr (reduce_dim == ReduceDim::REDUCE_COL) {
-        perform_reduce_col_sum_avg<pool_type, INSTRUCTION_MODE>();
+        perform_reduce_col_sum_avg<pool_type, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
     } else {
         static_assert(pool_type == PoolType::SUM, "Row reduction (REDUCE_ROW) is allowed only for SUM");
-        perform_reduce_row_sum<INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
+        perform_reduce_row_sum<INSTRUCTION_MODE, clear_high_bits, pack_low16>(block_ct_dim, block_rt_dim);
     }
     // For column reductions: sums are stored horizontally in the first row of tensor in dest reg
     // For row reductions: sums are stored vertically in the first column of tensor in dest reg
@@ -1113,21 +1368,81 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
 // ============================================================================
 
 /**
+ * @brief Unified reduction init kernel wrapper for SFPU reduce kernel.
+ *        Determines the instruction mode from format, then dispatches to the appropriate init kernel.
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
+ * @tparam format The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
+ * @param block_ct_dim Block dimension (used for MAX/MIN reduction to specify number of columns, default is 1 for single
+ * tile)
+ */
+template <PoolType pool_type, DataFormat format, bool is_fp32_dest_acc_en>
+inline void init_reduce(std::uint32_t block_ct_dim = 1) {
+    static_assert(
+        is_supported_reduce_format(format),
+        "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
+
+    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on
+    // two's-complement values (on Blackhole the load/store conversion is a no-op, so the reduce code casts
+    // sign-magnitude<->two's-complement explicitly). Int32 MAX/MIN keep plain INT32 (sign-magnitude):
+    // SFPSWAP(VEC_MIN_MAX) is a float/sign-magnitude comparator that orders sign-magnitude integers
+    // correctly, whereas two's-complement negatives would be mis-ordered.
+    constexpr bool int32_sum_avg =
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
+
+    // Garbage high bits needs to be cleared when loading UInt16 data
+    constexpr bool clear_high_bits = (is_fp32_dest_acc_en && format == DataFormat::UInt16);
+
+    if constexpr (clear_high_bits) {
+        // CLEAR_REG (sfpi::vConstIntPrgm0 / LREG12) holds the mask used by SFPLOAD_EXT to clear high bits.
+        sfpi::vConstIntPrgm0 = 0x0000FFFF;
+    }
+
+    // Dispatch to appropriate PoolType init
+    if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
+        if constexpr (clear_high_bits) {
+            // UInt16 in 32-bit dest uses the manual (non-LOADMACRO) compare-and-swap path so the
+            // garbage high bits can be masked before each swap. It reuses the Int32 path's 3-swap
+            // replay buffer and swap-direction config (the body is format-agnostic).
+            init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+        } else {
+            init_reduce_max_min<INSTRUCTION_MODE, pool_type, false>(block_ct_dim);
+        }
+    } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
+        init_reduce_sum_avg<INSTRUCTION_MODE, pool_type>();
+    } else {
+        static_assert(
+            pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
+                pool_type == PoolType::MIN,
+            "Unsupported pool_type. Currently supported: SUM, AVG, MAX, MIN");
+    }
+}
+
+/**
  * @brief Unified reduction kernel wrapper for a 32x32 tile.
- *
- * Determines the instruction mode from format, then dispatches to the appropriate reduction kernel.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
- * @tparam reduce_dim: The reduction dimension: REDUCE_COL for column-wise, REDUCE_ROW for row-wise (MAX only,
+ *        Determines the instruction mode from format, then dispatches to the appropriate reduction kernel.
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
+ * @tparam reduce_dim The reduction dimension: REDUCE_COL for column-wise, REDUCE_ROW for row-wise (MAX only,
  * FP32/Int32).
- * @tparam format: The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
- * @param block_ct_dim: Block dimension (used for SUM/AVG column reduction to specify number of columns, default is 1 for
+ * @tparam format The INPUT data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b). Drives the
+ *         instruction mode and load-time high-bit masking.
+ * @tparam output_format The packer-visible OUTPUT data format (defaults to @p format). Drives the final store mode:
+ *         UInt16 output in a 32-bit dest is stored via mode 9 (low->high 16-bit swap), while a 32-bit output (e.g.
+ *         UInt32) is stored with the plain instruction mode. This lets UInt16 input be summed into a UInt32 output
+ *         without overflow.
+ * @param block_ct_dim Block dimension (used for SUM/AVG column reduction to specify number of columns, default is 1 for
  * single tile)
- * @param block_rt_dim: Block dimension (used for MAX/MIN reduction to specify block height, or SUM/MAX row reduction;
+ * @param block_rt_dim Block dimension (used for MAX/MIN reduction to specify block height, or SUM/MAX row reduction;
  * default is 1 for single tile)
  */
-template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t block_ct_dim = 1, uint32_t block_rt_dim = 1) {
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    DataFormat format,
+    bool is_fp32_dest_acc_en,
+    DataFormat output_format = format>
+inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL || (pool_type == PoolType::SUM && reduce_dim == ReduceDim::REDUCE_ROW) ||
             (pool_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW),
@@ -1137,14 +1452,23 @@ inline void calculate_reduce(uint32_t block_ct_dim = 1, uint32_t block_rt_dim = 
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
     // Determine InstrModLoadStore from llk_defs.
-    // Column MAX/MIN with Int32 uses INT32_2S_COMP for the LOADMACRO-based compare-and-swap pipeline.
-    // Row MAX with Int32 uses plain INT32 (sign-magnitude) for direct SFPLOAD/SFPSTORE: the
-    // sign-magnitude ↔ 2's-complement casts are done inline around each SFPSWAP.
+    // Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on two's-complement values (on Blackhole the
+    // load/store conversion is a no-op, so the reduce code casts sign-magnitude<->two's-complement
+    // explicitly). Int32 MAX/MIN (both dims) keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX) is a
+    // float/sign-magnitude comparator that orders sign-magnitude integers correctly; two's-complement
+    // negatives are mis-ordered (min of negatives would return the least-negative value).
+    constexpr bool int32_sum_avg =
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
     constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
-         reduce_dim == ReduceDim::REDUCE_COL)
-            ? InstrModLoadStore::INT32_2S_COMP
-            : GetSfpLoadStoreInstrMod<format>();
+        int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP : GetSfpLoadStoreInstrMod<format, is_fp32_dest_acc_en>();
+
+    // Garbage high bits needs to be cleared when loading UInt16 data (driven by INPUT format).
+    constexpr bool clear_high_bits = (is_fp32_dest_acc_en && format == DataFormat::UInt16);
+
+    // The packer-visible result must go through mode-9 (low->high 16-bit) store only when the OUTPUT is UInt16
+    // in a 32-bit dest. A 32-bit output (e.g. UInt32) keeps the full word, so it uses the plain store. This is
+    // driven by the OUTPUT format and is independent of the load-time masking above.
+    constexpr bool pack_low16 = (is_fp32_dest_acc_en && output_format == DataFormat::UInt16);
 
     // Dispatch to appropriate reduction kernel based on PoolType
     if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
@@ -1155,53 +1479,16 @@ inline void calculate_reduce(uint32_t block_ct_dim = 1, uint32_t block_rt_dim = 
                 INSTRUCTION_MODE == InstrModLoadStore::FP32 || INSTRUCTION_MODE == InstrModLoadStore::INT32 ||
                     INSTRUCTION_MODE == InstrModLoadStore::FP16B,
                 "Row MAX reduction supports FP32, FP16B, and INT32 (sign-magnitude) instruction modes");
-            perform_reduce_row_max<INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
-        } else if constexpr (format == DataFormat::Int32) {
-            calculate_reduce_max_min_int32<INSTRUCTION_MODE, pool_type, reduce_dim>();
+            perform_reduce_row_max<INSTRUCTION_MODE, clear_high_bits, pack_low16>(block_ct_dim, block_rt_dim);
+        } else if constexpr (clear_high_bits) {
+            // UInt16 in 32-bit dest: manual load/mask/swap path (LOADMACRO cannot mask between load and swap).
+            calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
         } else {
-            calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE>(block_rt_dim);
+            calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>(block_rt_dim);
         }
     } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
-        calculate_reduce_sum_avg<pool_type, reduce_dim, INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
-    } else {
-        static_assert(
-            pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
-                pool_type == PoolType::MIN,
-            "Unsupported pool_type. Currently supported: SUM, AVG, MAX, MIN");
-    }
-}
-
-/**
- * @brief Unified reduction init kernel wrapper for SFPU reduce kernel.
- *
- * Determines the instruction mode from format, then dispatches to the appropriate init kernel.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
- * @tparam format: The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
- * @param block_ct_dim: Block dimension (used for MAX/MIN reduction to specify number of columns, default is 1 for single
- * tile)
- */
-template <PoolType pool_type, DataFormat format>
-inline void init_reduce(std::uint32_t block_ct_dim = 1) {
-    static_assert(
-        is_supported_reduce_format(format),
-        "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
-
-    // Determine InstrModLoadStore from llk_defs; Int32 MAX/MIN use INT32_2S_COMP for SFPSWAP
-    constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN))
-            ? InstrModLoadStore::INT32_2S_COMP
-            : GetSfpLoadStoreInstrMod<format>();
-
-    // Dispatch to appropriate PoolType init
-    if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
-        if constexpr (format == DataFormat::Int32) {
-            init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
-        } else {
-            init_reduce_max_min<INSTRUCTION_MODE, pool_type>(block_ct_dim);
-        }
-    } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
-        init_reduce_sum_avg<INSTRUCTION_MODE>();
+        calculate_reduce_sum_avg<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+            block_ct_dim, block_rt_dim);
     } else {
         static_assert(
             pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -19,6 +19,16 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+// Mask that keeps the low 16 bits (the UInt16 value) of a 32-bit dest word and clears the garbage high bits.
+constexpr std::uint16_t UINT16_LOW_MASK = 0xFFFF;
+
+// SFPSTORE mode that swaps the high and low 16 bits before writing, so a value computed in the low 16 bits
+// lands in the high 16 bits where the packer reads UInt16 out of a 32-bit dest word.
+constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
+
+// SFPGT mod1 selector that sets the destination to all-ones (-1) when the comparison is true.
+constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint16() {
 #ifdef DISABLE_SFPLOADMACRO
@@ -258,33 +268,14 @@ inline void calculate_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp32() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round | Store   |
-    // - | ---- | ----------------- | --- | ----- | ------- |
-    // 0 | [v]  |                   |     |       |         |
-    // 0 | ...  | [v] L16 = cast(v) |     |       |         |
-    // 0 | ...  |                   |     |       | [v] L16 |
-
-    constexpr int v = p_sfpu::LREG0;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -345,7 +336,7 @@ inline void calculate_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
@@ -355,46 +346,8 @@ inline void calculate_typecast_uint32_to_fp16b() {
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0);  // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // Note: L0=0.0 and L1=2**31.  The sign bit is stored in L7 and used to pick L0 or L1
-    // for SFPMAD's VA:
-    //
-    // - if sign bit is 0, then compute L0*1.0 + v = v
-    // - if sign bit is 1, then compute L1*1.0 + v = 2**31 + v
-    //
-    // t | Load | Simple             | MAD                     | Round            | Store   |
-    // - | ---- | ------------------ | ----------------------- | ---------------- | ------- |
-    // 0 | [v]  |                    |                         |                  |         |
-    // 1 |      |                    |                         | L7 = v >> 31     |         |
-    // 2 |      | v = setsgn(v, 0)   |                         |                  |         |
-    // 0 | ...  | [v] = cast(v)      |                         |                  |         |
-    // 1 | ...  |                    | [v] v = L[L7]*1.0 + v   |                  |         |
-    // 2 | ...  |                    |                         |                  |         |
-    // 0 | ...  |                    |                         | [v] L16 = rnd(v) |         |
-    // 1 | ...  |                    |                         |                  | [v] L16 |
-
-    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_USHORT, 0);
-    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, 0x4f00);  // 2**31
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_6, v >> 2);
-        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
-        TT_SFPSETSGN(0, v, v, 1);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -453,66 +406,27 @@ inline void calculate_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_uint32() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple | MAD | Round | Store |
-    // - | ---- | ------ | --- | ----- | ----- |
-    // 0 | [v]  |        |     |       |       |
-    // 0 | ...  |        |     |       | [v]   |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
-    }
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
-        TTI_SFPIADD(
-            0, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
-        TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TTI_SFPGT(0, p_sfpu::LCONST_0, p_sfpu::LREG0, SFPGT_MOD1_SET_ALL_ONES);  // Set LREG0 = -1 if greater than 0
+        TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);  // Leaves garbage in high bits, but packer will ignore it
+        TTI_SFPSTORE(p_sfpu::LREG1, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);  // Swap hi and low 16 before write
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple             | MAD | Round | Store   |
-    // - | ---- | ------------------ | --- | ----- | ------- |
-    // 0 | [a]  |                    |     |       |         |
-    // 1 | [b]  | [a] = a>0 ? -1 : 0 |     |       |         |
-    // 0 | ...  | [b] |= a           |     |       |         |
-    // 1 | ...  |                    |     |       | [b]     |
-
-    constexpr int a = p_sfpu::LREG0;
-    constexpr int b = p_sfpu::LREG1;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::LO16, ADDR_MOD_7, a >> 2);
-        TTI_SFPLOADMACRO((1 << 2) | (b & 3), InstrModLoadStore::INT32, ADDR_MOD_6, b >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -612,25 +526,7 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
-#ifndef DISABLE_SFPLOADMACRO
-    {
-        constexpr std::uint32_t simple_bits = 0;
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (0 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: INT32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -769,29 +665,7 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -825,42 +699,7 @@ inline void init_typecast_uint16_to_fp16b() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_fp16b() {
-#ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
-
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // InstructionTemplate[1]
-    TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4);  // SFPMAD_MOD1_INDIRECT_VA
-
-    // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (2 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (3 << 3) | (4 + 1);
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (5 << 3) | (4 + 2);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (6 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: DEFAULT,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
-#endif
-}
+inline void init_typecast_uint32_to_fp16b() {}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint16() {
@@ -893,44 +732,7 @@ inline void init_typecast_fp32_to_uint16() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int a = p_sfpu::LREG0;
-
-    // InstructionTemplate[0]
-    TTI_SFPGT(0, p_sfpu::LCONST_0, 12, 8);  // SFPGT_MOD1_SET_VD
-
-    // InstructionTemplate[1]
-    TTI_SFPOR(0, a, 13, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-
-        TTI_SFPCONFIG((mad_bits << 8) | simple_bits, 4 + 0, 1);
-    }
-
-    // Macro 1
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 1);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 1, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_uint32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_int32_to_uint16() {
@@ -999,7 +801,8 @@ inline void calculate_typecast_uint_to_uint8() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
-            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+            TTI_SFPAND(0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
         } else {
             TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         }
@@ -1017,6 +820,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
+    sfpi::vConstIntPrgm1 = 0x0000FFFF;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -177,7 +177,6 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -185,40 +184,9 @@ inline void calculate_typecast_fp32_to_fp16b() {
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                            // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);   // lreg[1] += lreg[0]
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_6, 0);
+        TTI_SFPAND(0, p_sfpu::LREG14, p_sfpu::LREG1, 0);                            // lreg[1] &= 0xFFFF0000
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple          | MAD | Round      | Store   |
-    // - | ---- | --------------- | --- | ---------- | ------- |
-    // 0 |  [a] |                 |     |            |         |
-    // 1 |  [b] |                 |     | [a] >>= 16 |         |
-    // 2 |      | a &= 1          |     |            |         |
-    // 0 |  ... | [b] += 0x7fff   |     |            |         |
-    // 1 |  ... | [a] L16 = a + b |     |            | [a]     |
-    // 2 |  ... |                 |     |            | [b] L16 |
-    //
-    // Note that [a] schedules a 32-bit store, writing all zeros except for the
-    // LSB, which may be 0 or 1.  Then, [b] schedules a 16-bit store with
-    // MOD0_FMT_BF16.  The zeros mean that even if rounding is applied by
-    // packers, the result will be truncated.
-
-    constexpr int b = p_sfpu::LREG2;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), 0, ADDR_MOD_7, a >> 2);
-        TTI_SFPLOADMACRO((1 << 2) | (b & 3), 0, ADDR_MOD_6, b >> 2);
-        TT_SFPAND(0, p_sfpu::LREG12, a, 0);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -400,50 +368,7 @@ template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_fp16b() {
     sfpi::vConstIntPrgm0 = 1;
     sfpi::vConstIntPrgm1 = 0x7fff;
-
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int b = p_sfpu::LREG2;
-
-    // InstructionTemplate[0]
-    TTI_SFPSHFT2(-16 & 0xfff, 0, 12, 6);  // SFPSHFT2_MOD1_SHFT_IMM
-
-    // InstructionTemplate[1]
-    TTI_SFPIADD(0, p_sfpu::LREG13, 13, sfpi::SFPIADD_MOD1_CC_NONE);
-
-    // InstructionTemplate[2]
-    TTI_SFPIADD(0, b, 14, sfpi::SFPIADD_MOD1_CC_NONE);
-
-    // Macro 0: [a]
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x40 | (3 << 3) | (4 + 2);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Macro 1: [b]
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 1);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 1, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP16B,
-    //   UsesLoadMod0ForStore: {1,0},
-    //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x310 | InstrModLoadStore::FP16B, 8, 1);
-#endif
+    sfpi::vConstIntPrgm2 = 0xffff0000;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -44,11 +44,11 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp16b() {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -31,70 +31,25 @@ constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round            | Store   |
-    // - | ---- | ----------------- | --- | ---------------- | ------- |
-    // 0 | [v]  |                   |     |                  |         |
-    // 1 | nop  | [v] = max(v, 0.0) |     |                  |         |
-    // 0 | ...  | (must be idle)    |     | (must be idle)   |         |
-    // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
-    // 0 | ...  |                   |     |                  | [v] L16 |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_6, v >> 2);
-        TTI_SFPNOP;
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple        | MAD | Round            | Store   |
-    // - | ---- | ------------- | --- | ---------------- | ------- |
-    // 0 | [v]  |               |     |                  |         |
-    // 0 | ...  | [v] = cast(v) |     |                  |         |
-    // 0 | ...  |               |     | [v] L16 = rnd(v) |         |
-    // 0 | ...  |               |     |                  | [v] L16 |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -431,47 +386,14 @@ inline void calculate_typecast_uint32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round            | Store   |
-    // - | ---- | ----------------- | --- | ---------------- | ------- |
-    // 0 | [a]  |                   |     |                  |         |
-    // 1 |      | a = cast_fp32(a)  |     |                  |         |
-    // 2 | nop  | [a] = max(0.0, a) |     |                  |         |
-    // 0 | ...  | (must be idle)    |     |                  |         |
-    // 1 | ...  |                   |     | [a] L16 = rnd(a) |         |
-    // 2 | ...  |                   |     |                  | [a] L16 |
-    //
-    // Simple/Round sub-units can be used simultaneously if one has VD=16 and
-    // the other VD!=16.  The following steps clamp the input value to 0-65535:
-    //
-    // a = cast_fp32(a); this allows us to use SFPSTOCHRND later to convert to uint16, clamping to 65535.
-    // swap_minmax(0.0, a); since SFPSTOCHRND takes the absolute value before clamping, we use SFPSWAP to clamp negative
-    // values to 0.0. L16 = rnd(a); finally, we use SFPSTOCHRND to clamp large values to 65535, using VD=16.
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_6, a >> 2);
-        TT_SFPCAST(a, a, 0);
-        TTI_SFPNOP;
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -670,99 +592,20 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (1 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (2 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: DEFAULT,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
-#endif
+    sfpi::vConstIntPrgm0 = 0x0000FFFF;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_fp16b() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_fp32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (2 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_fp32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_int32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (3 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (4 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_int32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint8() {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -290,7 +290,7 @@ inline void calculate_typecast_uint32_to_fp16b() {
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0);  // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_6, 0);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -637,7 +637,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
-    sfpi::vConstIntPrgm1 = 0x0000FFFF;
+    sfpi::vConstIntPrgm1 = UINT16_LOW_MASK;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -42,14 +42,35 @@ inline void calculate_typecast_fp32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp16b() {
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, 0);
-        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // t | Load | Simple        | MAD | Round            | Store   |
+    // - | ---- | ------------- | --- | ---------------- | ------- |
+    // 0 | [v]  |               |     |                  |         |
+    // 0 | ...  | [v] = cast(v) |     |                  |         |
+    // 0 | ...  |               |     | [v] L16 = rnd(v) |         |
+    // 0 | ...  |               |     |                  | [v] L16 |
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_6, v >> 2);
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -517,7 +538,32 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
-    sfpi::vConstIntPrgm0 = 0x0000FFFF;
+#ifndef DISABLE_SFPLOADMACRO
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (1 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (2 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: DEFAULT,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -31,6 +31,7 @@ constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint16() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -198,6 +199,7 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
@@ -375,6 +377,7 @@ inline void calculate_typecast_uint32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -29,7 +29,7 @@ constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
 // SFPGT mod1 selector that sets the destination to all-ones (-1) when the comparison is true.
 constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
     // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
@@ -37,7 +37,11 @@ inline void calculate_typecast_fp32_to_uint16() {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
+        if (DST_ACCUM_MODE) {
+            TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_6, 0);
+        }
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -35,13 +35,28 @@ constexpr std::uint32_t ROWS_PER_LOAD = 4;
 constexpr std::uint32_t AVG_SHIFT_AMOUNT = 5;    // 2^5 = 32
 constexpr std::uint32_t AVG_SHIFT_MASK = 0xfff;  // Mask for shift instruction encoding
 
-// FP16B representation of 1/32 = 0.03125
-constexpr std::uint32_t FP16B_ONE_OVER_32_HIGH = 0x3D00;
-constexpr std::uint32_t FP16B_ONE_OVER_32_LOW = 0x0000;
-
 // Constants for MAX/MIN reduction
 constexpr std::uint32_t ROWS_PER_TILE = 64;
 constexpr std::uint32_t ROWS_PER_FACE = 16;
+
+// Register holding the 0x0000FFFF mask used to clear garbage high bits when loading UInt16 data
+// from a 32-bit (fp32 dest accumulation) dest word. Maps to sfpi::vConstIntPrgm0 on Wormhole B0.
+constexpr std::uint32_t CLEAR_REG = p_sfpu::LREG12;
+
+// SFPLOAD wrapper that optionally clears the high 16 bits of the loaded value. Needed for UInt16
+// reduce with fp32 dest accumulation: the datum lives in the low 16 bits of a 32-bit dest word and
+// the high 16 bits are garbage, which would otherwise corrupt integer compare/add operations.
+template <bool clear_high_bits>
+inline void load_and_clear_high_bits(
+    const std::uint32_t lreg_ind,
+    const InstrModLoadStore instr_mod0,
+    const std::uint32_t sfpu_addr_mode,
+    const std::uint32_t dest_reg_addr) {
+    TT_SFPLOAD(lreg_ind, instr_mod0, sfpu_addr_mode, dest_reg_addr);
+    if constexpr (clear_high_bits) {
+        TT_SFPAND(0, CLEAR_REG, lreg_ind, 0);
+    }
+}
 
 // ============================================================================
 // Helper Functions
@@ -49,33 +64,34 @@ constexpr std::uint32_t ROWS_PER_FACE = 16;
 
 /**
  * @brief Load data from upper and lower faces into LREG0-7
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for load operations
- * @param upper_face_addr: Base address of upper face (Face 0 or Face 1)
- * @param lower_face_addr: Base address of lower face (Face 2 or Face 3)
- * @param column_offset: Column offset for the current iteration
+ * @tparam INSTRUCTION_MODE The instruction mode for load operations
+ * @param upper_face_addr Base address of upper face (Face 0 or Face 1)
+ * @param lower_face_addr Base address of lower face (Face 2 or Face 3)
+ * @param column_offset Column offset for the current iteration
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
 inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_face_addr, std::uint32_t column_offset) {
     // Load upper face data (Face 0 or Face 1) into LREG0-3
-    TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset);  // rows 0-3
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
+        p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG3,
         INSTRUCTION_MODE,
         ADDR_MOD_3,
         upper_face_addr + column_offset + 3 * ROWS_PER_LOAD);  // rows 12-15
 
     // Load lower face data (Face 2 or Face 3) into LREG4-7
-    TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, lower_face_addr + column_offset);  // rows 0-3
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
+        p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, lower_face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, lower_face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, lower_face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
-    TT_SFPLOAD(
+    load_and_clear_high_bits<clear_high_bits>(
         p_sfpu::LREG7,
         INSTRUCTION_MODE,
         ADDR_MOD_3,
@@ -83,15 +99,37 @@ inline void load_face_data(std::uint32_t upper_face_addr, std::uint32_t lower_fa
 }
 
 /**
+ * @brief Load all 16 rows of a single face into LREG0-3 (4 rows per LREG)
+ * @tparam INSTRUCTION_MODE The instruction mode for load operations
+ * @tparam clear_high_bits Whether to mask the garbage high bits on load (true for UInt16 in 32-bit dest)
+ * @param face_addr Base address of face
+ * @param column_offset Column offset for the current iteration: even columns (0) or odd columns (2) of the face
+ * @tparam DST_LREG_BASE First of the four consecutive LREGs to load into (defaults to LREG0).
+ */
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, std::uint32_t DST_LREG_BASE = p_sfpu::LREG0>
+inline void load_face_data(std::uint32_t face_addr, std::uint32_t column_offset) {
+    // Load the 4 row-groups into DST_LREG_BASE..DST_LREG_BASE+3. DST_LREG_BASE defaults to LREG0, but
+    // callers can target LREG4 to feed a recorded swap buffer that operates on LREG4-7 directly, avoiding
+    // a redundant LREG0-3 -> LREG4-7 shuffle.
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 0, INSTRUCTION_MODE, ADDR_MOD_3, face_addr + column_offset);  // rows 0-3
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 1, INSTRUCTION_MODE, ADDR_MOD_3, face_addr + column_offset + ROWS_PER_LOAD);  // rows 4-7
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 2, INSTRUCTION_MODE, ADDR_MOD_3, face_addr + column_offset + 2 * ROWS_PER_LOAD);  // rows 8-11
+    load_and_clear_high_bits<clear_high_bits>(
+        DST_LREG_BASE + 3, INSTRUCTION_MODE, ADDR_MOD_3, face_addr + column_offset + 3 * ROWS_PER_LOAD);  // rows 12-15
+}
+
+/**
  * @brief Perform integer averaging with proper handling of negative numbers
+ * @tparam INSTRUCTION_MODE The instruction mode (determines signed vs unsigned)
  *
  * For integer formats, we need to handle negative numbers properly for division by 32.
  * Since Wormhole B0 only supports logical shift (not arithmetic), we need to:
  * 1. Check if the number is negative using condition codes (only for signed formats)
  * 2. If negative, negate it, shift right by 5 bits, then negate back
  * 3. If positive, just shift right by 5 bits
- *
- * @tparam INSTRUCTION_MODE: The instruction mode (determines signed vs unsigned)
  */
 template <InstrModLoadStore INSTRUCTION_MODE>
 inline void perform_int_average() {
@@ -111,29 +149,47 @@ inline void perform_int_average() {
         TTI_SFPCOMPC(0, 0, 0, 0);              // Invert condition code (now true if original was negative)
         TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // Negate LREG0 if condition is true
         TTI_SFPENCC(0, 0, 0, 0);                             // Clear condition codes
+    } else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+        // Two's-complement signed divide-by-32 (round toward zero). SFPABS clears the sign bit and is
+        // only correct for sign-magnitude, so for 2's-complement we take the magnitude via a conditional
+        // negate (0 - x), logical-shift, then restore the sign with a second conditional negate.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);      // Save original (2's-complement) value for sign check
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, 4);                // cc if sign bit == 0 (non-negative)
+        TTI_SFPCOMPC(0, 0, 0, 0);                            // Invert -> cc if negative
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // LREG0 = -LREG0 (magnitude) when negative
+        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPSHFT(-AVG_SHIFT_AMOUNT & AVG_SHIFT_MASK, p_sfpu::LREG0, p_sfpu::LREG0, 0b01);  // |x| >> 5 (divide by 32)
+        TTI_SFPSETCC(0, p_sfpu::LREG1, 0, 4);                // cc if original sign bit == 0 (non-negative)
+        TTI_SFPCOMPC(0, 0, 0, 0);                            // Invert -> cc if original was negative
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 6);  // Restore sign (2's-complement negate) when negative
+        TTI_SFPENCC(0, 0, 0, 0);
     } else {
         // For unsigned formats (UInt32), just use logical shift directly since they can't be negative
         TTI_SFPSHFT(-AVG_SHIFT_AMOUNT & AVG_SHIFT_MASK, p_sfpu::LREG0, p_sfpu::LREG0, 0b01);
     }
 }
 
+// Programmable float constant register holding 1/32 (0.03125) for float AVG. Preloaded once by
+// init_reduce_sum_avg (only when pool_type == AVG and the format is float), so perform_float_average
+// avoids rebuilding the constant via two SFPLOADI on every column group. Maps to LREG12 on Wormhole B0
+// (sfpi::vConstFloatPrgm0); the float reduce path does not use the UInt16 high-bit mask, so this
+// register is free to hold the constant across the whole reduce.
+constexpr std::uint32_t AVG_RECIP_REG = p_sfpu::LREG12;
+
 /**
  * @brief Perform floating-point averaging (multiply by 1/32)
  *
  * For a 32x32 tile, each column sum represents the sum of exactly 32 values (one per row).
- * This function divides by 32 by multiplying by the constant 1/32 (0.03125).
+ * This function divides by 32 by multiplying by the constant 1/32 (0.03125), which
+ * init_reduce_sum_avg() preloaded into AVG_RECIP_REG (sfpi::vConstFloatPrgm0).
  */
 inline void perform_float_average() {
-    // Load 1/32 constant (0.03125) into LREG1 for float division
-    TTI_SFPLOADI(p_sfpu::LREG1, 8, FP16B_ONE_OVER_32_HIGH);  // Load 0.03125 as FP16B high part
-    TTI_SFPLOADI(p_sfpu::LREG1, 10, FP16B_ONE_OVER_32_LOW);  // Load 0.03125 as FP16B low part
-
-    // Multiply by 1/32 (divide by 32) - works for both float and integer formats
-    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    // Multiply by 1/32 (divide by 32) using the preloaded constant register.
+    TTI_SFPMUL(p_sfpu::LREG0, AVG_RECIP_REG, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
     TTI_NOP;  // Required after SFPMUL due to 2-cycle latency
 }
 
-template <PoolType pool_type, InstrModLoadStore INSTRUCTION_MODE>
+template <PoolType pool_type, InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_col_sum_avg() {
     // Determine if integer or float mode at compile time
     constexpr bool is_integer_mode =
@@ -149,7 +205,7 @@ inline void perform_reduce_col_sum_avg() {
         const std::uint32_t upper_face_addr = UPPER_FACE_ADDRS[i];
         const std::uint32_t lower_face_addr = LOWER_FACE_ADDRS[i];
         const std::uint32_t column_offset = COLUMN_OFFSETS[i];
-        load_face_data<INSTRUCTION_MODE>(upper_face_addr, lower_face_addr, column_offset);
+        load_face_data<INSTRUCTION_MODE, clear_high_bits>(upper_face_addr, lower_face_addr, column_offset);
 
         // Step 1: Tree-reduce across registers (LREG0-3→LREG0, LREG4-7→LREG4) without transpose.
         lltt::replay(0, 6);
@@ -172,11 +228,11 @@ inline void perform_reduce_col_sum_avg() {
             lltt::replay(0, 3);  // Reuse first 3 positions of sequential integer buffer (A1,A2,A3)
         } else {
             lltt::replay(6, 4);  // Half reduce with NOP for 2-cycle SFPADD latency
-            if constexpr (pool_type != PoolType::AVG) {
-                // SUM path: next op is SFPSTORE LREG0, needs NOP to cover SFPADD's 2-cycle latency.
-                // AVG path: first SFPLOADI in perform_float_average() is independent of LREG0 and fills the slot.
-                TTI_SFPNOP;
-            }
+            // The half reduce ends with an SFPADD producing LREG0 (2-cycle latency). The next consumer of
+            // LREG0 is either SFPSTORE (SUM path) or the SFPMUL in perform_float_average() (AVG path, which
+            // now reads the preloaded 1/32 constant register instead of rebuilding it with two independent
+            // SFPLOADI). Both consume LREG0 immediately, so a NOP is required in either case.
+            TTI_SFPNOP;
         }
 
         // Perform averaging if requested (different for int vs float)
@@ -187,13 +243,20 @@ inline void perform_reduce_col_sum_avg() {
                 perform_float_average();
             }
         }
-        // Store the final column sum/average to the first row
-        TTI_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, upper_face_addr + column_offset);
+        // Store the final column sum/average to the first row.
+        // Mode 9 (SFPSTORE_MOD0_FMT_LO16) is only needed when the packer-visible OUTPUT is UInt16 in a
+        // 32-bit dest: there the reduced value sits in the low 16 bits but the packer reads the high 16,
+        // so we move low->high. When the output is a full 32-bit format (e.g. UInt32) the packer reads
+        // the whole dest word, so we use the plain INSTRUCTION_MODE store even for UInt16 input.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TTI_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_3, upper_face_addr + column_offset);
     }
 }
 
 /**
- * @brief Performs two horizontal reductions in parallel (LREG0/LREG1 and LREG4/LREG5), interleaving instructions to hide SFPSHFT2 latency.
+ * @brief Performs two horizontal reductions in parallel (LREG0/LREG1 and LREG4/LREG5), interleaving
+ *        instructions to hide SFPSHFT2 latency.
  *
  * SFPU hardware operates on 8 column slices in parallel but independently; column slices cannot
  * directly communicate. SFPSHFT2 is the only instruction that moves data across columns.
@@ -212,7 +275,7 @@ inline void perform_reduce_col_sum_avg() {
  *   Phase 3: Shift by 1 and add -> 2 sums become 1 sum (col 7).
  *   Phase 4: Rotate right by 1  -> move the single sum from column 7 to column 0.
  *
- * @tparam is_integer_mode: True for integer types (uses SFPIADD), false for float (uses SFPADD)
+ * @tparam is_integer_mode True for integer types (uses SFPIADD), false for float (uses SFPADD)
  */
 template <bool is_integer_mode>
 inline void horizontal_reduce() {
@@ -322,8 +385,7 @@ inline void record_horizontal_reduce_max() {
 
 /**
  * @brief Executes horizontal max reduction: phase 1 inline, phases 2-4 via replay buffer.
- *
- * @pre @ref record_horizontal_reduce_max must be called once before first use.
+ *        record_horizontal_reduce_max() must have been called before first use.
  */
 inline void horizontal_reduce_max() {
     // Phase 1 (inline): Shift by 4 and max -> 8 values become 4 maxes (cols 4-7).
@@ -359,11 +421,11 @@ inline void horizontal_reduce_max() {
  * 4. Use horizontal_reduce_max to consolidate 8 SFPU columns into column 0
  * 5. Store the per-row max into column 0
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
- * @param tile_row_offset: Base row offset for this tile in the dest register
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
+ * @param tile_row_offset Base row offset for this tile in the dest register
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
-inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
+inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset, std::uint32_t result_store_mode) {
 #pragma GCC unroll 2
     for (std::uint32_t face_pair = 0; face_pair < 2; face_pair++) {
         std::uint32_t face_pair_base = face_pair * 2 * ROWS_PER_FACE;
@@ -373,31 +435,31 @@ inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
             std::uint32_t row_offset_first = row_group * 8;
             std::uint32_t row_offset_second = row_offset_first + 4;
 
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG2,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG3,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first + 2);
 
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG6,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG7,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
@@ -416,16 +478,18 @@ inline void perform_reduce_row_max_tile(std::uint32_t tile_row_offset) {
             // Horizontal max: consolidate 8 SFPU columns into column 0
             horizontal_reduce_max();
 
+            // result_store_mode is mode 9 only when this per-tile store is the final packer-visible
+            // result (single column tile); otherwise it is intermediate and stays in the low 16 bits.
             TT_SFPSTORE(
-                p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
+                p_sfpu::LREG0, result_store_mode, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
             TT_SFPSTORE(
-                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
+                p_sfpu::LREG4, result_store_mode, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
         }
     }
 }
 
-template <InstrModLoadStore INSTRUCTION_MODE>
-inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits>
+inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset, std::uint32_t result_store_mode) {
     // Determine if integer or float mode at compile time
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
@@ -445,32 +509,32 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
             std::uint32_t row_offset_second = row_offset_first + 4;  // 4 or 12
 
             // Load 4 rows from face 0 (or 2) and face 1 (or 3)
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG2,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG3,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_first + 2);
 
             // Load next 4 rows from face 0 (or 2) and face 1 (or 3)
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second + 2);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG6,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
                 tile_row_offset + face_pair_base + ROWS_PER_FACE + row_offset_second);
-            TT_SFPLOAD(
+            load_and_clear_high_bits<clear_high_bits>(
                 p_sfpu::LREG7,
                 INSTRUCTION_MODE,
                 ADDR_MOD_3,
@@ -482,10 +546,13 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
             // Horizontal reduction: consolidate all 8 SFPU columns into column 0 (interleaved for latency hiding)
             horizontal_reduce<is_integer_mode>();
 
+            // result_store_mode is mode 9 (SFPSTORE_MOD0_FMT_LO16) only when this per-tile store is the
+            // final, packer-visible result (single column tile); otherwise it is an intermediate store
+            // re-loaded by the cross-tile accumulation and must stay in the low 16 bits.
             TT_SFPSTORE(
-                p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
+                p_sfpu::LREG0, result_store_mode, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_first);
             TT_SFPSTORE(
-                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
+                p_sfpu::LREG4, result_store_mode, ADDR_MOD_3, tile_row_offset + face_pair_base + row_offset_second);
         }
     }
 }
@@ -505,11 +572,11 @@ inline void perform_reduce_row_sum_tile(std::uint32_t tile_row_offset) {
  * - Store LREG0-3 back to tile 0.
  * LREG4-7 hold the other tiles' data so loads and adds can be pipelined without NOPs.
  *
- * @tparam INSTRUCTION_MODE: The load/store instruction mode
- * @param tile_row_base: Base address of the first tile in this row of tiles
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
+ * @tparam INSTRUCTION_MODE The load/store instruction mode
+ * @param tile_row_base Base address of the first tile in this row of tiles
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uint32_t block_ct_dim) {
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
@@ -522,20 +589,28 @@ inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
         std::uint32_t base_idx = batch * 4;
 
         // Load tile 0's four LREGs at this batch's offsets (0,4,8,12 or 32,36,40,44) into LREG0-3
-        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPLOAD(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPLOAD(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
 
         // Accumulate from remaining tiles
         for (std::uint32_t t = 1; t < block_ct_dim; t++) {
             std::uint32_t tile_offset = tile_row_base + t * ROWS_PER_TILE;
 
             // Load tile t's four LREGs at the same offsets into LREG4-7
-            TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 0]);
-            TT_SFPLOAD(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 1]);
-            TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 2]);
-            TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 3]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 0]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 1]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 2]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 3]);
 
             // Add LREG4-7 into LREG0-3
             if constexpr (is_integer_mode) {
@@ -551,11 +626,15 @@ inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
             }
         }
 
-        // Store LREG0-3 back to tile 0
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPSTORE(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPSTORE(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        // Store LREG0-3 back to tile 0. This is the final, packer-visible result, so it uses mode 9
+        // (SFPSTORE_MOD0_FMT_LO16) only when the OUTPUT is UInt16 in a 32-bit dest (packer reads the
+        // high 16 bits); a 32-bit output (e.g. UInt32) is stored with the plain INSTRUCTION_MODE.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        TT_SFPSTORE(p_sfpu::LREG2, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        TT_SFPSTORE(p_sfpu::LREG3, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
     }
 }
 
@@ -565,29 +644,37 @@ inline void sum_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
  * Mirrors sum_first_columns_across_tiles but uses SFPSWAP instead of SFPADD
  * to keep maximum values rather than sums.
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32 or INT32_2S_COMP for signed int max)
- * @param tile_row_base: Base address of the first tile in this row of tiles
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32 or INT32_2S_COMP for signed int max)
+ * @param tile_row_base Base address of the first tile in this row of tiles
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void max_first_columns_across_tiles(std::uint32_t tile_row_base, std::uint32_t block_ct_dim) {
     constexpr std::uint32_t RESULT_ROWS[8] = {0, 4, 8, 12, 32, 36, 40, 44};
 
     for (std::uint32_t batch = 0; batch < 2; batch++) {
         std::uint32_t base_idx = batch * 4;
 
-        TT_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPLOAD(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPLOAD(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
 
         for (std::uint32_t t = 1; t < block_ct_dim; t++) {
             std::uint32_t tile_offset = tile_row_base + t * ROWS_PER_TILE;
 
-            TT_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 0]);
-            TT_SFPLOAD(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 1]);
-            TT_SFPLOAD(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 2]);
-            TT_SFPLOAD(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 3]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 0]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 1]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 2]);
+            load_and_clear_high_bits<clear_high_bits>(
+                p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, tile_offset + RESULT_ROWS[base_idx + 3]);
 
             TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, 1);
             TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG5, 1);
@@ -595,27 +682,40 @@ inline void max_first_columns_across_tiles(std::uint32_t tile_row_base, std::uin
             TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG7, 1);
         }
 
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
-        TT_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
-        TT_SFPSTORE(p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
-        TT_SFPSTORE(p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
+        // Final, packer-visible store: use mode 9 (SFPSTORE_MOD0_FMT_LO16) only when the OUTPUT is
+        // UInt16 in a 32-bit dest (pack_low16); a 32-bit output keeps the plain INSTRUCTION_MODE store.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 0]);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 1]);
+        TT_SFPSTORE(p_sfpu::LREG2, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 2]);
+        TT_SFPSTORE(p_sfpu::LREG3, STORE_MODE, ADDR_MOD_3, tile_row_base + RESULT_ROWS[base_idx + 3]);
     }
 }
 
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_row_sum(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
+    // When there is a single column tile, the per-tile store is the final packer-visible result and must
+    // use mode 9 only when the OUTPUT is UInt16 in a 32-bit dest (pack_low16). With multiple column tiles
+    // the per-tile store is intermediate (re-loaded by sum_first_columns_across_tiles) and must stay in the
+    // low 16 bits via INSTRUCTION_MODE; the final mode-9 (if any) is applied by the cross-tile store.
+    const std::uint32_t tile_store_mode = (pack_low16 && block_ct_dim == 1)
+                                              ? 9u /* SFPSTORE_MOD0_FMT_LO16 */
+                                              : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+
     for (std::uint32_t i = 0; i < block_rt_dim; i++) {
         std::uint32_t tile_row_offset = ROWS_PER_TILE * block_ct_dim * i;
 
         // Step 1: Reduce each tile individually (horizontal reduction within each tile)
         for (std::uint32_t j = 0; j < block_ct_dim; j++) {
             std::uint32_t tile_offset = tile_row_offset + (ROWS_PER_TILE * j);
-            perform_reduce_row_sum_tile<INSTRUCTION_MODE>(tile_offset);
+            perform_reduce_row_sum_tile<INSTRUCTION_MODE, clear_high_bits>(tile_offset, tile_store_mode);
         }
 
         // Step 2: Sum column 0 from all tiles in this row into tile 0's column 0 of this row
         if (block_ct_dim > 1) {
-            sum_first_columns_across_tiles<INSTRUCTION_MODE>(tile_row_offset, block_ct_dim);
+            sum_first_columns_across_tiles<INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+                tile_row_offset, block_ct_dim);
         }
     }
 }
@@ -627,31 +727,38 @@ inline void perform_reduce_row_sum(std::uint32_t block_ct_dim, std::uint32_t blo
  * then (if block_ct_dim > 1) accumulates the per-tile column-0 maxima across tiles using
  * compare-and-swap into tile 0's column 0.
  *
- * @tparam INSTRUCTION_MODE: Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
- * @param block_ct_dim: Number of tiles along x axis of tensor (column tiles)
- * @param block_rt_dim: Number of tiles along y axis of tensor (row tiles)
+ * @tparam INSTRUCTION_MODE Load/store instruction mode (FP32, FP16B, or INT32 for sign-magnitude int max)
+ * @param block_ct_dim Number of tiles along x axis of tensor (column tiles)
+ * @param block_rt_dim Number of tiles along y axis of tensor (row tiles)
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, bool clear_high_bits, bool pack_low16>
 inline void perform_reduce_row_max(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
     record_horizontal_reduce_max();
+
+    // Single column tile => per-tile store is the final packer-visible result, which uses mode 9 only
+    // when the OUTPUT is UInt16 in a 32-bit dest (pack_low16); otherwise it is intermediate and stays
+    // in the low 16 bits via INSTRUCTION_MODE.
+    const std::uint32_t tile_store_mode = (pack_low16 && block_ct_dim == 1)
+                                              ? 9u /* SFPSTORE_MOD0_FMT_LO16 */
+                                              : static_cast<std::uint32_t>(INSTRUCTION_MODE);
 
     for (std::uint32_t i = 0; i < block_rt_dim; i++) {
         std::uint32_t tile_row_offset = ROWS_PER_TILE * block_ct_dim * i;
 
         for (std::uint32_t j = 0; j < block_ct_dim; j++) {
             std::uint32_t tile_offset = tile_row_offset + (ROWS_PER_TILE * j);
-            perform_reduce_row_max_tile<INSTRUCTION_MODE>(tile_offset);
+            perform_reduce_row_max_tile<INSTRUCTION_MODE, clear_high_bits>(tile_offset, tile_store_mode);
         }
 
         if (block_ct_dim > 1) {
-            max_first_columns_across_tiles<INSTRUCTION_MODE>(tile_row_offset, block_ct_dim);
+            max_first_columns_across_tiles<INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+                tile_row_offset, block_ct_dim);
         }
     }
 }
 
 /**
  * @brief Runtime validation helper for supported data formats for reduce sfpu kernel
- *
  */
 constexpr bool is_supported_reduce_format(DataFormat format) {
     return format == DataFormat::Int32 || format == DataFormat::UInt32 || format == DataFormat::Float32 ||
@@ -660,8 +767,7 @@ constexpr bool is_supported_reduce_format(DataFormat format) {
 
 /**
  * @brief Configure address mode for SFPU reduce Max/Min kernel.
- *
- * @param num_cols: The number of columns in the tensor block of multiple tiles
+ * @param num_cols The number of columns in the tensor block of multiple tiles
  * @note One tile is 64 rows in dest
  */
 inline void configure_addrmod_max_min(std::uint32_t num_cols) {
@@ -688,19 +794,44 @@ inline void configure_addrmod_max_min(std::uint32_t num_cols) {
 // ============================================================================
 
 /**
- * @brief Initialization for SFPU reduce MAX/MIN kernel.
+ * @brief Initialization for the manual (non-LOADMACRO) SFPU reduce MAX/MIN compare-and-swap path.
+ *        Records a 3-instruction replay buffer that reduces LREG4-7 down to LREG4 via vertical
+ *        compare-and-swaps, and sets the swap-direction config. Used by the Int32 path and by the
+ *        UInt16-in-32-bit-dest path (calculate_reduce_max_min_uint16), where the load and the swap
+ *        cannot be fused into a LOADMACRO (the garbage high bits must be masked in between).
  *
- * Sets up LOADMACRO sequences for compare-and-swap operations, configures address modifiers,
- * and records replay buffers for efficient column-wise maximum/minimum reduction.
- * For MIN operations, inverts the swap direction by configuring the SFPU control register.
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
- * (FP32, FP16B)
- * @tparam pool_type: The PoolType enum value (MAX or MIN). MIN inverts the swap direction for minimum reduction.
- * @param num_cols: The number of columns to process (typically 32 for a single tile, or multiple of 32 for block
- * operations)
+ * @tparam INSTRUCTION_MODE The instruction mode (INT32 for UInt16 in 32-bit dest)
+ * @tparam pool_type The PoolType enum value (MAX or MIN). MAX inverts the swap direction here.
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type>
+inline void init_reduce_max_min_int32() {
+    // Initialize SFPU config and set swap direction
+    _init_sfpu_config_reg();
+    if constexpr (pool_type == PoolType::MAX) {
+        TTI_SFPLOADI(ckernel::p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0100);  // Load lower 16 bits (bit 8)
+        TTI_SFPLOADI(ckernel::p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x0000);  // Load upper 16 bits
+        TTI_SFPCONFIG(0, 0xF, 0);
+    }
+
+    lltt::record(0, 3);
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, 1);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG5, 1);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG4, 1);
+}
+
+/**
+ * @brief Initialization for SFPU reduce MAX/MIN kernel.
+ *        Sets up LOADMACRO sequences for compare-and-swap operations, configures address modifiers,
+ *        and records replay buffers for efficient column-wise maximum/minimum reduction.
+ *        For MIN operations, inverts the swap direction by configuring the SFPU control register.
+ *
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * (FP32, FP16B)
+ * @tparam pool_type The PoolType enum value (MAX or MIN). MIN inverts the swap direction for minimum reduction.
+ * @param num_cols The number of columns to process (typically 32 for a single tile, or multiple of 32 for block
+ * operations)
+ */
+template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
     _init_sfpu_config_reg();
@@ -727,12 +858,20 @@ inline void init_reduce_max_min(std::uint32_t num_cols) {
     configure_addrmod_max_min(num_cols);
 
     // Record replay buffer for compare-and-swap operations
-    // MAX uses LOADMACRO mechanism
-    lltt::record<lltt::NoExec>(0, 9);
+    // MAX uses LOADMACRO mechanism.
+    // When clearing high bits (UInt16 in 32-bit dest), two extra SFPAND ops mask the garbage high bits
+    // of the manually loaded face-1 columns (LREG0/LREG1) before the compare-and-swap, so the buffer
+    // grows from 9 to 11 instructions.
+    constexpr std::uint32_t buffer_len = clear_high_bits ? 11 : 9;
+    lltt::record<lltt::NoExec>(0, buffer_len);
     TTI_INCRWC(0, 4, 0, 0);
     TTI_SFPLOADMACRO(5, INSTRUCTION_MODE, ADDR_MOD_3, 2);
     TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 16);
     TTI_SFPLOAD(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 18);
+    if constexpr (clear_high_bits) {
+        TTI_SFPAND(0, CLEAR_REG, p_sfpu::LREG1, 0);
+        TTI_SFPAND(0, CLEAR_REG, p_sfpu::LREG0, 0);
+    }
     TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG1, 1);
     TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG0, 1);
     TTI_SFPLOADMACRO(0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
@@ -744,16 +883,16 @@ inline void init_reduce_max_min(std::uint32_t num_cols) {
 
 /**
  * @brief Initialization for SFPU reduce SUM and AVG kernels.
+ *        Records replay buffers for column-wise summation using tree reduction.
+ *        Integer: 6 sequential instructions (positions 0-5), first 3 reusable as half-reduce.
+ *        Float: 6 interleaved instructions (positions 0-5) + 5 half-reduce with NOPs (positions 6-10).
+ *        Interleaving eliminates NOPs in the full reduce by using B operations to hide A's 2-cycle latency.
  *
- * Records replay buffers for column-wise summation using tree reduction.
- * Integer: 6 sequential instructions (positions 0-5), first 3 reusable as half-reduce.
- * Float: 6 interleaved instructions (positions 0-5) + 5 half-reduce with NOPs (positions 6-10).
- * Interleaving eliminates NOPs in the full reduce by using B operations to hide A's 2-cycle latency.
- *
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
+ * @tparam pool_type The PoolType enum value (SUM or AVG). AVG with a float format preloads the 1/32 constant.
  */
-template <InstrModLoadStore INSTRUCTION_MODE>
+template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type>
 inline void init_reduce_sum_avg() {
     _init_sfpu_config_reg();
 
@@ -761,6 +900,15 @@ inline void init_reduce_sum_avg() {
     constexpr bool is_integer_mode =
         (INSTRUCTION_MODE == InstrModLoadStore::INT32 || INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP ||
          INSTRUCTION_MODE == InstrModLoadStore::LO16);
+
+    // Float AVG divides by 32 by multiplying by 1/32. Preload that constant once here (only when it is
+    // actually needed: float AVG) into the programmable float const register AVG_RECIP_REG so
+    // perform_float_average() collapses to a single SFPMUL instead of rebuilding the constant with two
+    // SFPLOADI on every column group. Integer AVG uses perform_int_average (shift) and pays nothing; SUM
+    // never averages, so it pays nothing either.
+    if constexpr (pool_type == PoolType::AVG && !is_integer_mode) {
+        sfpi::vConstFloatPrgm0 = 0.03125f;
+    }
 
     if constexpr (is_integer_mode) {
         // Integer replay buffer: 6 sequential instructions (1-cycle SFPIADD latency, no NOPs needed)
@@ -805,30 +953,135 @@ inline void init_reduce_sum_avg() {
 // ============================================================================
 
 /**
- * @brief Column-wise maximum/minimum reduction kernel for SFPU reduce MAX/MIN operation.
+ * @brief Column-wise MAX/MIN reduction for UInt16 data in a 32-bit (fp32) dest, single 32x32 tile.
  *
- * Processes a block of tiles vertically (block_height tiles stacked) and computes the maximum or minimum value
- * for each of the columns across all rows in the block. The maximum/minimum values are placed into
- * the first row of the output tile (row 0 of faces 0 and 1) in tilized format for each tile in the top row of
+ * The UInt16 datum lives in the low 16 bits of a 32-bit dest word with arbitrary garbage in the high
+ * 16 bits, so every value must be masked (AND 0x0000FFFF) before it participates in a compare-and-swap.
+ * The LOADMACRO pipeline used by calculate_reduce_max_min() fuses the load and the swap into a single
+ * macro, leaving no place to clear the high bits in between; the garbage then dominates the integer
+ * comparison and produces wrong minima/maxima for any non-constant input.
+ *
+ * Instead we use the same manual load/mask/swap structure as the Int32 path. Masked UInt16 values are
+ * always non-negative, so a plain integer SFPSWAP orders them correctly (no sign-magnitude cast needed);
+ * we move LREG0-3 -> LREG4-7 to feed the recorded swap buffer. Final, packer-visible results are written
+ * with SFPSTORE mode 9 (SFPSTORE_MOD0_FMT_LO16) so the packer reads the low bits.
+ *
+ * Reuses init_reduce_max_min_int32()'s 3-swap replay buffer and swap-direction config. Only a single
+ * 32x32 tile is processed per call, matching the column-reduce driver which invokes the kernel per tile.
+ *
+ * @tparam INSTRUCTION_MODE The instruction mode (INT32 for UInt16 in 32-bit dest)
+ * @tparam pool_type The pool type (MAX or MIN) to determine swap direction
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam clear_high_bits Whether to mask the garbage high bits on load (true for UInt16 in 32-bit dest)
+ * @tparam pack_low16 Whether the final packer-visible store uses mode 9 (true for UInt16 OUTPUT in 32-bit dest)
+ */
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
+inline void calculate_reduce_max_min_uint16() {
+    static_assert(reduce_dim == ReduceDim::REDUCE_COL, "Only column reduction (REDUCE_COL) is currently supported");
+    static_assert(
+        pool_type == PoolType::MAX || pool_type == PoolType::MIN,
+        "Only MAX and MIN pool types are supported for this function");
+
+    constexpr std::uint32_t ODD_COLUMNS = 2;
+    constexpr std::uint32_t COLUMN_OFFSETS[4] = {0, 2, 0, 2};  // even, odd, even, odd
+    constexpr std::uint32_t FACE_ADDRS[2][4] = {
+        {0, 0, 32, 32},   // j=0: Face 0 and Face 2
+        {16, 16, 48, 48}  // j=1: Face 1 and Face 3
+    };
+    constexpr std::uint32_t FINAL_REDUCE_ADDRS[2][2] = {
+        {0, 32},  // j=0: Face 0 and Face 2
+        {16, 48}  // j=1: Face 1 and Face 3
+    };
+
+    // The intermediate stores below land in non-row-0 dest slots that we reload, so they use the
+    // plain (full 32-bit) instruction mode. Only the final row-0 stores are packer-visible and use
+    // mode 9 (SFPSTORE_MOD0_FMT_LO16) when the OUTPUT is UInt16 in a 32-bit dest (pack_low16), so the
+    // packer reads the low 16 bits of the dest word.
+    constexpr std::uint32_t STORE_MODE =
+        pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+
+    for (std::uint32_t j = 0; j < 2; j++) {
+        std::uint32_t top_face_addr = FINAL_REDUCE_ADDRS[j][0];     // face 0 & 1 dst indices
+        std::uint32_t bottom_face_addr = FINAL_REDUCE_ADDRS[j][1];  // face 2 & 3 dst indices
+
+        // Reduce each of the four vertically adjacent faces (f0,f2 then f1,f3) within itself; the
+        // max/min of its 16 rows is left in the top 4 rows.
+        for (std::uint32_t i = 0; i < NUM_FACES; i++) {
+            // Masked load straight into LREG4-7, where the recorded swap buffer reduces them. Loading
+            // directly into the target registers eliminates the four LREG0-3 -> LREG4-7 moves (and the
+            // post-reduce LREG4 -> LREG0 move) that the previous LREG0-3 load required.
+            load_face_data<INSTRUCTION_MODE, clear_high_bits, p_sfpu::LREG4>(FACE_ADDRS[j][i], COLUMN_OFFSETS[i]);
+
+            lltt::replay(0, 3);  // compare-and-swap reduce LREG4-7 -> LREG4
+
+            TT_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, FACE_ADDRS[j][i] + COLUMN_OFFSETS[i]);
+        }
+
+        // Load the partial max/min (top 4 rows) of the two vertically adjacent faces into LREG0-3.
+        load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, top_face_addr);
+        load_and_clear_high_bits<clear_high_bits>(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, bottom_face_addr);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG2, INSTRUCTION_MODE, ADDR_MOD_3, top_face_addr + ODD_COLUMNS);
+        load_and_clear_high_bits<clear_high_bits>(
+            p_sfpu::LREG3, INSTRUCTION_MODE, ADDR_MOD_3, bottom_face_addr + ODD_COLUMNS);
+
+        // Move into LREG4-7 for the transpose + cross-row reduction.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+        // Transpose so the 4 partial results of each column sit in one register, reduce, transpose back.
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        lltt::replay(0, 3);
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        // Swap to combine the two vertically adjacent faces (even and odd columns).
+        TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, 1);  // odd columns of face pair
+        TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG4, 1);  // even columns of face pair
+
+        TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG6, p_sfpu::LREG1, 0);
+
+        TT_SFPSTORE(p_sfpu::LREG0, STORE_MODE, ADDR_MOD_3, top_face_addr);
+        TT_SFPSTORE(p_sfpu::LREG1, STORE_MODE, ADDR_MOD_3, top_face_addr + ODD_COLUMNS);
+    }
+}
+
+/**
+ * @brief Column-wise maximum/minimum reduction kernel for SFPU reduce MAX/MIN operation.
+ *        Processes a block of tiles vertically (block_height tiles stacked) and computes the maximum or minimum value
+ *        for each of the columns across all rows in the block. The maximum/minimum values are placed into
+ *        the first row of the output tile (row 0 of faces 0 and 1) in tilized format for each tile in the top row of
  * tiles in the block.
  *
- * Algorithm:
- * - Initializes LREG4-7 with the first face pair's data (even/odd columns from faces 0 and 1)
- * - For each tile in the block, performs compare-and-swap operations using replay buffers to find maxima/minima
- * - Uses SFPSWAP instruction for comparisons to determine maximum/minimum between two lregs storing column data
- * - For MIN operations, swap direction is inverted (configured during init via SFPU control register)
- * - Transposes and sorts results to align maxima/minima correctly across LREG4-7
- * - Stores final maximum/minimum values to row 0 (32 datums across faces 0 and 1)
+ *        Algorithm:
+ *        - Initializes LREG4-7 with the first face pair's data (even/odd columns from faces 0 and 1)
+ *        - For each tile in the block, performs compare-and-swap operations using replay buffers to find maxima/minima
+ *        - Uses SFPSWAP instruction for comparisons to determine maximum/minimum between two lregs storing column data
+ *        - For MIN operations, swap direction is inverted (configured during init via SFPU control register)
+ *        - Transposes and sorts results to align maxima/minima correctly across LREG4-7
+ *        - Stores final maximum/minimum values to row 0 (32 datums across faces 0 and 1)
  *
- * @tparam pool_type: The PoolType enum value (MAX or MIN). MIN uses inverted swap direction for minimum reduction.
- * @tparam reduce_dim: The reduction dimension: REDUCE_COL for column-wise, REDUCE_ROW for row-wise (MAX only,
+ * @tparam pool_type The PoolType enum value (MAX or MIN). MIN uses inverted swap direction for minimum reduction.
+ * @tparam reduce_dim The reduction dimension: REDUCE_COL for column-wise, REDUCE_ROW for row-wise (MAX only,
  * FP32/Int32).
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32_2S_COMP, LO16, DEFAULT (FP32,
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32_2S_COMP, LO16, DEFAULT (FP32,
  * FP16B)
- * @param block_ct_dim: Number of tiles along x axis (column tiles, default 1).
- * @param block_rt_dim: Number of tiles along y axis (row tiles, default 1).
+ * @param block_ct_dim Number of tiles along x axis (column tiles, default 1).
+ * @param block_rt_dim Number of tiles along y axis (row tiles, default 1).
  */
-template <PoolType pool_type, ReduceDim reduce_dim, InstrModLoadStore INSTRUCTION_MODE>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
 inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const std::uint32_t block_rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL || (pool_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW),
@@ -838,10 +1091,12 @@ inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const
         static_assert(
             pool_type == PoolType::MAX || pool_type == PoolType::SUM,
             "Row reduction (REDUCE_ROW) currently only supports MAX and SUM pool types");
-        perform_reduce_row_max<INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
+        perform_reduce_row_max<INSTRUCTION_MODE, clear_high_bits, pack_low16>(block_ct_dim, block_rt_dim);
     } else {
-        constexpr std::uint32_t replay_buffer_offset = 7;
-        constexpr std::uint32_t replay_buffer_next_face = 8;
+        // The recorded replay buffer in init_reduce_max_min has two extra SFPAND ops when clearing
+        // high bits, so the per-face-pair replay window grows accordingly.
+        constexpr std::uint32_t replay_buffer_offset = clear_high_bits ? 9 : 7;
+        constexpr std::uint32_t replay_buffer_next_face = clear_high_bits ? 10 : 8;
 
         // Initial loads: LREG4-7 will hold maximum values across F0 and F1
         TTI_SFPLOAD(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, 0);
@@ -882,33 +1137,42 @@ inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const
         TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, 1);
         TTI_SFPTRANSP(0, 0, 0, 0);
 
-        // Store results to first row
-        TTI_SFPSTORE(p_sfpu::LREG4, INSTRUCTION_MODE, ADDR_MOD_3, 0);
-        TTI_SFPSTORE(p_sfpu::LREG5, INSTRUCTION_MODE, ADDR_MOD_3, 2);
-        TTI_SFPSTORE(p_sfpu::LREG6, INSTRUCTION_MODE, ADDR_MOD_3, 16);
-        TTI_SFPSTORE(p_sfpu::LREG7, INSTRUCTION_MODE, ADDR_MOD_3, 18);
+        // Store results to first row.
+        // For UInt16 OUTPUT in a 32-bit dest the reduced value lives in the low 16 bits of the LREG, but
+        // the packer reads the high 16 bits of the dest word. SFPSTORE mode 9 (SFPSTORE_MOD0_FMT_LO16)
+        // writes the low 16 bits into the half the packer consumes; a 32-bit output keeps the plain store.
+        constexpr std::uint32_t STORE_MODE =
+            pack_low16 ? 9u /* SFPSTORE_MOD0_FMT_LO16 */ : static_cast<std::uint32_t>(INSTRUCTION_MODE);
+        TTI_SFPSTORE(p_sfpu::LREG4, STORE_MODE, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG5, STORE_MODE, ADDR_MOD_3, 2);
+        TTI_SFPSTORE(p_sfpu::LREG6, STORE_MODE, ADDR_MOD_3, 16);
+        TTI_SFPSTORE(p_sfpu::LREG7, STORE_MODE, ADDR_MOD_3, 18);
     }
 }
 
 /**
  * @brief Column-wise sum/average reduction kernel for SFPU reduce SUM and AVG operations.
+ *        Computes the sum or average of each column, placing the 32 output values into the first row
+ *        of the output tile (row 0 of faces 0 and 1).
  *
- * Computes the sum or average of each column, placing the 32 output values into the first row
- * of the output tile (row 0 of faces 0 and 1).
+ *        Uses a 4-iteration approach that processes vertically aligned face pairs (0+2, 1+3) to optimize
+ *        column operations and minimize load/store operations. Each iteration handles 8 columns using
+ *        transpose operations and replay buffers for tree reduction.
  *
- * Uses a 4-iteration approach that processes vertically aligned face pairs (0+2, 1+3) to optimize
- * column operations and minimize load/store operations. Each iteration handles 8 columns using
- * transpose operations and replay buffers for tree reduction.
+ *        For AVG mode: Integer formats use arithmetic shift with condition codes to handle negative numbers;
+ *        float formats multiply by 1/32 constant.
  *
- * For AVG mode: Integer formats use arithmetic shift with condition codes to handle negative numbers;
- * float formats multiply by 1/32 constant.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG)
- * @tparam reduce_dim: The reduction dimension (currently only REDUCE_COL is supported)
- * @tparam INSTRUCTION_MODE: The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG)
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam INSTRUCTION_MODE The instruction mode for integer and float formats: INT32, INT32_2S_COMP, LO16, DEFAULT
  * (FP32, FP16B)
  */
-template <PoolType pool_type, ReduceDim reduce_dim, InstrModLoadStore INSTRUCTION_MODE>
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    InstrModLoadStore INSTRUCTION_MODE,
+    bool clear_high_bits,
+    bool pack_low16>
 inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t block_rt_dim) {
     // Compile-time assertions to restrict to currently supported operations
     static_assert(
@@ -928,10 +1192,10 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
         "INSTRUCTION_MODE must be one of: INT32, INT32_2S_COMP, LO16, DEFAULT, FP32, FP16B");
 
     if constexpr (reduce_dim == ReduceDim::REDUCE_COL) {
-        perform_reduce_col_sum_avg<pool_type, INSTRUCTION_MODE>();
+        perform_reduce_col_sum_avg<pool_type, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
     } else {
         static_assert(pool_type == PoolType::SUM, "Row reduction (REDUCE_ROW) is allowed only for SUM");
-        perform_reduce_row_sum<INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
+        perform_reduce_row_sum<INSTRUCTION_MODE, clear_high_bits, pack_low16>(block_ct_dim, block_rt_dim);
     }
     // For column reductions: sums are stored horizontally in the first row of tensor in dest reg
     // For row reductions: sums are stored vertically in the first column of tensor in dest reg
@@ -942,22 +1206,82 @@ inline void calculate_reduce_sum_avg(std::uint32_t block_ct_dim, std::uint32_t b
 // ============================================================================
 
 /**
+ * @brief Unified reduction init kernel wrapper for SFPU reduce kernel.
+ *        Determines the instruction mode from format, then dispatches to the appropriate init kernel.
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX)
+ * @tparam format The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
+ * @param block_ct_dim Block dimension (used for MAX reduction to specify number of columns, default is 1 for single
+ * tile)
+ */
+template <PoolType pool_type, DataFormat format, bool is_fp32_dest_accum_en>
+inline void init_reduce(std::uint32_t block_ct_dim = 1) {
+    static_assert(
+        is_supported_reduce_format(format),
+        "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
+
+    // Determine InstrModLoadStore from llk_defs. Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates
+    // on two's-complement values. Int32 MAX/MIN keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX)
+    // is a float/sign-magnitude comparator and orders sign-magnitude integers correctly, whereas
+    // two's-complement negatives would be mis-ordered.
+    constexpr InstrModLoadStore INSTRUCTION_MODE =
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG))
+            ? InstrModLoadStore::INT32_2S_COMP
+        : (format == DataFormat::Float16_b) ? InstrModLoadStore::DEFAULT
+                                            : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
+
+    // Garbage high bits need to be cleared when loading UInt16 data from a 32-bit (fp32) dest word.
+    constexpr bool clear_high_bits = (is_fp32_dest_accum_en && format == DataFormat::UInt16);
+
+    if constexpr (clear_high_bits) {
+        // CLEAR_REG (sfpi::vConstIntPrgm0 / LREG12) holds the mask used by SFPLOAD_EXT to clear high bits.
+        sfpi::vConstIntPrgm0 = 0x0000FFFF;
+    }
+
+    // Dispatch to appropriate PoolType init
+    if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
+        if constexpr (clear_high_bits) {
+            // UInt16 in 32-bit dest uses the manual (non-LOADMACRO) compare-and-swap path so the
+            // garbage high bits can be masked before each swap. It reuses the Int32 path's 3-swap
+            // replay buffer and swap-direction config (the body is format-agnostic).
+            init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+        } else {
+            init_reduce_max_min<INSTRUCTION_MODE, pool_type, false>(block_ct_dim);
+        }
+    } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
+        init_reduce_sum_avg<INSTRUCTION_MODE, pool_type>();
+    } else {
+        static_assert(
+            pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX,
+            "Unsupported pool_type. Currently supported: SUM, AVG, MAX");
+    }
+}
+
+/**
  * @brief Unified reduction kernel wrapper for a 32x32 tile.
- *
- * Determines the instruction mode from format, then dispatches to the appropriate reduction kernel.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
- * @tparam reduce_dim: The reduction dimension (currently only REDUCE_COL is supported)
- * @tparam format: The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
- * @param block_ct_dim: Block dimension (used for SUM/AVG column reduction to specify number of columns, default is 1 for
+ *        Determines the instruction mode from format, then dispatches to the appropriate reduction kernel.
+ * @tparam pool_type The reduction operation, currently supported: (SUM, AVG, MAX, MIN)
+ * @tparam reduce_dim The reduction dimension (currently only REDUCE_COL is supported)
+ * @tparam format The INPUT data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b). Drives the
+ *         instruction mode and load-time high-bit masking.
+ * @tparam output_format The packer-visible OUTPUT data format (defaults to @p format). Drives the final store mode:
+ *         UInt16 output in a 32-bit dest is stored via mode 9 (low->high 16-bit swap), while a 32-bit output (e.g.
+ *         UInt32) is stored with the plain instruction mode. This lets UInt16 input be summed into a UInt32 output
+ *         without overflow.
+ * @param block_ct_dim Block dimension (used for SUM/AVG column reduction to specify number of columns, default is 1 for
  * single tile)
- * @param block_rt_dim: Block dimension (used for MAX/MIN reduction to specify block height, or SUM row reduction;
+ * @param block_rt_dim Block dimension (used for MAX/MIN reduction to specify block height, or SUM row reduction;
  * default is 1 for single tile)
+ *
  * @note Constraints (unable to static assert for block_rt_dim runtime parameter)
  *       - MAX/MIN with Int32 format only supports block_rt_dim == 1 (single tile)
  */
-template <PoolType pool_type, ReduceDim reduce_dim, DataFormat format>
-inline void calculate_reduce(uint32_t block_ct_dim = 1, uint32_t block_rt_dim = 1) {
+template <
+    PoolType pool_type,
+    ReduceDim reduce_dim,
+    DataFormat format,
+    bool is_fp32_dest_accum_en,
+    DataFormat output_format = format>
+inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL || (pool_type == PoolType::SUM && reduce_dim == ReduceDim::REDUCE_ROW) ||
             (pool_type == PoolType::MAX && reduce_dim == ReduceDim::REDUCE_ROW),
@@ -967,62 +1291,43 @@ inline void calculate_reduce(uint32_t block_ct_dim = 1, uint32_t block_rt_dim = 
         "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
 
     // Determine InstrModLoadStore from llk_defs.
-    // Column MAX/MIN with Int32 uses INT32_2S_COMP for the LOADMACRO-based compare-and-swap pipeline.
-    // Row MAX with Int32 uses plain INT32 (sign-magnitude) for direct SFPLOAD/SFPSTORE: dest stores
-    // integers in sign-magnitude format, and SFPSWAP(mod1=VEC_MIN_MAX) compares sign-magnitude
-    // values correctly without two's-complement conversion.
-    constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN) &&
-         reduce_dim == ReduceDim::REDUCE_COL)
-            ? InstrModLoadStore::INT32_2S_COMP
-        : (format == DataFormat::Float16_b) ? InstrModLoadStore::DEFAULT
-                                            : GetSfpLoadStoreInstrMod<format>();
+    // Int32 SUM/AVG use INT32_2S_COMP so SFPIADD operates on two's-complement values. Int32 MAX/MIN
+    // (both dims) keep plain INT32 (sign-magnitude): SFPSWAP(VEC_MIN_MAX) is a float/sign-magnitude
+    // comparator that orders sign-magnitude integers correctly; two's-complement negatives are
+    // mis-ordered (max of negatives would return the most-negative value).
+    constexpr bool int32_sum_avg =
+        (format == DataFormat::Int32 && (pool_type == PoolType::SUM || pool_type == PoolType::AVG));
+    constexpr InstrModLoadStore INSTRUCTION_MODE = int32_sum_avg ? InstrModLoadStore::INT32_2S_COMP
+                                                   : (format == DataFormat::Float16_b)
+                                                       ? InstrModLoadStore::DEFAULT
+                                                       : GetSfpLoadStoreInstrMod<format, is_fp32_dest_accum_en>();
+
+    // Garbage high bits need to be cleared when loading UInt16 data from a 32-bit (fp32) dest word
+    // (driven by INPUT format).
+    constexpr bool clear_high_bits = (is_fp32_dest_accum_en && format == DataFormat::UInt16);
+
+    // The packer-visible result must go through mode-9 (low->high 16-bit) store only when the OUTPUT is UInt16
+    // in a 32-bit dest. A 32-bit output (e.g. UInt32) keeps the full word, so it uses the plain store. This is
+    // driven by the OUTPUT format and is independent of the load-time masking above.
+    constexpr bool pack_low16 = (is_fp32_dest_accum_en && output_format == DataFormat::UInt16);
 
     // Dispatch to appropriate reduction kernel based on PoolType
     if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
-        calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
+        if constexpr (clear_high_bits) {
+            // UInt16 in 32-bit dest: manual load/mask/swap path (LOADMACRO cannot mask between load and swap).
+            calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
+        } else {
+            calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>(
+                block_ct_dim, block_rt_dim);
+        }
     } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
-        calculate_reduce_sum_avg<pool_type, reduce_dim, INSTRUCTION_MODE>(block_ct_dim, block_rt_dim);
+        calculate_reduce_sum_avg<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>(
+            block_ct_dim, block_rt_dim);
     } else {
         static_assert(
             pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX ||
                 pool_type == PoolType::MIN,
             "Unsupported pool_type. Currently supported: SUM, AVG, MAX, MIN");
-    }
-}
-
-/**
- * @brief Unified reduction init kernel wrapper for SFPU reduce kernel.
- *
- * Determines the instruction mode from format, then dispatches to the appropriate init kernel.
- *
- * @tparam pool_type: The reduction operation, currently supported: (SUM, AVG, MAX)
- * @tparam format: The data format, currently supported: (Int32, UInt32, UInt16, Float32, Float16_b)
- * @param block_ct_dim: Block dimension (used for MAX reduction to specify number of columns, default is 1 for single
- * tile)
- */
-template <PoolType pool_type, DataFormat format>
-inline void init_reduce(std::uint32_t block_ct_dim = 1) {
-    static_assert(
-        is_supported_reduce_format(format),
-        "Unsupported data format. Supported formats: Int32, UInt32, UInt16, Float32, Float16_b");
-
-    // Determine InstrModLoadStore from llk_defs; Int32 MAX/MIN use INT32_2S_COMP for SFPSWAP
-    constexpr InstrModLoadStore INSTRUCTION_MODE =
-        (format == DataFormat::Int32 && (pool_type == PoolType::MAX || pool_type == PoolType::MIN))
-            ? InstrModLoadStore::INT32_2S_COMP
-        : (format == DataFormat::Float16_b) ? InstrModLoadStore::DEFAULT
-                                            : GetSfpLoadStoreInstrMod<format>();
-
-    // Dispatch to appropriate PoolType init
-    if constexpr (pool_type == PoolType::MAX || pool_type == PoolType::MIN) {
-        init_reduce_max_min<INSTRUCTION_MODE, pool_type>(block_ct_dim);
-    } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
-        init_reduce_sum_avg<INSTRUCTION_MODE>();
-    } else {
-        static_assert(
-            pool_type == PoolType::SUM || pool_type == PoolType::AVG || pool_type == PoolType::MAX,
-            "Unsupported pool_type. Currently supported: SUM, AVG, MAX");
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -53,35 +53,14 @@ inline void calculate_typecast_fp32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple        | MAD | Round            | Store   |
-    // - | ---- | ------------- | --- | ---------------- | ------- |
-    // 0 | [v]  |               |     |                  |         |
-    // 0 | ...  | [v] = cast(v) |     |                  |         |
-    // 0 | ...  |               |     | [v] L16 = rnd(v) |         |
-    // 0 | ...  |               |     |                  | [v] L16 |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -735,32 +714,7 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (1 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (2 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: DEFAULT,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
-#endif
+    sfpi::vConstIntPrgm0 = 0x0000FFFF;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -53,14 +53,35 @@ inline void calculate_typecast_fp32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp16b() {
+#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
-        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
     }
+#else
+    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
+    //
+    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
+    //
+    // t | Load | Simple        | MAD | Round            | Store   |
+    // - | ---- | ------------- | --- | ---------------- | ------- |
+    // 0 | [v]  |               |     |                  |         |
+    // 0 | ...  | [v] = cast(v) |     |                  |         |
+    // 0 | ...  |               |     | [v] L16 = rnd(v) |         |
+    // 0 | ...  |               |     |                  | [v] L16 |
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
+        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
+    }
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -714,7 +735,32 @@ inline void init_typecast_uint16_to_fp32() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp16b() {
-    sfpi::vConstIntPrgm0 = 0x0000FFFF;
+#ifndef DISABLE_SFPLOADMACRO
+    // InstructionTemplate[0]
+    TTI_SFPCAST(0, 12, 0);
+
+    // InstructionTemplate[1]
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+
+    // Macro 0
+    {
+        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (0 << 3) | (4 + 0);
+        constexpr std::uint32_t mad_bits = 0;
+        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (1 << 3) | (4 + 1);
+        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (2 << 3) | 3;
+
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
+        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
+        TTI_SFPCONFIG(0, 4 + 0, 0);
+    }
+
+    // Misc: {
+    //   StoreMod0: DEFAULT,
+    //   UsesLoadMod0ForStore: {0},
+    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
+    // }
+    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
+#endif
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -634,7 +634,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
-    sfpi::vConstIntPrgm1 = 0x0000FFFF;
+    sfpi::vConstIntPrgm1 = UINT16_LOW_MASK;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -16,39 +16,22 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
+// Mask that keeps the low 16 bits (the UInt16 value) of a 32-bit dest word and clears the garbage high bits.
+constexpr std::uint16_t UINT16_LOW_MASK = 0xFFFF;
+
+// SFPSTORE mode that swaps the high and low 16 bits before writing, so a value computed in the low 16 bits
+// lands in the high 16 bits where the packer reads UInt16 out of a 32-bit dest word.
+constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round            | Store   |
-    // - | ---- | ----------------- | --- | ---------------- | ------- |
-    // 0 | [v]  |                   |     |                  |         |
-    // 1 | nop  | [v] = max(v, 0.0) |     |                  |         |
-    // 0 | ...  | (must be idle)    |     | (must be idle)   |         |
-    // 1 | ...  |                   |     | [v] L16 = rnd(v) |         |
-    // 0 | ...  |                   |     |                  | [v] L16 |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::DEFAULT, ADDR_MOD_2, v >> 2);
-        TTI_SFPNOP;
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -516,7 +499,7 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
-    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -655,7 +638,7 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
-    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, UINT16_LOW_MASK);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -727,34 +710,7 @@ inline void init_typecast_uint32_to_fp16b() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_fp32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (2 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_fp32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint32_to_uint16() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -25,6 +25,7 @@ constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint16() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -192,6 +193,7 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -275,6 +277,7 @@ inline void calculate_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_fp16b() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -355,6 +358,7 @@ inline void calculate_typecast_uint16_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_uint16() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -370,6 +374,7 @@ inline void calculate_typecast_uint32_to_uint16() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -209,7 +209,6 @@ inline void calculate_typecast_fp32_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
@@ -218,40 +217,9 @@ inline void calculate_typecast_fp32_to_fp16b() {
         TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);                            // lreg[0] &= 1
         TTI_SFPIADD(0, p_sfpu::LREG13, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);  // lreg[1] += 0x7FFF
         TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_CC_NONE);   // lreg[1] += lreg[0]
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);
+        TTI_SFPAND(0, p_sfpu::LREG14, p_sfpu::LREG1, 0);                            // lreg[1] &= 0xFFFF0000
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple          | MAD | Round      | Store   |
-    // - | ---- | --------------- | --- | ---------- | ------- |
-    // 0 |  [a] |                 |     |            |         |
-    // 1 |  [b] |                 |     | [a] >>= 16 |         |
-    // 2 |      | a &= 1          |     |            |         |
-    // 0 |  ... | [b] += 0x7fff   |     |            |         |
-    // 1 |  ... | [a] L16 = a + b |     |            | [a]     |
-    // 2 |  ... |                 |     |            | [b] L16 |
-    //
-    // Note that [a] schedules a 32-bit store, writing all zeros except for the
-    // LSB, which may be 0 or 1.  Then, [b] schedules a 16-bit store with
-    // MOD0_FMT_BF16.  The zeros mean that even if rounding is applied by
-    // packers, the result will be truncated.
-
-    constexpr int b = p_sfpu::LREG2;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), 0, ADDR_MOD_3, a >> 2);
-        TTI_SFPLOADMACRO((1 << 2) | (b & 3), 0, ADDR_MOD_2, b >> 2);
-        TT_SFPAND(0, p_sfpu::LREG12, a, 0);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -543,50 +511,7 @@ template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_fp16b() {
     sfpi::vConstIntPrgm0 = 1;
     sfpi::vConstIntPrgm1 = 0x7fff;
-
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int b = p_sfpu::LREG2;
-
-    // InstructionTemplate[0]
-    TTI_SFPSHFT2(-16 & 0xfff, 0, 12, 6);  // SFPSHFT2_MOD1_SHFT_IMM
-
-    // InstructionTemplate[1]
-    TTI_SFPIADD(0, p_sfpu::LREG13, 13, sfpi::SFPIADD_MOD1_CC_NONE);
-
-    // InstructionTemplate[2]
-    TTI_SFPIADD(0, b, 14, sfpi::SFPIADD_MOD1_CC_NONE);
-
-    // Macro 0: [a]
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x40 | (3 << 3) | (4 + 2);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Macro 1: [b]
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 1);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (3 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 1, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP16B,
-    //   UsesLoadMod0ForStore: {1,0},
-    //   UnitDelayKind: {1,1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x310 | InstrModLoadStore::FP16B, 8, 1);
-#endif
+    sfpi::vConstIntPrgm2 = 0xffff0000;
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -394,100 +394,28 @@ inline void calculate_typecast_uint16_to_uint32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
         TTI_SFPIADD(
             0, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
-        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 2 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple          | MAD | Round      | Store   |
-    // - | ---- | --------------- | --- | ---------- | ------- |
-    // 0 | [a]  |                 |     |            |         | Load high 16 bits, i.e. a = value >> 16
-    // 1 | ...  | [a] = 0 - a     |     |            |         |
-    // 0 | ...  |                 |     | [a] >>= 16 |         |
-    // 1 | [b]  |                 |     |            |         |
-    // 0 | ...  | [b] L16 = b | a |     |            |         |
-    // 1 | ...  |                 |     |            | [b] L16 |
-
-    constexpr int b = p_sfpu::LREG2;
-
-#pragma GCC unroll 9
-    for (int d = 0; d < ITERATIONS + 1; d++) {
-        int a = d & 1;                 // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        int macroIndex = 1 + (d & 1);  // alternate between macros 1 and 2
-        if (d < ITERATIONS) {
-            TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::LO16, ADDR_MOD_2, a >> 2);
-        } else {
-            TTI_SFPNOP;
-        }
-        if (d == 0) {
-            TTI_SFPNOP;
-        } else if (d < ITERATIONS) {
-            TTI_SFPLOADMACRO(
-                (macroIndex << 2) | (b & 3), InstrModLoadStore::INT32, ADDR_MOD_3, (-4 & 0x3ff) | (b >> 2));
-        } else {
-            TTI_SFPLOADMACRO(
-                (macroIndex << 2) | (b & 3), InstrModLoadStore::INT32, ADDR_MOD_2, (-2 & 0x3ff) | (b >> 2));
-        }
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_int32_to_uint16() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round            | Store   |
-    // - | ---- | ----------------- | --- | ---------------- | ------- |
-    // 0 | [a]  |                   |     |                  |         |
-    // 1 |      | a = cast_fp32(a)  |     |                  |         |
-    // 2 | nop  | [a] = max(0.0, a) |     |                  |         |
-    // 0 | ...  | (must be idle)    |     |                  |         |
-    // 1 | ...  |                   |     | [a] L16 = rnd(a) |         |
-    // 2 | ...  |                   |     |                  | [a] L16 |
-    //
-    // Simple/Round sub-units can be used simultaneously if one has VD=16 and
-    // the other VD!=16.  The following steps clamp the input value to 0-65535:
-    //
-    // a = cast_fp32(a); this allows us to use SFPSTOCHRND later to convert to uint16, clamping to 65535.
-    // swap_minmax(0.0, a); since SFPSTOCHRND takes the absolute value before clamping, we use SFPSWAP to clamp negative
-    // values to 0.0. L16 = rnd(a); finally, we use SFPSTOCHRND to clamp large values to 65535, using VD=16.
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int a = d & 1;  // alternate between p_sfpu::LREG0 and p_sfpu::LREG1
-        TT_SFPLOADMACRO((0 << 2) | (a & 3), InstrModLoadStore::INT32, ADDR_MOD_2, a >> 2);
-        TT_SFPCAST(a, a, 0);
-        TTI_SFPNOP;
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE>
@@ -713,97 +641,10 @@ template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int a0 = p_sfpu::LREG0;
-    constexpr int a1 = p_sfpu::LREG1;
-
-    // InstructionTemplate[0]
-    TTI_SFPIADD(0, p_sfpu::LCONST_0, 12, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
-
-    // InstructionTemplate[1]
-    TTI_SFPSHFT2(-16 & 0xfff, 0, 13, 6);  // SFPSHFT2_MOD1_SHFT_IMM
-
-    // InstructionTemplate[2]
-    TTI_SFPOR(0, a1, 14, 0);
-
-    // InstructionTemplate[3]
-    TTI_SFPOR(0, a0, 15, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x80 | 0x00 | (1 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Macro 1
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x40 | (0 << 3) | (4 + 2);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 1, 0);
-    }
-
-    // Macro 2
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x40 | (0 << 3) | (4 + 3);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 2, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0,0,0},
-    //   UnitDelayKind: {1,1,1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x700 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_uint32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_int32_to_uint16() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
-
-    // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x80 | 0x00 | (1 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (3 << 3) | (4 + 1);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (4 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: LO16,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::LO16, 8, 1);
-#endif
-}
+inline void init_typecast_int32_to_uint16() {}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_fp32_to_uint8() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -275,7 +275,6 @@ inline void calculate_typecast_int32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint32_to_fp16b() {
-#ifdef DISABLE_SFPLOADMACRO
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
@@ -285,46 +284,8 @@ inline void calculate_typecast_uint32_to_fp16b() {
         TTI_SFPADDI(0x4f00, p_sfpu::LREG1, 0);  // 2^31
         TTI_SFPENCC(0, 0, 0, 0);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 3 cycles per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // Note: L0=0.0 and L1=2**31.  The sign bit is stored in L7 and used to pick L0 or L1
-    // for SFPMAD's VA:
-    //
-    // - if sign bit is 0, then compute L0*1.0 + v = v
-    // - if sign bit is 1, then compute L1*1.0 + v = 2**31 + v
-    //
-    // t | Load | Simple             | MAD                     | Round            | Store   |
-    // - | ---- | ------------------ | ----------------------- | ---------------- | ------- |
-    // 0 | [v]  |                    |                         |                  |         |
-    // 1 |      |                    |                         | L7 = v >> 31     |         |
-    // 2 |      | v = setsgn(v, 0)   |                         |                  |         |
-    // 0 | ...  | [v] = cast(v)      |                         |                  |         |
-    // 1 | ...  |                    | [v] v = L[L7]*1.0 + v   |                  |         |
-    // 2 | ...  |                    |                         |                  |         |
-    // 0 | ...  |                    |                         | [v] L16 = rnd(v) |         |
-    // 1 | ...  |                    |                         |                  | [v] L16 |
-
-    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_USHORT, 0);
-    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, 0x4f00);  // 2**31
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        int v = 2 + (d & 1);  // alternate between p_sfpu::LREG2 and p_sfpu::LREG3
-        TT_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::INT32, ADDR_MOD_2, v >> 2);
-        TT_SFPSHFT2(v, p_sfpu::LREG12, p_sfpu::LREG7, 5);  // SFPSHFT2_MOD1_SHFT_LREG
-        TT_SFPSETSGN(0, v, v, 1);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -601,42 +562,7 @@ inline void init_typecast_uint16_to_fp16b() {
 }
 
 template <bool APPROXIMATION_MODE>
-inline void init_typecast_uint32_to_fp16b() {
-#ifndef DISABLE_SFPLOADMACRO
-    // SFPCAST interprets its input as sign-magnitude, so bit 31 of the source
-    // flags the case that needs a post-cast fixup. vConstIntPrgm0 (LREG12) is
-    // preloaded with -31 -- the shift amount used to extract that bit.
-    sfpi::vConstIntPrgm0 = -31;
-
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // InstructionTemplate[1]
-    TTI_SFPMAD(0, p_sfpu::LCONST_1, 0, 13, 4);  // SFPMAD_MOD1_INDIRECT_VA
-
-    // InstructionTemplate[2]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x00 | (2 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0x00 | 0x00 | (3 << 3) | (4 + 1);
-        constexpr std::uint32_t round_bits = 0x00 | 0x40 | (5 << 3) | (4 + 2);
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (6 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: DEFAULT,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::DEFAULT, 8, 1);
-#endif
-}
+inline void init_typecast_uint32_to_fp16b() {}
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_fp32_to_uint16() {}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -256,33 +256,14 @@ inline void calculate_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_fp32() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple            | MAD | Round | Store   |
-    // - | ---- | ----------------- | --- | ----- | ------- |
-    // 0 | [v]  |                   |     |       |         |
-    // 0 | ...  | [v] L16 = cast(v) |     |       |         |
-    // 0 | ...  |                   |     |       | [v] L16 |
-
-    constexpr int v = p_sfpu::LREG0;
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOADMACRO((0 << 2) | (v & 3), InstrModLoadStore::LO16, ADDR_MOD_2, v >> 2);
-    }
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -451,28 +432,13 @@ inline void calculate_typecast_uint32_to_fp32() {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_typecast_uint16_to_uint32() {
-#ifdef DISABLE_SFPLOADMACRO
+    // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+        TTI_SFPAND(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_2, 0);
     }
-#else
-    // This uses SFPLOADMACRO to achieve a throughput of 1 cycle per input row.
-    //
-    // Notation: [x] means scheduled by SFPLOADMACRO with VD=x.
-    //
-    // t | Load | Simple | MAD | Round | Store |
-    // - | ---- | ------ | --- | ----- | ----- |
-    // 0 | [v]  |        |     |       |       |
-    // 0 | ...  |        |     |       | [v]   |
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOADMACRO((0 << 2) | 0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
-    }
-    TTI_SFPNOP;
-#endif
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -625,25 +591,7 @@ inline void init_typecast_fp32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_uint32() {
-#ifndef DISABLE_SFPLOADMACRO
-    {
-        constexpr std::uint32_t simple_bits = 0;
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x00 | (0 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: INT32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::INT32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -782,29 +730,7 @@ inline void init_typecast_int32_to_fp16b() {
 
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint16_to_fp32() {
-#ifndef DISABLE_SFPLOADMACRO
-    // InstructionTemplate[0]
-    TTI_SFPCAST(0, 12, 0);
-
-    // Macro 0
-    {
-        constexpr std::uint32_t simple_bits = 0x00 | 0x40 | (0 << 3) | (4 + 0);
-        constexpr std::uint32_t mad_bits = 0;
-        constexpr std::uint32_t round_bits = 0;
-        constexpr std::uint32_t store_bits = 0x00 | 0x40 | (1 << 3) | 3;
-
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, (mad_bits << 8) | simple_bits);
-        TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (store_bits << 8) | round_bits);
-        TTI_SFPCONFIG(0, 4 + 0, 0);
-    }
-
-    // Misc: {
-    //   StoreMod0: FP32,
-    //   UsesLoadMod0ForStore: {0},
-    //   UnitDelayKind: {1}, (WaitForElapsedInstructions=1)
-    // }
-    TTI_SFPCONFIG(0x100 | InstrModLoadStore::FP32, 8, 1);
-#endif
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0xFFFF);
 }
 
 template <bool APPROXIMATION_MODE>
@@ -1035,7 +961,8 @@ inline void calculate_typecast_uint_to_uint8() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; ++d) {
         if constexpr (u16) {
-            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_3, 0);
+            TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
+            TTI_SFPAND(0, p_sfpu::LREG13, p_sfpu::LREG0, 0);
         } else {
             TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         }
@@ -1053,6 +980,7 @@ inline void init_typecast_fp32_to_uint8() {
 template <bool APPROXIMATION_MODE>
 inline void init_typecast_uint_to_uint8() {
     sfpi::vConstIntPrgm0 = 0xFF;
+    sfpi::vConstIntPrgm1 = 0x0000FFFF;
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -23,7 +23,7 @@ constexpr std::uint16_t UINT16_LOW_MASK = 0xFFFF;
 // lands in the high 16 bits where the packer reads UInt16 out of a 32-bit dest word.
 constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool DST_ACCUM_MODE>
 inline void calculate_typecast_fp32_to_uint16() {
     // TODO: Attempt to use LOADMACRO #46751
 #pragma GCC unroll 0
@@ -31,7 +31,11 @@ inline void calculate_typecast_fp32_to_uint16() {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
-        TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
+        if (DST_ACCUM_MODE) {
+            TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_2, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_2, 0);
+        }
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -398,6 +398,7 @@ inline void calculate_typecast_uint32_to_uint16() {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_3, 0);
         TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+        TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);
         TTI_SFPIADD(
             0, p_sfpu::LCONST_0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_CC_NONE | sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
         TTI_SFPSHFT((-16) & 0xFFF, 0, p_sfpu::LREG0, 1);

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -891,7 +891,7 @@ ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
         calculate_reduce,
-        (pool_type, reduce_dim, format),
+        (pool_type, reduce_dim, format, DST_ACCUM_MODE),
         idst,
         VectorMode::RC_custom,
         ct_dim,
@@ -916,7 +916,7 @@ ALWI void sfpu_reduce_init() {
             format == DataFormat::UInt16 || format == DataFormat::Float16_b,
         "Unsupported data format. Supported formats: Float32, Int32, UInt32, UInt16, Float16_b");
 
-    MATH(SFPU_UNARY_INIT_FN_ARGS(reduce, sfpu::init_reduce, (pool_type, format), 1 /*block_ct_dim*/));
+    MATH(SFPU_UNARY_INIT_FN_ARGS(reduce, sfpu::init_reduce, (pool_type, format, DST_ACCUM_MODE), 1 /* block_ct_dim */));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/typecast.h
@@ -63,7 +63,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_fp32_to_uint16,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float16_b) {
@@ -105,7 +105,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_fp32_to_uint16,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Float32) {
@@ -137,7 +137,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_fp32_to_uint16,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp8_b) {
@@ -258,7 +258,7 @@ ALWI void typecast_tile(uint32_t idst) {
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_typecast_fp32_to_uint16,
-            (APPROX, 8 /* ITERATIONS */),
+            (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
             idst,
             VectorMode::RC));
     } else if constexpr (in_format == DataFormat::UInt16 && out_format == DataFormat::Bfp4_b) {

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -148,7 +148,7 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
 {
     if constexpr (IN == DataFormat::Float16_b && OUT == DataFormat::UInt16)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Float16_b)
     {
@@ -168,7 +168,7 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
     }
     else if constexpr (IN == DataFormat::Float32 && OUT == DataFormat::UInt16)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Float32)
     {
@@ -184,7 +184,7 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
     }
     else if constexpr (IN == DataFormat::Bfp8_b && OUT == DataFormat::UInt16)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Bfp8_b)
     {
@@ -241,7 +241,7 @@ void call_unary_typecast_operation(std::uint32_t dst_index)
     }
     else if constexpr (IN == DataFormat::Bfp4_b && OUT == DataFormat::UInt16)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_typecast_fp32_to_uint16, (APPROX_MODE, ITERATIONS, DST_ACCUM_MODE), dst_index, VectorMode::RC);
     }
     else if constexpr (IN == DataFormat::UInt16 && OUT == DataFormat::Bfp4_b)
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -622,6 +622,16 @@ def data_formats(
             unpack_dst = input_format
             math_format = input_format
             pack_src_format = input_format
+            # Widening reductions (e.g. UInt16 reduce-sum) keep a narrow input but accumulate into a
+            # wider 32-bit value in a 32-bit dest. The kernel masks the garbage high bits on load (driven
+            # by the narrow math format) yet stores the full 32-bit result, so the packer must read the
+            # whole dest word: set pack_src to the 32-bit output format while leaving unpack/math narrow.
+            if (
+                is_fp32_dest_acc_en == DestAccumulation.Yes
+                and not input_format.is_32_bit()
+                and output_format.is_32_bit()
+            ):
+                pack_src_format = output_format
 
         # Even with inference disabled, UInt16 must ride the Int16 data path on Quasar: there is no
         # UInt16 HW encoding in the unpacker, the register files/dest, or the packer, so the whole

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -112,22 +112,32 @@ def _whole_number_float_spec(high: int) -> StimuliSpec:
     return StimuliSpec(distribution=dist, seed=0)
 
 
+def _preserve_fp32_precision(formats: InputOutputFormat) -> bool:
+    """preserve_fp32_precision exactly as ttnn.typecast computes it.
+
+    ttnn uses this single flag for two things: it forces fp32 dest acc (see
+    _production_dest_acc) and it selects UnpackToDestFp32 in the program
+    factories, so the test reuses it for both.
+    """
+    in_fmt = formats.input_format
+    out_fmt = formats.output_format
+    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
+    bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
+    return (
+        in_fmt == DataFormat.Float32
+        or (out_fmt == DataFormat.UInt8 and in_fmt in bf_family)
+        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
+        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
+    )
+
+
 def _production_dest_acc(formats: InputOutputFormat) -> list[DestAccumulation]:
     """Pick dest_acc the way ttnn.typecast does."""
 
     in_fmt = formats.input_format
     out_fmt = formats.output_format
-
-    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
-    _bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
-    preserve_fp32_precision = (
-        in_fmt == DataFormat.Float32
-        or (out_fmt == DataFormat.UInt8 and in_fmt in _bf_family)
-        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
-        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
-    )
     fp32_dest_acc_en = (
-        preserve_fp32_precision
+        _preserve_fp32_precision(formats)
         or out_fmt in (DataFormat.UInt32, DataFormat.Int32, DataFormat.Float32)
         or in_fmt in (DataFormat.UInt32, DataFormat.Int32)
         or out_fmt == DataFormat.Fp8_e4m3
@@ -182,9 +192,16 @@ def test_eltwise_unary_typecast(
         input_dimensions,
     )
 
-    # 32-bit inputs are unpacked straight into Dest (no Src-register staging).
-    unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    # Unpack straight into Dest when either:
+    #  * the input is 32-bit -- the unpacker has no SrcA/SrcB path for
+    #    Int32/UInt32/Float32, so is_unpacker_format_conversion_supported_dest
+    #    (cunpack_common.h) asserts unpack_to_dest for them; or
+    #  * production would, i.e. preserve_fp32_precision drives UnpackToDestFp32 in
+    #    the ttnn program factories.
+    # For non-32-bit inputs the unpack MOP still gates on is_32bit_input(), so the
+    # flag only actually changes the datapath for genuine 32-bit inputs.
+    unpack_to_dest = formats.input_format.is_32_bit() or _preserve_fp32_precision(
+        formats
     )
 
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -112,35 +112,33 @@ def _whole_number_float_spec(high: int) -> StimuliSpec:
     return StimuliSpec(distribution=dist, seed=0)
 
 
-def _valid_dest_acc_options(formats: InputOutputFormat) -> list[DestAccumulation]:
-    """Dest-accumulation modes worth exercising for a given format pair.
+def _production_dest_acc(formats: InputOutputFormat) -> list[DestAccumulation]:
+    """Pick dest_acc the way ttnn.typecast does."""
 
-    32-bit Dest is mandatory whenever the SFPU integer datapath is used: the
-    SFPU typecast computes the result into Dest before the packer reads it, and
-    the integer datapath always operates on 32-bit Dest data. So any integer
-    input or output (not just the 32-bit ones) requires ``dest_acc=Yes`` —
-    otherwise pack_src stays 16-bit and ``is_packer_to_L1_conversion_supported``
-    rejects the pack (LLK assert in configure_pack). 32-bit float formats also
-    require 32-bit Dest.
-
-    For the remaining (16-bit float / block-float) pairs both modes are valid,
-    so we sweep both to widen coverage.
-    """
     in_fmt = formats.input_format
     out_fmt = formats.output_format
-    if (
-        in_fmt.is_integer()
-        or out_fmt.is_integer()
-        or in_fmt.is_32_bit()
-        or out_fmt.is_32_bit()
-    ):
-        return [DestAccumulation.Yes]
-    return [DestAccumulation.No, DestAccumulation.Yes]
+
+    # bf16 / block-float inputs that promote to 32-bit Dest when packed to UInt8.
+    _bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
+    preserve_fp32_precision = (
+        in_fmt == DataFormat.Float32
+        or (out_fmt == DataFormat.UInt8 and in_fmt in _bf_family)
+        or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
+        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
+    )
+    fp32_dest_acc_en = (
+        preserve_fp32_precision
+        or out_fmt in (DataFormat.UInt32, DataFormat.Int32, DataFormat.Float32)
+        or in_fmt in (DataFormat.UInt32, DataFormat.Int32)
+        or out_fmt == DataFormat.Fp8_e4m3
+        or in_fmt == DataFormat.Fp8_e4m3
+    )
+    return [DestAccumulation.Yes if fp32_dest_acc_en else DestAccumulation.No]
 
 
 @parametrize(
     formats=TYPECAST_PAIRS,
-    dest_acc=_valid_dest_acc_options,
+    dest_acc=_production_dest_acc,
     approx_mode=[ApproximationMode.No],
     input_dimensions=[
         [32, 32]
@@ -228,6 +226,28 @@ def test_eltwise_unary_typecast(
         dest_acc=dest_acc,
         unpack_to_dest=unpack_to_dest,
     )
+
+    # pack_src fix for the SFPU typecast.
+    #
+    # The generic format inference models pack_src from the *input* (what the
+    # unpacker writes to Dest). For a typecast the SFPU overwrites Dest with the
+    # *output* value, so the packer must read the output's register
+    # representation, not the input's. In 16-bit Dest mode (dest_acc=No) the
+    # inferred pack_src would stay equal to the input format and the pack would
+    # be rejected (e.g. UInt16 -> Float16_b is not a supported packer
+    # conversion). Patch pack_src to the format the SFPU actually leaves in Dest:
+    # block-float outputs are produced as Float16_b and compressed by the packer;
+    # every other output is already in its packable register form. (For
+    # dest_acc=Yes the 32-bit gasket converts from Dest, and the inference
+    # already yields the output format, so no patch is needed there.)
+    if dest_acc == DestAccumulation.No:
+        pack_src = (
+            DataFormat.Float16_b
+            if _is_block_float(formats.output_format)
+            else formats.output_format
+        )
+        for fmt_config in configuration.formats_config:
+            fmt_config.pack_src = pack_src
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -125,9 +125,9 @@ def _preserve_fp32_precision(formats: InputOutputFormat) -> bool:
     bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
     return (
         in_fmt == DataFormat.Float32
-        or (out_fmt == DataFormat.UInt8 and in_fmt in bf_family)
+        or (in_fmt in bf_family)
         or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
-        or (in_fmt == DataFormat.UInt8 and out_fmt != DataFormat.Float16_b)
+        or (in_fmt == DataFormat.UInt8)
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_typecast.py
@@ -125,7 +125,7 @@ def _preserve_fp32_precision(formats: InputOutputFormat) -> bool:
     bf_family = (DataFormat.Float16_b, DataFormat.Bfp8_b, DataFormat.Bfp4_b)
     return (
         in_fmt == DataFormat.Float32
-        or (in_fmt in bf_family)
+        or (out_fmt == DataFormat.UInt8 and in_fmt in bf_family)
         or (in_fmt == DataFormat.UInt16 and out_fmt == DataFormat.UInt8)
         or (in_fmt == DataFormat.UInt8)
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_bcast.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_bcast.py
@@ -97,6 +97,15 @@ def test_unpack_bcast(
     ):
         pytest.skip("Unsupported for BH yet")
 
+    if (
+        dest_acc == DestAccumulation.Yes
+        and formats.input_format == DataFormat.UInt16
+        and broadcast_type == BroadcastType.None_
+    ):
+        pytest.skip(
+            "Data copy mechanism for SFPU (expects in low-bits) and Packer (expects in high-bits) conflict"
+        )
+
     # --- Skips from bugs --------------------------------------------------
 
     # TODO: pgardner - Column broadcast for tiny tiles needs kernel support

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_sfpu_reduce.py
@@ -22,7 +22,6 @@ from helpers.llk_params import (
 )
 from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
-    input_output_formats,
     parametrize,
 )
 from helpers.stimuli_config import StimuliConfig
@@ -63,6 +62,82 @@ def get_supported_reduce_axioms(reduce_pool: ReducePool) -> list[MathOperation]:
     return [MathOperation.ReduceColumn]
 
 
+# Base data formats exercised by the reduce suite.
+REDUCE_BASE_FORMATS = [
+    DataFormat.Float32,
+    DataFormat.Int32,
+    DataFormat.UInt32,
+    DataFormat.UInt16,
+    DataFormat.Float16_b,
+]
+
+
+def get_reduce_formats(reduce_pool: ReducePool) -> list[InputOutputFormat]:
+    """Input/output format pairs for the reduce suite.
+
+    A UInt16 Sum/Average reduction can exceed the UInt16 range: a single 32-wide tile row/column
+    sums up to 32 values, and a multi-tile row reduction sums even more (e.g. 128 columns of up to
+    1000 reaches ~128000 >> 65535). To avoid output overflow we widen the OUTPUT to UInt32 for those
+    cases; the SFPU already accumulates in 32-bit and stores the full word into a 32-bit (fp32) dest.
+    Every other case keeps input == output.
+    """
+    widening = reduce_pool in (ReducePool.Sum, ReducePool.Average)
+    return [
+        (
+            InputOutputFormat(fmt, DataFormat.UInt32)
+            if (widening and fmt == DataFormat.UInt16)
+            else InputOutputFormat(fmt, fmt)
+        )
+        for fmt in REDUCE_BASE_FORMATS
+    ]
+
+
+# Relative precision (unit roundoff) of the floating-point dest/output formats.
+# bf16 has 7 explicit mantissa bits, fp16 has 10, fp32 has 23.
+_FLOAT_FORMAT_EPS = {
+    DataFormat.Float16_b: 2.0**-8,
+    DataFormat.Float16: 2.0**-11,
+    DataFormat.Float32: 2.0**-24,
+}
+
+
+def get_reduce_sum_atol(
+    output_format, reduce_pool, mathop, input_dimensions, input_bounds
+):
+    """Absolute tolerance for accumulating float reductions (Sum/Average).
+
+    Summing N values of magnitude up to M in a low-precision float format accumulates
+    rounding error that scales like sqrt(N) * M * eps (the partial sums grow ~sqrt(N)*M
+    and each store rounds by ~eps). On rows whose terms nearly cancel, this absolute
+    error dwarfs the tiny true result, so a fixed atol/rtol spuriously fails even though
+    the hardware reduction is correct (PCC stays ~0.99999). We size atol to that bound
+    (with a 2x safety margin) so cancellation rows pass while genuine errors still fail.
+
+    Returns None for non-accumulating ops (Max/Min) and integer formats, leaving the
+    default exact/loose tolerances in place.
+    """
+    if reduce_pool not in (ReducePool.Sum, ReducePool.Average):
+        return None
+
+    eps = _FLOAT_FORMAT_EPS.get(output_format)
+    if eps is None:  # integer formats reduce exactly; keep exact comparison
+        return None
+
+    max_term = max(abs(input_bounds[0]), abs(input_bounds[1]))
+    # Number of terms accumulated per output element.
+    num_terms = input_dimensions[1] if mathop == MathOperation.ReduceRow else TILE_DIM
+
+    safety_factor = 2.0
+    atol = safety_factor * max_term * eps * (num_terms**0.5)
+
+    # Average divides the accumulated sum by the reduced extent, shrinking the error too.
+    if reduce_pool == ReducePool.Average:
+        atol /= num_terms
+
+    # Keep at least the baseline absolute tolerance used elsewhere.
+    return max(0.05, atol)
+
+
 def is_valid_reduce_dimension(mathop, dest_acc, formats, dim):
     """Check if a dimension is valid for the given reduce operation."""
 
@@ -84,19 +159,10 @@ def is_valid_reduce_dimension(mathop, dest_acc, formats, dim):
 
 
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float32,
-            DataFormat.Int32,
-            DataFormat.UInt32,
-            DataFormat.UInt16,
-            DataFormat.Float16_b,
-        ],
-        same=True,
-    ),
-    mathop=lambda reduce_pool: get_supported_reduce_axioms(reduce_pool),
+    formats=get_reduce_formats,
+    mathop=get_supported_reduce_axioms,
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    input_bounds=lambda formats: get_format_input_bounds(formats),
+    input_bounds=get_format_input_bounds,
     reduce_pool=[ReducePool.Min, ReducePool.Max, ReducePool.Sum, ReducePool.Average],
     dimension_combinations=lambda mathop, dest_acc, formats: [
         dim
@@ -121,6 +187,16 @@ def test_sfpu_reduce(
             reason="32-bit formats require DestAccumulation.Yes (HW cannot unpack into SrcA/SrcB)"
         )
 
+    if (
+        formats.input_format == DataFormat.UInt16
+        and formats.output_format.is_32_bit()
+        and dest_acc == DestAccumulation.No
+    ):
+        pytest.skip(
+            reason="UInt16 Sum/Average widens the output to UInt32, which needs a 32-bit (fp32) dest; "
+            "DestAccumulation.No has no room to store/pack the widened result"
+        )
+
     min_value, max_value = input_bounds
     input_dimensions = dimension_combinations
     torch_format = format_dict[formats.input_format]
@@ -139,14 +215,22 @@ def test_sfpu_reduce(
     )
 
     # STIMULI GENERATION
-    src_A = torch.randint(
-        low=min_value,
-        high=max_value,
-        size=(tile_cnt * ELEMENTS_PER_TILE,),
-        dtype=torch_format,
-    )
+    stimuli_size = (tile_cnt * ELEMENTS_PER_TILE,)
+    if formats.input_format.is_integer():
+        src_A = torch.randint(
+            low=min_value,
+            high=max_value,
+            size=stimuli_size,
+            dtype=torch_format,
+        )
+    else:
+        # Float formats need real fractional values, not integer-valued floats, so the
+        # float accumulation/rounding paths are actually exercised (randint would only
+        # ever produce whole numbers like 42.0).
+        src_A = torch.empty(stimuli_size, dtype=torch_format).uniform_(
+            min_value, max_value
+        )
     src_B = torch.zeros_like(src_A)
-    src_A = torch.ones_like(src_A)
 
     # Max Reduction can do block and single tile reduction whereas Sum/Avg only do single tile reduction, convert Sum/Avg golden to do block reduction by retilizing input to src_A
     # Dimensions for Max reduction work column wise, for Sum/Avg processing tiles independently is same as column reduction on dst block dimension [32, num_tiles * 32] where num rows is 32 i.e RT_DIM=1 (same as a single tile)
@@ -155,6 +239,7 @@ def test_sfpu_reduce(
         if mathop == MathOperation.ReduceColumn
         else input_dimensions
     )
+
     src_A = tilize_block(
         src_A, dst_dim, stimuli_format=formats.input_format
     ).flatten()  # Input tensor is tilized in dst register
@@ -206,112 +291,45 @@ def test_sfpu_reduce(
     res_tensor = untilize_block(res_tensor, formats.output_format, dst_dim)
 
     if mathop == MathOperation.ReduceColumn:
-        assert passed_test(golden_tensor[0], res_tensor[0], formats.output_format)
+        golden_slice = golden_tensor[0]
+        res_slice = res_tensor[0]
     elif mathop == MathOperation.ReduceRow:
-        assert passed_test(golden_tensor[:, 0], res_tensor[:, 0], formats.output_format)
+        golden_slice = golden_tensor[:, 0]
+        res_slice = res_tensor[:, 0]
     else:
         raise ValueError(f"Unsupported math operation: {mathop}")
 
-
-@parametrize(
-    formats=input_output_formats(
-        [DataFormat.Float32, DataFormat.Float16_b, DataFormat.Int32],
-        same=True,
-    ),
-    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
-    mathop=[MathOperation.ReduceRow],
-    reduce_pool=[ReducePool.Max],
-    input_bounds=lambda formats: get_format_input_bounds(formats),
-    input_dimensions=lambda mathop, dest_acc, formats: [
-        dim
-        for dim in [[32, 32], [64, 64], [64, 128], [128, 64], [256, 32], [32, 256]]
-        if is_valid_reduce_dimension(mathop, dest_acc, formats, dim)
-    ],
-)
-def test_reduce_row_max(
-    formats, dest_acc, mathop, reduce_pool, input_bounds, input_dimensions
-):
-    # Row max SFPU kernel uses SFPLOAD/SFPSTORE with format-specific instruction modes
-    # (e.g. FP16B for Float16_b). When dest_acc=Yes the dest register is 32-bit wide,
-    # so only 32-bit SFPU modes (FP32, INT32) can address it correctly.
-    if formats.input_format.is_32_bit() and dest_acc == DestAccumulation.No:
-        pytest.skip(
-            "32-bit formats require DestAccumulation.Yes (HW cannot unpack into SrcA/SrcB)"
-        )
-    min_value, max_value = input_bounds
-    torch_format = format_dict[formats.input_format]
-
-    tile_cnt = input_dimensions[0] * input_dimensions[1] // ELEMENTS_PER_TILE
-
-    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
-        DestSync.Half,
-        dest_acc,
-        formats,
-        input_dimensions,
-        TILE_DIMENSIONS,
-        BlocksCalculationAlgorithm.Standard,
+    # Accumulating float reductions lose precision proportional to the number of summed
+    # terms; size the absolute tolerance accordingly (PCC still guards correctness).
+    reduce_atol = get_reduce_sum_atol(
+        formats.output_format, reduce_pool, mathop, input_dimensions, input_bounds
     )
 
-    if torch_format in (torch.int32, torch.int64):
-        src_A = torch.randint(
-            low=min_value,
-            high=max_value,
-            size=(tile_cnt * ELEMENTS_PER_TILE,),
-            dtype=torch_format,
-        )
-    else:
-        src_A = torch.empty(tile_cnt * ELEMENTS_PER_TILE, dtype=torch_format).uniform_(
-            min_value, max_value
-        )
-    src_B = torch.zeros_like(src_A)
-
-    dst_dim = input_dimensions
-    src_A = tilize_block(src_A, dst_dim, stimuli_format=formats.input_format).flatten()
-    src_A_untilized = untilize_block(src_A, formats.input_format, dst_dim)
-
-    golden_tensor = get_golden_generator(UnarySFPUGolden)(
-        mathop,
-        src_A_untilized,
-        formats.output_format,
-        dest_acc,
-        formats.input_format,
-        dst_dim,
-        reduce_pool=reduce_pool,
+    passed = passed_test(
+        golden_slice, res_slice, formats.output_format, custom_atol=reduce_atol
     )
 
-    configuration = TestConfig(
-        "sources/sfpu_reduce_test.cpp",
-        formats,
-        templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
-            APPROX_MODE(ApproximationMode.No),
-            MATH_OP(mathop=mathop, pool_type=reduce_pool),
-        ],
-        runtimes=[
-            NUM_BLOCKS(num_blocks),
-            NUM_TILES_IN_BLOCK(num_tiles_in_block),
-            TILE_COUNT(tile_cnt),
-        ],
-        variant_stimuli=StimuliConfig(
-            src_A,
-            formats.input_format,
-            src_B,
-            formats.input_format,
-            formats.output_format,
-            tile_count_A=tile_cnt,
-            tile_count_B=1,
-            tile_count_res=tile_cnt,
-        ),
-        dest_acc=dest_acc,
-        unpack_to_dest=True,
-        disable_format_inference=True,
-        compile_time_formats=True,
-    )
-    res_from_L1 = configuration.run().result
+    if not passed:
+        # Dump the exact input/golden/result to the (CI) console so a non-reproducible-locally
+        # failure can be replayed. Print the full tensors (torch truncates by default) and the
+        # tilized src_A bytes that were actually sent to L1 so the case can be hardcoded.
+        torch.set_printoptions(
+            threshold=1_000_000, precision=6, sci_mode=False, linewidth=200
+        )
+        print("\n================= SFPU REDUCE FAILURE DEBUG =================")
+        print(
+            f"formats={formats} mathop={mathop} dest_acc={dest_acc} "
+            f"reduce_pool={reduce_pool} input_bounds={input_bounds} dims={input_dimensions}"
+        )
+        print(
+            f"num_blocks={num_blocks} num_tiles_in_block={num_tiles_in_block} tile_cnt={tile_cnt}"
+        )
+        print(f"src_A (tilized, sent to L1):\n{src_A.tolist()}")
+        print(f"src_A_untilized (golden input):\n{src_A_untilized}")
+        print(f"golden_slice:\n{golden_slice}")
+        print(f"res_slice:\n{res_slice}")
+        mism = (golden_slice != res_slice).nonzero().flatten().tolist()
+        print(f"mismatch indices ({len(mism)}): {mism}")
+        print("============================================================\n")
 
-    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
-    res_tensor = untilize_block(res_tensor, formats.output_format, dst_dim)
-
-    golden = golden_tensor[:, 0]
-    result = res_tensor[:, 0]
-    assert passed_test(golden, result, formats.output_format)
+    assert passed

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
@@ -80,9 +80,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Copy SrcA to Dest (datacopy A2D). Integer inputs always run with 32-bit
-    // Dest (dest_acc=Yes), which already routes the copy so the raw bits land in
-    // Dest unmodified; no separate integer-FPU flag is needed here.
+    // Copy SrcA to Dest (datacopy A2D). The A2D copy preserves the raw datum
+    // bits in Dest (the SFPU below interprets/converts them), so no separate
+    // integer-FPU flag is needed here. dest_acc follows production
+    // (fp32_dest_acc_en): integer pairs that production runs in 16-bit Dest stay
+    // in 16-bit Dest here too.
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
         TILE_NUM_FACES, formats.math);
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_typecast_test.cpp
@@ -88,14 +88,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
 
-    // The typecast SFPU integer datapath relies on debug feature bit 11 (32-bit
-    // dest mode) being set. In production this is owned by the LLK API; here we
-    // set it explicitly around the compute and clear it again below.
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     // Program the SFPU for this specific typecast pair (no-op for pairs handled
     // purely by unpacker/packer format conversion). Goes through the shared
     // unary-SFPU dispatch under SfpuType::typecast, with the (IN, OUT) format
@@ -138,12 +130,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 TYPECAST_OUT_FORMAT>(block_tile);
         }
         _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
-    }
-
-    // Clear debug feature bit 11, restoring default FPU behavior.
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
     }
 }
 

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -112,7 +112,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
         _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
-        init_reduce<POOL_TYPE, static_cast<DataFormat>(formats.math)>();
+        init_reduce<POOL_TYPE, static_cast<DataFormat>(formats.math), is_fp32_dest_acc_en>();
 
         PROFILER_SYNC();
     }
@@ -134,7 +134,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(BLOCK_CT_DIM, BLOCK_RT_DIM);
+                    calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math), is_fp32_dest_acc_en>(BLOCK_CT_DIM, BLOCK_RT_DIM);
                     TTI_CLEARDVALID(1, 0);
                 }
             }
@@ -155,7 +155,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
 
                 _llk_math_eltwise_sfpu_start_(0);
-                calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(BLOCK_CT_DIM, BLOCK_RT_DIM);
+                calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math), is_fp32_dest_acc_en>(BLOCK_CT_DIM, BLOCK_RT_DIM);
                 _llk_math_eltwise_sfpu_done_();
                 _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -120,7 +120,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
 
         // Initialize SDPA reduce using unified function
-        init_reduce<PoolType::MAX, DataFormat::Float16_b>(BLOCK_CT_DIM);
+        init_reduce<PoolType::MAX, DataFormat::Float16_b, is_fp32_dest_acc_en>(BLOCK_CT_DIM);
 
         PROFILER_SYNC();
     }
@@ -149,7 +149,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // Run the SFPU reduce SDPA calculation
                     // This is the core computation we want to measure
 
-                    calculate_reduce<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b>(1, block_height);
+                    calculate_reduce<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b, is_fp32_dest_acc_en>(1, block_height);
 
                     // Clear the valid flag for source A
                     TTI_CLEARDVALID(1, 0);
@@ -185,7 +185,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     // Call the SFPU SDPA reduce function
                     const std::uint32_t block_height = BLOCK_RT_DIM;
-                    calculate_reduce<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b>(1, block_height);
+                    calculate_reduce<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b, is_fp32_dest_acc_en>(1, block_height);
 
                     _llk_math_eltwise_sfpu_done_();
                     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -59,7 +59,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
         4 /* num_faces */, formats.math);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
@@ -69,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_tiles_in_block = params.NUM_TILES_IN_BLOCK;
 
     _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
-    ckernel::sfpu::init_reduce<POOL_TYPE, static_cast<DataFormat>(formats.math)>();
+    ckernel::sfpu::init_reduce<POOL_TYPE, static_cast<DataFormat>(formats.math), is_fp32_dest_acc_en>();
 
     if (REDUCE_DIM == ReduceDim::REDUCE_COL)
     {
@@ -92,7 +92,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     (tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
                     "Block tile index exceeds maximum destination tiles");
                 _llk_math_eltwise_sfpu_start_(tile);
-                ckernel::sfpu::calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>();
+                ckernel::sfpu::calculate_reduce<
+                    POOL_TYPE,
+                    REDUCE_DIM,
+                    static_cast<DataFormat>(formats.math),
+                    is_fp32_dest_acc_en,
+                    static_cast<DataFormat>(formats.pack_dst)>();
             }
 
             _llk_math_eltwise_sfpu_done_();
@@ -114,7 +119,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_math_eltwise_sfpu_start_(0);
-        ckernel::sfpu::calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math)>(BLOCK_CT_DIM, BLOCK_RT_DIM);
+        ckernel::sfpu::
+            calculate_reduce<POOL_TYPE, REDUCE_DIM, static_cast<DataFormat>(formats.math), is_fp32_dest_acc_en, static_cast<DataFormat>(formats.pack_dst)>(
+                BLOCK_CT_DIM, BLOCK_RT_DIM);
 
 #ifdef ADD_TOP_ROW
         _llk_math_eltwise_binary_sfpu_init_<SfpuType::add_top_row>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -216,7 +216,7 @@ constexpr std::uint32_t operator|(InstrModLoadStore mod, std::uint32_t bits)
     return operator|(bits, mod);
 }
 
-template <DataFormat format>
+template <DataFormat format, bool is_fp32_dest_acc_en = false>
 constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
 {
     switch (format)
@@ -224,7 +224,9 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::Float32:
             return InstrModLoadStore::FP32; // spec value 3: fp32 format
         case DataFormat::Float16:
-            return InstrModLoadStore::FP16A; // spec value 1: fp16_a format
+            // With 32-bit (fp32) dest accumulation the datum is stored as full fp32 in the dest word, so
+            // SFPLOAD/SFPSTORE must use FP32 access; otherwise the narrow fp16_a format applies.
+            return is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::FP16A; // spec value 1: fp16_a format
         case DataFormat::Bfp8:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Bfp4:
@@ -232,7 +234,9 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::Bfp2:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Float16_b:
-            return InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
+            // With 32-bit (fp32) dest accumulation the datum is stored as full fp32 in the dest word, so
+            // SFPLOAD/SFPSTORE must use FP32 access; otherwise the narrow fp16_b format applies.
+            return is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
         case DataFormat::Bfp8_b:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Bfp4_b:
@@ -246,7 +250,7 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::UInt8:
             return InstrModLoadStore::INT8; // spec value 5: int8 format
         case DataFormat::UInt16:
-            return InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
+            return is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
         case DataFormat::Int32:
             return InstrModLoadStore::INT32; // spec value 4: int32 format
         case DataFormat::UInt32:

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -82,17 +82,6 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
 
-    // Workaround for HW bugs:
-    // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
-    // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest = is_fp32_dest_acc_en && ((srca_data_format == ckernel::to_underlying(DataFormat::UInt16)) ||
-                                                         (srcb_data_format == ckernel::to_underlying(DataFormat::UInt16)));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     // Establish the operand-driven baseline for the Src zero-substitution flag.
     _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -220,6 +220,19 @@ inline void _llk_math_eltwise_unary_datacopy_(
     {
         math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
+        if constexpr (is_fp32_dest_acc_en && src_b_bcast_type != BroadcastType::NONE)
+        {
+            // UInt16 case needs to use format switching for 32bit dest
+            // without the debug bit 11 hack to write into high bits
+            // avoiding BroadcastType::NONE mode as that path is used by SFPU
+            if (dst_format == to_underlying(DataFormat::UInt16))
+            {
+                TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+                cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+            }
+        }
+
         if constexpr (type == DataCopyType::A2D)
         {
             ckernel_template::run();
@@ -237,6 +250,16 @@ inline void _llk_math_eltwise_unary_datacopy_(
             else
             {
                 ckernel_template::run();
+            }
+        }
+
+        if constexpr (is_fp32_dest_acc_en && src_b_bcast_type != BroadcastType::NONE)
+        {
+            // Undo format switching option
+            if (dst_format == to_underlying(DataFormat::UInt16))
+            {
+                TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
+                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
             }
         }
 
@@ -366,9 +389,17 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }
+        else if (is_fp32_dest_acc_en && (dst_format == to_underlying(DataFormat::UInt16)))
+        {
+            // Typecasting uint16 to 32bit data, need data to be written to lower 16 bits without modification
+            // to be consumed by SFPU easily.
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
+            tmp.program();
+        }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_NORM, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -216,7 +216,7 @@ constexpr std::uint32_t operator|(InstrModLoadStore mod, std::uint32_t bits)
     return operator|(bits, mod);
 }
 
-template <DataFormat format>
+template <DataFormat format, bool is_fp32_dest_acc_en = false>
 constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
 {
     switch (format)
@@ -224,7 +224,9 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::Float32:
             return InstrModLoadStore::FP32; // spec value 3: fp32 format
         case DataFormat::Float16:
-            return InstrModLoadStore::FP16A; // spec value 1: fp16_a format
+            // With 32-bit (fp32) dest accumulation the datum is stored as full fp32 in the dest word, so
+            // SFPLOAD/SFPSTORE must use FP32 access; otherwise the narrow fp16_a format applies.
+            return is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::FP16A; // spec value 1: fp16_a format
         case DataFormat::Bfp8:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Bfp4:
@@ -232,7 +234,9 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::Bfp2:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Float16_b:
-            return InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
+            // With 32-bit (fp32) dest accumulation the datum is stored as full fp32 in the dest word, so
+            // SFPLOAD/SFPSTORE must use FP32 access; otherwise the narrow fp16_b format applies.
+            return is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::FP16B; // spec value 2: bfloat/fp16_b
         case DataFormat::Bfp8_b:
             return InstrModLoadStore::DEFAULT; // spec value 0: default format
         case DataFormat::Bfp4_b:
@@ -246,7 +250,9 @@ constexpr InstrModLoadStore GetSfpLoadStoreInstrMod()
         case DataFormat::UInt8:
             return InstrModLoadStore::INT8; // spec value 5: int8 format
         case DataFormat::UInt16:
-            return InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
+            // With 32-bit (fp32) dest accumulation the UInt16 datum is written into the lower 16 bits of a
+            // 32-bit dest word (high bits are garbage), so SFPLOAD/SFPSTORE must use full-width INT32 access.
+            return is_fp32_dest_acc_en ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16; // spec value 6: unsigned int16 format
         case DataFormat::Int32:
             return InstrModLoadStore::INT32; // spec value 4: int32 format
         case DataFormat::UInt32:

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -77,13 +77,13 @@ inline void _llk_math_set_fp32_dest_acc_(bool enable)
  * @brief Configure the math (FPU) thread's ALU control registers for the given source data formats.
  *
  * Programs the source A/B ALU formats, enables INT8 math when either source is Int8/Int32, and sets FP32 dest
- * accumulation mode. Applies HW-bug workarounds (disables debug feature bit 11) for INT8 math and for the
- * UInt16-with-FP32-dest combination, otherwise re-enables it.
+ * accumulation mode. Always clears debug feature bit 11 (32-bit dest mode workaround) to establish a known-good
+ * baseline; bit 11 is never set by any math/SFPU path (tt-llk#1568).
  *
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
  * @param srca_data_format: Data format of source A (DataFormat enum underlying value).
  * @param srcb_data_format: Data format of source B (DataFormat enum underlying value).
- * @note May disable debug feature bit 11 via @ref _llk_math_dbg_feature_disable_ for INT8/UInt16 workarounds (budabackend#1948).
+ * @note Clears debug feature bit 11 via @ref _llk_math_dbg_feature_enable_; it is never set here.
  * @note srcb_data_format programs ALU_FORMAT_SPEC_REG1_SrcB, which the SFPU also reads to interpret data it loads from DEST.
  *       For SFPU work, pass a srcb_data_format whose exponent family (BF16 vs FP16) matches the data in DEST (tt-llk #951).
  */
@@ -103,21 +103,6 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
-
-    // Workaround for HW bugs:
-    // budabackend#1948: int32 dest and movd2a/b with int8 srcA/B
-    // budabackend#1948: fp32 dest and movd2a/b with UInt16 srcA/B
-    bool uint16_with_fp32_dest =
-        is_fp32_dest_acc_en && ((srca_data_format == to_underlying(DataFormat::UInt16)) || (srcb_data_format == to_underlying(DataFormat::UInt16)));
-
-    if (int8_math_enabled || uint16_with_fp32_dest)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-    else
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 
     // Establish the operand-driven baseline for the Src zero-substitution flag.
     _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -37,10 +37,6 @@ inline void _llk_math_eltwise_sfpu_inc_dst_face_addr_()
 
 inline void _llk_math_eltwise_sfpu_uninit_()
 {
-    if (cfg_read(ALU_ACC_CTRL_Fp32_enabled_ADDR32) & ALU_ACC_CTRL_Fp32_enabled_MASK)
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 }
 
 template <DstSync Dst, bool Accum>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -195,6 +195,19 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
     {
         math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
+        if constexpr (is_fp32_dest_acc_en && src_b_bcast_type != BroadcastType::NONE)
+        {
+            // UInt16 case needs to use format switching for 32bit dest
+            // without the debug bit 11 hack to write into high bits
+            // avoiding BroadcastType::NONE mode as that path is used by SFPU
+            if (dst_format == to_underlying(DataFormat::UInt16))
+            {
+                cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+                cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+            }
+        }
+
         if constexpr (type == DataCopyType::A2D)
         {
             ckernel_template::run();
@@ -212,6 +225,17 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             else
             {
                 ckernel_template::run();
+            }
+        }
+
+        if constexpr (is_fp32_dest_acc_en && src_b_bcast_type != BroadcastType::NONE)
+        {
+            // Undo format switching option: clear the override and zero-flag-disable bits set above so the
+            // implied SrcA format and default zero-flag behavior are restored (matches the Blackhole path).
+            if (dst_format == to_underlying(DataFormat::UInt16))
+            {
+                cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
             }
         }
 
@@ -343,9 +367,17 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }
+        else if (is_fp32_dest_acc_en && (dst_format == to_underlying(DataFormat::UInt16)))
+        {
+            // Typecasting uint16 to 32bit data, need data to be written to lower 16 bits without modification
+            // to be consumed by SFPU easily.
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
+            tmp.program();
+        }
         else
         {
-            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
+            ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(p_mov::DEST_NORM, 0, ADDR_MOD_2, p_mova2d::MOV_8_ROWS, 0));
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_AB));
             tmp.program();
         }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -61,13 +61,6 @@ inline void eltwise_unary_sfpu_configure_addrmod()
 template <SfpuType sfpu_op>
 inline void _llk_math_eltwise_unary_sfpu_init_()
 {
-    if constexpr (sfpu_op == SfpuType::typecast)
-    {
-        if (cfg_read(ALU_ACC_CTRL_Fp32_enabled_ADDR32) & ALU_ACC_CTRL_Fp32_enabled_MASK)
-        {
-            _llk_math_dbg_feature_disable_();
-        }
-    }
     sfpu::_init_sfpu_config_reg();
     eltwise_unary_sfpu_configure_addrmod<sfpu_op>();
     math::reset_counters(p_setrwc::SET_ABD_F);

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -34,8 +34,7 @@ inline Tensor typecast_impl(
         (input_dtype == DataType::FLOAT32) or
         (output_dtype == DataType::UINT8 and (input_dtype == DataType::BFLOAT16 or input_dtype == DataType::BFLOAT8_B or
                                               input_dtype == DataType::BFLOAT4_B)) or
-        (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or
-        (input_dtype == DataType::UINT8 and output_dtype != DataType::BFLOAT16);
+        (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or (input_dtype == DataType::UINT8);
     bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
                             input_dtype == DataType::UINT32 or input_dtype == DataType::INT32 or

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -30,11 +30,10 @@ inline Tensor typecast_impl(
 
     // Device tensor path
     DataType input_dtype = input_tensor.dtype();
-    bool preserve_fp32_precision =
-        (input_dtype == DataType::FLOAT32) or
-        (output_dtype == DataType::UINT8 and (input_dtype == DataType::BFLOAT16 or input_dtype == DataType::BFLOAT8_B or
-                                              input_dtype == DataType::BFLOAT4_B)) or
-        (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or (input_dtype == DataType::UINT8);
+    bool preserve_fp32_precision = (input_dtype == DataType::FLOAT32 or input_dtype == DataType::BFLOAT16 or
+                                    input_dtype == DataType::BFLOAT8_B or input_dtype == DataType::BFLOAT4_B) or
+                                   (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or
+                                   (input_dtype == DataType::UINT8);
     bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
                             input_dtype == DataType::UINT32 or input_dtype == DataType::INT32 or

--- a/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/typecast.cpp
@@ -30,10 +30,11 @@ inline Tensor typecast_impl(
 
     // Device tensor path
     DataType input_dtype = input_tensor.dtype();
-    bool preserve_fp32_precision = (input_dtype == DataType::FLOAT32 or input_dtype == DataType::BFLOAT16 or
-                                    input_dtype == DataType::BFLOAT8_B or input_dtype == DataType::BFLOAT4_B) or
-                                   (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or
-                                   (input_dtype == DataType::UINT8);
+    bool preserve_fp32_precision =
+        (input_dtype == DataType::FLOAT32) or
+        (output_dtype == DataType::UINT8 and (input_dtype == DataType::BFLOAT16 or input_dtype == DataType::BFLOAT8_B or
+                                              input_dtype == DataType::BFLOAT4_B)) or
+        (input_dtype == DataType::UINT16 and output_dtype == DataType::UINT8) or (input_dtype == DataType::UINT8);
     bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
                             input_dtype == DataType::UINT32 or input_dtype == DataType::INT32 or


### PR DESCRIPTION
### PR Category
Bug fix. Related Issue : https://github.com/tenstorrent/tt-metal/issues/41163, https://github.com/tenstorrent/tt-metal/issues/46233

### Summary
Typecast operations depend on debug bit 11. This PR resovles that. LOADMACROS can utilized in a future PR. 
SFPU reduce also depends on debug bit 11, and is handled in this PR.
Currently skipping tests related to unused sfpu_reduce for uint16, which will be handled in a future PR
https://github.com/tenstorrent/tt-metal/issues/41163

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/remove_dbg_bit_11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/remove_dbg_bit_11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/remove_dbg_bit_11)