### PR TITLE
Cleanup: Limit oneAPI repository to TBB packages in install_dependencies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -316,6 +316,10 @@ enabled=1
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+# Keep the Intel repository scoped to the oneAPI TBB packages tt-metal needs.
+# Without this, DNF may satisfy unrelated dependencies (for example OpenMPI)
+# from oneAPI, pulling older Intel packages signed by keys not listed above.
+includepkgs=intel-oneapi-tbb* intel-oneapi-common-* intel-oneapi-tcm-*
 REPO_EOF
 }
 


### PR DESCRIPTION
### Summary

On Red Hat family distributions (Rocky Linux 9, Rocky Linux 10), `prep_redhat_system()` adds the Intel oneAPI repository to obtain oneTBB 2021+. 
The repository configuration currently has no `includepkgs` restriction, which means DNF may satisfy unrelated packages (e.g. OpenMPI) from the oneAPI repository.

When this happens, DNF can pull in older Intel RPMs signed with GPG keys not listed in the repository config, causing package verification failures.  This is intermittent but completely blocks the install when it occurs.

This PR adds an `includepkgs` directive to scope the oneAPI repository to only the TBB-related packages tt-metal needs.  tt-metal's sole use of the oneAPI repository is for `intel-oneapi-tbb-devel`, so the restriction has no functional impact.  `repo_gpgcheck` and `gpgcheck` are preserved.

Closes #46277

### Notes for reviewers

- Four-line addition to `install_dependencies.sh`, in `prep_redhat_system()`.
- The `includepkgs` pattern covers `intel-oneapi-tbb*`, `intel-oneapi-common-*`, and `intel-oneapi-tcm-*` — the packages required by `intel-oneapi-tbb-devel`.
- Validated through
[tetsuh/tt-metal-community-distro-matrix](https://github.com/tetsuh/tt-metal-community-distro-matrix) on Rocky Linux 9 and Rocky Linux 10 — both pass the full `install_dependencies.sh` + `build_metal.sh` pipeline, and the intermittent GPG verification failures no longer occur.