### PR TITLE
Fix BFP2/BFP4 unpack format inference

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -139,12 +139,12 @@ def infer_unpack_out(
     if input_format.is_mx_format():
         return DataFormat.Float16_b
 
-    # Sub-byte BFP formats can only exist in L1.
-    # The Wormhole HW unpacker only supports BFP4_b → BFP8_b conversion
-    # (not BFP4_b → Float16_b). The unpacker expands 4-bit mantissas to 8-bit
-    # in the BFP8_b register format, preserving the shared exponent structure.
+    # Sub-byte BFP formats can only exist in L1. For UNPACR configuration,
+    # BFP2/BFP4/BFP8 inputs keep matching InDataFormat/OutDataFormat values;
+    # the unpacker internally normalizes the datum into the BF16 source-register
+    # representation before math consumes it.
     if input_format in [DataFormat.Bfp4_b, DataFormat.Bfp2_b]:
-        return DataFormat.Bfp8_b
+        return input_format
 
     if (
         input_format == DataFormat.Float32


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`data_format_inference.py` was inferring `Bfp2_b`/`Bfp4_b` L1 inputs as unpacking to `Bfp8_b`, and the surrounding comment incorrectly described the unpacker as expanding sub-byte BFP mantissas into a `Bfp8_b` register format. That is not the actual programming model: for UNPACR, BFP2/4/8 inputs use matching `InDataFormat`/`OutDataFormat` values, and the unpacker internally decodes those block-float values into the BF16-style source-register representation consumed by math. The change keeps the inferred unpack output format equal to the input format for `Bfp2_b` and `Bfp4_b`, avoiding UndefinedBehavior, and updates the comment to describe the actual hardware contract. This avoids programming an invalid `BFP4 -> BFP8` unpack format pair and removes a misleading explanation that implied a nonexistent BFP8 register representation.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-unpack-fmt-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-unpack-fmt-inference)