### PR TITLE
[Quasar][LLK] Remove redundant unpack_to_dest template param (#43769)

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -66,9 +66,9 @@ inline void llk_unpack_A_init(
                     operand_id, tensor_shape, 1);
             }
         } else {
-            constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_A : p_unpacr::UNP_B;
+            constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_B;
             constexpr bool is_fp32_dest_acc_en = unpack_to_dest ? false : DST_ACCUM_MODE;
-            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, unpack_to_dest, is_fp32_dest_acc_en>(
+            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, is_fp32_dest_acc_en>(
                 operand_id, 1);
         }
     }
@@ -81,7 +81,7 @@ inline void llk_unpack_A_init(
  * @tparam BType: Broadcast type; BroadcastType::NONE selects the plain unary path
  * @tparam acc_to_dest: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @tparam binary_reuse_dest: Dest reuse mode (unary path only)
- * @tparam unpack_to_dest: Broadcast path only — when true, unpack targets dest (UNP_A); otherwise SrcB (UNP_B)
+ * @tparam unpack_to_dest: Broadcast path only — when true, unpack targets dest (UNP_DEST); otherwise SrcB (UNP_B)
  * @param operand: The logical dataflow buffer id
  * @param tile_index: The index in the input CB to read from
  */
@@ -100,8 +100,8 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
         _llk_unpack_unary_operand_<p_unpacr::UNP_A, binary_reuse_dest>(l1_tile_idx, tensor_shape);
     } else {
-        constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_A : p_unpacr::UNP_B;
-        _llk_unpack_unary_broadcast_operands_<unp_sel, unpack_to_dest>(l1_tile_idx);
+        constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_B;
+        _llk_unpack_unary_broadcast_operands_<unp_sel>(l1_tile_idx);
     }
     WAYPOINT("UPAD");
 }
@@ -112,7 +112,7 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
  * @tparam BType: Broadcast type; BroadcastType::NONE selects the plain unary path
  * @tparam acc_to_dest: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @tparam binary_reuse_dest: Dest reuse mode (unary path only)
- * @tparam unpack_to_dest: Broadcast path only — when true, unpack targets dest (UNP_A); otherwise SrcB (UNP_B)
+ * @tparam unpack_to_dest: Broadcast path only — when true, unpack targets dest (UNP_DEST); otherwise SrcB (UNP_B)
  * @param operand: The logical dataflow buffer id
  * @param start_tile_index: The starting tile index within the input buffer
  * @param ntiles: The number of consecutive tiles to unpack
@@ -134,8 +134,8 @@ inline void llk_unpack_A_block(
         if constexpr (BType == BroadcastType::NONE) {
             _llk_unpack_unary_operand_<p_unpacr::UNP_A, binary_reuse_dest>(rd_entry_idx + tile_index, tensor_shape);
         } else {
-            constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_A : p_unpacr::UNP_B;
-            _llk_unpack_unary_broadcast_operands_<unp_sel, unpack_to_dest>(rd_entry_idx + tile_index);
+            constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_B;
+            _llk_unpack_unary_broadcast_operands_<unp_sel>(rd_entry_idx + tile_index);
         }
         WAYPOINT("UPAD");
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -86,18 +86,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if constexpr (unpack_to_dest)
     {
-        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_A, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id_a, 1);
+        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_DEST, BROADCAST_TYPE, is_fp32_dest_acc_en>(buf_desc_id_a, 1);
         for (std::uint32_t i = 0; i < num_tiles_per_unpack; ++i)
         {
-            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_A, unpack_to_dest>(i);
+            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_DEST>(i);
         }
     }
     else
     {
-        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id_b, 1);
+        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, BROADCAST_TYPE, is_fp32_dest_acc_en>(buf_desc_id_b, 1);
         for (std::uint32_t i = 0; i < num_tiles_per_unpack; ++i)
         {
-            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_B, unpack_to_dest>(i);
+            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_B>(i);
         }
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
@@ -17,22 +17,30 @@ using namespace ckernel;
 /**
  * @brief Builds the MOP for unpacking unary broadcast operands.
  *
- * @tparam UNP_SEL: Unpacker select; must be UNP_B unless unpack_to_dest (then UNP_A), values = <p_unpacr::UNP_A/UNP_B>
+ * @tparam UNP_SEL: Unpacker select; UNP_DEST means "unpack targets math dest" (formerly the
+ *         unpack_to_dest = true case), UNP_B means "unpack targets srcB" (the default path).
+ *         UNP_A and UNP_S are not supported on the broadcast path on Quasar (movA2D broadcast is
+ *         not working). UNP_DEST shares UNP_A's counter hardware, so counter instructions use UNP_A.
+ *         values = <p_unpacr::UNP_DEST/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: When true, unpack targets math dest (UNP_A); otherwise SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Float32 dest accumulation enable. Must be false when unpack_to_dest is true
- *         until that path is supported (enforced by static_assert below), values = <true/false>
+ * @tparam is_fp32_dest_acc_en: Float32 dest accumulation enable. Must be false when UNP_SEL is UNP_DEST
+ *         (dest path) until that path is supported (enforced by static_assert below), values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Outer MOP loop count (tiles to unpack from L1).
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     static_assert(
-        unpack_to_dest || (UNP_SEL == p_unpacr::UNP_B),
-        "UNP_SEL must be p_unpacr::UNP_B when unpack_to_dest is false - movA2D broadcast is not working on Quasar");
+        (UNP_SEL == p_unpacr::UNP_DEST) || (UNP_SEL == p_unpacr::UNP_B),
+        "UNP_SEL must be p_unpacr::UNP_DEST (dest path) or p_unpacr::UNP_B (srcB path) - "
+        "UNP_A/UNP_S are not supported and movA2D broadcast is not working on Quasar");
     static_assert((BROADCAST_TYPE != BroadcastType::NONE), "Broadcast type cannot be NONE for this operation");
-    static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
+    static_assert(
+        !((UNP_SEL == p_unpacr::UNP_DEST) && is_fp32_dest_acc_en),
+        "Unary broadcast: dest path (UNP_SEL == UNP_DEST) with Float32 dest accumulation is not supported yet");
+
+    constexpr bool unpack_to_dest = (UNP_SEL == p_unpacr::UNP_DEST);
 
     const std::uint32_t MOP_OUTER_LOOP            = num_tiles;
     constexpr std::uint32_t MOP_INNER_LOOP        = 1;
@@ -94,15 +102,9 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
             });
     }
 
-    std::uint32_t inc_src_tile_instrn;
-    if constexpr (unpack_to_dest)
-    {
-        inc_src_tile_instrn = TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 1);
-    }
-    else
-    {
-        inc_src_tile_instrn = TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, 1);
-    }
+    // UNP_DEST shares UNP_A's counter hardware, so use UNP_A for counter instructions.
+    constexpr std::uint32_t inc_src_tile_unp_sel = (UNP_SEL == p_unpacr::UNP_DEST) ? p_unpacr::UNP_A : UNP_SEL;
+    const std::uint32_t inc_src_tile_instrn = TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, inc_src_tile_unp_sel, 1);
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), inc_src_tile_instrn);
     temp.program_bank0_sw_cntl(instrn_buffer);
@@ -111,37 +113,38 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
 /**
  * @brief Initializes the unpacker for unary operations with broadcasts.
  *
- * @tparam UNP_SEL: Unpacker resource; must be UNP_B unless unpack_to_dest, values = <p_unpacr::UNP_A/UNP_B>
+ * @tparam UNP_SEL: Unpacker resource; must be p_unpacr::UNP_DEST (dest path) or p_unpacr::UNP_B (srcB path), values = <p_unpacr::UNP_DEST/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: Route unpack to dest (UNP_A) vs SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Forwarded to mop_config; must be false when unpack_to_dest is true, values = <true/false>
+ * @tparam is_fp32_dest_acc_en: Forwarded to mop_config; must be false when UNP_SEL is UNP_DEST (dest path), values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Number of tiles in the outer unpack loop.
- * @note On the math thread, pair with @ref _llk_math_eltwise_unary_broadcast_init_ (T1) with matching BROADCAST_TYPE/unpack_to_dest.
+ * @note On the math thread, pair with @ref _llk_math_eltwise_unary_broadcast_init_ (T1) with matching BROADCAST_TYPE/UNP_SEL.
  * @note @ref _llk_unpack_unary_broadcast_operands_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_unary_broadcast_operands_init_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
-    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
 }
 
 /**
  * @brief Runs the bank0 unpack MOP for one invocation (sets tile/face indices then executes the replay).
  *
- * @tparam UNP_SEL: Logical unpack select for static checks; counter uses UNP_A when unpack_to_dest, values = <p_unpacr::UNP_A/UNP_B>
- * @tparam unpack_to_dest: Use the UNP_A dest path vs the UNP_B SrcB path, values = <true/false>
+ * @tparam UNP_SEL: Unpacker select; must be p_unpacr::UNP_DEST (dest path) or p_unpacr::UNP_B (srcB path), values = <p_unpacr::UNP_DEST/UNP_B>
  * @param start_l1_tile_idx: Starting source tile index for face/row counters.
+ * @note Counter instructions use UNP_A when UNP_SEL is UNP_DEST (shared counter hardware).
  * @note Call @ref _llk_unpack_unary_broadcast_operands_init_ with matching template args before this function.
  */
-template <std::uint32_t UNP_SEL, bool unpack_to_dest = false>
+template <std::uint32_t UNP_SEL>
 inline void _llk_unpack_unary_broadcast_operands_(const std::uint32_t start_l1_tile_idx)
 {
     static_assert(
-        unpack_to_dest || (UNP_SEL == p_unpacr::UNP_B),
-        "UNP_SEL must be p_unpacr::UNP_B when unpack_to_dest is false - movA2D broadcast is not working on Quasar");
+        (UNP_SEL == p_unpacr::UNP_DEST) || (UNP_SEL == p_unpacr::UNP_B),
+        "UNP_SEL must be p_unpacr::UNP_DEST (dest path) or p_unpacr::UNP_B (srcB path) - "
+        "UNP_A/UNP_S are not supported and movA2D broadcast is not working on Quasar");
 
-    constexpr std::uint32_t counter_unp_sel = unpack_to_dest ? p_unpacr::UNP_A : UNP_SEL;
+    // UNP_DEST shares UNP_A's counter hardware, so use UNP_A for counter instructions.
+    constexpr std::uint32_t counter_unp_sel = (UNP_SEL == p_unpacr::UNP_DEST) ? p_unpacr::UNP_A : UNP_SEL;
     TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, counter_unp_sel, start_l1_tile_idx);
     TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, counter_unp_sel, 0);
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);


### PR DESCRIPTION
## Summary

Closes #43769.

`_llk_unpack_unary_broadcast_operands_{mop_config,init,}` previously took two related template params:
- `std::uint32_t UNP_SEL` (with a `static_assert` restricting it to `UNP_B` except when `unpack_to_dest` was true)
- `bool unpack_to_dest` (which, when true, forced the dest path and effectively meant "treat UNP_SEL as UNP_A")

The two were never independent. In every caller (`llk_unpack_A_api.h`, `eltwise_unary_broadcast_quasar_test.cpp`):
- `unpack_to_dest = true`  always paired with  `UNP_SEL = UNP_A`
- `unpack_to_dest = false` always paired with  `UNP_SEL = UNP_B`

Following the convention in `llk_unpack_unary_operand.h` (single `UNP_SEL` covering `UNP_A`/`UNP_B`/`UNP_DEST`), this PR collapses the two into `UNP_SEL` alone:

- `UNP_SEL == p_unpacr::UNP_A` means "unpack targets math dest" (formerly `unpack_to_dest == true`)
- `UNP_SEL == p_unpacr::UNP_B` means "unpack targets srcB" (the default path)

The updated `static_assert` enforces `UNP_SEL` must be `UNP_A` or `UNP_B`. `UNP_DEST` and `UNP_S` remain unsupported on the broadcast path and `movA2D` broadcast is still not working on Quasar, so the constraint is at least as strict as before.

## Files

| File | Change |
| --- | --- |
| `tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h` | Remove `unpack_to_dest` template param from the three internal functions; rewrite `static_assert`; introduce local `constexpr bool unpack_to_dest = (UNP_SEL == p_unpacr::UNP_A)` to keep `if constexpr` blocks readable; collapse the `inc_src_tile_instrn` `if/else` since both branches selected the same unpacker after the simplification. |
| `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h` | Update the three internal call sites to drop the now-removed `unpack_to_dest` template argument. Public `llk_unpack_A_*` API surface (which still takes `unpack_to_dest`) is unchanged. |
| `tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp` | Update the two internal call sites for the test. |

## Behaviour preservation

- `unpack_to_dest = true,  UNP_SEL = UNP_A` -> `UNP_SEL = UNP_A` (dest path, identical body)
- `unpack_to_dest = false, UNP_SEL = UNP_B` -> `UNP_SEL = UNP_B` (srcB path, identical body)

No other `(UNP_SEL, unpack_to_dest)` combination existed in any caller, and the original `static_assert` would have rejected them. The new `static_assert` rejects the same set (and additionally `UNP_DEST`/`UNP_S`, which were already implicitly rejected by the old check via `unpack_to_dest=false && UNP_SEL != UNP_B`).

## Public API impact

None. `llk_unpack_A_init`, `llk_unpack_A`, `llk_unpack_A_block` in `llk_unpack_A_api.h` keep their `unpack_to_dest` template parameter. The function still translates `unpack_to_dest` to `UNP_A`/`UNP_B` internally (it already did this) before forwarding into the `llk_lib` layer. No kernel using the public API needs to change.

## Reference

`tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h` already follows this pattern: it accepts `UNP_SEL` covering `UNP_A`/`UNP_B`/`UNP_DEST` and has no separate `unpack_to_dest` flag. This PR brings the broadcast path to the same shape.

## Testing notes

The test file (`eltwise_unary_broadcast_quasar_test.cpp`) was updated to use the new signatures. Local build was not run; please verify on the Quasar CI path before merge.
