### PR TITLE
Fix LLK BFP4/BFP2 unpack format inference

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -139,12 +139,12 @@ def infer_unpack_out(
     if input_format.is_mx_format():
         return DataFormat.Float16_b
 
-    # Sub-byte BFP formats can only exist in L1.
-    # The Wormhole HW unpacker only supports BFP4_b → BFP8_b conversion
-    # (not BFP4_b → Float16_b). The unpacker expands 4-bit mantissas to 8-bit
-    # in the BFP8_b register format, preserving the shared exponent structure.
+    # Sub-byte BFP formats can only exist in L1. For UNPACR configuration,
+    # BFP2/BFP4/BFP8 inputs keep matching InDataFormat/OutDataFormat values;
+    # the unpacker internally normalizes the datum into the BF16 source-register
+    # representation before math consumes it.
     if input_format in [DataFormat.Bfp4_b, DataFormat.Bfp2_b]:
-        return DataFormat.Bfp8_b
+        return input_format
 
     if (
         input_format == DataFormat.Float32
@@ -286,6 +286,14 @@ def infer_pack_in(
     return output_format if is_fp32_dest_acc_en == DestAccumulation.Yes else unpack_out
 
 
+def infer_downstream_unpack_out(unpack_out: DataFormat) -> DataFormat:
+    # Keep BFP2/BFP4 only in the UNPACR config fields; downstream test
+    # inference historically models the unpacked payload as BFP8_b.
+    if unpack_out in [DataFormat.Bfp4_b, DataFormat.Bfp2_b]:
+        return DataFormat.Bfp8_b
+    return unpack_out
+
+
 def infer_math_format(a: DataFormat, b: DataFormat = None) -> DataFormat:
     # Design rationale:
     # - The only constraint enforced here is that both inputs belong to the same exponent "family"
@@ -357,8 +365,12 @@ def infer_data_formats(
         unpacking_to_srcs,
     )
 
+    downstream_unpack_out_A = infer_downstream_unpack_out(unpack_out_A)
+    downstream_unpack_out_B = infer_downstream_unpack_out(unpack_out_B)
+    downstream_unpack_out_S = infer_downstream_unpack_out(unpack_out_S)
+
     # The data format used for mathematical computations, desired format in dest register (typically matches unpack_out if both regs have same format)
-    math = infer_math_format(unpack_out_A, unpack_out_B)
+    math = infer_math_format(downstream_unpack_out_A, downstream_unpack_out_B)
 
     # FP8 is a compressed L1 format; hardware unpacks it to Float16 (float16_a) in
     # source registers. The ALU and packer must see Float16, not Lf8/Fp8_e4m3.
@@ -385,7 +397,7 @@ def infer_data_formats(
     pack_in_S = infer_pack_in(
         input_format,
         output_format,
-        unpack_out_S,
+        downstream_unpack_out_S,
         is_fp32_dest_acc_en,
         unpacking_to_dest,
         chip_arch,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
LLK pytest format inference was using one inferred unpack output format for both the hardware UNPACR configuration and the downstream math/packer model. That caused BFP4/BFP2 inputs to choose between two bad options: configuring UNPACR as if it converted BFP4 to BFP8, or propagating BFP4 into math and packer source formats where it is not a valid register-side format. This change keeps BFP4/BFP2 only in the emitted UNPACR input/output format fields, where the fields must match, while remapping the downstream inferred payload format back to BFP8_b for math and packer inference. This preserves the existing LLK pytest pipeline behavior while avoiding invalid unpacker and packer format programming.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-format-inference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-format-inference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-format-inference)