### PR TITLE
Optimize ring joint SDPA CI tests

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -18,6 +18,7 @@ Model Configurations:
 
 BH adaptation: uses init_device_compute_kernel_config instead of WormholeComputeKernelConfig.
 """
+
 import os
 import math
 from unittest import mock
@@ -25,7 +26,7 @@ from unittest import mock
 import torch
 from dataclasses import dataclass, replace
 from itertools import product
-from typing import List, Dict
+from typing import List, Dict, Sequence, Tuple
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -265,6 +266,15 @@ def fa_rand(*shape):
     return normal_1 + normal_2 * bernoulli
 
 
+def deterministic_input_tensor(*shape, offset=0.0):
+    """Generate cheap finite inputs for determinism tests, where accuracy is checked elsewhere."""
+    _, h, s, d = shape
+    seq_pattern = (torch.arange(s, dtype=torch.float32).view(1, 1, s, 1) % 251) * 0.001
+    head_pattern = (torch.arange(h, dtype=torch.float32).view(1, h, 1, 1) % 31) * 0.01
+    dim_pattern = (torch.arange(d, dtype=torch.float32).view(1, 1, 1, d) % 37) * 0.0001
+    return (seq_pattern + head_pattern + dim_pattern + offset).expand(shape).contiguous()
+
+
 def torch_sdpa_reference(q, k, v, is_causal=False):
     """
     Memory-efficient PyTorch reference for ring joint attention.
@@ -316,6 +326,149 @@ def torch_sdpa_reference(q, k, v, is_causal=False):
     return attn_out
 
 
+def compute_pcc_rmse(expected, actual):
+    if expected.dtype != actual.dtype:
+        actual = actual.type(expected.dtype)
+
+    expected_flat = expected.reshape(-1).float()
+    actual_flat = actual.reshape(-1).float()
+    diff = expected_flat - actual_flat
+    rmse = torch.linalg.vector_norm(diff).item() / math.sqrt(diff.numel())
+
+    if not math.isfinite(rmse):
+        return 0.0, rmse
+    if torch.equal(expected_flat, actual_flat):
+        return 1.0, rmse
+    if expected_flat.numel() == 1:
+        return float(torch.equal(expected_flat, actual_flat)), rmse
+
+    expected_centered = expected_flat.double()
+    actual_centered = actual_flat.double()
+    expected_centered = expected_centered - expected_centered.mean()
+    actual_centered = actual_centered - actual_centered.mean()
+    denom = torch.linalg.vector_norm(expected_centered) * torch.linalg.vector_norm(actual_centered)
+    if denom == 0:
+        return float(torch.isclose(torch.max(expected_flat), torch.max(actual_flat)).item()), rmse
+
+    pcc = (torch.dot(expected_centered, actual_centered) / denom).clamp(-1.0, 1.0).item()
+    return pcc, rmse
+
+
+def assert_pcc_rmse(expected, actual, pcc_threshold, rmse_threshold, label):
+    pcc, rmse = compute_pcc_rmse(expected, actual)
+    logger.info(f"{label} - PCC: {pcc}, RMSE: {rmse:.6f}")
+
+    if rmse_threshold is not None:
+        assert rmse < rmse_threshold, f"{label} RMSE {rmse:.6f} exceeds threshold {rmse_threshold}"
+    assert pcc >= pcc_threshold, f"{label} PCC {pcc} below threshold {pcc_threshold}"
+    return pcc, rmse
+
+
+def device_tensors_mismatch_marker(reference_tensor, actual_tensor):
+    """Return a reduced device tensor that is non-zero when any mesh shard has an exact mismatch."""
+    mismatch = ttnn.ne(reference_tensor, actual_tensor, dtype=ttnn.bfloat16)
+    return ttnn.max(mismatch)
+
+
+def merge_device_mismatch_markers(current_marker, new_marker):
+    if current_marker is None:
+        return new_marker
+    return ttnn.maximum(current_marker, new_marker)
+
+
+def device_mismatch_marker_is_set(mismatch_marker):
+    mismatch_marker_host = ttnn.from_device(mismatch_marker)
+    return any(float(ttnn.to_torch(shard).item()) != 0.0 for shard in ttnn.get_device_tensors(mismatch_marker_host))
+
+
+@dataclass
+class RingJointSDPARuntime:
+    mesh_device: object
+    topology: object
+    sp_axis: int
+    tp_axis: int
+    num_links: int
+    sdpa_compute_grid: Tuple[int, int]
+    ccl_column: int
+    worker_sub_device_id: object
+    ccl_semaphore_handles: object
+    compute_kernel_config: object
+
+
+def open_ring_joint_sdpa_runtime(mesh_config):
+    use_ring = mesh_config.sp_size > 2
+    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
+    topology = Topology.Ring if use_ring else Topology.Linear
+
+    sp_axis = 1
+    tp_axis = 0
+
+    if mesh_config.sp_size < 2:
+        pytest.skip(f"Ring joint attention requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
+
+    mesh_device = None
+
+    try:
+        ttnn.set_fabric_config(
+            fabric_config,
+            ttnn.FabricReliabilityMode.STRICT_INIT,
+            None,
+            ttnn.FabricTensixConfig.DISABLED,
+            ttnn.FabricUDMMode.DISABLED,
+            ttnn.FabricManagerMode.DEFAULT,
+        )
+
+        mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
+        mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+        full_compute_grid = mesh_device.compute_with_storage_grid_size()
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
+        )
+        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+        mesh_device.load_sub_device_manager(sub_device_manager)
+        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+        return RingJointSDPARuntime(
+            mesh_device=mesh_device,
+            topology=topology,
+            sp_axis=sp_axis,
+            tp_axis=tp_axis,
+            num_links=2,
+            sdpa_compute_grid=(mesh_config.sdpa_cols, mesh_config.grid_rows),
+            ccl_column=mesh_config.ccl_column,
+            worker_sub_device_id=worker_sub_device_id,
+            ccl_semaphore_handles=create_global_semaphores(mesh_device, ccl_sub_device_crs, 0),
+            compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                mesh_device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=False,
+            ),
+        )
+    except Exception:
+        try:
+            if mesh_device is not None:
+                ttnn.close_mesh_device(mesh_device)
+        finally:
+            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        raise
+
+
+def close_ring_joint_sdpa_runtime(runtime: RingJointSDPARuntime, *, clear_program_cache=False):
+    try:
+        if clear_program_cache:
+            runtime.mesh_device.disable_and_clear_program_cache()
+    finally:
+        try:
+            ttnn.close_mesh_device(runtime.mesh_device)
+        finally:
+            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
 def nd_sharded_dram_memory_config(device, head_dim):
     num_dram_banks = device.dram_grid_size().x
     core_ranges = [
@@ -338,6 +491,11 @@ def nd_sharded_dram_memory_config(device, head_dim):
 def get_test_case_id(config: ModelConfig, q_chunk_size: int, k_chunk_size: int) -> str:
     """Generate a unique test case ID based on model config and chunk sizes."""
     return f"{config.name}-q{q_chunk_size}-k{k_chunk_size}"
+
+
+def get_model_qk_configs(config: ModelConfig) -> List[Tuple[int, int]]:
+    """Return all Q/K chunk-size combinations covered by a model config."""
+    return list(product(config.q_chunk_sizes, config.k_chunk_sizes))
 
 
 def generate_test_configs(mesh_config: MeshConfig, model_configs: Dict[str, ModelConfig]):
@@ -538,66 +696,23 @@ def run_ring_joint_sdpa(
     if nhk != 1 and nhq != nhk:
         pytest.skip(f"Ring joint attention requires nhq == nhk or nhk == 1, got nhq={nhq}, nhk={nhk}")
 
-    # Auto-detect mesh configuration based on available devices
-
-    # Ring topology requires >2 devices; fall back to linear for <=2
-    use_ring = mesh_config.sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-
-    # Configure fabric for ring joint attention
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    # Mesh axis configuration
-    sp_axis = 1  # Column axis for sequence parallel (ring axis)
-    tp_axis = 0  # Row axis for tensor parallel (head axis)
-
-    if mesh_config.sp_size < 2:
-        pytest.skip(f"Ring joint attention requires at least 2 devices in ring, got SP={mesh_config.sp_size}")
-
-    # Open mesh device based on calculated configuration
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
-    num_links = 2
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
         if mesh_config.tp_size > 1 and nhq % mesh_config.tp_size != 0:
             pytest.skip(
                 f"num_heads ({nhq}) must be divisible by TP size ({mesh_config.tp_size}) for multi-ring architecture"
             )
-
-        # Configure compute grid and CCL coordination
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-
-        # Get actual device grid for sub-device creation
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-
-        # Create sub-device for CCL operations - Must include ALL cores that operations will use
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device = ttnn.SubDevice(
-            [
-                ccl_sub_device_crs,
-            ]
-        )
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-
-        # Set up sub-device manager with stall group
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        sub_device_stall_group = [worker_sub_device_id]
-        mesh_device.set_sub_device_stall_group(sub_device_stall_group)
-
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
 
         # Create tensors with appropriate shapes
         # Q: [b, nhq, sq, d_q]
@@ -657,15 +772,6 @@ def run_ring_joint_sdpa(
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
             exp_approx_mode=False,
-        )
-
-        # BH adaptation: use init_device_compute_kernel_config instead of WormholeComputeKernelConfig
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
         )
 
         # Convert to TT tensors with appropriate mesh sharding
@@ -786,11 +892,252 @@ def run_ring_joint_sdpa(
         assert out_pass_main, f"Main PCC {out_pcc_main} below threshold {pcc_threshold}"
 
     finally:
-        # Clean up mesh device
-        ttnn.close_mesh_device(mesh_device)
+        close_ring_joint_sdpa_runtime(runtime)
 
-        # Restore fabric to disabled state
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+def run_ring_joint_sdpa_model_configs(
+    mesh_config,
+    model: ModelConfig,
+    qk_configs: Sequence[Tuple[int, int]],
+    *,
+    pcc_threshold=DEFAULT_PCC_THRESHOLD,
+    rmse_threshold=None,
+    do_check=True,
+    num_iterations=1,
+    runtime: RingJointSDPARuntime = None,
+):
+    """Run all q/k configs for one model while reusing shared inputs, mesh setup, and reference data."""
+    qk_configs = list(qk_configs)
+    assert qk_configs, f"No q/k configs provided for {model.name}"
+
+    torch.manual_seed(1234)
+
+    b = BATCH_SIZE
+    nhq = model.nhq * mesh_config.tp_size
+    nhk = model.nhk * (mesh_config.tp_size if model.nhk != 1 else 1)
+    nhv = model.nhv * mesh_config.tp_size
+    sq = model.seq_len * mesh_config.sp_size
+    d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
+    q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
+    is_causal, is_balanced = model.is_causal, model.is_balanced
+
+    logger.debug(
+        f"run_ring_joint_sdpa_model_configs params: model={model.name}, b={b}, "
+        f"nhq={nhq}, nhk={nhk}, nhv={nhv}, sq={sq}, d_q={d_q}, d_k={d_k}, d_v={d_v}, "
+        f"qk_configs={qk_configs}, q_dtype={q_dtype}, kv_dtype={kv_dtype}, "
+        f"is_causal={is_causal}, is_balanced={is_balanced}, "
+        f"pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}, "
+        f"do_check={do_check}, num_iterations={num_iterations}"
+    )
+
+    if nhk != 1 and nhq != nhk:
+        pytest.skip(f"Ring joint attention requires nhq == nhk or nhk == 1, got nhq={nhq}, nhk={nhk}")
+
+    owns_runtime = runtime is None
+    if runtime is None:
+        runtime = open_ring_joint_sdpa_runtime(mesh_config)
+
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
+    worker_sub_device_id = runtime.worker_sub_device_id
+
+    try:
+        if mesh_config.tp_size > 1 and nhq % mesh_config.tp_size != 0:
+            pytest.skip(
+                f"num_heads ({nhq}) must be divisible by TP size ({mesh_config.tp_size}) for multi-ring architecture"
+            )
+
+        if num_iterations > 1:
+            Q = deterministic_input_tensor(b, nhq, sq, d_q, offset=0.125)
+            K = deterministic_input_tensor(b, nhk, sq, d_k, offset=0.25)
+            V = deterministic_input_tensor(b, nhv, sq, d_v, offset=0.375)
+        else:
+            Q = fa_rand(b, nhq, sq, d_q)
+            K = fa_rand(b, nhk, sq, d_k)
+            V = fa_rand(b, nhv, sq, d_v)
+        Q_original, K_original, V_original = Q, K, V
+
+        chunk_order = None
+        if is_balanced:
+            chunk_order = create_balanced_chunk_order(mesh_config.sp_size)
+            Q = reorder_tensor_chunks(Q, chunk_order)
+            K = reorder_tensor_chunks(K, chunk_order)
+            V = reorder_tensor_chunks(V, chunk_order)
+
+        kv_shard_dims = [None, None]
+        kv_shard_dims[sp_axis] = None
+        if mesh_config.tp_size > 1:
+            kv_shard_dims[tp_axis] = 1
+
+        persistent_k_shard_dims = [None, None]
+        persistent_k_shard_dims[sp_axis] = None
+        if mesh_config.tp_size > 1 and nhk != 1:
+            persistent_k_shard_dims[tp_axis] = 1
+
+        sdpa_input_shard_dims = [None, None]
+        sdpa_input_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            sdpa_input_shard_dims[tp_axis] = 1
+
+        sdpa_k_shard_dims = [None, None]
+        sdpa_k_shard_dims[sp_axis] = 2
+        if mesh_config.tp_size > 1 and nhk != 1:
+            sdpa_k_shard_dims[tp_axis] = 1
+
+        tt_Q = ttnn.from_torch(
+            Q,
+            dtype=q_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+            ),
+        )
+        tt_K = ttnn.from_torch(
+            K,
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_k_shard_dims
+            ),
+        )
+        tt_V = ttnn.from_torch(
+            V,
+            dtype=kv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+            ),
+        )
+
+        main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
+        main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+        mesh_composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim))
+
+        gt_main = None
+        if do_check and num_iterations == 1:
+            gt_main = torch_sdpa_reference(Q_original, K_original, V_original, is_causal=is_causal)
+
+        use_device_determinism_compare = num_iterations > 1 and sq % ttnn.TILE_SIZE == 0 and d_v % ttnn.TILE_SIZE == 0
+
+        def create_persistent_buffers():
+            persistent_output_buffer_k = ttnn.from_torch(
+                torch.zeros(b, nhk, sq, d_k),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_k_shard_dims
+                ),
+            )
+            persistent_output_buffer_v = ttnn.from_torch(
+                torch.zeros(b, nhv, sq, d_v),
+                dtype=kv_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims
+                ),
+            )
+            return persistent_output_buffer_k, persistent_output_buffer_v
+
+        persistent_output_buffer_k, persistent_output_buffer_v = create_persistent_buffers()
+        model_mismatch_marker = None
+        model_mismatch_markers_by_config = []
+        for q_chunk_size, k_chunk_size in qk_configs:
+            config_id = get_test_case_id(model, q_chunk_size, k_chunk_size)
+            logger.info(f"Running ring joint SDPA {config_id}")
+
+            program_config = ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=sdpa_compute_grid,
+                q_chunk_size=q_chunk_size,
+                k_chunk_size=k_chunk_size,
+                exp_approx_mode=False,
+            )
+
+            reference_output = None
+            reference_tt_out = None
+            mismatch_marker = None
+            tt_out_torch = None
+            for i in range(num_iterations):
+                tt_out = call_sdpa(
+                    tt_Q,
+                    tt_K,
+                    tt_V,
+                    sq,
+                    is_causal=is_causal,
+                    is_balanced=is_balanced,
+                    p_buf_k=persistent_output_buffer_k,
+                    p_buf_v=persistent_output_buffer_v,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                    ccl_semaphore_handles=ccl_semaphore_handles,
+                    num_links=num_links,
+                    sp_axis=sp_axis,
+                    mesh_device=mesh_device,
+                    topology=topology,
+                    worker_sub_device_id=worker_sub_device_id,
+                    ccl_column=ccl_column,
+                )
+
+                if use_device_determinism_compare:
+                    if reference_tt_out is None:
+                        reference_tt_out = tt_out
+                    else:
+                        mismatch_marker = merge_device_mismatch_markers(
+                            mismatch_marker,
+                            device_tensors_mismatch_marker(reference_tt_out, tt_out),
+                        )
+                    continue
+
+                tt_out_torch = ttnn.to_torch(tt_out, mesh_composer=mesh_composer)
+                tt_out_torch = tt_out_torch[:, :, :sq, :]
+
+                if do_check and num_iterations == 1 and is_balanced and chunk_order is not None:
+                    tt_out_torch = reverse_reorder_tensor_chunks(tt_out_torch, chunk_order)
+
+                if num_iterations > 1:
+                    if reference_output is None:
+                        reference_output = tt_out_torch
+                    elif not torch.equal(reference_output, tt_out_torch):
+                        diff_mask = reference_output != tt_out_torch
+                        num_diffs = diff_mask.sum().item()
+                        max_diff = (reference_output - tt_out_torch).abs().max().item()
+                        pytest.fail(
+                            f"Ring joint SDPA {config_id} output at iteration {i} differs from iteration 0: "
+                            f"{num_diffs} differing elements, max diff = {max_diff}"
+                        )
+
+            if num_iterations > 1:
+                if use_device_determinism_compare and mismatch_marker is not None:
+                    model_mismatch_marker = merge_device_mismatch_markers(model_mismatch_marker, mismatch_marker)
+                    model_mismatch_markers_by_config.append((config_id, mismatch_marker))
+                elif not use_device_determinism_compare:
+                    logger.info(f"Ring joint SDPA {config_id} determinism verified: all {num_iterations} outputs match")
+            elif do_check:
+                assert_pcc_rmse(gt_main, tt_out_torch, pcc_threshold, rmse_threshold, f"Main output {config_id}")
+
+        if num_iterations > 1 and use_device_determinism_compare and model_mismatch_marker is not None:
+            if device_mismatch_marker_is_set(model_mismatch_marker):
+                for config_id, mismatch_marker in model_mismatch_markers_by_config:
+                    if device_mismatch_marker_is_set(mismatch_marker):
+                        pytest.fail(f"Ring joint SDPA {config_id} produced output that differs from iteration 0")
+                pytest.fail(f"Ring joint SDPA {model.name} produced output that differs from iteration 0")
+            for config_id, _ in model_mismatch_markers_by_config:
+                logger.info(f"Ring joint SDPA {config_id} determinism verified: all {num_iterations} outputs match")
+
+    finally:
+        if owns_runtime:
+            close_ring_joint_sdpa_runtime(runtime)
 
 
 def run_ring_mla_sdpa(
@@ -823,39 +1170,19 @@ def run_ring_mla_sdpa(
 
     torch.manual_seed(1234)
 
-    use_ring = mesh_config.sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-    sp_axis = 1
-    tp_axis = 0
-
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, mesh_config.sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
-    num_links = 2
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
-
         Q = fa_rand(b, nhq, sq, d_q)
         KV = fa_rand(b, nhk, sq, d_k)
         V_prefix = KV[:, :, :, :d_v]
@@ -884,13 +1211,6 @@ def run_ring_mla_sdpa(
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
             exp_approx_mode=False,
-        )
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
         )
 
         sdpa_input_shard_dims = [None, None]
@@ -985,8 +1305,7 @@ def run_ring_mla_sdpa(
         assert out_pass, f"ring_mla PCC {out_pcc} below threshold {pcc_threshold}"
 
     finally:
-        ttnn.close_mesh_device(mesh_device)
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 # ============================================================================
@@ -1032,6 +1351,7 @@ def run_ring_joint_sdpa_chunked(
     rmse_threshold: float = None,
     q_chunk_size: int = None,
     k_chunk_size: int = None,
+    qk_configs: Sequence[Tuple[int, int]] = None,
     num_iterations: int = 1,
     indexed_nd_sharded_kv_cache: bool = False,
     kv_cache_batch_idx: int = 1,
@@ -1040,20 +1360,20 @@ def run_ring_joint_sdpa_chunked(
     use_ring_mla: bool = False,
 ):
     """
-    Validate ring joint SDPA chunked-prefill against a full-sequence torch oracle.
+    Validate ring joint SDPA chunked-prefill, or verify deterministic replay.
 
     SUT: n_chunks calls; each call passes a short Q chunk at absolute positions
     [i*c, (i+1)*c) against a K/V cache holding the first (i+1)*c rows.
     If persistent_buffer_mode="reuse_max", one max-length persistent K/V buffer
     pair is allocated once and reused across all chunks and iterations.
 
-    num_iterations > 1 switches to determinism mode: replay the full n_chunks
-    sequence num_iterations times and require bit-exact equality of per-chunk
-    outputs to iteration 0. PCC check is skipped in determinism mode.
+    num_iterations > 1 switches to determinism mode: each chunk's uploaded
+    device inputs are reused for num_iterations calls, and later outputs must
+    be bit-exact with iteration 0. PCC/RMSE coverage is handled by accuracy tests.
 
     use_ring_mla=True drives ttnn.transformer.ring_mla instead of the classic
     separate-K/V op: K and V live in a single latent K/V tensor (width d_k) and V
-    is its first d_v columns. This is the MLA latent-V deployment shape (e.g. d_v=512).
+    is its first d_v columns. This is the MLA latent-V deployment shape.
     """
     torch.manual_seed(CHUNKED_PREFILL_SEED)
 
@@ -1089,10 +1409,16 @@ def run_ring_joint_sdpa_chunked(
     # identical whether run in isolation or as part of the full sequence.
     only_chunk = get_chunked_only_chunk_id(n_chunks)
 
-    if q_chunk_size is None:
-        q_chunk_size = model.q_chunk_sizes[0]
-    if k_chunk_size is None:
-        k_chunk_size = model.k_chunk_sizes[0]
+    if qk_configs is None:
+        if q_chunk_size is None:
+            q_chunk_size = model.q_chunk_sizes[0]
+        if k_chunk_size is None:
+            k_chunk_size = model.k_chunk_sizes[0]
+        qk_configs = [(q_chunk_size, k_chunk_size)]
+    else:
+        qk_configs = list(qk_configs)
+        assert qk_configs, f"No q/k configs provided for chunked model {model.name}"
+
     # model.nhq/nhk/nhv are PER RING; scale to total head counts across all TP shards
     # (mirrors the sweep convention; nhk=1 stays 1 for MLA's single shared K head).
     nhq = model.nhq * mesh_config.tp_size
@@ -1104,51 +1430,38 @@ def run_ring_joint_sdpa_chunked(
 
     b = BATCH_SIZE
 
-    use_ring = sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    sp_axis = 1
-    tp_axis = 0
-    num_links = 2
-
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
-
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
-
         torch.manual_seed(CHUNKED_PREFILL_SEED)
-        Q_full = fa_rand(b, nhq, total_seq, d_q)
-        K_full = fa_rand(b, nhk, total_seq, d_k)
+        if num_iterations > 1:
+            Q_full = deterministic_input_tensor(b, nhq, total_seq, d_q, offset=0.125)
+            K_full = deterministic_input_tensor(b, nhk, total_seq, d_k, offset=0.25)
+        else:
+            Q_full = fa_rand(b, nhq, total_seq, d_q)
+            K_full = fa_rand(b, nhk, total_seq, d_k)
+
         if use_ring_mla:
-            # MLA latent: a single shared K/V tensor; V is its first d_v columns (broadcast to all Q heads).
+            # MLA latent: a single shared K/V tensor; V is its first d_v columns.
             V_full = K_full[:, :, :, :d_v]
+        elif num_iterations > 1:
+            V_full = deterministic_input_tensor(b, nhv, total_seq, d_v, offset=0.375)
         else:
             V_full = fa_rand(b, nhv, total_seq, d_v)
-        ref_full = torch_sdpa_reference(Q_full, K_full, V_full, is_causal=True)
+
+        ref_full = None
+        if num_iterations == 1:
+            ref_full = torch_sdpa_reference(Q_full, K_full, V_full, is_causal=True)
 
         sdpa_input_shard_dims = [None, None]
         sdpa_input_shard_dims[sp_axis] = 2
@@ -1169,23 +1482,23 @@ def run_ring_joint_sdpa_chunked(
         if mesh_config.tp_size > 1:
             kv_persistent_shard_dims[tp_axis] = 1
 
-        program_config = ttnn.SDPAProgramConfig(
-            compute_with_storage_grid_size=sdpa_compute_grid,
-            q_chunk_size=q_chunk_size,
-            k_chunk_size=k_chunk_size,
-            exp_approx_mode=False,
-        )
+        program_configs = {
+            (q_chunk, k_chunk): ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=sdpa_compute_grid,
+                q_chunk_size=q_chunk,
+                k_chunk_size=k_chunk,
+                exp_approx_mode=False,
+            )
+            for q_chunk, k_chunk in qk_configs
+        }
 
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
+        use_device_determinism_compare = (
+            num_iterations > 1 and chunk_size % ttnn.TILE_SIZE == 0 and d_v % ttnn.TILE_SIZE == 0
         )
 
         main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
         main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
+        mesh_composer = ttnn.create_mesh_composer(mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim))
 
         def upload_q(q_host):
             return ttnn.from_torch(
@@ -1229,12 +1542,7 @@ def run_ring_joint_sdpa_chunked(
             )
 
         def to_host(tt_out, expected_q_len):
-            out = ttnn.to_torch(
-                tt_out,
-                mesh_composer=ttnn.create_mesh_composer(
-                    mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
-                ),
-            )
+            out = ttnn.to_torch(tt_out, mesh_composer=mesh_composer)
             return out[:, :, :expected_q_len, :]
 
         def create_persistent_buffers(seq_len, kv_buffer_batch):
@@ -1288,7 +1596,7 @@ def run_ring_joint_sdpa_chunked(
         logger.info(
             f"Chunked prefill: model={model.name}, use_ring_mla={use_ring_mla}, total_seq={total_seq}, "
             f"sp_size={sp_size}, per-device Q seq_len={total_seq // sp_size}, "
-            f"q_chunk={q_chunk_size}, k_chunk={k_chunk_size}, "
+            f"qk_configs={qk_configs}, "
             f"indexed_nd_sharded_kv_cache={indexed_nd_sharded_kv_cache}, "
             f"persistent_buffer_mode={persistent_buffer_mode}"
         )
@@ -1302,171 +1610,270 @@ def run_ring_joint_sdpa_chunked(
 
         k_memory_config = nd_sharded_dram_memory_config(mesh_device, d_k) if indexed_nd_sharded_kv_cache else None
         v_memory_config = nd_sharded_dram_memory_config(mesh_device, d_v) if indexed_nd_sharded_kv_cache else None
+
+        def prepare_chunk_inputs(i):
+            s, e = i * chunk_size, (i + 1) * chunk_size
+
+            Q_chunk = Q_full[:, :, s:e, :].contiguous()
+            K_balanced = to_balanced_growing_cache_layout(K_full, sp_size, chunk_size, i)
+            kv_buffer_batch = b
+            kv_cache_batch_idx_arg = None
+
+            if use_ring_mla:
+                return (
+                    s,
+                    e,
+                    kv_buffer_batch,
+                    kv_cache_batch_idx_arg,
+                    upload_q(Q_chunk),
+                    upload_kv(K_balanced),
+                    None,
+                )
+
+            V_balanced = to_balanced_growing_cache_layout(V_full, sp_size, chunk_size, i)
+            if indexed_nd_sharded_kv_cache:
+                kv_buffer_batch = cache_batch
+                kv_cache_batch_idx_arg = kv_cache_batch_idx
+                K_input = torch.randn(cache_batch, nhk, e, d_k, dtype=K_balanced.dtype) * 100
+                V_input = torch.randn(cache_batch, nhv, e, d_v, dtype=V_balanced.dtype) * 100
+                K_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = K_balanced
+                V_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = V_balanced
+            else:
+                K_input = K_balanced
+                V_input = V_balanced
+
+            return (
+                s,
+                e,
+                kv_buffer_batch,
+                kv_cache_batch_idx_arg,
+                upload_q(Q_chunk),
+                upload_k(K_input, memory_config=k_memory_config),
+                upload_v(V_input, memory_config=v_memory_config),
+            )
+
+        def get_persistent_buffers(shared_persistent_buffers, chunk_persistent_buffers):
+            if persistent_buffer_mode == "reuse_max":
+                return shared_persistent_buffers
+            return chunk_persistent_buffers
+
+        def run_chunk_call(
+            config_id,
+            program_config,
+            it,
+            i,
+            s,
+            e,
+            tt_Q,
+            tt_K,
+            tt_V,
+            persistent_output_buffer_k,
+            persistent_output_buffer_v,
+            kv_cache_batch_idx_arg,
+        ):
+            try:
+                if use_ring_mla:
+                    tt_out, _ = ttnn.transformer.ring_mla(
+                        tt_Q,
+                        tt_K,
+                        persistent_output_buffer_kv=persistent_output_buffer_k,
+                        head_dim_v=d_v,
+                        logical_n=e,
+                        is_balanced=is_balanced,
+                        program_config=program_config,
+                        compute_kernel_config=compute_kernel_config,
+                        dim=2,
+                        multi_device_global_semaphore=ccl_semaphore_handles,
+                        num_links=num_links,
+                        cluster_axis=sp_axis,
+                        mesh_device=mesh_device,
+                        topology=topology,
+                        subdevice_id=worker_sub_device_id,
+                        ccl_core_grid_offset=(ccl_column, 0),
+                        use_column_major_ccl=True,
+                    )
+                    return tt_out
+
+                return call_sdpa(
+                    tt_Q,
+                    tt_K,
+                    tt_V,
+                    e,
+                    is_causal=True,
+                    is_balanced=is_balanced,
+                    p_buf_k=persistent_output_buffer_k,
+                    p_buf_v=persistent_output_buffer_v,
+                    program_config=program_config,
+                    compute_kernel_config=compute_kernel_config,
+                    ccl_semaphore_handles=ccl_semaphore_handles,
+                    num_links=num_links,
+                    sp_axis=sp_axis,
+                    mesh_device=mesh_device,
+                    topology=topology,
+                    worker_sub_device_id=worker_sub_device_id,
+                    ccl_column=ccl_column,
+                    kv_cache_batch_idx=kv_cache_batch_idx_arg,
+                )
+            except Exception as exc:
+                op_name = "ring_mla" if use_ring_mla else "SDPA"
+                pytest.fail(
+                    f"Chunked prefill {op_name} {config_id} call raised on iter {it}, chunk {i} "
+                    f"(Q rows [{s}, {e}), logical_n={e}): {type(exc).__name__}: {exc}"
+                )
+                raise
+
+        def record_chunk_accuracy(config_id, per_chunk_results, i, s, e, out_i):
+            expected_i = ref_full[:, :, s:e, :]
+            pcc, rmse = compute_pcc_rmse(expected_i, out_i)
+            pcc_passed = pcc >= pcc_threshold
+            rmse_passed = rmse_threshold is None or rmse < rmse_threshold
+            logger.info(
+                f"{config_id} chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: PCC={pcc} RMSE={rmse:.6f} "
+                f"-> {'PASS' if pcc_passed and rmse_passed else 'FAIL'}"
+            )
+            per_chunk_results.append((i, e, pcc_passed, pcc, rmse_passed, rmse))
+
+        config_ids = {(q, k): get_test_case_id(model, q, k) for q, k in qk_configs}
+        per_chunk_results_by_config = {config_id: [] for config_id in config_ids.values()}
+        determinism_mismatch_marker = None
         shared_persistent_buffers = None
         if persistent_buffer_mode == "reuse_max":
             shared_persistent_buffers = (
                 create_ring_mla_kv_buffer(total_seq, b) if use_ring_mla else create_persistent_buffers(total_seq, b)
             )
 
-        # SUT: per-chunk calls with growing K/V cache + growing logical_n.
-        # In determinism mode (num_iterations > 1), the entire n_chunks sequence is
-        # replayed and per-chunk outputs from iteration 0 are compared bit-exact.
-        reference_outputs = None
-        per_chunk_results = []
-        for it in range(num_iterations):
-            iter_outputs = [] if num_iterations > 1 else None
-            for i in range(n_chunks):
-                if only_chunk is not None and i != only_chunk:
-                    continue
-                s, e = i * chunk_size, (i + 1) * chunk_size
-                Q_chunk = Q_full[:, :, s:e, :].contiguous()
-                tt_Q = upload_q(Q_chunk)
+        for i in range(n_chunks):
+            if only_chunk is not None and i != only_chunk:
+                continue
 
+            (
+                s,
+                e,
+                kv_buffer_batch,
+                kv_cache_batch_idx_arg,
+                tt_Q,
+                tt_K,
+                tt_V,
+            ) = prepare_chunk_inputs(i)
+            chunk_persistent_buffers = None
+            if persistent_buffer_mode != "reuse_max":
+                chunk_persistent_buffers = (
+                    create_ring_mla_kv_buffer(e, kv_buffer_batch)
+                    if use_ring_mla
+                    else create_persistent_buffers(e, kv_buffer_batch)
+                )
+
+            for q_chunk_size, k_chunk_size in qk_configs:
+                config_id = config_ids[(q_chunk_size, k_chunk_size)]
+                program_config = program_configs[(q_chunk_size, k_chunk_size)]
+                persistent_buffers = get_persistent_buffers(shared_persistent_buffers, chunk_persistent_buffers)
                 if use_ring_mla:
-                    # Single shared latent K/V cache; V is its first d_v columns.
-                    KV_balanced = to_balanced_growing_cache_layout(K_full, sp_size, chunk_size, i)
-                    tt_KV = upload_kv(KV_balanced)
-                    persistent_output_buffer_kv = (
-                        shared_persistent_buffers
-                        if persistent_buffer_mode == "reuse_max"
-                        else create_ring_mla_kv_buffer(e, b)
-                    )
-                    try:
-                        tt_out, _ = ttnn.transformer.ring_mla(
-                            tt_Q,
-                            tt_KV,
-                            persistent_output_buffer_kv=persistent_output_buffer_kv,
-                            head_dim_v=d_v,
-                            logical_n=e,
-                            is_balanced=is_balanced,
-                            program_config=program_config,
-                            compute_kernel_config=compute_kernel_config,
-                            dim=2,
-                            multi_device_global_semaphore=ccl_semaphore_handles,
-                            num_links=num_links,
-                            cluster_axis=sp_axis,
-                            mesh_device=mesh_device,
-                            topology=topology,
-                            subdevice_id=worker_sub_device_id,
-                            ccl_core_grid_offset=(ccl_column, 0),
-                            use_column_major_ccl=True,
-                        )
-                    except Exception as exc:
-                        pytest.fail(
-                            f"Chunked prefill ring_mla call raised on iter {it}, chunk {i} "
-                            f"(Q rows [{s}, {e}), logical_n={e}): {type(exc).__name__}: {exc}"
-                        )
-                    out_i = to_host(tt_out, chunk_size)[:, :, :, :d_v]
+                    persistent_output_buffer_k = persistent_buffers
+                    persistent_output_buffer_v = None
                 else:
-                    K_balanced = to_balanced_growing_cache_layout(K_full, sp_size, chunk_size, i)
-                    V_balanced = to_balanced_growing_cache_layout(V_full, sp_size, chunk_size, i)
-                    kv_buffer_batch = b
-                    kv_cache_batch_idx_arg = None
+                    persistent_output_buffer_k, persistent_output_buffer_v = persistent_buffers
 
-                    if indexed_nd_sharded_kv_cache:
-                        kv_buffer_batch = cache_batch
-                        kv_cache_batch_idx_arg = kv_cache_batch_idx
-                        K_input = torch.randn(cache_batch, nhk, e, d_k, dtype=K_balanced.dtype) * 100
-                        V_input = torch.randn(cache_batch, nhv, e, d_v, dtype=V_balanced.dtype) * 100
-                        K_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = K_balanced
-                        V_input[kv_cache_batch_idx : kv_cache_batch_idx + 1] = V_balanced
-                    else:
-                        K_input = K_balanced
-                        V_input = V_balanced
-
-                    tt_K = upload_k(K_input, memory_config=k_memory_config)
-                    tt_V = upload_v(V_input, memory_config=v_memory_config)
-
-                    if persistent_buffer_mode == "reuse_max":
-                        persistent_output_buffer_k, persistent_output_buffer_v = shared_persistent_buffers
-                    else:
-                        # AllGather output buffer sized to post-gather K/V: N_global == (i+1) * chunk_size.
-                        persistent_output_buffer_k, persistent_output_buffer_v = create_persistent_buffers(
-                            e, kv_buffer_batch
-                        )
-
-                    try:
-                        tt_out = call_sdpa(
+                if num_iterations > 1:
+                    reference_output = None
+                    reference_tt_out = None
+                    mismatch_marker = None
+                    for it in range(num_iterations):
+                        tt_out = run_chunk_call(
+                            config_id,
+                            program_config,
+                            it,
+                            i,
+                            s,
+                            e,
                             tt_Q,
                             tt_K,
                             tt_V,
-                            e,
-                            is_causal=True,
-                            is_balanced=is_balanced,
-                            p_buf_k=persistent_output_buffer_k,
-                            p_buf_v=persistent_output_buffer_v,
-                            program_config=program_config,
-                            compute_kernel_config=compute_kernel_config,
-                            ccl_semaphore_handles=ccl_semaphore_handles,
-                            num_links=num_links,
-                            sp_axis=sp_axis,
-                            mesh_device=mesh_device,
-                            topology=topology,
-                            worker_sub_device_id=worker_sub_device_id,
-                            ccl_column=ccl_column,
-                            kv_cache_batch_idx=kv_cache_batch_idx_arg,
-                        )
-                    except Exception as exc:
-                        pytest.fail(
-                            f"Chunked prefill SDPA call raised on iter {it}, chunk {i} "
-                            f"(Q rows [{s}, {e}), logical_n={e}): {type(exc).__name__}: {exc}"
+                            persistent_output_buffer_k,
+                            persistent_output_buffer_v,
+                            kv_cache_batch_idx_arg,
                         )
 
-                    out_i = to_host(tt_out, chunk_size)
+                        if use_device_determinism_compare:
+                            if reference_tt_out is None:
+                                reference_tt_out = tt_out
+                            else:
+                                mismatch_marker = merge_device_mismatch_markers(
+                                    mismatch_marker,
+                                    device_tensors_mismatch_marker(reference_tt_out, tt_out),
+                                )
+                            continue
 
-                if num_iterations > 1:
-                    iter_outputs.append(out_i)
-                    continue
+                        out_i = to_host(tt_out, chunk_size)
+                        if use_ring_mla:
+                            out_i = out_i[:, :, :, :d_v]
 
-                expected_i = ref_full[:, :, s:e, :]
-                passed, pcc = comp_pcc(expected_i, out_i, pcc_threshold)
-                rmse = torch.sqrt(((expected_i - out_i) ** 2).mean()).item()
-                rmse_passed = rmse_threshold is None or rmse < rmse_threshold
-                logger.info(
-                    f"Chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: PCC={pcc} RMSE={rmse:.6f} "
-                    f"-> {'PASS' if passed and rmse_passed else 'FAIL'}"
-                )
-                per_chunk_results.append((i, e, passed, pcc, rmse_passed, rmse))
-
-            if num_iterations > 1:
-                if reference_outputs is None:
-                    reference_outputs = iter_outputs
+                        if reference_output is None:
+                            reference_output = out_i
+                        elif not torch.equal(reference_output, out_i):
+                            num_diffs = (reference_output != out_i).sum().item()
+                            max_diff = (reference_output - out_i).abs().max().item()
+                            pytest.fail(
+                                f"Chunked prefill {config_id} determinism failed at iter {it}, chunk {i}: "
+                                f"{num_diffs} differing elements, max diff = {max_diff}"
+                            )
+                    if use_device_determinism_compare and mismatch_marker is not None:
+                        determinism_mismatch_marker = merge_device_mismatch_markers(
+                            determinism_mismatch_marker, mismatch_marker
+                        )
                 else:
-                    diffs = []
-                    for i, (ref, cur) in enumerate(zip(reference_outputs, iter_outputs)):
-                        if not torch.equal(ref, cur):
-                            num_diffs = (ref != cur).sum().item()
-                            max_diff = (ref - cur).abs().max().item()
-                            diffs.append((i, num_diffs, max_diff))
-                            logger.warning(f"  iter {it} chunk {i}: {num_diffs} diffs, max={max_diff}")
-                    if diffs:
-                        details = "; ".join(f"chunk {i}: {n} diffs, max={m}" for i, n, m in diffs)
-                        pytest.fail(f"Chunked prefill determinism failed at iter {it}: {details}")
+                    tt_out = run_chunk_call(
+                        config_id,
+                        program_config,
+                        0,
+                        i,
+                        s,
+                        e,
+                        tt_Q,
+                        tt_K,
+                        tt_V,
+                        persistent_output_buffer_k,
+                        persistent_output_buffer_v,
+                        kv_cache_batch_idx_arg,
+                    )
+                    out_i = to_host(tt_out, chunk_size)
+                    if use_ring_mla:
+                        out_i = out_i[:, :, :, :d_v]
+                    record_chunk_accuracy(
+                        config_id,
+                        per_chunk_results_by_config[config_id],
+                        i,
+                        s,
+                        e,
+                        out_i,
+                    )
 
-        if num_iterations > 1:
-            logger.info(
-                f"Chunked prefill determinism verified: all {num_iterations} runs of "
-                f"{len(reference_outputs)} chunks are exactly equal"
-            )
-            return
+        if num_iterations > 1 and use_device_determinism_compare and determinism_mismatch_marker is not None:
+            assert not device_mismatch_marker_is_set(
+                determinism_mismatch_marker
+            ), "Chunked prefill produced output that differs from iteration 0"
 
-        failures = [
-            (i, e, pcc, rmse)
-            for i, e, passed, pcc, rmse_passed, rmse in per_chunk_results
-            if not passed or not rmse_passed
-        ]
-        if failures:
-            details = "; ".join(
-                f"chunk {i} (logical_n={e}): PCC={pcc}, RMSE={rmse:.6f}" for i, e, pcc, rmse in failures
-            )
-            pytest.fail(
-                f"Chunked prefill PCC/RMSE failures "
-                f"(pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}): {details}"
-            )
+        for config_id, per_chunk_results in per_chunk_results_by_config.items():
+            failures = [
+                (i, e, pcc, rmse)
+                for i, e, passed, pcc, rmse_passed, rmse in per_chunk_results
+                if not passed or not rmse_passed
+            ]
+            if failures:
+                details = "; ".join(
+                    f"chunk {i} (logical_n={e}): PCC={pcc}, RMSE={rmse:.6f}" for i, e, pcc, rmse in failures
+                )
+                pytest.fail(
+                    f"Chunked prefill {config_id} PCC/RMSE failures "
+                    f"(pcc_threshold={pcc_threshold}, rmse_threshold={rmse_threshold}): {details}"
+                )
+            if num_iterations > 1:
+                logger.info(
+                    f"Chunked prefill {config_id} determinism verified: "
+                    f"all {num_iterations} runs of {n_chunks if only_chunk is None else 1} chunks are exactly equal"
+                )
 
     finally:
-        ttnn.close_mesh_device(mesh_device)
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 def torch_chunked_causal_sdpa_reference(q, k, v, q_abs_offset, scale=None):
@@ -1681,38 +2088,19 @@ def run_ring_joint_sdpa_kv_pad_rotation_case(
     )
     cache_seq_per_dev = num_cache_slabs * chunk_size_local
 
-    use_ring = sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    sp_axis = 1
-    tp_axis = 0
-    num_links = 2
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
-
         sdpa_input_shard_dims = [None, None]
         sdpa_input_shard_dims[sp_axis] = 2
         if mesh_config.tp_size > 1:
@@ -1765,13 +2153,6 @@ def run_ring_joint_sdpa_kv_pad_rotation_case(
             k_chunk_size=32,
             exp_approx_mode=False,
         )
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
-        )
 
         logger.info(
             f"KV-pad rotation: sp_size={sp_size}, chunk_size_global={chunk_size_global}, "
@@ -1820,8 +2201,7 @@ def run_ring_joint_sdpa_kv_pad_rotation_case(
         )
 
     finally:
-        ttnn.close_mesh_device(mesh_device)
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
@@ -1874,38 +2254,19 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
     q_full = fa_rand(b, nhq, total_seq, d_q)
     kv_full = fa_rand(b, nhk, total_seq, d_k)
 
-    use_ring = sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    sp_axis = 1
-    tp_axis = 0
-    num_links = 2
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
-
         sdpa_input_shard_dims = [None, None]
         sdpa_input_shard_dims[sp_axis] = 2
         if mesh_config.tp_size > 1:
@@ -1944,13 +2305,6 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
             q_chunk_size=32,
             k_chunk_size=32,
             exp_approx_mode=False,
-        )
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
         )
 
         logger.info(
@@ -2112,9 +2466,7 @@ def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
         )
 
     finally:
-        mesh_device.disable_and_clear_program_cache()
-        ttnn.close_mesh_device(mesh_device)
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def run_ring_mla_sdpa_chunked_indexed_kv_cache(
@@ -2166,41 +2518,19 @@ def run_ring_mla_sdpa_chunked_indexed_kv_cache(
     d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
     q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
 
-    use_ring = sp_size > 2
-    fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
-    topology = Topology.Ring if use_ring else Topology.Linear
-
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.STRICT_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-    )
-
-    sp_axis = 1
-    tp_axis = 0
-    num_links = 2
-    mesh_shape = ttnn.MeshShape(mesh_config.tp_size, sp_size)
-    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    topology = runtime.topology
+    sp_axis = runtime.sp_axis
+    tp_axis = runtime.tp_axis
+    num_links = runtime.num_links
+    sdpa_compute_grid = runtime.sdpa_compute_grid
+    ccl_column = runtime.ccl_column
+    worker_sub_device_id = runtime.worker_sub_device_id
+    ccl_semaphore_handles = runtime.ccl_semaphore_handles
+    compute_kernel_config = runtime.compute_kernel_config
 
     try:
-        sdpa_compute_grid = (mesh_config.sdpa_cols, mesh_config.grid_rows)
-        ccl_column = mesh_config.ccl_column
-        full_compute_grid = mesh_device.compute_with_storage_grid_size()
-
-        ccl_sub_device_crs = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(full_compute_grid.x - 1, full_compute_grid.y - 1))}
-        )
-        worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
-        worker_sub_device_id = ttnn.SubDeviceId(0)
-        sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
-        mesh_device.load_sub_device_manager(sub_device_manager)
-        mesh_device.set_sub_device_stall_group([worker_sub_device_id])
-
-        ccl_semaphore_handles = create_global_semaphores(mesh_device, ccl_sub_device_crs, 0)
-
         Q_full = fa_rand(b, nhq, total_seq, d_q)
         KV_full = fa_rand(b, nhk, total_seq, d_k)
         V_full = KV_full[:, :, :, :d_v]
@@ -2223,13 +2553,6 @@ def run_ring_mla_sdpa_chunked_indexed_kv_cache(
             q_chunk_size=q_chunk_size,
             k_chunk_size=k_chunk_size,
             exp_approx_mode=False,
-        )
-        compute_kernel_config = ttnn.init_device_compute_kernel_config(
-            mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
         )
 
         kv_memory_config = nd_sharded_dram_memory_config(mesh_device, d_k)
@@ -2366,8 +2689,7 @@ def run_ring_mla_sdpa_chunked_indexed_kv_cache(
         logger.info(f"ring_mla chunked indexed-cache verified: {n_chunks} chunks replayed {num_iterations} times")
 
     finally:
-        ttnn.close_mesh_device(mesh_device)
-        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 def test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy():
@@ -2540,6 +2862,15 @@ def generate_ring_mla_test_configs(mesh_config: MeshConfig, model_configs: Dict[
 RING_MLA_TEST_CONFIGS, RING_MLA_TEST_CONFIG_IDS = generate_ring_mla_test_configs(MESH_CONFIG, MODEL_CONFIGS)
 
 
+def _generate_standard_model_groups():
+    if os.environ.get("CI") == "true":
+        return [tuple(TEST_CONFIG_MODELS)], ["all-models"]
+    return [(model_name,) for model_name in TEST_CONFIG_MODELS], TEST_CONFIG_MODELS
+
+
+STANDARD_MODEL_GROUPS, STANDARD_MODEL_GROUP_IDS = _generate_standard_model_groups()
+
+
 # === TEST 1: PERFORMANCE SWEEP (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
 @pytest.mark.parametrize(
@@ -2629,30 +2960,10 @@ def test_ring_mla_sweep_perf_impl(
 
 
 # === TEST 2: ACCURACY VERIFICATION ===
-@pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
-    TEST_CONFIGS,
-    ids=TEST_CONFIG_IDS,
-)
-def test_ring_joint_attention_sdpa_accuracy(
-    b,
-    sq,
-    nhq,
-    nhk,
-    nhv,
-    d_q,
-    d_k,
-    d_v,
-    q_chunk_size,
-    k_chunk_size,
-    is_causal,
-    is_balanced,
-    q_dtype,
-    kv_dtype,
-):
+@pytest.mark.parametrize("model_name", TEST_CONFIG_MODELS)
+def test_ring_joint_attention_sdpa_accuracy(model_name):
     """
-    Accuracy verification test for ring joint attention SDPA.
-    Supports both WAN and MLA configurations.
+    Accuracy verification for every q/k chunk-size config in a model.
 
     ACCURACY METRICS:
     - PCC (Pearson Correlation Coefficient): Measures linear correlation
@@ -2662,25 +2973,14 @@ def test_ring_joint_attention_sdpa_accuracy(
     - PCC = 0.994: Relaxed for joint attention complexity
     """
     mesh_config = MESH_CONFIG
+    model = MODEL_CONFIGS[model_name]
 
     pcc_threshold = DEFAULT_PCC_THRESHOLD
     rmse_threshold = DEFAULT_RMSE_THRESHOLD
-    run_ring_joint_sdpa(
+    run_ring_joint_sdpa_model_configs(
         mesh_config,
-        b,
-        nhq,
-        nhk,
-        sq,
-        d_q,
-        q_chunk_size,
-        k_chunk_size,
-        q_dtype,
-        nhv=nhv,
-        d_k=d_k,
-        d_v=d_v,
-        kv_dtype=kv_dtype,
-        is_causal=is_causal,
-        is_balanced=is_balanced,
+        model,
+        get_model_qk_configs(model),
         pcc_threshold=pcc_threshold,
         rmse_threshold=rmse_threshold,
     )
@@ -2724,50 +3024,30 @@ def test_ring_mla_accuracy(
 
 # === TEST 3: DETERMINISM VERIFICATION ===
 @pytest.mark.parametrize(
-    "b,sq,nhq,nhk,nhv,d_q,d_k,d_v,q_chunk_size,k_chunk_size,is_causal,is_balanced,q_dtype,kv_dtype",
-    TEST_CONFIGS,
-    ids=TEST_CONFIG_IDS,
+    "model_names",
+    STANDARD_MODEL_GROUPS,
+    ids=STANDARD_MODEL_GROUP_IDS,
 )
-def test_ring_joint_attention_sdpa_determinism(
-    b,
-    sq,
-    nhq,
-    nhk,
-    nhv,
-    d_q,
-    d_k,
-    d_v,
-    q_chunk_size,
-    k_chunk_size,
-    is_causal,
-    is_balanced,
-    q_dtype,
-    kv_dtype,
-):
+def test_ring_joint_attention_sdpa_determinism(model_names):
     """
-    Test ring joint attention SDPA determinism: run 10 times with same inputs and verify outputs match exactly.
+    Test determinism for every q/k chunk-size config in a model.
     """
     mesh_config = MESH_CONFIG
-
     num_iterations = 10
-    run_ring_joint_sdpa(
-        mesh_config,
-        b,
-        nhq,
-        nhk,
-        sq,
-        d_q,
-        q_chunk_size,
-        k_chunk_size,
-        q_dtype,
-        nhv=nhv,
-        d_k=d_k,
-        d_v=d_v,
-        kv_dtype=kv_dtype,
-        is_causal=is_causal,
-        is_balanced=is_balanced,
-        num_iterations=num_iterations,
-    )
+
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    try:
+        for model_name in model_names:
+            model = MODEL_CONFIGS[model_name]
+            run_ring_joint_sdpa_model_configs(
+                mesh_config,
+                model,
+                get_model_qk_configs(model),
+                num_iterations=num_iterations,
+                runtime=runtime,
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 @pytest.mark.parametrize(
@@ -2810,7 +3090,6 @@ def test_ring_mla_determinism(
 
 # === TEST 4: PERFORMANCE TABLE GENERATOR (skipped on CI) ===
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test - skip on CI")
-@pytest.mark.timeout(1000)
 @pytest.mark.parametrize("model_name", TEST_CONFIG_MODELS)
 def test_ring_joint_attention_create_perf_table(model_name):
     """
@@ -3036,7 +3315,6 @@ RING_JOINT_PERF_CHECK_CONFIGS = [
     os.environ.get("SDPA_PERF_CHECKS") != "1",
     reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
 )
-@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util",
     RING_JOINT_PERF_CHECK_CONFIGS,
@@ -3218,14 +3496,40 @@ CHUNKED_CONFIGS, CHUNKED_CONFIG_IDS = _generate_chunked_configs(CHUNKED_PREFILL_
 RING_MLA_CHUNKED_CONFIGS, RING_MLA_CHUNKED_CONFIG_IDS = _generate_chunked_configs(RING_MLA_CHUNKED_MODEL_CONFIGS)
 
 
-@pytest.mark.timeout(1200)
+def _generate_chunked_test_configs(model_configs, chunked_configs, chunked_config_ids):
+    if os.environ.get("CI") == "true":
+        configs = []
+        ids = []
+        for model_name, model in model_configs.items():
+            configs.append((model_name, get_model_qk_configs(model)))
+            ids.append(f"{model_name}-all-qk")
+        return configs, ids
+
+    configs = []
+    for model_name, q_chunk_size, k_chunk_size in chunked_configs:
+        configs.append((model_name, [(q_chunk_size, k_chunk_size)]))
+    return configs, chunked_config_ids
+
+
+CHUNKED_TEST_CONFIGS, CHUNKED_TEST_CONFIG_IDS = _generate_chunked_test_configs(
+    CHUNKED_PREFILL_MODEL_CONFIGS,
+    CHUNKED_CONFIGS,
+    CHUNKED_CONFIG_IDS,
+)
+RING_MLA_CHUNKED_TEST_CONFIGS, RING_MLA_CHUNKED_TEST_CONFIG_IDS = _generate_chunked_test_configs(
+    RING_MLA_CHUNKED_MODEL_CONFIGS,
+    RING_MLA_CHUNKED_CONFIGS,
+    RING_MLA_CHUNKED_CONFIG_IDS,
+)
+
+
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(
-    "model_name,q_chunk_size,k_chunk_size",
-    CHUNKED_CONFIGS,
-    ids=CHUNKED_CONFIG_IDS,
+    "model_name,qk_configs",
+    CHUNKED_TEST_CONFIGS,
+    ids=CHUNKED_TEST_CONFIG_IDS,
 )
-def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, q_chunk_size, k_chunk_size, chunk_size):
+def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, qk_configs, chunk_size):
     """Validate ring joint SDPA chunked prefill with reusable max-sized K/V buffers."""
     mesh_config = MESH_CONFIG
 
@@ -3233,20 +3537,18 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, q_chunk_size, k_
         mesh_config,
         CHUNKED_PREFILL_MODEL_CONFIGS[model_name],
         chunk_size=chunk_size,
-        q_chunk_size=q_chunk_size,
-        k_chunk_size=k_chunk_size,
+        qk_configs=qk_configs,
         persistent_buffer_mode="reuse_max",
     )
 
 
-@pytest.mark.timeout(1200)
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(
-    "model_name,q_chunk_size,k_chunk_size",
-    RING_MLA_CHUNKED_CONFIGS,
-    ids=RING_MLA_CHUNKED_CONFIG_IDS,
+    "model_name,qk_configs",
+    RING_MLA_CHUNKED_TEST_CONFIGS,
+    ids=RING_MLA_CHUNKED_TEST_CONFIG_IDS,
 )
-def test_ring_mla_chunked_accuracy(model_name, q_chunk_size, k_chunk_size, chunk_size):
+def test_ring_mla_chunked_accuracy(model_name, qk_configs, chunk_size):
     """Validate ring_mla (latent V) chunked prefill with reusable max-sized K/V buffers."""
     mesh_config = MESH_CONFIG
 
@@ -3254,52 +3556,47 @@ def test_ring_mla_chunked_accuracy(model_name, q_chunk_size, k_chunk_size, chunk
         mesh_config,
         RING_MLA_CHUNKED_MODEL_CONFIGS[model_name],
         chunk_size=chunk_size,
-        q_chunk_size=q_chunk_size,
-        k_chunk_size=k_chunk_size,
+        qk_configs=qk_configs,
         persistent_buffer_mode="reuse_max",
         use_ring_mla=True,
     )
 
 
 # === TEST 7: CHUNKED-PREFILL DETERMINISM ===
-@pytest.mark.timeout(1800)
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(
-    "model_name,q_chunk_size,k_chunk_size",
-    CHUNKED_CONFIGS,
-    ids=CHUNKED_CONFIG_IDS,
+    "model_name,qk_configs",
+    CHUNKED_TEST_CONFIGS,
+    ids=CHUNKED_TEST_CONFIG_IDS,
 )
-def test_ring_joint_attention_sdpa_chunked_determinism(model_name, q_chunk_size, k_chunk_size, chunk_size):
-    """Replay ring joint SDPA chunked prefill 3 times and require bit-exact per-chunk outputs."""
+def test_ring_joint_attention_sdpa_chunked_determinism(model_name, qk_configs, chunk_size):
+    """Run each chunked prefill step 3 times and require bit-exact per-chunk outputs."""
     mesh_config = MESH_CONFIG
 
     run_ring_joint_sdpa_chunked(
         mesh_config,
         CHUNKED_PREFILL_MODEL_CONFIGS[model_name],
         chunk_size=chunk_size,
-        q_chunk_size=q_chunk_size,
-        k_chunk_size=k_chunk_size,
+        qk_configs=qk_configs,
         num_iterations=3,
     )
 
 
-@pytest.mark.timeout(1800)
 @pytest.mark.parametrize("chunk_size", [CHUNKED_PREFILL_CHUNK_SIZE], ids=[f"chunk{CHUNKED_PREFILL_CHUNK_SIZE}"])
 @pytest.mark.parametrize(
-    "model_name,q_chunk_size,k_chunk_size",
-    RING_MLA_CHUNKED_CONFIGS,
-    ids=RING_MLA_CHUNKED_CONFIG_IDS,
+    "model_name,qk_configs",
+    RING_MLA_CHUNKED_TEST_CONFIGS,
+    ids=RING_MLA_CHUNKED_TEST_CONFIG_IDS,
 )
-def test_ring_mla_chunked_determinism(model_name, q_chunk_size, k_chunk_size, chunk_size):
-    """Replay ring_mla (latent V) chunked prefill 3 times and require bit-exact per-chunk outputs."""
+def test_ring_mla_chunked_determinism(model_name, qk_configs, chunk_size):
+    """Run each ring_mla chunked prefill step 3 times and require bit-exact per-chunk outputs."""
     mesh_config = MESH_CONFIG
 
     run_ring_joint_sdpa_chunked(
         mesh_config,
         RING_MLA_CHUNKED_MODEL_CONFIGS[model_name],
         chunk_size=chunk_size,
-        q_chunk_size=q_chunk_size,
-        k_chunk_size=k_chunk_size,
+        qk_configs=qk_configs,
         num_iterations=3,
         use_ring_mla=True,
     )


### PR DESCRIPTION
## Summary

Batch ring joint SDPA CI coverage around model-level runs instead of running one pytest item per q/k config.

Key changes:
- run all q/k chunk-size configs for each model with shared Q/K/V uploads, persistent buffers, mesh composer, and torch reference
- group standard determinism into one CI item and reuse the mesh runtime across models
- group chunked-prefill q/k configs into one CI item while preserving coverage for every q/k pair
- use deterministic finite inputs and device-side mismatch markers for determinism checks to avoid repeated large host transfers
- centralize mesh/fabric setup and teardown in `RingJointSDPARuntime`, including fabric cleanup on setup/close failure paths
- preserve program-cache cleanup for the `ring_mla` `kv_actual_isl` reuse-max path through the shared close helper
- remove per-test timeout decorators and rely on the suite-level pytest timeout

## Impact

Measured on a local 4-device Blackhole system with:

```bash
CI=true python -m pytest -q -ra tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
```

Before, at measured `origin/main` baseline `186872f46bc`:

```text
66 passed, 39 skipped in 1142.01s (0:19:02)
```

After this change, rebased onto `origin/main` `97dedae4413`:

```text
20 passed, 39 skipped in 410.30s (0:06:50)
```

This is a `2.78x` speedup, saving `731.71s` of wall time, about a `64%` reduction.

The passed-test count drops because CI now batches q/k configs into fewer pytest items. Coverage still includes every configured q/k pair.

## Tests

- [x] `python -m py_compile tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py`
- [x] `python -m pytest --collect-only -q tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py`
- [x] `./build_metal.sh --release`
- [x] `CI=true python -m pytest -q -ra tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py`
- [ ] [![BH e2e SDPA](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Apjosipovic%2Fring-joint-sdpa-test-optimization) `(Blackhole) e2e tests`, `test-selection=sdpa`, branch runs: https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Apjosipovic%2Fring-joint-sdpa-test-optimization

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-test-optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-test-optimization)