### PR TITLE
[Bug fix] Quasar: read NoC cmdbuf registers via RoCC

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -386,6 +386,9 @@ void RunTestOnCore(
             use_inline_dw_write_from_state = true;
             break;
         case SanitizeNOCInlineWriteWithState:
+            if (hal.get_arch() == tt::ARCH::BLACKHOLE) {
+                GTEST_SKIP() << "cq_noc_inline_dw_write_with_state-style helper is not exposed on Blackhole";
+            }
             output_buf_noc_xy.x = 26;
             output_buf_noc_xy.y = 18;
             use_inline_dw_write_with_state = true;
@@ -957,7 +960,7 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCWriteWithState) {
 
 // Regression test for the inline-dw-write NOC sanitizer, exercised through noc_inline_dw_write_set_state:
 // the destination is programmed into the inline command buffer and then sanitized via
-// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. This covers Quasar simple-command-buffer readback.
+// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE.
 TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteFromState) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
@@ -969,7 +972,7 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteFromState) {
 
 // Regression test for the inline-dw-write NOC sanitizer, exercised the way cq_noc_inline_dw_write_with_state
 // does: the destination is programmed into the WR_REG command buffer and then sanitized via
-// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. This covers Quasar complex-command-buffer readback.
+// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE.
 TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteWithState) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -61,6 +61,7 @@ enum watcher_features_t {
     SanitizeNOCMulticastInvalidRange,
     SanitizeNOCWriteWithStateBadCoord,
     SanitizeNOCInlineWriteFromState,
+    SanitizeNOCInlineWriteWithState,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -269,7 +270,8 @@ void RunTestOnCore(
                       "mcast_dst_end_x",
                       "mcast_dst_end_y",
                       "use_write_with_state",
-                      "use_inline_dw_write_from_state"}},
+                      "use_inline_dw_write_from_state",
+                      "use_inline_dw_write_with_state"}},
             .hw_config = dm_cfg,
         };
         experimental::WorkUnitSpec wu{
@@ -307,6 +309,7 @@ void RunTestOnCore(
     uint32_t mcast_dst_end_y = 0;
     bool use_write_with_state = false;
     bool use_inline_dw_write_from_state = false;
+    bool use_inline_dw_write_with_state = false;
     switch (feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -375,12 +378,17 @@ void RunTestOnCore(
             break;
         case SanitizeNOCInlineWriteFromState:
             // Bad destination coordinate, but keep the (nonzero) destination offset: this exercises
-            // DEBUG_SANITIZE_NOC_ADDR_FROM_STATE the way cq_noc_inline_dw_write_with_state does, and the
-            // reported offset discriminates the low-bits bug (the fixed sanitizer reports the real offset,
-            // whereas dropping NOC_TARG_ADDR_LO would report offset 0).
+            // DEBUG_SANITIZE_NOC_ADDR_FROM_STATE after noc_inline_dw_write_set_state. The reported offset
+            // discriminates low-bits bugs: dropping NOC_TARG_ADDR_LO on tt-1xx or NOC_RET_ADDR_LO on tt-2xx
+            // would report offset 0 instead of the real destination offset.
             output_buf_noc_xy.x = 26;
             output_buf_noc_xy.y = 18;
             use_inline_dw_write_from_state = true;
+            break;
+        case SanitizeNOCInlineWriteWithState:
+            output_buf_noc_xy.x = 26;
+            output_buf_noc_xy.y = 18;
+            use_inline_dw_write_with_state = true;
             break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
@@ -406,7 +414,8 @@ void RunTestOnCore(
         mcast_dst_end_x,
         mcast_dst_end_y,
         use_write_with_state,
-        use_inline_dw_write_from_state};
+        use_inline_dw_write_from_state,
+        use_inline_dw_write_with_state};
 
     if (is_eth_core) {
         // ETH cores still go through the legacy API.
@@ -434,7 +443,8 @@ void RunTestOnCore(
                    {"mcast_dst_end_x", mcast_dst_end_x},
                    {"mcast_dst_end_y", mcast_dst_end_y},
                    {"use_write_with_state", use_write_with_state},
-                   {"use_inline_dw_write_from_state", use_inline_dw_write_from_state}}}},
+                   {"use_inline_dw_write_from_state", use_inline_dw_write_from_state},
+                   {"use_inline_dw_write_with_state", use_inline_dw_write_with_state}}}},
         }};
         experimental::SetProgramRunArgs(program, params);
     }
@@ -637,6 +647,7 @@ void RunTestOnCore(
                 (eth_dest_overflow_addr_words << 4));
         } break;
         case SanitizeNOCInlineWriteFromState:
+        case SanitizeNOCInlineWriteWithState:
             // Inline dw write sanitized straight from the command-buffer state (DEBUG_SANITIZE_NOC_ADDR_FROM_STATE
             // uses read semantics with l1_addr 0). The destination coordinate is invalid; [addr=...] is the
             // reconstructed destination offset, which must be the real offset rather than 0.
@@ -944,16 +955,26 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCWriteWithState) {
         this->devices_[0]);
 }
 
-// Regression test for the inline-dw-write NOC sanitizer, exercised the way cq_noc_inline_dw_write_with_state
-// does: the destination is programmed into the WR_REG command buffer and then sanitized via
-// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. That macro had dropped NOC_TARG_ADDR_LO (the destination offset), so it
-// reconstructed offset 0; this test programs a nonzero offset and checks the reported [addr=...] is the real
-// offset, not 0.
+// Regression test for the inline-dw-write NOC sanitizer, exercised through noc_inline_dw_write_set_state:
+// the destination is programmed into the inline command buffer and then sanitized via
+// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. This covers Quasar simple-command-buffer readback.
 TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteFromState) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInlineWriteFromState);
+        },
+        this->devices_[0]);
+}
+
+// Regression test for the inline-dw-write NOC sanitizer, exercised the way cq_noc_inline_dw_write_with_state
+// does: the destination is programmed into the WR_REG command buffer and then sanitized via
+// DEBUG_SANITIZE_NOC_ADDR_FROM_STATE. This covers Quasar complex-command-buffer readback.
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteWithState) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInlineWriteWithState);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -70,6 +70,7 @@ void kernel_main() {
     std::uint32_t mcast_dst_end_y = get_arg(args::mcast_dst_end_y);
     bool use_write_with_state = static_cast<bool>(get_arg(args::use_write_with_state));
     bool use_inline_dw_write_from_state = static_cast<bool>(get_arg(args::use_inline_dw_write_from_state));
+    bool use_inline_dw_write_with_state = static_cast<bool>(get_arg(args::use_inline_dw_write_with_state));
 
     // We will assert later. This kernel will hang.
     // Need to signal completion to dispatcher before hanging so that
@@ -149,14 +150,18 @@ void kernel_main() {
             {.noc_x = dst_noc_x, .noc_y = dst_noc_y, .addr = buffer_dst_addr});
         noc.async_write_barrier();
     } else if (use_inline_dw_write_from_state) {
-        // Mirror cq_noc_inline_dw_write_with_state: program the inline-write destination into the WR_REG
-        // command buffer, then sanitize it straight from those registers via DEBUG_SANITIZE_NOC_ADDR_FROM_STATE
-        // (the macro under test). The destination coordinate is invalid, so the sanitizer must flag the
-        // programmed target. We never issue the write -- the sanitizer hangs first, matching cq's
-        // sanitize-before-send ordering.
+        // set_state programs the inline/atomic command buffer (AT/simple on Quasar); sanitize reads that state back
+        // before issue.
         uint64_t dst = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
-        noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(
-            dst, local_buffer[0], 0xF, NCRISC_WR_REG_CMD_BUF, noc_index);
+        noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(dst, local_buffer[0], 0xF);
+        DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, write_at_cmd_buf);
+    } else if (use_inline_dw_write_with_state) {
+        // with_state mirrors cq_noc_inline_dw_write_with_state: program WR/complex command-buffer state, then
+        // sanitize before issue. CQ_NOC_send is 0, so the write is not issued.
+        uint64_t dst = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
+        noc_inline_dw_write_init_state<NCRISC_WR_REG_CMD_BUF, CQ_NOC_mkp>(noc_index, NOC_UNICAST_WRITE_VC);
+        noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, CQ_NOC_INLINE_NDVB, CQ_NOC_wait, CQ_NOC_send>(
+            noc_index, dst, local_buffer[0], 0xF);
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, NCRISC_WR_REG_CMD_BUF);
     } else {
         noc.async_write(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -156,6 +156,7 @@ void kernel_main() {
         noc_inline_dw_write_set_state<false /*posted*/, true /*set_val*/>(dst, local_buffer[0], 0xF);
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, write_at_cmd_buf);
     } else if (use_inline_dw_write_with_state) {
+#if defined(ARCH_WORMHOLE) || defined(ARCH_QUASAR)
         // with_state mirrors cq_noc_inline_dw_write_with_state: program WR/complex command-buffer state, then
         // sanitize before issue. CQ_NOC_send is 0, so the write is not issued.
         uint64_t dst = get_noc_addr(dst_noc_x, dst_noc_y, buffer_dst_addr);
@@ -163,6 +164,7 @@ void kernel_main() {
         noc_inline_dw_write_with_state<NCRISC_WR_REG_CMD_BUF, CQ_NOC_INLINE_NDVB, CQ_NOC_wait, CQ_NOC_send>(
             noc_index, dst, local_buffer[0], 0xF);
         DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, NCRISC_WR_REG_CMD_BUF);
+#endif
     } else {
         noc.async_write(
             local_buffer,

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -691,9 +691,17 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
         NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO),                                             \
         NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_AT_LEN_BE),                                                \
         false);
-// Used for inline writes, whose destination (coordinate + address) lives in NOC_TARG_ADDR. The low 32 bits
-// (NOC_TARG_ADDR_LO) must be OR'd in: a stray comma operator previously discarded them, leaving the local
-// offset reading as 0 and defeating the address check.
+// Used for inline writes. On tt-1xx, the destination lives in NOC_TARG_ADDR; on Quasar RoCC-backed command
+// buffers, the destination lives in DEST, exposed through the legacy NOC_RET_ADDR aliases.
+#if defined(ARCH_QUASAR)
+#define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                  \
+    DEBUG_SANITIZE_NOC_ADDR(                                                                                 \
+        noc_id,                                                                                              \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_MID) << 32) |                      \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_LO)),                              \
+        4);
+#else
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                   \
     DEBUG_SANITIZE_NOC_ADDR(                                                                                  \
         noc_id,                                                                                               \
@@ -701,6 +709,7 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_MID) << 32) |                      \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO)),                              \
         4);
+#endif
 #define DEBUG_SANITIZE_NOC_ADDR_(noc_id, a, l, check_linked)                                                     \
     debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ, check_linked); \
     LOG_LEN(l)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -133,7 +133,7 @@ inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc, uint32_t buf, uint32_t addr) {
-    // change NOC_TARG_ADDR_* to SRC_{ADDR,COORD}: remote side for reads, local side for writes
+    // NOC_TARG_ADDR_* -> cmd-buf SRC_{ADDR,COORD} (data source: remote for reads, local for writes)
     if (addr == NOC_TARG_ADDR_LO) {
         return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
             buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8);
@@ -145,7 +145,7 @@ inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc
         return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
             buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8);
     }
-    // change NOC_RET_ADDR_* to DEST_{ADDR,COORD}: local side for reads, remote side for writes
+    // NOC_RET_ADDR_* -> cmd-buf DEST_{ADDR,COORD} (data dest: local for reads, remote for writes)
     else if (addr == NOC_RET_ADDR_LO) {
         return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
             buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8);
@@ -172,8 +172,9 @@ inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc
     else if (addr == NOC_CMD_CTRL) {
         return 0;
     }
-    // NOC_NODE_ID and other NOC config registers are true MMIO - not cmd buf registers.
+    // NOC_NODE_ID and other NOC config registers are true MMIO globals - not cmd buf registers (buf-independent).
     else {
+        ASSERT(buf == 0);  // cmd-buf regs route through RoCC above; this path is globals-only
         uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
         return *((volatile uint32_t*)offset);
     }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -133,9 +133,50 @@ inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc, uint32_t buf, uint32_t addr) {
-    uintptr_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
-    volatile uint32_t* ptr = (volatile uint32_t*)offset;
-    return *ptr;
+    // change NOC_TARG_ADDR_* to SRC_{ADDR,COORD}: remote side for reads, local side for writes
+    if (addr == NOC_TARG_ADDR_LO) {
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8);
+    } else if (addr == NOC_TARG_ADDR_MID) {
+        return (uint32_t)(__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+                              buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8) >>
+                          32);
+    } else if (addr == NOC_TARG_ADDR_HI) {  // NOC_TARG_ADDR_COORDINATE aliases this
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8);
+    }
+    // change NOC_RET_ADDR_* to DEST_{ADDR,COORD}: local side for reads, remote side for writes
+    else if (addr == NOC_RET_ADDR_LO) {
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8);
+    } else if (addr == NOC_RET_ADDR_MID) {
+        return (uint32_t)(__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+                              buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8) >>
+                          32);
+    } else if (addr == NOC_RET_ADDR_HI) {  // NOC_RET_ADDR_COORDINATE aliases this
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_COORD_REG_OFFSET / 8);
+    }
+    // NOC_AT_LEN_BE aliases NOC_AT_LEN on Quasar
+    else if (addr == NOC_AT_LEN) {
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8);
+    }
+    // Inline write / atomic data value
+    else if (addr == NOC_AT_DATA) {
+        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
+            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_INLINE_DATA_REG_OFFSET / 8);
+    }
+    // NOC_CMD_CTRL is the transaction trigger on BH/WH (written as 0x1 to fire);
+    // on Quasar the trigger is cmdbuf_issue_trans() with no stored state.
+    else if (addr == NOC_CMD_CTRL) {
+        return 0;
+    }
+    // NOC_NODE_ID and other NOC config registers are true MMIO - not cmd buf registers.
+    else {
+        uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+        return *((volatile uint32_t*)offset);
+    }
 }
 
 inline __attribute__((always_inline)) uint32_t NOC_STATUS_REG_ADDR(uint32_t noc, uint32_t reg_id) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -132,51 +132,65 @@ inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(
     *ptr = val;
 }
 
+inline __attribute__((always_inline)) uint64_t NOC_CMD_BUF_READ_OVERLAY_REG(uint32_t buf, uint32_t reg_offset) {
+    // The AT buffer is backed by Quasar's simple command buffer; WR/RD buffers are regular indexed command buffers.
+    if (buf == OVERLAY_AT_CMD_BUF) {
+        return __builtin_riscv_ttrocc_scmdbuf_rd_reg(reg_offset / 8);
+    }
+    return __builtin_riscv_ttrocc_cmdbuf_rd_reg(buf, reg_offset / 8);
+}
+
 inline __attribute__((always_inline)) uint32_t NOC_CMD_BUF_READ_REG(uint32_t noc, uint32_t buf, uint32_t addr) {
-    // NOC_TARG_ADDR_* -> cmd-buf SRC_{ADDR,COORD} (data source: remote for reads, local for writes)
-    if (addr == NOC_TARG_ADDR_LO) {
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8);
-    } else if (addr == NOC_TARG_ADDR_MID) {
-        return (uint32_t)(__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-                              buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET / 8) >>
+    switch (addr) {
+        // NOC_TARG_ADDR_* -> cmd-buf SRC_{ADDR,COORD} (data source: remote for reads, local for writes)
+        case NOC_TARG_ADDR_LO:
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET);
+
+        case NOC_TARG_ADDR_MID:
+            return (
+                uint32_t)(NOC_CMD_BUF_READ_OVERLAY_REG(buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_ADDR_REG_OFFSET) >>
                           32);
-    } else if (addr == NOC_TARG_ADDR_HI) {  // NOC_TARG_ADDR_COORDINATE aliases this
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET / 8);
-    }
-    // NOC_RET_ADDR_* -> cmd-buf DEST_{ADDR,COORD} (data dest: local for reads, remote for writes)
-    else if (addr == NOC_RET_ADDR_LO) {
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8);
-    } else if (addr == NOC_RET_ADDR_MID) {
-        return (uint32_t)(__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-                              buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET / 8) >>
-                          32);
-    } else if (addr == NOC_RET_ADDR_HI) {  // NOC_RET_ADDR_COORDINATE aliases this
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_COORD_REG_OFFSET / 8);
-    }
-    // NOC_AT_LEN_BE aliases NOC_AT_LEN on Quasar
-    else if (addr == NOC_AT_LEN) {
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET / 8);
-    }
-    // Inline write / atomic data value
-    else if (addr == NOC_AT_DATA) {
-        return (uint32_t)__builtin_riscv_ttrocc_cmdbuf_rd_reg(
-            buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_INLINE_DATA_REG_OFFSET / 8);
-    }
-    // NOC_CMD_CTRL is the transaction trigger on BH/WH (written as 0x1 to fire);
-    // on Quasar the trigger is cmdbuf_issue_trans() with no stored state.
-    else if (addr == NOC_CMD_CTRL) {
-        return 0;
-    }
-    // NOC_NODE_ID and other NOC config registers are true MMIO globals - not cmd buf registers (buf-independent).
-    else {
-        ASSERT(buf == 0);  // cmd-buf regs route through RoCC above; this path is globals-only
-        uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
-        return *((volatile uint32_t*)offset);
+
+        case NOC_TARG_ADDR_HI:  // NOC_TARG_ADDR_COORDINATE aliases this
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_SRC_COORD_REG_OFFSET);
+
+        // NOC_RET_ADDR_* -> cmd-buf DEST_{ADDR,COORD} (data dest: local for reads, remote for writes)
+        case NOC_RET_ADDR_LO:
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET);
+
+        case NOC_RET_ADDR_MID:
+            return (uint32_t)(NOC_CMD_BUF_READ_OVERLAY_REG(
+                                  buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_ADDR_REG_OFFSET) >>
+                              32);
+
+        // NOC_RET_ADDR_COORDINATE aliases this
+        case NOC_RET_ADDR_HI:
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_DEST_COORD_REG_OFFSET);
+
+        // NOC_AT_LEN_BE aliases NOC_AT_LEN on Quasar
+        case NOC_AT_LEN:
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_LEN_BYTES_REG_OFFSET);
+
+        // Inline write / atomic data value
+        case NOC_AT_DATA:
+            return (uint32_t)NOC_CMD_BUF_READ_OVERLAY_REG(
+                buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_INLINE_DATA_REG_OFFSET);
+
+        // NOC_CMD_CTRL is the transaction trigger on BH/WH (written as 0x1 to fire);
+        // on Quasar the trigger is cmdbuf_issue_trans() with no stored state.
+        case NOC_CMD_CTRL: return 0;
+
+        // NOC_NODE_ID and other NOC config registers are true MMIO globals - not cmd buf registers (buf-independent).
+        default: {
+            ASSERT(buf == 0);  // cmd-buf regs route through RoCC above; this path is globals-only
+            uintptr_t offset = (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
+            return *((volatile uint32_t*)offset);
+        }
     }
 }
 


### PR DESCRIPTION
### PR Category
Bug fix https://github.com/tenstorrent/tt-metal/issues/45878

### Summary
On Quasar, NoC transactions are programmed into the RoCC command-buffer register file, not the legacy memory-mapped NoC window. The old `NOC_CMD_BUF_READ_REG` still read cmd-buf registers over MMIO, so it returned stale/garbage state instead of the transaction the hardware will actually execute - breaking the watcher NoC sanitizer  (`sanitize.h`) with state API used in dispatch and elsewhere, which reads these registers back to validate and report transactions.

This updates Quasar `NOC_CMD_BUF_READ_REG` to route overlay command-buffer register reads through RoCC readback:
- `OVERLAY_AT_CMD_BUF` reads from the simple command buffer via `__builtin_riscv_ttrocc_scmdbuf_rd_reg`
- `OVERLAY_WR_CMD_BUF` / `OVERLAY_RD_CMD_BUF` read from indexed command buffers via `__builtin_riscv_ttrocc_cmdbuf_rd_reg`

It also maps the legacy BH/WH register names to the corresponding Quasar RoCC fields:
- `NOC_TARG_ADDR_*` -> `SRC_{ADDR,COORD}`
- `NOC_RET_ADDR_*` -> `DEST_{ADDR,COORD}`
- `NOC_AT_LEN` / `NOC_AT_LEN_BE` -> `LEN_BYTES`
- `NOC_AT_DATA` -> `INLINE_DATA`
- `NOC_CMD_CTRL` -> `0`, since Quasar transactions fire through `issue_trans` rather than a stored trigger register

True NoC config globals (NOC_NODE_ID, etc.) keep the MMIO path, which is now globals-only and asserted to be buf-independent.

The watcher inline-write sanitizer also now reconstructs Quasar inline-write destinations from `NOC_RET_ADDR_*` / `DEST_*`, while tt-1xx continues using `NOC_TARG_ADDR_*`.

### Notes for reviewers
- Focus on the register-name to RoCC-offset mapping in NOC_CMD_BUF_READ_REG. Offsets are derived from `tt_rocc_accel_reg.h`
- The MMIO else branch intentionally drops the buf shift (globals are buf-independent) and now ASSERT(buf == 0) to catch misuse

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/28985922516

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/qsr_add_overlay_cmdbuf_noc_reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/qsr_add_overlay_cmdbuf_noc_reads)