### PR TITLE
[sweeps] quiesce mesh CQs before closing parent in all_gather teardown

### DIFF
--- a/tests/sweep_framework/sweep_utils/ccl_common.py
+++ b/tests/sweep_framework/sweep_utils/ccl_common.py
@@ -67,8 +67,8 @@ def device_context(mesh_shape, fabric_config, device_params=None, full_mesh_shap
                 # failure must never mask the real test result.
                 try:
                     parent_device.quiesce_devices()
-                except Exception as e:
-                    logger.warning(f"quiesce_devices during teardown failed: {e}")
+                except Exception:
+                    logger.opt(exception=True).warning("quiesce_devices during teardown failed")
                 ttnn.close_mesh_device(parent_device)
             elif mesh_device:
                 ttnn.close_mesh_device(mesh_device)

--- a/tests/sweep_framework/sweep_utils/ccl_common.py
+++ b/tests/sweep_framework/sweep_utils/ccl_common.py
@@ -59,6 +59,16 @@ def device_context(mesh_shape, fabric_config, device_params=None, full_mesh_shap
             # Closing the parent (full) mesh tears down its submeshes; only close the
             # standalone mesh directly when no parent was opened.
             if parent_device is not None:
+                # The carved submesh shares the parent's command queue. Closing the
+                # parent while that CQ is still flagged in-use throws
+                # "cq ID 0 is in use by child submesh" (mesh_device.cpp). quiesce_devices()
+                # drains the parent's and all submeshes' CQs and resets their in-use state
+                # (the only path that does so), so the close is clean. Guard it: a drain
+                # failure must never mask the real test result.
+                try:
+                    parent_device.quiesce_devices()
+                except Exception as e:
+                    logger.warning(f"quiesce_devices during teardown failed: {e}")
                 ttnn.close_mesh_device(parent_device)
             elif mesh_device:
                 ttnn.close_mesh_device(mesh_device)

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -293,6 +293,7 @@ void py_module(nb::module_& mod) {
         .def(
             "quiesce_devices",
             &MeshDevice::quiesce_devices,
+            nb::call_guard<nb::gil_scoped_release>(),
             R"doc(
               Drain all command queues of this MeshDevice and its submeshes and reset their
               in-use state. Call before closing a mesh that has carved submeshes so the shared

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -291,6 +291,14 @@ void py_module(nb::module_& mod) {
                     List[MeshDevice]: The submeshes created on this MeshDevice.
         )doc")
         .def(
+            "quiesce_devices",
+            &MeshDevice::quiesce_devices,
+            R"doc(
+              Drain all command queues of this MeshDevice and its submeshes and reset their
+              in-use state. Call before closing a mesh that has carved submeshes so the shared
+              command queue is idle, otherwise close throws "cq is in use by child submesh".
+        )doc")
+        .def(
             "compute_with_storage_grid_size",
             &MeshDevice::compute_with_storage_grid_size,
             R"doc(


### PR DESCRIPTION
## Summary

Fixes the "cq ID 0 is in use by child submesh" crash during sweep teardown when all_gather_async tests carve submeshes from a full Galaxy mesh.

**Passing CI run (validates fix):** https://github.com/tenstorrent/tt-metal/actions/runs/27052036258

### Problem

When `device_context` opens a full Galaxy mesh and carves a submesh via `create_submesh`, the submesh shares the parent's command queue. On teardown, `ttnn.close_mesh_device(parent_device)` throws because the shared CQ is still flagged as in-use by the child submesh.

### Fix

1. **`ccl_common.py`**: Call `parent_device.quiesce_devices()` before closing the parent mesh. This drains all CQs (parent + submeshes) and resets their in-use state — the only path that does so. Guarded with try/except so a drain failure doesn't mask the test result.

2. **`distributed_nanobind.cpp`**: Expose `MeshDevice::quiesce_devices()` to Python (was C++-only).

## Test plan
- [x] Run all_gather_async sweep on Galaxy — verified no "cq is in use" crash on teardown
- [x] Verify other sweep ops still pass (quiesce is only called when parent_device is not None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/sweeps_patch_glx)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/sweeps_patch_glx)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/sweeps_patch_glx)