### PR TITLE
Add documentation comment to kernel_main in blank example

### DIFF
--- a/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/blank.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/blank.cpp
@@ -2,4 +2,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/// @brief Main kernel function for data flow processing in blank example.
 void kernel_main() {}


### PR DESCRIPTION
**Problem Background**
The public function `kernel_main` in the blank example kernel lacked documentation comments. As a kernel entry point, this reduced code readability and maintainability, making it harder for developers to understand its purpose.

**Changes**
- Added a Doxygen-style comment (`/// @brief Main kernel function for data flow processing in blank example.`) to `kernel_main` in `ttnn/cpp/ttnn/operations/examples/example/device/kernels/dataflow/blank.cpp` to clearly describe its role.

**Verification**
- The modification is documentation-only, so the code's functionality and API remain unchanged.
- Review the comment to ensure it accurately explains the function's purpose and aligns with the repository's existing coding style for consistency.