### PR TITLE
[Bug fix] Fix and re-enable Top32RmDevPipelineCompletes test

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
@@ -234,11 +234,13 @@ bool run_top32_rm_dev(
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     std::vector<uint32_t> compute_compile_args = {row_elements, num_in_tiles, kOutputTiles};
+    // The v2 kernel handles >= 1024 elements (whole 1024-chunk pre-sort path), while the original
+    // kernel handles < 1024 elements (64-elements-at-a-time path).
+    const char* compute_kernel = (row_elements >= 1024)
+                                     ? "tests/tt_metal/tt_metal/test_kernels/compute/top32_rm_dev_compute_v2.cpp"
+                                     : "tests/tt_metal/tt_metal/test_kernels/compute/top32_rm_dev_compute.cpp";
     CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/compute/top32_rm_dev_compute_v2.cpp",
-        crs,
-        ComputeConfig{.fp32_dest_acc_en = true, .compile_args = compute_compile_args});
+        program_, compute_kernel, crs, ComputeConfig{.fp32_dest_acc_en = true, .compile_args = compute_compile_args});
 
     SetRuntimeArgs(program_, reader, core, {buf_in0->address(), 0u, buf_in1->address(), 0u, num_in_tiles});
     SetRuntimeArgs(program_, writer, core, {buf_out0->address(), 0u, buf_out1->address(), 0u, kOutputTiles});
@@ -260,8 +262,11 @@ bool run_top32_rm_dev(
 
 }  // namespace unit_tests::compute::top32_rm_dev
 
-// Disabled: test is currently failing. See https://github.com/tenstorrent/tt-metal/issues/45713
-TEST_F(MeshDeviceFixture, DISABLED_Top32RmDevPipelineCompletes) {
+TEST_F(MeshDeviceFixture, Top32RmDevPipelineCompletes) {
+    // The top32_rm_dev kernels rely on Blackhole-only DeepSeek LLK headers; no WH B0 port exists yet.
+    if (this->arch_ != tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP() << "top32_rm_dev kernels are only supported on Blackhole";
+    }
     for (uint32_t row : {64u, 128u, 160u, 3232u}) {
         log_info(LogTest, "Top32 RM dev row_elements={}", row);
         EXPECT_TRUE(unit_tests::compute::top32_rm_dev::run_top32_rm_dev(this->devices_.at(0), row, 12345u));


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`MeshDeviceFixture.Top32RmDevPipelineCompletes` was disabled due to consistent `trisc1 compile failure` errors in the `top32_rm_dev_compute_v2` kernel across all CI hardware variants. Two root causes:

1. **Wrong architecture**: `top32_rm_dev_compute_v2.cpp` includes Blackhole-only DeepSeek LLK headers. The test was being run on Wormhole B0 devices where those headers cannot compile.

2. **Wrong kernel for small row sizes**: The test was hardcoded to always use `top32_rm_dev_compute_v2.cpp`, which implements the whole-1024-chunk pre-sort path (`row_elements >= 1024`). Test parameters include rows of 64, 128, and 160 elements, which require the original `top32_rm_dev_compute.cpp` (64-elements-at-a-time path).

This PR fixes both issues and re-enables the test.

Closes #45713

### Notes for reviewers

Changes are confined to `tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp`:

- Removes the `DISABLED_` prefix to re-enable the test.
- Adds a `GTEST_SKIP()` guard at the top of the test body for non-Blackhole architectures, since both compute kernels depend on Blackhole-specific LLK headers with no WH B0 port yet.
- Replaces the hardcoded `top32_rm_dev_compute_v2.cpp` path with a conditional: `>= 1024` elements uses v2 (whole-chunk pre-sort), `< 1024` uses the original (64-elements-at-a-time).

The CI disable entries in `tt-metal-l2-nightly.yaml` and `disabled_llk_filter` (PR #44767) can be removed after this lands.

Passing [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/27124578493)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/45713_fix_top32_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/45713_fix_top32_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/45713_fix_top32_test)