### PR TITLE
deepseek_v3_d_p MLA: chunked-prefill model path + unified test

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -102,7 +102,7 @@ ttnn:
 
 shield:
   e2e:
-    wh_llmbox: 53
+    wh_llmbox: 110
 
 # Former fabric + scaleout budgets merged under team scaleout (see tests/pipeline_reorg).
 scaleout:

--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -12,6 +12,7 @@ on:
           - module
           - moe_gate
           - mla
+          - mla_chunked
           - kv_cache_table
           - prefill_block
           - prefill_transformer

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
@@ -20,7 +20,8 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import rotate_half
-from models.demos.deepseek_v3_d_p.tt.mla.rope import block_cyclic_reorder, get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
+from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # RoPE is applied to the qk_rope_head_dim slice (64) in MLA. The op is dtype-agnostic; we use a

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -512,7 +512,7 @@ def _run_chunked_prefill(
       * "cpu"   -> synthetic inputs + torch MLA reference (k_pe in Meta basis). Partial-chunk iters
                    (rotation) allowed; any prefix is preloaded from the CPU reference KV.
       * "trace" -> GPU-trace inputs + reference (k_pe in HF basis, re-interleaved to compare). TRACE
-                   ONLY: requires DEEPSEEK_MLA_TRACE_DIR (skips if unset) and full-chunk iters.
+                   ONLY: requires DEEPSEEK_MLA_TRACE_DIR (skips if unset); supports partial iters.
       * None    -> no reference (functional/perf): random inputs + random prefix, finite-output check.
     Multi-user partitions iters_isl across users (last gets the remainder); each user is independent in
     its own cache slot, so cross-user contamination surfaces as a per-user output PCC drop.

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -21,11 +21,20 @@ from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_m
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
+    blockcyclic_cache_host,
+    blockcyclic_positions,
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
+    rotated_chip_positions,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import (
+    cpu_mla_reference,
+    discover_traces,
+    load_trace,
+    partition_iters,
+)
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -460,3 +469,341 @@ def test_kimi_mla(
         is_ci_v2_env,
         device_params,
     )
+
+
+# ---------------------------------------------------------------------------------------------------
+# Unified chunked-prefill driver. One loop (preload -> N iters of write+rope+ring_mla -> compare)
+# parametrized by where the prefix/reference come from. See test_mla_chunked_prefill below.
+# ---------------------------------------------------------------------------------------------------
+# Set DEEPSEEK_MLA_TRACE_DIR to the ROOT dir holding one subdir per layer-0 GPU trace (each with
+# mla_io/ + kv_cache/). It enables the prefill>0 scenarios (load the prior KV + reference from the
+# real GPU run); multi-user pulls one trace per user, cycling if there are fewer traces than users.
+DEEPSEEK_MLA_TRACE_DIR = os.environ.get("DEEPSEEK_MLA_TRACE_DIR")
+
+# Per-iteration VALID token counts for the rotation/padding edge cases, tuned for the TARGET 8x4 mesh
+# (sp=8, chunk_local=640, chunk=5120). Each cumulative kv_actual lands on a distinct rotation edge:
+# which chip the boundary falls on (0..7), chip-aligned vs mid-chip straddle (offset != 0), single vs
+# multi-slab, and how much of the chunk is pad. All values are tile-aligned (multiple of 32).
+ROTATED_VALID_LISTS = [
+    [640, 5120],  # aligned_min: iter0 = 1 chip valid (7 chips pad), then chip-1 rotated full
+    [672, 5120],  # midchip_straddle: frontier 1 tile into chip 1, then rotated with offset=32 straddle
+    [4480, 5120],  # lastchip: iter0 = 7 chips, rotation at the LAST chip (chip 7)
+    [1280, 1920, 5120],  # rot_partial: iter1 is rotated AND partial (3-chip valid, 5-chip pad)
+    [5120, 1280, 5120],  # multislab: rotation in slab 1 (multi-slab), partial then full
+    [5120, 5120],  # allfull: sanity, two full chunks at slab boundaries (aligned, no rotation)
+]
+ROTATED_VALID_IDS = ["aligned_min", "midchip_straddle", "lastchip", "rot_partial", "multislab", "allfull"]
+
+
+def _run_chunked_prefill(
+    request,
+    mesh_device,
+    *,
+    iters_isl,
+    reference="cpu",
+    chunk_size_global=5120,
+    prefill_len=0,
+    num_users=1,
+    use_pretrained=False,
+):
+    """Unified chunked-prefill scenario, decoupled from the reference.
+
+    `reference` selects how inputs + ground truth are produced -- independent of prefill_len / env:
+      * "cpu"   -> synthetic inputs + torch MLA reference (k_pe in Meta basis). Partial-chunk iters
+                   (rotation) allowed; any prefix is preloaded from the CPU reference KV.
+      * "trace" -> GPU-trace inputs + reference (k_pe in HF basis, re-interleaved to compare). TRACE
+                   ONLY: requires DEEPSEEK_MLA_TRACE_DIR (skips if unset) and full-chunk iters.
+      * None    -> no reference (functional/perf): random inputs + random prefix, finite-output check.
+    Multi-user partitions iters_isl across users (last gets the remainder); each user is independent in
+    its own cache slot, so cross-user contamination surfaces as a per-user output PCC drop.
+    """
+    assert reference in ("cpu", "trace", None), f"reference must be 'cpu'|'trace'|None, got {reference!r}"
+    sp_axis, tp_axis = 0, 1
+    mesh_shape = list(mesh_device.shape)
+    sp = mesh_shape[sp_axis]
+    tile = ttnn.TILE_SIZE
+    chunk_local = chunk_size_global // sp
+
+    assert chunk_size_global % (tile * sp) == 0, f"chunk_size_global {chunk_size_global} % (TILE*sp={tile * sp}) != 0"
+    for v in iters_isl:
+        assert 0 < v <= chunk_size_global and v % tile == 0, f"iter isl {v}: tile-aligned and <= {chunk_size_global}"
+    assert prefill_len % tile == 0, f"prefill_len {prefill_len} must be tile-aligned"
+
+    use_trace = reference == "trace"
+    if use_trace:
+        if DEEPSEEK_MLA_TRACE_DIR is None:
+            pytest.skip("reference='trace' requires DEEPSEEK_MLA_TRACE_DIR (trace-only scenario)")
+        # The trace is a DENSE token sequence; iters_isl just chunks it variably. Partial iters pad
+        # the device's fixed-width chunk (masked by causality) -- they are not pad in the sequence --
+        # so any iters_isl / prefill works exactly like the CPU ref. The only trace constraint is
+        # total_len <= trace length, asserted per-user below.
+        use_pretrained = True  # the GPU trace was generated with the real checkpoint
+
+    groups = partition_iters(iters_isl, num_users)
+    traces = discover_traces(DEEPSEEK_MLA_TRACE_DIR, num_users) if use_trace else None
+
+    # Cache holds the max (kv_actual + chunk) window across all users/iters, slab-aligned, >= 2 slabs.
+    max_window = chunk_size_global * 2
+    for g in groups:
+        ka = prefill_len
+        for v in g:
+            max_window = max(max_window, ka + chunk_size_global)
+            ka += v
+    seq_len_cache = ((max_window + chunk_size_global - 1) // chunk_size_global) * chunk_size_global
+
+    if use_pretrained:
+        config, sd = request.getfixturevalue("pretrained_transformer_weights")
+        weights = sd["layers"][0]["mla_weights"]
+    else:
+        config, weights = request.getfixturevalue("random_weights")
+    config.max_seq_len = seq_len_cache
+    kvpe_dim = config.kv_lora_rank + config.qk_rope_head_dim
+    hidden_size = config.hidden_size
+
+    logger.info(
+        f"chunked prefill: mesh={tuple(mesh_device.shape)} chunk={chunk_size_global} prefill={prefill_len} "
+        f"iters={iters_isl} users={num_users} reference={reference} "
+        f"weights={'pretrained' if use_pretrained else 'random'} seq_len_cache={seq_len_cache}"
+    )
+
+    # ---- per-user inputs + references. Each source provides hidden + (ref_out, ref_kvpe); the prior
+    #      prefix KV is carved from that same reference (random for the functional, ref-less mode). ----
+    users = []  # each: {group, total_len, hidden, ref_out|None, kv_prior|None, kv_post|None}
+    for u in range(num_users):
+        g = groups[u]
+        total_len = prefill_len + sum(g)
+        if reference == "trace":
+            mi, mo, kv = load_trace(traces[u])
+            assert total_len <= mi.shape[0], f"user {u}: prefill+iters {total_len} > trace len {mi.shape[0]}"
+            hidden, ref_out, ref_kvpe = mi[:total_len], mo[:total_len], kv[:total_len]
+        elif reference == "cpu":
+            torch.manual_seed(42 + u)
+            hidden = torch.randn(total_len, hidden_size, dtype=torch.bfloat16)
+            ref_out, ref_kvpe = cpu_mla_reference(config, weights, hidden)
+        else:  # None -> functional / perf, no reference
+            torch.manual_seed(100 + u)
+            hidden = torch.randn(total_len, hidden_size, dtype=torch.bfloat16)
+            ref_out, ref_kvpe = None, None
+
+        if prefill_len == 0:
+            kv_prior = None
+        elif ref_kvpe is not None:
+            kv_prior = ref_kvpe[:prefill_len]  # preload the reference's prior KV (cpu or trace)
+        else:
+            kv_prior = torch.randn(prefill_len, kvpe_dim, dtype=torch.bfloat16)  # functional: random prefix
+        users.append(
+            dict(group=g, total_len=total_len, hidden=hidden, ref_out=ref_out, kv_prior=kv_prior, kv_post=ref_kvpe)
+        )
+
+    # ---- device setup ----
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len_cache,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        topology=ttnn.Topology.Linear,
+        is_chunked=True,
+        slot_num=num_users,
+        layer_num=1,
+    )
+    rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
+    indexed_rope = rope_setup.get_rope_tensors_indexed(
+        cache_seq_len_global=seq_len_cache, chunk_size_global=chunk_size_global
+    )
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=kvpe_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len_cache,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=num_users,
+    )
+
+    hidden_shard_dims = [None, None]
+    hidden_shard_dims[tp_axis] = -1
+    hidden_shard_dims[sp_axis] = -2
+    out_concat_dims = [None, None]
+    out_concat_dims[tp_axis] = -1
+    out_concat_dims[sp_axis] = -2
+    cache_shard_dims = [None, None]
+    cache_shard_dims[sp_axis] = 2
+
+    # ---- preload the prior prefix (trace or random) into each slot, block-cyclic ----
+    if prefill_len > 0:
+        logger.info(f"Preloading {prefill_len}-token prefix into {num_users} slot(s) (block-cyclic host->device)...")
+        cache_host = torch.zeros(num_users, 1, seq_len_cache, kvpe_dim, dtype=torch.bfloat16)
+        for u in range(num_users):
+            cache_host[u, 0] = blockcyclic_cache_host(
+                users[u]["kv_prior"], sp, chunk_size_global, seq_len_cache, kvpe_dim
+            )[0, 0]
+        cache_host_tt = ttnn.from_torch(
+            cache_host,
+            dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=cache_shard_dims),
+        )
+        ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache)
+        ttnn.synchronize_device(mesh_device)
+
+    mesh_device.enable_program_cache()
+    # Accumulated natural-order output per user (only the measured region is filled).
+    out_accum = [torch.zeros(1, 1, users[u]["total_len"], hidden_size, dtype=torch.bfloat16) for u in range(num_users)]
+
+    # ---- iterate: interleave users by local iter index (exercises cross-user isolation) ----
+    n_iters = max(len(u["group"]) for u in users)
+    logger.info(f"Starting DEVICE chunked prefill: up to {n_iters} iters x {num_users} user(s)")
+    for i in range(n_iters):
+        for u in range(num_users):
+            g = users[u]["group"]
+            if i >= len(g):
+                continue
+            isl = g[i]
+            kv_actual = prefill_len + sum(g[:i])
+            valid_end = kv_actual + isl
+            total_len = users[u]["total_len"]
+
+            positions = rotated_chip_positions(kv_actual, sp, chunk_local)
+            flat = [positions[c][r] for c in range(sp) for r in range(chunk_local)]
+            gather_idx = torch.tensor([min(gp, total_len - 1) for gp in flat], dtype=torch.long)
+            chunk_in = users[u]["hidden"][gather_idx].clone()
+            chunk_in[torch.tensor([gp >= valid_end for gp in flat])] = 0.0
+
+            tt_h = ttnn.from_torch(
+                chunk_in.reshape(1, 1, chunk_size_global, hidden_size),
+                device=mesh_device,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=hidden_shard_dims
+                ),
+            )
+            tt_out = mla_tt.forward(
+                hidden_states=tt_h,
+                rope_tensors=indexed_rope,
+                kvpe_cache=tt_kvpe_cache,
+                kv_actual_isl=kv_actual,
+                cache_user_id=u,
+            )
+            out_flat = ttnn.to_torch(
+                tt_out,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(
+                    mesh_device, dims=out_concat_dims, mesh_shape=mesh_device.shape
+                ),
+            ).to(torch.bfloat16)[0, 0]
+
+            assert torch.isfinite(out_flat).all(), f"user {u} iter {i}: non-finite output"
+            valid_pairs = [(row, gp) for row, gp in enumerate(flat) if gp < valid_end]
+            src = torch.tensor([row for row, _ in valid_pairs], dtype=torch.long)
+            dst = torch.tensor([gp for _, gp in valid_pairs], dtype=torch.long)
+            out_accum[u][0, 0, dst, :] = out_flat[src, :]
+
+            if users[u]["ref_out"] is not None:
+                _, msg = assert_with_pcc(
+                    users[u]["ref_out"][kv_actual:valid_end].reshape(1, 1, isl, hidden_size),
+                    out_accum[u][:, :, kv_actual:valid_end, :],
+                    0.98,
+                )
+                rot = "rotated" if kv_actual % chunk_size_global != 0 else "aligned"
+                logger.info(f"  user {u} iter {i} (kv_actual={kv_actual} isl={isl} {rot}): out PCC {msg}")
+        ttnn.synchronize_device(mesh_device)
+        ttnn.distributed_context_barrier()
+
+    if reference is None:
+        logger.success(f"✓ Functional chunked prefill ran ({num_users} user(s), finite output)")
+        return
+
+    # ---- per-user full-measured-region output PCC ----
+    for u in range(num_users):
+        if users[u]["ref_out"] is None:
+            continue
+        meas = out_accum[u][:, :, prefill_len:, :]
+        ref_meas = users[u]["ref_out"][prefill_len:].reshape(1, 1, -1, hidden_size)
+        _, msg = assert_with_pcc(ref_meas, meas, 0.98)
+        logger.info(f"  user {u} full measured output PCC: {msg}")
+
+    # ---- check the measured KV cache vs the reference. The rotation accumulates into the canonical
+    #      block-cyclic layout, so blockcyclic_positions un-rotates the final cache (incl. partial
+    #      chunks). k_nope is compared directly; k_pe is direct for the CPU ref (mla_reference is
+    #      Meta-style) but re-interleaved for the GPU trace (HF half-split -> device Meta basis). ----
+    if any(users[u]["kv_post"] is not None for u in range(num_users)):
+        cache_sr = ttnn.to_torch(
+            tt_kvpe_cache,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+        ).to(torch.float32)[
+            :, :1
+        ]  # TP replica 0 -> [num_users, 1, seq_cache, kvpe]
+        p = blockcyclic_positions(sp, chunk_size_global, seq_len_cache)
+        kv_lora = config.kv_lora_rank
+        d = kvpe_dim - kv_lora
+        for u in range(num_users):
+            if users[u]["kv_post"] is None:
+                continue
+            nat = torch.empty(seq_len_cache, kvpe_dim, dtype=torch.float32)
+            nat[p] = cache_sr[u, 0]
+            dev = nat[prefill_len : users[u]["total_len"]]
+            ref = users[u]["kv_post"][prefill_len:].to(torch.float32)
+            ref_pe = ref[:, kv_lora:]
+            if use_trace:  # GPU trace stores k_pe HF half-split -> re-interleave to the device Meta basis
+                ref_pe = torch.stack([ref_pe[:, : d // 2], ref_pe[:, d // 2 :]], dim=-1).reshape(-1, d)
+            _, nope_msg = assert_with_pcc(ref[:, :kv_lora], dev[:, :kv_lora], 0.98)
+            _, pe_msg = assert_with_pcc(ref_pe, dev[:, kv_lora:], 0.98)
+            basis = "Meta-aligned" if use_trace else "direct"
+            logger.info(f"  user {u} KV cache PCC -- k_nope: {nope_msg}  k_pe[{basis}]: {pe_msg}")
+
+    logger.success(f"✓ Chunked prefill passed ({'trace' if use_trace else 'cpu'} ref, {num_users} user(s))")
+
+
+# Functionality scenarios (id, kwargs) -- PURE FUNCTIONALITY: no mesh, no reference. Mesh and
+# reference are SEPARATE pytest axes below (chunk=5120 is valid for sp in {2,4,8}), so the same
+# scenario runs on any mesh and is validated against either ground truth (or run functional) without
+# duplicating the case.
+_CHUNKED_SCENARIOS = (
+    [(f"rot-{rid}", dict(iters_isl=lst)) for rid, lst in zip(ROTATED_VALID_IDS, ROTATED_VALID_LISTS)]
+    # One representative case packing the most sp=8 edges: iter0 aligned partial, iter1 rotated
+    # chip-aligned (offset=0) partial, iter2 rotated mid-chip straddle (offset=32) + multi-slab + full.
+    + [("maxedge", dict(iters_isl=[2560, 2592, 5120]))]
+    + [
+        ("production-50k+5k", dict(iters_isl=[5120] * 11)),
+        ("multiuser-U2", dict(iters_isl=[5120] * 4, num_users=2)),
+        # Multi-user WITH padding/rotation: each user runs the full maxedge pattern in its own slot
+        # (partition splits [..]*2 into one maxedge per user), exercising rotation + cross-user isolation.
+        ("maxedge-multiuser-U2", dict(iters_isl=[2560, 2592, 5120] * 2, num_users=2)),
+        ("deep-50k+5k", dict(iters_isl=[5120], prefill_len=50 * 1024)),
+        ("deep-multiuser-U2", dict(iters_isl=[5120, 5120], prefill_len=50 * 1024, num_users=2)),
+    ]
+)
+
+
+# TODO(FABRIC_2D): the BH Galaxy 8x4 prefill target moved to FABRIC_2D (#45595, which fixed the MLA
+# ring all-gather writer this path uses). Add a fabric2d device_params variant (router config +
+# RELAXED_INIT + per-mesh num_links, via conftest's FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS) in a
+# follow-up, validated on BH Galaxy. This test currently covers FABRIC_1D only.
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], ids=["line"], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize("reference", ["cpu", "trace", None], ids=["cpu", "trace", "func"])
+@pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
+@pytest.mark.parametrize("variant", ["deepseek_v3_d_p", "kimi_k2_6"], indirect=True, ids=["deepseek_v3", "kimi"])
+@pytest.mark.timeout(0)
+def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_params, variant):
+    """Unified chunked-prefill driver crossed with independent mesh and reference axes. Each
+    functionality scenario (rotation edges, production depth, multi-user, deep prefix) runs on any mesh
+    and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', skips without
+    DEEPSEEK_MLA_TRACE_DIR), or run with no reference ('func'). Select with e.g.
+    -k 'maxedge and trace and 8x4'. See _run_chunked_prefill.
+
+    kimi_k2_6 reuses the same config-driven driver but is only supported for the random-weights,
+    non-trace path: the GPU traces are deepseek-only, and the chunked kimi path is validated against
+    the CPU torch reference with random weights (mirroring test_kimi_mla)."""
+    if variant.name == "kimi_k2_6":
+        if not is_blackhole():
+            pytest.skip("kimi_k2_6 requires Blackhole")
+        if reference == "trace":
+            pytest.skip("kimi_k2_6: GPU traces are deepseek-only (no Kimi traces)")
+        assert not kwargs.get("use_pretrained", False), "kimi_k2_6 chunked-prefill: random weights only"
+    _run_chunked_prefill(request, mesh_device, reference=reference, **kwargs)

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -797,13 +797,20 @@ def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_par
     DEEPSEEK_MLA_TRACE_DIR), or run with no reference ('func'). Select with e.g.
     -k 'maxedge and trace and 8x4'. See _run_chunked_prefill.
 
-    kimi_k2_6 reuses the same config-driven driver but is only supported for the random-weights,
-    non-trace path: the GPU traces are deepseek-only, and the chunked kimi path is validated against
-    the CPU torch reference with random weights (mirroring test_kimi_mla)."""
-    if variant.name == "kimi_k2_6":
-        if not is_blackhole():
-            pytest.skip("kimi_k2_6 requires Blackhole")
-        if reference == "trace":
-            pytest.skip("kimi_k2_6: GPU traces are deepseek-only (no Kimi traces)")
-        assert not kwargs.get("use_pretrained", False), "kimi_k2_6 chunked-prefill: random weights only"
+    Real weights on the CPU-reference path: point the variant's HF env var (DEEPSEEK_V3_HF_MODEL /
+    KIMI_K2_6_HF_MODEL) at a checkpoint to validate the chunked path against the CPU torch reference
+    with pretrained weights instead of random. create_mla_reference is config-driven and
+    architecture-agnostic (Kimi's YaRN/theta flow through, absorbed-MLA math matches the variant's own
+    reference), so this works for both variants. It complements the deepseek GPU-trace path, which only
+    replays full-chunk iters and so never exercises real weights across the rotation/partial-chunk edge
+    scenarios that the cpu path covers. Without the env var, fall back to random (mirroring
+    test_kimi_mla). kimi_k2_6 has no trace path (traces are deepseek-only) but otherwise runs the same
+    config-driven driver on any arch/mesh."""
+    if variant.name == "kimi_k2_6" and reference == "trace":
+        pytest.skip("kimi_k2_6: GPU traces are deepseek-only (no Kimi traces)")
+    # Opt into real weights on the cpu path when the variant's checkpoint env var is set. The "trace"
+    # path already forces pretrained; "func" is ref-less so weights don't matter. The pretrained
+    # fixture skips the test if the env var is set but the checkpoint is incomplete.
+    if reference == "cpu" and os.environ.get(variant.env_var) and not kwargs.get("use_pretrained"):
+        kwargs = {**kwargs, "use_pretrained": True}
     _run_chunked_prefill(request, mesh_device, reference=reference, **kwargs)

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -223,12 +223,22 @@ class ttMLA:
         is_balanced: bool = False,
         topology=ttnn.Topology.Linear,
         weight_cache_path: Optional[Path] = None,
+        is_chunked: bool = False,
+        slot_num: int = 1,
+        layer_num: int = 61,
     ):
         self.config = config
         self.mesh_device = mesh_device
         self.layer_idx = layer_idx
         self.is_balanced = is_balanced
         self.weight_cache_path = weight_cache_path
+        self.is_chunked = is_chunked
+        self.slot_num = slot_num
+        self.layer_num = layer_num
+
+        # The RoPE op is fixed by the configured mode: chunked prefill uses the indexed op,
+        # single-shot uses rotary_embedding_llama. Bind once here so forward doesn't re-decide.
+        self._apply_rope = self._apply_rope_padded if is_chunked else self._apply_rope_one_shot
 
         self.sp_axis = sp_axis
         self.tp_axis = tp_axis
@@ -293,71 +303,101 @@ class ttMLA:
         self.ccl_num_links = 2 if is_blackhole() else 1
         self.ccl_topology = topology
 
-        # ring attention setup
-        persistent_v_shard_dims = [None, None]
-        persistent_v_shard_dims[self.tp_axis] = 1  # TP heads
-        persistent_k_shard_dims = [None, None]
+        # Ring-attention persistent buffers. Chunked prefill (ring_mla) and the standard ring
+        # joint SDPA use disjoint buffer sets, so allocate only the one the configured mode needs --
+        # holding both would waste DRAM.
+        # TODO: these are scratch buffers reused across the whole ring op and don't hold per-layer
+        # state, so they should be allocated ONCE and shared by all layers. With the current per-layer
+        # ttMLA instance they are re-allocated for every layer -- wasted DRAM that scales with depth.
+        # Hoist them to a shared owner (or pass them in) when ttMLA instances are created per layer.
+        if self.is_chunked:
+            # Single combined gathered-KV buffer for ring_mla: K and V both come from the latent
+            # kvpe cache, so one (cache_batch, 1, seq_len, kvpe_dim) buffer replaces the separate
+            # per-K/per-V ring-SDPA buffers (and the dummy joint tensors) used in the other mode.
+            #
+            # TODO: reduce DRAM pressure -- ring_mla only ever gathers into the single
+            # kv_cache_batch_idx slot, but the op's TT_FATAL forces gathered-KV batch == cache
+            # batch (slot_num * layer_num). Allocating the full batch wastes DRAM for all but one
+            # slot; relaxing the op to index the gathered buffer independently (always slot 0)
+            # would let this be a batch-1 buffer.
+            cache_batch = self.slot_num * self.layer_num
+            kvpe_dim = self.kv_lora_rank + self.qk_rope_head_dim
+            self._chunked_kv_buf = ttnn.from_torch(
+                torch.zeros(cache_batch, 1, seq_len, kvpe_dim),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=[None, None]
+                ),
+            )
+        else:
+            # ring attention setup
+            persistent_v_shard_dims = [None, None]
+            persistent_v_shard_dims[self.tp_axis] = 1  # TP heads
+            persistent_k_shard_dims = [None, None]
 
-        ag_output_shape_k = (1, 1, seq_len, self.kv_lora_rank + self.qk_rope_head_dim)
-        ag_output_shape_v = (1, self.num_heads, seq_len, self.v_head_dim)
+            ag_output_shape_k = (1, 1, seq_len, self.kv_lora_rank + self.qk_rope_head_dim)
+            ag_output_shape_v = (1, self.num_heads, seq_len, self.v_head_dim)
 
-        self.persistent_k_output_buffer = ttnn.from_torch(
-            torch.zeros(ag_output_shape_k),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,  # hardcoded for now
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_k_shard_dims
-            ),
-        )
+            self.persistent_k_output_buffer = ttnn.from_torch(
+                torch.zeros(ag_output_shape_k),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,  # hardcoded for now
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_k_shard_dims
+                ),
+            )
 
-        self.persistent_v_output_buffer = ttnn.from_torch(
-            torch.zeros(ag_output_shape_v),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,  # hardcoded for now
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_v_shard_dims
-            ),
-        )
+            self.persistent_v_output_buffer = ttnn.from_torch(
+                torch.zeros(ag_output_shape_v),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,  # hardcoded for now
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_v_shard_dims
+                ),
+            )
 
-        # Pre-allocate dummy joint tensors for ring_joint_scaled_dot_product_attention (seq_len=0)
-        num_heads_local = self.num_heads // self.tp_factor
-        joint_shard_dims = [None, None]
-        joint_shard_dims[self.tp_axis] = 1  # shard on head dimension
+            # Pre-allocate dummy joint tensors for ring_joint_scaled_dot_product_attention (seq_len=0)
+            num_heads_local = self.num_heads // self.tp_factor
+            joint_shard_dims = [None, None]
+            joint_shard_dims[self.tp_axis] = 1  # shard on head dimension
 
-        self.joint_q = ttnn.from_torch(
-            torch.zeros(1, num_heads_local, 0, self.qk_head_dim),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
-            ),
-        )
+            self.joint_q = ttnn.from_torch(
+                torch.zeros(1, num_heads_local, 0, self.qk_head_dim),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
+                ),
+            )
 
-        self.joint_kv = ttnn.from_torch(
-            torch.zeros(1, 1, 0, self.kv_lora_rank + self.qk_rope_head_dim),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-        )
+            self.joint_kv = ttnn.from_torch(
+                torch.zeros(1, 1, 0, self.kv_lora_rank + self.qk_rope_head_dim),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
 
-        self.joint_v = ttnn.from_torch(
-            torch.zeros(1, num_heads_local, 0, self.v_head_dim),
-            device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ShardTensor2dMesh(
-                self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
-            ),
-        )
+            self.joint_v = ttnn.from_torch(
+                torch.zeros(1, num_heads_local, 0, self.v_head_dim),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
+                ),
+            )
 
         # Load weights to TT device
         weights = self._convert_and_cache_weights(
@@ -496,6 +536,113 @@ class ttMLA:
             exp_approx_mode=False,
         )
 
+    def _apply_rope_padded(self, t: ttnn.Tensor, rope_tensors: dict, kv_actual_isl: int) -> ttnn.Tensor:
+        """Chunked rotated RoPE via the indexed op. rope_tensors carry the whole-cache,
+        block-cyclic-sharded cos/sin (built once via RotarySetup.get_rope_tensors_indexed); the op
+        derives this chunk's per-chip shard offset on-device from kv_actual_global -- the same
+        update_idxt math the KV-cache writer uses, keeping rotation and cache write consistent.
+        """
+        return ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+            t,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            kv_actual_global=kv_actual_isl,
+            cluster_axis=self.sp_axis,
+        )
+
+    def _apply_rope_one_shot(
+        self, t: ttnn.Tensor, rope_tensors: dict, kv_actual_isl: Optional[int] = None
+    ) -> ttnn.Tensor:
+        """Single-shot RoPE: natural-order rope_tensors + rotary_embedding_llama."""
+        return ttnn.experimental.rotary_embedding_llama(
+            t,
+            rope_tensors["cos_matrix"],
+            rope_tensors["sin_matrix"],
+            rope_tensors["trans_matrix"],
+            is_decode_mode=False,
+        )
+
+    def _chunked_attn(
+        self,
+        *,
+        tt_q: ttnn.Tensor,
+        tt_kvpe: ttnn.Tensor,
+        kvpe_cache: ttnn.Tensor,
+        kv_actual_isl: int,
+        cache_batch_idx: int,
+        cache_layer_idx: int,
+        cache_user_id: int,
+        seq_len_local: int,
+        on_layer_complete: Optional[Callable[[int], None]],
+    ) -> ttnn.Tensor:
+        """Chunked-prefill attention via update_padded_kv_cache + ring_mla.
+
+        Unified path for both rotated (kv_actual_isl mid-slab) and chunk-aligned prefill: the
+        chunk-aligned case is the degenerate kv_actual_isl = n * chunk_size_global, where
+        update_padded_kv_cache reduces to a uniform per-chip write and the indexed rope/SDPA reduce
+        to natural order. K and V both come from the single latent kvpe cache -- ring_mla reads V as
+        the first kv_lora_rank columns of KV and materializes it in-op, so wkv_b2 is applied to the
+        compact (kv_lora_rank-wide) attention output afterwards. Returns attn_out in v_head_dim space.
+        """
+        assert not self.is_balanced, "chunked prefill currently requires is_balanced=False"
+        assert on_layer_complete is None, "on_layer_complete not yet supported in chunked prefill"
+
+        tile_size = ttnn.TILE_SIZE
+        chunk_size_global = seq_len_local * self.sp_factor
+        assert chunk_size_global % (tile_size * self.sp_factor) == 0, (
+            f"chunk_size_global ({chunk_size_global}) must be a multiple of "
+            f"TILE_SIZE * sp_factor ({tile_size * self.sp_factor})"
+        )
+        assert kv_actual_isl % tile_size == 0, f"kv_actual_isl ({kv_actual_isl}) must be tile-aligned"
+
+        # Write this chunk into the cache. update_padded_kv_cache derives each chip's local write
+        # offset on-device from kv_actual_global (chunk-aligned kv_actual -> uniform per-chip write).
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            kvpe_cache,
+            tt_kvpe,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self.layer_num,
+            kv_actual_global=kv_actual_isl,
+            cluster_axis=self.sp_axis,
+        )
+
+        # K and V are the single latent kvpe cache (V = first kv_lora_rank columns, materialized
+        # in-op). logical_n = prior valid length + this chunk; cache_batch_idx selects this
+        # user/layer's slot; kv_actual_isl drives the on-device rotation/causality offset.
+        attn_out, _ = ttnn.transformer.ring_mla(
+            tt_q,
+            kvpe_cache,
+            persistent_output_buffer_kv=self._chunked_kv_buf,
+            head_dim_v=self.kv_lora_rank,
+            logical_n=kv_actual_isl + chunk_size_global,
+            program_config=self._get_sdpa_program_config(seq_len_local),
+            scale=self.scale,
+            compute_kernel_config=self.default_compute_kernel_config,
+            dim=2,
+            multi_device_global_semaphore=self.tt_ccl.ring_attention_ccl_semaphore_handles,
+            num_links=self.ccl_num_links,
+            cluster_axis=self.sp_axis,
+            mesh_device=self.mesh_device,
+            topology=self.ccl_topology,
+            subdevice_id=self.tt_ccl.worker_sub_device_id,
+            ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
+            use_column_major_ccl=True,
+            is_balanced=self.is_balanced,
+            kv_cache_batch_idx=cache_batch_idx,
+            kv_actual_isl=kv_actual_isl,
+        )
+
+        # ring_mla output is in kv_lora_rank (latent V) space; expand to v_head_dim per head.
+        attn_out = ttnn.linear(
+            attn_out,
+            self.wkv_b2_weight,
+            compute_kernel_config=self.default_compute_kernel_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return attn_out
+
     # Expects ativation in form of:
     # [1, batch_size == 1, seq_len // sp_factor, hidden_size // tp_factor]
     def forward(
@@ -506,10 +653,31 @@ class ttMLA:
         cache_layer_idx: int = 0,
         on_layer_complete: Optional[Callable[[int], None]] = None,
         actual_isl: Optional[int] = None,
+        kv_actual_isl: Optional[int] = None,
+        cache_user_id: int = 0,
     ) -> ttnn.Tensor:
         signpost(header="MLA_START")
         num_heads_local = self.num_heads // self.tp_factor
         seq_len_local = hidden_states.shape[2]
+
+        # Chunked-prefill mode is selected by passing kv_actual_isl (the cumulative count of valid
+        # KV tokens already in the cache before this chunk; 0 for the first chunk). When None we run
+        # the original single-shot path. The two paths share the Q/KV projection + rope prologue and
+        # the nlp_concat_heads + o_proj epilogue; they differ only in cache write, attention op, and
+        # where wkv_b2 is applied. See _chunked_attn for the unified chunked implementation.
+        is_chunked = kv_actual_isl is not None
+        # Buffers are pre-allocated per-mode in __init__, so the per-call mode must match how this
+        # ttMLA was constructed (chunked -> _chunked_kv_buf; non-chunked -> persistent_k/v + joint).
+        assert is_chunked == self.is_chunked, (
+            f"forward mode (is_chunked={is_chunked}, from kv_actual_isl) does not match construction "
+            f"(self.is_chunked={self.is_chunked}); the required ring buffers are not allocated"
+        )
+
+        # Cache batch dim is user-major: each user reserves self.layer_num contiguous slots, so the
+        # flat slot is cache_user_id * layer_num + cache_layer_idx (reduces to cache_layer_idx for the
+        # single-user default cache_user_id == 0).
+        assert cache_user_id < self.slot_num, f"cache_user_id {cache_user_id} >= slot_num {self.slot_num}"
+        cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
 
         # q_projection
         tt_q = ttnn.linear(
@@ -582,13 +750,7 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b1", seq_len_local),
         )
 
-        tt_q_rope = ttnn.experimental.rotary_embedding_llama(
-            tt_q_rope,
-            rope_tensors["cos_matrix"],
-            rope_tensors["sin_matrix"],
-            rope_tensors["trans_matrix"],
-            is_decode_mode=False,
-        )
+        tt_q_rope = self._apply_rope(tt_q_rope, rope_tensors, kv_actual_isl)
 
         # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
         tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
@@ -634,74 +796,87 @@ class ttMLA:
             compute_kernel_config=self.default_compute_kernel_config,
         )
 
-        tt_kv_rope = ttnn.experimental.rotary_embedding_llama(
-            tt_kv_rope,
-            rope_tensors["cos_matrix"],
-            rope_tensors["sin_matrix"],
-            rope_tensors["trans_matrix"],
-            is_decode_mode=False,
-        )
+        tt_kv_rope = self._apply_rope(tt_kv_rope, rope_tensors, kv_actual_isl)
 
         # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
         tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
         ttnn.deallocate(tt_kv_rope)
         tt_kvpe = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
 
-        # Zero the padding region of THIS layer's slot before fill so migration
-        # streams clean zeros (not residual data from a prior request) for the
-        # decode side. Slice the cache to batch=cache_layer_idx so the page math
-        # in zero_cache_range hits this layer's slot, not layer 0.
-        if on_layer_complete is not None:
-            assert actual_isl is not None, "actual_isl required when on_layer_complete is set"
-            seq_len_local = kvpe_cache.shape[2]
-            seq_len_total = seq_len_local * self.sp_factor
-            zero_cache_padding_zigzag(
-                kvpe_cache=kvpe_cache[cache_layer_idx],
-                global_end_token=actual_isl,
-                sp_factor=self.sp_factor,
-                seq_len=seq_len_total,
-                decode_chunk_align=DECODE_CHUNK_ALIGN,
-                tp_factor=self.tp_factor,
+        if not is_chunked:
+            # === single-shot prefill: fill the whole local slot, run on-device ring SDPA with a
+            # materialized V (wkv_b2 applied before attention). Unchanged from the original path. ===
+
+            # Zero the padding region of THIS layer's slot before fill so migration
+            # streams clean zeros (not residual data from a prior request) for the
+            # decode side. Slice the cache to batch=cache_layer_idx so the page math
+            # in zero_cache_range hits this layer's slot, not layer 0.
+            if on_layer_complete is not None:
+                assert actual_isl is not None, "actual_isl required when on_layer_complete is set"
+                seq_len_local = kvpe_cache.shape[2]
+                seq_len_total = seq_len_local * self.sp_factor
+                zero_cache_padding_zigzag(
+                    kvpe_cache=kvpe_cache[cache_layer_idx],
+                    global_end_token=actual_isl,
+                    sp_factor=self.sp_factor,
+                    seq_len=seq_len_total,
+                    decode_chunk_align=DECODE_CHUNK_ALIGN,
+                    tp_factor=self.tp_factor,
+                )
+
+            ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
+
+            if on_layer_complete is not None:
+                on_layer_complete(self.layer_idx)
+
+            tt_v_embedding = ttnn.linear(
+                tt_kv_nope,
+                self.wkv_b2_weight,
+                compute_kernel_config=self.default_compute_kernel_config,
+                **self._get_mm_kwargs("wkv_b2", seq_len_local),
             )
 
-        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
-
-        if on_layer_complete is not None:
-            on_layer_complete(self.layer_idx)
-
-        tt_v_embedding = ttnn.linear(
-            tt_kv_nope,
-            self.wkv_b2_weight,
-            compute_kernel_config=self.default_compute_kernel_config,
-            **self._get_mm_kwargs("wkv_b2", seq_len_local),
-        )
-
-        attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
-            tt_q,
-            tt_kvpe,
-            tt_v_embedding,
-            self.joint_q,
-            self.joint_kv,
-            self.joint_v,
-            persistent_output_buffer_k=self.persistent_k_output_buffer,
-            persistent_output_buffer_v=self.persistent_v_output_buffer,
-            joint_strategy="rear",
-            logical_n=seq_len_local * self.sp_factor,
-            program_config=self._get_sdpa_program_config(seq_len_local),
-            compute_kernel_config=self.default_compute_kernel_config,
-            dim=2,
-            multi_device_global_semaphore=self.tt_ccl.ring_attention_ccl_semaphore_handles,
-            num_links=self.ccl_num_links,
-            cluster_axis=self.sp_axis,
-            mesh_device=self.mesh_device,
-            topology=self.ccl_topology,
-            subdevice_id=self.tt_ccl.worker_sub_device_id,
-            ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
-            use_column_major_ccl=True,
-            is_causal=True,
-            scale=self.scale,
-            is_balanced=self.is_balanced,
-        )
+            attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                tt_q,
+                tt_kvpe,
+                tt_v_embedding,
+                self.joint_q,
+                self.joint_kv,
+                self.joint_v,
+                persistent_output_buffer_k=self.persistent_k_output_buffer,
+                persistent_output_buffer_v=self.persistent_v_output_buffer,
+                joint_strategy="rear",
+                logical_n=seq_len_local * self.sp_factor,
+                program_config=self._get_sdpa_program_config(seq_len_local),
+                compute_kernel_config=self.default_compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=self.tt_ccl.ring_attention_ccl_semaphore_handles,
+                num_links=self.ccl_num_links,
+                cluster_axis=self.sp_axis,
+                mesh_device=self.mesh_device,
+                topology=self.ccl_topology,
+                subdevice_id=self.tt_ccl.worker_sub_device_id,
+                ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
+                use_column_major_ccl=True,
+                is_causal=True,
+                scale=self.scale,
+                is_balanced=self.is_balanced,
+            )
+        else:
+            # === chunked prefill: write this chunk into the cache at its per-chip offset, then run
+            # ring_mla over the populated prefix with V materialized in-op from the latent KV. wkv_b2
+            # is applied to the compact attention output afterwards (see _chunked_attn). ===
+            attn_out = self._chunked_attn(
+                tt_q=tt_q,
+                tt_kvpe=tt_kvpe,
+                kvpe_cache=kvpe_cache,
+                kv_actual_isl=kv_actual_isl,
+                cache_batch_idx=cache_batch_idx,
+                cache_layer_idx=cache_layer_idx,
+                cache_user_id=cache_user_id,
+                seq_len_local=seq_len_local,
+                on_layer_complete=on_layer_complete,
+            )
 
         v_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         v_out = ttnn.linear(

--- a/models/demos/deepseek_v3_d_p/tt/mla/rope.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/rope.py
@@ -6,7 +6,11 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3YarnRotaryEmbedding
-from models.demos.deepseek_v3_d_p.tt.mla.utils import create_balanced_chunk_order, reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.tt.mla.utils import (
+    block_cyclic_reorder,
+    create_balanced_chunk_order,
+    reorder_tensor_chunks,
+)
 
 
 def get_rot_transformation_mat():
@@ -55,24 +59,6 @@ def get_cos_sin_matrix(hf_config):
     return cos, sin
 
 
-def block_cyclic_reorder(matrix: torch.Tensor, chunk_local: int, sp_factor: int, seq_dim: int = 2) -> torch.Tensor:
-    """Reorder a [.., seq, ..] matrix into block-cyclic order keyed by `chunk_local`.
-
-    Splits the sequence into blocks of `chunk_local` rows and concatenates them so that device c's
-    contiguous shard (after a plain SP shard over `seq_dim`) holds blocks c, c+sp, c+2sp, ... — the
-    same block-cyclic layout the per-chip KV cache writes into. This makes the indexed-RoPE op's
-    contiguous, `update_idxt`-offset read of each device's cos/sin shard land on the right global
-    positions, including the boundary chip's older-then-wrap rows.
-    """
-    seq_len = matrix.shape[seq_dim]
-    assert seq_len % chunk_local == 0, f"seq_len {seq_len} must be a multiple of chunk_local {chunk_local}"
-    num_blocks = seq_len // chunk_local
-    assert num_blocks % sp_factor == 0, f"num_blocks {num_blocks} must be a multiple of sp_factor {sp_factor}"
-    blocks = list(torch.split(matrix, chunk_local, dim=seq_dim))
-    order = [b for c in range(sp_factor) for b in range(c, num_blocks, sp_factor)]
-    return torch.cat([blocks[b] for b in order], dim=seq_dim)
-
-
 class RotarySetup:
     """Rotary positional embedding setup for MLA prefill with SP sharding and balanced reordering."""
 
@@ -107,6 +93,80 @@ class RotarySetup:
             chunk_order = create_balanced_chunk_order(self.sp_factor)
             cos_matrix_torch = reorder_tensor_chunks(cos_matrix_torch, chunk_order, seq_dim=2)
             sin_matrix_torch = reorder_tensor_chunks(sin_matrix_torch, chunk_order, seq_dim=2)
+
+        shard_dims = [None, None]
+        shard_dims[self.sp_axis] = 2
+
+        cos_matrix = ttnn.from_torch(
+            cos_matrix_torch,
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.mesh_device.shape),
+        )
+        sin_matrix = ttnn.from_torch(
+            sin_matrix_torch,
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.mesh_device.shape),
+        )
+
+        trans_mat_torch = get_rot_transformation_mat()
+        trans_matrix = ttnn.from_torch(
+            trans_mat_torch,
+            device=self.mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        return {"cos_matrix": cos_matrix, "sin_matrix": sin_matrix, "trans_matrix": trans_matrix}
+
+    def get_rope_tensors_indexed(self, cache_seq_len_global: int, chunk_size_global: int) -> dict[str, ttnn.Tensor]:
+        """Get whole-cache cos/sin/trans matrices for the KV-pad-aware *indexed* rotated path.
+
+        This builds the rope values for the *entire* cache once. The cos/sin are
+        block-cyclic-reordered keyed by the per-chip chunk size and SP-sharded, so device ``c``'s
+        contiguous shard holds -- in local-cache-row order -- the rope values for every global
+        position it will ever carry. ``rotary_embedding_indexed`` then derives each chunk's start
+        row in that shard on-device from a single ``kv_actual_global`` runtime arg (the same
+        ``update_idxt`` math the per-chip KV-cache writer uses), so the same tensors are reused
+        across all chunks and only ``kv_actual_global`` varies.
+
+        Args:
+            cache_seq_len_global: total cache length in tokens across all SP devices (the cos/sin
+                cover every position the cache can hold). Per-chip shard = cache_seq_len_global // sp.
+            chunk_size_global: global chunk size (one chunk across all SP devices). Per-chip chunk =
+                chunk_size_global // sp_factor, which keys the block-cyclic reorder.
+
+        Constraints (mirroring the block-cyclic / cache layout):
+            * ``cache_seq_len_global <= max_seq_len``
+            * ``chunk_size_global % (TILE_SIZE * sp_factor) == 0``
+            * ``cache_seq_len_global % chunk_size_global == 0``
+        """
+        assert not self.is_balanced, "indexed rotated rope is incompatible with is_balanced"
+        sp = self.sp_factor
+        assert (
+            cache_seq_len_global <= self.hf_config.max_seq_len
+        ), f"cache_seq_len_global ({cache_seq_len_global}) must be <= max_seq_len {self.hf_config.max_seq_len}"
+        assert (
+            chunk_size_global % (ttnn.TILE_SIZE * sp) == 0
+        ), f"chunk_size_global ({chunk_size_global}) must be a multiple of TILE_SIZE * sp ({ttnn.TILE_SIZE * sp})"
+        assert cache_seq_len_global % chunk_size_global == 0, (
+            f"cache_seq_len_global ({cache_seq_len_global}) must be a multiple of "
+            f"chunk_size_global ({chunk_size_global})"
+        )
+        chunk_local = chunk_size_global // sp
+
+        cos_matrix_torch, sin_matrix_torch = get_cos_sin_matrix(self.hf_config)
+        cos_matrix_torch = cos_matrix_torch[..., :cache_seq_len_global, :]
+        sin_matrix_torch = sin_matrix_torch[..., :cache_seq_len_global, :]
+
+        # Block-cyclic reorder keyed by the per-chip chunk so a plain SP shard hands device c the
+        # rope values for every global position it carries, in local-cache-row order.
+        cos_matrix_torch = block_cyclic_reorder(cos_matrix_torch, chunk_local, sp, seq_dim=2)
+        sin_matrix_torch = block_cyclic_reorder(sin_matrix_torch, chunk_local, sp, seq_dim=2)
 
         shard_dims = [None, None]
         shard_dims[self.sp_axis] = 2

--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -66,6 +66,87 @@ def reverse_reorder_tensor_chunks(tensor: torch.Tensor, chunk_order: list[int], 
     return reorder_tensor_chunks(tensor, inverse_order, seq_dim)
 
 
+def block_cyclic_reorder(matrix: torch.Tensor, chunk_local: int, sp_factor: int, seq_dim: int = 2) -> torch.Tensor:
+    """Reorder a [.., seq, ..] matrix into block-cyclic order keyed by `chunk_local`.
+
+    Splits the sequence into blocks of `chunk_local` rows and concatenates them so that device c's
+    contiguous shard (after a plain SP shard over `seq_dim`) holds blocks c, c+sp, c+2sp, ... — the
+    same block-cyclic layout the per-chip KV cache writes into. This makes the indexed-RoPE op's
+    contiguous, `update_idxt`-offset read of each device's cos/sin shard land on the right global
+    positions, including the boundary chip's older-then-wrap rows.
+    """
+    seq_len = matrix.shape[seq_dim]
+    assert seq_len % chunk_local == 0, f"seq_len {seq_len} must be a multiple of chunk_local {chunk_local}"
+    num_blocks = seq_len // chunk_local
+    assert num_blocks % sp_factor == 0, f"num_blocks {num_blocks} must be a multiple of sp_factor {sp_factor}"
+    blocks = list(torch.split(matrix, chunk_local, dim=seq_dim))
+    order = [b for c in range(sp_factor) for b in range(c, num_blocks, sp_factor)]
+    return torch.cat([blocks[b] for b in order], dim=seq_dim)
+
+
+def rotated_chip_positions(kv_actual_isl: int, sp: int, chunk_local: int) -> list[list[int]]:
+    """Per-chip global position for each chip-local row after the server's KV-pad-aware rotation,
+    mirroring the writer kernel EXACTLY. positions[c][r] is the global token position carried by
+    chip c's r-th rotated row.
+
+    Slab-aware: each chip writes chunk_local rows starting at update_idxt, and the cache cell at
+    local row lr on chip c holds global position (lr // chunk_local)*chunk_size_global +
+    c*chunk_local + (lr % chunk_local). The union over all (c, r) tiles
+    [kv_actual_isl, kv_actual_isl + chunk_size_global) exactly, so the first new_actual_isl
+    positions are the contiguous valid range and the rest are pad (masked by causality) -- no
+    separate new_actual_isl plumbing needed.
+    """
+    chunk_size_global = sp * chunk_local
+    boundary_slab = kv_actual_isl // chunk_size_global
+    boundary_chip = (kv_actual_isl // chunk_local) % sp
+    boundary_offset = kv_actual_isl % chunk_local
+
+    positions = [[0] * chunk_local for _ in range(sp)]
+    for c in range(sp):
+        if c < boundary_chip:
+            update_idxt = (boundary_slab + 1) * chunk_local
+        elif c == boundary_chip:
+            update_idxt = boundary_slab * chunk_local + boundary_offset
+        else:
+            update_idxt = boundary_slab * chunk_local
+        for r in range(chunk_local):
+            lr = update_idxt + r
+            positions[c][r] = (lr // chunk_local) * chunk_size_global + c * chunk_local + (lr % chunk_local)
+    return positions
+
+
+def blockcyclic_positions(sp: int, chunk_size_global: int, seq_len_cache: int) -> torch.Tensor:
+    """Global natural position held by each block-cyclic shard row (device-major: an SP-contiguous
+    split of the cache's seq dim yields each chip's rows).
+
+    Shard row r -> chip c = r // seq_len_local, local row lr = r % seq_len_local, and that row holds
+    global position (lr // chunk_local) * chunk_size_global + c * chunk_local + (lr % chunk_local) --
+    the inverse of the update_padded_kv_cache writer. Returns a [seq_len_cache] index tensor.
+    """
+    seq_len_local = seq_len_cache // sp
+    chunk_local = chunk_size_global // sp
+    c = torch.arange(sp).repeat_interleave(seq_len_local)
+    lr = torch.arange(seq_len_local).repeat(sp)
+    slab, off = lr // chunk_local, lr % chunk_local
+    return slab * chunk_size_global + c * chunk_local + off
+
+
+def blockcyclic_cache_host(
+    kv_natural: torch.Tensor, sp: int, chunk_size_global: int, seq_len_cache: int, kvpe_dim: int
+) -> torch.Tensor:
+    """Arrange a natural-order [seq, kvpe] KV tensor into the device cache's block-cyclic slab-major
+    layout so that an SP-contiguous shard of dim 2 gives each chip its own rows. Rows whose global
+    position is beyond the provided KV (e.g. the not-yet-written new chunk) stay zero. Returns
+    [1, 1, seq_len_cache, kvpe_dim].
+    """
+    prior_len = kv_natural.shape[0]
+    p = blockcyclic_positions(sp, chunk_size_global, seq_len_cache)
+    out = torch.zeros(seq_len_cache, kvpe_dim, dtype=kv_natural.dtype)
+    valid = p < prior_len
+    out[valid] = kv_natural[p[valid]]
+    return out.reshape(1, 1, seq_len_cache, kvpe_dim)
+
+
 def global_to_local_token_id(
     global_token_id: int,
     sp_factor: int,

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -20,11 +20,12 @@ from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_refe
 
 
 def discover_traces(root, num_users):
-    """Immediate subdirs of `root`, one per user (cycled if fewer than num_users). Assert mla_io/."""
+    """Immediate subdirs of `root`, one per user (cycled if fewer than num_users). Assert mla_io/ + kv_cache/."""
     dirs = sorted(d for d in Path(root).iterdir() if d.is_dir())
     assert dirs, f"no trace subdirs under {root}"
     for d in dirs:
         assert (d / "mla_io").is_dir(), f"trace dir {d} is missing mla_io/"
+        assert (d / "kv_cache").is_dir(), f"trace dir {d} is missing kv_cache/"
     return [dirs[u % len(dirs)] for u in range(num_users)]
 
 

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test helpers for the unified chunked-prefill MLA test (test_mla.py::test_mla_chunked_prefill):
+GPU-trace discovery/loading, multi-user iteration partitioning, and the CPU torch MLA reference.
+
+Kept out of tt/mla/utils.py on purpose: these pull the reference model + safetensors, which should
+not enter the production model import path.
+"""
+
+import time
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors.torch import load_file
+from transformers.cache_utils import DynamicCache
+
+from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
+
+
+def discover_traces(root, num_users):
+    """Immediate subdirs of `root`, one per user (cycled if fewer than num_users). Assert mla_io/."""
+    dirs = sorted(d for d in Path(root).iterdir() if d.is_dir())
+    assert dirs, f"no trace subdirs under {root}"
+    for d in dirs:
+        assert (d / "mla_io").is_dir(), f"trace dir {d} is missing mla_io/"
+    return [dirs[u % len(dirs)] for u in range(num_users)]
+
+
+def load_trace(d):
+    """Return (mla_input [S,H], mla_output [S,H], kv_post [S,kvpe]) for layer 0, all bf16."""
+    mi = load_file(d / "mla_io" / "mla_input_layer_0.safetensors")["mla_input_layer_0"]
+    mo = load_file(d / "mla_io" / "mla_output_layer_0.safetensors")["mla_output_layer_0"]
+    kv = load_file(d / "kv_cache" / "layer_0.safetensors")["kv_post_transform_layer_0"]
+    return mi.to(torch.bfloat16), mo.to(torch.bfloat16), kv.to(torch.bfloat16)
+
+
+def partition_iters(iters_isl, num_users):
+    """Split iters_isl into num_users contiguous groups; the LAST user takes the remainder."""
+    assert len(iters_isl) >= num_users, f"need >= {num_users} iters to split across {num_users} users"
+    base = len(iters_isl) // num_users
+    groups, idx = [], 0
+    for u in range(num_users):
+        n = base if u < num_users - 1 else len(iters_isl) - base * (num_users - 1)
+        groups.append(list(iters_isl[idx : idx + n]))
+        idx += n
+    return groups
+
+
+def cpu_mla_reference(config, weights, hidden_2d):
+    """torch MLA forward over [S, H] hidden. Returns (output [S, H], kvpe [S, kvpe]) bf16 -- kvpe is
+    the reference KV cache (Meta-style rope), for comparing the device cache directly. Host-attn logs."""
+    mla_ref = (
+        create_mla_reference(
+            config=config,
+            state_dict={"model.layers.0.self_attn." + k: v for k, v in weights.items()},
+            layer_idx=0,
+            module_path="model.layers.0.self_attn",
+        )
+        .eval()
+        .to(torch.bfloat16)
+    )
+    pos = torch.arange(hidden_2d.shape[0], dtype=torch.long).unsqueeze(0)
+    logger.warning(
+        f"===== HOST ATTENTION START: torch MLA reference over {hidden_2d.shape[0]} tokens "
+        f"(CPU chunked-flash, {config.num_attention_heads} heads) -- slow CPU phase ====="
+    )
+    t0 = time.perf_counter()
+    ref_cache = DynamicCache()
+    with torch.no_grad():
+        out, _, ref_cache = mla_ref(
+            hidden_states=hidden_2d.unsqueeze(0), position_ids=pos, past_key_value=ref_cache, use_cache=True
+        )
+    logger.warning(f"===== HOST ATTENTION END: torch reference done in {time.perf_counter() - t0:.1f}s =====")
+    kvpe = ref_cache.key_cache[0][0, 0]  # [S, kvpe], latent k_nope + roped k_pe (Meta basis)
+    return out[0].to(torch.bfloat16), kvpe.to(torch.bfloat16)

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -147,7 +147,7 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
     return lookup_table
 
 
-def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers):
+def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers, num_users=1):
     """
     Initialize KVPE cache for MLA.
 
@@ -157,15 +157,18 @@ def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_ax
         seq_len: Sequence length
         mesh_shape: Shape of mesh device
         sp_axis: Sequence parallel axis
-        num_kvpe_cache_layers: Number of layers for KVPE cache
+        num_kvpe_cache_layers: Number of layers per user in the cache.
+        num_users: Number of independent users sharing the cache. The batch dim
+            is laid out user-major: slot index = user_id * num_kvpe_cache_layers + layer_idx,
+            so each user's layers stay contiguous.
 
     Returns:
         tt_kvpe_cache: Initialized KVPE cache on device
     """
-    # hack in num_layers into batch size, so they are contiguous in memory
+    # hack in num_users * num_layers into batch size, so each user's layers are contiguous in memory
     num_layers = num_kvpe_cache_layers
     seq_len_local = seq_len // mesh_shape[sp_axis]
-    torch_kvpe_cache = torch.zeros(num_layers, 1, seq_len_local, kvpe_cache_head_dim)
+    torch_kvpe_cache = torch.zeros(num_users * num_layers, 1, seq_len_local, kvpe_cache_head_dim)
 
     core_ranges = [
         ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -261,6 +261,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and pcc_check and not fabric2d' -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d" -vvv --tb=short --timeout=900 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device and not fabric2d-" -vvv --tb=short || exit_code=$?
     exit $exit_code

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -39,6 +39,19 @@
   owner_id: U08RL15T4N8
   team: models
 
+- name: "(Galaxy) DeepSeek Prefill - MLA Chunked"
+  cmd: |
+    export MESH_DEVICE=TG
+    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 8x4 and line and not multiuser" -vvv --tb=short
+  test_type: mla_chunked
+  test_group: module
+  skus:
+    bh_galaxy:
+      timeout: 30
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+
 - name: "(Galaxy) DeepSeek Prefill - KV cache table"
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -131,6 +131,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -vvv --tb=short -k "mesh-4x2" --timeout 900
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run and pcc_check and not fabric2d' -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short
   skus:
     wh_llmbox:
       timeout: 18

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -134,7 +134,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short
   skus:
     wh_llmbox:
-      timeout: 18
+      timeout: 75
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield
   model-name: deepseek_prefill


### PR DESCRIPTION
Resolves #46349. Rebases the chunked-prefill MLA work onto `main` (the ops — `update_padded_kv_cache`, `rotary_embedding_indexed`, `ring_mla` — are already upstream) and adds a single, decoupled test driver for it.

## Model (`tt/mla/mla.py`)
- `is_chunked` / `slot_num` / `layer_num` init params; ring buffers allocated **per-mode** (chunked → one combined `_chunked_kv_buf`; non-chunked → `persistent_k/v` + joint) so the unused set's DRAM isn't paid. `forward` asserts the per-call mode matches construction. *(TODO noted: hoist the per-layer scratch buffers to a shared owner.)*
- `_apply_rope` bound at init to the indexed (chunked) vs `rotary_embedding_llama` (single-shot) op.
- Chunked `ring_mla` SDPA `program_config` now comes from model config (`_get_sdpa_program_config`), like the non-chunked path; dropped the per-call `chunked_q/k_chunk_size` forward args.
- Dropped `num_cache_layers` from `forward`/`_chunked_attn`; the cache slot derives from `self.layer_num` (`cache_user_id * layer_num + cache_layer_idx`).

## Utils
- `tt/mla/utils.py`: KV-layout helpers (`block_cyclic_reorder`, `rotated_chip_positions`, `blockcyclic_positions`, `blockcyclic_cache_host`) — torch-only, safe for the model import path.
- `utils/chunked_prefill_utils.py`: test-only helpers (GPU-trace I/O, multi-user iter partition, CPU torch MLA reference) — kept **off** the model import path (they pull the reference model + safetensors).

## Test (`tests/test_mla.py`)
One driver, `test_mla_chunked_prefill`, crossed over **three independent axes** — functionality scenario × mesh × reference. Reference (`cpu` torch / `trace` GPU ground-truth / `func`) and mesh are no longer baked into a case.

Scenarios: sp=8-tuned **rotation edge** patterns (each isolates one edge), a **`maxedge`** representative (chip-aligned + mid-chip straddle + multi-slab in 3 iters), **production**/**deep**-prefix, and **multi-user** (incl. a padded `maxedge-multiuser`).

Checks: per-iter + full-prefix output PCC, plus a per-user **KV-cache** check (`k_nope` direct; `k_pe` Meta-aligned for the HF trace basis). `reference="trace"` skips without `DEEPSEEK_MLA_TRACE_DIR` and asserts the trace is long enough.

**Variants:** the config-driven driver runs both `deepseek_v3_d_p` and `kimi_k2_6` (64 heads vs 128, same kvpe=576). Kimi is supported on the **random-weights, non-trace** path only (GPU traces are deepseek-only): kimi+`trace` and kimi+non-Blackhole skip, kimi+pretrained asserts. Validated: `kimi-maxedge-cpu-2x2` passes vs the CPU reference.

Validated on hardware: 2x2 CPU rotation + multi-user (PCC ≥ 0.996, cache ≈ 0.9998); single-step 8x4 vs GPU trace (output 0.9941, `k_nope` 0.99986, `k_pe` 0.99994 after Meta-interleave).

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased) 
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased) -> chunked mla tests pass
- [x] [![t3000-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased) -> chunked mla tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/chunked_prefill_mla_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/chunked_prefill_mla_rebased)
