### PR TITLE
Add H2D op sync in prefill runner

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_socket_sync.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_socket_sync.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// One-shot worker-side handshake for H2DStreamService.
+//
+// Implements steps 4 and 5 of the per-iteration protocol from
+// h2d_stream_service.md:
+//   1. Wait on the local data_ready_sem until > 0 (set by the service core's
+//      multicast-inc), then reset it to 0.
+//   2. Copy this worker's [start_page, end_page) slice of the backing tensor
+//      into the output tensor (page-by-page, via a single-slot scratch CB).
+//   3. Atomic-inc the consumed_counter at the service core's physical NoC
+//      coords. The service core polls for exactly `num_workers` acks per
+//      transfer before reading the next transfer.
+//
+// Re-enqueued per `forward_to_tensor_bytes` call — no outer loop. Persistent
+// variant lives in persistent_h2d_receiver.cpp.
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+
+// CT-arg layout (must stay in sync with h2d_socket_sync_op.py).
+constexpr uint32_t data_ready_sem_addr = get_compile_time_arg_val(0);
+constexpr uint32_t backing_tensor_addr = get_compile_time_arg_val(1);
+constexpr uint32_t output_tensor_addr = get_compile_time_arg_val(2);
+constexpr uint32_t page_size = get_compile_time_arg_val(3);
+constexpr uint32_t num_pages = get_compile_time_arg_val(4);
+constexpr uint32_t scratch_cb_index = get_compile_time_arg_val(5);
+
+void kernel_main() {
+    // RT args (per coord, per worker).
+    const uint32_t consumed_counter_addr = get_arg_val<uint32_t>(0);
+    const uint32_t service_noc_x = get_arg_val<uint32_t>(1);
+    const uint32_t service_noc_y = get_arg_val<uint32_t>(2);
+    const uint32_t start_page = get_arg_val<uint32_t>(3);
+    const uint32_t end_page = get_arg_val<uint32_t>(4);
+
+    // TensorAccessorArgs blocks: backing first, then output. The host packs
+    // them back-to-back starting at CT-arg index 6.
+    constexpr auto backing_accessor_args = TensorAccessorArgs<6>();
+    constexpr auto output_accessor_args = TensorAccessorArgs<backing_accessor_args.next_compile_time_args_offset()>();
+
+    auto backing = TensorAccessor(backing_accessor_args, backing_tensor_addr);
+    auto output = TensorAccessor(output_accessor_args, output_tensor_addr);
+
+    const uint32_t cb_l1 = get_write_ptr(scratch_cb_index);
+
+    volatile tt_l1_ptr uint32_t* data_ready = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(data_ready_sem_addr);
+
+    // 1. Wait for the service core to signal a fresh transfer, then reset.
+    //    The next service-core multicast-inc will set this back to 1.
+    while (*data_ready == 0) {
+        invalidate_l1_cache();
+    }
+    *data_ready = 0;
+
+    // 2. Copy this worker's slice of the backing tensor into the output. Use
+    //    the scratch CB as a per-page staging area. read_barrier before write
+    //    so we don't issue a write off an unwritten L1 region; write_barrier
+    //    before reusing the slot for the next page.
+    for (uint32_t p = start_page; p < end_page; ++p) {
+        noc_async_read(backing.get_noc_addr(p), cb_l1, page_size);
+        noc_async_read_barrier();
+
+        const uint64_t out_noc = output.get_noc_addr(p);
+        noc_async_write(cb_l1, out_noc, page_size);
+        noc_async_write_barrier();
+    }
+
+    // 3. Ack the service core. Exactly one inc per worker per transfer; the
+    //    service core's poll checks (cur - last_consumed) == num_workers.
+    const uint64_t consumed_noc = get_noc_addr(service_noc_x, service_noc_y, consumed_counter_addr);
+    noc_semaphore_inc(consumed_noc, 1);
+    noc_async_atomic_barrier();
+}

--- a/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Smoke test that runs only the DeepSeek V3 parallel embedding on an 8x4 Galaxy mesh.
+
+No RotaryEmbedding, no attention, no FFN — just construct TtParallelEmbedding,
+forward a batch of random token IDs, and sanity-check the output shape.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
+from models.demos.deepseek_v3_d_p.tt.runners.h2d_socket_sync_op import h2d_socket_sync
+from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from tests.ttnn.utils_for_testing import comp_pcc
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (8, 4),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_embedding_8x4_galaxy(mesh_device):
+    sp_axis = 0
+    tp_axis = 1
+    sp_factor = mesh_device.shape[sp_axis]
+    tp_factor = mesh_device.shape[tp_axis]
+
+    seq_len_total = 5 * 1024
+    assert seq_len_total % sp_factor == 0, f"seq_len_total ({seq_len_total}) must divide sp_factor ({sp_factor})"
+    isl_per_chip = seq_len_total // sp_factor
+    assert (
+        isl_per_chip % ttnn.TILE_SIZE == 0
+    ), f"isl_per_chip ({isl_per_chip}) must be a multiple of TILE_SIZE ({ttnn.TILE_SIZE})"
+
+    vocab_size = DeepSeekV3Config.VOCAB_SIZE
+    emb_dim = DeepSeekV3Config.EMB_SIZE
+
+    logger.info(
+        f"Running TtParallelEmbedding on {mesh_device.shape} "
+        f"(seq_len_total={seq_len_total}, isl_per_chip={isl_per_chip}, vocab_size={vocab_size}, emb_dim={emb_dim})"
+    )
+
+    torch.manual_seed(42)
+    torch_weight = torch.randn(vocab_size, emb_dim, dtype=torch.float32)
+    torch_tokens = torch.randint(0, vocab_size, (sp_factor, 1, isl_per_chip))
+
+    tt_emb = TtParallelEmbedding(
+        mesh_device=mesh_device,
+        vocab_size=vocab_size,
+        emb_dim=emb_dim,
+        torch_weight=torch_weight,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+    )
+
+    # Push tokens through a persistent H2DStreamService. Worker_cores is set so
+    # the service-core kernel multicasts a data-ready inc after each transfer;
+    # the h2d_socket_sync op below waits on that, copies the backing tensor
+    # into a fresh output, and acks the service core — replacing the host-side
+    # `service.barrier()` round-trip.
+    per_chip_bytes = isl_per_chip * 4  # uint32
+    global_spec = ttnn.TensorSpec(
+        shape=ttnn.Shape([sp_factor, 1, isl_per_chip]),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+    mapper = ttnn.create_mesh_mapper(
+        mesh_device,
+        ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()],
+        ),
+    )
+    worker_cores = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
+    h2d_service = ttnn.H2DStreamService(
+        mesh_device=mesh_device,
+        global_spec=global_spec,
+        fifo_size_bytes=8 * per_chip_bytes,
+        scratch_cb_size_bytes=per_chip_bytes,
+        mapper=mapper,
+        worker_cores=worker_cores,
+    )
+    logger.info(
+        f"[h2d] H2DStreamService built: global_shape=({sp_factor},1,{isl_per_chip}) "
+        f"uint32 ROW_MAJOR DRAM, per_chip_bytes={per_chip_bytes}, worker_cores={worker_cores}"
+    )
+
+    logger.info(f"torch_tokens shape: {torch_tokens.shape}")
+    # uint32 bit pattern == int32 bit pattern for non-negative ids (vocab fits in 18 bits).
+    flat_tokens = torch_tokens.to(torch.int32).contiguous().numpy()
+
+    for i in range(20):
+        h2d_service.forward_to_tensor_bytes(flat_tokens)
+        # Device-side sync: workers wait on data_ready_sem, copy backing -> fresh
+        # output, ack consumed_counter. No host barrier needed.
+        tt_tokens = h2d_socket_sync(h2d_service, worker_cores)
+        logger.info(f"tt_tokens shape (synced from H2D service): {tt_tokens.shape}")
+
+        tt_output = tt_emb(tt_tokens)
+
+        # ttnn.embedding squeezes the leading singleton: per-chip output is
+        # [1, isl_per_chip, emb_dim / tp_factor] (3D), not the 4D shape the docstring claims.
+        expected_per_chip_shape = (1, isl_per_chip, emb_dim // tp_factor)
+        assert (
+            tuple(tt_output.shape) == expected_per_chip_shape
+        ), f"Embedding output shape {tuple(tt_output.shape)} != expected {expected_per_chip_shape}"
+        logger.info(f"Embedding output per-chip shape: {tuple(tt_output.shape)}")
+
+        # Host reference: torch.nn.functional.embedding on the same tokens/weight.
+        # F.embedding on tokens [sp_factor, 1, isl_per_chip] returns [sp_factor, 1, isl_per_chip, emb_dim];
+        # squeeze the spare singleton to match the gathered TT shape [sp_factor, isl_per_chip, emb_dim].
+        torch_output = F.embedding(torch_tokens, torch_weight).squeeze(1)
+
+        # Gather: TP composer composes mesh dim 0 (SP) along tensor dim 0, mesh dim 1 (TP) along dim -1.
+        tt_host = ttnn.to_torch(tt_output, mesh_composer=get_tp_mesh_composer(mesh_device), dtype=torch.bfloat16)
+        logger.info(f"TT gathered host shape: {tuple(tt_host.shape)}")
+
+        pcc_threshold = 0.999
+        _, pcc = comp_pcc(torch_output.float(), tt_host.float())
+        logger.info(f"Embedding PCC vs host reference: {pcc:.6f} (threshold {pcc_threshold})")
+        assert pcc > pcc_threshold, f"Embedding PCC {pcc:.6f} below threshold {pcc_threshold}"

--- a/models/demos/deepseek_v3_d_p/tt/runners/h2d_socket_sync_op.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/h2d_socket_sync_op.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Worker-side handshake for `ttnn.H2DStreamService` exposed as a one-shot ttnn op.
+
+Pairs with `models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_socket_sync.cpp`:
+each worker core waits on the service's `data_ready_sem`, copies its slice of
+the backing tensor into a freshly allocated output tensor, then acks the
+service core's `consumed_counter`. Replaces `service.barrier()` for the common
+pipeline pattern
+
+    service.forward_to_tensor_bytes(data)
+    synced = h2d_socket_sync(service)
+    downstream = tt_emb(synced)
+"""
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import get_tensor_accessor_args
+
+_KERNEL_PATH = "models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_socket_sync.cpp"
+_SCRATCH_CB_INDEX = 0
+
+
+def _worker_cores_in_range(core_range: ttnn.CoreRange) -> list[ttnn.CoreCoord]:
+    """Enumerate worker cores in `core_range` in row-major order. Match
+    HostInterface's CoreRange enumeration so per-worker page slices stay stable."""
+    cores: list[ttnn.CoreCoord] = []
+    for y in range(core_range.start.y, core_range.end.y + 1):
+        for x in range(core_range.start.x, core_range.end.x + 1):
+            cores.append(ttnn.CoreCoord(x, y))
+    return cores
+
+
+def h2d_socket_sync(service: ttnn.H2DStreamService, worker_cores: ttnn.CoreRange) -> ttnn.Tensor:
+    """Wait for the next H2D transfer to land in `service.get_backing_tensor()`,
+    copy it into a fresh device tensor, and ack the service core's consumed counter.
+
+    Args:
+        service: A persistent H2DStreamService constructed with `worker_cores` set
+            to the same CoreRange passed here. Provides the data-ready semaphore,
+            per-coord consumed counter, and per-coord service-core coordinates.
+        worker_cores: Worker CoreRange — must match the `worker_cores` the service
+            was constructed with. Each core runs one iteration of the
+            wait → copy slice → ack protocol.
+
+    Returns:
+        A new ttnn.Tensor with the same per-shard spec as `service.get_backing_tensor()`,
+        populated with the latest transfer's data. Independent of the backing tensor —
+        the next `forward_to_tensor` call will not overwrite it.
+    """
+    backing = service.get_backing_tensor()
+    mesh_device = backing.device()
+    mesh_shape = mesh_device.shape
+
+    # --- allocate output (same per-shard spec as backing) ---
+    output = ttnn.allocate_tensor_on_device(
+        backing.shape,
+        backing.dtype,
+        backing.layout,
+        mesh_device,
+        backing.memory_config(),
+    )
+
+    # --- distribute pages across the worker cores in row-major order ---
+    workers = _worker_cores_in_range(worker_cores)
+    num_workers = len(workers)
+    assert num_workers > 0, "h2d_socket_sync: worker_cores must contain at least one core"
+
+    page_size = backing.buffer_page_size()
+    num_pages = backing.buffer_num_pages()
+    # Contiguous chunks; the last worker absorbs the remainder so we never drop pages.
+    base_pages_per_worker = num_pages // num_workers
+    remainder = num_pages % num_workers
+    page_ranges: list[tuple[int, int]] = []
+    cursor = 0
+    for i in range(num_workers):
+        n = base_pages_per_worker + (1 if i < remainder else 0)
+        page_ranges.append((cursor, cursor + n))
+        cursor += n
+    assert cursor == num_pages, f"page distribution mismatch: covered {cursor}/{num_pages}"
+
+    # --- CT args (uniform across mesh) ---
+    backing_acc_args = get_tensor_accessor_args(backing)
+    output_acc_args = get_tensor_accessor_args(output)
+    ct_args = [
+        service.get_data_ready_sem_addr(),
+        backing.buffer_address(),
+        output.buffer_address(),
+        page_size,
+        num_pages,
+        _SCRATCH_CB_INDEX,
+    ]
+    ct_args.extend(backing_acc_args)
+    ct_args.extend(output_acc_args)
+
+    # --- scratch CB (single slot, sized to one page) ---
+    cb_descriptor = ttnn.CBDescriptor(
+        total_size=page_size,
+        core_ranges=ttnn.CoreRangeSet([worker_cores]),
+        format_descriptors=[
+            ttnn.CBFormatDescriptor(
+                buffer_index=_SCRATCH_CB_INDEX,
+                data_format=backing.dtype,
+                page_size=page_size,
+            )
+        ],
+    )
+
+    # --- per-coord Program ---
+    mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+
+    for row in range(mesh_shape[0]):
+        for col in range(mesh_shape[1]):
+            coord = ttnn.MeshCoordinate(row, col)
+
+            # Logical service core for this device → physical NoC coord.
+            service_logical = service.get_service_core(coord)
+            service_phys = mesh_device.worker_core_from_logical_core(service_logical)
+            consumed_addr = service.get_consumed_counter_addr(coord)
+
+            kernel_descriptor = ttnn.KernelDescriptor(
+                kernel_source=_KERNEL_PATH,
+                source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+                core_ranges=ttnn.CoreRangeSet([worker_cores]),
+                compile_time_args=ct_args,
+                config=ttnn.WriterConfigDescriptor(),
+            )
+
+            program = ttnn.ProgramDescriptor(
+                kernels=[kernel_descriptor],
+                semaphores=[],
+                cbs=[cb_descriptor],
+            )
+
+            # Per-worker RT args: ack target + page slice.
+            for worker, (start_page, end_page) in zip(workers, page_ranges):
+                program.kernels[0].runtime_args[worker.x][worker.y] = [
+                    consumed_addr,
+                    service_phys.x,
+                    service_phys.y,
+                    start_page,
+                    end_page,
+                ]
+
+            mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+    # io_tensors order: output first (so generic_op returns it), backing second
+    # so its buffer is reachable from the kernel via the address baked into CT args.
+    return ttnn.generic_op([output, backing], mesh_program_descriptor)


### PR DESCRIPTION
adds a sync op that integrates the H2DSocketService into the prefill runner -> runner reads input from socket instead of the SHM

further work will port this op into proper C++ expected API and move it to another location