### PR TITLE
emule: drop tilize-kernel TRISC-skip; let the compute path run

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1266,23 +1266,7 @@ static void collect_kernels(
             // bodies and the downstream `where_tile` reads stale data. Define
             // all three so the kernel's `#ifdef TRISC_*` blocks execute exactly
             // once on the unified thread.
-            //
-            // EXCEPT for tilize kernels: emule's host-side
-            // `tilize_with_val_padding` already produces tiled data, so an
-            // additional kernel-side tilize would re-tilize and corrupt the
-            // layout. Skip TRISC defines when the kernel source mentions
-            // `llk_unpack_tilize` (the tilize compute path).
-            bool is_tilize_kernel = false;
             if (is_tensix && !is_quasar_compute) {
-                std::ifstream kscan(src_path);
-                if (!kscan) {
-                    throw std::runtime_error(
-                        "collect_kernels: cannot read kernel source for TRISC-define gating: " + src_path);
-                }
-                std::string content((std::istreambuf_iterator<char>(kscan)), std::istreambuf_iterator<char>());
-                is_tilize_kernel = content.find("llk_unpack_tilize") != std::string::npos;
-            }
-            if (is_tensix && !is_quasar_compute && !is_tilize_kernel) {
                 defines["TRISC_UNPACK"] = "1";
                 defines["TRISC_MATH"] = "1";
                 defines["TRISC_PACK"] = "1";


### PR DESCRIPTION
## Summary

Remove the source-grep skip in `emulated_program_runner.cpp` that suppressed `TRISC_UNPACK/MATH/PACK` defines whenever a kernel source mentioned `llk_unpack_tilize`. The skip was a workaround for an emule-side shortcut where `compute_kernel_lib::tilize` memcpy'd input pages to output pages and relied on host-side tilization having already produced TILE-layout L1 bytes.

That shortcut is being removed in the companion tt-emule change (`include/jit_hw/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp` now calls the canonical `tilize_block`, doing a real RM→nfaces conversion). With the real conversion in place, the device tilize op needs the TRISC defines to run end-to-end — exactly what this PR re-enables.

## Why this matters

ttnn's distributed-mapper path (`construct_on_mesh_device=true`) lands RM bytes in L1 and dispatches a tilize op to convert them to TILE. With the skip active, that op no-op'd and the RM bytes stayed in L1; any downstream kernel that read the CB directly (e.g. matmul with `WIDTH_SHARDED` weights) saw row-major bytes where it expected nfaces face-packed tiles, producing garbage output.

## Test plan

Curated ttnn pytest CI suite (`scripts/run_ttnn_pytests_{wormhole,blackhole}.sh`) on both architectures:

| Arch | Baseline | This PR | Δ |
|---|---|---|---|
| Wormhole (N150) | 65P / 31F | **68P / 28F** | +3 / −3 |
| Blackhole (P100) | 66P / 31F | **69P / 28F** | +3 / −3 |

Identical 3 entries flip FAIL → PASS on both arches:
- `dm_test_repeat_interleave`
- `bf_test_roll`
- `bf_test_to_layout` (the canonical RM→TILE path)

**0 PASS → FAIL** regressions on either arch.

## Dependency

Requires the corresponding emule shim change in `include/jit_hw/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp` (separate PR to tt-emule). Without it the device tilize will run but use the broken memcpy shim. The two changes ship together.

## Test plan checklist

- [x] Wormhole ttnn pytest CI suite: +3 PASS, 0 regression
- [x] Blackhole ttnn pytest CI suite: +3 PASS, 0 regression
- [x] Companion tt-emule shim change verified locally

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-updates)