### PR TITLE
Deprecation reaper to track and remind about deprecated API removal

### DIFF
--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Tracked deprecations awaiting removal. The deprecation-reaper workflow reads this file weekly, looks up when each entry's PR merged (its exact mergedAt timestamp), and once mergedAt + grace has elapsed it opens/refreshes a tracking issue and pings the owners. Entries whose PR is not merged yet are ignored, so the clock only starts at merge. Remove an entry once its functions are deleted.",
+  "deprecations": [
+    {
+      "id": "matmul-legacy-mm-inits",
+      "description": "Legacy matmul init API in tt_metal/hw/inc/api/compute/matmul.h: mm_init, mm_block_init, mm_init_short, mm_block_init_short, mm_init_short_with_dt, mm_block_init_short_with_dt, mm_block_init_short_with_both_dt, and matmul_tiles_math. Replaced by compute_kernel_hw_startup<SrcOrder::Reverse>() + the matmul_*_init API.",
+      "files": ["tt_metal/hw/inc/api/compute/matmul.h"],
+      "introduced_by_pr": 27166,
+      "grace": "30d",
+      "owners": ["ncvetkovicTT"]
+    }
+  ]
+}

--- a/.github/scripts/deprecation_reaper.py
+++ b/.github/scripts/deprecation_reaper.py
@@ -169,7 +169,8 @@ def main():
         manifest = json.load(f)
 
     now = dt.datetime.now(dt.timezone.utc)
-    print(f"deprecation-reaper: {len(manifest.get('deprecations', []))} tracked entr(ies), now={now.isoformat()}")
+    count = len(manifest.get("deprecations", []))
+    print(f"deprecation-reaper: checking {count} tracked deprecation(s) at {now.isoformat()}")
     overdue = find_overdue(manifest, now)
     existing = find_tracking_issue()
 

--- a/.github/scripts/deprecation_reaper.py
+++ b/.github/scripts/deprecation_reaper.py
@@ -85,24 +85,27 @@ def find_overdue(manifest, now):
 
 
 def build_body(overdue):
-    lines = [
-        MARKER,
+    header_note = (
         "_Auto-managed by the deprecation-reaper workflow. Do not edit by hand; "
-        "remove the entry from `.github/deprecations.json` once the code is deleted._",
-        "",
+        + "remove the entry from `.github/deprecations.json` once the code is deleted._"
+    )
+    intro = (
         "The following deprecated APIs have passed their scheduled removal date and "
-        "should be deleted in a follow-up PR:",
-        "",
-    ]
+        + "should be deleted in a follow-up PR:"
+    )
+    lines = [MARKER, header_note, "", intro, ""]
     owners = set()
     for d in overdue:
         owners.update(d.get("owners", []))
+        introduced = (
+            f"- Introduced by [#{d['introduced_by_pr']}]({d['pr_url']}) "
+            + f"(merged {d['merged_at'].date()}, removal due {d['deadline'].date()})"
+        )
         lines += [
             f"### `{d['id']}` — overdue by {d['days_overdue']} day(s)",
             f"- {d['description']}",
             f"- Files: {', '.join('`'+f+'`' for f in d['files'])}",
-            f"- Introduced by [#{d['introduced_by_pr']}]({d['pr_url']}) "
-            f"(merged {d['merged_at'].date()}, removal due {d['deadline'].date()})",
+            introduced,
             f"- Owners: {', '.join('@'+o for o in d.get('owners', []))}",
             "",
         ]
@@ -196,9 +199,7 @@ def main():
     else:
         ensure_label(args.dry_run)
         if args.dry_run:
-            print(
-                f"[dry-run] create issue '{TRACKING_TITLE}' (label {TRACKING_LABEL}, " f"assignees {owners}):\n{body}"
-            )
+            print(f"[dry-run] create issue '{TRACKING_TITLE}' (label {TRACKING_LABEL}, assignees {owners}):\n{body}")
         else:
             create = [
                 "gh",

--- a/.github/scripts/deprecation_reaper.py
+++ b/.github/scripts/deprecation_reaper.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Deprecation reaper.
+
+Reads .github/deprecations.json, and for each tracked deprecation looks up when its
+PR merged (the PR's exact mergedAt timestamp, via `gh`). Once mergedAt + grace has
+elapsed, the deprecation is "overdue". The script then keeps a single tracking issue
+in sync:
+
+  * if there are overdue deprecations, it opens the issue (or refreshes its body) and
+    assigns/@-mentions the owners;
+  * if there are none, it closes the tracking issue if one is open.
+
+Deprecations whose PR is not merged yet are ignored, so the countdown only starts at
+merge time -- you never have to know the merge date in advance.
+
+Run locally with --dry-run to preview without touching GitHub.
+"""
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "tenstorrent/tt-metal")
+MANIFEST = ".github/deprecations.json"
+TRACKING_LABEL = "deprecation-reaper"
+TRACKING_TITLE = "Deprecations past their scheduled removal date"
+MARKER = "<!-- deprecation-reaper:managed -->"
+
+
+def run(args, check=True):
+    res = subprocess.run(args, capture_output=True, text=True)
+    if check and res.returncode != 0:
+        sys.stderr.write(f"command failed: {' '.join(args)}\n{res.stderr}\n")
+        sys.exit(1)
+    return res.stdout.strip()
+
+
+def parse_grace(s):
+    m = re.fullmatch(r"\s*(\d+)\s*([dwm])\s*", s)
+    if not m:
+        raise ValueError(f"invalid grace {s!r} (use e.g. 30d, 2w, 1m)")
+    n, unit = int(m.group(1)), m.group(2)
+    return dt.timedelta(days=n * {"d": 1, "w": 7, "m": 30}[unit])
+
+
+def pr_merged_at(pr):
+    out = run(["gh", "pr", "view", str(pr), "--repo", REPO, "--json", "mergedAt,title,url"])
+    data = json.loads(out)
+    merged = data.get("mergedAt")
+    return (
+        dt.datetime.fromisoformat(merged.replace("Z", "+00:00")) if merged else None,
+        data.get("title", ""),
+        data.get("url", ""),
+    )
+
+
+def find_overdue(manifest, now):
+    overdue = []
+    for d in manifest.get("deprecations", []):
+        merged_at, pr_title, pr_url = pr_merged_at(d["introduced_by_pr"])
+        if merged_at is None:
+            print(f"  - {d['id']}: PR #{d['introduced_by_pr']} not merged yet -> clock not started")
+            continue
+        deadline = merged_at + parse_grace(d["grace"])
+        if now >= deadline:
+            days = (now - deadline).days
+            print(f"  - {d['id']}: OVERDUE by {days}d (merged {merged_at.date()}, due {deadline.date()})")
+            overdue.append(
+                {
+                    **d,
+                    "merged_at": merged_at,
+                    "deadline": deadline,
+                    "days_overdue": days,
+                    "pr_title": pr_title,
+                    "pr_url": pr_url,
+                }
+            )
+        else:
+            print(f"  - {d['id']}: not due yet (due {deadline.date()})")
+    return overdue
+
+
+def build_body(overdue):
+    lines = [
+        MARKER,
+        "_Auto-managed by the deprecation-reaper workflow. Do not edit by hand; "
+        "remove the entry from `.github/deprecations.json` once the code is deleted._",
+        "",
+        "The following deprecated APIs have passed their scheduled removal date and "
+        "should be deleted in a follow-up PR:",
+        "",
+    ]
+    owners = set()
+    for d in overdue:
+        owners.update(d.get("owners", []))
+        lines += [
+            f"### `{d['id']}` — overdue by {d['days_overdue']} day(s)",
+            f"- {d['description']}",
+            f"- Files: {', '.join('`'+f+'`' for f in d['files'])}",
+            f"- Introduced by [#{d['introduced_by_pr']}]({d['pr_url']}) "
+            f"(merged {d['merged_at'].date()}, removal due {d['deadline'].date()})",
+            f"- Owners: {', '.join('@'+o for o in d.get('owners', []))}",
+            "",
+        ]
+    if owners:
+        lines.append("cc " + " ".join("@" + o for o in sorted(owners)))
+    return "\n".join(lines), sorted(owners)
+
+
+def find_tracking_issue():
+    out = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            REPO,
+            "--label",
+            TRACKING_LABEL,
+            "--state",
+            "open",
+            "--json",
+            "number,body",
+            "--limit",
+            "50",
+        ]
+    )
+    for issue in json.loads(out or "[]"):
+        if MARKER in (issue.get("body") or ""):
+            return issue["number"]
+    return None
+
+
+def ensure_label(dry):
+    if dry:
+        print(f"[dry-run] ensure label {TRACKING_LABEL!r} exists")
+        return
+    run(
+        [
+            "gh",
+            "label",
+            "create",
+            TRACKING_LABEL,
+            "--repo",
+            REPO,
+            "--color",
+            "B60205",
+            "--description",
+            "Tracks deprecated APIs past their scheduled removal date",
+            "--force",
+        ],
+        check=False,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    with open(MANIFEST) as f:
+        manifest = json.load(f)
+
+    now = dt.datetime.now(dt.timezone.utc)
+    print(f"deprecation-reaper: {len(manifest.get('deprecations', []))} tracked entr(ies), now={now.isoformat()}")
+    overdue = find_overdue(manifest, now)
+    existing = find_tracking_issue()
+
+    if not overdue:
+        print("No overdue deprecations.")
+        if existing:
+            msg = "All tracked deprecations have been removed or are no longer overdue. Closing."
+            if args.dry_run:
+                print(f"[dry-run] comment + close issue #{existing}: {msg}")
+            else:
+                run(["gh", "issue", "comment", str(existing), "--repo", REPO, "--body", msg])
+                run(["gh", "issue", "close", str(existing), "--repo", REPO])
+        return
+
+    body, owners = build_body(overdue)
+    if existing:
+        if args.dry_run:
+            print(f"[dry-run] update issue #{existing} with refreshed body:\n{body}")
+        else:
+            run(["gh", "issue", "edit", str(existing), "--repo", REPO, "--body", body])
+            if owners:
+                run(
+                    ["gh", "issue", "edit", str(existing), "--repo", REPO, "--add-assignee", ",".join(owners)],
+                    check=False,
+                )
+        print(f"Updated tracking issue #{existing}.")
+    else:
+        ensure_label(args.dry_run)
+        if args.dry_run:
+            print(
+                f"[dry-run] create issue '{TRACKING_TITLE}' (label {TRACKING_LABEL}, " f"assignees {owners}):\n{body}"
+            )
+        else:
+            create = [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                REPO,
+                "--title",
+                TRACKING_TITLE,
+                "--label",
+                TRACKING_LABEL,
+                "--body",
+                body,
+            ]
+            if owners:
+                create += ["--assignee", ",".join(owners)]
+            url = run(create)
+            print(f"Opened tracking issue: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/deprecation-reaper.yml
+++ b/.github/workflows/deprecation-reaper.yml
@@ -14,6 +14,12 @@ permissions:
   contents: read
   issues: write
 
+# Serialize runs so a scheduled run and a manual dispatch cannot race while
+# creating/editing/closing the single tracking issue.
+concurrency:
+  group: deprecation-reaper
+  cancel-in-progress: false
+
 jobs:
   reap:
     runs-on: ubuntu-latest

--- a/.github/workflows/deprecation-reaper.yml
+++ b/.github/workflows/deprecation-reaper.yml
@@ -1,0 +1,25 @@
+name: "Deprecation reaper"
+
+# Weekly check that opens (and keeps in sync) a tracking issue for deprecated APIs
+# whose scheduled removal date has passed. The removal date is computed from the exact
+# merge time of each deprecation's PR plus its grace period, both listed in
+# .github/deprecations.json -- so the countdown starts at merge and nobody has to
+# remember a date. Run it on demand from the Actions tab via "Run workflow".
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  reap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reap overdue deprecations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/deprecation_reaper.py


### PR DESCRIPTION
### PR Category
Feature

### Summary
We keep adding `[[deprecated]]` APIs that are meant to be removed a while after their PR merges (the matmul init cleanup in #27166 is the latest example), but it is easy to forget to go back and delete them. The repo already has ~40 deprecated markers and no mechanism that tells anyone when they are due for removal. A calendar reminder does not work well because you do not know the merge date when you open the PR.

This adds a small reminder that drives off the merge itself, so nobody has to guess a date.

How it works:
- `.github/deprecations.json` lists each pending removal: a short description, the files, the PR that introduced the deprecation, a grace period (e.g. `30d`), and the owners.
- `.github/workflows/deprecation-reaper.yml` runs once a week (and on demand from the Actions tab).
- `.github/scripts/deprecation_reaper.py` looks up the exact merge time of each entry's PR (`gh pr view --json mergedAt`). Once `mergedAt + grace` has passed, it opens a single tracking issue listing everything that is overdue and assigns the owners. If a PR has not merged yet, the entry is ignored, so the countdown only starts at merge. When all overdue entries are removed from the manifest, the issue is closed automatically.

The first entry tracks the legacy matmul `mm_*` init API deprecated in #27166 (30 days after it merges).

To track a new deprecation later, just add an entry to `.github/deprecations.json` in the same PR that adds the `[[deprecated]]`.

### Notes for reviewers
- Three new files, nothing else is touched.
- The script is standard library only (no pip installs) and uses the workflow's `GITHUB_TOKEN`. It is idempotent: it keeps one tracking issue in sync rather than opening a new one each week.
- You can try it without side effects: `python3 .github/scripts/deprecation_reaper.py --dry-run`. Right now it prints that #27166 has not merged yet, so there is nothing to do.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/deprecation-reaper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/deprecation-reaper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/deprecation-reaper)
