### PR TITLE
#46124: add back to back output equality to mm/fused/reduce tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -12,6 +12,10 @@ from models.common.utility_functions import tt2torch_tensor, torch2tt_tensor
 
 from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_allclose, comp_pcc
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_rms_norm_post_all_gather,
+    ttnn_layer_norm_post_all_gather,
+)
 
 
 def reference_layernorm(x, gamma, beta, epsilon, is_rmsnorm):
@@ -95,7 +99,7 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
         )
 
         if is_rmsnorm:
-            tt_lnp2_out = ttnn.rms_norm_post_all_gather(
+            tt_lnp2_out = ttnn_rms_norm_post_all_gather(
                 tt_inp,
                 tt_stats,
                 epsilon=epsilon,
@@ -104,7 +108,7 @@ def run_layernorm_part_2(inp_shape, n_devices, is_rmsnorm, input_dtype, output_d
                 dtype=output_dtype,
             )
         else:
-            tt_lnp2_out = ttnn.layer_norm_post_all_gather(
+            tt_lnp2_out = ttnn_layer_norm_post_all_gather(
                 tt_inp,
                 tt_stats,
                 epsilon=epsilon,
@@ -235,7 +239,7 @@ def test_layer_norm_post_all_gather_non_tile_aligned_width(device, input_w):
         )
 
     epsilon = 1e-5
-    out_ttnn = ttnn.layer_norm_post_all_gather(
+    out_ttnn = ttnn_layer_norm_post_all_gather(
         to_device(inp),
         to_device(stats),
         epsilon=epsilon,
@@ -323,7 +327,7 @@ def test_layer_norm_post_all_gather_bias_only_matches_torch(device):
         tt_memory_config=dram_memcfg,
     )
 
-    tt_out = ttnn.layer_norm_post_all_gather(
+    tt_out = ttnn_layer_norm_post_all_gather(
         tt_inp,
         tt_stats,
         epsilon=epsilon,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -12,6 +12,13 @@ import ttnn
 from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_allclose_and_pcc
 from tests.ttnn.utils_for_testing import assert_equal, assert_numeric_metrics, tt_dtype_to_torch_dtype
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_layer_norm_pre_all_gather,
+    ttnn_rms_norm_pre_all_gather,
+    ttnn_layer_norm_post_all_gather,
+    ttnn_layer_norm,
+)
+
 
 TEST_PADDING_VALUE = -42
 
@@ -73,9 +80,9 @@ def ln_pre_allgather_op(xs, n_devices, is_rmsnorm, out_dtpe, kernel_config):
     tt_out = []
     for d in range(n_devices):
         if is_rmsnorm:
-            tt_out.append(ttnn.rms_norm_pre_all_gather(xs[d], compute_kernel_config=kernel_config, dtype=out_dtpe))
+            tt_out.append(ttnn_rms_norm_pre_all_gather(xs[d], compute_kernel_config=kernel_config, dtype=out_dtpe))
         else:
-            tt_out.append(ttnn.layer_norm_pre_all_gather(xs[d], compute_kernel_config=kernel_config, dtype=out_dtpe))
+            tt_out.append(ttnn_layer_norm_pre_all_gather(xs[d], compute_kernel_config=kernel_config, dtype=out_dtpe))
     return tt_out
 
 
@@ -252,7 +259,7 @@ def run_layernorm_pre_post_gamma_only_pcc(device, use_pre_all_gather: bool):
         tt_memory_config=dram_memcfg,
     )
 
-    tt_out = ttnn.layer_norm_post_all_gather(
+    tt_out = ttnn_layer_norm_post_all_gather(
         tt_inp,
         tt_stats,
         epsilon=epsilon,
@@ -532,7 +539,7 @@ def test_layernorm_pre_all_gather_residual_padding_zeroed(device, inp_shape):
     # Poison residual's implicit tile padding. A correct op must ignore these values.
     tt_res = ttnn.fill_implicit_tile_padding(tt_res, POISON)
 
-    tt_stats = ttnn.layer_norm_pre_all_gather(
+    tt_stats = ttnn_layer_norm_pre_all_gather(
         tt_inp,
         residual_input_tensor=tt_res,
         dtype=ttnn.bfloat16,
@@ -611,7 +618,7 @@ def test_layernorm_pre_all_gather_residual_mismatched_dtype(device, inp_dtype, r
         torch_res, tt_dtype=res_dtype, tt_device=device, tt_layout=ttnn.TILE_LAYOUT, tt_memory_config=dram_memcfg
     )
 
-    tt_stats = ttnn.layer_norm_pre_all_gather(
+    tt_stats = ttnn_layer_norm_pre_all_gather(
         tt_inp,
         residual_input_tensor=tt_res,
         dtype=ttnn.bfloat16,
@@ -775,7 +782,7 @@ def test_layernorm_pre_all_gather_welford_residual(device, inp_shape, inp_dtype,
     # Passing residual_input_tensor causes the program factory to set the FUSE_PRE_ADD
     # compile-time define, so the kernel is compiled with the in-kernel add path: it reads
     # tt_inp and tt_res into separate CBs and adds them via add_tiles before the welford pass.
-    stats_fused = ttnn.layer_norm_pre_all_gather(
+    stats_fused = ttnn_layer_norm_pre_all_gather(
         tt_inp,
         residual_input_tensor=tt_res,
         dtype=stats_dtype,
@@ -787,7 +794,7 @@ def test_layernorm_pre_all_gather_welford_residual(device, inp_shape, inp_dtype,
     # No residual_input_tensor is passed, so the program factory does not set FUSE_PRE_ADD
     # and the kernel is compiled without the in-kernel add path entirely. The kernel sees
     # a single, already-summed input. Mathematically equivalent to stats_fused.
-    stats_combined = ttnn.layer_norm_pre_all_gather(
+    stats_combined = ttnn_layer_norm_pre_all_gather(
         tt_combined,
         dtype=stats_dtype,
         compute_kernel_config=kernel_config,
@@ -900,11 +907,11 @@ def test_pre_allgather_ignores_implicit_tile_padding(device, inp_shape):
         device=device,
     )
 
-    stats_from_torch = ttnn.layer_norm_pre_all_gather(
+    stats_from_torch = ttnn_layer_norm_pre_all_gather(
         tt_from_torch,
         dtype=ttnn.bfloat16,
     )
-    stats_from_ones = ttnn.layer_norm_pre_all_gather(
+    stats_from_ones = ttnn_layer_norm_pre_all_gather(
         tt_ones,
         dtype=ttnn.bfloat16,
     )
@@ -980,7 +987,7 @@ def test_layernorm_pre_all_gather_welford_fp32_precision(device, inp_shape, offs
         )
         residual_kwargs["residual_input_tensor"] = tt_res
 
-    tt_stats = ttnn.layer_norm_pre_all_gather(
+    tt_stats = ttnn_layer_norm_pre_all_gather(
         tt_inp,
         dtype=ttnn.float32,
         compute_kernel_config=kernel_config,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -16,7 +16,6 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_layer_norm_pre_all_gather,
     ttnn_rms_norm_pre_all_gather,
     ttnn_layer_norm_post_all_gather,
-    ttnn_layer_norm,
 )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
@@ -8,6 +8,10 @@ import ttnn
 
 from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_rms_norm_pre_all_gather,
+    ttnn_rms_norm_post_all_gather,
+)
 
 
 def _run_distributed_rmsnorm_single_device(
@@ -68,7 +72,7 @@ def _run_distributed_rmsnorm_single_device(
 
     # Step 1: per-shard pre-all-gather stats.
     tt_stats = [
-        ttnn.rms_norm_pre_all_gather(
+        ttnn_rms_norm_pre_all_gather(
             t,
             compute_kernel_config=compute_kernel_config,
             dtype=ttnn.bfloat16,
@@ -82,7 +86,7 @@ def _run_distributed_rmsnorm_single_device(
 
     # Step 3: per-shard post-all-gather norm using the gathered stats.
     tt_outputs = [
-        ttnn.rms_norm_post_all_gather(
+        ttnn_rms_norm_post_all_gather(
             tt_inputs[i],
             tt_stats_gathered,
             epsilon=eps,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -10,6 +10,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import run_for_blackhole
 
 import tests.ttnn.unit_tests.operations.fused.test_group_norm as base
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_group_norm
 
 
 @pytest.mark.parametrize("specify_grid", [True, False])
@@ -47,7 +48,7 @@ def test_group_norm_large_ex_external_cb(device, specify_grid):
             is_row_major=False,
         )
 
-    output_tensor_tt = ttnn.group_norm(
+    output_tensor_tt = ttnn_group_norm(
         input_tensor_tt,
         num_groups=num_groups,
         epsilon=eps,
@@ -171,7 +172,7 @@ def test_group_norm_sharded_ex_external_cb_gap(device, specify_grid):
     )
     input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem_config)
 
-    output_tensor = ttnn.group_norm(
+    output_tensor = ttnn_group_norm(
         input_tensor,
         num_groups=num_groups,
         epsilon=eps,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm.py
@@ -10,7 +10,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from models.common.utility_functions import run_for_blackhole
 
 import tests.ttnn.unit_tests.operations.fused.test_group_norm as base
-from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_group_norm
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_group_norm, ttnn_group_norm_in_place
 
 
 @pytest.mark.parametrize("specify_grid", [True, False])
@@ -172,7 +172,9 @@ def test_group_norm_sharded_ex_external_cb_gap(device, specify_grid):
     )
     input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem_config)
 
-    output_tensor = ttnn_group_norm(
+    # group_norm defaults to inplace=True here, which mutates the input; use the in-place
+    # determinism wrapper so the two runs each get a fresh clone of the input.
+    output_tensor = ttnn_group_norm_in_place(
         input_tensor,
         num_groups=num_groups,
         epsilon=eps,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -34,6 +34,8 @@ from loguru import logger
 
 import ttnn
 from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm
+
 
 # Poison value to ensure Welford's algorithm ignores padded elements (#31982)
 PAD_VALUE = -42
@@ -103,7 +105,7 @@ def _run_ttnn_layer_norm(
         ln_kwargs["weight"] = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
     if torch_bias is not None:
         ln_kwargs["bias"] = ttnn.from_torch(torch_bias, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.layer_norm(input_tensor, **ln_kwargs)
+    output_tensor = ttnn_layer_norm(input_tensor, **ln_kwargs)
     output_tensor = ttnn.from_device(output_tensor)
     return ttnn.to_torch(output_tensor)
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -33,6 +33,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm
 
@@ -264,7 +265,7 @@ _FP32_NEAR_ZERO_ATOL_FRACTION = 0.004
 @pytest.mark.parametrize("distribution", ["normal", "wide_uniform", "centered_uniform"])
 def test_layer_norm_ulp_fp32_no_weight_bias(device, h, w, desc, use_welford, distribution):
     """FP32 layer_norm ULP vs torch float32 golden (no weight/bias); fp32_dest_acc_en=True only."""
-    if ttnn.is_blackhole(device) and use_welford and w == 4096:
+    if is_blackhole() and use_welford and w == 4096:
         # The large-tensor Welford layer_norm kernels produce nondeterministic FP32 output on
         # Blackhole (back-to-back runs differ; failure disappears under watcher), so the
         # determinism check in ttnn_layer_norm trips. Tracked in issue #46523.

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -264,6 +264,11 @@ _FP32_NEAR_ZERO_ATOL_FRACTION = 0.004
 @pytest.mark.parametrize("distribution", ["normal", "wide_uniform", "centered_uniform"])
 def test_layer_norm_ulp_fp32_no_weight_bias(device, h, w, desc, use_welford, distribution):
     """FP32 layer_norm ULP vs torch float32 golden (no weight/bias); fp32_dest_acc_en=True only."""
+    if ttnn.is_blackhole(device) and use_welford and w == 4096:
+        # The large-tensor Welford layer_norm kernels produce nondeterministic FP32 output on
+        # Blackhole (back-to-back runs differ; failure disappears under watcher), so the
+        # determinism check in ttnn_layer_norm trips. Tracked in issue #46523.
+        pytest.skip("Blackhole large-tensor Welford layer_norm is nondeterministic (FP32); see #46523")
     torch.manual_seed(0)
     torch_input_tensor = _make_ln_input(h, w, torch.float32, distribution)
     golden = torch.nn.functional.layer_norm(torch_input_tensor, normalized_shape=[w])

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -12,6 +12,7 @@ import ttnn
 
 from models.common.utility_functions import torch2tt_tensor, run_for_blackhole
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm, ttnn_rms_norm
 
 TEST_PADDING_VALUE = -42
 
@@ -61,7 +62,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
         )
 
         if test_id == 0:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -69,7 +70,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 1:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -78,7 +79,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 2:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -88,7 +89,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 3:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -96,7 +97,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 4:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -105,7 +106,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 5:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t,
                 residual_input_tensor=in1_t,
                 epsilon=epsf,
@@ -115,11 +116,11 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 6:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t, epsilon=epsf, memory_config=out_mem_config, compute_kernel_config=compute_kernel_config
             )
         if test_id == 7:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t,
                 epsilon=epsf,
                 weight=gamma_t,
@@ -127,7 +128,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 8:
-            ttz = ttnn.layer_norm(
+            ttz = ttnn_layer_norm(
                 in0_t,
                 epsilon=epsf,
                 weight=gamma_t,
@@ -136,11 +137,11 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 9:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t, epsilon=epsf, memory_config=out_mem_config, compute_kernel_config=compute_kernel_config
             )
         if test_id == 10:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t,
                 epsilon=epsf,
                 weight=gamma_t,
@@ -148,7 +149,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
                 compute_kernel_config=compute_kernel_config,
             )
         if test_id == 11:
-            ttz = ttnn.rms_norm(
+            ttz = ttnn_rms_norm(
                 in0_t,
                 epsilon=epsf,
                 weight=gamma_t,
@@ -304,7 +305,7 @@ def test_layer_norm_block_sharded_height_pad(device, grid_end, shard_orientation
         fp32_dest_acc_en=True,
     )
 
-    out = ttnn.layer_norm(
+    out = ttnn_layer_norm(
         x,
         weight=weight,
         bias=bias,
@@ -349,7 +350,7 @@ def test_layer_norm_4D_llama(device, h, w, num_chunks):
     weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
     bias = ttnn.from_torch(torch_bias, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias)
+    output_tensor = ttnn_layer_norm(input_tensor, weight=weight, bias=bias)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -11,7 +11,10 @@ import math
 
 from models.common.utility_functions import torch2tt_tensor
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
-from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm, ttnn_rms_norm
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_layer_norm_in_place,
+    ttnn_rms_norm_in_place,
+)
 
 
 def rms_norm(x, dim, gamma, beta, eps):
@@ -147,7 +150,7 @@ def test_layernorm_sharded_mix_precision_rm(
     )
 
     if test_id == 0:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -156,7 +159,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 1:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -166,7 +169,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 2:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -177,7 +180,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 3:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -186,7 +189,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 4:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -196,7 +199,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 5:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -207,7 +210,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 6:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -215,7 +218,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 7:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -224,7 +227,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 8:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -234,7 +237,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 9:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -242,7 +245,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 10:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -251,7 +254,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 11:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -425,7 +428,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
     )
 
     if test_id == 0:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -434,7 +437,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 1:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -444,7 +447,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 2:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -455,7 +458,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 3:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -464,7 +467,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 4:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -474,7 +477,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 5:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -485,7 +488,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 6:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -493,7 +496,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 7:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -502,7 +505,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 8:
-        ttz = ttnn_layer_norm(
+        ttz = ttnn_layer_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -512,7 +515,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 9:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -520,7 +523,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 10:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -529,7 +532,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 11:
-        ttz = ttnn_rms_norm(
+        ttz = ttnn_rms_norm_in_place(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -11,6 +11,7 @@ import math
 
 from models.common.utility_functions import torch2tt_tensor
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm, ttnn_rms_norm
 
 
 def rms_norm(x, dim, gamma, beta, eps):
@@ -146,7 +147,7 @@ def test_layernorm_sharded_mix_precision_rm(
     )
 
     if test_id == 0:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -155,7 +156,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 1:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -165,7 +166,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 2:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -176,7 +177,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 3:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -185,7 +186,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 4:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -195,7 +196,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 5:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -206,7 +207,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 6:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -214,7 +215,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 7:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -223,7 +224,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 8:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -233,7 +234,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 9:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -241,7 +242,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 10:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -250,7 +251,7 @@ def test_layernorm_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 11:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -424,7 +425,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
     )
 
     if test_id == 0:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -433,7 +434,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 1:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -443,7 +444,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 2:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -454,7 +455,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 3:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -463,7 +464,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 4:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -473,7 +474,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 5:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             residual_input_tensor=in1_t_shard,
             epsilon=epsf,
@@ -484,7 +485,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 6:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -492,7 +493,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 7:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -501,7 +502,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 8:
-        ttz = ttnn.layer_norm(
+        ttz = ttnn_layer_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -511,7 +512,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 9:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             memory_config=out_mem_config,
@@ -519,7 +520,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 10:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,
@@ -528,7 +529,7 @@ def test_layernorm_1d_sharded_mix_precision_rm(
             compute_kernel_config=compute_kernel_config,
         )
     if test_id == 11:
-        ttz = ttnn.rms_norm(
+        ttz = ttnn_rms_norm(
             in0_t_shard,
             epsilon=epsf,
             weight=gamma_t,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
@@ -18,6 +18,7 @@ from tt_lib.utils import (
 )
 from models.common.utility_functions import is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_rms_norm
 
 TEST_PADDING_VALUE = -42
 
@@ -79,13 +80,13 @@ def run_rmsnorm_tests(test_id, dtype, in0_mem_config, out_mem_config, device):
 
         if test_id == 0:
             logger.info("Running RMSN_NOGB")
-            ttz = ttnn.rms_norm(ttx, epsilon=epsf, memory_config=out_mem_config)
+            ttz = ttnn_rms_norm(ttx, epsilon=epsf, memory_config=out_mem_config)
         elif test_id == 1:
             logger.info("Running RMSN_G")
-            ttz = ttnn.rms_norm(ttx, epsilon=epsf, weight=ttgamma, memory_config=out_mem_config)
+            ttz = ttnn_rms_norm(ttx, epsilon=epsf, weight=ttgamma, memory_config=out_mem_config)
         elif test_id == 2:
             logger.info("Running RMSN_GB")
-            ttz = ttnn.rms_norm(ttx, epsilon=epsf, weight=ttgamma, bias=ttbeta, memory_config=out_mem_config)
+            ttz = ttnn_rms_norm(ttx, epsilon=epsf, weight=ttgamma, bias=ttbeta, memory_config=out_mem_config)
         else:
             assert False
         logger.info("Done")
@@ -162,7 +163,7 @@ def test_llama_4D_rms_norm(device, h, w):
     input_tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
     weight = ttnn.from_torch(torch_weight.reshape(1, 1, w // 32, 32), device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
-    output_tensor = ttnn.rms_norm(input_tensor, weight=weight)
+    output_tensor = ttnn_rms_norm(input_tensor, weight=weight)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -212,7 +213,7 @@ def test_large_tensor_rms_norm(device, batch_size, w):
             packer_l1_acc=True,
         )
 
-        output_tensor = ttnn.rms_norm(
+        output_tensor = ttnn_rms_norm(
             input_tensor,
             weight=weight,
             epsilon=epsilon,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_single_core_fused_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_single_core_fused_ops.py
@@ -10,6 +10,8 @@ import ttnn
 
 from models.common.utility_functions import torch2tt_tensor
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax_in_place, ttnn_layer_norm
+
 
 TEST_PADDING_VALUE = -42
 
@@ -22,7 +24,7 @@ def test_softmax(shape, device):
     x = torch.randn(shape).bfloat16().float()
     xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
     xt = ttnn.fill_implicit_tile_padding(xt, TEST_PADDING_VALUE)
-    xtt = ttnn.softmax_in_place(xt)
+    xtt = ttnn_softmax_in_place(xt)
 
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
@@ -50,7 +52,7 @@ def test_layernorm(shape, device):
     gammat = torch2tt_tensor(gamma, device)
     betat = torch2tt_tensor(beta, device)
 
-    xtt = ttnn.layer_norm(xt, epsilon=1e-5, weight=gammat, bias=betat)
+    xtt = ttnn_layer_norm(xt, epsilon=1e-5, weight=gammat, bias=betat)
 
     tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax
 
 
 @pytest.mark.parametrize("shape", [[2, 10, 512, 8192]])
@@ -23,7 +24,7 @@ def test_ttnn_softmax_sdxl_attention(device, shape):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     torch_output = F.softmax(torch_input, dim=-1, dtype=torch.bfloat16)
-    tt_output = ttnn.softmax(tt_input, dim=-1, numeric_stable=True)
+    tt_output = ttnn_softmax(tt_input, dim=-1, numeric_stable=True)
     tt_output_torch = ttnn.to_torch(tt_output)
     # PCC at bf16 on Wt=256 numeric-stable softmax is sensitive to the small/large-kernel
     # choice in softmax_program_factory_attention_optimized.cpp; 0.998 is within bf16 noise.
@@ -38,7 +39,7 @@ def test_ttnn_softmax_sdxl_attention(device, shape):
 
     # test program cache
     torch_output2 = F.softmax(torch_output, dim=-1, dtype=torch.bfloat16)
-    tt_output2 = ttnn.softmax(tt_output, dim=-1, numeric_stable=True)
+    tt_output2 = ttnn_softmax(tt_output, dim=-1, numeric_stable=True)
     tt_output_torch2 = ttnn.to_torch(tt_output2)
     assert_numeric_metrics(
         torch_output2,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
@@ -16,6 +16,13 @@ from tt_lib.utils import (
 )
 from models.common.utility_functions import print_diff_argmax
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_softmax,
+    ttnn_scale_mask_softmax,
+    ttnn_softmax_in_place,
+    ttnn_scale_mask_softmax_in_place,
+)
+
 
 TEST_PADDING_VALUE = -42
 
@@ -28,7 +35,7 @@ TEST_PADDING_VALUE = -42
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax(device, inplace, dtype):
     torch.manual_seed(0)
-    sm_op = ttnn.softmax_in_place if inplace else ttnn.softmax
+    sm_op = ttnn_softmax_in_place if inplace else ttnn_softmax
 
     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32), (1, 64, 24, 42)]
 
@@ -74,7 +81,7 @@ def test_softmax(device, inplace, dtype):
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax_with_program_cache(device, inplace):
     torch.manual_seed(0)
-    sm_op = ttnn.softmax_in_place if inplace else ttnn.softmax
+    sm_op = ttnn_softmax_in_place if inplace else ttnn_softmax
 
     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32), (1, 64, 24, 42)]
 
@@ -109,7 +116,7 @@ def test_softmax_with_program_cache(device, inplace):
 @pytest.mark.parametrize("inplace", [True, False])
 def test_softmax_mix_precision(device, inplace, in_dtype):
     torch.manual_seed(0)
-    sm_op = ttnn.softmax_in_place if inplace else ttnn.softmax
+    sm_op = ttnn_softmax_in_place if inplace else ttnn_softmax
 
     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32), (1, 64, 24, 42)]
 
@@ -215,7 +222,7 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, causal_mas
             fp32_dest_acc_en=False,
         )
 
-    tt_output = ttnn.scale_mask_softmax_in_place(
+    tt_output = ttnn_scale_mask_softmax_in_place(
         in1_t, scale, attention_mask_t, is_causal_mask=causal_mask, compute_kernel_config=compute_kernel_config
     )
 
@@ -275,7 +282,7 @@ def test_scale_mask_softmax(device, in_dtype, in0_mem_config):
         input_tensor, dtype=in_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in0_mem_config
     )
 
-    tt_output = ttnn.scale_mask_softmax(in1_t, scale, attention_mask_t)
+    tt_output = ttnn_scale_mask_softmax(in1_t, scale, attention_mask_t)
 
     tt_output_tensor = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
     tt_output_tensor = ttnn.from_device(tt_output_tensor)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_sharded.py
@@ -15,6 +15,7 @@ from tt_lib.utils import (
     untilize,
 )
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_scale_mask_softmax_in_place
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
@@ -32,7 +33,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 )
 def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
     torch.manual_seed(0)
-    sm_op = ttnn.scale_mask_softmax_in_place
+    sm_op = ttnn_scale_mask_softmax_in_place
 
     fuse_head = 2
 
@@ -115,7 +116,7 @@ def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
 )
 def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
     torch.manual_seed(0)
-    sm_op = ttnn.scale_mask_softmax_in_place
+    sm_op = ttnn_scale_mask_softmax_in_place
 
     fuse_head = 2
 
@@ -207,7 +208,7 @@ def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
 )
 def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
     torch.manual_seed(0)
-    sm_op = ttnn.scale_mask_softmax_in_place
+    sm_op = ttnn_scale_mask_softmax_in_place
 
     fuse_head = 1
 
@@ -303,7 +304,7 @@ def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
 )
 def test_softmax_with_sharded_mask(device, in_dtype, in0_mem_config, shard_orient):
     torch.manual_seed(0)
-    sm_op = ttnn.scale_mask_softmax_in_place
+    sm_op = ttnn_scale_mask_softmax_in_place
 
     grid_size = (8, 4)
     input_shape = (1, 32, 32, 1024)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_sharded.py
@@ -33,7 +33,9 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttn
 )
 def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
     torch.manual_seed(0)
-    sm_op = ttnn_scale_mask_softmax_in_place
+    # Single-call (no determinism wrapper): the in-place wrapper clones the sharded input, and
+    # on Blackhole that extra L1 buffer clashes with the statically-allocated circular buffers.
+    sm_op = ttnn.scale_mask_softmax_in_place
 
     fuse_head = 2
 
@@ -116,7 +118,9 @@ def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
 )
 def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
     torch.manual_seed(0)
-    sm_op = ttnn_scale_mask_softmax_in_place
+    # Single-call (no determinism wrapper): the in-place wrapper clones the sharded input, and
+    # on Blackhole that extra L1 buffer exhausts L1 / clashes with the static circular buffers.
+    sm_op = ttnn.scale_mask_softmax_in_place
 
     fuse_head = 2
 
@@ -208,7 +212,9 @@ def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
 )
 def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
     torch.manual_seed(0)
-    sm_op = ttnn_scale_mask_softmax_in_place
+    # Single-call (no determinism wrapper): the in-place wrapper clones the sharded input, and
+    # on Blackhole that extra L1 buffer exhausts L1 / clashes with the static circular buffers.
+    sm_op = ttnn.scale_mask_softmax_in_place
 
     fuse_head = 1
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_ulp.py
@@ -34,6 +34,7 @@ from loguru import logger
 
 import ttnn
 from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +71,7 @@ def _run_ttnn_softmax(
 ) -> torch.Tensor:
     tt_input = ttnn.from_torch(input_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn.fill_implicit_tile_padding(tt_input, 42)
-    tt_out = ttnn.softmax(
+    tt_out = ttnn_softmax(
         tt_input,
         dim=dim,
         compute_kernel_config=compute_kernel_config,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -58,6 +58,12 @@ def ttnn_group_norm(*args, **kwargs):
     return _run_twice(ttnn.group_norm, *args, **kwargs)
 
 
+def ttnn_group_norm_in_place(input_tensor, *args, **kwargs):
+    # ``ttnn.group_norm`` defaults to ``inplace=True``, which mutates ``input_tensor``; clone
+    # the input before each run so both runs see identical (unmutated) inputs.
+    return _run_twice_in_place(ttnn.group_norm, input_tensor, *args, **kwargs)
+
+
 def ttnn_layer_norm_pre_all_gather(*args, **kwargs):
     return _run_twice(ttnn.layer_norm_pre_all_gather, *args, **kwargs)
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -50,8 +50,20 @@ def ttnn_layer_norm(*args, **kwargs):
     return _run_twice(ttnn.layer_norm, *args, **kwargs)
 
 
+def ttnn_layer_norm_in_place(input_tensor, *args, **kwargs):
+    # A sharded program_config with ``inplace=True`` makes ttnn.layer_norm write its result back
+    # into ``input_tensor``; clone the input before each run so both runs see identical inputs.
+    return _run_twice_in_place(ttnn.layer_norm, input_tensor, *args, **kwargs)
+
+
 def ttnn_rms_norm(*args, **kwargs):
     return _run_twice(ttnn.rms_norm, *args, **kwargs)
+
+
+def ttnn_rms_norm_in_place(input_tensor, *args, **kwargs):
+    # A sharded program_config with ``inplace=True`` makes ttnn.rms_norm write its result back
+    # into ``input_tensor``; clone the input before each run so both runs see identical inputs.
+    return _run_twice_in_place(ttnn.rms_norm, input_tensor, *args, **kwargs)
 
 
 def ttnn_group_norm(*args, **kwargs):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Determinism wrappers for the fused (norm / softmax) op tests.
+
+Each ``ttnn_<op>`` helper runs ``ttnn.<op>`` twice with the same inputs, asserts
+the two runs produce identical outputs, and returns the first one (a drop-in
+replacement for the original ``ttnn.<op>`` call).
+
+In-place ops mutate their input tensor, so the ``*_in_place`` helpers clone the
+input before each run to give both runs identical inputs.
+"""
+
+import torch
+import ttnn
+
+
+def _run_twice(op, *args, **kwargs):
+    output1 = op(*args, **kwargs)
+    output2 = op(*args, **kwargs)
+    assert torch.equal(ttnn.to_torch(output1), ttnn.to_torch(output2))
+    return output1
+
+
+def _run_twice_in_place(op, input_tensor, *args, **kwargs):
+    output1 = op(ttnn.clone(input_tensor), *args, **kwargs)
+    output2 = op(ttnn.clone(input_tensor), *args, **kwargs)
+    assert torch.equal(ttnn.to_torch(output1), ttnn.to_torch(output2))
+    return output1
+
+
+def ttnn_softmax(*args, **kwargs):
+    return _run_twice(ttnn.softmax, *args, **kwargs)
+
+
+def ttnn_scale_mask_softmax(*args, **kwargs):
+    return _run_twice(ttnn.scale_mask_softmax, *args, **kwargs)
+
+
+def ttnn_softmax_in_place(input_tensor, *args, **kwargs):
+    return _run_twice_in_place(ttnn.softmax_in_place, input_tensor, *args, **kwargs)
+
+
+def ttnn_scale_mask_softmax_in_place(input_tensor, *args, **kwargs):
+    return _run_twice_in_place(ttnn.scale_mask_softmax_in_place, input_tensor, *args, **kwargs)
+
+
+def ttnn_layer_norm(*args, **kwargs):
+    return _run_twice(ttnn.layer_norm, *args, **kwargs)
+
+
+def ttnn_rms_norm(*args, **kwargs):
+    return _run_twice(ttnn.rms_norm, *args, **kwargs)
+
+
+def ttnn_group_norm(*args, **kwargs):
+    return _run_twice(ttnn.group_norm, *args, **kwargs)
+
+
+def ttnn_layer_norm_pre_all_gather(*args, **kwargs):
+    return _run_twice(ttnn.layer_norm_pre_all_gather, *args, **kwargs)
+
+
+def ttnn_layer_norm_post_all_gather(*args, **kwargs):
+    return _run_twice(ttnn.layer_norm_post_all_gather, *args, **kwargs)
+
+
+def ttnn_rms_norm_pre_all_gather(*args, **kwargs):
+    return _run_twice(ttnn.rms_norm_pre_all_gather, *args, **kwargs)
+
+
+def ttnn_rms_norm_post_all_gather(*args, **kwargs):
+    return _run_twice(ttnn.rms_norm_post_all_gather, *args, **kwargs)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
@@ -9,7 +9,6 @@ import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_attn_matmul, ttnn_group_attn_matmul
-import ttnn
 
 
 def generate_input_shapes():

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_attn_matmul.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_attn_matmul, ttnn_group_attn_matmul
 import ttnn
 
 
@@ -46,7 +47,7 @@ def test_attn_matmul(num_loops, in0_dtype, in1_dtype, out_dtype, device):
             tt_input_tensor_a = tt_input_tensor_a.to(device)
             tt_input_tensor_b = tt_input_tensor_b.to(device)
             compute_grid_size = device.compute_with_storage_grid_size()
-            tt_output_tensor_on_device = ttnn.experimental.attn_matmul(
+            tt_output_tensor_on_device = ttnn_attn_matmul(
                 tt_input_tensor_a,
                 tt_input_tensor_b,
                 compute_with_storage_grid_size=ttnn.CoreCoord(compute_grid_size.x, compute_grid_size.y),
@@ -111,7 +112,7 @@ def test_attn_matmul_fp32(num_loops, in_dtype, device):
                 packer_l1_acc=False,
             )
 
-            tt_output_tensor_on_device = ttnn.experimental.attn_matmul(
+            tt_output_tensor_on_device = ttnn_attn_matmul(
                 tt_input_tensor_a,
                 tt_input_tensor_b,
                 compute_with_storage_grid_size=ttnn.CoreCoord(compute_grid_size.x, compute_grid_size.y),
@@ -289,7 +290,7 @@ def test_group_attn_matmul(
         else:
             output_mem_config = interleaved_mem_config
 
-        tt_output_tensor_on_device = ttnn.experimental.group_attn_matmul(
+        tt_output_tensor_on_device = ttnn_group_attn_matmul(
             tt_input_tensor_a,
             tt_input_tensor_b,
             compute_with_storage_grid_size=compute_grid_size,
@@ -532,7 +533,7 @@ def test_group_attn_matmul_fp32(
             packer_l1_acc=False,
         )
 
-        tt_output_tensor_on_device = ttnn.experimental.group_attn_matmul(
+        tt_output_tensor_on_device = ttnn_group_attn_matmul(
             tt_input_tensor_a,
             tt_input_tensor_b,
             compute_with_storage_grid_size=compute_grid_size,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_bert_matmuls.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import math
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
     pytorch_ops,
@@ -178,7 +179,7 @@ def test_bert_linear_batch7(
     )
 
     if has_bias:
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -187,7 +188,7 @@ def test_bert_linear_batch7(
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -309,7 +310,7 @@ def run_bert_linear_batch4(
     )
 
     if has_bias:
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -318,7 +319,7 @@ def run_bert_linear_batch4(
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -549,7 +550,7 @@ def test_bert_linear_batch4_fp32_input_output(
     )
 
     if has_bias:
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -558,7 +559,7 @@ def test_bert_linear_batch4_fp32_input_output(
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
 
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.unit_tests.operations.matmul.test_matmul_deepseek import _run_matmul_2d_interleaved_in0_sharded_in1
@@ -110,14 +111,14 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
     pcc = 0.94 if dtype == ttnn.bfloat8_b else 0.98
 
     if has_bias:
-        output_tensor = ttnn.linear(
+        output_tensor = ttnn_linear(
             input_tensor_a,
             input_tensor_b,
             bias=input_tensor_c,
             core_grid=core_grid,
         )
     else:
-        output_tensor = ttnn.matmul(
+        output_tensor = ttnn_matmul(
             input_tensor_a,
             input_tensor_b,
             core_grid=core_grid,
@@ -203,7 +204,7 @@ def test_sdxl_matmul(
         packer_l1_acc=True,
     )
 
-    output_tensor = ttnn.linear(
+    output_tensor = ttnn_linear(
         tt_act_block_sharded,
         tt_weights,
         bias=tt_bias,
@@ -337,10 +338,10 @@ def test_matmul_transpose_a_with_low_precision_rhs(device, rhs_dtype):
         packer_l1_acc=True,
     )
 
-    out_ref = ttnn.to_torch(ttnn.matmul(a_perm_ref, b, compute_kernel_config=compute_kernel_config))
+    out_ref = ttnn.to_torch(ttnn_matmul(a_perm_ref, b, compute_kernel_config=compute_kernel_config))
 
     out_candidate = ttnn.to_torch(
-        ttnn.matmul(a_perm_cand, b, transpose_a=True, compute_kernel_config=compute_kernel_config)
+        ttnn_matmul(a_perm_cand, b, transpose_a=True, compute_kernel_config=compute_kernel_config)
     )
 
     assert out_ref.shape == out_candidate.shape
@@ -439,7 +440,7 @@ def test_matmul_transpose_a_fuse_batch(device, batch, m, k, n, program_config):
         packer_l1_acc=True,
     )
 
-    output = ttnn.matmul(
+    output = ttnn_matmul(
         a,
         b,
         transpose_a=True,
@@ -489,7 +490,7 @@ def test_matmul_m_direction_padding(device):
     )
 
     # Perform matrix multiplication
-    result = ttnn.matmul(
+    result = ttnn_matmul(
         tensor_a,
         tensor_b,
         program_config=program_config,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul2.py
@@ -9,6 +9,7 @@ from models.common.utility_functions import is_wormhole_b0
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
@@ -93,7 +94,7 @@ def test_matmul_1d_in0_batched(
             fused_activation=None,
             mcast_in0=True,
         )
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -206,7 +207,7 @@ def test_linear_fp32_acc_l1(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -310,7 +311,7 @@ def test_matmul_no_mcast_fp32_acc_l1(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -429,7 +430,7 @@ def test_matmul_1d_fp32_input_output(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -541,7 +542,7 @@ def test_matmul_no_mcast_fp32_input_output(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -656,7 +657,7 @@ def test_matmul_no_untilize_output_param(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -747,7 +748,7 @@ def test_sharded_matmul_2d(
         transpose_mcast=False,
         fused_activation=None,
     )
-    output_t = ttnn.linear(
+    output_t = ttnn_linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -848,7 +849,7 @@ def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
         fused_activation=None,
     )
     output_mem_config = sharded_block_mem_config if out_sharded else interleaved_mem_config
-    output_t = ttnn.linear(
+    output_t = ttnn_linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -939,7 +940,7 @@ def test_sharded_matmul_2d_transposed(
         transpose_mcast=True,
         fused_activation=None,
     )
-    output_t = ttnn.linear(
+    output_t = ttnn_linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -1037,7 +1038,7 @@ def test_resharded_binary_to_matmul(device, function_level_defaults):
         transpose_mcast=True,
         fused_activation=None,
     )
-    output_matmul_t = ttnn.linear(
+    output_matmul_t = ttnn_linear(
         output_binary_t,
         weight_t,
         bias=bias_t,
@@ -1127,7 +1128,7 @@ def test_sharded_matmul_1d_in0(
         fused_activation=None,
         mcast_in0=True,
     )
-    output_t = ttnn.linear(
+    output_t = ttnn_linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -1206,7 +1207,7 @@ def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
         fused_activation=None,
         mcast_in0=False,
     )
-    output_t = ttnn.linear(
+    output_t = ttnn_linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -1297,7 +1298,7 @@ def test_sharded_matmul_no_mcast(
         per_core_N=N // 32,
     )
 
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_1d_2d.py
@@ -5,6 +5,7 @@
 import pytest
 from loguru import logger
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
@@ -145,7 +146,7 @@ def test_llama2_matmul(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -468,7 +469,10 @@ def test_multi_core_matmul_2d_wh(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttnn.matmul(
+    # The determinism wrapper runs matmul twice; for the largest sharded shape that
+    # exhausts device memory, so use a single matmul call for it.
+    matmul_op = ttnn.matmul if (M, K, N) == (1792, 2048, 4096) else ttnn_matmul
+    output_t = matmul_op(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -778,7 +782,10 @@ def test_multi_core_matmul_1d_wh(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttnn.matmul(
+    # The determinism wrapper runs matmul twice; for the largest sharded shape that
+    # exhausts device memory, so use a single matmul call for it.
+    matmul_op = ttnn.matmul if (M, K, N) == (512, 8192, 8192) else ttnn_matmul
+    output_t = matmul_op(
         in0_t,
         in1_t,
         program_config=program_config,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_activations.py
@@ -7,6 +7,7 @@
 import pytest
 from loguru import logger
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
 from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 import torch.nn.functional as F
@@ -211,7 +212,7 @@ def test_matmul_with_fused_activations(
     )
 
     # Run matmul with fused activation
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -308,7 +309,7 @@ def test_matmul_with_custom_activation_params(
     )
 
     # Run matmul with custom activation
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -440,7 +441,7 @@ def test_activation_with_different_program_configs(
     )
 
     # Run matmul
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -686,7 +687,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
 
     # Run the operation
     if has_bias:
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -696,7 +697,7 @@ def run_test_matmul_dram_sharded_with_bias_and_activation(
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -1030,7 +1031,7 @@ def test_matmul_1d_gather_with_activations(
 
     # Run matmul with fused activation
     try:
-        output_ttnn = ttnn.matmul(
+        output_ttnn = ttnn_matmul(
             in0_ttnn,
             in1_ttnn,
             program_config=program_config,
@@ -1040,7 +1041,7 @@ def test_matmul_1d_gather_with_activations(
     except Exception as e:
         # If it fails with this config, try without the specific program config
         logger.warning(f"Failed with 1D program config: {e}, trying without specific config")
-        output_ttnn = ttnn.matmul(
+        output_ttnn = ttnn_matmul(
             in0_ttnn,
             in1_ttnn,
             activation=activation_param,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
@@ -25,6 +25,7 @@ Test cases:
 import pytest
 import torch
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -172,7 +173,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should complete without hanging
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -219,7 +220,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should complete without hanging
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -265,7 +266,7 @@ class TestMatmulBlockSharded1DGrid:
             ),
         )
 
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -288,7 +289,7 @@ class TestMatmulBlockSharded1DGrid:
         tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
 
         # matmul without memory_config should work
-        output = ttnn.matmul(tt_a, tt_b)
+        output = ttnn_matmul(tt_a, tt_b)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -415,7 +416,7 @@ class TestMatmulBlockSharded1DGridEdgeCases:
             ),
         )
 
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -453,7 +454,7 @@ class TestMatmulBlockSharded1DGridEdgeCases:
             ),
         )
 
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)
@@ -491,7 +492,7 @@ class TestMatmulBlockSharded1DGridEdgeCases:
             ),
         )
 
-        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        output = ttnn_matmul(tt_a, tt_b, memory_config=memory_config)
         ttnn.synchronize_device(device)
 
         output_torch = ttnn.to_torch(output)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -440,7 +440,7 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
         compute_kernel_config=compute_kernel_config,
     )
 
-    for _ in range(200):
+    for _ in range(100):
         output_t = ttnn_matmul(
             in0_t,
             in1_t,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py
@@ -14,6 +14,7 @@ from models.common.utility_functions import torch2tt_tensor, tt2torch_tensor
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul, ttnn_linear
 from tt_lib.utils import (
     pad_weight,
     tilize_to_list,
@@ -430,7 +431,7 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     )
 
     # 1st mm
-    output_t = ttnn.matmul(
+    output_t = ttnn_matmul(
         in0_t,
         in1_t,
         program_config=program_config,
@@ -440,7 +441,7 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     )
 
     for _ in range(200):
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,
@@ -653,7 +654,7 @@ def test_matmul_2d_in1_dram_sharded(
         packer_l1_acc=packer_l1_acc,
     )
     if has_bias:
-        output_t = ttnn.linear(
+        output_t = ttnn_linear(
             in0_t,
             in1_t,
             bias=bias_t,
@@ -662,7 +663,7 @@ def test_matmul_2d_in1_dram_sharded(
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttnn.matmul(
+        output_t = ttnn_matmul(
             in0_t,
             in1_t,
             program_config=program_config,

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_hpadding_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_hpadding_matmul.py
@@ -4,6 +4,7 @@
 
 
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul
 from loguru import logger
 from tt_lib.utils import (
     tilize_to_list,
@@ -43,7 +44,7 @@ def run_tilize_matmul_test(M, K, N, device):
         device,
     )
     print("Shape of B_t - " + str(b_t.padded_shape))
-    t2 = ttnn.matmul(a_t, b_t)
+    t2 = ttnn_matmul(a_t, b_t)
     assert list(t2.padded_shape) == output_shape
     tt_host_rm = t2.cpu().to_torch_with_padded_shape()
     pyt_got_back = tt_host_rm.reshape(output_shape)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_tilize_matmul.py
@@ -4,6 +4,7 @@
 
 
 import ttnn
+from tests.ttnn.nightly.unit_tests.operations.matmul.utility_functions import ttnn_matmul
 from loguru import logger
 
 from models.common.utility_functions import untilize, tilize_to_list, skip_for_blackhole
@@ -33,7 +34,7 @@ def run_tilize_matmul_test(M, K, N, device):
         ttnn.TILE_LAYOUT,
         device,
     )
-    t2 = ttnn.matmul(a_t, b_t)
+    t2 = ttnn_matmul(a_t, b_t)
     assert list(t2.padded_shape) == [1, 1, M, N]
     tt_host_rm = t2.cpu().to_torch()
     pyt_got_back = tt_host_rm.reshape((1, 1, M, N))

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/utility_functions.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Determinism wrappers for the matmul op tests.
+
+Each ``ttnn_<op>`` helper runs ``ttnn.<op>`` (or the ``ttnn.experimental.<op>``
+equivalent) twice with the same inputs, asserts the two runs produce identical
+outputs, and returns the first one (a drop-in replacement for the original call).
+
+The equality check handles single tensors, tuples/lists of tensors, ``None``
+(ops invoked with a preallocated ``output_tensor=`` may return ``None``), integer
+outputs, and treats NaNs in matching positions as equal (``torch.equal`` reports
+NaN == NaN as False, so a re-run producing bit-identical output still compares
+equal).
+"""
+
+import torch
+import ttnn
+
+
+def _assert_outputs_equal(output1, output2):
+    if output1 is None or output2 is None:
+        assert output1 is None and output2 is None, "one run returned None, the other did not"
+        return
+    if isinstance(output1, (tuple, list)):
+        assert len(output1) == len(output2)
+        for a, b in zip(output1, output2):
+            _assert_outputs_equal(a, b)
+        return
+    a = ttnn.to_torch(output1)
+    b = ttnn.to_torch(output2)
+    assert a.shape == b.shape, f"shape mismatch between the two runs: {a.shape} vs {b.shape}"
+    if a.is_floating_point():
+        both_nan = a.isnan() & b.isnan()
+        assert bool(torch.all((a == b) | both_nan)), "the two runs produced different outputs"
+    else:
+        assert torch.equal(a, b), "the two runs produced different outputs"
+
+
+def _run_twice(op, *args, **kwargs):
+    output1 = op(*args, **kwargs)
+    output2 = op(*args, **kwargs)
+    _assert_outputs_equal(output1, output2)
+    return output1
+
+
+def ttnn_matmul(*args, **kwargs):
+    return _run_twice(ttnn.matmul, *args, **kwargs)
+
+
+def ttnn_linear(*args, **kwargs):
+    return _run_twice(ttnn.linear, *args, **kwargs)
+
+
+def ttnn_attn_matmul(*args, **kwargs):
+    return _run_twice(ttnn.experimental.attn_matmul, *args, **kwargs)
+
+
+def ttnn_group_attn_matmul(*args, **kwargs):
+    return _run_twice(ttnn.experimental.group_attn_matmul, *args, **kwargs)
+
+
+def ttnn_attn_matmul_from_cache(*args, **kwargs):
+    return _run_twice(ttnn.experimental.attn_matmul_from_cache, *args, **kwargs)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_deepseek_grouped_gate.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_deepseek_grouped_gate.py
@@ -10,6 +10,7 @@ from loguru import logger
 # Import from local reference files
 from models.demos.deepseek_v3.reference.configuration_deepseek import DeepseekV3Config
 from models.demos.deepseek_v3.reference.modeling_deepseek import MoEGate
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_deepseek_grouped_gate
 
 TEST_PADDING_VALUE = -42
 
@@ -445,7 +446,7 @@ def test_grouped_gate(device, num_batches, batch_size, seq_len):
     ttnn_bias = ttnn.from_torch(bias, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn_scores = ttnn.fill_implicit_tile_padding(ttnn_scores, TEST_PADDING_VALUE)
     ttnn_bias = ttnn.fill_implicit_tile_padding(ttnn_bias, TEST_PADDING_VALUE)
-    ttnn_scores, ttnn_top_k_experts_indices = ttnn.experimental.deepseek_grouped_gate(
+    ttnn_scores, ttnn_top_k_experts_indices = ttnn_deepseek_grouped_gate(
         ttnn_scores,
         ttnn_bias,
         n_groups=n_groups,

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py
@@ -48,6 +48,7 @@ from loguru import logger
 
 import ttnn
 from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_mean
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +88,7 @@ def _run_ttnn_mean(
     """Send tensor to device, run ttnn.mean, return host torch tensor."""
     tt_input = ttnn.from_torch(input_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn.fill_implicit_tile_padding(tt_input, 42)
-    tt_out = ttnn.mean(tt_input, dim=dim, keepdim=keepdim, compute_kernel_config=compute_kernel_config)
+    tt_out = ttnn_mean(tt_input, dim=dim, keepdim=keepdim, compute_kernel_config=compute_kernel_config)
     return ttnn.to_torch(tt_out)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -7,6 +7,7 @@ import pytest
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.utils_for_testing import assert_equal
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_max, ttnn_min, ttnn_mean
 
 TEST_PADDING_VALUE = -42
 
@@ -68,12 +69,12 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
         tt_input = ttnn.fill_implicit_tile_padding(tt_input, TEST_PADDING_VALUE)
 
     if kind == "max":
-        tt_npu = ttnn.max(tt_input)
+        tt_npu = ttnn_max(tt_input)
     elif kind == "min":
-        tt_npu = ttnn.min(tt_input)
+        tt_npu = ttnn_min(tt_input)
     else:
         assert kind == "mean"
-        tt_npu = ttnn.mean(tt_input)
+        tt_npu = ttnn_mean(tt_input)
 
     tt_output = tt_npu.cpu().to_torch()
     if kind == "mean":

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_prod
 
 
 def get_tensors(input_shape, output_shape, device):
@@ -44,7 +45,7 @@ def test_prod(shapes, device):
     torch_output = torch.prod(torch_input)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = ttnn.prod(tt_input).cpu().to(cpu_layout).to_torch()
+    tt_output_cpu = ttnn_prod(tt_input).cpu().to(cpu_layout).to_torch()
     N = tt_output_cpu.shape
     torch.set_printoptions(threshold=10000, precision=5, sci_mode=False)
     logger.info("Input shape")

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_prod
 
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
@@ -73,7 +74,7 @@ def test_prod_dims(input_shape, dims, device):
     torch_output = torch.prod(torch_input, dims[0], True)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = ttnn.prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).to_torch()
+    tt_output_cpu = ttnn_prod(tt_input, tt_output, dims=dims).cpu().to(cpu_layout).to_torch()
 
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_max, TTNN_REDUCTION_WRAPPERS
 
 
 @pytest.mark.parametrize("N", [8, 16])
@@ -55,7 +56,7 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
             ttnn.ShardOrientation.COL_MAJOR,
         )
 
-    yt = ttnn.max(xt, 2, memory_config=out_mem_config)
+    yt = ttnn_max(xt, 2, memory_config=out_mem_config)
 
     if out_sharded:
         yt = ttnn.sharded_to_interleaved(
@@ -134,7 +135,7 @@ def test_nd_sharded_reduce_h_no_output_shard_spec(op, device, function_level_def
         ttnn.ShardOrientation.COL_MAJOR,
     )
 
-    ttnn_op = getattr(ttnn, op)
+    ttnn_op = TTNN_REDUCTION_WRAPPERS[op]
     torch_op_name = {"max": "amax", "min": "amin"}.get(op, op)
     torch_op = getattr(torch, torch_op_name)
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -13,6 +13,14 @@ import ttnn
 
 from models.common.utility_functions import comp_allclose_and_pcc, torch_random, is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import (
+    ttnn_sum,
+    ttnn_topk,
+    ttnn_argmax,
+    ttnn_moe,
+    ttnn_sampling,
+    TTNN_REDUCTION_WRAPPERS,
+)
 from loguru import logger
 
 TEST_PADDING_VALUE = -42
@@ -38,7 +46,7 @@ def _run_topk_with_preallocated(input_tensor, k, dim, device, ttnn_result):
         device=device,
         memory_config=ttnn_result[1].memory_config(),
     )
-    ttnn.topk(input_tensor, k, dim=dim, output_tensor=(prealloc_values, prealloc_indices))
+    ttnn_topk(input_tensor, k, dim=dim, output_tensor=(prealloc_values, prealloc_indices))
     return (
         ttnn.to_torch(ttnn.from_device(prealloc_values)),
         ttnn.to_torch(ttnn.from_device(prealloc_indices)),
@@ -58,7 +66,7 @@ def _run_argmax_with_preallocated(input_tensor, dim, keepdim, device, ttnn_resul
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn.argmax(input_tensor, dim=dim, keepdim=keepdim, output_tensor=prealloc_output)
+    ttnn_argmax(input_tensor, dim=dim, keepdim=keepdim, output_tensor=prealloc_output)
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
 
@@ -91,7 +99,7 @@ def _run_moe_with_preallocated(input_tensor, expert_mask_tensor, topk_mask_tenso
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn.moe(input_tensor, expert_mask_tensor, topk_mask_tensor, k, output_tensor=prealloc_output)
+    ttnn_moe(input_tensor, expert_mask_tensor, topk_mask_tensor, k, output_tensor=prealloc_output)
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
 
@@ -109,7 +117,7 @@ def _run_sampling_with_preallocated(
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn.sampling(
+    ttnn_sampling(
         input_values,
         input_indices,
         k=k_tensor,
@@ -213,7 +221,7 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
     torch_op_name = {"max": "amax", "min": "amin"}.get(op, op)
     torch_op = getattr(torch, torch_op_name)
 
-    ttnn_op = getattr(ttnn, op)
+    ttnn_op = TTNN_REDUCTION_WRAPPERS[op]
 
     # Run on both and flag exceptions
     torch_errored = False
@@ -340,6 +348,8 @@ def test_generic_ops_ndim_shard(device, shapes, keepdim, layout, op, explicit_ou
     torch_op = getattr(torch, torch_op_name)
     torch_output_tensor = torch_op(torch_input_tensor, dim=dim, keepdim=keepdim)
 
+    # Use the op directly (not the ttnn_<op> determinism wrapper): the wrapper's
+    # second execution exhausts device memory for the larger sharded shapes here.
     ttnn_op = getattr(ttnn, op)
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
@@ -454,7 +464,7 @@ def test_generic_ops_wh_block_shard(
     torch_op = getattr(torch, torch_op_name)
     torch_output_tensor = torch_op(torch_input_tensor, dim=dim, keepdim=keepdim)
 
-    ttnn_op = getattr(ttnn, op)
+    ttnn_op = TTNN_REDUCTION_WRAPPERS[op]
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
         dtype=ttnn.float32,
@@ -586,7 +596,7 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
     torch_input = torch.randn(shape, dtype=dtype)
 
     ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_op = getattr(ttnn, op)
+    ttnn_op = TTNN_REDUCTION_WRAPPERS[op]
     ttnn_result = ttnn.to_torch(ttnn_op(ttnn_input, dim=dim, scalar=scalar, correction=correction))
 
     # torch.max/min don't accept a tuple for dim; use amax/amin which do.
@@ -775,7 +785,7 @@ def test_generic_ops_dtypes_layouts(device, op, dtype, layout):
     torch_op = getattr(torch, torch_op_name)
     torch_result = torch_op(torch_tensor, dim=dim)
 
-    ttnn_op = getattr(ttnn, op)
+    ttnn_op = TTNN_REDUCTION_WRAPPERS[op]
     ttnn_result = ttnn_op(ttnn_tensor, dim=dim)
 
     # Validate output dtype matches input dtype
@@ -832,7 +842,7 @@ def test_topk(device, tensor_shape, dim, dtype, layout, k):
 
     ttnn_errored = False
     try:
-        ttnn_result = ttnn.topk(ttnn_tensor, k, dim=dim)
+        ttnn_result = ttnn_topk(ttnn_tensor, k, dim=dim)
     except (IndexError, TypeError, RuntimeError) as e:
         ttnn_errored = True
         if not torch_errored:
@@ -954,7 +964,7 @@ def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout):
 
     ttnn_errored = False
     try:
-        ttnn_result = ttnn.argmax(ttnn_tensor, dim=dim, keepdim=keepdim)
+        ttnn_result = ttnn_argmax(ttnn_tensor, dim=dim, keepdim=keepdim)
     except (IndexError, TypeError, RuntimeError) as e:
         ttnn_errored = True
         if not torch_errored:
@@ -1054,7 +1064,7 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
     pad_value = 1.0 if op == "cumprod" else None
     ttnn_tensor = ttnn.from_torch(torch_tensor, layout=layout, device=device, pad_value=pad_value)
 
-    torch_op, ttnn_op = getattr(torch, op), getattr(ttnn, op)
+    torch_op, ttnn_op = getattr(torch, op), TTNN_REDUCTION_WRAPPERS[op]
 
     # Run on both and flag exceptions
     torch_errored = False
@@ -1180,7 +1190,7 @@ def test_moe(device, tensor_shape, dtype, layout):
         ttnn_expert_mask = ttnn.fill_implicit_tile_padding(ttnn_expert_mask, TEST_PADDING_VALUE)
         ttnn_topE_mask = ttnn.from_torch(topE_mask, layout=layout, device=device)
         ttnn_topE_mask = ttnn.fill_implicit_tile_padding(ttnn_topE_mask, TEST_PADDING_VALUE)
-        ttnn_result = ttnn.moe(ttnn_input, ttnn_expert_mask, ttnn_topE_mask, k)
+        ttnn_result = ttnn_moe(ttnn_input, ttnn_expert_mask, ttnn_topE_mask, k)
     except (IndexError, TypeError, RuntimeError) as e:
         ttnn_errored = True
         if not torch_errored:
@@ -1283,7 +1293,7 @@ def test_sampling(device, tensor_shape, dtype, layout):
         k_tensor = ttnn.from_torch(k_vals, device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
         p_tensor = ttnn.from_torch(p_vals, device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
         temp_tensor = ttnn.from_torch(temp_vals, device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-        ttnn_result = ttnn.sampling(
+        ttnn_result = ttnn_sampling(
             input_values,
             input_indices,
             k=k_tensor,
@@ -1319,7 +1329,7 @@ def test_sampling(device, tensor_shape, dtype, layout):
         return
 
     # Determinism: two ttnn runs with same seed must match (we cannot compare to torch; RNG differs).
-    ttnn_result_2 = ttnn.sampling(
+    ttnn_result_2 = ttnn_sampling(
         input_values, input_indices, k=k_tensor, p=p_tensor, temp=temp_tensor, seed=SAMPLING_SEED
     )
     ttnn_result_2_torch = ttnn.to_torch(ttnn.from_device(ttnn_result_2))
@@ -1355,7 +1365,7 @@ def test_sum_multi_dim_row_major(device, input_shape, dims, keepdim):
 
     assert input_tensor.layout == ttnn.ROW_MAJOR_LAYOUT, "Input should be in ROW_MAJOR_LAYOUT"
 
-    output_tensor = ttnn.sum(input_tensor, dim=dims, keepdim=keepdim)
+    output_tensor = ttnn_sum(input_tensor, dim=dims, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
 
     # This test uses larger absolute values, so we need to use a larger atol.

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -19,7 +19,12 @@ from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import
     ttnn_argmax,
     ttnn_moe,
     ttnn_sampling,
+    ttnn_topk_preallocated,
+    ttnn_argmax_preallocated,
+    ttnn_moe_preallocated,
+    ttnn_sampling_preallocated,
     TTNN_REDUCTION_WRAPPERS,
+    TTNN_REDUCTION_PREALLOCATED_WRAPPERS,
 )
 from loguru import logger
 
@@ -46,7 +51,7 @@ def _run_topk_with_preallocated(input_tensor, k, dim, device, ttnn_result):
         device=device,
         memory_config=ttnn_result[1].memory_config(),
     )
-    ttnn_topk(input_tensor, k, dim=dim, output_tensor=(prealloc_values, prealloc_indices))
+    ttnn_topk_preallocated((prealloc_values, prealloc_indices), input_tensor, k, dim=dim)
     return (
         ttnn.to_torch(ttnn.from_device(prealloc_values)),
         ttnn.to_torch(ttnn.from_device(prealloc_indices)),
@@ -66,11 +71,11 @@ def _run_argmax_with_preallocated(input_tensor, dim, keepdim, device, ttnn_resul
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn_argmax(input_tensor, dim=dim, keepdim=keepdim, output_tensor=prealloc_output)
+    ttnn_argmax_preallocated(prealloc_output, input_tensor, dim=dim, keepdim=keepdim)
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
 
-def _run_accumulation_with_preallocated(ttnn_op, input_tensor, dim, device, ttnn_result_tensor):
+def _run_accumulation_with_preallocated(prealloc_op, input_tensor, dim, device, ttnn_result_tensor):
     """
     Helper function that calls a cumulative op (cumsum/cumprod) with preallocated output tensor,
     whose shape is determined by the ttnn_result obtained from a previous run without
@@ -83,7 +88,7 @@ def _run_accumulation_with_preallocated(ttnn_op, input_tensor, dim, device, ttnn
         device=device,
         memory_config=ttnn_result_tensor.memory_config(),
     )
-    ttnn_op(input_tensor, dim, out=prealloc_output)
+    prealloc_op(prealloc_output, input_tensor, dim)
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
 
@@ -99,7 +104,7 @@ def _run_moe_with_preallocated(input_tensor, expert_mask_tensor, topk_mask_tenso
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn_moe(input_tensor, expert_mask_tensor, topk_mask_tensor, k, output_tensor=prealloc_output)
+    ttnn_moe_preallocated(prealloc_output, input_tensor, expert_mask_tensor, topk_mask_tensor, k)
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
 
@@ -117,14 +122,14 @@ def _run_sampling_with_preallocated(
         device=device,
         memory_config=ttnn_result.memory_config(),
     )
-    ttnn_sampling(
+    ttnn_sampling_preallocated(
+        prealloc_output,
         input_values,
         input_indices,
         k=k_tensor,
         p=p_tensor,
         temp=temp_tensor,
         seed=seed,
-        output_tensor=prealloc_output,
     )
     return ttnn.to_torch(ttnn.from_device(prealloc_output))
 
@@ -1097,7 +1102,9 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
         ), f"Shape mismatch on 0-volume result: torch: {torch_result.shape}, ttnn: {ttnn_result_in_torch.shape}"
 
         # Repeat the test with preallocated output tensor.
-        prealloc_result = _run_accumulation_with_preallocated(ttnn_op, ttnn_tensor, dim, device, ttnn_result)
+        prealloc_result = _run_accumulation_with_preallocated(
+            TTNN_REDUCTION_PREALLOCATED_WRAPPERS[op], ttnn_tensor, dim, device, ttnn_result
+        )
         # The two methods should produce identical results.
         assert (
             torch_result.shape == prealloc_result.shape
@@ -1113,7 +1120,9 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
     assert passing, f"{output_pcc}, torch: {torch_result}, ttnn: {ttnn_result_in_torch}"
 
     # Repeat the test with preallocated output tensor.
-    prealloc_result = _run_accumulation_with_preallocated(ttnn_op, ttnn_tensor, dim, device, ttnn_result)
+    prealloc_result = _run_accumulation_with_preallocated(
+        TTNN_REDUCTION_PREALLOCATED_WRAPPERS[op], ttnn_tensor, dim, device, ttnn_result
+    )
     # The two methods should produce identical results.
     assert torch.equal(
         prealloc_result, ttnn_result_in_torch

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -6,6 +6,8 @@ import torch
 import pytest
 import ttnn
 
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_sum
+
 TEST_PADDING_VALUE = -42
 
 
@@ -36,7 +38,7 @@ def test_sum_for_dim_hw(device, shape_dim):
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     dev_x = ttnn.fill_implicit_tile_padding(dev_x, TEST_PADDING_VALUE)
-    tt_npu = ttnn.sum(dev_x, dim=dim, keepdim=True)
+    tt_npu = ttnn_sum(dev_x, dim=dim, keepdim=True)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
     assert torch.equal(tt_dev[0, 0, 0, 0], torch.Tensor([value]).bfloat16()[0])
 
@@ -67,6 +69,6 @@ def test_sum_global(device, shape):
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     dev_x = ttnn.fill_implicit_tile_padding(dev_x, TEST_PADDING_VALUE)
 
-    tt_npu = ttnn.sum(dev_x)
+    tt_npu = ttnn_sum(dev_x)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
     assert torch.equal(tt_dev.bfloat16(), torch_output.bfloat16())

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/utility_functions.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Determinism wrappers for the reduction op tests.
+
+Each ``ttnn_<op>`` helper runs ``ttnn.<op>`` twice with the same inputs, asserts
+the two runs produce identical outputs, and returns the first one (a drop-in
+replacement for the original ``ttnn.<op>`` call).
+
+The equality check is deliberately stricter / more tolerant than ``torch.equal``:
+  * tuples/lists are compared element-wise (e.g. ``ttnn.topk`` -> (values, indices)),
+  * ``None`` is accepted (ops invoked with a preallocated ``output_tensor=`` /
+    ``out=`` may return ``None``),
+  * integer outputs (e.g. ``argmax`` / ``topk`` indices) use exact equality,
+  * floating outputs treat NaNs in matching positions as equal, since reduction
+    outputs may legitimately contain NaN (e.g. ``prod`` over NaN tile padding) and
+    ``torch.equal`` reports NaN == NaN as False.
+"""
+
+import torch
+import ttnn
+
+
+def _assert_outputs_equal(output1, output2):
+    if output1 is None or output2 is None:
+        assert output1 is None and output2 is None, "one run returned None, the other did not"
+        return
+    if isinstance(output1, (tuple, list)):
+        assert len(output1) == len(output2)
+        for a, b in zip(output1, output2):
+            _assert_outputs_equal(a, b)
+        return
+    a = ttnn.to_torch(output1)
+    b = ttnn.to_torch(output2)
+    assert a.shape == b.shape, f"shape mismatch between the two runs: {a.shape} vs {b.shape}"
+    if a.is_floating_point():
+        both_nan = a.isnan() & b.isnan()
+        assert bool(torch.all((a == b) | both_nan)), "the two runs produced different outputs"
+    else:
+        assert torch.equal(a, b), "the two runs produced different outputs"
+
+
+def _run_twice(op, *args, **kwargs):
+    output1 = op(*args, **kwargs)
+    output2 = op(*args, **kwargs)
+    _assert_outputs_equal(output1, output2)
+    return output1
+
+
+def ttnn_sum(*args, **kwargs):
+    return _run_twice(ttnn.sum, *args, **kwargs)
+
+
+def ttnn_mean(*args, **kwargs):
+    return _run_twice(ttnn.mean, *args, **kwargs)
+
+
+def ttnn_max(*args, **kwargs):
+    return _run_twice(ttnn.max, *args, **kwargs)
+
+
+def ttnn_min(*args, **kwargs):
+    return _run_twice(ttnn.min, *args, **kwargs)
+
+
+def ttnn_prod(*args, **kwargs):
+    return _run_twice(ttnn.prod, *args, **kwargs)
+
+
+def ttnn_std(*args, **kwargs):
+    return _run_twice(ttnn.std, *args, **kwargs)
+
+
+def ttnn_var(*args, **kwargs):
+    return _run_twice(ttnn.var, *args, **kwargs)
+
+
+def ttnn_cumsum(*args, **kwargs):
+    return _run_twice(ttnn.cumsum, *args, **kwargs)
+
+
+def ttnn_cumprod(*args, **kwargs):
+    return _run_twice(ttnn.cumprod, *args, **kwargs)
+
+
+def ttnn_topk(*args, **kwargs):
+    return _run_twice(ttnn.topk, *args, **kwargs)
+
+
+def ttnn_argmax(*args, **kwargs):
+    return _run_twice(ttnn.argmax, *args, **kwargs)
+
+
+def ttnn_moe(*args, **kwargs):
+    return _run_twice(ttnn.moe, *args, **kwargs)
+
+
+def ttnn_sampling(*args, **kwargs):
+    return _run_twice(ttnn.sampling, *args, **kwargs)
+
+
+def ttnn_deepseek_grouped_gate(*args, **kwargs):
+    return _run_twice(ttnn.experimental.deepseek_grouped_gate, *args, **kwargs)
+
+
+# Maps the parametrized ``op`` name to its determinism wrapper, for tests that
+# dispatch dynamically (previously via ``getattr(ttnn, op)``).
+TTNN_REDUCTION_WRAPPERS = {
+    "sum": ttnn_sum,
+    "mean": ttnn_mean,
+    "max": ttnn_max,
+    "min": ttnn_min,
+    "prod": ttnn_prod,
+    "std": ttnn_std,
+    "var": ttnn_var,
+    "cumsum": ttnn_cumsum,
+    "cumprod": ttnn_cumprod,
+}

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/utility_functions.py
@@ -31,8 +31,8 @@ def _assert_outputs_equal(output1, output2):
         for a, b in zip(output1, output2):
             _assert_outputs_equal(a, b)
         return
-    a = ttnn.to_torch(output1)
-    b = ttnn.to_torch(output2)
+    a = output1 if isinstance(output1, torch.Tensor) else ttnn.to_torch(output1)
+    b = output2 if isinstance(output2, torch.Tensor) else ttnn.to_torch(output2)
     assert a.shape == b.shape, f"shape mismatch between the two runs: {a.shape} vs {b.shape}"
     if a.is_floating_point():
         both_nan = a.isnan() & b.isnan()
@@ -41,11 +41,41 @@ def _assert_outputs_equal(output1, output2):
         assert torch.equal(a, b), "the two runs produced different outputs"
 
 
+def _snapshot(output):
+    """Deep-copy ``output`` to host so it survives a later in-place overwrite.
+
+    Returns ``None`` for ``None``, recurses into tuples/lists, and otherwise converts the
+    (ttnn) tensor to a cloned torch tensor.
+    """
+    if output is None:
+        return None
+    if isinstance(output, (tuple, list)):
+        return type(output)(_snapshot(x) for x in output)
+    return ttnn.to_torch(output).clone()
+
+
 def _run_twice(op, *args, **kwargs):
     output1 = op(*args, **kwargs)
     output2 = op(*args, **kwargs)
     _assert_outputs_equal(output1, output2)
     return output1
+
+
+def _run_twice_into(op, prealloc, out_kwarg, *args, **kwargs):
+    """Run ``op`` twice writing into the preallocated buffer(s) ``prealloc`` (passed via the
+    ``out_kwarg`` keyword, e.g. ``output_tensor`` or ``out``), asserting both runs leave
+    identical contents in the buffer.
+
+    Both runs target the same memory, so comparing the live buffer to itself (or comparing
+    return values that alias it) would be vacuous. Instead the buffer is snapshotted to host
+    after the first run, before the second run overwrites it, and the snapshot is compared
+    against the buffer's contents after the second run.
+    """
+    op(*args, **{out_kwarg: prealloc}, **kwargs)
+    snapshot1 = _snapshot(prealloc)
+    op(*args, **{out_kwarg: prealloc}, **kwargs)
+    _assert_outputs_equal(snapshot1, prealloc)
+    return prealloc
 
 
 def ttnn_sum(*args, **kwargs):
@@ -104,6 +134,33 @@ def ttnn_deepseek_grouped_gate(*args, **kwargs):
     return _run_twice(ttnn.experimental.deepseek_grouped_gate, *args, **kwargs)
 
 
+# Preallocated-output variants: each runs the op twice into the same preallocated buffer and
+# asserts determinism by snapshotting the buffer between runs. ``prealloc`` is the buffer (or
+# tuple of buffers, e.g. ``ttnn.topk`` -> (values, indices)) and is returned after both runs.
+def ttnn_topk_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.topk, prealloc, "output_tensor", *args, **kwargs)
+
+
+def ttnn_argmax_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.argmax, prealloc, "output_tensor", *args, **kwargs)
+
+
+def ttnn_cumsum_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.cumsum, prealloc, "out", *args, **kwargs)
+
+
+def ttnn_cumprod_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.cumprod, prealloc, "out", *args, **kwargs)
+
+
+def ttnn_moe_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.moe, prealloc, "output_tensor", *args, **kwargs)
+
+
+def ttnn_sampling_preallocated(prealloc, *args, **kwargs):
+    return _run_twice_into(ttnn.sampling, prealloc, "output_tensor", *args, **kwargs)
+
+
 # Maps the parametrized ``op`` name to its determinism wrapper, for tests that
 # dispatch dynamically (previously via ``getattr(ttnn, op)``).
 TTNN_REDUCTION_WRAPPERS = {
@@ -116,4 +173,10 @@ TTNN_REDUCTION_WRAPPERS = {
     "var": ttnn_var,
     "cumsum": ttnn_cumsum,
     "cumprod": ttnn_cumprod,
+}
+
+# Same mapping for the preallocated-output (``out=``) accumulation variants.
+TTNN_REDUCTION_PREALLOCATED_WRAPPERS = {
+    "cumsum": ttnn_cumsum_preallocated,
+    "cumprod": ttnn_cumprod_preallocated,
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #46124 

Add in checks that output is identical for back to back calls of the same ops to nightly tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-46124_double_out_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-46124_double_out_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-46124_double_out_test)