### PR TITLE
Cleanup: Migrate the remaining 15 kernels off deprecated destination-register helpers

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -599,7 +599,7 @@ void run_top32_llk(uint32_t row_elements, uint32_t num_input_tiles, uint32_t pha
     cb_reserve_back(out_scores_cb, 1);
     cb_reserve_back(out_indices_cb, 1);
 
-    acquire_dst();
+    tile_regs_acquire();
 
     uint32_t num_faces = 4;
     reconfig_data_format_srca(in_scores_cb);
@@ -654,15 +654,18 @@ void run_top32_llk(uint32_t row_elements, uint32_t num_input_tiles, uint32_t pha
         MATH((llk_math_deepseek_top32_rm_merge<false, DST_ACCUM_MODE>(value_offset_tiles, true)));
         MATH((llk_math_deepseek_top32_rm_rebuild<false, DST_ACCUM_MODE>(value_offset_tiles, decreasing, true)));
     }
+    tile_regs_commit();
+    tile_regs_wait();
 
     PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
+
     ckernel::pack_reconfig_data_format(out_scores_cb);
     ckernel::pack_tile(value_offset_tiles, out_scores_cb);
     ckernel::pack_reconfig_data_format(out_indices_cb);
     ckernel::pack_tile(index_offset_tiles, out_indices_cb);
     PACK(TTI_SETADCXX(p_setadc::PAC, FACE_C_DIM - 1, 0x0));
 
-    release_dst();
+    tile_regs_release();
 
     cb_pop_front(in_scores_cb, num_input_tiles);
     cb_pop_front(in_indices_cb, num_input_tiles);
@@ -697,7 +700,7 @@ void run_top32_llk_presorted_1024_opt(uint32_t row_elements, uint32_t num_input_
     cb_reserve_back(out_scores_cb, 1);
     cb_reserve_back(out_indices_cb, 1);
 
-    acquire_dst();
+    tile_regs_acquire();
 
     const uint32_t num_chunks = row_elements / chunk_size;
 
@@ -756,9 +759,12 @@ void run_top32_llk_presorted_1024_opt(uint32_t row_elements, uint32_t num_input_
         MATH((llk_math_deepseek_top32_rm_merge<false, DST_ACCUM_MODE>(value_offset_tiles, true)));
         MATH((llk_math_deepseek_top32_rm_rebuild<false, DST_ACCUM_MODE>(value_offset_tiles, decreasing, true)));
     }
+    tile_regs_commit();
+    tile_regs_wait();
 
     // Step 10: pack final top-32 scores/indices.
     PACK(TTI_SETADCXX(p_setadc::PAC, 1 - 1, 0x0));
+
     ckernel::pack_reconfig_data_format(out_scores_cb);
     ckernel::pack_tile(value_offset_tiles, out_scores_cb);
     ckernel::pack_reconfig_data_format(out_indices_cb);
@@ -771,7 +777,7 @@ void run_top32_llk_presorted_1024_opt(uint32_t row_elements, uint32_t num_input_
     UNPACK(TTI_SETADCXY(p_setadc::UNP_A, 0, 0, 0, 0, 0b1111));
     UNPACK(TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b1111));
 
-    release_dst();
+    tile_regs_release();
 
     cb_pop_front(in_scores_cb, num_input_tiles);
     cb_pop_front(in_indices_cb, num_input_tiles);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
             for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                    acquire_dst();
+                    tile_regs_acquire();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -89,11 +89,13 @@ void kernel_main() {
 #ifdef FUSE_BIAS
                         // Move matmul result to interm buffer
                         cb_reserve_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, mm_bias_intermediate_cb_id);
                         }
                         cb_push_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
-                        release_dst();
+                        tile_regs_release();
 
                         // Redundant wait since we know data was just pushed
                         cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
@@ -103,7 +105,7 @@ void kernel_main() {
                         reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure packer df for out
                         pack_reconfig_data_format(out_cb_id);
-                        acquire_dst();
+                        tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                             uint32_t bcast_tile_idx = in1_index_subblock_offset;
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
@@ -131,6 +133,8 @@ void kernel_main() {
 #endif
                         // Pack out to output buffer
                         cb_reserve_back(out_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, out_cb_id);
                         }
@@ -146,13 +150,15 @@ void kernel_main() {
 #endif
                         // Move partial result to interm buffer
                         cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, mm_partials_cb_id);
                         }
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst();
+                    tile_regs_release();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/bmm_large_block_zm_fused_bias_activation.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
             for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
                 int in1_index_subblock_offset = 0;
                 for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
-                    acquire_dst();
+                    tile_regs_acquire();
 
                     if (enable_reload) {
                         // Reconfigure input
@@ -89,11 +89,13 @@ void kernel_main() {
 #ifdef FUSE_BIAS
                         // Move matmul result to interm buffer
                         cb_reserve_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, mm_bias_intermediate_cb_id);
                         }
                         cb_push_back(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
-                        release_dst();
+                        tile_regs_release();
 
                         // Redundant wait since we know data was just pushed
                         cb_wait_front(mm_bias_intermediate_cb_id, out_subblock_num_tiles);
@@ -103,7 +105,7 @@ void kernel_main() {
                         reconfig_data_format(mm_bias_intermediate_cb_id, bias_cb_id);
                         // reconfigure packer df for out
                         pack_reconfig_data_format(out_cb_id);
-                        acquire_dst();
+                        tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
                             uint32_t bcast_tile_idx = in1_index_subblock_offset;
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
@@ -127,6 +129,8 @@ void kernel_main() {
 #endif
                         // Pack out to output buffer
                         cb_reserve_back(out_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, out_cb_id);
                         }
@@ -139,13 +143,15 @@ void kernel_main() {
                         }
                         // Move partial result to interm buffer
                         cb_reserve_back(mm_partials_cb_id, out_subblock_num_tiles);
+                        tile_regs_commit();
+                        tile_regs_wait();
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, mm_partials_cb_id);
                         }
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);
                     }
 
-                    release_dst();
+                    tile_regs_release();
                     in1_index_subblock_offset += out_subblock_w;
                 }
                 in0_index_subblock_offset += in0_subblock_num_tiles;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/compute_local_l1.cpp
@@ -15,14 +15,16 @@ void kernel_main() {
 
     for (uint32_t mt = 0; mt < sub_Mt; ++mt) {
         for (uint32_t nt = 0; nt < sub_Nt; ++nt) {
-            acquire_dst();
+            tile_regs_acquire();
             for (uint32_t kt = 0; kt < Kt; ++kt) {
                 matmul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, mt * Kt + kt, nt * Kt + kt, 0);
             }
             cb_reserve_back(tt::CBIndex::c_16, onetile);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(0, tt::CBIndex::c_16);
             cb_push_back(tt::CBIndex::c_16, onetile);
-            release_dst();
+            tile_regs_release();
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast.cpp
@@ -33,11 +33,13 @@ void kernel_main() {
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             dfb_src.wait_front(1);
             dfb_dst.reserve_back(1);
-            acquire_dst();
+            tile_regs_acquire();
             // One tile visible per iteration: unpack always reads fifo front (index 0); dst slot is tile_index.
             unary_bcast<BCAST_DIM>(icb, 0, tile_index);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(tile_index, ocb);
-            release_dst();
+            tile_regs_release();
             dfb_src.pop_front(1);
             dfb_dst.push_back(1);
         }
@@ -55,10 +57,12 @@ void kernel_main() {
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             cb0.wait_front(1);
             cb16.reserve_back(1);
-            acquire_dst();
+            tile_regs_acquire();
             unary_bcast<BCAST_DIM>(tt::CBIndex::c_0, 0, tile_index);
+            tile_regs_commit();
+            tile_regs_wait();
             pack_tile(tile_index, tt::CBIndex::c_16);
-            release_dst();
+            tile_regs_release();
             cb0.pop_front(1);
             cb16.push_back(1);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
     constexpr uint32_t prev_max_dst_idx = 1;
 
     for (uint32_t i = 0; i < rows; i++) {
-        acquire_dst();
+        tile_regs_acquire();
         reduce_block_max_row_init<cols>(out_max_cb);
         reduce_block_max_row<cols>(qk_im_cb, scale_cb, i * cols, reduce_dst_idx);
         reduce_block_max_row_uninit(qk_im_cb);
@@ -57,8 +57,10 @@ void kernel_main() {
             binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx);
         }
 
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(reduce_dst_idx, out_max_cb);
-        release_dst();
+        tile_regs_release();
     }
 
     cb_push_back(out_max_cb, rows);

--- a/ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp
@@ -14,18 +14,20 @@ void kernel_main() {
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_init(tt::CBIndex::c_0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
-        acquire_dst();
+        tile_regs_acquire();
 
         // Pop tile after tile, copy to DST and pack
         cb_wait_front(tt::CBIndex::c_0, 1);
         cb_reserve_back(tt::CBIndex::c_16, 1);
         copy_tile(tt::CBIndex::c_0, 0, 0);
 
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, tt::CBIndex::c_16);
 
         cb_pop_front(tt::CBIndex::c_0, 1);
         cb_push_back(tt::CBIndex::c_16, 1);
 
-        release_dst();
+        tile_regs_release();
     }
 }

--- a/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/moreh_common.hpp
@@ -23,8 +23,14 @@
 #include "api/compute/tile_move_copy.h"
 
 // Deprecated
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
 
 namespace ckernel {
 

--- a/ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp
+++ b/ttnn/cpp/ttnn/kernel/compute/transpose_wh.cpp
@@ -18,10 +18,12 @@ void kernel_main() {
         cb_wait_front(tt::CBIndex::c_0, 1);
         cb_reserve_back(tt::CBIndex::c_16, 1);
 
-        acquire_dst();
+        tile_regs_acquire();
         transpose_wh_tile(tt::CBIndex::c_0, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, tt::CBIndex::c_16);
-        release_dst();
+        tile_regs_release();
 
         cb_push_back(tt::CBIndex::c_16, 1);
         cb_pop_front(tt::CBIndex::c_0, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
@@ -80,7 +80,7 @@ void process_and_sort_tiles(
     cb_wait_front(cb_expert_index_template, Wt);
     cb_wait_front(cb_biased_scores, Wt);
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
-        acquire_dst();
+        tile_regs_acquire();
         // transpose and unpack into dest regs
         reconfig_data_format_srca(cb_biased_scores);
         transpose_wh_init_short(cb_biased_scores);
@@ -99,6 +99,8 @@ void process_and_sort_tiles(
         // pack sorted score tiles
         pack_reconfig_data_format(cb_sorted_group_scores);
         cb_reserve_back(cb_sorted_group_scores, 1);
+        tile_regs_commit();
+        tile_regs_wait();
         pack_tile(0, cb_sorted_group_scores);
         cb_push_back(cb_sorted_group_scores, 1);
 
@@ -119,7 +121,7 @@ void process_and_sort_tiles(
         cb_wait_front(cb_sorted_expert_indices_temp, 2);
         cb_pop_front(cb_sorted_expert_indices_temp, 2);
 
-        release_dst();
+        tile_regs_release();
         ascending = switch_dir ? !ascending : ascending;
     }
 }
@@ -158,7 +160,7 @@ void topk_group_scores(
     cb_reserve_back(cb_sorted_group_order, 1);
 
     // Sort single input and index tile that have already ben transposed.
-    acquire_dst();
+    tile_regs_acquire();
     // local sort into k groups
     cb_wait_front(cb_group_summed_scores, 1);
     cb_wait_front(cb_group_index_template, 1);
@@ -172,12 +174,14 @@ void topk_group_scores(
     // llk_topk_sort -> inplace
     ckernel::topk_local_sort<stable_sort>(0, (int)ascending, log_topk_groups);
 
+    tile_regs_commit();
+    tile_regs_wait();
     // pack index tile into cb_sorted_group_order
     pack_reconfig_data_format(cb_sorted_group_order);
     pack_tile(2, cb_sorted_group_order);
     cb_pop_front(cb_group_summed_scores, 1);
     // don't pop group indices as it gets reused for the next tile heights
-    release_dst();
+    tile_regs_release();
 
     cb_push_back(cb_sorted_group_order, 1);
 }
@@ -191,7 +195,6 @@ void transpose_and_pack(const uint32_t input_cb_index, const uint32_t output_cb_
         cb_wait_front(input_cb_index, 1);
         transpose_wh_tile(input_cb_index, 0, 0);
         tile_regs_commit();
-
         tile_regs_wait();
         cb_reserve_back(output_cb_index, 1);
 
@@ -254,7 +257,6 @@ void topk(
     }
     ckernel::topk_rebuild<stable_sort>(0, (int)ascending, 0, 32, 5, true);
     tile_regs_commit();
-
     tile_regs_wait();
     cb_reserve_back(cb_final_indices_transposed, 1);
     pack_reconfig_data_format(cb_final_indices_transposed);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -23,13 +23,15 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
-            acquire_dst();
+            tile_regs_acquire();
+            tile_regs_wait();
             copy_tile(in_cb, tile_id, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
             pack_tile(fused_act_dst_id, out_cb);
-            release_dst();
+            tile_regs_commit();
+            tile_regs_release();
             tile_id++;
         }
         cb_push_back(out_cb, N_block_tiles);
@@ -54,13 +56,15 @@ void add_bias_block(uint32_t in_cb, uint32_t bias_cb, uint32_t out_cb, uint32_t 
     uint32_t tile_id = 0;
     for (uint32_t m = 0; m < M_block_tiles; m++) {
         for (uint32_t n = 0; n < N_block_tiles; n++) {
-            acquire_dst();
+            tile_regs_acquire();
+            tile_regs_wait();
             add_tiles_bcast<BroadcastType::ROW>(in_cb, bias_cb, tile_id, n, fused_act_dst_id /*dst*/);
 #ifdef SFPU_OP_INIT_ACTIVATION
             SFPU_OP_FUNC_ACTIVATION
 #endif
             pack_tile(fused_act_dst_id, out_cb);
-            release_dst();
+            tile_regs_commit();
+            tile_regs_release();
             tile_id++;
         }
         cb_push_back(out_cb, N_block_tiles);
@@ -107,7 +111,6 @@ void add_bias_and_addcmul_block(
             add_tiles_bcast<BroadcastType::ROW>(intermediate_cb, bias_cb, tile_id, n, DST_ID);
 
             tile_regs_commit();
-
             tile_regs_wait();
             pack_tile(DST_ID, intermediate_cb);
             tile_regs_release();
@@ -245,7 +248,6 @@ void add_bias_and_addcmul_block(
             add_tiles(intermediate_cb, ternary_a_cb, tile_id, n, DST_ID);
 
             tile_regs_commit();
-
             tile_regs_wait();
             pack_tile(DST_ID, out_cb);
             tile_regs_release();
@@ -296,7 +298,6 @@ void matmul_blocks(
                 in1_index += full_N_block_tiles;
             }
             tile_regs_commit();
-
             tile_regs_wait();
             uint32_t write_dst_index = 0;
             for (uint32_t h = 0; h < subblock_h; h++) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
@@ -10,8 +10,14 @@
 #include "api/compute/matmul.h"
 #include "api/dataflow/circular_buffer.h"
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
 
 void kernel_main() {
     uint32_t argrt = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -10,8 +10,14 @@
 #include "api/compute/matmul.h"
 #include "api/dataflow/circular_buffer.h"
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -10,8 +10,14 @@
 #include "api/compute/matmul.h"
 #include "api/dataflow/circular_buffer.h"
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
 
 void kernel_main() {
     // TODO: Add back early return? Currently, running out of code size in TRISC2 by 4B

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded_row_major.cpp
@@ -10,8 +10,14 @@
 #include "api/compute/matmul.h"
 #include "api/dataflow/circular_buffer.h"
 
-ALWI void ACQ() { acquire_dst(); }
-ALWI void REL() { release_dst(); }
+ALWI void ACQ() {
+    tile_regs_acquire();
+    tile_regs_wait();
+}
+ALWI void REL() {
+    tile_regs_commit();
+    tile_regs_release();
+}
 
 void kernel_main() {
     // TODO: Add back early return? Currently, running out of code size in TRISC2 by 4B


### PR DESCRIPTION
### PR Category
Cleanup / Refactor

### Summary
Follow-up to #46112. That PR migrated 31 of 46 compute kernels off the deprecated `acquire_dst()` / `release_dst()` helpers and onto the explicit `tile_regs_*` lifecycle. Commit [3175bfb](https://github.com/tenstorrent/tt-metal/pull/46112/commits/3175bfb5d25c92f6de7b191b176164d74c9ca523) (`Revert changes for some files.`) dropped 15 files from #46112 so the merge queue would not stall on the codeowner groups that had not yet approved at the time. This PR re-applies the migration to those 15 files using the same MATH→PACK ordering:

```cpp
tile_regs_acquire();   // MATH
// compute work
tile_regs_commit();    // MATH
tile_regs_wait();      // PACK
// pack work
tile_regs_release();   // PACK
```

For helper wrappers (`ACQ()` / `REL()` in `moreh_common.hpp`) the original deprecated semantics are preserved by mapping them to `tile_regs_acquire(); tile_regs_wait();` / `tile_regs_commit(); tile_regs_release();` — matching the approach #46112 used for similar wrappers.

Files in scope (grouped by codeowner team that was `Pending approval` at #46112 merge time):

- `tenstorrent/metalium-developers-ds-prefill` (1): `ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp`
- `tenstorrent/metalium-developers-ttnn-core` (3): `ttnn/cpp/ttnn/kernel/compute/{eltwise_copy.cpp, moreh_common.hpp, transpose_wh.cpp}`
- `tenstorrent/metallium-maintainers-llama-models` (4): `ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama{,_fused_qk}/device/kernels/compute/*`
- `models/demos/deepseek_v3_b1` (1): `models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp`
- `tests/tt_metal/tt_metal/` (5): `bmm_large_block_zm_fused_bias_activation.cpp` (×2), `compute_local_l1.cpp`, `unary_bcast.cpp`, `reduce_block_max_row/compute.cpp`
- `ttnn/cpp/ttnn/operations/experimental/minimal_matmul/` (1): `device/kernels/compute.cpp`

Closes #46341
Relates to #46111, follows up on #46112

### Notes for reviewers
- For 14 of the 15 files this is the exact same migration #46112 already applied (then reverted); reviewers from the previously-pending codeowner groups can re-confirm their domain code with the original PR diff as reference.
- `models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp` was substantially refactored on `main` after #46112 was opened (the old `softmax_*` helper functions are gone). Only the 4 remaining `acquire_dst()` / `release_dst()` sites in `run_top32_llk` and `run_top32_llk_presorted_1024_opt` were migrated; the rest of the file already uses `tile_regs_*`. The MATH→PACK split is placed around the existing `PACK(TTI_SETADCXX(...))` / `pack_reconfig_data_format` / `pack_tile` block, mirroring what #46112 did for the same functions before they were reverted.
- `tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp` also evolved on `main` (`reduce_block_max_row_init<cols>` now takes `out_max_cb` as an argument); the new argument is preserved and `acquire_dst()` is replaced with `tile_regs_acquire()`.
- Please pay particular attention to nested or loop-carried acquire/release regions to confirm the explicit MATH/PACK boundaries still match the original critical sections.


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/deprecated_function_usages_follow_up)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/deprecated_function_usages_follow_up)