### PR TITLE
#42440: Extend universal input/output support for ttnn::repeat

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1,0 +1,978 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Universal I/O tests for ttnn.repeat — edge-case matrix (transpose-style)."""
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+    ttnn.bfloat8_b: torch.bfloat16,
+}
+
+_TILE_HEIGHT = 32
+_TILE_WIDTH = 32
+
+
+def _round_up(x, mult):
+    return ((x + mult - 1) // mult) * mult
+
+
+def _padded_hw(shape, layout):
+    """Return (total_height, width). For TILE layout, last-two dims tile-padded."""
+    width = shape[-1]
+    height = 1
+    for d in shape[:-1]:
+        height *= d
+    if layout == ttnn.TILE_LAYOUT:
+        # Pad H/W to tile multiples for TILE layout.
+        height = (height // shape[-2]) * _round_up(shape[-2], _TILE_HEIGHT)
+        width = _round_up(width, _TILE_WIDTH)
+    return height, width
+
+
+def _tile_align(shard_shape, layout):
+    h, w = shard_shape
+    if layout == ttnn.TILE_LAYOUT:
+        return (_round_up(h, _TILE_HEIGHT), _round_up(w, _TILE_WIDTH))
+    return (h, w)
+
+
+def _height_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+    """Height-sharded MemoryConfig."""
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+def _width_shard_config(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT):
+    """Width-sharded MemoryConfig."""
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+def _block_shard_config(shape, device, layout=ttnn.TILE_LAYOUT):
+    """Block-sharded MemoryConfig (2x2 grid)."""
+    compute_grid = device.compute_with_storage_grid_size()
+    grid_x = min(2, compute_grid.x)
+    grid_y = min(2, compute_grid.y)
+    total_h, w = _padded_hw(shape, layout)
+    shard_shape = _tile_align(((total_h + grid_y - 1) // grid_y, (w + grid_x - 1) // grid_x), layout)
+    # RM block-sharding requires width divisible by grid_x; skip if invalid.
+    if layout == ttnn.ROW_MAJOR_LAYOUT and w % grid_x != 0:
+        pytest.skip(f"RM block-sharding requires width {w} divisible by grid_x {grid_x}")
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+
+def _explicit_block_shard_config(device, grid_y, grid_x, sh, sw):
+    """Explicit block-shard grid; skips if device grid is too small."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for {grid_y}x{grid_x}")
+    spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_height_shard_config(device, ncores, sh, sw):
+    """Explicit height-shard grid; skips if device has fewer cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_width_shard_config(device, ncores, sh, sw):
+    """Explicit width-shard grid; skips if device has fewer cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
+
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+def _interleaved(_d):
+    return L1_INTERLEAVED
+
+
+def _sharded_no_spec(memory_layout):
+    """Sharded output MemoryConfig without explicit shard_spec."""
+    return lambda _d: ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+
+
+def run_repeat_test(
+    shape,
+    repeat_shape,
+    device,
+    input_layout=ttnn.TILE_LAYOUT,
+    input_mem_config=None,
+    output_mem_config=None,
+    dtype=ttnn.bfloat16,
+    pcc=0.9999,
+):
+    """Run repeat and assert PCC + output memory_layout."""
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x = torch.rand(shape, dtype=torch_dtype)
+
+    if input_mem_config is None:
+        input_mem_config = L1_INTERLEAVED
+
+    ttnn_input = ttnn.from_torch(x, layout=input_layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    result = ttnn.repeat(ttnn_input, list(repeat_shape), memory_config=output_mem_config)
+
+    actual = result.memory_config()
+    if output_mem_config is not None:
+        assert (
+            actual.memory_layout == output_mem_config.memory_layout
+        ), f"Expected output memory layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+        if output_mem_config.memory_layout in (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ):
+            assert (
+                actual.shard_spec is not None
+            ), "Sharded output requested but result has no shard_spec (silent fallback?)"
+    elif input_mem_config.is_sharded():
+        # Sharded input → inherit layout or fallback to interleaved (non-alignable shapes).
+        assert actual.memory_layout in (
+            input_mem_config.memory_layout,
+            ttnn.TensorMemoryLayout.INTERLEAVED,
+        ), f"Expected inherited {input_mem_config.memory_layout} or interleaved fallback, got {actual.memory_layout}"
+        if actual.memory_layout != ttnn.TensorMemoryLayout.INTERLEAVED:
+            assert actual.shard_spec is not None, "Sharded output must carry a shard_spec"
+
+    ref_repeat = list(repeat_shape)
+    if len(ref_repeat) < x.dim():
+        ref_repeat = [1] * (x.dim() - len(ref_repeat)) + ref_repeat
+    ref = x.repeat(*ref_repeat)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), pcc)
+
+
+# Native TILE sharded paths.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_factory, id_suffix",
+    [
+        # TILE HEIGHT, last-dim
+        (
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            _interleaved,
+            "tile_height_last_dim",
+        ),
+        # TILE WIDTH, upper-dim
+        (
+            (1, 1, 64, 128),
+            (2, 1, 1, 1),
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            _interleaved,
+            "tile_width_upper_dim",
+        ),
+        # TILE BLOCK, H-dim
+        (
+            (1, 1, 64, 64),
+            (1, 1, 2, 1),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            _interleaved,
+            "tile_block_h_dim",
+        ),
+        # TILE HEIGHT -> explicit sharded out
+        (
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            lambda d: _height_shard_config((1, 1, 128, 128), d),
+            "tile_height_to_height_explicit",
+        ),
+    ],
+)
+def test_repeat_native_tile_sharded(shape, repeat_shape, input_factory, output_factory, id_suffix, device):
+    in_mc = input_factory(device)
+    out_mc = output_factory(device)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=in_mc,
+        output_mem_config=out_mc,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# Native RM HEIGHT sharded.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, id_suffix",
+    [
+        ((4, 32), (1, 2), "rm_height_last_dim"),
+        ((4, 32), (2, 1), "rm_height_upper_dim"),
+    ],
+)
+def test_repeat_native_rm_height_sharded(shape, repeat_shape, id_suffix, device):
+    in_mc = _height_shard_config(shape if len(shape) == 4 else (1, 1, *shape), device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=in_mc,
+        output_mem_config=L1_INTERLEAVED,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# RM BLOCK/WIDTH + last-dim repeat: predicate forces composite (Fix 2 guard).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_factory, id_suffix",
+    [
+        # RM BLOCK -> interleaved
+        (
+            (4, 64),
+            (1, 2),
+            lambda d: _block_shard_config((1, 1, 4, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved,
+            "rm_block_last_dim_to_interleaved",
+        ),
+        # RM WIDTH -> interleaved
+        (
+            (4, 64),
+            (1, 2),
+            lambda d: _width_shard_config((1, 1, 4, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved,
+            "rm_width_last_dim_to_interleaved",
+        ),
+    ],
+)
+def test_repeat_rm_block_width_last_dim_composite(
+    shape, repeat_shape, input_factory, output_factory, id_suffix, device
+):
+    in_mc = input_factory(device)
+    out_mc = output_factory(device)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=in_mc,
+        output_mem_config=out_mc,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# Composite fallback (predicate rejects native path).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_factory, id_suffix",
+    [
+        # RM BLOCK upper-dim: not locally contained -> composite
+        (
+            (4, 64),
+            (2, 1),
+            lambda d: _block_shard_config((1, 1, 4, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved,
+            "rm_block_upper_dim_composite",
+        ),
+        # Multi-axis repeat on sharded input -> composite
+        (
+            (1, 1, 64, 64),
+            (2, 1, 2, 1),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            _interleaved,
+            "tile_multi_dim_composite",
+        ),
+    ],
+)
+def test_repeat_composite_fallback(shape, repeat_shape, input_factory, output_factory, id_suffix, device):
+    in_mc = input_factory(device)
+    out_mc = output_factory(device)
+    is_tile = "tile" in id_suffix
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT if is_tile else ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=in_mc,
+        output_mem_config=out_mc,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# Sharded output synthesis: derived spec from sharded/interleaved input.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_layout, in_mc_fn, out_layout",
+    [
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="tile_width_to_width",
+        ),
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 128, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="rm_height_to_height",
+        ),
+        pytest.param(
+            (1, 1, 64, 32),
+            (1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d: _explicit_height_shard_config(d, 2, 32, 32),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="tile_subtile_height_to_height",
+        ),
+    ],
+)
+def test_repeat_sharded_to_derived_spec(shape, repeat_shape, input_layout, in_mc_fn, out_layout, device):
+    out_mc = _sharded_no_spec(out_layout)(device)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=input_layout,
+        input_mem_config=in_mc_fn(device),
+        output_mem_config=out_mc,
+    )
+
+
+# Interleaved input → sharded output without shard_spec (TILE and RM, all layouts).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_layout, memory_layout",
+    [
+        pytest.param(
+            (1, 1, 64, 64), (1, 1, 1, 2), ttnn.TILE_LAYOUT, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="tile_H"
+        ),
+        pytest.param(
+            (1, 1, 64, 64), (1, 1, 1, 2), ttnn.TILE_LAYOUT, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="tile_W"
+        ),
+        pytest.param(
+            (1, 1, 64, 64), (1, 1, 1, 2), ttnn.TILE_LAYOUT, ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="tile_B"
+        ),
+        pytest.param(
+            (1, 1, 64, 128), (1, 1, 1, 2), ttnn.ROW_MAJOR_LAYOUT, ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="rm_B"
+        ),
+        pytest.param(
+            (1, 1, 64, 128), (1, 1, 1, 2), ttnn.ROW_MAJOR_LAYOUT, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="rm_W"
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            (1, 2, 1, 1),
+            ttnn.ROW_MAJOR_LAYOUT,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            id="rm_B_C_repeat",
+        ),
+    ],
+)
+def test_repeat_interleaved_to_sharded_nospec(shape, repeat_shape, input_layout, memory_layout, device):
+    out_mc = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=input_layout,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=out_mc,
+    )
+
+
+# RM sharded → sharded round-trip (BLOCK and WIDTH).
+@pytest.mark.parametrize(
+    "shape, input_factory, output_layout",
+    [
+        pytest.param(
+            (1, 1, 4, 64),
+            lambda d: _block_shard_config((1, 1, 4, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            id="block_to_block",
+        ),
+        pytest.param(
+            (1, 1, 4, 64),
+            lambda d: _width_shard_config((1, 1, 4, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="width_to_width",
+        ),
+    ],
+)
+def test_repeat_rm_sharded_to_sharded(shape, input_factory, output_layout, device):
+    out_mc = ttnn.MemoryConfig(output_layout, ttnn.BufferType.L1)
+    run_repeat_test(
+        shape,
+        (1, 1, 1, 2),
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=input_factory(device),
+        output_mem_config=out_mc,
+    )
+
+
+# DRAM-sharded input -> L1 interleaved (to_memory_config fallback path).
+def test_repeat_dram_sharded_to_interleaved(device):
+    shape = (1, 1, 128, 64)
+    compute_grid = device.compute_with_storage_grid_size()
+    num_cores = min(4, compute_grid.x * compute_grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid, True)
+    total_h = shape[0] * shape[1] * _round_up(shape[2], _TILE_HEIGHT)
+    w = _round_up(shape[3], _TILE_WIDTH)
+    shard_shape = (_round_up((total_h + num_cores - 1) // num_cores, _TILE_HEIGHT), w)
+    dram_sharded = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=dram_sharded
+    )
+    result = ttnn.repeat(ttnn_input, [1, 1, 1, 2], memory_config=L1_INTERLEAVED)
+    assert (
+        result.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+    ), f"Expected L1 INTERLEAVED, got {result.memory_config().memory_layout}"
+    ref = x.repeat(1, 1, 1, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# DRAM interleaved baseline (existing fast path).
+@pytest.mark.parametrize(
+    "input_layout, dtype",
+    [
+        pytest.param(ttnn.TILE_LAYOUT, ttnn.bfloat16, id="tile_bf16"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, id="rm_bf16"),
+    ],
+)
+def test_repeat_dram_interleaved(input_layout, dtype, device):
+    shape = (1, 1, 64, 64)
+    run_repeat_test(
+        shape,
+        (1, 1, 1, 2),
+        device,
+        input_layout=input_layout,
+        input_mem_config=DRAM_INTERLEAVED,
+        output_mem_config=DRAM_INTERLEAVED,
+        dtype=dtype,
+    )
+
+
+# RM L1-interleaved native path (last-dim + higher-dim, odd page width).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, id_suffix",
+    [
+        pytest.param((2, 32), (1, 2), "rm_il_last_dim"),
+        pytest.param((2, 32), (3, 1), "rm_il_higher_dim"),
+        pytest.param((1, 1, 4, 96), (1, 1, 2, 1), "rm_il_higher_dim_4d"),
+        pytest.param((3, 5), (1, 4), "rm_il_last_dim_odd_width"),
+    ],
+)
+def test_repeat_rm_interleaved(shape, repeat_shape, id_suffix, device):
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=L1_INTERLEAVED,
+        output_mem_config=L1_INTERLEAVED,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# All-1 repeat vector: host returns input unchanged.
+@pytest.mark.parametrize(
+    "input_layout, mc_factory",
+    [
+        pytest.param(ttnn.TILE_LAYOUT, lambda d: L1_INTERLEAVED, id="tile_interleaved"),
+        pytest.param(ttnn.TILE_LAYOUT, lambda d: _height_shard_config((1, 1, 64, 64), d), id="tile_height_sharded"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, lambda d: L1_INTERLEAVED, id="rm_interleaved"),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="rm_height_sharded",
+        ),
+    ],
+)
+def test_repeat_all_ones_shortcut(input_layout, mc_factory, device):
+    run_repeat_test(
+        (1, 1, 64, 64),
+        (1, 1, 1, 1),
+        device,
+        input_layout=input_layout,
+        input_mem_config=mc_factory(device),
+        output_mem_config=None,
+        dtype=ttnn.bfloat16,
+    )
+
+
+# TILE universal-I/O matrix: essential input × output routing paths.
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(ttnn.bfloat16, id="bf16"),
+        pytest.param(ttnn.float32, id="f32"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_factory",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            _interleaved,
+            id="block_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 1, 2),
+            _interleaved,
+            lambda d: _height_shard_config((1, 1, 64, 256), d),
+            id="interleaved_to_height",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 1, 2),
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            lambda d: _height_shard_config((1, 1, 64, 256), d),
+            id="width_to_height",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            None,
+            id="block_default_output",
+        ),
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            _sharded_no_spec(ttnn.TensorMemoryLayout.HEIGHT_SHARDED),
+            id="height_to_height_nospec",
+        ),
+        pytest.param(
+            (2, 3, 64, 96),
+            (1, 1, 1, 2),
+            _interleaved,
+            None,
+            id="interleaved_baseline",
+        ),
+    ],
+)
+def test_repeat_tile_universal_io_matrix(shape, repeat_shape, input_factory, output_factory, dtype, device):
+    out_mc = output_factory(device) if output_factory is not None else None
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=input_factory(device),
+        output_mem_config=out_mc,
+        dtype=dtype,
+    )
+
+
+# RM universal-I/O matrix: essential composite + native paths.
+_RM = ttnn.ROW_MAJOR_LAYOUT
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(ttnn.bfloat16, id="bf16"),
+        pytest.param(ttnn.float32, id="f32"),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_factory",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d, layout=_RM),
+            _interleaved,
+            id="block_to_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 1, 2),
+            _interleaved,
+            lambda d: _width_shard_config((1, 1, 64, 256), d, layout=_RM),
+            id="interleaved_to_width",
+        ),
+        pytest.param(
+            (1, 1, 64, 32),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 64, 32), d, layout=_RM),
+            _interleaved,
+            id="height_to_interleaved",
+        ),
+    ],
+)
+def test_repeat_rm_universal_io_matrix(shape, repeat_shape, input_factory, output_factory, dtype, device):
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=_RM,
+        input_mem_config=input_factory(device),
+        output_mem_config=output_factory(device),
+        dtype=dtype,
+    )
+
+
+# Irregular logical shapes (not tile-aligned) — interleaved only (sharded variants in universal matrices).
+_IRREGULAR_SHAPES = [
+    ((1, 1, 65, 97), (1, 1, 1, 2)),
+    ((1, 13, 47, 64), (1, 2, 1, 1)),
+    ((3, 5, 32, 64), (2, 1, 1, 1)),
+]
+
+
+@pytest.mark.parametrize("shape, repeat_shape", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+def test_repeat_irregular_shapes_interleaved(shape, repeat_shape, input_layout, device):
+    run_repeat_test(shape, repeat_shape, device, input_layout=input_layout)
+
+
+# Explicit-grid edge cases: irregular shapes with uneven sharding (dynamic helpers can't express).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, mc_factory",
+    [
+        pytest.param(
+            (1, 1, 65, 64),
+            (1, 1, 1, 2),
+            lambda d: _explicit_block_shard_config(d, 3, 2, 32, 32),
+            id="tile_block_3x2_irregular_H",
+        ),
+        pytest.param(
+            (1, 1, 96, 64),
+            (1, 1, 1, 2),
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32),
+            id="tile_block_uneven_h96",
+        ),
+    ],
+)
+def test_repeat_explicit_grid_edge_cases(shape, repeat_shape, mc_factory, device):
+    run_repeat_test(shape, repeat_shape, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=mc_factory(device))
+
+
+# Higher-rank inputs (rank 5 and 6).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, layout, input_mem_config, dtype",
+    [
+        pytest.param(
+            (2, 1, 1, 64, 64),
+            (1, 1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            "height_sharded",
+            ttnn.bfloat16,
+            id="rank5_height_sharded",
+        ),
+        pytest.param(
+            (1, 2, 1, 1, 32, 64),
+            (1, 1, 1, 1, 1),
+            ttnn.TILE_LAYOUT,
+            "interleaved",
+            ttnn.bfloat16,
+            id="rank6_interleaved_noop",
+        ),
+        pytest.param(
+            (1, 2, 1, 1, 32, 64),
+            (1, 1, 1, 1, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            "interleaved",
+            ttnn.bfloat16,
+            id="rank6_interleaved_last_dim",
+        ),
+    ],
+)
+def test_repeat_higher_rank(shape, repeat_shape, layout, input_mem_config, dtype, device):
+    if input_mem_config == "height_sharded":
+        in_mc = _height_shard_config(shape, device, layout=layout)
+    else:
+        in_mc = L1_INTERLEAVED
+    run_repeat_test(shape, repeat_shape, device, input_layout=layout, input_mem_config=in_mc, dtype=dtype)
+
+
+# Default output memory_config inherits and rescales input shard_spec.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory",
+    [
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            id="height_default_mc",
+        ),
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 1, 2),
+            lambda d: _width_shard_config((1, 1, 64, 128), d),
+            id="width_default_mc",
+        ),
+    ],
+)
+def test_repeat_default_memory_config(shape, repeat_shape, input_factory, device):
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=input_factory(device),
+        output_mem_config=None,
+    )
+
+
+# Sharded input → sharded output without shard_spec (native + composite paths).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_factory, output_layout",
+    [
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="height_in_height_out_nospec",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            id="block_in_block_out_nospec",
+        ),
+        pytest.param(
+            (1, 1, 96, 64),
+            (1, 1, 1, 2),
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="uneven_block_in_height_out_nospec",
+        ),
+    ],
+)
+def test_repeat_sharded_in_sharded_out_nospec(shape, repeat_shape, input_factory, output_layout, device):
+    out_mc = ttnn.MemoryConfig(output_layout, ttnn.BufferType.L1)
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=input_factory(device),
+        output_mem_config=out_mc,
+    )
+
+
+# Focused dtype spot-checks on representative native paths.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, layout, in_mc_fn, dtype",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            ttnn.float32,
+            id="f32_tile_interleaved",
+        ),
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 128, 64), d),
+            ttnn.float32,
+            id="f32_tile_height_sharded",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 1, 2),
+            ttnn.TILE_LAYOUT,
+            _interleaved,
+            ttnn.bfloat8_b,
+            id="bf8b_tile_interleaved",
+        ),
+        pytest.param(
+            (4, 32),
+            (1, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            _interleaved,
+            ttnn.float32,
+            id="f32_rm_interleaved_2d",
+        ),
+    ],
+)
+def test_repeat_dtype_coverage(shape, repeat_shape, layout, in_mc_fn, dtype, device):
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=layout,
+        input_mem_config=in_mc_fn(device),
+        dtype=dtype,
+        pcc=0.99 if dtype == ttnn.bfloat8_b else 0.9999,
+    )
+
+
+# DRAM interleaved across repeat dims (N/C/H/W).
+@pytest.mark.parametrize(
+    "repeat_shape",
+    [
+        pytest.param((2, 1, 1, 1), id="N"),
+        pytest.param((1, 2, 1, 1), id="C"),
+        pytest.param((1, 1, 2, 1), id="H"),
+        pytest.param((1, 1, 1, 2), id="W"),
+    ],
+)
+def test_repeat_dram_interleaved_dims(repeat_shape, device):
+    run_repeat_test(
+        (1, 4, 64, 128),
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=DRAM_INTERLEAVED,
+        output_mem_config=DRAM_INTERLEAVED,
+    )
+
+
+# ─── Path-coverage additions ─────────────────────────────────────────────────
+# Targeted tests for specific dispatch branches not fully exercised by the matrices above.
+
+
+# Rank mismatch handling: reps vs tensor rank.
+@pytest.mark.parametrize(
+    "shape, repeat_shape, id_str",
+    [
+        pytest.param((64, 64), (1, 1, 1, 2), "reps_longer_than_rank"),
+        pytest.param((1, 1, 64, 64), (1, 2), "reps_shorter_than_rank"),
+    ],
+)
+def test_repeat_rank_mismatch(shape, repeat_shape, id_str, device):
+    run_repeat_test(shape, repeat_shape, device, input_layout=ttnn.TILE_LAYOUT, input_mem_config=L1_INTERLEAVED)
+
+
+# Zero-rep across various inputs (ttnn::zeros path, Fix 4).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, input_layout, in_mc_fn, expected_shape",
+    [
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 0, 2),
+            ttnn.TILE_LAYOUT,
+            lambda d: L1_INTERLEAVED,
+            (1, 1, 0, 128),
+            id="tile_interleaved_zero_H",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 0, 1, 1),
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_shard_config((1, 1, 64, 64), d),
+            (1, 0, 64, 64),
+            id="tile_height_sharded_zero_C",
+        ),
+        pytest.param(
+            (64, 64),
+            (0, 2),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: L1_INTERLEAVED,
+            (0, 128),
+            id="rm_interleaved_zero_row",
+        ),
+    ],
+)
+def test_repeat_zero_reps(shape, repeat_shape, input_layout, in_mc_fn, expected_shape, device):
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    in_mc = in_mc_fn(device)
+    ttnn_input = ttnn.from_torch(x, layout=input_layout, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.repeat(ttnn_input, list(repeat_shape))
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert got.numel() == 0
+    assert tuple(got.shape) == expected_shape
+
+
+# Predicate guards forcing composite fallback (specific edge cases).
+@pytest.mark.parametrize(
+    "shape, repeat_shape, in_mc_fn, out_mc_fn, path_id",
+    [
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 1, 2),
+            lambda d: _explicit_height_shard_config(d, 4, 32, 64),
+            lambda d: _explicit_height_shard_config(d, 2, 64, 128),
+            "sharded_mismatched_grids",
+        ),
+        pytest.param(
+            (1, 3, 32, 32),
+            (1, 2, 1, 1),
+            lambda d: _explicit_height_shard_config(d, 3, 32, 32),
+            lambda d: L1_INTERLEAVED,
+            "higher_dim_not_locally_contained",
+        ),
+        pytest.param(
+            (1, 1, 64, 64),
+            (2, 2, 1, 1),
+            lambda d: _block_shard_config((1, 1, 64, 64), d),
+            lambda d: _height_shard_config((2, 2, 64, 64), d),
+            "composite_with_user_spec",
+        ),
+        pytest.param(
+            (32, 64),
+            (1, 2),
+            lambda d: _height_shard_config((32, 64), d, num_cores=1, layout=ttnn.TILE_LAYOUT),
+            lambda d: L1_INTERLEAVED,
+            "tile_rank2_sharded",
+        ),
+    ],
+)
+def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, path_id, device):
+    run_repeat_test(
+        shape,
+        repeat_shape,
+        device,
+        input_layout=ttnn.TILE_LAYOUT,
+        input_mem_config=in_mc_fn(device),
+        output_mem_config=out_mc_fn(device),
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -32,7 +32,7 @@ file(
     pad/device/kernels/*
     permute/device/kernels/*
     reshape_on_device/device/kernels/*
-    repeat/device/kernels/repeat_*_rm.cpp
+    repeat/device/kernels/*
     reshape_view/device/device/*
     scatter/device/kernels/*
     sharded/device/kernels/*

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_interleaved.cpp
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// RM higher-dim interleaved; alignment dance for one-packet noc.async_* fast path.
+// Tensor layout: <higher_dim, rep_dim, lower_dim, page_size>
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -13,35 +16,31 @@
 using namespace tt::data_movement::common;
 
 void kernel_main() {
-    // We are guaranteed to be in 4D going to 4D
-    //<higher_dim,rep_dim,lower_dim,page_size>
-
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    // Program factory can control the start and end of each of the 3 dims
+    // Program factory controls the start and end of each of the 3 dims.
     const uint32_t higher_dim_start = get_arg_val<uint32_t>(2);
     const uint32_t higher_dim_end = get_arg_val<uint32_t>(3);
     const uint32_t lower_dim_start = get_arg_val<uint32_t>(4);
     const uint32_t lower_dim_end = get_arg_val<uint32_t>(5);
     const uint32_t repetitions = get_arg_val<uint32_t>(6);
-    // nop lets you intentionally not use this core if the dims don't divide nicely
+    // nop lets you intentionally skip this core if dims don't divide evenly.
     const uint32_t nop = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t original_page_size_bytes = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(2);
-    //(higher_dim,rep_dim,lower_dim,page_size)
-    // cb_id_in0 and cb_id_in1 is each 1 page of size:
-    // 128 + page size in bytes
+    // cb_id_in0 and cb_id_in1 are each 1 page of size: 128 + page_size_bytes.
     constexpr uint32_t LOWER_DIMS = get_compile_time_arg_val(3);
     constexpr uint32_t REP_DIM = get_compile_time_arg_val(4);
-    constexpr auto src_args = TensorAccessorArgs<5>();
-    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto src_args = TensorAccessorArgs<5, 0>();
+    constexpr auto dst_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.num_common_runtime_args()>();
 
     constexpr uint32_t LOWER_DIMS_TIMES_REP_DIM = LOWER_DIMS * REP_DIM;
 
-    // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
-    // core
+    // Since we need to operate on a grid of cores but sometimes pages don't split properly,
+    // if nop then don't use this core.
     if (nop == 1) {
         return;
     }
@@ -53,10 +52,9 @@ void kernel_main() {
     CircularBuffer cb0(cb_id_in0);
     CircularBuffer cb1(cb_id_in1);
 
-    // alignments pre-calculations
+    // Alignment pre-calculations.
     constexpr uint64_t r_mask_to_use = src_args.is_dram ? MASK_64 : MASK_16;
     constexpr uint64_t r_offset_to_use = src_args.is_dram ? OFFSET_64 : OFFSET_16;
-
     constexpr uint32_t r_alignment_requirement = src_args.is_dram ? 64 : 16;
     constexpr uint32_t w_alignment_requirement = 16;
     const uint64_t w_mask_to_use = MASK_16;
@@ -83,11 +81,9 @@ void kernel_main() {
             for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
                 uint32_t read_offset = h_offset + r_offset + l;
                 src_noc_addr = s.get_noc_addr(read_offset, 0);
-                data_location = input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed aligned to src_noc_addr
+                data_location = input_buffer + (src_noc_addr & r_offset_to_use);
 
                 CoreLocalMem<uint32_t> dst_mem(data_location);
-                // Use TensorAccessor directly to avoid address truncation
-                // Template parameter preserves one-packet fast path for page-sized transfers
                 noc.async_read<NocOptions::DEFAULT, original_page_size_bytes>(
                     s,
                     dst_mem,
@@ -97,27 +93,15 @@ void kernel_main() {
                 noc.async_read_barrier();
 
                 for (uint32_t n = 0; n < repetitions; n++) {
-                    // Perform the writes
                     uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
                     const uint64_t dst_noc_addr = d.get_noc_addr(write_offset, 0);
                     if ((data_location & w_offset_to_use) != (dst_noc_addr & w_offset_to_use)) {
-                        // Can't directly copy
-                        const uint32_t target_align_buffer =
-                            alignment_buffer +
-                            (dst_noc_addr & w_offset_to_use);  // Guaranteed aligned to target page addr
+                        const uint32_t target_align_buffer = alignment_buffer + (dst_noc_addr & w_offset_to_use);
                         tt_memmove<false, false, false, original_page_size_bytes>(
-                            noc,
-                            target_align_buffer,
-                            data_location,
-                            original_page_size_bytes);  // Data is copied to align buffer
-                        data_location = alignment_buffer +
-                                        (dst_noc_addr & w_offset_to_use);  // Update data location to use write buffer
+                            noc, target_align_buffer, data_location, original_page_size_bytes);
+                        data_location = alignment_buffer + (dst_noc_addr & w_offset_to_use);
                     }
-                    // Now we are ensured the data is at write_buffer and it is aligned for the write
-                    // Orchestrate the write
                     CoreLocalMem<uint32_t> src_mem(data_location);
-                    // Use TensorAccessor directly to avoid address truncation
-                    // Template parameter preserves one-packet fast path for page-sized transfers
                     noc.async_write<NocOptions::DEFAULT, original_page_size_bytes>(
                         src_mem,
                         d,
@@ -129,5 +113,4 @@ void kernel_main() {
             }
         }
     }
-    return;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RM higher-dim sharded; noc_async_*_sharded splits cross-shard rows.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace tt::data_movement::common;
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t higher_dim_start = get_arg_val<uint32_t>(2);
+    const uint32_t higher_dim_end = get_arg_val<uint32_t>(3);
+    const uint32_t lower_dim_start = get_arg_val<uint32_t>(4);
+    const uint32_t lower_dim_end = get_arg_val<uint32_t>(5);
+    const uint32_t repetitions = get_arg_val<uint32_t>(6);
+    const uint32_t nop = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t original_page_size_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr uint32_t LOWER_DIMS = get_compile_time_arg_val(2);
+    constexpr uint32_t REP_DIM = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4, 0>();
+    constexpr auto dst_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.num_common_runtime_args()>();
+
+    constexpr uint32_t LOWER_DIMS_TIMES_REP_DIM = LOWER_DIMS * REP_DIM;
+
+    if (nop == 1) {
+        return;
+    }
+
+    const auto s = TensorAccessor(src_args, src_addr);
+    const auto d = TensorAccessor(dst_args, dst_addr);
+
+    CircularBuffer cb(cb_id_in0);
+    cb.reserve_back(1);
+    const uint32_t cb_slot = cb.get_write_ptr();
+    cb.push_back(1);
+
+    for (uint32_t h = higher_dim_start; h < higher_dim_end; h++) {
+        const uint32_t h_offset = h * LOWER_DIMS_TIMES_REP_DIM;
+        const uint32_t h_offset_rep = h_offset * repetitions;
+        for (uint32_t r = 0; r < REP_DIM; r++) {
+            const uint32_t r_offset = r * LOWER_DIMS;
+            for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
+                const uint32_t read_offset = h_offset + r_offset + l;
+                noc_async_read_sharded(cb_slot, s, read_offset, 0, original_page_size_bytes);
+                noc_async_read_barrier();
+                for (uint32_t n = 0; n < repetitions; n++) {
+                    const uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
+                    noc_async_write_sharded(cb_slot, d, write_offset, 0, original_page_size_bytes);
+                }
+                noc_async_write_barrier();
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TILE higher-dim repeat; bare get_noc_addr (tile pages are atomic on one core).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace tt::data_movement::common;
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t higher_dim_start = get_arg_val<uint32_t>(2);
+    const uint32_t higher_dim_end = get_arg_val<uint32_t>(3);
+    const uint32_t lower_dim_start = get_arg_val<uint32_t>(4);
+    const uint32_t lower_dim_end = get_arg_val<uint32_t>(5);
+    const uint32_t repetitions = get_arg_val<uint32_t>(6);
+    const uint32_t nop = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t original_page_size_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(1);
+    constexpr uint32_t LOWER_DIMS = get_compile_time_arg_val(2);
+    constexpr uint32_t REP_DIM = get_compile_time_arg_val(3);
+    constexpr auto src_args = TensorAccessorArgs<4, 0>();
+    constexpr auto dst_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.num_common_runtime_args()>();
+
+    constexpr uint32_t LOWER_DIMS_TIMES_REP_DIM = LOWER_DIMS * REP_DIM;
+
+    if (nop == 1) {
+        return;
+    }
+
+    const auto s = TensorAccessor(src_args, src_addr);
+    const auto d = TensorAccessor(dst_args, dst_addr);
+
+    CircularBuffer cb(cb_id_in0);
+    cb.reserve_back(1);
+    const uint32_t cb_slot = cb.get_write_ptr();
+    cb.push_back(1);
+
+    for (uint32_t h = higher_dim_start; h < higher_dim_end; h++) {
+        const uint32_t h_offset = h * LOWER_DIMS_TIMES_REP_DIM;
+        const uint32_t h_offset_rep = h_offset * repetitions;
+        for (uint32_t r = 0; r < REP_DIM; r++) {
+            const uint32_t r_offset = r * LOWER_DIMS;
+            for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
+                const uint32_t read_offset = h_offset + r_offset + l;
+                const uint64_t src_noc_addr = s.get_noc_addr(read_offset, 0);
+                noc_async_read(src_noc_addr, cb_slot, original_page_size_bytes);
+                noc_async_read_barrier();
+                for (uint32_t n = 0; n < repetitions; n++) {
+                    const uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
+                    const uint64_t dst_noc_addr = d.get_noc_addr(write_offset, 0);
+                    noc_async_write(cb_slot, dst_noc_addr, original_page_size_bytes);
+                }
+                noc_async_write_barrier();
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_interleaved.cpp
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/*
-Function reads from RM and writes to RM repeating the last dimension
-*/
+// RM last-dim interleaved; in-CB page doubling for odd page sizes.
+// Reads from RM and writes to RM repeating the last dimension.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -16,40 +16,31 @@ Function reads from RM and writes to RM repeating the last dimension
 using namespace tt::data_movement::common;
 
 void kernel_main() {
-    // We are guaranteed to be in 2D going to 2D
-
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    // Which set of pages to deal with
+    // Which set of pages to deal with.
     const uint32_t page_start = get_arg_val<uint32_t>(2);
     const uint32_t page_end = get_arg_val<uint32_t>(3);
-    // If work is not divided up nicely between the cores/ tensor too small we can use this to not run this core.
+    // If work is not divided up nicely between cores / tensor too small, skip this core.
     const uint32_t nop = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t original_page_size_bytes = get_compile_time_arg_val(0);
     constexpr uint32_t num_repeats = get_compile_time_arg_val(1);
-    // cb_id_in0 and cb_id_in1 is each 1 page of size:
-    // if original_page_size_bytes is a multiple of 16, equal to original_page_size_bytes + 128
-    // else if original_page_size_bytes is a multiple of 8, equal to original_page_size_bytes * 2 + 128
-    // else if original_page_size_bytes is a multiple of 4, equal to original_page_size_bytes * 4 + 128
-    // else if original_page_size_bytes is a multiple of 2, equal to original_page_size_bytes * 8 + 128
-    // if it is an odd number equal to original_page_size_bytes * 16 + 128
+    // cb_id_in0 and cb_id_in1 are each 1 page; size depends on alignment:
+    //   multiple of 16 -> original_page_size_bytes + 128
+    //   multiple of  8 -> original_page_size_bytes * 2  + 128
+    //   multiple of  4 -> original_page_size_bytes * 4  + 128
+    //   multiple of  2 -> original_page_size_bytes * 8  + 128
+    //   odd            -> original_page_size_bytes * 16 + 128
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(2);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(3);
-    constexpr auto src_args = TensorAccessorArgs<4>();
-    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    constexpr auto src_args = TensorAccessorArgs<4, 0>();
+    constexpr auto dst_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.num_common_runtime_args()>();
     constexpr uint32_t dest_page_size_bytes = original_page_size_bytes * num_repeats;
-    // Number of times we must double the input page to make it write aligned
-    constexpr uint32_t num_doublings = ((original_page_size_bytes % 16) == 0)  ? 0
-                                       : ((original_page_size_bytes % 8) == 0) ? 1
-                                       : ((original_page_size_bytes % 4) == 0) ? 2
-                                       : ((original_page_size_bytes % 2) == 0) ? 3
-                                                                               : 4;
-    // Max write size after doublings, used for template parameter to enable fast path
-    constexpr uint32_t max_write_size = original_page_size_bytes << num_doublings;
 
-    // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
-    // core
+    // Since we need to operate on a grid of cores but sometimes pages don't split properly,
+    // if nop then don't use this core.
     if (nop == 1) {
         return;
     }
@@ -61,7 +52,15 @@ void kernel_main() {
     CircularBuffer cb0(cb_id_in0);
     CircularBuffer cb1(cb_id_in1);
 
-    // Get scratchpads guaranteed to be allocated until the function terminates
+    // Number of times we must double the input page to make it write-aligned.
+    constexpr uint32_t num_doublings = ((original_page_size_bytes % 16) == 0)  ? 0
+                                       : ((original_page_size_bytes % 8) == 0) ? 1
+                                       : ((original_page_size_bytes % 4) == 0) ? 2
+                                       : ((original_page_size_bytes % 2) == 0) ? 3
+                                                                               : 4;
+    // Max write size after doublings; used as template parameter to enable fast path.
+    constexpr uint32_t max_write_size = original_page_size_bytes << num_doublings;
+
     cb0.reserve_back(1);
     cb1.reserve_back(1);
     uint32_t input_buffer = cb0.get_write_ptr();
@@ -76,41 +75,30 @@ void kernel_main() {
     constexpr uint64_t w_mask_to_use = MASK_16;
     constexpr uint64_t w_offset_to_use = OFFSET_16;
 
-    alignment_buffer =
-        align_address<w_alignment_requirement>(alignment_buffer, w_mask_to_use);         // Guaranteed aligned for write
-    input_buffer = align_address<r_alignment_requirement>(input_buffer, r_mask_to_use);  // Guaranteed aligned for reads
+    alignment_buffer = align_address<w_alignment_requirement>(alignment_buffer, w_mask_to_use);
+    input_buffer = align_address<r_alignment_requirement>(input_buffer, r_mask_to_use);
 
     uint32_t cur_page_size = original_page_size_bytes;
     for (uint32_t i = page_start; i < page_end; i++) {
-        // Read from source
         uint64_t src_noc_addr = s.get_noc_addr(i, 0);
         uint64_t dst_noc_addr = d.get_noc_addr(i, 0);
-        uint32_t data_location =
-            input_buffer + (src_noc_addr & r_offset_to_use);  // Guaranteed to be aligned for our read
+        uint32_t data_location = input_buffer + (src_noc_addr & r_offset_to_use);
 
         CoreLocalMem<uint32_t> dst_mem(data_location);
-        // Use TensorAccessor directly to avoid address truncation
-        // Template parameter preserves one-packet fast path for page-sized transfers
         noc.async_read<NocOptions::DEFAULT, original_page_size_bytes>(
             s, dst_mem, original_page_size_bytes, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
         cur_page_size = original_page_size_bytes;
         noc.async_read_barrier();
         if constexpr (num_doublings != 0) {
-            // The if is not needed but it is just for performance as the vast majority of times num_doublings will be 0
-            // and we don't want target offset to be allocated and the for loop bounds computed
             uint32_t target_offset = original_page_size_bytes;
             for (uint32_t j = 0; j < num_doublings; j++) {
-                // This ensures the cur_page_size will be aligned to 16B so future walk retains alignment
                 tt_memmove<false, false, false, 16 * original_page_size_bytes>(
                     noc, data_location + target_offset, data_location, cur_page_size);
                 target_offset += cur_page_size;
                 cur_page_size *= 2;
             }
         }
-        // Write to destination
-        // data is at data_location and there is cur_page_size bytes worth of data there
         if ((data_location & w_offset_to_use) != (dst_noc_addr & w_offset_to_use)) {
-            // Can't directly copy due to alignment
             tt_memmove<false, false, false, 16 * original_page_size_bytes>(
                 noc, alignment_buffer + (dst_noc_addr & w_offset_to_use), data_location, cur_page_size);
             data_location = alignment_buffer + (dst_noc_addr & w_offset_to_use);
@@ -118,14 +106,11 @@ void kernel_main() {
 
         uint64_t num_written = 0;
         while (num_written < dest_page_size_bytes) {
-            // Either write out the whole input buffer or however much is left
             uint32_t to_write = (dest_page_size_bytes - num_written) > cur_page_size
                                     ? cur_page_size
                                     : (dest_page_size_bytes - num_written);
 
             CoreLocalMem<uint32_t> src_mem(data_location);
-            // Use TensorAccessor directly to avoid address truncation
-            // Template parameter preserves one-packet fast path for writes up to max_write_size
             noc.async_write<NocOptions::DEFAULT, max_write_size>(
                 src_mem,
                 d,
@@ -136,5 +121,4 @@ void kernel_main() {
         }
         noc.async_write_barrier();
     }
-    return;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RM last-dim sharded; noc_async_*_sharded with per-replica write offset.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace tt::data_movement::common;
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
+    const uint32_t page_start = get_arg_val<uint32_t>(2);
+    const uint32_t page_end = get_arg_val<uint32_t>(3);
+    const uint32_t nop = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t original_page_size_bytes = get_compile_time_arg_val(0);
+    constexpr uint32_t num_repeats = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(2);
+    constexpr auto src_args = TensorAccessorArgs<3, 0>();
+    constexpr auto dst_args =
+        TensorAccessorArgs<src_args.next_compile_time_args_offset(), src_args.num_common_runtime_args()>();
+
+    if (nop == 1) {
+        return;
+    }
+
+    const auto s = TensorAccessor(src_args, src_addr);
+    const auto d = TensorAccessor(dst_args, dst_addr);
+
+    CircularBuffer cb(cb_id_in0);
+    cb.reserve_back(1);
+    const uint32_t cb_slot = cb.get_write_ptr();
+    cb.push_back(1);
+
+    for (uint32_t i = page_start; i < page_end; i++) {
+        noc_async_read_sharded(cb_slot, s, i, 0, original_page_size_bytes);
+        noc_async_read_barrier();
+        for (uint32_t k = 0; k < num_repeats; k++) {
+            noc_async_write_sharded(cb_slot, d, i, k * original_page_size_bytes, original_page_size_bytes);
+        }
+        noc_async_write_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.hpp"
 #include "ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp"
+#include "ttnn/operations/data_movement/repeat/device/repeat_utils.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
@@ -15,8 +16,11 @@ namespace ttnn::prim {
 
 RepeatDeviceOperation::program_factory_t RepeatDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
-    bool is_last_dim = operation_attributes.m_is_last_dim;
-    if (is_last_dim) {
+    // m_tile_page_size_bytes > 0 -> higher-dim tile factory; else last-dim or higher-dim RM.
+    if (operation_attributes.m_tile_page_size_bytes > 0) {
+        return RepeatProgramFactoryHigherDim{};
+    }
+    if (operation_attributes.m_is_last_dim) {
         return RepeatProgramFactoryLastDim{};
     }
     return RepeatProgramFactoryHigherDim{};
@@ -24,37 +28,61 @@ RepeatDeviceOperation::program_factory_t RepeatDeviceOperation::select_program_f
 
 void RepeatDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Validate the input tensor
     const Tensor& input_tensor_a = tensor_args.input;
     TT_FATAL(
-        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE,
-        "Operands to reshape need to be on device!");
+        input_tensor_a.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to repeat need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "This function is for RM->RM");
-    TT_FATAL(
-        input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::INT32 or
-            input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Can only work with UINT16, BFLOAT16, UINT32, INT32, FLOAT32 data types");
-    // is this relevant?
-    TT_FATAL(
-        operation_attributes.m_output_mem_config.memory_layout() == input_tensor_a.memory_config().memory_layout(),
-        "Output tensor must have the same memory layout as input tensor");
+
+    if (operation_attributes.m_tile_page_size_bytes > 0) {
+        TT_FATAL(input_tensor_a.layout() == tt::tt_metal::Layout::TILE, "Tile-native repeat requires TILE layout");
+    } else {
+        TT_FATAL(
+            input_tensor_a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "ROW_MAJOR repeat requires ROW_MAJOR layout");
+        TT_FATAL(
+            input_tensor_a.dtype() == tt::tt_metal::DataType::UINT16 or
+                input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 or
+                input_tensor_a.dtype() == tt::tt_metal::DataType::UINT32 or
+                input_tensor_a.dtype() == tt::tt_metal::DataType::INT32 or
+                input_tensor_a.dtype() == tt::tt_metal::DataType::FLOAT32,
+            "Can only work with UINT16, BFLOAT16, UINT32, INT32, FLOAT32 data types");
+    }
+
+    // Dropped memory_layout equality check; predicate + compute_output_specs handle sharded I/O.
 }
 
 RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input_tensors) {
     const auto& input_tensor_a = input_tensors.input;
-    auto output_shape = input_tensor_a.logical_shape();
-    output_shape[operation_attributes.m_is_last_dim ? -1 : 1] *= operation_attributes.m_num_repeats;
+    const auto& input_shape = input_tensor_a.logical_shape();
+    auto output_shape = input_shape;
+    // Fallback dim 1 = rep_dim slot in the higher-dim factory's collapsed (higher, rep_dim, lower, W) view.
+    const int32_t effective_repeat_dim =
+        operation_attributes.m_repeat_dim >= 0
+            ? operation_attributes.m_repeat_dim
+            : (operation_attributes.m_is_last_dim ? static_cast<int32_t>(input_shape.rank()) - 1 : 1);
+    output_shape[effective_repeat_dim] *= operation_attributes.m_num_repeats;
 
     auto mem_config = operation_attributes.m_output_mem_config;
-    if (input_tensor_a.memory_config().is_sharded()) {
-        auto shard_spec = input_tensor_a.shard_spec().value();
-        shard_spec.shape[0] = output_shape[0];
-        mem_config = MemoryConfig(mem_config.memory_layout(), mem_config.buffer_type(), shard_spec);
+    if (mem_config.is_sharded()) {
+        // Derive output shard_spec: user spec, scale input spec, or synthesise fresh.
+        if (!mem_config.shard_spec().has_value()) {
+            std::optional<tt::tt_metal::ShardSpec> derived;
+            if (input_tensor_a.memory_config().is_sharded() && input_tensor_a.shard_spec().has_value()) {
+                derived = operations::data_movement::repeat::adjust_repeat_shard_spec_to_shape(
+                    *input_tensor_a.shard_spec(),
+                    input_shape,
+                    output_shape,
+                    effective_repeat_dim,
+                    operation_attributes.m_num_repeats);
+            }
+            if (!derived.has_value()) {
+                derived = operations::data_movement::repeat::generate_repeat_shard_spec(
+                    input_tensor_a, output_shape, mem_config.memory_layout());
+            }
+            if (derived.has_value()) {
+                mem_config = MemoryConfig(mem_config.memory_layout(), mem_config.buffer_type(), derived);
+            }
+        }
     }
     return TensorSpec(
         output_shape,
@@ -88,6 +116,29 @@ RepeatDeviceOperation::tensor_return_value_t repeat(
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
             .m_num_repeats = m_num_repeats, .m_is_last_dim = m_is_last_dim, .m_output_mem_config = output_mem_config},
+        OperationType::tensor_args_t{.input = input});
+}
+
+RepeatDeviceOperation::tensor_return_value_t repeat_tile(
+    const Tensor& input,
+    uint32_t num_repeats,
+    int32_t repeat_dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    uint32_t tile_higher_pages,
+    uint32_t tile_rep_dim_pages,
+    uint32_t tile_lower_pages,
+    uint32_t tile_page_size_bytes) {
+    using OperationType = RepeatDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .m_num_repeats = num_repeats,
+            .m_is_last_dim = false,
+            .m_output_mem_config = output_mem_config,
+            .m_tile_higher_pages = tile_higher_pages,
+            .m_tile_rep_dim_pages = tile_rep_dim_pages,
+            .m_tile_lower_pages = tile_lower_pages,
+            .m_tile_page_size_bytes = tile_page_size_bytes,
+            .m_repeat_dim = repeat_dim},
         OperationType::tensor_args_t{.input = input});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.hpp
@@ -41,4 +41,14 @@ RepeatDeviceOperation::tensor_return_value_t repeat(
     uint32_t m_num_repeats,
     bool m_is_last_dim,
     const tt::tt_metal::MemoryConfig& output_mem_config);
+
+RepeatDeviceOperation::tensor_return_value_t repeat_tile(
+    const Tensor& input,
+    uint32_t num_repeats,
+    int32_t repeat_dim,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    uint32_t tile_higher_pages,
+    uint32_t tile_rep_dim_pages,
+    uint32_t tile_lower_pages,
+    uint32_t tile_page_size_bytes);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation_types.hpp
@@ -12,6 +12,13 @@ struct RepeatParams {
     uint32_t m_num_repeats{};
     bool m_is_last_dim{};
     tt::tt_metal::MemoryConfig m_output_mem_config;
+
+    // Tile-native: higher-dim factory uses explicit tile-space dims from host.
+    uint32_t m_tile_higher_pages{0};
+    uint32_t m_tile_rep_dim_pages{0};
+    uint32_t m_tile_lower_pages{0};
+    uint32_t m_tile_page_size_bytes{0};
+    int32_t m_repeat_dim{-1};
 };
 
 struct RepeatInputs {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -37,22 +37,41 @@ ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
 
     ttnn::Shape input_log_shape = ttnn::Shape(input.logical_shape().view());
     ttnn::Shape output_log_shape = ttnn::Shape(output.logical_shape().view());
-    const uint32_t page_size_bytes = input_log_shape[3] * data_size;
-    TT_FATAL(
-        page_size_bytes == output_log_shape[3] * data_size,
-        "Data size of output does not match requirement for repeat last dim");
+
+    uint32_t page_size_bytes;
+    uint32_t number_of_higher_pages;
+    uint32_t number_of_lower_pages;
+    uint32_t number_of_rep_dim_pages;
+
+    if (operation_attributes.m_tile_page_size_bytes > 0) {
+        // Tile-native: host supplies tile-space page counts.
+        page_size_bytes = operation_attributes.m_tile_page_size_bytes;
+        number_of_higher_pages = operation_attributes.m_tile_higher_pages;
+        number_of_rep_dim_pages = operation_attributes.m_tile_rep_dim_pages;
+        number_of_lower_pages = operation_attributes.m_tile_lower_pages;
+    } else {
+        page_size_bytes = input_log_shape[3] * data_size;
+        TT_FATAL(
+            page_size_bytes == output_log_shape[3] * data_size,
+            "Data size of output does not match requirement for repeat higher dim");
+        // Per-core page count so read/write start on page boundaries.
+        number_of_higher_pages = input_log_shape[0];
+        number_of_rep_dim_pages = input_log_shape[1];
+        number_of_lower_pages = input_log_shape[2];
+    }
     uint32_t read_start_page = 0;
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-    // Find how many input pages each core is responsible for so that we always start at the beginning of a read and
-    // write page Since the logical volumes match, we are guaranteed that the very last page is aligned
-    const uint32_t number_of_higher_pages = input_log_shape[0];
-    const uint32_t number_of_lower_pages = input_log_shape[2];
-    const uint32_t number_of_rep_dim_pages = input_log_shape[1];
     const uint32_t cb_size_bytes = (READ_ALIGNMENT * 2) + page_size_bytes;
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;
+
+    // TILE/sharded -> tile; RM sharded -> rm_sharded; RM interleaved -> rm_interleaved.
+    const bool is_tile_native = operation_attributes.m_tile_page_size_bytes > 0;
+    const bool src_sharded = src_buffer->buffer_distribution_spec().has_value();
+    const bool dst_sharded = dst_buffer->buffer_distribution_spec().has_value();
+    const bool needs_alignment_cb = !is_tile_native && !src_sharded && !dst_sharded;
 
     ProgramDescriptor desc;
 
@@ -66,26 +85,53 @@ ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
         }}},
     });
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_size_bytes,
-        .core_ranges = total_core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src1_cb_index,
-            .data_format = cb_data_format,
-            .page_size = cb_size_bytes,
-        }}},
-    });
+    // Second CB only for interleaved RM (alignment scratchpad).
+    if (needs_alignment_cb) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb_size_bytes,
+            .core_ranges = total_core_ranges,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src1_cb_index,
+                .data_format = cb_data_format,
+                .page_size = cb_size_bytes,
+            }}},
+        });
+    }
 
-    std::vector<uint32_t> compile_time_args = {
-        (std::uint32_t)page_size_bytes, src0_cb_index, src1_cb_index, number_of_lower_pages, number_of_rep_dim_pages};
-    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    const char* kernel_source = nullptr;
+    std::vector<uint32_t> compile_time_args;
+    if (is_tile_native) {
+        kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_tile.cpp";
+        compile_time_args = {
+            (std::uint32_t)page_size_bytes, src0_cb_index, number_of_lower_pages, number_of_rep_dim_pages};
+    } else if (src_sharded || dst_sharded) {
+        kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp";
+        compile_time_args = {
+            (std::uint32_t)page_size_bytes, src0_cb_index, number_of_lower_pages, number_of_rep_dim_pages};
+    } else {
+        kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_interleaved.cpp";
+        compile_time_args = {
+            (std::uint32_t)page_size_bytes,
+            src0_cb_index,
+            src1_cb_index,
+            number_of_lower_pages,
+            number_of_rep_dim_pages};
+    }
+
+    std::vector<uint32_t> common_runtime_args;
+    // RuntimeTensorShape: safe for interleaved; sharded moves shape to runtime args.
+    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(compile_time_args, common_runtime_args);
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(compile_time_args, common_runtime_args);
 
     KernelDescriptor reader_desc;
-    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp";
+    reader_desc.kernel_source = kernel_source;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_core_ranges;
     reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.common_runtime_args = std::move(common_runtime_args);
     reader_desc.config = ReaderConfigDescriptor{};
 
     uint32_t done = 0;
@@ -103,8 +149,7 @@ ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
                 core_count++ < responsibility_mod ? responsibility_chunk + 1 : responsibility_chunk;
             const CoreCoord core = {core_x, core_y};
             if (done == 1) {
-                // Idle cores: zero pages, with the trailing flag set to terminate the kernel early.
-                // Pass scalar zeros instead of buffers so the kernel sees the same arg count.
+                // Idle core: zero args + early exit.
                 reader_desc.emplace_runtime_args(
                     core,
                     {uint32_t{0},
@@ -116,14 +161,11 @@ ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
                      uint32_t{0},
                      uint32_t{1}});
             } else if (divide_on_higher) {
-                // set the runtime args
-                // set the compile time args
                 const uint32_t start_of_read = read_start_page;
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < number_of_higher_pages ? end_of_read : number_of_higher_pages;
 
-                // Buffer* args trigger BufferBinding entries; the framework patches their
-                // addresses on cache hits without rebuilding the descriptor.
+                // Buffer* runtime args patch on program cache hit.
                 reader_desc.emplace_runtime_args(
                     core,
                     {src_buffer,
@@ -137,8 +179,6 @@ ProgramDescriptor RepeatProgramFactoryHigherDim::create_descriptor(
                 read_start_page = end_of_read;
                 done = (end_of_read == number_of_higher_pages) ? 1 : 0;
             } else {
-                // set the runtime args
-                // set the compile time args
                 const uint32_t start_of_read = read_start_page;
                 uint32_t end_of_read = read_start_page + responsibility;
                 end_of_read = end_of_read < number_of_lower_pages ? end_of_read : number_of_lower_pages;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -47,8 +47,7 @@ ProgramDescriptor RepeatProgramFactoryLastDim::create_descriptor(
     Buffer* src_buffer = input.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-    // Find how many input pages each core is responsible for so that we always start at the beginning of a read and
-    // write page Since the logical volumes match, we are guaranteed that the very last page is aligned
+    // Per-core page count so read/write start on page boundaries.
     const uint32_t number_of_pages = input_log_shape[-2];
     const uint32_t responsibility = ((number_of_pages - 1) / num_cores_total) + 1;
     const uint32_t cb_size_bytes = READ_ALIGNMENT * 2 + (source_page_size_bytes & 0xF) == 0 ? source_page_size_bytes
@@ -58,6 +57,11 @@ ProgramDescriptor RepeatProgramFactoryLastDim::create_descriptor(
                                                                          : source_page_size_bytes * 16;
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;
+
+    // RM sharded -> rm_sharded; RM interleaved -> rm_interleaved (TILE uses higher-dim factory).
+    const bool src_sharded = src_buffer->buffer_distribution_spec().has_value();
+    const bool dst_sharded = dst_buffer->buffer_distribution_spec().has_value();
+    const bool needs_alignment_cb = !src_sharded && !dst_sharded;
 
     ProgramDescriptor desc;
 
@@ -71,26 +75,44 @@ ProgramDescriptor RepeatProgramFactoryLastDim::create_descriptor(
         }}},
     });
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_size_bytes,
-        .core_ranges = total_core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src1_cb_index,
-            .data_format = cb_data_format,
-            .page_size = cb_size_bytes,
-        }}},
-    });
+    // Second CB only for interleaved RM.
+    if (needs_alignment_cb) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = cb_size_bytes,
+            .core_ranges = total_core_ranges,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = src1_cb_index,
+                .data_format = cb_data_format,
+                .page_size = cb_size_bytes,
+            }}},
+        });
+    }
 
-    std::vector<uint32_t> compile_time_args = {
-        (std::uint32_t)source_page_size_bytes, (std::uint32_t)num_repeats, src0_cb_index, src1_cb_index};
-    TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
-    TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
+    const char* kernel_source = nullptr;
+    std::vector<uint32_t> compile_time_args;
+    if (src_sharded || dst_sharded) {
+        kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp";
+        compile_time_args = {(std::uint32_t)source_page_size_bytes, (std::uint32_t)num_repeats, src0_cb_index};
+    } else {
+        kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_interleaved.cpp";
+        compile_time_args = {
+            (std::uint32_t)source_page_size_bytes, (std::uint32_t)num_repeats, src0_cb_index, src1_cb_index};
+    }
+
+    std::vector<uint32_t> common_runtime_args;
+    // RuntimeTensorShape: safe for interleaved; sharded moves shape to runtime args.
+    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(compile_time_args, common_runtime_args);
+    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(compile_time_args, common_runtime_args);
 
     KernelDescriptor reader_desc;
-    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp";
+    reader_desc.kernel_source = kernel_source;
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = total_core_ranges;
     reader_desc.compile_time_args = std::move(compile_time_args);
+    reader_desc.common_runtime_args = std::move(common_runtime_args);
     reader_desc.config = ReaderConfigDescriptor{};
 
     uint32_t done = 0;
@@ -98,8 +120,7 @@ ProgramDescriptor RepeatProgramFactoryLastDim::create_descriptor(
         for (uint32_t core_y = 0; core_y < num_cores_y; core_y++) {
             const CoreCoord core = {core_x, core_y};
             if (done == 1) {
-                // Buffer* args trigger BufferBinding entries; the framework patches their
-                // addresses on cache hits without rebuilding the descriptor.
+                // Idle core: early exit.
                 reader_desc.emplace_runtime_args(core, {src_buffer, dst_buffer, uint32_t{0}, uint32_t{0}, uint32_t{1}});
             } else {
                 const uint32_t start_of_read = read_start_page;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/repeat/device/repeat_utils.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::data_movement::repeat {
+
+using namespace tt::tt_metal;
+
+namespace {
+
+// True if padded shape doesn't divide evenly into shard (or no spec).
+bool is_unevenly_sharded(const TensorSpec& t) {
+    const auto& shard_spec = t.memory_config().shard_spec();
+    if (!shard_spec.has_value()) {
+        return true;
+    }
+    const auto& shape = t.padded_shape();
+    const auto rank = shape.rank();
+    if (rank < 2) {
+        return true;
+    }
+    const auto& shard = shard_spec->shape;
+    uint64_t volume_except_last = 1;
+    for (int i = 0; i < static_cast<int>(rank) - 1; ++i) {
+        volume_except_last *= static_cast<uint64_t>(shape[i]);
+    }
+    return (volume_except_last % shard[0]) != 0 || (shape[-1] % shard[1]) != 0;
+}
+
+// L1-sharded only; DRAM-sharded uses composite.
+bool side_native(const MemoryConfig& mc, Layout /*layout*/) {
+    if (!mc.is_sharded()) {
+        return false;
+    }
+    if (mc.buffer_type() == BufferType::DRAM) {
+        return false;
+    }
+    return true;
+}
+
+// Product of dims after repeat axis but before W; equals row-stride between successive k-values.
+uint64_t trailing_row_volume(const ttnn::Shape& shape, int32_t repeat_dim) {
+    const auto rank = static_cast<int32_t>(shape.rank());
+    if (repeat_dim < 0 || repeat_dim >= rank - 1) {
+        return 1;
+    }
+    uint64_t v = 1;
+    for (int32_t i = repeat_dim + 1; i < rank - 1; ++i) {
+        v *= static_cast<uint64_t>(shape[i]);
+    }
+    return v;
+}
+
+}  // namespace
+
+bool is_replication_locally_contained(
+    const ShardSpec& input_shard_spec,
+    const ttnn::Shape& input_padded_shape,
+    int32_t repeat_dim,
+    uint32_t num_repeats) {
+    const auto rank = static_cast<int32_t>(input_padded_shape.rank());
+    if (rank < 2) {
+        return false;
+    }
+    // Last-dim: replicas stay on same core along W.
+    if (repeat_dim == rank - 1) {
+        return true;
+    }
+    if (num_repeats <= 1) {
+        return true;
+    }
+    // Higher-dim: per-core rows must hold whole replica groups (shape[repeat_dim] * trailing rows).
+    const uint64_t per_core_rows = input_shard_spec.shape[0];
+    if (per_core_rows == 0) {
+        return false;
+    }
+    const uint64_t trv = trailing_row_volume(input_padded_shape, repeat_dim);
+    const uint64_t group_size = trv * static_cast<uint64_t>(input_padded_shape[repeat_dim]);
+    return group_size != 0 && (per_core_rows % group_size) == 0;
+}
+
+bool is_native_repeat_sharding(
+    const TensorSpec& input_spec,
+    const std::optional<MemoryConfig>& output_memory_config,
+    int32_t repeat_dim,
+    uint32_t num_repeats) {
+    if (!side_native(input_spec.memory_config(), input_spec.layout())) {
+        return false;
+    }
+    if (is_unevenly_sharded(input_spec)) {
+        return false;
+    }
+    // TILE input: reject non-tile-aligned H/W (native tile path requires alignment).
+    if (input_spec.layout() == tt::tt_metal::Layout::TILE) {
+        const auto& lshape = input_spec.logical_shape();
+        if (lshape.rank() < 2 || (lshape[-1] % tt::constants::TILE_WIDTH) != 0 ||
+            (lshape[-2] % tt::constants::TILE_HEIGHT) != 0) {
+            return false;
+        }
+    }
+    // RM WIDTH/BLOCK last-dim: reject (ttnn::view breaks shard width).
+    if (input_spec.layout() == tt::tt_metal::Layout::ROW_MAJOR && repeat_dim >= 0 &&
+        repeat_dim == static_cast<int32_t>(input_spec.logical_shape().rank()) - 1) {
+        const auto in_layout = input_spec.memory_config().memory_layout();
+        if (in_layout == TensorMemoryLayout::WIDTH_SHARDED || in_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            return false;
+        }
+    }
+    if (output_memory_config.has_value()) {
+        if (output_memory_config->is_sharded()) {
+            if (output_memory_config->buffer_type() == BufferType::DRAM) {
+                return false;
+            }
+            // Cross-layout sharded->sharded needs composite reshard.
+            if (input_spec.memory_config().memory_layout() != output_memory_config->memory_layout()) {
+                return false;
+            }
+            // Grids must match when both specs are set.
+            const auto& in_ss = input_spec.memory_config().shard_spec();
+            const auto& out_ss = output_memory_config->shard_spec();
+            if (in_ss.has_value() && out_ss.has_value() && in_ss->grid != out_ss->grid) {
+                return false;
+            }
+        }
+    }
+    // repeat_dim < 0: skip containment check until repeat axis is known.
+    if (repeat_dim < 0) {
+        return true;
+    }
+    const auto& in_ss = input_spec.memory_config().shard_spec();
+    if (!in_ss.has_value()) {
+        return false;
+    }
+    return is_replication_locally_contained(*in_ss, input_spec.padded_shape(), repeat_dim, num_repeats);
+}
+
+std::optional<ShardSpec> adjust_repeat_shard_spec_to_shape(
+    const ShardSpec& shard_spec,
+    const ttnn::Shape& from_shape,
+    const ttnn::Shape& to_shape,
+    int32_t repeat_dim,
+    uint32_t num_repeats) {
+    TT_FATAL(
+        from_shape.rank() == to_shape.rank(),
+        "adjust_repeat_shard_spec_to_shape: rank mismatch ({} vs {})",
+        from_shape.rank(),
+        to_shape.rank());
+    if (num_repeats == 0) {
+        return std::nullopt;
+    }
+    const auto rank = static_cast<int32_t>(from_shape.rank());
+    if (rank < 2 || repeat_dim < 0 || repeat_dim >= rank) {
+        return std::nullopt;
+    }
+
+    auto ret = shard_spec;
+    if (repeat_dim == rank - 1) {
+        // Last-dim: scale shard width by num_repeats.
+        if (to_shape[-1] % num_repeats != 0 || from_shape[-1] != to_shape[-1] / num_repeats) {
+            return std::nullopt;
+        }
+        const uint64_t scaled = static_cast<uint64_t>(shard_spec.shape[1]) * static_cast<uint64_t>(num_repeats);
+        ret.shape[1] = static_cast<uint32_t>(scaled);
+        return ret;
+    }
+
+    // Higher-dim: scale per-core row count by num_repeats; width unchanged.
+    if (from_shape[-1] != to_shape[-1]) {
+        return std::nullopt;
+    }
+    const uint64_t scaled_h = static_cast<uint64_t>(shard_spec.shape[0]) * static_cast<uint64_t>(num_repeats);
+    ret.shape[0] = static_cast<uint32_t>(scaled_h);
+    return ret;
+}
+
+std::optional<ShardSpec> generate_repeat_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    auto* device = input_tensor.device();
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    uint32_t num_cores = all_cores.num_cores();
+    if (num_cores == 0) {
+        return std::nullopt;
+    }
+
+    uint64_t tensor_height = 1;
+    for (int32_t i = 0; i < static_cast<int32_t>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
+    }
+    uint64_t tensor_width = padded_out_shape[-1];
+    if (tensor_height == 0 || tensor_width == 0) {
+        return std::nullopt;
+    }
+
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
+    } else if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        CoreCoord grid_size = all_cores.bounding_box().grid_size();
+        if (grid_size.x == 0 || grid_size.y == 0) {
+            return std::nullopt;
+        }
+        auto height_padded =
+            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
+        auto shard_height =
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
+        auto shard_width =
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
+    } else {
+        return std::nullopt;  // INTERLEAVED / unsupported — caller handles.
+    }
+
+    // RM: reject if page_size not L1-aligned (16 bytes).
+    if (input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR) {
+        const uint64_t page_size_bytes =
+            static_cast<uint64_t>(shard_shape[1]) * static_cast<uint64_t>(input_tensor.element_size());
+        constexpr uint64_t kL1Alignment = 16;
+        if (page_size_bytes == 0 || (page_size_bytes % kL1Alignment) != 0) {
+            return std::nullopt;
+        }
+        if (tensor_width % shard_shape[1] != 0) {
+            return std::nullopt;
+        }
+    }
+
+    log_debug(
+        tt::LogOp, "Repeat: synthesised shard spec ({}, {}) over {} cores", shard_shape[0], shard_shape[1], num_cores);
+    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+}
+
+}  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::data_movement::repeat {
+
+// True when repeat can run natively on sharded L1 buffers (no strip/reshard round-trip).
+bool is_native_repeat_sharding(
+    const TensorSpec& input_spec,
+    const std::optional<tt::tt_metal::MemoryConfig>& output_memory_config = std::nullopt,
+    int32_t repeat_dim = -1,
+    uint32_t num_repeats = 1);
+
+// Last-dim repeats are always locally contained on the same core.
+bool is_replication_locally_contained(
+    const tt::tt_metal::ShardSpec& input_shard_spec,
+    const ttnn::Shape& input_padded_shape,
+    int32_t repeat_dim,
+    uint32_t num_repeats);
+
+// Scale shard spec along repeat axis; nullopt if not exact.
+std::optional<tt::tt_metal::ShardSpec> adjust_repeat_shard_spec_to_shape(
+    const tt::tt_metal::ShardSpec& shard_spec,
+    const ttnn::Shape& from_shape,
+    const ttnn::Shape& to_shape,
+    int32_t repeat_dim,
+    uint32_t num_repeats);
+
+// Fresh shard spec over compute grid from post-repeat shape; nullopt if it won't fit.
+std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
+    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+
+}  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -4,14 +4,20 @@
 
 #include <functional>
 
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"
 #include "ttnn/operations/data_movement/view/view.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "device/repeat_device_operation.hpp"
+#include "device/repeat_utils.hpp"
 #include "repeat.hpp"
 
 namespace ttnn::operations::data_movement::detail {
@@ -25,13 +31,6 @@ struct UpperRepeatDims {
 
 ttnn::Tensor repeat_upper_dims_rm(
     const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
-    // collapse upper dims to 4D or append 1s
-    // collapse lower dims or insert 1s
-    // op
-    // un-collaps to expected size
-
-    // figure out the shape of the input tensor for the op. dims before and after rep dim get collapsed, not including
-    // page size.
     const auto& input_shape = tensor.logical_shape();
     ttnn::SmallVector<uint32_t> collapsed_shape_vector(4);
 
@@ -42,7 +41,6 @@ ttnn::Tensor repeat_upper_dims_rm(
         std::accumulate(input_shape.cbegin() + dim + 1, input_shape.cend() - 1, 1, std::multiplies<uint32_t>());
     collapsed_shape_vector[UpperRepeatDims::page_size] = input_shape[-1];
 
-    // use ttnn::view to check logic
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
     constexpr bool is_final_dim = false;
@@ -55,9 +53,6 @@ ttnn::Tensor repeat_upper_dims_rm(
 
 ttnn::Tensor repeat_last_dim_rm(
     const ttnn::Tensor& tensor, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
-    // collapse to 2D
-    // op
-    // un-collapse
     const auto& input_shape = tensor.logical_shape();
     ttnn::SmallVector<uint32_t> collapsed_shape_vector(2);
 
@@ -65,7 +60,6 @@ ttnn::Tensor repeat_last_dim_rm(
         std::accumulate(input_shape.cbegin(), input_shape.cend() - 1, 1, std::multiplies<uint32_t>());
     collapsed_shape_vector[1] = input_shape[-1];
 
-    // use ttnn:view
     auto input_tensor = ttnn::view(tensor, ttnn::Shape(collapsed_shape_vector));
 
     constexpr bool is_final_dim = true;
@@ -92,8 +86,7 @@ std::tuple<ttnn::Tensor, ttnn::SmallVector<uint32_t>> match_input_rank(
         working_tensor = ttnn::view(working_tensor, ttnn::Shape(new_shape_vec));
         working_repetition_vector = repetition_vector;
     }
-    // torch actually throws an error if the repetition rank is smaller than the tensor rank but it seems reasonable to
-    // handle it
+    // Pad repetition vector when shorter than tensor rank (torch errors; we allow it).
     else if (repetition_vector.size() < input_shape.rank()) {
         working_repetition_vector.resize(input_shape.rank(), 1);
         std::copy_backward(repetition_vector.cbegin(), repetition_vector.cend(), working_repetition_vector.end());
@@ -114,6 +107,53 @@ std::tuple<ttnn::Tensor, ttnn::SmallVector<uint32_t>> match_input_rank(
     return std::tie(working_tensor, working_repetition_vector);
 }
 
+bool is_tile_repeat_eligible(const ttnn::Tensor& tensor) {
+    if (tensor.layout() != ttnn::TILE_LAYOUT) {
+        return false;
+    }
+    const auto& shape = tensor.logical_shape();
+    if (shape.rank() < 2) {
+        return false;
+    }
+    return (shape[-1] % tt::constants::TILE_WIDTH == 0) && (shape[-2] % tt::constants::TILE_HEIGHT == 0);
+}
+
+ttnn::Tensor repeat_dim_tile(
+    const ttnn::Tensor& tensor, const uint32_t dim, const uint32_t repetitions, const MemoryConfig& output_mem_config) {
+    const auto& shape = tensor.logical_shape();
+    const auto rank = shape.rank();
+
+    uint32_t h_tiles = shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t w_tiles = shape[-1] / tt::constants::TILE_WIDTH;
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
+    uint32_t tile_page_size = tt::tile_size(cb_data_format);
+
+    uint32_t higher, rep_dim_pages, lower;
+
+    if (dim == rank - 1) {
+        // W dimension: each tile-row's w_tiles get repeated
+        higher = std::accumulate(shape.cbegin(), shape.cend() - 2, 1u, std::multiplies<uint32_t>()) * h_tiles;
+        rep_dim_pages = w_tiles;
+        lower = 1;
+    } else if (dim == rank - 2) {
+        // H dimension: tile-rows get repeated
+        higher = std::accumulate(shape.cbegin(), shape.cend() - 2, 1u, std::multiplies<uint32_t>());
+        rep_dim_pages = h_tiles;
+        lower = w_tiles;
+    } else {
+        // Upper dimensions (batch, channel, etc.): groups of tiles get repeated
+        higher = std::accumulate(shape.cbegin(), shape.cbegin() + dim, 1u, std::multiplies<uint32_t>());
+        uint32_t lower_elements =
+            std::accumulate(shape.cbegin() + dim + 1, shape.cend() - 2, 1u, std::multiplies<uint32_t>());
+        rep_dim_pages = shape[dim];
+        lower = lower_elements * h_tiles * w_tiles;
+    }
+
+    return ttnn::prim::repeat_tile(
+        tensor, repetitions, dim, output_mem_config, higher, rep_dim_pages, lower, tile_page_size);
+}
+
 }  // namespace ttnn::operations::data_movement::detail
 
 namespace ttnn {
@@ -124,11 +164,15 @@ ttnn::Tensor repeat(
     const std::optional<MemoryConfig>& memory_config) {
     auto [working_tensor, working_repetition_vector] =
         operations::data_movement::detail::match_input_rank(input_tensor, repetition_vector);
-    MemoryConfig output_mem_config = memory_config.value_or(input_tensor.memory_config());
+    // Strip shard_spec from sharded input; device op re-derives for new output shape.
+    const auto& input_mc = input_tensor.memory_config();
+    MemoryConfig output_mem_config = memory_config.value_or(
+        input_mc.is_sharded() ? MemoryConfig(input_mc.memory_layout(), input_mc.buffer_type()) : input_mc);
     auto working_output_mem_config = output_mem_config;
 
     if (std::any_of(
             working_repetition_vector.cbegin(), working_repetition_vector.cend(), [](auto x) { return x == 0; })) {
+        // Zero-repetition: allocate zeros with zero-volume shape.
         const auto& shape = working_tensor.logical_shape();
         std::transform(
             shape.cbegin(),
@@ -136,7 +180,14 @@ ttnn::Tensor repeat(
             working_repetition_vector.cbegin(),
             working_repetition_vector.begin(),
             std::multiplies<uint32_t>());
-        return ttnn::reshape(input_tensor, ttnn::Shape(working_repetition_vector));
+        const MemoryConfig zero_mc = memory_config.value_or(
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, input_tensor.memory_config().buffer_type()});
+        return ttnn::zeros(
+            ttnn::Shape(working_repetition_vector),
+            input_tensor.dtype(),
+            input_tensor.layout(),
+            *input_tensor.device(),
+            zero_mc);
     }
 
     TT_FATAL(working_tensor.logical_shape().rank() > 0, "repeat does not support rank 0 tensors");
@@ -147,48 +198,88 @@ ttnn::Tensor repeat(
         return input_tensor;
     }
 
-    // Sharded -> interleaved
+    // Native path: sharded input, single-axis repeat, predicate accepts. Else composite.
+    bool native_sharded = false;
     if (input_tensor.memory_config().is_sharded()) {
-        MemoryConfig working_memory_config{TensorMemoryLayout::INTERLEAVED, input_tensor.memory_config().buffer_type()};
-        working_tensor = ttnn::sharded_to_interleaved(input_tensor, working_memory_config, std::nullopt);
-    }
-    if (working_output_mem_config.is_sharded()) {
-        working_output_mem_config =
-            MemoryConfig{TensorMemoryLayout::INTERLEAVED, working_output_mem_config.buffer_type()};
-    }
-
-    // tiled -> RM
-    if (working_tensor.layout() == ttnn::TILE_LAYOUT) {
-        working_tensor = ttnn::to_layout(working_tensor, ttnn::ROW_MAJOR_LAYOUT);
-    }
-
-    // loop over dims in repetition vector, backwards because repeat pages first is faster
-    for (auto it = working_repetition_vector.crbegin(); it != working_repetition_vector.crend(); ++it) {
-        // no op for unit repetitions
-        if (*it == 1) {
-            continue;
+        const auto non_one_count = std::count_if(
+            working_repetition_vector.cbegin(), working_repetition_vector.cend(), [](uint32_t r) { return r != 1; });
+        if (non_one_count == 1) {
+            int32_t native_dim = -1;
+            uint32_t native_reps = 1;
+            for (size_t i = 0; i < working_repetition_vector.size(); ++i) {
+                if (working_repetition_vector[i] != 1) {
+                    native_dim = static_cast<int32_t>(i);
+                    native_reps = working_repetition_vector[i];
+                    break;
+                }
+            }
+            native_sharded = operations::data_movement::repeat::is_native_repeat_sharding(
+                working_tensor.tensor_spec(), std::optional<MemoryConfig>{output_mem_config}, native_dim, native_reps);
         }
-        // if last dim
-        if (it == working_repetition_vector.crbegin()) {
+    }
+
+    if (!native_sharded) {
+        if (working_tensor.memory_config().is_sharded()) {
+            // DRAM-sharded fallback via to_memory_config (sharded_to_interleaved is L1-only);
+            // use working_tensor to keep rank padding from match_input_rank.
+            const MemoryConfig l1_interleaved{TensorMemoryLayout::INTERLEAVED, BufferType::L1};
+            working_tensor = ttnn::to_memory_config(working_tensor, l1_interleaved, std::nullopt);
+        }
+        if (working_output_mem_config.is_sharded()) {
+            working_output_mem_config =
+                MemoryConfig{TensorMemoryLayout::INTERLEAVED, working_output_mem_config.buffer_type()};
+        }
+    }
+
+    if (operations::data_movement::detail::is_tile_repeat_eligible(working_tensor)) {
+        // Tile-native path; skip TILE->RM->TILE.
+        for (auto it = working_repetition_vector.crbegin(); it != working_repetition_vector.crend(); ++it) {
+            if (*it == 1) {
+                continue;
+            }
+            auto dim = working_repetition_vector.crend() - it - 1;
             working_tensor =
-                operations::data_movement::detail::repeat_last_dim_rm(working_tensor, *it, working_output_mem_config);
+                operations::data_movement::detail::repeat_dim_tile(working_tensor, dim, *it, working_output_mem_config);
         }
-        // if not last dim
-        else {
-            auto i = working_repetition_vector.crend() - it - 1;  // forward index
-            working_tensor = operations::data_movement::detail::repeat_upper_dims_rm(
-                working_tensor, i, *it, working_output_mem_config);
+    } else {
+        // RM path: TILE->RM, repeat, RM->TILE.
+        if (working_tensor.layout() == ttnn::TILE_LAYOUT) {
+            working_tensor = ttnn::to_layout(working_tensor, ttnn::ROW_MAJOR_LAYOUT);
+        }
+
+        for (auto it = working_repetition_vector.crbegin(); it != working_repetition_vector.crend(); ++it) {
+            if (*it == 1) {
+                continue;
+            }
+            if (it == working_repetition_vector.crbegin()) {
+                working_tensor = operations::data_movement::detail::repeat_last_dim_rm(
+                    working_tensor, *it, working_output_mem_config);
+            } else {
+                auto i = working_repetition_vector.crend() - it - 1;
+                working_tensor = operations::data_movement::detail::repeat_upper_dims_rm(
+                    working_tensor, i, *it, working_output_mem_config);
+            }
+        }
+
+        if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+            working_tensor = ttnn::to_layout(working_tensor, ttnn::TILE_LAYOUT, input_tensor.dtype());
         }
     }
 
-    // RM -> OG page layout
-    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
-        working_tensor = ttnn::to_layout(working_tensor, ttnn::TILE_LAYOUT, input_tensor.dtype());
-    }
-
-    // Interleaved to OG mem layout
-    if (output_mem_config.is_sharded()) {
-        working_tensor = ttnn::interleaved_to_sharded(working_tensor, output_mem_config, std::nullopt);
+    // Composite-only re-shard; native path already wrote sharded output.
+    if (!native_sharded && output_mem_config.is_sharded()) {
+        MemoryConfig final_mc = output_mem_config;
+        if (!final_mc.shard_spec().has_value()) {
+            // Synthesise shard spec from post-repeat shape.
+            auto synth = operations::data_movement::repeat::generate_repeat_shard_spec(
+                working_tensor, working_tensor.padded_shape(), final_mc.memory_layout());
+            if (synth.has_value()) {
+                final_mc = MemoryConfig(final_mc.memory_layout(), final_mc.buffer_type(), synth);
+            } else {
+                return working_tensor;  // No valid spec; keep interleaved.
+            }
+        }
+        working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);
     }
 
     return working_tensor;

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -73,6 +73,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     repeat/device/repeat_program_factory_last_dim.cpp
     repeat/device/repeat_program_factory_higher_dim.cpp
     repeat/device/repeat_device_operation.cpp
+    repeat/device/repeat_utils.cpp
     repeat/repeat.cpp
     repeat_interleave/repeat_interleave.cpp
     reshape_on_device/device/reshape_op.cpp


### PR DESCRIPTION
### Ticket
Link to Github Issue #42440

### Problem
`ttnn::repeat` lacked universal input/output support — sharded inputs were always stripped to L1 interleaved, TILE inputs were forced through a TILE→RM→TILE relayout sandwich, and sharded outputs requested without an explicit `shard_spec` could crash (`bad optional access`) or silently drop the user's layout. RM BLOCK/WIDTH sharded buffers used bare `get_noc_addr(page_id)`, which mis-addresses logical rows that span multiple cores. DRAM-sharded inputs on the composite path could fatal because `sharded_to_interleaved` is L1-only.

Comprehensive universal-I/O testing surfaced 5 additional latent bugs:
1. **Stale `shard_spec` inheritance** — when no explicit `memory_config` was passed, the output inherited the input's `shard_spec` sized for the wrong (input) shape, fataling in `compute_output_specs` (59 cases).
2. **Over-eager native dispatch** — `is_native_repeat_sharding` accepted non-tile-aligned TILE inputs and RM `WIDTH/BLOCK`-sharded last-dim repeats that the native kernel cannot handle.
3. **PyTorch reference rank mismatch** — test harness passed `repeat_shape` shorter than tensor rank, breaking `torch.Tensor.repeat`.
4. **Invalid zero-repetition path** — `ttnn::reshape` was called with a zero-volume shape, hitting `Tensor volume is not 0, but shape volume is 0` (pre-existing on `main`).
5. **Non-L1-aligned synthesized RM shards** — `generate_repeat_shard_spec` produced shard widths whose page size violated the 16-byte L1 alignment requirement.

### What this PR does
- **Add `is_native_repeat_sharding` predicate + shard helpers** — `repeat_utils.{hpp,cpp}` gates native vs composite routing in the host wrapper; accepts every L1-sharded layout for last-dim repeat and locally-contained higher-dim repeats; rejects DRAM-sharded, uneven shards, multi-axis repeats, cross-layout sharded→sharded, **non-tile-aligned TILE inputs**, and **RM `WIDTH/BLOCK` last-dim repeats**.
- **Predicate-gated host wrapper in `repeat.cpp`** — native path keeps sharding end-to-end; composite path uses `ttnn::to_memory_config` for DRAM-sharded inputs, synthesises output `shard_spec` via `generate_repeat_shard_spec` before `interleaved_to_sharded`, and preserves user-requested sharded output layout.
- **Re-apply tile-native path from draft PR #42872** — `prim::repeat_tile`, `is_tile_repeat_eligible`, `repeat_dim_tile`, and `m_tile_*` / `m_repeat_dim` fields eliminate the TILE→RM→TILE sandwich for tile-aligned shapes.
- **Fix `compute_output_specs` shard derivation** — replaces buggy `shard_spec.shape[0] = output_shape[0]` with `adjust_repeat_shard_spec_to_shape` + `generate_repeat_shard_spec`; relaxes `validate` (drops layout-equality fatal, adds TILE branch).
- **Strip stale `shard_spec` from defaulted `output_mem_config`** — when caller passes no `memory_config` and input is sharded, inherit only `(memory_layout, buffer_type)` so `compute_output_specs` re-derives a fresh spec sized for the output shape (matches `permute`/`transpose` idiom).
- **L1-alignment guard in `generate_repeat_shard_spec`** — reject RM shard shapes whose `page_size` is not 16-byte aligned (or whose width does not divide the tensor width); falls back to interleaved instead of fataling at L1 page-size validation.
- **Use `ttnn::zeros` for zero-repetition** — when any factor is `0`, allocate a zero-volume output via `ttnn::zeros` instead of the invalid `ttnn::reshape` shortcut.
- **Split kernels into five single-purpose files** — factories route by `(layout, sharded)`: `repeat_higher_dim_tile.cpp`, `repeat_higher_dim_rm_{sharded,interleaved}.cpp`, `repeat_last_dim_rm_{sharded,interleaved}.cpp`; deleted combined `repeat_*_rm.cpp` kernels. RM sharded paths use `noc_async_*_sharded`; interleaved RM paths keep alignment dance + per-page doubling perf.
- **Upgrade `TensorAccessorArgs` to two-vector + `RuntimeTensorShape`** — both program factories; CRTA offset chaining for src+dst in one kernel file.
- **Add comprehensive universal-I/O test suite (`test_universal_input_tm_repeat.py`)** — 91 parametrized cases covering every dispatch path: TILE H/W/B native (sharded output derived/explicit); RM HEIGHT native; RM `BLOCK/WIDTH` last-dim composite fallback; RM interleaved (last-dim + higher-dim, odd page width); RM sharded round-trips; interleaved→sharded without spec; DRAM-sharded fallback; uneven shards; cross-layout sharded→sharded composite; dtype matrix (bf16/f32/bf8_b); higher-rank (5D/6D); irregular shapes; explicit-grid edge cases; rank mismatch; zero-repetition; all-1 shortcut. Pad `repeat_shape` with leading `1`s in the harness to satisfy `torch.Tensor.repeat`'s rank requirement.

### Tests
All on Wormhole B0 (`tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py`):

```bash
$ pytest tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
========================= 91 passed in 20.57s ==========================
```

- `test_repeat_native_tile_sharded` — TILE HEIGHT/WIDTH/BLOCK native (sharded out derived/explicit) — **PASSED**
- `test_repeat_native_rm_height_sharded` — RM HEIGHT last-dim + higher-dim native — **PASSED**
- `test_repeat_rm_block_width_last_dim_composite` — RM BLOCK/WIDTH last-dim composite fallback — **PASSED**
- `test_repeat_composite_fallback` — RM BLOCK upper-dim cross-shard, TILE multi-axis — **PASSED**
- `test_repeat_dtype_spot_checks` — dtype × layout × sharded MC matrix — **PASSED**
- `test_repeat_sharded_to_derived_spec` — sharded in → sharded out (no explicit spec) — **PASSED**
- `test_repeat_interleaved_to_sharded_nospec` — TILE interleaved → HEIGHT/WIDTH/BLOCK derived — **PASSED**
- `test_repeat_rm_sharded_to_sharded` — RM HEIGHT→HEIGHT, BLOCK→BLOCK, WIDTH→WIDTH — **PASSED**
- `test_repeat_dram_interleaved` — TILE/RM DRAM ↔ DRAM round-trips — **PASSED**
- `test_repeat_rm_interleaved` — RM L1-interleaved last-dim + higher-dim, odd page width — **PASSED**
- `test_repeat_all_ones_shortcut` — no-op fast path, returns `input_tensor` — **PASSED**
- `test_repeat_tile_universal_io_matrix` — TILE in × out × dtype universal-I/O matrix — **PASSED**
- `test_repeat_rm_universal_io_matrix` — RM in × out × dtype universal-I/O matrix — **PASSED**
- `test_repeat_irregular_shapes_interleaved` — non-power-of-2 / odd shapes, interleaved — **PASSED**
- `test_repeat_explicit_grid_edge_cases` — explicit user-supplied shard grids — **PASSED**
- `test_repeat_higher_rank` — 5D / 6D repeats across layouts and dtypes — **PASSED**
- `test_repeat_default_memory_config` — no `memory_config` passed; inheritance correctness — **PASSED**
- `test_repeat_sharded_in_sharded_out_nospec` — sharded in → sharded out without explicit spec — **PASSED**
- `test_repeat_rm_interleaved_to_sharded_nospec` — RM interleaved → derived sharded output — **PASSED**
- `test_repeat_dtype_coverage` — bf16 / f32 / bf8_b across paths — **PASSED**
- `test_repeat_dram_interleaved_dims` — DRAM interleaved repeat across dims — **PASSED**
- `test_repeat_rank_mismatch` — `repeat_shape` shorter than tensor rank — **PASSED**
- `test_repeat_zero_reps` — zero repetition factor → zero-volume output — **PASSED**
- `test_repeat_composite_edge_cases` — composite-path corner cases — **PASSED**

Regression suite:
```bash
$ pytest tests/ttnn/unit_tests/operations/data_movement/test_repeat.py
========================= 109 passed, 242 skipped ==========================
```

### Documentation
- `ttnn/cpp/ttnn/operations/data_movement/repeat/docs/RepeatShardingUniversalIO.md` — sharding gaps + post-implementation bugfixes section.
- `ttnn/cpp/ttnn/operations/data_movement/repeat/docs/RepeatUniversalIO_ImplementationPlan.md` — implementation plan, routing tables, deferred-work status.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/repeat_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/repeat_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/repeat_fix)