### PR TITLE
Cleanup: Replace deprecated apt-key with gpg --dearmor in install_dependencies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -275,10 +275,15 @@ prep_ubuntu_system() {
     apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
 
     # Add LLVM repository for Clang 17
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/apt-llvm-org.gpg
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
+    local llvm_keyring="/usr/share/keyrings/llvm-snapshot.gpg"
+    local llvm_keyring_tmp
+    llvm_keyring_tmp="$(mktemp "${llvm_keyring}.XXXXXX")"
+    ( set -o pipefail; wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor --batch --yes --no-tty -o "$llvm_keyring_tmp" )
+    chmod 0644 "$llvm_keyring_tmp"
+    mv -f "$llvm_keyring_tmp" "$llvm_keyring"
+    echo "deb [signed-by=$llvm_keyring] https://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
     # Also v20
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+    echo "deb [signed-by=$llvm_keyring] https://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
     # Install CMake from GitHub releases (skip in Docker, cmake provided via tool image)
     if [ "$docker" -ne 1 ]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -275,7 +275,7 @@ prep_ubuntu_system() {
     apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
 
     # Add LLVM repository for Clang 17
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/apt-llvm-org.gpg
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
     # Also v20
     echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list


### PR DESCRIPTION
### Summary

`install_dependencies.sh` uses `apt-key add` in `prep_ubuntu_system()` to
register the LLVM repository signing key.  `apt-key` has been deprecated
since Debian 11 / Ubuntu 20.04 and was removed entirely in Debian 13
(trixie) and Ubuntu 26.04 (resolute).  On those distros the script fails
with `apt-key: command not found`.  Even on currently supported platforms
(Ubuntu 22.04, 24.04, Debian 12) a deprecation warning is emitted on
every run.

This PR replaces `apt-key add` with `gpg --dearmor -o`, the migration
path recommended by Debian and Ubuntu.  The resulting key file under
`/etc/apt/trusted.gpg.d/` is functionally identical — no change to which
repositories are trusted.

Closes #46275

### Notes for reviewers

- One-line change in `install_dependencies.sh`, in `prep_ubuntu_system()`.
- `gpg --dearmor -o` has been the standard replacement for `apt-key add` since 2021.  The `gnupg` package is already installed earlier in the same function, so no new dependency is introduced.
- Validated through
[tetsuh/tt-metal-community-distro-matrix](https://github.com/tetsuh/tt-metal-community-distro-matrix) on Debian 12, Debian 13, Ubuntu 22.04, 24.04, and 26.04 — all pass the full `install_dependencies.sh` + `build_metal.sh` pipeline with this change applied.