### PR TITLE
Remove default input CB id from llk_math_*unary_* datacopy APIs

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
@@ -59,8 +59,9 @@ ALWI void tilize_block_custom(uint32_t icb, uint32_t num_chunks, uint32_t chunk,
         PACK((t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU)));
         for (uint32_t t = 0; t < chunk; t++) {
             // Datacopy
-            MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-                dst_index + t /*dst index*/, icb /*operand*/)));
+            MATH((
+                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+                    dst_index + t /*dst index*/, icb /*operand*/)));
             PACK((llk_pack<DST_ACCUM_MODE>(dst_index + t /*tile index*/, ocb)));
         }
         PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_tilize.h
@@ -60,7 +60,7 @@ ALWI void tilize_block_custom(uint32_t icb, uint32_t num_chunks, uint32_t chunk,
         for (uint32_t t = 0; t < chunk; t++) {
             // Datacopy
             MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
-                dst_index + t /*dst index*/)));
+                dst_index + t /*dst index*/, icb /*operand*/)));
             PACK((llk_pack<DST_ACCUM_MODE>(dst_index + t /*tile index*/, ocb)));
         }
         PACK(t6_semaphore_get<p_stall::PACK>(semaphore::FPU_SFPU));

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -9,12 +9,12 @@
 #include "llk_math_matmul_api.h"
 
 inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks) {
-    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
+    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
     for (uint32_t in0_subblock = 0U; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t i = 0U; i < in0_subblock_h; i++) {
             for (uint32_t j = 0U; j < in0_block_w; j++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }
@@ -22,13 +22,13 @@ inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uin
 }
 
 inline void reblock_and_untilize_output(uint32_t out_subblock_h, uint32_t out_block_w) {
-    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
+    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
 
     for (uint32_t i = 0; i < out_subblock_h; i++) {
         for (int j = 0; j < 2; j++) {
             for (uint32_t k = 0; k < out_block_w; k++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }
@@ -87,9 +87,9 @@ void kernel_main() {
             for (uint32_t in1_subblock = 0U; in1_subblock < in1_num_subblocks; in1_subblock++) {
                 llk_math_wait_for_dest_available();
                 if (enable_reload) {
-                    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>();
+                    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
                     for (uint32_t i = 0U; i < out_subblock_num_tiles; i++) {
-                        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i);
+                        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i, 0);
                     }
                 }
                 llk_math_matmul_init<MATH_FIDELITY>(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_math.cpp
@@ -9,12 +9,13 @@
 #include "llk_math_matmul_api.h"
 
 inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uint32_t in0_num_subblocks) {
-    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0 /* operand */);
     for (uint32_t in0_subblock = 0U; in0_subblock < in0_num_subblocks; in0_subblock++) {
         for (uint32_t i = 0U; i < in0_subblock_h; i++) {
             for (uint32_t j = 0U; j < in0_block_w; j++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
+                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+                    0 /* dst_index */, 0 /* operand */);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }
@@ -22,13 +23,14 @@ inline void tilize_activation(uint32_t in0_subblock_h, uint32_t in0_block_w, uin
 }
 
 inline void reblock_and_untilize_output(uint32_t out_subblock_h, uint32_t out_block_w) {
-    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0 /* operand */);
 
     for (uint32_t i = 0; i < out_subblock_h; i++) {
         for (int j = 0; j < 2; j++) {
             for (uint32_t k = 0; k < out_block_w; k++) {
                 llk_math_wait_for_dest_available();
-                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
+                llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+                    0 /* dst_index */, 0 /* operand */);
                 llk_math_dest_section_done<DST_ACCUM_MODE>();
             }
         }
@@ -87,9 +89,11 @@ void kernel_main() {
             for (uint32_t in1_subblock = 0U; in1_subblock < in1_num_subblocks; in1_subblock++) {
                 llk_math_wait_for_dest_available();
                 if (enable_reload) {
-                    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+                    llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+                        0 /* operand */);
                     for (uint32_t i = 0U; i < out_subblock_num_tiles; i++) {
-                        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(i, 0);
+                        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+                            i /* dst_index */, 0 /* operand */);
                     }
                 }
                 llk_math_matmul_init<MATH_FIDELITY>(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -21,7 +21,7 @@ void core_agnostic_main() {
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();
-        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0);
+        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
         llk_math_dest_section_done<DST_ACCUM_MODE>();
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -21,7 +21,8 @@ void core_agnostic_main() {
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_math_wait_for_dest_available();
-        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(0, 0);
+        llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(
+            0 /* dst_index */, 0 /* operand */);
         llk_math_dest_section_done<DST_ACCUM_MODE>();
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -16,7 +16,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand) {
+inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index, std::uint32_t operand) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -29,7 +29,8 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand) {
+inline void llk_math_eltwise_unary_datacopy_block(
+    std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -16,7 +16,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
+inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -29,7 +29,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand = 0) {
+inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
@@ -46,7 +46,7 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
     PackMode pack_mode = PackMode::Default>
-inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0) {
+inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
         "Blackhole math datacopy init supports only PackMode::Default and PackMode::Tilize");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -39,7 +39,7 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     [[maybe_unused]] bool is_int_fpu_en = false,
     [[maybe_unused]] bool tilize = false>
-inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0) {
+inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
@@ -67,14 +67,14 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
  * @tparam src_b_bcast_type Broadcast mode; non-NONE with unpack_to_dest false uses unary-broadcast math
  * @tparam unpack_to_dest when true, unpack-to-dest path; plain datacopy otherwise
  * @param dst_index Tile index into the destination register.
- * @param operand Logical dataflow buffer id for the input operand (defaults to 0 for legacy call sites).
+ * @param operand Logical dataflow buffer id for the input operand.
  */
 template <
     DataCopyType type = DataCopyType::A2D,
     bool EN_32BIT_DEST = false,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const std::uint32_t operand = 0) {
+inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
@@ -93,10 +93,10 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
  *
  * @param start_dst_index Starting tile index in the destination register.
  * @param ntiles Number of tiles to copy to the destination register.
- * @param operand Logical dataflow buffer id for the input operand (defaults to 0 for legacy call sites).
+ * @param operand Logical dataflow buffer id for the input operand.
  */
 inline void llk_math_eltwise_unary_datacopy_block(
-    const std::uint32_t start_dst_index, const std::uint32_t ntiles, const std::uint32_t operand = 0) {
+    const std::uint32_t start_dst_index, const std::uint32_t ntiles, const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -17,7 +17,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
+inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -30,7 +30,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand = 0) {
+inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
@@ -47,7 +47,7 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en = false,
     PackMode pack_mode = PackMode::Default>
-inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0) {
+inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize || pack_mode == PackMode::Tilize,
         "Wormhole B0 math datacopy init: use PackMode::Default, PackMode::Untilize, or PackMode::Tilize (tilize is "

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -17,7 +17,7 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand) {
+inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index, std::uint32_t operand) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -30,7 +30,8 @@ template <
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
-inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand) {
+inline void llk_math_eltwise_unary_datacopy_block(
+    std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -160,9 +160,8 @@ void kernel_main() {
                 mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
                 mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
 
-                MATH(( llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, BroadcastType::NONE,
-                DST_ACCUM_MODE>(cb_id_out))); MATH(( llk_math_eltwise_unary_datacopy<DataCopyType::A2D,
-                BroadcastType::NONE, DST_ACCUM_MODE>(0, cb_id_out) ));
+                MATH(( llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(cb_id_out)));
+                MATH(( llk_math_eltwise_unary_datacopy<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
 
                 pack_tile(0, cb_id_out);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/kernels/ssm_eltwise_mul.cpp
@@ -160,8 +160,9 @@ void kernel_main() {
                 mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
                 mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
 
-                MATH(( llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(cb_id_out)));
-                MATH(( llk_math_eltwise_unary_datacopy<DataCopyType::A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
+                MATH(( llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, BroadcastType::NONE,
+                DST_ACCUM_MODE>(cb_id_out))); MATH(( llk_math_eltwise_unary_datacopy<DataCopyType::A2D,
+                BroadcastType::NONE, DST_ACCUM_MODE>(0, cb_id_out) ));
 
                 pack_tile(0, cb_id_out);
 


### PR DESCRIPTION
### What

The `operand` (input CB id) had a default of `0` in the eltwise unary datacopy LLK APIs (`llk_math_eltwise_unary_datacopy`, `_block`, `_init`) on Wormhole, Blackhole and Quasar. Relying on the default is error-prone, so this drops it and makes the CB id explicit.

### Changes

- Removed the `operand = 0` default from the three datacopy APIs across all three arches.
- Updated the few call sites that relied on the default to pass the CB id explicitly (`eltwise_copy_3m.cpp`, the orphaned `zm_3m_math.cpp`, and a commented-out block in `ssm_eltwise_mul.cpp`). All copy CB 0, so behavior is unchanged.

The compute API layer (`copy_tile`, `tilize`, `transpose_wh`, `bcast`, etc.) already forwards the CB id, so nothing else needed touching.

Closes #23995

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/issue-23995-no-default-cb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/issue-23995-no-default-cb-id)