### PR TITLE
[Bug fix] Align sharded distributed layernorm stats ordering

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py
@@ -256,8 +256,8 @@ def run_pre_allgather_layernorm(
                     frobenius_threshold=0.15,
                 )
             else:
-                tt_ex = tt_pre_allgather_torch[..., :1]
-                tt_ex2 = tt_pre_allgather_torch[..., 32:33]
+                tt_ex2 = tt_pre_allgather_torch[..., :1]
+                tt_ex = tt_pre_allgather_torch[..., 32:33]
                 torch_ex = torch.mean(torch_input_chunks[d], dim=-1, keepdim=True)
                 torch_ex2 = torch.mean(torch_input_chunks[d] ** 2, dim=-1, keepdim=True)
                 assert_numeric_metrics(
@@ -421,8 +421,8 @@ def test_post_allgather_layernorm(
             local_ex = torch.nn.functional.pad(local_ex, (0, 31), "constant", 0)
             local_ex2 = torch.mean(torch_input_chunks[d] ** 2, dim=-1, keepdim=True)
             local_ex2 = torch.nn.functional.pad(local_ex2, (0, 31), "constant", 0)
-            device_stats_list.append(local_ex)
             device_stats_list.append(local_ex2)
+            device_stats_list.append(local_ex)
 
     device_stats = torch.cat(device_stats_list, dim=-1)
     tt_device_stats = ttnn.from_torch(

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -130,14 +130,14 @@ void kernel_main() {
             cb_scaler_global_obj.wait_front(1);
             reduce_init<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(cb_stats, cb_scaler_global, cb_var);
             tile_regs_acquire();
-            // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
+            // striding over cb_stats, consisting [E(X^2), E(X)] from all the distributed devices in interleaved order
             for (uint32_t w = 0; w < stats_tiles * num_distributed_blocks; w++) {
                 reduce_tile<PoolType::AVG, ReduceDim::REDUCE_ROW, FLOAT32_REDUCTION>(
                     cb_stats,
                     cb_scaler_global,
                     0,
                     scaler0,
-                    w % stats_tiles);  // reducing E(x) and E(x^2) separately to different dst
+                    w % stats_tiles);  // reducing E(x^2) and E(x) separately to different dst
                 cb_stats_obj.pop_front(1);
             }
             tile_regs_commit();
@@ -146,8 +146,8 @@ void kernel_main() {
 #ifdef RMSNORM
             pack_tile(dst0, cb_var);
 #else
-            pack_tile(dst0, cb_stats_reduced);
-            pack_tile(dst1, cb_ex2);
+            pack_tile(dst1, cb_stats_reduced);
+            pack_tile(dst0, cb_ex2);
 #endif
             tile_regs_release();
             reduce_uninit();
@@ -166,7 +166,7 @@ void kernel_main() {
             cb_stats_reduced_obj.wait_front(1);
             tile_regs_acquire();
             mul_tiles_init(cb_stats_reduced, cb_stats_reduced);
-            mul_tiles(cb_stats_reduced, cb_stats_reduced, 0, 0, dst0);  // first tile in stats is always E(x)
+            mul_tiles(cb_stats_reduced, cb_stats_reduced, 0, 0, dst0);  // cb_stats_reduced stores E(x)
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex_sqr);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -172,7 +172,7 @@ void kernel_main() {
     cb_scaler_obj.wait_front(1);
 #endif  // RMSNORM
 
-    // RMS E(x2) #Layernorm //E(x) and E(x^2)
+    // Reduce the local x^2 partials. For layernorm, the final exported tile order is [E(x^2), E(x)].
     compute_kernel_lib::
         reduce<PoolType::AVG, ReduceDim::REDUCE_ROW, compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop>(
             cb_x2,
@@ -203,15 +203,15 @@ void kernel_main() {
                     cb_scaler_global,
                     0,
                     scaler0,
-                    w % num_tiles_per_partial_result);  // E(x) and E(x^2) interleaved so we reduce each one into
-                                                        // different dest reg
+                    w % num_tiles_per_partial_result);  // SUM(X) and SUM(X^2) are interleaved, so we reduce each one
+                                                        // into a different dest reg
                 cb_ex_external2_obj.pop_front(1);
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(dst0, cb_reduction_out);
-#ifndef RMSNORM
             pack_tile(dst1, cb_reduction_out);
+#ifndef RMSNORM
+            pack_tile(dst0, cb_reduction_out);
 #endif
             tile_regs_release();
         }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -24,8 +24,8 @@ void kernel_main() {
     const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(2);
     const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(3);
 
-    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // [E[x], E[x^2]] local to sender
-    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // [E[x], E[X^2]] global to all cores
+    constexpr uint32_t cb_stats_reduced = tt::CBIndex::c_21;  // [E[x^2], E[x]] local to sender
+    constexpr uint32_t cb_ex_global = tt::CBIndex::c_15;      // [E[x^2], E[x]] global to all cores
 
     Noc noc;
     Semaphore<> reduce_sender_sem(get_compile_time_arg_val(1));

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -210,7 +210,7 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
         if (operation_attributes.norm_type == LayerNormType::LAYERNORM) {
             TT_FATAL(
                 stats.value().padded_shape()[-1] % (2 * tile_width) == 0,
-                "Stats is expected to have E(x) and E(x^2) for each device stacked interleaved in the last dimension");
+                "Stats is expected to have E(x^2) and E(x) for each device stacked interleaved in the last dimension");
         } else {
             TT_FATAL(
                 stats.value().padded_shape()[-1] % tile_width == 0,


### PR DESCRIPTION
PR Category
Bug fix

Summary
The sharded distributed layernorm path used a different per-device stats tile order from the dedicated distributed layernorm path for layer_norm_post_all_gather.

The dedicated distributed post-allgather kernels consume stats as [E(x^2), E(x)] per device. The sharded pre path, sharded post path, and the sharded manual-stats unit test were still producing or expecting [E(x), E(x^2)].

This change aligns the sharded path with the existing distributed contract by updating the sharded pre/post kernels, the sharded validator text, and the sharded unit test expectations.

Notes for reviewers
Please review the sharded pre/post contract boundary first.

The dedicated distributed post-allgather kernels already reduce stats in [sum(x^2), sum(x)] order, and the sharded unit test now checks the same per-device tile order in both the pre-allgather and manual-stats post-allgather paths.

Validation boundary:
git diff --check
python3 -m py_compile tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm_sharded.py

I did not use the local mock setup as numeric proof for this path. In the available mock environment, both sharded and dedicated layer_norm_post_all_gather paths collapse to zero outputs, so that setup is not a trustworthy oracle for this bug.
