### PR TITLE
Move all kernel side bfloat16 collaterals to bfloat16.h

### DIFF
--- a/tt_metal/hw/inc/api/numeric/bfloat16.h
+++ b/tt_metal/hw/inc/api/numeric/bfloat16.h
@@ -14,6 +14,16 @@ inline constexpr uint16_t POS_INF_BFLOAT16 = 0x7F80;    // Representation of pos
 inline constexpr uint16_t NAN_BFLOAT16 = 0x7FFF;        // Representation of NaN in bfloat16
 inline constexpr uint16_t BFLOAT16_SIGN_MASK = 0x8000;  // Sign bit mask for bfloat16
 
+// Convert bfloat16 (stored as uint16_t) to float.
+// Bfloat16 occupies the high 16 bits of a float's bit representation; this
+// zero-extends the value into the low 16 bits.
+FORCE_INLINE float bf16_to_fp32(std::uint16_t bf16) {
+    std::uint32_t bits = static_cast<std::uint32_t>(bf16) << 16;
+    float result;
+    std::memcpy(&result, &bits, sizeof(result));
+    return result;
+}
+
 // Convert a single-precision float to bfloat16 using IEEE 754 round-to-nearest-even.
 // Matches the packer hardware semantics, so values produced via this helper compare
 // bit-identically against values rounded down to bf16 by the packer.
@@ -27,6 +37,30 @@ FORCE_INLINE std::uint16_t fp32_to_bf16(float x) {
 
     return static_cast<std::uint16_t>(bits >> 16);
 }
+
+// Convert a single-precision float to bfloat16 by truncation (round toward zero).
+// Faster than fp32_to_bf16 but drops the low 16 mantissa bits without rounding.
+// Suitable for intermediate computations where the small rounding error is acceptable.
+FORCE_INLINE std::uint16_t fp32_to_bf16_truncate(float x) {
+    std::uint32_t bits;
+    std::memcpy(&bits, &x, sizeof(bits));
+    return static_cast<std::uint16_t>(bits >> 16);
+}
+
+// Split a float into its high and low 16-bit halves for SFPU register loads,
+// which only accept 16-bit immediate values.
+// high16 holds the bfloat16 representation; low16 holds the discarded mantissa bits.
+struct FloatBits {
+    std::uint16_t high16;
+    std::uint16_t low16;
+
+    explicit FloatBits(float value) {
+        std::uint32_t bits;
+        std::memcpy(&bits, &value, sizeof(bits));
+        high16 = static_cast<std::uint16_t>(bits >> 16);
+        low16 = static_cast<std::uint16_t>(bits & 0xFFFFu);
+    }
+};
 
 // Optimized function to compare two bfloat16 values using integer arithmetic
 bool bfloat16_greater(uint16_t bf16_a, uint16_t bf16_b) {

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/kernels/dataflow/reader.cpp
@@ -4,31 +4,10 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "tt-metalium/constants.hpp"
+#include "api/numeric/bfloat16.h"
 
 #include <cstdint>
 #include <cstring>
-
-/**
- * @brief Converts a 32-bit IEEE 754 float to 16-bit bfloat16 format.
- *
- * This function performs a simple truncation conversion from float32 to bfloat16
- * by extracting the upper 16 bits (sign, exponent, and upper 7 bits of mantissa)
- * of the IEEE 754 float representation. The lower 16 bits of the mantissa are
- * discarded, which may result in precision loss but maintains the same range
- * as float32.
- *
- * @param value The input 32-bit floating point value to convert
- * @return uint16_t The resulting 16-bit bfloat16 value in its binary representation
- *
- * @note This implementation uses simple truncation without rounding, which may
- *       introduce quantization errors for values that cannot be exactly
- *       represented in bfloat16 format - it is sufficient for this example.
- */
-inline uint16_t float_to_bfloat16(float value) {
-    uint32_t tmp;
-    std::memcpy(&tmp, &value, sizeof(tmp));
-    return static_cast<uint16_t>(tmp >> 16);
-}
 
 void kernel_main() {
     // Runtime args
@@ -57,7 +36,7 @@ void kernel_main() {
     const uint32_t ones_l1_write_addr = get_write_ptr(ones_cb_index);
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(ones_l1_write_addr);
     for (uint32_t i = 0; i < tt::constants::TILE_HW; i++) {
-        ptr[i] = float_to_bfloat16(1.0f);
+        ptr[i] = fp32_to_bf16_truncate(1.0f);
     }
     cb_push_back(ones_cb_index, one_tile);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_welfords.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_welfords.h
@@ -7,23 +7,10 @@
 #include <array>
 #include <cstdint>
 
+#include "api/numeric/bfloat16.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
-
-// Optimized float to 16-bit parts conversion
-struct FloatBits
-{
-    std::uint16_t high16;
-    std::uint16_t low16;
-
-    explicit FloatBits(float value)
-    {
-        const std::uint32_t bits = __builtin_bit_cast(std::uint32_t, value);
-        high16                   = static_cast<std::uint16_t>(bits >> 16);
-        low16                    = static_cast<std::uint16_t>(bits & 0xFFFF);
-    }
-};
 
 /**
  * @brief Loads the reciprocal of (idx + 1) into LREG7, using a lookup table if available.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
@@ -7,23 +7,10 @@
 #include <array>
 #include <cstdint>
 
+#include "api/numeric/bfloat16.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "sfpi.h"
-
-// Optimized float to 16-bit parts conversion
-struct FloatBits
-{
-    std::uint16_t high16;
-    std::uint16_t low16;
-
-    explicit FloatBits(float value)
-    {
-        const std::uint32_t bits = __builtin_bit_cast(std::uint32_t, value);
-        high16                   = static_cast<std::uint16_t>(bits >> 16);
-        low16                    = static_cast<std::uint16_t>(bits & 0xFFFF);
-    }
-};
 
 /**
  * @brief Loads the reciprocal of (idx + 1) into LREG7, using a lookup table if available.

--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -12,28 +12,13 @@
 #include "tt-metalium/constants.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "noc/noc_parameters.h"
+#include "api/numeric/bfloat16.h"
 
 constexpr std::uint32_t NOC_MINIMUM_READ_SIZE = 32;  // 32 Bytes
 
-static inline float bfloat16_to_float(uint16_t bfloat_val) {
-    uint32_t uint32_data = ((uint32_t)bfloat_val) << 16;
-    float f;
-    std::memcpy(&f, &uint32_data, sizeof(f));
-    return f;
-}
-
-static inline uint16_t float_to_bfloat16(float val) {
-    union {
-        float f;
-        uint32_t u;
-    } ret;
-    ret.f = val;
-    return uint16_t(ret.u >> 16);
-}
-
 #if defined(FP32_DEST_ACC_EN)
 using FP32_DEST_ACC_FTYPE = float;
-FORCE_INLINE FP32_DEST_ACC_FTYPE fp32_dest_acc_cast(uint16_t val) { return bfloat16_to_float(val); }
+FORCE_INLINE FP32_DEST_ACC_FTYPE fp32_dest_acc_cast(uint16_t val) { return bf16_to_fp32(val); }
 FORCE_INLINE FP32_DEST_ACC_FTYPE fp32_dest_acc_cast(float val) { return val; }
 #else
 using FP32_DEST_ACC_FTYPE = uint16_t;

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -91,43 +91,6 @@ FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_a
     }
 }
 
-// this function is useful for converting bfloat16 values to float32
-FORCE_INLINE float bfloat16_to_float32(uint16_t bfloat16_data) {
-    uint32_t bits = static_cast<uint32_t>(bfloat16_data) << 16;
-
-    // Extract the sign bit
-    uint32_t sign = bits & 0x80000000;
-
-    // Extract the exponent
-    uint32_t exponent = bits & 0x7F800000;
-
-    // Extract the mantissa
-    uint32_t mantissa = bits & 0x007FFFFF;
-
-    // Handle special cases
-    if (exponent == 0 && mantissa == 0) {
-        // Zero
-        return sign ? -0.0f : 0.0f;
-    } else if (exponent == 0x7F800000) {
-        if (mantissa == 0) {
-            // Infinity
-            return sign ? -__builtin_huge_valf() : __builtin_huge_valf();
-        } else {
-            // NaN
-            return __builtin_nanf("");
-        }
-    }
-
-    // Assemble the float
-    union {
-        uint32_t u;
-        float f;
-    } ieee_float;
-
-    ieee_float.u = sign | exponent | mantissa;
-    return ieee_float.f;
-}
-
 template <typename T = uint32_t>
 FORCE_INLINE void fill_with_val(uint32_t begin_addr, uint32_t n, T val) {
     auto* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(begin_addr);

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -12,15 +12,8 @@
 
 namespace {
 
-FORCE_INLINE static float bfloat16_to_float(uint16_t bfloat_val) {
-    uint32_t uint32_data = ((uint32_t)bfloat_val) << 16;
-    float f;
-    std::memcpy(&f, &uint32_data, sizeof(f));
-    return f;
-}
-
 FORCE_INLINE float perform_reduction(float input, uint16_t source_value, ScatterReductionType scatter_reduction_type) {
-    float fp32_source_value = bfloat16_to_float(source_value);
+    float fp32_source_value = bf16_to_fp32(source_value);
     switch (scatter_reduction_type) {
         case ScatterReductionType::ADD: {
             return input + fp32_source_value;
@@ -97,7 +90,7 @@ FORCE_INLINE void copy_input_to_fp32_temp(uint32_t input_cb, uint32_t fp32_temp_
     volatile tt_l1_ptr float* fp32_temp_l1_write_ptr =
         reinterpret_cast<volatile tt_l1_ptr float*>(fp32_temp_l1_write_addr);
     for (uint32_t index_in_input_chunk = 0; index_in_input_chunk < input_chunk_size; ++index_in_input_chunk) {
-        fp32_temp_l1_write_ptr[index_in_input_chunk] = bfloat16_to_float(input_l1_read_ptr[index_in_input_chunk]);
+        fp32_temp_l1_write_ptr[index_in_input_chunk] = bf16_to_fp32(input_l1_read_ptr[index_in_input_chunk]);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_2d.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
 
     cb_output_grad_obj.wait_front(Nt);
 
-    auto zero = float_to_bfloat16(0.0f);
+    auto zero = fp32_to_bf16_truncate(0.0f);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -91,13 +91,13 @@ void kernel_main() {
                 uint16_t input_grad_val;
 
                 if (target_val != ignore_index && target_val == static_cast<int32_t>(c)) {
-                    float output_grad_val = bfloat16_to_float(output_grad_l1_ptr[n]);
+                    float output_grad_val = bf16_to_fp32(output_grad_l1_ptr[n]);
 #if defined(WEIGHT)
-                    float weight_val = bfloat16_to_float(weight_l1_ptr[target_val]);
+                    float weight_val = bf16_to_fp32(weight_l1_ptr[target_val]);
 
-                    input_grad_val = float_to_bfloat16(-output_grad_val * weight_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val * weight_val);
 #else
-                    input_grad_val = float_to_bfloat16(-output_grad_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val);
 #endif
                 } else {
                     input_grad_val = zero;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_3d.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
 
     const auto addrg_output_grad = TensorAccessor(output_grad_args, output_grad_addr);
 
-    auto zero = float_to_bfloat16(0.0f);
+    auto zero = fp32_to_bf16_truncate(0.0f);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -91,14 +91,14 @@ void kernel_main() {
                 uint16_t input_grad_val;
 
                 if (target_val != ignore_index && target_val == static_cast<int32_t>(c)) {
-                    float output_grad_val = bfloat16_to_float(output_grad_l1_ptr[nw_tilized_idx]);
+                    float output_grad_val = bf16_to_fp32(output_grad_l1_ptr[nw_tilized_idx]);
 
 #if defined(WEIGHT)
-                    float weight_val = bfloat16_to_float(weight_l1_ptr[target_val]);
+                    float weight_val = bf16_to_fp32(weight_l1_ptr[target_val]);
 
-                    input_grad_val = float_to_bfloat16(-output_grad_val * weight_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val * weight_val);
 #else
-                    input_grad_val = float_to_bfloat16(-output_grad_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val);
 #endif
                 } else {
                     input_grad_val = zero;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/kernels/reader_moreh_nll_loss_unreduced_backward_4d.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
     CoreLocalMem<volatile uint16_t> weight_l1_ptr(cb_weight_obj.get_read_ptr());
 #endif
 
-    auto zero = float_to_bfloat16(0.0f);
+    auto zero = fp32_to_bf16_truncate(0.0f);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -87,14 +87,14 @@ void kernel_main() {
                 uint16_t input_grad_val;
 
                 if (target_val != ignore_index && target_val == static_cast<int32_t>(c)) {
-                    float output_grad_val = bfloat16_to_float(output_grad_l1_ptr[idx]);
+                    float output_grad_val = bf16_to_fp32(output_grad_l1_ptr[idx]);
 
 #if defined(WEIGHT)
-                    float weight_val = bfloat16_to_float(weight_l1_ptr[target_val]);
+                    float weight_val = bf16_to_fp32(weight_l1_ptr[target_val]);
 
-                    input_grad_val = float_to_bfloat16(-output_grad_val * weight_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val * weight_val);
 #else
-                    input_grad_val = float_to_bfloat16(-output_grad_val);
+                    input_grad_val = fp32_to_bf16_truncate(-output_grad_val);
 #endif
                 } else {
                     input_grad_val = zero;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h
@@ -12,34 +12,9 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 #include <type_traits>
 
-/// @brief Helper functions for float <-> bfloat16 conversion.
-namespace detail {
-/**
- * @brief Convert bfloat16 (uint16_t) to float for arithmetic.
- * @param bf16 bfloat16 value as uint16_t.
- * @return float representation.
- */
-inline float bfloat16_to_float(uint16_t bf16) {
-    uint32_t float_bits = static_cast<uint32_t>(bf16) << 16;
-    float result;
-    std::memcpy(&result, &float_bits, sizeof(float));
-    return result;
-}
-
-/**
- * @brief Convert float to bfloat16 (stored as uint16_t).
- * @param f Float value.
- * @return bfloat16 representation as uint16_t.
- */
-inline uint16_t float_to_bfloat16(float f) {
-    uint32_t float_bits;
-    std::memcpy(&float_bits, &f, sizeof(float));
-    return static_cast<uint16_t>(float_bits >> 16);
-}
-}  // namespace detail
+#include "api/numeric/bfloat16.h"
 
 /**
  * @brief Struct to hold Welford stats for a single subgroup (mean, variance, count).
@@ -122,21 +97,21 @@ inline WelfordStats<uint16_t> combine_welford_stats(T means, T vars) {
         "T must be uint16_t* or volatile uint16_t*");
 
     WelfordStats<float> overall;
-    overall.mean = detail::bfloat16_to_float(means[0]);
-    overall.variance = detail::bfloat16_to_float(vars[0]);
+    overall.mean = bf16_to_fp32(means[0]);
+    overall.variance = bf16_to_fp32(vars[0]);
     overall.count = COUNT_PER_VALUE;
 
     for (uint32_t i = 1; i < ARRAY_SIZE; ++i) {
         WelfordStats<float> next;
-        next.mean = detail::bfloat16_to_float(means[i * STRIDE]);
-        next.variance = detail::bfloat16_to_float(vars[i * STRIDE]);
+        next.mean = bf16_to_fp32(means[i * STRIDE]);
+        next.variance = bf16_to_fp32(vars[i * STRIDE]);
         next.count = COUNT_PER_VALUE;
         overall = combine(overall, next);
     }
 
     WelfordStats<uint16_t> result;
-    result.mean = detail::float_to_bfloat16(overall.mean);
-    result.variance = detail::float_to_bfloat16(overall.variance);
+    result.mean = fp32_to_bf16_truncate(overall.mean);
+    result.variance = fp32_to_bf16_truncate(overall.variance);
     result.count = overall.count;
 
     return result;

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/dataflow/writer_grid_sample_nearest_sharded.cpp
@@ -67,8 +67,8 @@ ALWI void process_grid_point_nearest(
             const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
             const uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
             const uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
-            h_coord_rel = bfloat16_to_float(h_coord_raw);
-            w_coord_rel = bfloat16_to_float(w_coord_raw);
+            h_coord_rel = bf16_to_fp32(h_coord_raw);
+            w_coord_rel = bf16_to_fp32(w_coord_raw);
         }
 
         // Transform to image coordinates using the same formula as prepare_grid.cpp

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/kernels/grid_sample_reader_common.hpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <api/dataflow/dataflow_api.h>
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "api/numeric/bfloat16.h"
 
 #define ALWI inline __attribute__((always_inline))
 
@@ -29,19 +30,6 @@ ALWI void fill_four_val(uint32_t begin_addr, uint16_t val, uint16_t val1, uint16
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(begin_addr);
     ptr[0] = (val | (val1 << 16));
     ptr[1] = (val2 | (val3 << 16));
-}
-
-ALWI uint16_t float_to_bfloat16(float value) {
-    uint32_t tmp;
-    std::memcpy(&tmp, &value, sizeof(tmp));
-    return static_cast<uint16_t>(tmp >> 16);
-}
-
-ALWI float bfloat16_to_float(uint16_t bf16) {
-    uint32_t tmp = static_cast<uint32_t>(bf16) << 16;
-    float result;
-    std::memcpy(&result, &tmp, sizeof(result));
-    return result;
 }
 
 // Grid coordinate reading functions
@@ -96,8 +84,8 @@ struct GridCoordinateReader {
                 const uint32_t coordinate_pair_offset = grid_idx * STANDARD_GRID_ELEMENTS_PER_POINT;
                 const uint16_t h_coord_raw = grid_ptr[coordinate_pair_offset + 1];  // y coordinate
                 const uint16_t w_coord_raw = grid_ptr[coordinate_pair_offset + 0];  // x coordinate
-                h_coord_rel = bfloat16_to_float(h_coord_raw);
-                w_coord_rel = bfloat16_to_float(w_coord_raw);
+                h_coord_rel = bf16_to_fp32(h_coord_raw);
+                w_coord_rel = bf16_to_fp32(w_coord_raw);
             }
 
             const float h_coord_image = h_coord_rel * height_scale + height_offset;
@@ -128,10 +116,10 @@ struct GridCoordinateReader {
             const float weight_sw = (h1_valid && w0_valid) ? (h_frac * w_frac_inv) : 0.0f;      // South-West
             const float weight_se = (h1_valid && w1_valid) ? (h_frac * w_frac) : 0.0f;          // South-East
 
-            weight_nw_bf = float_to_bfloat16(weight_nw);
-            weight_ne_bf = float_to_bfloat16(weight_ne);
-            weight_sw_bf = float_to_bfloat16(weight_sw);
-            weight_se_bf = float_to_bfloat16(weight_se);
+            weight_nw_bf = fp32_to_bf16_truncate(weight_nw);
+            weight_ne_bf = fp32_to_bf16_truncate(weight_ne);
+            weight_sw_bf = fp32_to_bf16_truncate(weight_sw);
+            weight_se_bf = fp32_to_bf16_truncate(weight_se);
         }
     }
 };


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes #28668

Previously, bfloat16 collaterals were duplicated and spread across multiple files:
```
ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h
tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_welfords.h
tt_metal/hw/inc/utils/bfloat16.h
```

The implementation has been refactored to reuse the common definitions from bfloat16.h, reducing code duplication and improving maintainability, discoverability, and consistency across fused-op and kernel code paths.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

1. Main review focus should be on the migration of bfloat16 helper functions/macros to bfloat16.h.
2. Functionality is intended to remain unchanged; this is primarily a code organization and maintainability improvement.
3. Existing behavior for Welford-related computations and bfloat16 conversions should be preserved.
4. The change removes duplicated implementations and establishes bfloat16.h as the single source of truth for bfloat16 utilities.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/fused_bf16_collaterals_to_bf16)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/fused_bf16_collaterals_to_bf16)