### PR TITLE
fix large tensor softmax inplace hang

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
@@ -7,8 +7,9 @@ import torch
 import torch.nn.functional as F
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax
+from models.common.utility_functions import torch_random
 
 
 @pytest.mark.parametrize("shape", [[2, 10, 512, 8192]])
@@ -49,3 +50,45 @@ def test_ttnn_softmax_sdxl_attention(device, shape):
         atol=0.001,
         frobenius_threshold=0.068,
     )
+
+
+@pytest.mark.parametrize("target_sequence_size", [8192])
+@pytest.mark.parametrize("sequence_size", [384])
+@pytest.mark.parametrize("iterations", [50])
+def test_transformer_attention_softmax_inplace_large_kernel_stress(
+    device, target_sequence_size, sequence_size, iterations
+):
+    """Regression test for #45200: in-place attention_softmax_ on a large-kernel tensor"""
+    torch.manual_seed(0)
+
+    input_shape = (1, 1, sequence_size, target_sequence_size)
+    torch_input_tensor = torch_random(input_shape, -5.0, 5.0, dtype=torch.bfloat16)
+    torch_attention_mask = torch_random(input_shape, 0, 1.0, dtype=torch.bfloat16)
+
+    golden_function = ttnn.get_golden_function(ttnn.transformer.attention_softmax_)
+    torch_output_tensor = golden_function(torch_input_tensor, head_size=None, attention_mask=torch_attention_mask)
+
+    # Mask is read-only across iterations, so upload once.
+    attention_mask = ttnn.from_torch(torch_attention_mask, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    first_output = None
+    for i in range(iterations):
+        # Re-upload the input every iteration because attention_softmax_ mutates it in place.
+        input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        input_addr = input_tensor.buffer_address()
+        output_tensor = ttnn.transformer.attention_softmax_(
+            input_tensor, head_size=None, attention_mask=attention_mask, causal_mask=True
+        )
+        # The op must remain truly in-place (output aliases the input buffer).
+        assert output_tensor.buffer_address() == input_addr
+        output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor))
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+
+        if first_output is None:
+            first_output = output_tensor
+        else:
+            assert torch.equal(first_output, output_tensor), (
+                f"In-place large-kernel softmax is non-deterministic at iteration {i}: "
+                f"output differs from iteration 0 (max abs delta "
+                f"{(first_output - output_tensor).abs().max().item()})"
+            )

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -42
@@ -771,3 +771,55 @@ def test_softmax_large_kernel_mask_padded(device, shape, dim):
         ulp_threshold=15,
         check_ulp=True,
     )
+
+
+@pytest.mark.parametrize("target_sequence_size", [8192])
+@pytest.mark.parametrize("sequence_size", [384])
+@pytest.mark.parametrize("iterations", [50])
+def test_transformer_attention_softmax_inplace_large_kernel_stress(
+    device, target_sequence_size, sequence_size, iterations
+):
+    """Regression test for issue #45200: in-place attention_softmax_ on a tensor large enough to
+    select the large-tensor kernel used to be blocked by a "Tensor is too large to run softmax
+    inplace" assertion, and removing that assertion hung. The real cause was the fused scale+mask
+    large kernel passing the full capped CB length instead of the per-chunk length, which
+    over-consumed the input CB (and deadlocked dispatch) whenever Wt was not a multiple of the
+    capped CB length. Verify the op now runs in-place without hanging and returns deterministic,
+    correct results across repeated iterations.
+
+    Note: the input range is kept moderate because attention_softmax_ uses numeric_stable=False, so
+    extreme magnitudes would overflow the (unstable) exp and diverge from the stable torch golden -
+    a numerics artifact unrelated to this fix (see issue #28525)."""
+    torch.manual_seed(0)
+
+    input_shape = (1, 1, sequence_size, target_sequence_size)
+    torch_input_tensor = torch_random(input_shape, -5.0, 5.0, dtype=torch.bfloat16)
+    torch_attention_mask = torch_random(input_shape, 0, 1.0, dtype=torch.bfloat16)
+
+    golden_function = ttnn.get_golden_function(ttnn.transformer.attention_softmax_)
+    torch_output_tensor = golden_function(torch_input_tensor, head_size=None, attention_mask=torch_attention_mask)
+
+    # Mask is read-only across iterations, so upload once.
+    attention_mask = ttnn.from_torch(torch_attention_mask, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+    first_output = None
+    for i in range(iterations):
+        # Re-upload the input every iteration because attention_softmax_ mutates it in place.
+        input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        input_addr = input_tensor.buffer_address()
+        output_tensor = ttnn.transformer.attention_softmax_(
+            input_tensor, head_size=None, attention_mask=attention_mask, causal_mask=True
+        )
+        # The op must remain truly in-place (output aliases the input buffer).
+        assert output_tensor.buffer_address() == input_addr
+        output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor))
+        assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+
+        if first_output is None:
+            first_output = output_tensor
+        else:
+            assert torch.equal(first_output, output_tensor), (
+                f"In-place large-kernel softmax is non-deterministic at iteration {i}: "
+                f"output differs from iteration 0 (max abs delta "
+                f"{(first_output - output_tensor).abs().max().item()})"
+            )

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -42
@@ -18,6 +18,7 @@ TEST_PADDING_VALUE = -42
 @pytest.mark.parametrize(
     "batch_size, h, w, dim",
     [
+        (1, 128, 128000, -1),
         (1, 32, 128000, -1),
         (1, 2048, 32000, -1),
         (1, 512, 32000, -1),
@@ -771,55 +772,3 @@ def test_softmax_large_kernel_mask_padded(device, shape, dim):
         ulp_threshold=15,
         check_ulp=True,
     )
-
-
-@pytest.mark.parametrize("target_sequence_size", [8192])
-@pytest.mark.parametrize("sequence_size", [384])
-@pytest.mark.parametrize("iterations", [50])
-def test_transformer_attention_softmax_inplace_large_kernel_stress(
-    device, target_sequence_size, sequence_size, iterations
-):
-    """Regression test for issue #45200: in-place attention_softmax_ on a tensor large enough to
-    select the large-tensor kernel used to be blocked by a "Tensor is too large to run softmax
-    inplace" assertion, and removing that assertion hung. The real cause was the fused scale+mask
-    large kernel passing the full capped CB length instead of the per-chunk length, which
-    over-consumed the input CB (and deadlocked dispatch) whenever Wt was not a multiple of the
-    capped CB length. Verify the op now runs in-place without hanging and returns deterministic,
-    correct results across repeated iterations.
-
-    Note: the input range is kept moderate because attention_softmax_ uses numeric_stable=False, so
-    extreme magnitudes would overflow the (unstable) exp and diverge from the stable torch golden -
-    a numerics artifact unrelated to this fix (see issue #28525)."""
-    torch.manual_seed(0)
-
-    input_shape = (1, 1, sequence_size, target_sequence_size)
-    torch_input_tensor = torch_random(input_shape, -5.0, 5.0, dtype=torch.bfloat16)
-    torch_attention_mask = torch_random(input_shape, 0, 1.0, dtype=torch.bfloat16)
-
-    golden_function = ttnn.get_golden_function(ttnn.transformer.attention_softmax_)
-    torch_output_tensor = golden_function(torch_input_tensor, head_size=None, attention_mask=torch_attention_mask)
-
-    # Mask is read-only across iterations, so upload once.
-    attention_mask = ttnn.from_torch(torch_attention_mask, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-
-    first_output = None
-    for i in range(iterations):
-        # Re-upload the input every iteration because attention_softmax_ mutates it in place.
-        input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-        input_addr = input_tensor.buffer_address()
-        output_tensor = ttnn.transformer.attention_softmax_(
-            input_tensor, head_size=None, attention_mask=attention_mask, causal_mask=True
-        )
-        # The op must remain truly in-place (output aliases the input buffer).
-        assert output_tensor.buffer_address() == input_addr
-        output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor))
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
-
-        if first_output is None:
-            first_output = output_tensor
-        else:
-            assert torch.equal(first_output, output_tensor), (
-                f"In-place large-kernel softmax is non-deterministic at iteration {i}: "
-                f"output differs from iteration 0 (max abs delta "
-                f"{(first_output - output_tensor).abs().max().item()})"
-            )

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -383,8 +383,8 @@ void kernel_main() {
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
 #if FUSED_SCALE_MASK
-            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
-            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
+            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cur_cb_length_t, blk);
+            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cur_cb_length_t, blk, do_mask);
             reduce_cb_pass<PoolType::MAX, cb_x, cb_max_scaler, cb_max, cb_prev_max>(
                 cur_pass, use_prev_reduce, cur_cb_length_t);
 #else
@@ -419,8 +419,8 @@ void kernel_main() {
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
 #if FUSED_SCALE_MASK
-            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
-            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
+            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cur_cb_length_t, blk);
+            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cur_cb_length_t, blk, do_mask);
             exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
             reduce_cb_pass<PoolType::SUM, cb_exps, cb_sum_scaler, cb_sumexps, cb_prev_reduce>(
                 cur_pass, use_prev_reduce, cur_cb_length_t);
@@ -482,8 +482,8 @@ void kernel_main() {
         for (uint32_t cur_pass = 0; cur_pass < num_cb_passes; cur_pass++) {
             bool do_mask = mask_padded_data && (cur_pass == num_cb_passes - 1);
 #if FUSED_SCALE_MASK
-            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cb_length_t, blk);
-            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cb_length_t, blk, do_mask);
+            apply_fused_scale_mask(cb_in0, cb_fused_scale, cb_scale_mask, cur_cb_length_t, blk);
+            apply_fused_attn_mask(cb_scale_mask, cb_fused_attn, cb_x, cur_cb_length_t, blk, do_mask);
             exp_cb(cb_x, cb_exps, cb_max_final, cur_cb_length_t, blk);
 #else
             if (do_mask && cur_pass == num_cb_passes - 1) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -135,7 +135,6 @@ tt::tt_metal::ProgramDescriptor SoftmaxDeviceOperation::SoftmaxProgramFactoryAtt
         im4_t = large_kernel_cb_size;
         im0_t = large_kernel_cb_size;
         im3_t = large_kernel_cb_size;
-        TT_FATAL(!attributes.inplace, "Tensor is too large to run softmax inplace, please use standard softmax");
     }
     if (!use_large_kernel) {
         TT_FATAL(


### PR DESCRIPTION
## PR Category

Bug fix — TTNN softmax. 
 #45200

## Summary

In-place softmax on tensors large enough to hit the attention **large-tensor kernel** was blocked by a `TT_FATAL(!attributes.inplace, ...)` assertion; removing it hung.

**Root cause** : in `softmax_large_tensor.cpp`, the fused `apply_fused_scale_mask` / `apply_fused_attn_mask` calls were passed the full capped CB length `cb_length_t` instead of the per-chunk `cur_cb_length_t` (which every other op in the loop uses). When `Wt` isn't a multiple of the capped length (e.g. `W=8192`→`Wt=256`, cap `80`, last chunk `16`), this over-consumed the input/mask CBs on the final chunk, desynced the pipeline, and deadlocked dispatch. The assertion was masking this bug, which also affected the non-in-place masked large path.

### Changes


1. `softmax_large_tensor.cpp` — pass `cur_cb_length_t` (not `cb_length_t`) to the fused scale/mask calls in all three passes (max / sum / final), matching every other op in the loop.
2. `softmax_program_factory_attention_optimized.cpp` — remove the now-unnecessary `TT_FATAL(!attributes.inplace, ...). With the kernel correct, true in-place is safe`: the compute pipeline guarantees each input tile is read before the writer overwrites it (verified on device).
3. `test_softmax.py` — add a regression test mirroring the issue's repro (in-place causal attention_softmax_, (1,1,384,8192), 50 iterations) asserting no-hang, in-place aliasing, PCC vs golden, and bit-exact determinism.


### Notes for reviewers

- Fix is the kernel one-liner (×6 sites); the assertion removal just unblocks it. No changes to output-spec/aliasing logic, so small-kernel and sharded in-place are untouched.
- In-place aliasing is safe: the reader→compute→writer CB chain enforces read-before-write per tile (verified on N150 — output aliases input, no hang, bit-identical across 50 iters).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/45200-fix-softmax-large-inplace-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/45200-fix-softmax-large-inplace-hang)
