### PR TITLE
[Performance] ring_mla kt_inplace_v: batched pack + full-Sk single-pass softmax@V

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3495,7 +3495,7 @@ def test_ring_mla_create_chunked_perf_table(model_name, q_chunk_size, k_chunk_si
 RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
     # 4-device ring (QuietBox, 100 SDPA cores)
-    ("kimi50k", 32, 640, 4, 63.3),
+    ("kimi50k", 32, 640, 4, 66.05),
 ]
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -314,14 +314,18 @@ void blocked_matmul_and_pack(
 }
 
 /**
- * kt_inplace_v batched softmax@V: for each DST-sized batch of output columns, matmul the full
- * active_Sk (inner_dim tiles) against those columns into DST, then pack the batch in one shot.
+ * Matmul + pack of the already-softmaxed scores against latent V, specialized for in-place latent-V
+ * (V read straight from K^T: V[sk][vd] == K^T[vd][sk]). Output column vd comes from its own matmul
+ * chain over K^T row vd (in1 base vd*KT_stride, inner stride 1). Unlike blocked_matmul_and_pack —
+ * which walks one contiguous in1 subblock from a single base — the columns here sit at strided in1
+ * bases (different K^T rows), so they are independent chains and can't be folded into one matmul.
  *
- * In-place latent-V reads output column vd from K^T row vd (in1 base vd*KT_stride, inner stride 1),
- * so each output column is an independent matmul chain. Doing one column at a time pays a full
- * tile_regs_acquire/commit/wait/release handshake plus a pack-configure per column, leaving the FPU
- * idle ~2/3 of the time; batching every column that fits in DST under one handshake and one pack
- * raises the FPU duty cycle. Numerically identical — same per-column matmul, just reordered.
+ * To keep the FPU busy it batches: every output column that fits in DST shares one
+ * tile_regs_acquire/commit/wait/release handshake and one pack, instead of paying that handshake +
+ * a pack-configure per column (which left the FPU idle ~2/3 of the time for the 1-wide path).
+ *
+ * noinline on Wormhole, mirroring blocked_matmul_and_pack: keeps sdpa_inner_loop_step's frame off
+ * the TR0 stack so the ring cases stay within budget; WH-only to avoid the call overhead elsewhere.
  */
 template <uint32_t vDHt, uint32_t dst_size, uint32_t subblock_h>
 #if defined(ARCH_WORMHOLE)
@@ -1166,45 +1170,9 @@ static void sdpa_inner_loop_step(
             // the V-matmul unpack; only needed when q_num_subblocks==1 (Phase 1's hold_wr_ptr
             // didn't sync them).
 
-            if constexpr (kt_inplace_v) {
-                // Full-Sk single pass: softmax the whole row, then one matmul chain per output
-                // column over all active_Sk tiles (DST-accumulated, packed once per DST group). Vs
-                // split-drain this drops the L1-acc and the per-kt_sub packs/barriers. active_Sk ==
-                // kt_num_full_subblocks * actual_sbw exactly, so one pass covers the full row.
-                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
-                    sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
-                        cb_qkt_im,
-                        cur.max,
-                        cur.sum,
-                        KT_stride,
-                        q_num_subblocks - 1,
-                        kt_sub * actual_sbw,
-                        qkt_subblock_h,
-                        actual_sbw);
-                }
-                if constexpr (q_num_subblocks == 1) {
-                    PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
-                    UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
-                    UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
-                }
-                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-                {
-                    MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
-                    sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
-                        out_cb, out_cb);
-                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
-                    inplace_v_matmul_pack_batched<vDHt, dst_size, qktv_h>(
-                        cb_qkt_im,
-                        cb_v_in,
-                        out_cb,
-                        qktv_in0_index_offset,
-                        /*inner_dim=*/kt_num_full_subblocks * matmul_inner,
-                        KT_stride);
-                    sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
-                }
-            } else {
-                // Split-drain: interleave each column-subblock's sub_exp with its partial V matmul;
-                // partial products accumulate across kt_sub via L1.
+            if constexpr (!kt_inplace_v) {
+                // Split-drain (common, materialized-V path): interleave each column-subblock's
+                // sub_exp with its partial V matmul; partial products accumulate across kt_sub via L1.
                 for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
                     sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
                         cb_qkt_im,
@@ -1262,6 +1230,42 @@ static void sdpa_inner_loop_step(
                     if (kt_sub > 0) {
                         PACK((llk_pack_reconfig_l1_acc(0)));
                     }
+                }
+            } else {
+                // In-place latent-V full-Sk single pass: softmax the whole row, then one matmul chain
+                // per output column over all active_Sk tiles (DST-accumulated, packed once per DST
+                // group). Vs split-drain this drops the L1-acc and the per-kt_sub packs/barriers.
+                // active_Sk == kt_num_full_subblocks * actual_sbw exactly, so one pass covers the row.
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
+                        cb_qkt_im,
+                        cur.max,
+                        cur.sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_sub * actual_sbw,
+                        qkt_subblock_h,
+                        actual_sbw);
+                }
+                if constexpr (q_num_subblocks == 1) {
+                    PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
+                    UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
+                    UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
+                }
+                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                {
+                    MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
+                    sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
+                        out_cb, out_cb);
+                    mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
+                    inplace_v_matmul_pack_batched<vDHt, dst_size, qktv_h>(
+                        cb_qkt_im,
+                        cb_v_in,
+                        out_cb,
+                        qktv_in0_index_offset,
+                        /*inner_dim=*/kt_num_full_subblocks * matmul_inner,
+                        KT_stride);
+                    sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
                 }
             }
             qktv_in0_index_offset += qktv_h * KT_stride;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -323,18 +323,17 @@ void blocked_matmul_and_pack(
  * idle ~2/3 of the time; batching every column that fits in DST under one handshake and one pack
  * raises the FPU duty cycle. Numerically identical — same per-column matmul, just reordered.
  */
-template <uint32_t vDHt, uint32_t dst_size>
+template <uint32_t vDHt, uint32_t dst_size, uint32_t subblock_h>
 #if defined(ARCH_WORMHOLE)
 __attribute__((noinline))
 #endif
 void inplace_v_matmul_pack_batched(
-    uint32_t in0_cb,
-    uint32_t in1_cb,
-    uint32_t out_cb,
-    uint32_t in0_index_start,
-    uint32_t inner_dim,
-    uint32_t KT_stride,
-    uint32_t subblock_h) {
+    uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t in0_index_start, uint32_t inner_dim, uint32_t KT_stride) {
+    // Each output column is written column-major into DST (column c at c*subblock_h), but the
+    // pack below reads DST row-major; the two orderings only coincide when subblock_h==1, which
+    // kt_inplace_v guarantees via Sq_chunk_t==1. Enforce it so this can't silently corrupt if
+    // reused with multi-tile Q.
+    static_assert(subblock_h == 1, "inplace_v_matmul_pack_batched requires single-tile Q (subblock_h==1)");
     // subblock_h DST tiles per output column; batch as many columns as DST holds.
     const uint32_t cols_per_batch = dst_size / subblock_h;
     for (uint32_t vs0 = 0; vs0 < vDHt; vs0 += cols_per_batch) {
@@ -1194,14 +1193,13 @@ static void sdpa_inner_loop_step(
                     sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
                         out_cb, out_cb);
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
-                    inplace_v_matmul_pack_batched<vDHt, dst_size>(
+                    inplace_v_matmul_pack_batched<vDHt, dst_size, qktv_h>(
                         cb_qkt_im,
                         cb_v_in,
                         out_cb,
                         qktv_in0_index_offset,
                         /*inner_dim=*/kt_num_full_subblocks * matmul_inner,
-                        KT_stride,
-                        qktv_h);
+                        KT_stride);
                     sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
                 }
             } else {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -314,6 +314,51 @@ void blocked_matmul_and_pack(
 }
 
 /**
+ * kt_inplace_v batched softmax@V: for each DST-sized batch of output columns, matmul the full
+ * active_Sk (inner_dim tiles) against those columns into DST, then pack the batch in one shot.
+ *
+ * In-place latent-V reads output column vd from K^T row vd (in1 base vd*KT_stride, inner stride 1),
+ * so each output column is an independent matmul chain. Doing one column at a time pays a full
+ * tile_regs_acquire/commit/wait/release handshake plus a pack-configure per column, leaving the FPU
+ * idle ~2/3 of the time; batching every column that fits in DST under one handshake and one pack
+ * raises the FPU duty cycle. Numerically identical — same per-column matmul, just reordered.
+ */
+template <uint32_t vDHt, uint32_t dst_size>
+#if defined(ARCH_WORMHOLE)
+__attribute__((noinline))
+#endif
+void inplace_v_matmul_pack_batched(
+    uint32_t in0_cb,
+    uint32_t in1_cb,
+    uint32_t out_cb,
+    uint32_t in0_index_start,
+    uint32_t inner_dim,
+    uint32_t KT_stride,
+    uint32_t subblock_h) {
+    // subblock_h DST tiles per output column; batch as many columns as DST holds.
+    const uint32_t cols_per_batch = dst_size / subblock_h;
+    for (uint32_t vs0 = 0; vs0 < vDHt; vs0 += cols_per_batch) {
+        const uint32_t cols = (vDHt - vs0 < cols_per_batch) ? (vDHt - vs0) : cols_per_batch;
+        tile_regs_acquire();
+        for (uint32_t c = 0; c < cols; ++c) {
+            uint32_t in0_index = in0_index_start;
+            uint32_t in1_index = (vs0 + c) * KT_stride;
+            for (uint32_t inner = 0; inner < inner_dim; ++inner) {
+                matmul_block_no_mop(
+                    in0_cb, in1_cb, in0_index, in1_index, c * subblock_h, false, 1, subblock_h, KT_stride);
+                in0_index++;
+                in1_index++;
+            }
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        configure_row_pack_width(out_cb, cols);
+        pack_contiguous_rows_nocfg(out_cb, 0, subblock_h, vDHt, vs0, cols);
+        tile_regs_release();
+    }
+}
+
+/**
  * Per-row-group max reduction with optional eltwise_max against prev values.
  * Reads from in0_cb at row group offset, writes to out_cb sequentially.
  */
@@ -1115,80 +1160,110 @@ static void sdpa_inner_loop_step(
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)@V");
-            // Split-drain: interleave per-column-subblock sub_exp with partial V matmul.
-            // Each kt_sub softmaxes one column chunk of the last row, then multiplies
-            // with the corresponding V rows; partial products accumulate via L1.
             const uint32_t matmul_inner = actual_sbw;
-            for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
-                sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
-                    cb_qkt_im,
-                    cur.max,
-                    cur.sum,
-                    KT_stride,
-                    q_num_subblocks - 1,
-                    kt_sub * actual_sbw,
-                    qkt_subblock_h,
-                    actual_sbw);
-                // PACK-to-UNPACK barrier: sub_exp writes cb_qkt_im in-place via pack_tile<true>;
-                // V matmul UNPACK below reads the same positions and needs to see those writes.
-                // For q_num_subblocks==1 the cb_wait_front was already satisfied by Phase 1's
-                // cb_push_back_hold_wr_ptr, so it doesn't sync sub_exp's writes; explicit
-                // semaphore handshake required.
+
+            // sub_exp_block_bcast_cols softmaxes the last Q row in place, one column-subblock at a
+            // time. The PACK->UNPACK barrier after it makes those in-place pack writes visible to
+            // the V-matmul unpack; only needed when q_num_subblocks==1 (Phase 1's hold_wr_ptr
+            // didn't sync them).
+
+            if constexpr (kt_inplace_v) {
+                // Full-Sk single pass: softmax the whole row, then one matmul chain per output
+                // column over all active_Sk tiles (DST-accumulated, packed once per DST group). Vs
+                // split-drain this drops the L1-acc and the per-kt_sub packs/barriers. active_Sk ==
+                // kt_num_full_subblocks * actual_sbw exactly, so one pass covers the full row.
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
+                        cb_qkt_im,
+                        cur.max,
+                        cur.sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_sub * actual_sbw,
+                        qkt_subblock_h,
+                        actual_sbw);
+                }
                 if constexpr (q_num_subblocks == 1) {
                     PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
                     UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
                     UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
                 }
-                if (kt_sub == 0) {
-                    cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-                    // In-place latent-V reads V from K^T, already fronted by Phase 1's K^T wait.
-                    if constexpr (!kt_inplace_v) {
-                        cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
-                    }
-                }
-                if (kt_sub > 0) {
-                    PACK((llk_pack_reconfig_l1_acc(1)));
-                }
-
+                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
                 {
                     MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
-                    uint32_t v_index_offset = 0;
                     sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
                         out_cb, out_cb);
-                    // cb_qkt_im rows are laid out at KT_stride even when this kt_sub only consumes a
-                    // narrower logical width. Keep unpack init on the physical stride; inner_dim below
-                    // still limits how many V rows are multiplied.
                     mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
-                    // Configure once before v_subblock loop; skip inside.
-                    configure_row_pack_width(out_cb, qktv_subblock_w);
-                    for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
-                        // In-place latent-V reads V column v_subblock straight from K^T row v_subblock,
-                        // walking that row with in1 stride 1; the materialized path reads contiguous V
-                        // columns (in1 stride vDHt). qktv_subblock_w is 1 for the in-place path (the
-                        // host forces it), so the pack offset / width below collapse to one tile.
-                        const uint32_t qktv_in1_index = kt_inplace_v ? (v_subblock * KT_stride + kt_sub * matmul_inner)
-                                                                     : (kt_sub * matmul_inner * vDHt + v_index_offset);
-                        blocked_matmul_and_pack<false, kt_inplace_v ? 1 : vDHt, vDHt>(
-                            cb_qkt_im,
-                            cb_v_in,
-                            out_cb,
-                            qktv_in0_index_offset + kt_sub * matmul_inner,
-                            qktv_in1_index,
-                            0,
-                            v_subblock * qktv_subblock_w,
-                            qktv_subblock_w,
-                            qktv_h,
-                            matmul_inner,
-                            KT_stride,
-                            /*trigger_reduce=*/false,
-                            /*skip_pack_configure=*/true);
-                        v_index_offset += qktv_subblock_w;
-                    }
+                    inplace_v_matmul_pack_batched<vDHt, dst_size>(
+                        cb_qkt_im,
+                        cb_v_in,
+                        out_cb,
+                        qktv_in0_index_offset,
+                        /*inner_dim=*/kt_num_full_subblocks * matmul_inner,
+                        KT_stride,
+                        qktv_h);
                     sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
                 }
+            } else {
+                // Split-drain: interleave each column-subblock's sub_exp with its partial V matmul;
+                // partial products accumulate across kt_sub via L1.
+                for (uint32_t kt_sub = 0; kt_sub < kt_num_full_subblocks; ++kt_sub) {
+                    sub_exp_block_bcast_cols<profiling_enabled, scale_fp32>(
+                        cb_qkt_im,
+                        cur.max,
+                        cur.sum,
+                        KT_stride,
+                        q_num_subblocks - 1,
+                        kt_sub * actual_sbw,
+                        qkt_subblock_h,
+                        actual_sbw);
+                    if constexpr (q_num_subblocks == 1) {
+                        PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
+                        UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
+                        UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
+                    }
+                    if (kt_sub == 0) {
+                        cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                        cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+                    }
+                    if (kt_sub > 0) {
+                        PACK((llk_pack_reconfig_l1_acc(1)));
+                    }
 
-                if (kt_sub > 0) {
-                    PACK((llk_pack_reconfig_l1_acc(0)));
+                    {
+                        MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
+                        uint32_t v_index_offset = 0;
+                        sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
+                            out_cb, out_cb);
+                        // cb_qkt_im rows are laid out at KT_stride even when this kt_sub only consumes a
+                        // narrower logical width. Keep unpack init on the physical stride; inner_dim below
+                        // still limits how many V rows are multiplied.
+                        mm_no_mop_reinit_short(cb_qkt_im, cb_v_in, false, qktv_subblock_w, qktv_h, KT_stride);
+                        configure_row_pack_width(out_cb, qktv_subblock_w);
+                        for (uint32_t v_subblock = 0; v_subblock < qktv_v_num_subblocks; ++v_subblock) {
+                            const uint32_t qktv_in1_index = kt_sub * matmul_inner * vDHt + v_index_offset;
+                            blocked_matmul_and_pack<false, vDHt, vDHt>(
+                                cb_qkt_im,
+                                cb_v_in,
+                                out_cb,
+                                qktv_in0_index_offset + kt_sub * matmul_inner,
+                                qktv_in1_index,
+                                0,
+                                v_subblock * qktv_subblock_w,
+                                qktv_subblock_w,
+                                qktv_h,
+                                matmul_inner,
+                                KT_stride,
+                                /*trigger_reduce=*/false,
+                                /*skip_pack_configure=*/true);
+                            v_index_offset += qktv_subblock_w;
+                        }
+                        sdpa_maybe_reconfig_data_format<cb_v_in, cb_qkt_im, cb_qkt_im, cb_qkt_im>();
+                    }
+
+                    if (kt_sub > 0) {
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+                    }
                 }
             }
             qktv_in0_index_offset += qktv_h * KT_stride;


### PR DESCRIPTION
### PR Category
Performance

### Summary

Two optimizations to the ring_mla `kt_inplace_v` latent-V chunked-prefill softmax@V drain, which was matrix-unit bound:

1. **Batched pack** — compute all output columns of softmax@V into DST and pack them in DST-sized groups, instead of a per-column `tile_regs` handshake + pack-configure.
2. **Full-Sk single-pass softmax** — softmax the whole row once, then run a single matmul chain per output column over the full key length (accumulated in DST, packed once), dropping the per-subblock L1 accumulation and barriers.

Both are guarded by `kt_inplace_v`; the materialized path is preserved verbatim. Accuracy and determinism are unchanged.

### Perf

50k+5k chunked kimi case on SDPA moved from **66% → 68.5%** math util on Galaxy.

### Additional CI

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/ring-mla-softmax-v-fullsk-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/ring-mla-softmax-v-fullsk-opt)