### PR TITLE
Support streaming SDPA sliding-window prefill

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -1887,3 +1887,57 @@ def test_sdpa_with_attention_sink_sliding_window(
         sliding_window=sliding_window,
         rmse_threshold=rmse_threshold,
     )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+def test_sdpa_with_attention_sink_gpt_oss_prefill_forward_progress(device, dtype, reset_seeds):
+    b = 1
+    nh = 64
+    nkv = 8
+    s = 4096
+    d = 64
+    q_chunk_size = 256
+    k_chunk_size = 256
+    sliding_window = 128
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+        q_chunk_size=q_chunk_size,
+        k_chunk_size=k_chunk_size,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    Q = fa_rand(b, nh, s, d)
+    K = fa_rand(b, nkv, s, d)
+    V = fa_rand(b, nkv, s, d)
+
+    # GPT-OSS stores sink logits in the already-scaled attention-score domain. TTNN SDPA
+    # applies the softmax scale internally, so provide sink / scale to match model usage.
+    scale = 1.0 / math.sqrt(d)
+    S = (torch.rand(1, nh, 1, 1) * 4.0) / scale
+
+    tt_Q = ttnn.from_torch(Q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_K = ttnn.from_torch(K, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_V = ttnn.from_torch(V, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+    tt_S = ttnn.from_torch(S, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, pad_value=0.0)
+
+    tt_back = ttnn.transformer.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=True,
+        sliding_window_size=sliding_window,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        attention_sink=tt_S,
+    )
+    tt_back = ttnn.to_torch(tt_back)[:, :, :s, :]
+
+    assert tt_back.shape == (b, nh, s, d)
+    assert torch.isfinite(tt_back).all()

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -1940,4 +1940,5 @@ def test_sdpa_with_attention_sink_gpt_oss_prefill_forward_progress(device, dtype
     tt_back = ttnn.to_torch(tt_back)[:, :, :s, :]
 
     assert tt_back.shape == (b, nh, s, d)
+    # This GPT-OSS-scale case guards forward progress; smaller parametrized cases above check numerical accuracy.
     assert torch.isfinite(tt_back).all()

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -1529,6 +1529,29 @@ def reference_sdpa_with_attention_sinks(Q, K, V, S, is_causal=True, sliding_wind
     return output
 
 
+def reference_causal_attention_sink_sliding_window_rows(Q, K, V, S, query_positions, sliding_window):
+    b, nh, s, d = Q.shape
+    _, nkv, _, _ = K.shape
+    assert nh % nkv == 0
+    assert S.shape == (1, nh, 1, 1), f"Expected S shape {(1, nh, 1, 1)}, got {S.shape}"
+
+    K_repeated = torch.cat([K[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    V_repeated = torch.cat([V[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1)
+    sink_scores = S.repeat_interleave(b, dim=0) * (1.0 / math.sqrt(d))
+
+    rows = []
+    for q_pos in query_positions:
+        window_start = max(0, q_pos + 1 - sliding_window)
+        q = Q[:, :, q_pos : q_pos + 1, :]
+        k = K_repeated[:, :, window_start : q_pos + 1, :]
+        v = V_repeated[:, :, window_start : q_pos + 1, :]
+        qk = torch.matmul(q, k.transpose(-2, -1)) * (1.0 / math.sqrt(d))
+        weights = torch.softmax(torch.cat([qk, sink_scores], dim=-1), dim=-1)[..., :-1]
+        rows.append(torch.matmul(weights, v).squeeze(-2))
+
+    return torch.stack(rows, dim=2)
+
+
 def reference_flash_attention_with_sinks(Q, K, V, S, is_causal=True, q_chunk_size=32, k_chunk_size=32):
     """
     Flash Attention implementation with attention sinks using chunked processing.
@@ -1890,7 +1913,7 @@ def test_sdpa_with_attention_sink_sliding_window(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
-def test_sdpa_with_attention_sink_gpt_oss_prefill_forward_progress(device, dtype, reset_seeds):
+def test_sdpa_with_attention_sink_gpt_oss_prefill_sampled_accuracy(device, dtype, reset_seeds):
     b = 1
     nh = 64
     nkv = 8
@@ -1940,5 +1963,15 @@ def test_sdpa_with_attention_sink_gpt_oss_prefill_forward_progress(device, dtype
     tt_back = ttnn.to_torch(tt_back)[:, :, :s, :]
 
     assert tt_back.shape == (b, nh, s, d)
-    # This GPT-OSS-scale case guards forward progress; smaller parametrized cases above check numerical accuracy.
     assert torch.isfinite(tt_back).all()
+
+    query_positions = [0, sliding_window - 1, sliding_window, q_chunk_size - 1, q_chunk_size, s // 2, s - 1]
+    gt = reference_causal_attention_sink_sliding_window_rows(Q, K, V, S, query_positions, sliding_window)
+    tt_rows = tt_back[:, :, query_positions, :]
+
+    out_pass, out_pcc = comp_pcc(gt, tt_rows, 0.99)
+    logger.debug(f"sampled pytorch vs tt: {out_pcc}")
+    rmse = torch.sqrt(((gt - tt_rows) ** 2).mean()).item()
+    logger.debug(f"sampled rmse: {rmse}")
+    assert rmse < 0.02, f"RMSE {rmse} exceeds threshold 0.02"
+    assert out_pass, f"PCC check failed: {out_pcc}"

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -468,7 +468,7 @@ def run_test_sdpa_sliding_window(
 
 
 def run_test_sdpa_with_attention_sink(
-    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sink_values=None, rmse_threshold=None
+    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, is_causal=True, sink_values=None, rmse_threshold=None
 ):
     """Test SDPA with attention sinks using per-head sink values."""
     program_config = ttnn.SDPAProgramConfig(
@@ -508,7 +508,7 @@ def run_test_sdpa_with_attention_sink(
         tt_Q,
         tt_K,
         tt_V,
-        is_causal=True,
+        is_causal=is_causal,
         program_config=program_config,
         compute_kernel_config=compute_kernel_config,
         attention_sink=tt_S,
@@ -527,14 +527,14 @@ def run_test_sdpa_with_attention_sink(
         K_repeated,
         V_repeated,
         S_padded,
-        is_causal=True,
+        is_causal=is_causal,
     )
     gt_flash = reference_flash_attention_with_sinks(
         Q,
         K_repeated,
         V_repeated,
         S_padded,
-        is_causal=True,
+        is_causal=is_causal,
         q_chunk_size=q_chunk_size,
         k_chunk_size=k_chunk_size,
     )
@@ -744,13 +744,14 @@ def test_sdpa_sliding_window_streaming_parity(
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("is_causal", [True, False], ids=["causal", "noncausal"])
 @pytest.mark.parametrize("q_chunk_size", [32], ids=["q32"])
 @pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d",
     ([1, 8, 1, 256, 32],),
 )
-def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_chunk_size, reset_seeds):
+def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, is_causal, q_chunk_size, k_chunk_size, reset_seeds):
     """Test SDPA with per-head attention sinks on device."""
     if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
@@ -759,5 +760,5 @@ def test_sdpa_with_attention_sink(device, b, nh, nkv, s, d, dtype, q_chunk_size,
 
     rmse_threshold = 0.02
     run_test_sdpa_with_attention_sink(
-        device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold
+        device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, is_causal=is_causal, rmse_threshold=rmse_threshold
     )

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -696,7 +696,10 @@ def test_sdpa_tt_with_program_cache(device, b, nh, nkv, s, d, q_chunk_size, k_ch
 @pytest.mark.parametrize("k_chunk_size", [256], ids=["k256"])
 @pytest.mark.parametrize(
     "b, nh, nkv, s, d, sliding_window",
-    ([1, 8, 1, 2048, 128, 128],),
+    (
+        [1, 8, 1, 2048, 128, 128],
+        [1, 8, 1, 8192, 128, 512],
+    ),
 )
 def test_sdpa_sliding_window(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_chunk_size, sliding_window):
     """Test sliding window attention functionality in SDPA prefill."""
@@ -708,6 +711,35 @@ def test_sdpa_sliding_window(device, b, nh, nkv, s, d, dtype, q_chunk_size, k_ch
     rmse_threshold = 0.01
     run_test_sdpa_sliding_window(
         device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, sliding_window, rmse_threshold=rmse_threshold
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, q_chunk_size, k_chunk_size, sliding_window, is_causal",
+    (
+        [1, 8, 1, 2048, 128, 256, 256, 130, True],
+        [1, 8, 1, 1024, 128, 256, 256, 130, False],
+    ),
+)
+def test_sdpa_sliding_window_streaming_parity(
+    device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, sliding_window, is_causal, dtype
+):
+    """Covers streaming sliding-window cases that previously fell back to legacy compute."""
+    rmse_threshold = 0.01
+    run_test_sdpa_sliding_window(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        sliding_window,
+        is_causal=is_causal,
+        rmse_threshold=rmse_threshold,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1516,7 +1516,7 @@ void apply_causal_mask_lightweight(
 }
 
 /**
- * Context for lightweight mask application in ring joint SDPA.
+ * Context for lightweight mask application.
  * All mask tiles reside in a single CB. This struct stores the pre-resolved mask metadata used when
  * lightweight masking is enabled; enablement itself is controlled by the `lightweight_mask_enabled`
  * template parameter(s), not by default-constructing this context.
@@ -1525,6 +1525,10 @@ struct LightweightMaskContext {
     bool is_causal = false;                  // Causal masking active for this context instance
     uint32_t neginf_tile_idx = 0;            // Index of -inf tile in the mask CB
     uint32_t causal_diag_tile_idx = 0;       // Index of causal diagonal tile in the mask CB
+    uint32_t primary_diag_tile_idx = 0;      // Causal diagonal, or sliding-window trailing-primary tile
+    uint32_t sliding_leading_prev_tile_idx = 0;   // Index of previous sliding-window leading tile
+    uint32_t sliding_leading_tile_idx = 0;        // Index of current sliding-window leading tile in the mask CB
+    uint32_t sliding_trailing_next_tile_idx = 0;  // Index of next sliding-window trailing tile
     uint32_t global_n_padded_tiles = 0;      // Fully padded K tile columns for global_n chunk
     uint32_t local_n_padded_tiles = 0;       // Fully padded K tile columns for local_n chunk
     uint32_t joint_n_padded_tiles = 0;       // Fully padded K tile columns for joint_l chunk

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -18,6 +18,7 @@
 #include "api/compute/experimental/matmul_custom.h"
 #include "api/compute/experimental/sdpa_sub_custom.h"
 #endif
+#include "api/compute/eltwise_binary_sfpu.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 // Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
@@ -624,9 +625,24 @@ template <
     uint32_t dst_size,
     uint32_t col_identity_cb,
     uint32_t scratch_cb,
-    uint32_t normalized_out_cb>
+    uint32_t normalized_out_cb,
+    uint32_t scale_fp32 = 0,
+    bool use_attention_sink = false,
+    uint32_t cb_attention_sink = INVALID_CB>
 static __attribute__((noinline, noclone)) void normalize_row_streaming(
-    uint32_t cur_sum_cb, uint32_t cur_out_cb, uint32_t sbh) {
+    uint32_t cur_sum_cb,
+    uint32_t cur_out_cb,
+    uint32_t sbh,
+    [[maybe_unused]] uint32_t cur_max_cb_rt = 0,
+    [[maybe_unused]] uint32_t sink_row_offset = 0) {
+    // Attention sink: cb_attention_sink holds raw per-head sink logits (column 0, zeros elsewhere).
+    // exp((sink - max)*scale) is computed inline per-row via sub_bcast_cols+exp, then folded into
+    // the col-reduced denominator (DST[0]). sbh tiles consumed per call, popped once at end;
+    // across all normalize calls for the chunk this consumes exactly Sq_chunk_t tiles.
+    if constexpr (use_attention_sink) {
+        cb_wait_front(cb_attention_sink, sbh);
+        cb_wait_front(cur_max_cb_rt, sink_row_offset + sbh);
+    }
     configure_single_tile_pack(scratch_cb);
     for (uint32_t s = 0; s < sbh; s++) {
         // 1+2. Fused matmul_reduce + recip: sum × col_identity → recip → 1/sum in scratch
@@ -645,6 +661,18 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             cb_reserve_back(scratch_cb, 1);
             tile_regs_acquire();
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
+            if constexpr (use_attention_sink) {
+                // DST[1] = exp((sink[s] - max[row_offset+s]) * scale); DST[0] += DST[1].
+                sub_bcast_cols_init_short(cb_attention_sink, cur_max_cb_rt);
+                sub_tiles_bcast_cols(cb_attention_sink, cur_max_cb_rt, s, sink_row_offset + s, 1);
+                // The custom first-column exp needs generic unary SFPU addrmod state, but not the
+                // Blackhole approximate exp_init macro/replay setup used by exp_tile<true>.
+                MATH((llk_math_eltwise_unary_sfpu_init<SfpuType::exponential>()));
+                constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
+                MATH((exp_tile_first_column<EXP_APPROX_MODE, scale_bf16>(1)));
+                add_binary_tile_init();
+                add_binary_tile(0, 1, 0);
+            }
 #ifdef ARCH_BLACKHOLE
             recip_tile_init<false>();
             MATH((recip_tile<false>(0 /*dst_index*/, VectorMode::C)));
@@ -693,6 +721,9 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             cb_pop_front(scratch_cb, 1);
             cb_pop_front(cur_out_cb, head_dim_t_);
         }
+    }
+    if constexpr (use_attention_sink) {
+        cb_pop_front(cb_attention_sink, sbh);
     }
     // Restore pack format to scratch_cb (im_df = Float16_b) so that subsequent ops
     // (e.g. salad_correct_fused on the next K-chunk's drain row) pack to F16b CBs
@@ -1020,7 +1051,9 @@ template <
     uint32_t kv_pad_kv_local_padded_Nt = 0,
     uint32_t v_cb_physical_width_t = vDHt,
     bool kt_inplace_v = false,
-    uint32_t sliding_window_size = 0>
+    uint32_t sliding_window_size = 0,
+    bool use_attention_sink = false,
+    uint32_t cb_attention_sink = INVALID_CB>
 static void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
@@ -1343,6 +1376,7 @@ static void sdpa_inner_loop_step(
 
         // Per-row normalization lambda — fires on last K chunk (standard or deferred norm).
         // Takes sbh so it works for both full subblocks (qktv_h) and remainder (qktv_remainder_h).
+        [[maybe_unused]] uint32_t sink_row_offset = 0;
         [[maybe_unused]] auto normalize_row = [&](uint32_t& pushed, uint32_t sbh) {
             MaybeDeviceZoneScopedN(profiling_enabled, "ROW_NORM");
             cb_push_back(cur.sum, sbh);
@@ -1353,7 +1387,13 @@ static void sdpa_inner_loop_step(
                 dst_size,
                 cb_col_identity,
                 cb_recip_scratch,
-                cb_normalized_out>(cur.sum, out_cb, sbh);
+                cb_normalized_out,
+                scale_fp32,
+                use_attention_sink,
+                cb_attention_sink>(cur.sum, out_cb, sbh, cur.max, sink_row_offset);
+            if constexpr (use_attention_sink) {
+                sink_row_offset += sbh;
+            }
             pushed++;
         };
 
@@ -1594,7 +1634,9 @@ template <
     uint32_t cb_normalized_out,
     uint32_t cb_mask_in,
     uint32_t sliding_window_size = 0,
-    bool is_causal_sdpa = false>
+    bool is_causal_sdpa = false,
+    bool use_attention_sink = false,
+    uint32_t cb_attention_sink = INVALID_CB>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
     const uint32_t k_num_chunks,
@@ -1725,7 +1767,9 @@ void sdpa_standard_v2(
                 0,
                 vDHt,
                 false,
-                sliding_window_size>(
+                sliding_window_size,
+                use_attention_sink,
+                cb_attention_sink>(
                 prev,
                 cur,
                 is_last,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -207,6 +207,14 @@ ALWI bool configure_row_pack_width(uint32_t cb, uint32_t pack_width) {
     return use_blocked_pack_width;
 }
 
+ALWI void init_sdpa_streaming_semaphores() {
+    // reduce_trigger splits QK row-max reduce across a PACK->UNPACK handshake:
+    // PACK posts FPU_SFPU after QK writes are visible, then UNPACK waits before
+    // running the second half of the reduce MOP. Default firmware init covers
+    // common math/pack semaphores, but not FPU_SFPU, so initialize it here.
+    PACK((t6_semaphore_init(semaphore::FPU_SFPU, 0, 1)));
+}
+
 #if defined(TRISC_MATH) && defined(ARCH_WORMHOLE)
 ALWI void recip_tile_first_column_wh_idst0_direct() {
     // WH SDPA normalize always operates on DST tile 0. The generic unary-SFPU
@@ -1601,6 +1609,8 @@ void sdpa_standard_v2(
     const LightweightMaskContext& lw_mask = {},
     const uint32_t q_num_chunks = 0,
     const bool use_zigzag_balancing = false) {
+    init_sdpa_streaming_semaphores();
+
     // use_padded_mask + is_causal_sdpa is handled at the host level (mutually exclusive).
     static_assert(
         !(use_padded_mask && is_causal_sdpa), "use_padded_mask and is_causal_sdpa are mutually exclusive in v2");
@@ -1931,6 +1941,8 @@ void sdpa_ring_v2(
     const bool use_zigzag_balancing = false,
     const ChunkedContext& chunked = {},
     const bool is_first_active_iter = true) {
+    init_sdpa_streaming_semaphores();
+
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
     // is_causal: diagonal stamp only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
     const bool is_causal_iter = (is_causal_sdpa && (ring_iter == 0)) || chunked_enabled;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -12,6 +12,7 @@
 
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sdpa_streaming_qktv.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
 
 #if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 #include "api/compute/experimental/matmul_custom.h"
@@ -76,9 +77,9 @@ struct RingAccumulatorState {
 };
 
 // Ring-streaming lightweight-mask context. Field NAMES match LightweightMaskContext so sdpa_ring_v2's
-// generic `lw_mask.<field>` reads work for either type, BUT the 9 compile-time-constant fields are
+// generic `lw_mask.<field>` reads work for either type, BUT the 10 compile-time-constant fields are
 // template params (static constexpr → zero per-instance storage), leaving only the 3 per-ring-iter
-// runtime fields on the stack. Shrinks the live lw_mask object ~48 B → ~12 B on kernel_main's frame.
+// runtime fields on the stack. Shrinks the live lw_mask object ~56 B → ~12 B on kernel_main's frame.
 // Only the ring_joint_sdpa producer uses it; exp_ring keeps the plain LightweightMaskContext —
 // sdpa_ring_v2's MaskCtx template param is deduced per caller.
 template <
@@ -99,6 +100,7 @@ struct RingStreamingMaskCtx {
     // Compile-time-constant fields (no per-instance storage):
     static constexpr uint32_t neginf_tile_idx = NeginfTileIdx;
     static constexpr uint32_t causal_diag_tile_idx = CausalDiagTileIdx;
+    static constexpr uint32_t primary_diag_tile_idx = CausalDiagTileIdx;
     static constexpr uint32_t local_n_padded_tiles = LocalNPaddedTiles;
     static constexpr uint32_t joint_n_padded_tiles = JointNPaddedTiles;
     static constexpr uint32_t global_n_partial_col = GlobalNPartialCol;
@@ -115,6 +117,7 @@ struct RingStreamingMaskCtx {
         m.is_causal = is_causal;
         m.neginf_tile_idx = neginf_tile_idx;
         m.causal_diag_tile_idx = causal_diag_tile_idx;
+        m.primary_diag_tile_idx = primary_diag_tile_idx;
         m.global_n_padded_tiles = global_n_padded_tiles;
         m.local_n_padded_tiles = local_n_padded_tiles;
         m.joint_n_padded_tiles = joint_n_padded_tiles;
@@ -730,6 +733,91 @@ static inline void l1_acc_causal_col_mask(
 }
 
 /**
+ * Row-local mask stamping primitives for one Q row of a subblock. All column writes clamp to
+ * [0, mask_cols), so callers can pass raw (possibly out-of-range) diagonal columns directly.
+ */
+struct RowMaskStamper {
+    uint32_t mask_cb;
+    uint32_t out_cb;
+    uint32_t neginf_idx;
+    uint32_t row_offset;
+    uint32_t mask_cols;
+
+    // L1-accumulate diagonal tile `tile_idx` at column `col` (no-op if col out of range).
+    inline void stamp_tile_at(int32_t col, uint32_t tile_idx) const {
+        if (col >= 0 && static_cast<uint32_t>(col) < mask_cols) {
+            l1_acc_single_tile(mask_cb, tile_idx, out_cb, row_offset + static_cast<uint32_t>(col));
+        }
+    }
+    // Fill columns [0, end) with neginf.
+    inline void neginf_prefix(int32_t end) const {
+        if (end > 0) {
+            const uint32_t e = static_cast<uint32_t>(end) < mask_cols ? static_cast<uint32_t>(end) : mask_cols;
+            l1_acc_neginf_cols(mask_cb, out_cb, row_offset, 0, e, neginf_idx);
+        }
+    }
+    // Fill columns [start, mask_cols) with neginf (start <= 0 ⇒ whole row).
+    inline void neginf_suffix(int32_t start) const {
+        const uint32_t s =
+            start <= 0 ? 0u : (static_cast<uint32_t>(start) < mask_cols ? static_cast<uint32_t>(start) : mask_cols);
+        l1_acc_neginf_cols(mask_cb, out_cb, row_offset, s, mask_cols, neginf_idx);
+    }
+};
+
+// Stamp the leading (left) sliding-window edge for one Q row: neginf everything before the window,
+// then the diagonal edge tile(s). When the edge straddles two K tiles (leading_remainder != 0) the
+// previous tile carries the neginf run and both straddle tiles are stamped.
+template <uint32_t leading_base_tiles, uint32_t leading_remainder>
+static inline void stamp_sliding_leading_edge(
+    const RowMaskStamper& stamper,
+    int32_t q_pos,
+    uint32_t k_start_tile,
+    uint32_t sliding_leading_prev_idx,
+    uint32_t sliding_leading_idx) {
+    const int32_t leading_col = q_pos - static_cast<int32_t>(leading_base_tiles) - static_cast<int32_t>(k_start_tile);
+    if constexpr (leading_remainder == 0) {
+        // Window edge tile-aligned: single leading diagonal tile.
+        stamper.neginf_prefix(leading_col);
+        stamper.stamp_tile_at(leading_col, sliding_leading_idx);
+    } else {
+        // Window edge straddles two K tiles: prev tile carries the neginf run.
+        const int32_t leading_prev_col = leading_col - 1;
+        stamper.neginf_prefix(leading_prev_col);
+        stamper.stamp_tile_at(leading_prev_col, sliding_leading_prev_idx);
+        stamper.stamp_tile_at(leading_col, sliding_leading_idx);
+    }
+}
+
+// Stamp the trailing (right) sliding-window edge for one Q row (non-causal centered windows): the
+// diagonal edge tile(s) followed by neginf for everything past the window. When the edge straddles
+// into the next K tile (trailing_remainder != 0) both straddle tiles are stamped.
+template <uint32_t trailing_base_tiles, uint32_t trailing_remainder>
+static inline void stamp_sliding_trailing_edge(
+    const RowMaskStamper& stamper,
+    int32_t q_pos,
+    uint32_t k_start_tile,
+    uint32_t trailing_primary_idx,
+    uint32_t sliding_trailing_next_idx) {
+    const int32_t trailing_col = q_pos + static_cast<int32_t>(trailing_base_tiles) - static_cast<int32_t>(k_start_tile);
+    if constexpr (trailing_remainder == 0) {
+        // Window edge tile-aligned: single trailing diagonal tile.
+        if (trailing_col < 0) {
+            stamper.neginf_suffix(0);
+        } else if (static_cast<uint32_t>(trailing_col) < stamper.mask_cols) {
+            stamper.stamp_tile_at(trailing_col, trailing_primary_idx);
+            stamper.neginf_suffix(trailing_col + 1);
+        }
+    } else if (trailing_col < -1) {
+        stamper.neginf_suffix(0);
+    } else {
+        // Window edge straddles into the next K tile.
+        stamper.stamp_tile_at(trailing_col, trailing_primary_idx);
+        stamper.stamp_tile_at(trailing_col + 1, sliding_trailing_next_idx);
+        stamper.neginf_suffix(trailing_col + 2);
+    }
+}
+
+/**
  * Combined lightweight mask for streaming ring SDPA. Applies causal, partial, and padded masks.
  * KV-pad rotation reuses the causal path with a compile-time-selected Q row mapping.
  * Caller must set up copy_tile_to_dst_init_short and llk_pack_reconfig_l1_acc(1) before calling,
@@ -741,7 +829,8 @@ template <
     bool kv_pad_rotation_enabled = false,
     uint32_t kv_pad_q_local_padded_Nt = 0,
     uint32_t kv_pad_chunk_size_t = 0,
-    uint32_t kv_pad_kv_local_padded_Nt = 0>
+    uint32_t kv_pad_kv_local_padded_Nt = 0,
+    uint32_t sliding_window_size = 0>
 static void apply_lightweight_mask_streaming(
     uint32_t mask_cb,
     uint32_t out_cb,
@@ -752,10 +841,14 @@ static void apply_lightweight_mask_streaming(
     uint32_t sbh,
     bool apply_causal,
     uint32_t neginf_idx,
-    uint32_t causal_diag_idx,
+    uint32_t primary_diag_idx,
+    uint32_t sliding_leading_prev_idx,
+    uint32_t sliding_leading_idx,
+    uint32_t sliding_trailing_next_idx,
     uint32_t q_start_tile,
     uint32_t k_start_tile,
     uint32_t active_Sk,
+    bool apply_sliding_window = false,
     uint32_t straddle_col = 0,
     uint32_t straddle_jump = 0,
     const KVPadRotationContext& kv_pad_rotation = {}) {
@@ -765,12 +858,22 @@ static void apply_lightweight_mask_streaming(
 
     // Caller-owned contract (see function comment): pack state for mask_cb is initialized
     // before entry via copy_tile_to_dst_init_short + llk_pack_reconfig_l1_acc(1).
+    // Per-row stamp geometry: floor division + remainder, distinct from the ceil-based loop
+    // bounds in SlidingWindowLoopGeometry (causal reach here is `window`, not `window - 1`).
+    constexpr bool has_sliding_window = sliding_window_size > 0;
+    constexpr uint32_t half_window = sliding_window_size / 2;
+    constexpr uint32_t leading_base_tiles =
+        has_sliding_window ? (is_causal_sdpa ? (sliding_window_size / TILE_HEIGHT) : (half_window / TILE_HEIGHT)) : 0;
+    constexpr uint32_t leading_remainder =
+        has_sliding_window ? (is_causal_sdpa ? (sliding_window_size % TILE_HEIGHT) : (half_window % TILE_HEIGHT)) : 0;
+    constexpr uint32_t trailing_base_tiles = has_sliding_window && !is_causal_sdpa ? (half_window / TILE_HEIGHT) : 0;
+    constexpr uint32_t trailing_remainder = has_sliding_window && !is_causal_sdpa ? (half_window % TILE_HEIGHT) : 0;
     for (uint32_t row = 0; row < sbh; row++) {
         uint32_t row_offset = (q_subblock * sbh + row) * num_cols;
 
-        // Causal mask: per-row diagonal + trailing neginf
-        if constexpr (is_causal_sdpa) {
-            if (apply_causal || kv_pad_rotation_enabled) {
+        // Causal / sliding mask: per-row diagonal stamps plus full-neginf regions.
+        if constexpr (is_causal_sdpa || has_sliding_window) {
+            if (apply_causal || apply_sliding_window || kv_pad_rotation_enabled) {
                 const uint32_t q_tile = q_subblock * sbh + row;
                 const uint32_t q_pos_u32 =
                     q_global_tile_for_mask_row<kv_pad_rotation_enabled>(q_tile, q_start_tile, kv_pad_rotation);
@@ -783,6 +886,15 @@ static void apply_lightweight_mask_streaming(
                 }
 
                 const int32_t q_pos = static_cast<int32_t>(q_pos_u32);
+                [[maybe_unused]] const RowMaskStamper stamper{mask_cb, out_cb, neginf_idx, row_offset, mask_cols};
+
+                if constexpr (has_sliding_window) {
+                    if (apply_sliding_window) {
+                        stamp_sliding_leading_edge<leading_base_tiles, leading_remainder>(
+                            stamper, q_pos, k_start_tile, sliding_leading_prev_idx, sliding_leading_idx);
+                    }
+                }
+
                 if constexpr (kv_pad_rotation_enabled) {
                     for (uint32_t col = 0; col < mask_cols; col++) {
                         const uint32_t local_k_tile = kv_pad_rotation.k_local_start_tile + col;
@@ -799,29 +911,36 @@ static void apply_lightweight_mask_streaming(
                         }
                         const int32_t k_pos = static_cast<int32_t>(k_pos_u32);
                         l1_acc_causal_col_mask(
-                            mask_cb, out_cb, row_offset, col, q_pos, k_pos, neginf_idx, causal_diag_idx);
+                            mask_cb, out_cb, row_offset, col, q_pos, k_pos, neginf_idx, primary_diag_idx);
                     }
                 } else if (straddle_col == 0) {
                     // Fast path: K coords contiguous across cols.
-                    int32_t diag_col = q_pos - static_cast<int32_t>(k_start_tile);
-                    if (diag_col < 0) {
-                        l1_acc_neginf_cols(mask_cb, out_cb, row_offset, 0, mask_cols, neginf_idx);
-                    } else if (static_cast<uint32_t>(diag_col) < mask_cols) {
-                        l1_acc_single_tile(
-                            mask_cb, causal_diag_idx, out_cb, row_offset + static_cast<uint32_t>(diag_col));
-                        l1_acc_neginf_cols(
-                            mask_cb, out_cb, row_offset, static_cast<uint32_t>(diag_col) + 1, mask_cols, neginf_idx);
+                    if (apply_causal) {
+                        const int32_t diag_col = q_pos - static_cast<int32_t>(k_start_tile);
+                        if (diag_col < 0) {
+                            stamper.neginf_suffix(0);
+                        } else if (static_cast<uint32_t>(diag_col) < mask_cols) {
+                            stamper.stamp_tile_at(diag_col, primary_diag_idx);
+                            stamper.neginf_suffix(diag_col + 1);
+                        }
+                    } else if constexpr (has_sliding_window && !is_causal_sdpa) {
+                        if (apply_sliding_window) {
+                            stamp_sliding_trailing_edge<trailing_base_tiles, trailing_remainder>(
+                                stamper, q_pos, k_start_tile, primary_diag_idx, sliding_trailing_next_idx);
+                        }
                     }
                 } else {
                     // Chunked-prefill straddle: K coord jumps by straddle_jump at col >= straddle_col
                     // (the K-chunk crosses a slab boundary). Evaluate per-col.
-                    for (uint32_t col = 0; col < mask_cols; col++) {
-                        int32_t k_pos = static_cast<int32_t>(k_start_tile) + static_cast<int32_t>(col);
-                        if (col >= straddle_col) {
-                            k_pos += static_cast<int32_t>(straddle_jump);
+                    if (apply_causal) {
+                        for (uint32_t col = 0; col < mask_cols; col++) {
+                            int32_t k_pos = static_cast<int32_t>(k_start_tile) + static_cast<int32_t>(col);
+                            if (col >= straddle_col) {
+                                k_pos += static_cast<int32_t>(straddle_jump);
+                            }
+                            l1_acc_causal_col_mask(
+                                mask_cb, out_cb, row_offset, col, q_pos, k_pos, neginf_idx, primary_diag_idx);
                         }
-                        l1_acc_causal_col_mask(
-                            mask_cb, out_cb, row_offset, col, q_pos, k_pos, neginf_idx, causal_diag_idx);
                     }
                 }
             }
@@ -892,7 +1011,8 @@ template <
     uint32_t kv_pad_chunk_size_t = 0,
     uint32_t kv_pad_kv_local_padded_Nt = 0,
     uint32_t v_cb_physical_width_t = vDHt,
-    bool kt_inplace_v = false>
+    bool kt_inplace_v = false,
+    uint32_t sliding_window_size = 0>
 static void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
@@ -909,7 +1029,11 @@ static void sdpa_inner_loop_step(
     const uint32_t mask_q_start_tile = 0,
     const uint32_t mask_k_start_tile = 0,
     const uint32_t neginf_idx = 0,
-    const uint32_t causal_diag_idx = 0,
+    const uint32_t primary_diag_idx = 0,
+    const uint32_t sliding_leading_prev_idx = 0,
+    const uint32_t sliding_leading_idx = 0,
+    const uint32_t sliding_trailing_next_idx = 0,
+    const bool apply_sliding_window = false,
     const uint32_t mask_straddle_col = 0,
     const uint32_t mask_straddle_jump = 0,
     const KVPadRotationContext& kv_pad_rotation = {}) {
@@ -1002,9 +1126,9 @@ static void sdpa_inner_loop_step(
         // Lightweight mask stamp: L1-accumulate causal and/or padding masks onto cb_qkt_im
         // for this row group. Active for ring, causal non-ring, or non-causal padded with a
         // partial-tile mask (single-chip streaming partial-K case).
-        if constexpr (ring_mode || is_causal_sdpa || use_padded_mask) {
-            const bool should_apply_lightweight_mask =
-                kv_pad_rotation_enabled || (is_causal_sdpa && apply_causal) || (apply_mask && lw_partial_tile_idx > 0);
+        if constexpr (ring_mode || is_causal_sdpa || use_padded_mask || sliding_window_size > 0) {
+            const bool should_apply_lightweight_mask = kv_pad_rotation_enabled || (is_causal_sdpa && apply_causal) ||
+                                                       apply_sliding_window || (apply_mask && lw_partial_tile_idx > 0);
             if (should_apply_lightweight_mask) {
                 // MOP is configured for actual_sbw tiles (blocked matmul); mask needs 1 tile per pack.
                 configure_single_tile_pack(cb_qkt_im);
@@ -1016,7 +1140,8 @@ static void sdpa_inner_loop_step(
                     kv_pad_rotation_enabled,
                     kv_pad_q_local_padded_Nt,
                     kv_pad_chunk_size_t,
-                    kv_pad_kv_local_padded_Nt>(
+                    kv_pad_kv_local_padded_Nt,
+                    sliding_window_size>(
                     cb_mask_in,
                     cb_qkt_im,
                     q_subblock,
@@ -1026,10 +1151,14 @@ static void sdpa_inner_loop_step(
                     qkt_subblock_h,
                     kv_pad_rotation_enabled || apply_causal,
                     neginf_idx,
-                    causal_diag_idx,
+                    primary_diag_idx,
+                    sliding_leading_prev_idx,
+                    sliding_leading_idx,
+                    sliding_trailing_next_idx,
                     mask_q_start_tile,
                     mask_k_start_tile,
                     kv_pad_rotation_enabled ? KT_stride : active_Sk,
+                    apply_sliding_window,
                     mask_straddle_col,
                     mask_straddle_jump,
                     kv_pad_rotation);
@@ -1456,6 +1585,7 @@ template <
     uint32_t cb_recip_scratch,
     uint32_t cb_normalized_out,
     uint32_t cb_mask_in,
+    uint32_t sliding_window_size = 0,
     bool is_causal_sdpa = false>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
@@ -1474,6 +1604,11 @@ void sdpa_standard_v2(
     // use_padded_mask + is_causal_sdpa is handled at the host level (mutually exclusive).
     static_assert(
         !(use_padded_mask && is_causal_sdpa), "use_padded_mask and is_causal_sdpa are mutually exclusive in v2");
+    // K-loop bound geometry shared with the reader (see sliding_window_geometry.hpp).
+    using window_geom = SlidingWindowLoopGeometry<sliding_window_size, is_causal_sdpa, TILE_HEIGHT>;
+    constexpr bool has_sliding_window = window_geom::has_sliding_window;
+    constexpr uint32_t left_window_tiles = window_geom::left_window_tiles;
+    constexpr uint32_t right_window_tiles = window_geom::right_window_tiles;
 
     // Neginf tile is permanently fronted by the writer — wait once before any K-chunk loop.
     constexpr uint32_t padded_k_tiles_inner = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
@@ -1504,13 +1639,14 @@ void sdpa_standard_v2(
         constexpr bool can_reduce_trigger_padded = (padded_k_tiles_inner > 0) && (last_chunk_Sk % padded_sbw == 0) &&
                                                    (last_chunk_Sk / padded_sbw > 1) && (last_chunk_Sk % 2 == 0);
 
-        // Causal-only: optional zigzag Q-chunk remap, per-Q diagonal K-chunk limit, and
-        // q_start_tile (the only causal-mask consumer downstream). Non-causal builds skip
-        // the whole block — q_chunk_local stays in-order, q_start_tile=0, k_loop_end=full.
+        // Optional zigzag Q-chunk remap plus per-Q K-chunk bounds. Causal uses the
+        // diagonal upper bound; sliding-window adds a lower bound and, for non-causal
+        // centered windows, an upper bound around the Q chunk.
         uint32_t q_chunk_local = local_q_start + q;
         uint32_t q_start_tile = 0;
+        uint32_t k_loop_start = 0;
         uint32_t k_loop_end = k_num_chunks;
-        if constexpr (is_causal_sdpa) {
+        if constexpr (is_causal_sdpa || has_sliding_window) {
             // Reader and writer apply the same remap; compute must agree or causal
             // masks and output positions desync. The mod is a no-op when the input is per-head
             // ([0, q_num_chunks)) and extracts the per-head q_chunk when it's a flat global index
@@ -1520,8 +1656,20 @@ void sdpa_standard_v2(
             // chunked-prefill shifts this via chunked_q_chunk_offset.
             const uint32_t q_chunk_global = q_chunk_local + chunked_q_chunk_offset;
             q_start_tile = q_chunk_global * Sq_chunk_t;
-            const uint32_t limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
-            k_loop_end = limit < k_num_chunks ? limit : k_num_chunks;
+            if constexpr (is_causal_sdpa) {
+                const uint32_t limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
+                k_loop_end = limit < k_num_chunks ? limit : k_num_chunks;
+            }
+            if constexpr (has_sliding_window) {
+                if (q_start_tile > left_window_tiles) {
+                    k_loop_start = (q_start_tile - left_window_tiles) / Sk_chunk_t;
+                }
+                if constexpr (!is_causal_sdpa) {
+                    const uint32_t limit =
+                        (q_start_tile + Sq_chunk_t + right_window_tiles + Sk_chunk_t - 1) / Sk_chunk_t;
+                    k_loop_end = limit < k_num_chunks ? limit : k_num_chunks;
+                }
+            }
         }
 
         auto call_step = [&](auto profiling_tag,
@@ -1533,7 +1681,8 @@ void sdpa_standard_v2(
                              bool apply_causal,
                              uint32_t k_start_tile,
                              bool apply_mask,
-                             uint32_t lw_partial_tile_idx) {
+                             uint32_t lw_partial_tile_idx,
+                             bool apply_sliding_window) {
             sdpa_inner_loop_step<
                 decltype(profiling_tag)::value,
                 Sq_chunk_t,
@@ -1558,7 +1707,15 @@ void sdpa_standard_v2(
                 cb_col_identity,
                 cb_recip_scratch,
                 cb_normalized_out,
-                cb_mask_in>(
+                cb_mask_in,
+                Sk_chunk_t,
+                false,
+                0,
+                0,
+                0,
+                vDHt,
+                false,
+                sliding_window_size>(
                 prev,
                 cur,
                 is_last,
@@ -1574,15 +1731,20 @@ void sdpa_standard_v2(
                 q_start_tile,
                 k_start_tile,
                 lw_mask.neginf_tile_idx,
-                lw_mask.causal_diag_tile_idx);
+                lw_mask.primary_diag_tile_idx,
+                lw_mask.sliding_leading_prev_tile_idx,
+                lw_mask.sliding_leading_tile_idx,
+                lw_mask.sliding_trailing_next_tile_idx,
+                apply_sliding_window);
         };
 
-        for (uint32_t k_chunk = 0; k_chunk < k_loop_end; k_chunk++) {
-            bool is_first = (k_chunk == 0);
+        for (uint32_t k_chunk = k_loop_start; k_chunk < k_loop_end; k_chunk++) {
+            bool is_first = (k_chunk == k_loop_start);
             bool is_last = (k_chunk == k_loop_end - 1);
 
             // Padded path is non-causal only (use_padded_mask && is_causal_sdpa rejected by static_assert).
-            const bool is_padded = !is_causal_sdpa && is_last && (padded_k_tiles_inner > 0);
+            // With sliding-window loop narrowing, the loop's last chunk may not be the tensor's final K chunk.
+            const bool is_padded = !is_causal_sdpa && (k_chunk == k_num_chunks - 1) && (padded_k_tiles_inner > 0);
             uint32_t chunk_active_Sk = is_padded ? last_chunk_Sk : Sk_chunk_t;
             bool chunk_reduce_trigger = is_padded ? can_reduce_trigger_padded : can_reduce_trigger;
             uint32_t chunk_sbw = is_padded ? padded_sbw : full_sbw;
@@ -1597,18 +1759,33 @@ void sdpa_standard_v2(
             // - Non-causal partial: trailing fully-padded tiles → neginf via num_padded; partial
             //   boundary tile → vertical-bar mask tile via apply_mask + lw_partial_tile_idx.
             bool apply_partial_mask = false;
+            bool apply_sliding_mask = false;
+            bool apply_causal_mask = is_causal_sdpa;
             uint32_t target_active_Sk = chunk_active_Sk;
             if constexpr (use_padded_mask && !is_causal_sdpa) {
-                if (is_last && lw_mask.global_n_partial_col > 0) {
+                if (is_padded && lw_mask.global_n_partial_col > 0) {
                     target_active_Sk = Sk_chunk_t - lw_mask.global_n_padded_tiles;
                     apply_partial_mask = true;
+                }
+            }
+            if constexpr (has_sliding_window) {
+                const uint32_t k_start_tile = k_chunk * Sk_chunk_t;
+                const uint32_t trailing_range_end =
+                    is_causal_sdpa ? (q_start_tile + Sq_chunk_t) : (q_start_tile + Sq_chunk_t + right_window_tiles);
+                apply_sliding_mask = true;
+                if constexpr (is_causal_sdpa) {
+                    const uint32_t k_end_tile = k_start_tile + Sk_chunk_t;
+                    apply_causal_mask = (q_start_tile < k_end_tile) && ((q_start_tile + Sq_chunk_t) > k_start_tile);
+                }
+                if (is_last && trailing_range_end > k_start_tile) {
+                    const uint32_t window_active_Sk = trailing_range_end - k_start_tile;
+                    target_active_Sk = target_active_Sk < window_active_Sk ? target_active_Sk : window_active_Sk;
                 }
             } else if constexpr (is_causal_sdpa) {
                 if (is_last) {
                     target_active_Sk = q_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
                 }
             }
-            const bool apply_causal = is_causal_sdpa;
             if (target_active_Sk < chunk_active_Sk) {
                 chunk_active_Sk = target_active_Sk;
                 chunk_sbw = largest_factor_le(chunk_active_Sk, qkt_subblock_w);
@@ -1623,10 +1800,11 @@ void sdpa_standard_v2(
                 chunk_active_Sk,
                 chunk_reduce_trigger,
                 chunk_sbw,
-                apply_causal,
+                apply_causal_mask,
                 k_chunk * Sk_chunk_t,
                 apply_partial_mask,
-                apply_partial_mask ? lw_mask.global_n_partial_tile_idx : 0u);
+                apply_partial_mask ? lw_mask.global_n_partial_tile_idx : 0u,
+                apply_sliding_mask);
 
             // Post-iteration cleanup
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
@@ -2142,6 +2320,10 @@ void sdpa_ring_v2(
                 step_k_start_tile,
                 lw_mask.neginf_tile_idx,
                 lw_mask.causal_diag_tile_idx,
+                0,      // sliding_leading_prev_idx (not used in ring)
+                0,      // sliding_leading_idx (not used in ring)
+                0,      // sliding_trailing_next_idx (not used in ring)
+                false,  // apply_sliding_window
                 step_straddle_col,
                 step_straddle_jump,
                 step_kv_pad_rotation);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -169,7 +169,9 @@ void kernel_main() {
             cb_out,  // normalized output goes directly to output CB
             cb_mask_in,
             sliding_window_size,
-            is_causal>(
+            is_causal,
+            use_attention_sink,
+            cb_attention_sink>(
             global_q_count,
             k_num_chunks,
             cb_out_im_A,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -112,24 +112,34 @@ void kernel_main() {
         // Wait once for identity scale; v2 removes per-call waits inside reduce_c_row_group
         cb_wait_front(cb_identity_scale_in, 1);
 
-        // Lightweight-mask context: writer pre-generates [neginf(0), causal_diag?, k_partial?] tiles
-        // permanently fronted. Causal uses neginf + diag (2 tiles). Non-causal partial-tile K
-        // uses neginf + partial (2 tiles); the per-row stamp masks the partial col + trailing neginf.
+        // Lightweight-mask context: writer pre-generates either [neginf, causal_diag, partial?]
+        // or, for sliding, [neginf, trailing_primary, leading_prev, leading_current, trailing_next, partial?].
+        // primary_diag_tile_idx is the per-layout tile used for the row-local diagonal stamp.
         LightweightMaskContext lw_mask;
-        if constexpr (is_causal) {
-            lw_mask.is_causal = true;
-            lw_mask.neginf_tile_idx = 0;
-            lw_mask.causal_diag_tile_idx = 1;
-            cb_wait_front(cb_mask_in, 2);
-        } else if constexpr (k_partial_col > 0) {
+        uint32_t lw_mask_tile_count = 1;
+        lw_mask.neginf_tile_idx = 0;
+        lw_mask.is_causal = is_causal;
+        if constexpr (sliding_window_size > 0) {
+            lw_mask.primary_diag_tile_idx = 1;
+            lw_mask.sliding_leading_prev_tile_idx = 2;
+            lw_mask.sliding_leading_tile_idx = 3;
+            lw_mask.sliding_trailing_next_tile_idx = 4;
+            lw_mask_tile_count = 5;
+        } else if constexpr (is_causal) {
+            lw_mask.causal_diag_tile_idx = lw_mask_tile_count++;
+            lw_mask.primary_diag_tile_idx = lw_mask.causal_diag_tile_idx;
+        }
+        if constexpr (k_partial_col > 0) {
             lw_mask.global_n_partial_col = k_partial_col;
-            lw_mask.global_n_partial_tile_idx = 1;  // [neginf(0), partial(1)]
+            lw_mask.global_n_partial_tile_idx = lw_mask_tile_count++;
             // global_n_padded_tiles = Sk_chunk_t - valid_tiles_in_last_chunk
             constexpr uint32_t last_chunk_first_tile =
                 (valid_Skt > Sk_chunk_t) ? ((valid_Skt - 1) / Sk_chunk_t) * Sk_chunk_t : 0u;
             constexpr uint32_t valid_tiles_in_last_chunk = valid_Skt - last_chunk_first_tile;
             lw_mask.global_n_padded_tiles = Sk_chunk_t - valid_tiles_in_last_chunk;
-            cb_wait_front(cb_mask_in, 2);
+        }
+        if constexpr (is_causal || sliding_window_size > 0 || k_partial_col > 0) {
+            cb_wait_front(cb_mask_in, lw_mask_tile_count);
         }
 
         // Global Q scheduling: sdpa_standard_v2 walks the per-core flat range over
@@ -158,6 +168,7 @@ void kernel_main() {
             cb_recip_scratch,
             cb_out,  // normalized output goes directly to output CB
             cb_mask_in,
+            sliding_window_size,
             is_causal>(
             global_q_count,
             k_num_chunks,
@@ -181,6 +192,7 @@ void kernel_main() {
             lw_mask.is_causal = true;
             lw_mask.neginf_tile_idx = 0;
             lw_mask.causal_diag_tile_idx = 1;
+            lw_mask.primary_diag_tile_idx = lw_mask.causal_diag_tile_idx;
             cb_wait_front(cb_mask_in, 2);
         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/constants.hpp>
 #include "api/debug/assert.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
 
 template <uint32_t tile_bytes, uint32_t num_readers>
 constexpr uint32_t get_barrier_read_threshold() {
@@ -464,8 +465,111 @@ void fill_causal_diagonal_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
 }
 
 /**
+ * Fill a bf16 tile with a diagonal-edge mask pattern relative to `boundary_col = row + diagonal_offset`:
+ *   - leading edge (leading_edge=true):  col c is -inf if c < boundary_col
+ *   - trailing edge (leading_edge=false): col c is -inf if c > boundary_col
+ */
+template <uint32_t tile_bytes, int32_t diagonal_offset = 0, bool leading_edge = true>
+void fill_diagonal_edge_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
+    fill_tile_zeros<tile_bytes>(cb_id, tile_id);
+
+    constexpr uint32_t neginf_bf16 = 0xFF80;
+    constexpr uint32_t bf16_per_uint32 = 2;
+    constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
+    constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
+
+    volatile tt_l1_ptr uint32_t* ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+
+    constexpr uint32_t face_offsets[4] = {
+        0,
+        uint32_per_face,
+        2 * uint32_per_face,
+        3 * uint32_per_face,
+    };
+    constexpr uint32_t face_row_starts[4] = {0, 0, 16, 16};
+    constexpr uint32_t face_col_starts[4] = {0, 16, 0, 16};
+
+    for (uint32_t f = 0; f < 4; f++) {
+        const uint32_t face_base = face_offsets[f];
+        const uint32_t row_start = face_row_starts[f];
+        const uint32_t col_start = face_col_starts[f];
+        for (uint32_t row = 0; row < tt::constants::FACE_HEIGHT; row++) {
+            const uint32_t global_row = row_start + row;
+            const int32_t boundary_col = static_cast<int32_t>(global_row) + diagonal_offset;
+            const uint32_t row_base = face_base + row * uint32_per_face_row;
+            for (uint32_t word = 0; word < uint32_per_face_row; word++) {
+                const int32_t col0 = static_cast<int32_t>(col_start + word * bf16_per_uint32);
+                const int32_t col1 = col0 + 1;
+                uint32_t mask_word = 0;
+                if constexpr (leading_edge) {
+                    if (col0 < boundary_col) {
+                        mask_word |= neginf_bf16;
+                    }
+                    if (col1 < boundary_col) {
+                        mask_word |= neginf_bf16 << 16;
+                    }
+                } else {
+                    if (col0 > boundary_col) {
+                        mask_word |= neginf_bf16;
+                    }
+                    if (col1 > boundary_col) {
+                        mask_word |= neginf_bf16 << 16;
+                    }
+                }
+                if (mask_word != 0) {
+                    ptr[row_base + word] = mask_word;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Emit the four sliding-window edge tiles (trailing_primary, leading_prev, leading_current,
+ * trailing_next) starting at `start_tile_idx` in the mask CB.
+ *
+ * The per-tile diagonal offsets place each edge's transition at the correct sub-tile column.
+ * `leading_remainder`/`trailing_remainder` are the window edges' positions within a 32-row tile;
+ * when they are 0 the window is tile-aligned and the prev/next straddle tiles go unused. The
+ * causal window has only a leading (left) edge — its trailing tile reuses the plain causal diagonal.
+ *
+ * NOTE: this is per-row *stamp* geometry (floor + remainder), intentionally distinct from the
+ * ceil-based loop bounds in SlidingWindowLoopGeometry. See sliding_window_geometry.hpp.
+ */
+template <uint32_t sliding_window_size, bool is_causal_lw, uint32_t cb_mask_in, uint32_t tile_bytes>
+void fill_sliding_window_edge_tiles(uint32_t start_tile_idx) {
+    constexpr uint32_t half_window = sliding_window_size / 2;
+    constexpr uint32_t leading_remainder =
+        is_causal_lw ? (sliding_window_size % tt::constants::TILE_HEIGHT) : (half_window % tt::constants::TILE_HEIGHT);
+    constexpr uint32_t trailing_remainder = is_causal_lw ? 0 : (half_window % tt::constants::TILE_HEIGHT);
+    constexpr int32_t leading_prev_offset =
+        is_causal_lw ? (leading_remainder == 0 ? 1 : static_cast<int32_t>(33 - leading_remainder))
+                     : (leading_remainder == 0 ? 0 : static_cast<int32_t>(32 - leading_remainder));
+    constexpr int32_t leading_current_offset =
+        is_causal_lw ? (leading_remainder == 0 ? 1 : 1 - static_cast<int32_t>(leading_remainder))
+                     : (leading_remainder == 0 ? 0 : -static_cast<int32_t>(leading_remainder));
+    constexpr int32_t trailing_primary_offset = static_cast<int32_t>(trailing_remainder);
+    constexpr int32_t trailing_next_offset = static_cast<int32_t>(trailing_remainder) - 32;
+
+    // Tile 0: trailing/right edge. Causal uses the normal causal diagonal.
+    fill_diagonal_edge_tile_bf16<tile_bytes, trailing_primary_offset, /*leading_edge=*/false>(
+        cb_mask_in, start_tile_idx);
+    // Tile 1/2: left edge when it straddles two K tiles; tile 1 is unused for aligned windows.
+    fill_diagonal_edge_tile_bf16<tile_bytes, leading_prev_offset, /*leading_edge=*/true>(
+        cb_mask_in, start_tile_idx + 1);
+    fill_diagonal_edge_tile_bf16<tile_bytes, leading_current_offset, /*leading_edge=*/true>(
+        cb_mask_in, start_tile_idx + 2);
+    // Tile 3: non-causal right edge when it straddles into the next K tile; unused for causal/aligned windows.
+    fill_diagonal_edge_tile_bf16<tile_bytes, trailing_next_offset, /*leading_edge=*/false>(
+        cb_mask_in, start_tile_idx + 3);
+}
+
+/**
  * Generate lightweight mask tiles into a single CB for ring joint SDPA.
- * Layout: [neginf_tile(0)] [causal_diag_tile?(1)] [global_n_partial_tile?] [joint_l_partial_tile?]
+ * Layout without sliding: [neginf_tile(0)] [causal_diag_tile?] [global_n_partial_tile?] [joint_l_partial_tile?]
+ * Layout with sliding:    [neginf_tile(0)] [trailing_primary(1)] [leading_prev(2)]
+ *                         [leading_current(3)] [trailing_next(4)] [partial tiles...]
  * Tiles are pushed once and stay permanently fronted for the entire kernel lifetime.
  *
  * @tparam global_n_partial_col  Column within tile where global_n padding starts (0 = tile-aligned, no partial)
@@ -473,11 +577,18 @@ void fill_causal_diagonal_tile_bf16(uint32_t cb_id, uint32_t tile_id) {
  * @tparam cb_mask_in            CB to generate mask tiles into (must be constexpr for get_tile_size)
  * @tparam is_causal_lw          Whether to include the causal diagonal tile
  */
-template <uint32_t global_n_partial_col, uint32_t joint_l_partial_col, uint32_t cb_mask_in, bool is_causal_lw = false>
+template <
+    uint32_t global_n_partial_col,
+    uint32_t joint_l_partial_col,
+    uint32_t cb_mask_in,
+    bool is_causal_lw = false,
+    uint32_t sliding_window_size = 0>
 void generate_lightweight_mask_tiles() {
     constexpr uint32_t partial_mask_tiles = (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
-    constexpr uint32_t causal_diag_tiles = is_causal_lw ? 1 : 0;
-    constexpr uint32_t total_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
+    constexpr bool has_sliding_window = sliding_window_size > 0;
+    constexpr uint32_t sliding_diag_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : 0;
+    constexpr uint32_t causal_diag_tiles = (!has_sliding_window && is_causal_lw) ? 1 : 0;
+    constexpr uint32_t total_mask_tiles = 1 + sliding_diag_tiles + causal_diag_tiles + partial_mask_tiles;
     constexpr uint32_t mask_tile_size_bytes = get_tile_size(cb_mask_in);
 
     cb_reserve_back(cb_mask_in, total_mask_tiles);
@@ -487,8 +598,10 @@ void generate_lightweight_mask_tiles() {
 
     uint32_t tile_idx = 1;
 
-    // Tile 1 (if causal): causal diagonal tile
-    if constexpr (is_causal_lw) {
+    if constexpr (has_sliding_window) {
+        fill_sliding_window_edge_tiles<sliding_window_size, is_causal_lw, cb_mask_in, mask_tile_size_bytes>(tile_idx);
+        tile_idx += kSlidingWindowEdgeTiles;
+    } else if constexpr (is_causal_lw) {
         fill_causal_diagonal_tile_bf16<mask_tile_size_bytes>(cb_mask_in, tile_idx++);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -70,15 +70,17 @@ void kernel_main() {
     constexpr uint32_t use_mla = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t mla_kv_overlap = get_compile_time_arg_val(25) == 1;
     constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(26);
+    constexpr uint32_t sliding_window_size = get_compile_time_arg_val(27);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(28) == 1;
 
     // Semaphore IDs for KV chain forwarding (non-causal only, but always present in compile args)
-    constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(27);
-    constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(28);
-    constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(29);
-    constexpr bool mcast_enabled = get_compile_time_arg_val(30) == 1;
-    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(31) == 1;
+    constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(29);
+    constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(30);
+    constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(31);
+    constexpr bool mcast_enabled = get_compile_time_arg_val(32) == 1;
+    constexpr bool use_zigzag_balancing = get_compile_time_arg_val(33) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<32>();
+    constexpr auto q_args = TensorAccessorArgs<34>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -366,6 +368,21 @@ void kernel_main() {
             } else {
                 q_high_idx = Skt;
             }
+            uint32_t k_loop_start = 0;
+            if constexpr (use_streaming_compute && sliding_window_size > 0) {
+                // Must match the compute kernel's K-loop bounds (see sliding_window_geometry.hpp).
+                using window_geom =
+                    SlidingWindowLoopGeometry<sliding_window_size, is_causal, tt::constants::TILE_HEIGHT>;
+                constexpr uint32_t left_window_tiles = window_geom::left_window_tiles;
+                constexpr uint32_t right_window_tiles = window_geom::right_window_tiles;
+                if (q_low_idx > left_window_tiles) {
+                    k_loop_start = (q_low_idx - left_window_tiles) / Sk_chunk_t;
+                }
+                if constexpr (!is_causal) {
+                    const uint32_t window_high_unclamped = q_low_idx + Sq_chunk_t + right_window_tiles;
+                    q_high_idx = window_high_unclamped < Skt ? window_high_unclamped : Skt;
+                }
+            }
 
             const uint32_t k_head = nq / q_heads_per_k;
             const uint32_t v_head = nq / q_heads_per_v;
@@ -380,7 +397,7 @@ void kernel_main() {
             }
 
             // loop while k_low < q_high
-            for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
+            for (uint32_t k_chunk = k_loop_start; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
                 const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
                 const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
                 const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
@@ -525,7 +542,7 @@ void kernel_main() {
                 // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
                 // when NOC writes are in-flight).
                 if constexpr (use_q_subblock_push) {
-                    if (k_chunk == 0) {
+                    if (k_chunk == k_loop_start) {
                         for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
                             read_q_subblock<q_tile_bytes>(
                                 q_reader,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -80,11 +80,17 @@ void kernel_main() {
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
 
     // Lightweight mask: generate template tiles once, leave permanently fronted.
-    // Layout: [neginf(0)] [causal_diag?(1)] [k_partial?].
+    // Sliding layout: [neginf, trailing_primary, leading_prev, leading_current, trailing_next, k_partial?].
+    // Non-sliding layout: [neginf, causal_diag?, k_partial?].
     if constexpr (use_lightweight_mask) {
         // is_causal handles K-partial via causal stamp; skip emitting partial tile in causal mode.
         constexpr uint32_t writer_partial_col = is_causal ? 0u : k_partial_col;
-        generate_lightweight_mask_tiles<writer_partial_col, /*joint_l*/ 0u, cb_mask_in, is_causal>();
+        generate_lightweight_mask_tiles<
+            writer_partial_col,
+            /*joint_l*/ 0u,
+            cb_mask_in,
+            is_causal,
+            sliding_window_size>();
     }
 
     if constexpr (is_chunked) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Number of diagonal edge tiles a sliding window contributes to the lightweight mask CB:
+// trailing_primary, leading_prev, leading_current, trailing_next.
+constexpr uint32_t kSlidingWindowEdgeTiles = 4;
+
+/**
+ * Shared sliding-window K-loop bound geometry.
+ *
+ * The reader and the streaming compute kernel both narrow the per-Q K-chunk loop
+ * to the window. They MUST compute identical bounds or the lightweight masks and
+ * output positions desync. This is the single source for that math.
+ *
+ * Token counts:
+ *   - causal window:          left = window - 1 tokens behind the diagonal, no right reach.
+ *   - non-causal centered:    left = right = window / 2 tokens around the Q position.
+ *
+ * Tile counts use ceil division so the loop bound never clips a partially-covered K tile.
+ *
+ * NOTE: these are *loop-bound* tiles (ceil). They are intentionally distinct from the
+ * per-row stamp geometry in apply_lightweight_mask_streaming / generate_lightweight_mask_tiles,
+ * which uses floor division + remainder and (for causal) a `window` rather than `window - 1`
+ * reach. Do not unify the two — they answer different questions.
+ *
+ * @tparam sliding_window_size  Window size in tokens (0 = no sliding window).
+ * @tparam is_causal            Causal (left-only) vs non-causal centered window.
+ * @tparam tile_height          TILE_HEIGHT for the current kernel domain (compute vs dataflow
+ *                              expose it under different symbols; both equal 32).
+ */
+template <uint32_t sliding_window_size, bool is_causal, uint32_t tile_height>
+struct SlidingWindowLoopGeometry {
+    static constexpr bool has_sliding_window = sliding_window_size > 0;
+    static constexpr uint32_t half_window = sliding_window_size / 2;
+    static constexpr uint32_t left_window_tokens =
+        has_sliding_window ? (is_causal ? (sliding_window_size - 1) : half_window) : 0;
+    static constexpr uint32_t right_window_tokens = (has_sliding_window && !is_causal) ? half_window : 0;
+    static constexpr uint32_t left_window_tiles = (left_window_tokens + tile_height - 1) / tile_height;
+    static constexpr uint32_t right_window_tiles = (right_window_tokens + tile_height - 1) / tile_height;
+};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -288,17 +288,19 @@ ProgramDescriptor RingDistributedSdpaDeviceOperation::RingDistributedSdpaProgram
         static_cast<uint32_t>(is_chunked),  //(uint32_t)is_chunked,
         block_size_t,
         page_table_stick_size,
-        0,                 // use_attention_sink
-        0,                 // use_mla
-        0,                 // mla_kv_overlap
-        qk_out_subblock_h  // qk_subblock_h
+        0,                  // use_attention_sink
+        0,                  // use_mla
+        0,                  // mla_kv_overlap
+        qk_out_subblock_h,  // qk_subblock_h
+        0,                  // sliding_window_size (ring uses no sliding window)
+        0                   // use_streaming_compute (ring uses legacy compute)
     };
-    // Semaphore placeholders (not used in ring, but kernel expects them at indices 27-30)
+    // Semaphore placeholders (not used in ring, but kernel expects them at indices 29-32)
     reader_compile_time_args.push_back(0);  // sender_semaphore_id
     reader_compile_time_args.push_back(0);  // receiver_semaphore_id
     reader_compile_time_args.push_back(0);  // valid_semaphore_id
     reader_compile_time_args.push_back(0);  // mcast_enabled
-    reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 31
+    reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 33
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -73,10 +73,10 @@ tt::DataFormat select_mask_dataformat(const std::optional<Tensor>& attn_mask, bo
     return use_streaming_compute ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp4_b;
 }
 
-// Streaming compute v2 eligibility. Sliding-window, causal, and chunked modes are handled downstream.
-// User-provided masks, attention sink, and fp32 dest accumulators still require the legacy path.
-bool can_use_streaming_compute(bool use_provided_mask, bool use_attention_sink, bool fp32_dest_acc_en) {
-    return !use_provided_mask && !use_attention_sink && !fp32_dest_acc_en;
+// Streaming compute v2 eligibility. Sliding-window, causal, chunked, and attention-sink modes are
+// handled downstream. User-provided masks and fp32 dest accumulators still require the legacy path.
+bool can_use_streaming_compute(bool use_provided_mask, bool fp32_dest_acc_en) {
+    return !use_provided_mask && !fp32_dest_acc_en;
 }
 
 uint32_t lightweight_mask_tile_count(bool is_causal, bool has_sliding_window, bool has_k_partial_mask) {
@@ -360,8 +360,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     auto [qk_out_subblock_h, qk_out_subblock_w] =
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
-    const bool use_streaming_compute =
-        can_use_streaming_compute(use_provided_mask, use_attention_sink, fp32_dest_acc_en);
+    const bool use_streaming_compute = can_use_streaming_compute(use_provided_mask, fp32_dest_acc_en);
 
     const bool has_sliding_window = sliding_window_size.value_or(0) != 0;
     const bool lightweight_causal = is_causal && !use_provided_mask && !has_sliding_window;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -5,7 +5,7 @@
 #include "ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_interleaved_cb_ids.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
-#include "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_interleaved_cb_ids.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
+#include "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -72,20 +73,23 @@ tt::DataFormat select_mask_dataformat(const std::optional<Tensor>& attn_mask, bo
     return use_streaming_compute ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp4_b;
 }
 
-// Streaming compute v2 eligibility. Returns false for features the streaming kernel doesn't
-// support: user-provided mask, attention sink, sliding window, fp32_dest_acc.
-bool can_use_streaming_compute(
-    bool use_provided_mask,
-    bool use_attention_sink,
-    const std::optional<uint32_t>& sliding_window_size,
-    bool fp32_dest_acc_en) {
-    if (use_provided_mask || use_attention_sink) {
-        return false;
+// Streaming compute v2 eligibility. Sliding-window, causal, and chunked modes are handled downstream.
+// User-provided masks, attention sink, and fp32 dest accumulators still require the legacy path.
+bool can_use_streaming_compute(bool use_provided_mask, bool use_attention_sink, bool fp32_dest_acc_en) {
+    return !use_provided_mask && !use_attention_sink && !fp32_dest_acc_en;
+}
+
+uint32_t lightweight_mask_tile_count(bool is_causal, bool has_sliding_window, bool has_k_partial_mask) {
+    uint32_t tiles = 1;  // neginf
+    if (has_sliding_window) {
+        tiles += kSlidingWindowEdgeTiles;
+    } else if (is_causal) {
+        tiles++;  // causal diagonal
     }
-    if (sliding_window_size.value_or(0) != 0 || fp32_dest_acc_en) {
-        return false;
+    if (has_k_partial_mask) {
+        tiles++;  // partial K tile
     }
-    return true;
+    return tiles;
 }
 
 // Compute the largest granularity that evenly divides both DHt and vDHt (up to dst_size).
@@ -357,10 +361,13 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         detail::determine_largest_subblock_size(Sq_chunk_t, Sk_chunk_t, dst_size);
 
     const bool use_streaming_compute =
-        can_use_streaming_compute(use_provided_mask, use_attention_sink, sliding_window_size, fp32_dest_acc_en);
+        can_use_streaming_compute(use_provided_mask, use_attention_sink, fp32_dest_acc_en);
 
-    const bool lightweight_causal = is_causal && !use_provided_mask && sliding_window_size.value_or(0) == 0;
-    const bool lightweight_mask = (use_streaming_compute && use_padded_mask) || lightweight_causal;
+    const bool has_sliding_window = sliding_window_size.value_or(0) != 0;
+    const bool lightweight_causal = is_causal && !use_provided_mask && !has_sliding_window;
+    const bool lightweight_streaming_mask =
+        use_streaming_compute && (is_causal || has_sliding_window || use_padded_mask);
+    const bool lightweight_mask = lightweight_causal || lightweight_streaming_mask;
     // Non-causal partial-tile K (Sk % TILE != 0) needs a partial-tile mask in cb_mask_in.
     const uint32_t k_partial_col =
         (use_streaming_compute && use_padded_mask && (Sk % TILE_HEIGHT != 0)) ? (Sk % TILE_HEIGHT) : 0;
@@ -369,8 +376,9 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;            // double buffer
     uint32_t v_tiles = Sk_chunk_t * vDHt * 2;           // double buffer
-    uint32_t mask_tiles = lightweight_mask ? (1 + (lightweight_causal ? 1 : 0) + (lw_partial_active ? 1 : 0))
-                                           : Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
+    uint32_t mask_tiles = lightweight_mask
+                              ? lightweight_mask_tile_count(is_causal, has_sliding_window, lw_partial_active)
+                              : Sq_chunk_t * Sk_chunk_t * 2;  // double buffer
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
     uint32_t out_im_tiles = Sq_chunk_t * vDHt;
     uint32_t out0_t = Sq_chunk_t * vDHt;  // finalized below once out_out_subblock_h is known
@@ -481,7 +489,9 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
                                                       static_cast<uint32_t>(use_attention_sink),
                                                       static_cast<uint32_t>(use_mla),
                                                       static_cast<uint32_t>(mla_kv_overlap),
-                                                      qk_out_subblock_h};
+                                                      qk_out_subblock_h,
+                                                      sliding_window_size.value_or(0),
+                                                      static_cast<uint32_t>(use_streaming_compute)};
 
     // Placeholder semaphore IDs for KV chain forwarding (will be filled later if enabled)
     // Add these BEFORE TensorAccessorArgs to keep indexing consistent with kernel expectations
@@ -490,7 +500,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     reader_compile_time_args.push_back(0);  // receiver_semaphore_id placeholder
     reader_compile_time_args.push_back(0);  // valid_semaphore_id placeholder
     reader_compile_time_args.push_back(0);  // mcast_enabled placeholder
-    reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 31
+    reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 33
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -549,7 +559,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         static_cast<uint32_t>(use_padded_mask),
         static_cast<uint32_t>(is_chunked),
         sliding_window_size.value_or(0),
-        static_cast<uint32_t>(lightweight_mask),       // arg 20: lightweight mask (causal or streaming padded)
+        static_cast<uint32_t>(lightweight_mask),       // arg 20: lightweight mask
         static_cast<uint32_t>(use_streaming_compute),  // arg 21: row-grouped cb_out drain
         out_out_subblock_h,                            // arg 22: drain group height
         k_partial_col,                                 // arg 23: K partial-tile col (0 = no partial)
@@ -766,7 +776,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     std::vector<std::vector<HeadSegmentRef>> head_segments;
     uint32_t mcast_chains = 0;
 
-    if (!is_causal && !is_chunked) {
+    if (!is_causal && !is_chunked && !has_sliding_window) {
         head_segments.resize(total_heads);
 
         log_debug(tt::LogOp, "=== Building KV chain forwarding topology ===");


### PR DESCRIPTION
## Summary
This PR enables SDPA streaming compute in two additional prefill cases that previously stayed on the legacy compute path:
- sliding-window attention, including causal and non-causal centered windows
- attention-sink attention, including sink+sliding-window GPT-OSS/Gemma-style cases

## What Changed
- Added sliding-window loop geometry shared by the reader and compute kernel, so streaming compute only iterates the active K/V window for each Q block.
- Added lightweight sliding-window edge masking using pre-generated diagonal edge tiles instead of materializing full-window mask work.
- Realigned the ring-distributed SDPA program factory after the new reader compile-time args shifted semaphore IDs and TensorAccessorArgs offsets.
- Initialized the streaming reduce-trigger semaphore used by the PACK-to-UNPACK reduce handshake.
- Reworked attention-sink normalization on the streaming path so the sink contribution is folded into the per-row denominator with a first-column exp contribution, without adding per-K work.
- Extended unit and nightly SDPA prefill coverage for sliding-window, streaming parity, attention-sink, sink+sliding-window, and GPT-OSS forward-progress cases.

## Perf Notes
- Sliding-window prefill is 9.9x faster in aggregate across 56 comparable nightly rows, with median row speedup of 2.2x.
- Plain attention-sink prefill is roughly unchanged in aggregate across 12 comparable nightly rows, with median row speedup of 1.05x.
- Attention-sink plus sliding-window / GPT-OSS forward-progress coverage is 3.3x faster in aggregate across 5 comparable nightly rows, with median row speedup of 3.7x.
- Across the comparable affected nightly rows, total SDPA device kernel time improves from 151.0 ms to 23.6 ms, a 6.4x aggregate speedup.

## Additional CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-unit-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-unit-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/streaming-sliding-window-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/streaming-sliding-window-sdpa)