### PR TITLE
[LLK] Clean-up and replace ALWI with sfpi_inline in piecewise rational SFPU helpers

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -13,7 +13,7 @@
  *   - Interleaved Horner: back-to-back SFPMAD on numer/denom hides pipeline latency
  *   - Parity x²-Horner: halves FMA count for odd-num/even-den (atanh, erfinv, erf)
  *   - Deferred reciprocal: ONE sfpu_reciprocal for all segments
- *   - Recursive template unrolling: ALWI prevents spills
+ *   - Recursive template unrolling: sfpi_inline prevents spills
  *   - Range reduction: Cody-Waite for exp/trig, mantissa/exponent for log
  *
  * Usage:
@@ -99,7 +99,7 @@ inline sfpi::vFloat piecewise_log_expand(sfpi::vFloat poly_result, sfpi::vInt e_
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
-ALWI void piecewise_rational_eval_numer_denom(
+sfpi_inline void piecewise_rational_eval_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -139,7 +139,7 @@ ALWI void piecewise_rational_eval_numer_denom(
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
-ALWI void piecewise_rational_eval_parity_numer_denom(
+sfpi_inline void piecewise_rational_eval_parity_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -187,7 +187,7 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE, bool USE_PARITY = false>
-ALWI void piecewise_rational_dispatch_numer_denom(
+sfpi_inline void piecewise_rational_dispatch_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -213,7 +213,7 @@ template <
     uint32_t NUM_SEGMENTS,
     uint32_t LUT_SIZE,
     bool USE_PARITY = false>
-ALWI void piecewise_rational_unroll_segment(
+sfpi_inline void piecewise_rational_unroll_segment(
     const std::array<float, LUT_SIZE>& lut,
     sfpi::vFloat x,
     sfpi::vFloat& numer,
@@ -246,7 +246,7 @@ template <
     uint32_t LUT_SIZE,
     bool USE_PARITY = false,
     bool APPROX_RECIP = false>
-ALWI sfpi::vFloat piecewise_rational_eval(const std::array<float, LUT_SIZE>& lut, sfpi::vFloat x) {
+sfpi_inline sfpi::vFloat piecewise_rational_eval(const std::array<float, LUT_SIZE>& lut, sfpi::vFloat x) {
     constexpr uint32_t NUM_COEFFS = NUM_DEGREE + 1;
     constexpr uint32_t COEFF_OFFSET = NUM_SEGMENTS + 1;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -13,7 +13,7 @@
  *   - Interleaved Horner: back-to-back SFPMAD on numer/denom hides pipeline latency
  *   - Parity x²-Horner: halves FMA count for odd-num/even-den (atanh, erfinv, erf)
  *   - Deferred reciprocal: ONE sfpu_reciprocal for all segments
- *   - Recursive template unrolling: ALWI prevents spills
+ *   - Recursive template unrolling: sfpi_inline prevents spills
  *   - Range reduction: Cody-Waite for exp/trig, mantissa/exponent for log
  *
  * Usage:
@@ -99,7 +99,7 @@ inline sfpi::vFloat piecewise_log_expand(sfpi::vFloat poly_result, sfpi::vInt e_
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
-ALWI void piecewise_rational_eval_numer_denom(
+sfpi_inline void piecewise_rational_eval_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -139,7 +139,7 @@ ALWI void piecewise_rational_eval_numer_denom(
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
-ALWI void piecewise_rational_eval_parity_numer_denom(
+sfpi_inline void piecewise_rational_eval_parity_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -187,7 +187,7 @@ ALWI void piecewise_rational_eval_parity_numer_denom(
 // ============================================================================
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE, bool USE_PARITY = false>
-ALWI void piecewise_rational_dispatch_numer_denom(
+sfpi_inline void piecewise_rational_dispatch_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
     sfpi::vFloat x,
@@ -213,7 +213,7 @@ template <
     uint32_t NUM_SEGMENTS,
     uint32_t LUT_SIZE,
     bool USE_PARITY = false>
-ALWI void piecewise_rational_unroll_segment(
+sfpi_inline void piecewise_rational_unroll_segment(
     const std::array<float, LUT_SIZE>& lut,
     sfpi::vFloat x,
     sfpi::vFloat& numer,
@@ -246,7 +246,7 @@ template <
     uint32_t LUT_SIZE,
     bool USE_PARITY = false,
     bool APPROX_RECIP = false>
-ALWI sfpi::vFloat piecewise_rational_eval(const std::array<float, LUT_SIZE>& lut, sfpi::vFloat x) {
+sfpi_inline sfpi::vFloat piecewise_rational_eval(const std::array<float, LUT_SIZE>& lut, sfpi::vFloat x) {
     constexpr uint32_t NUM_COEFFS = NUM_DEGREE + 1;
     constexpr uint32_t COEFF_OFFSET = NUM_SEGMENTS + 1;
 


### PR DESCRIPTION
### PR Category

Small cleanup

### Summary

Context: https://github.com/tenstorrent/tt-metal/pull/45920#discussion_r3371550522

`ALWI` is defined in a metal related file [Source](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/hw/inc/api/compute/common_globals.h) that is 'typically' not included in LLK-related files.

As suggested by #45920, the piecewise rational helper file does not include this (and assumes "including" files define this macro).

This PR replaces the `ALWI` in `ckernel_sfpu_piecewise_rational.h` with `sfpi_inline` which is defined by sfpi compiler.

### Notes for reviewers

Right now, `ALWI` and `sfpi_inline` use comparable `__attribute__((always_inline)) inline` definitions:
- `#define ALWI inline __attribute__((always_inline))` [Source](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/hw/inc/api/compute/common_globals.h)  (also redefined in [compute_kernel_api.h](https://github.com/tenstorrent/tt-metal/blob/8d901046bb169c9c3de1a68d284fba502371a820/tt_metal/hw/inc/api/compute/compute_kernel_api.h#L17) for some reason)
- `#define sfpi_inline __attribute__((always_inline)) inline` [Source](https://github.com/tenstorrent/sfpi/blob/ed989b9d133c2d239b8eb98d6522293d46020dd6/include/wormhole/sfpi_hw.h#L16)

Here, all the helpers are sfpi-related. Making these functions as `sfpi_inline` would make sense and remove the dependency.

The CI failure observed in the initial run ("build-artifact / 🛠️ Build Release ubuntu 22.04", job `80049881594`) was a transient HTTP 504 Gateway Timeout when the proxy failed to reach GitHub to download the sfpi toolchain package. This was not caused by the code changes in this PR and resolved on re-run.


Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/27124595615
BHAPC: https://github.com/tenstorrent/tt-metal/actions/runs/27124609320

Both fails on unrelated errors. 