### PR TITLE
Fix Gemma4 accuracy issues found by AutoFix

### DIFF
--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -76,6 +76,7 @@ class Gemma4Attention:
         max_seq_len=131072,
         weight_dtype=ttnn.bfloat16,
         bounded_sliding_kv_cache: bool = False,
+        is_kv_shared: bool = False,
         # Legacy parameter — ignored (no longer needed with HF-style RoPE)
         transformation_mats=None,
     ):
@@ -104,6 +105,7 @@ class Gemma4Attention:
             mesh_config=mesh_config,
             tensor_cache_path=tensor_cache_path,
             weight_dtype=weight_dtype,
+            is_kv_shared=is_kv_shared,
         )
 
         if create_kv_cache:

--- a/models/demos/gemma4/tt/attention/weights.py
+++ b/models/demos/gemma4/tt/attention/weights.py
@@ -42,6 +42,7 @@ def load_attention_weights(
     mesh_config: MeshConfig,
     weight_dtype=ttnn.bfloat16,
     tensor_cache_path=None,
+    is_kv_shared=False,
 ) -> AttentionWeights:
     """
     Load and fuse attention weights with tensor parallelism.
@@ -65,10 +66,18 @@ def load_attention_weights(
 
     if state_dict:
         q_w = state_dict["q_proj.weight"]  # [q_size, H]
-        k_w = state_dict["k_proj.weight"]  # [kv_size, H]
+        if is_kv_shared:
+            k_w = state_dict.get("k_proj.weight", torch.zeros(kv_size, hidden_size, dtype=q_w.dtype, device=q_w.device))
+        else:
+            k_w = state_dict["k_proj.weight"]  # [kv_size, H]
 
         if not is_global:
-            v_w = state_dict["v_proj.weight"]  # [kv_size, H]
+            if is_kv_shared:
+                v_w = state_dict.get(
+                    "v_proj.weight", torch.zeros(kv_size, hidden_size, dtype=q_w.dtype, device=q_w.device)
+                )
+            else:
+                v_w = state_dict["v_proj.weight"]  # [kv_size, H]
         else:
             v_w = k_w  # K=V tying: duplicate K as V
 
@@ -115,8 +124,15 @@ def load_attention_weights(
             o_w = torch.nn.functional.pad(o_w, (0, padded_hidden - hidden_size), "constant", 0.0)
 
         # Per-head norm weights: [head_dim] -> [1, 1, head_dim/TILE_SIZE, TILE_SIZE]
-        q_norm_w = state_dict["q_norm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
-        k_norm_w = state_dict["k_norm.weight"].reshape(1, 1, -1, ttnn.TILE_SIZE)
+        q_norm = state_dict["q_norm.weight"]
+        q_norm_w = q_norm.reshape(1, 1, -1, ttnn.TILE_SIZE)
+        if is_kv_shared:
+            k_norm = state_dict.get(
+                "k_norm.weight", torch.zeros(config.head_dim, dtype=q_norm.dtype, device=q_norm.device)
+            )
+        else:
+            k_norm = state_dict["k_norm.weight"]
+        k_norm_w = k_norm.reshape(1, 1, -1, ttnn.TILE_SIZE)
     else:
         qkv = None
         o_w = None

--- a/models/demos/gemma4/tt/layer.py
+++ b/models/demos/gemma4/tt/layer.py
@@ -69,6 +69,7 @@ class Gemma4DecoderLayer:
         experts_dtype=None,
         router_dtype=None,
         bounded_sliding_kv_cache: bool = False,
+        is_kv_shared: bool = False,
         transformation_mats=None,  # Legacy — ignored (HF-style RoPE needs no transformation mats)
     ):
         # Per-module dtype overrides default to the model-wide ``dtype`` so
@@ -138,6 +139,7 @@ class Gemma4DecoderLayer:
             tensor_cache_path=f"{tensor_cache_path}/layer_{layer_idx}/self_attn" if tensor_cache_path else None,
             weight_dtype=attention_dtype,
             bounded_sliding_kv_cache=bounded_sliding_kv_cache,
+            is_kv_shared=is_kv_shared,
         )
 
         # Shared/dense MLP (HF key: "mlp")
@@ -293,7 +295,7 @@ class Gemma4DecoderLayer:
         if self.hidden_size_per_layer_input and per_layer_input is not None and hasattr(self, "per_layer_input_gate"):
             residual_pli = hidden_states
             gated = ttnn.linear(hidden_states, self.per_layer_input_gate)
-            gated = ttnn.gelu(gated, fast_and_approximate_mode=True)
+            gated = ttnn.gelu(gated, fast_and_approximate_mode=False)
             gated = ttnn.mul(gated, per_layer_input)
             projected = ttnn.linear(gated, self.per_layer_projection)
             normed_pli = self.post_per_layer_input_norm.forward(projected)

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -129,7 +129,9 @@ class Gemma4Model:
         self.hidden_size = hf_config.hidden_size
         self.vocab_size = hf_config.vocab_size
         self.final_logit_softcapping = hf_config.final_logit_softcapping
-        self.embed_scale = hf_config.hidden_size**0.5
+        # HF stores Gemma4TextScaledWordEmbedding.embed_scale as a BF16
+        # buffer, so sqrt(hidden_size) is rounded before multiplying.
+        self.embed_scale = torch.tensor(hf_config.hidden_size**0.5, dtype=torch.bfloat16).item()
         self.ccl_manager = ccl_manager
         self.max_seq_len = max_seq_len
         self.hidden_size_per_layer_input = getattr(hf_config, "hidden_size_per_layer_input", 0) or 0
@@ -154,8 +156,11 @@ class Gemma4Model:
 
         # KV sharing map: layers after (full_n_layers - num_kv_shared_layers) share KV
         # from the last non-shared layer of the same type
-        full_n_layers = hf_config.num_hidden_layers
+        full_n_layers = (
+            len(hf_config.layer_types) if getattr(hf_config, "layer_types", None) else hf_config.num_hidden_layers
+        )
         num_kv_shared = getattr(hf_config, "num_kv_shared_layers", 0) or 0
+        num_kv_shared = max(0, min(num_kv_shared, full_n_layers))
         first_shared_idx = full_n_layers - num_kv_shared
         self.kv_shared_layer_map = {}  # layer_idx -> source_layer_idx
         if num_kv_shared > 0 and first_shared_idx < n_layers:
@@ -302,6 +307,7 @@ class Gemma4Model:
                 max_seq_len=max_seq_len,
                 max_local_batch_size=max_local_batch_size,
                 bounded_sliding_kv_cache=bounded_sliding_kv_cache,
+                is_kv_shared=i in self.kv_shared_layer_map,
             )
             # Create KV cache for non-shared layers only
             # Shared layers will use their source layer's KV cache
@@ -428,9 +434,11 @@ class Gemma4Model:
         pli_embed = F.embedding(input_ids_torch.long(), embed_w) * self.per_layer_embed_scale
         pli_embed = pli_embed.reshape(*input_ids_torch.shape, full_n_layers, pli_size)
 
-        # 2. Projection from main embeddings
+        # 2. Projection from main embeddings. HF runs the Linear in the
+        # module dtype (BF16 for Gemma4 checkpoints) and only upcasts inside
+        # RMSNorm, so keep the same dtype path here.
         proj_w = w["per_layer_model_projection"]  # [full_n_layers * pli_size, hidden]
-        pli_proj = F.linear(embeds_torch.float(), proj_w.float()) * self.per_layer_model_projection_scale
+        pli_proj = F.linear(embeds_torch.to(proj_w.dtype), proj_w) * self.per_layer_model_projection_scale
         pli_proj = pli_proj.reshape(*embeds_torch.shape[:-1], full_n_layers, pli_size)
 
         # 3. Norm the projection
@@ -438,10 +446,10 @@ class Gemma4Model:
         eps = self.hf_config.rms_norm_eps
         pli_proj_f = pli_proj.float()
         var = pli_proj_f.pow(2).mean(-1, keepdim=True)
-        pli_proj = (pli_proj_f * torch.rsqrt(var + eps) * norm_w.float()).to(pli_proj.dtype)
+        pli_proj = (pli_proj_f * torch.pow(var + eps, -0.5) * norm_w.float()).to(pli_proj.dtype)
 
         # 4. Combine: (projection + embed) * scale
-        per_layer_inputs = (pli_proj + pli_embed.float()) * self.per_layer_input_scale
+        per_layer_inputs = (pli_proj + pli_embed) * self.per_layer_input_scale
 
         # Return as list of per-layer tensors
         return [per_layer_inputs[:, :, i, :].to(torch.bfloat16) for i in range(n_layers)]

--- a/models/demos/gemma4/tt/shared_mlp.py
+++ b/models/demos/gemma4/tt/shared_mlp.py
@@ -101,7 +101,7 @@ class SharedMLP:
         """
         # gate = GELU(x @ gate_proj)
         gate = ttnn.linear(hidden_states, self.gate_proj)
-        gate = ttnn.gelu(gate, fast_and_approximate_mode=True)
+        gate = ttnn.gelu(gate, fast_and_approximate_mode=False)
 
         # up = x @ up_proj
         up = ttnn.linear(hidden_states, self.up_proj)


### PR DESCRIPTION
## Summary
- Fix Gemma4 shared-KV layer construction so shared layers tolerate missing K/V projection and K-norm weights while still loading their Q/O weights.
- Match HF Gemma4 numerics more closely by using exact GELU and BF16 embedding/per-layer-input arithmetic.
- This patch was generated by a Codex AutoFix/AutoDebug run, then applied as a clean focused commit with pre-commit formatting.

## AutoFix / AutoDebug provenance
- Generated by a standalone Codex AutoFix/AutoDebug debug run on `wh-lb-90` under `/localdev/moconnor/gemma4-existing-debug`.
- Target was the existing repo implementation under `models/demos/gemma4`, checkpoint `google/gemma-4-E2B-it`, not an autoport.
- The run kept only hypotheses it verified with focused experiments and reverted refuted experiments.
- Final AutoFix report recorded remaining top-1 misses as top-1/top-2 swaps from accumulated hidden-state numerical drift before final norm/LM head, with no remaining verified semantic bug.

## Evidence
Reference generation:
```bash
HF_HOME=/localdev/moconnor/gemma4-existing-debug/hf_cache \
python -m models.common.readiness_check.generate \
  --hf-model google/gemma-4-E2B-it \
  --prompt-len 128 \
  --gen-len 256 \
  --top-k 100 \
  --num-entries 1 \
  --output /localdev/moconnor/gemma4-existing-debug/gemma4_e2b_p128_g256.refpt
```

Final eval:
```bash
HF_HOME=/localdev/moconnor/gemma4-existing-debug/hf_cache \
HF_HUB_OFFLINE=1 \
HF_MODEL=google/gemma-4-E2B-it \
TT_CACHE_PATH=/localdev/moconnor/gemma4-existing-debug/tt_cache/google--gemma-4-E2B-it \
python /localdev/moconnor/gemma4-existing-debug/gemma4_topk_eval.py \
  --model google/gemma-4-E2B-it \
  --reference /localdev/moconnor/gemma4-existing-debug/gemma4_e2b_p128_g256.refpt \
  --mesh-device N150 \
  --max-seq-len 512 \
  --page-block-size 64 \
  --prefill-len 128 \
  --progress-interval 32 \
  --output-json /localdev/moconnor/gemma4-existing-debug/e2b_n150_p128_g256_final_current.json
```

Final metrics from the AutoFix run:
- `top1=0.91796875` (`235/256`)
- `top5=1.0` (`256/256`)
- Top-5 misses: none
- Earlier verified shared-KV fix result: `top1=224/256`, `top5=255/256`
- Final kept fixes combined with exact GELU and BF16 PLI/embed arithmetic: `top1=235/256`, `top5=256/256`

Refuted and reverted experiments included LM-head FP32, broad dense-linear HiFi3/FP32, RMSNorm HiFi3/FP32, disabling decode sliding window, SDPA decode HiFi3/FP32, and attention FP32 weights.

## Local verification
- `python -m py_compile models/demos/gemma4/tt/attention/__init__.py models/demos/gemma4/tt/attention/weights.py models/demos/gemma4/tt/layer.py models/demos/gemma4/tt/model.py models/demos/gemma4/tt/shared_mlp.py`
- Commit hooks passed: trailing whitespace, end-of-file, black, autoflake, isort, large-file check, Metal include validation, and related pre-commit checks.

## CI Badge
Not triggered yet.

### CI Status

[![All Model Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gemma4-autofix-topk-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml)