### PR TITLE
chore(wan): Add import statement

### DIFF
--- a/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
@@ -9,6 +9,7 @@ on CPU before TT conversion so inference has no LoRA-specific runtime cost.
 See ``experimental/models/Wan2_2_LoRA.md`` for the adapter-key formats
 detected by ``fuse_lora_state_dict`` and the supported namespaces.
 """
+from __future__ import annotations
 import hashlib
 import re
 from collections.abc import Sequence


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
We've been seeing the following error when deploying WAN/LoRA models

```
[1,0]<stderr>: Traceback (most recent call last):
[1,0]<stderr>:   File "/opt/tt-inference-server/tt-media-server/tt_model_runners/../tt_model_runners/dit_runners.py", line 808, in create_pipeline
[1,0]<stderr>:     from models.tt_dit.experimental.pipelines.pipeline_wan_lora import (
[1,0]<stderr>:   File "/home/user/tt-metal/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py", line 289, in <module>
[1,0]<stderr>:     class WanPipelineI2VLora(WanPipelineI2V):
[1,0]<stderr>:   File "/home/user/tt-metal/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py", line 400, in WanPipelineI2VLora
[1,0]<stderr>:     ) -> WanPipelineI2VLora:
[1,0]<stderr>: NameError: name 'WanPipelineI2VLora' is not defined. Did you mean: 'WanPipelineI2V'?
[1,0]<stderr>: 
[1,0]<stderr>: 2026-06-08 11:54:03,044 - ERROR - Device : Exception during model loading
[1,0]<stderr>: Traceback (most recent call last):
[1,0]<stderr>:   File "/opt/tt-inference-server/tt-media-server/tt_model_runners/../tt_model_runners/dit_runners.py", line 131, in warmup
[1,0]<stderr>:     await asyncio.wait_for(
[1,0]<stderr>:   File "/usr/local/share/uv/cpython-3.10.19-linux-x86_64-gnu/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
[1,0]<stderr>:     return fut.result()
[1,0]<stderr>:   File "/usr/local/share/uv/cpython-3.10.19-linux-x86_64-gnu/lib/python3.10/asyncio/threads.py", line 25, in to_thread
[1,0]<stderr>:     return await loop.run_in_executor(None, func_call)
[1,0]<stderr>:   File "/usr/local/share/uv/cpython-3.10.19-linux-x86_64-gnu/lib/python3.10/concurrent/futures/thread.py", line 58, in run
[1,0]<stderr>:     result = self.fn(*self.args, **self.kwargs)
[1,0]<stderr>:   File "/opt/tt-inference-server/tt-media-server/tt_model_runners/../tt_model_runners/dit_runners.py", line 124, in distribute_block
[1,0]<stderr>:     self.pipeline = self.create_pipeline()
[1,0]<stderr>:   File "/opt/tt-inference-server/tt-media-server/tt_model_runners/../tt_model_runners/dit_runners.py", line 808, in create_pipeline
[1,0]<stderr>:     from models.tt_dit.experimental.pipelines.pipeline_wan_lora import (
[1,0]<stderr>:   File "/home/user/tt-metal/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py", line 289, in <module>
[1,0]<stderr>:     class WanPipelineI2VLora(WanPipelineI2V):
[1,0]<stderr>:   File "/home/user/tt-metal/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py", line 400, in WanPipelineI2VLora
[1,0]<stderr>:     ) -> WanPipelineI2VLora:
[1,0]<stderr>: NameError: name 'WanPipelineI2VLora' is not defined. Did you mean: 'WanPipelineI2V'?
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afoley/nnyamagoudar/subtorus-wan-testing-add-imports)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afoley/nnyamagoudar/subtorus-wan-testing-add-imports)