### PR TITLE
[cleanup] Fix some includes to reference headers from public include directories

### DIFF
--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -14,7 +14,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "context_types.hpp"
 #include <tt-metalium/experimental/context/metal_env.hpp>
-#include "hostdevcommon/api/hostdevcommon/common_values.hpp"
+#include "hostdevcommon/common_values.hpp"
 namespace tt::tt_fabric {
 class ControlPlane;
 }  // namespace tt::tt_fabric

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -23,11 +23,11 @@
 #include <utility>
 #include <vector>
 #include "llrt/hal_proc_set.hpp"  // HalProcessorSet — internal, no full Hal singleton
-#include "core_coord.hpp"
-#include "dispatch_core_common.hpp"  // For DispatchCoreConfig
 #include "tt_target_device.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>  // For DispatchCoreConfig
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "tt_metal/hw/inc/hostdev/fabric_telemetry_msgs.h"
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -5,9 +5,10 @@
 #pragma once
 
 #include "hostdevcommon/fabric_common.h"
-#include <tt-metalium/experimental/fabric/fabric_types.hpp>
-#include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/cluster.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include "llrt/metal_soc_descriptor.hpp"
 #include "llrt/rtoptions.hpp"
 #include "llrt/tt_target_device.hpp"
 #include <cstddef>
@@ -22,7 +23,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "core_coord.hpp"
 #include <umd/device/cluster.hpp>
 #include <umd/device/driver_atomics.hpp>
 #include <umd/device/cluster_descriptor.hpp>


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Including these headers from out-of-tree code is problematic because they reference the in-tree headers, instead of headers copied into include directories, e.g. `build/include`. This conflicts with other references of these files from the include directories, since `#pragma once` treats them as different files.

I change the includes that would match the files in the include directories.

### Notes for reviewers
Should work if build works, but this could potentially affect projects that use this library differently depending on how they've set up their include directories.

The greater goal I'm trying to achieve is to access the umd Cluster object in order to send mesages to call set_power_state to reduce power usage when idle. I notice that MetalEnv does not have an accessor to the Cluster object, only `MetalContext` does. 