### PR TITLE
Implementation of KV cache table for Kimi K2.6

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
@@ -15,7 +15,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    create_kv_chunk_address_table,
+    create_kv_chunk_address_table_ds,
     init_kvpe_cache,
 )
 
@@ -64,7 +64,7 @@ def test_kv_cache_address_table(mesh_device, seq_len):
     config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     config.chunk_size_bytes = CHUNK_SIZE_BYTES
 
-    lookup_table = create_kv_chunk_address_table(
+    lookup_table = create_kv_chunk_address_table_ds(
         config=config,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -17,7 +17,9 @@ from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_refe
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla.utils import reverse_reorder_tensor_chunks
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+    BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
+    PREFILL_CHUNK_OUTPUT_TOKENS,
     create_kv_chunk_address_table,
     create_kv_chunk_address_table_kimi,
     init_kvpe_cache,
@@ -197,25 +199,22 @@ def test_kv_cache_table(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        },
+        }
     ],
-    ids=["line", "ring"],
+    ids=["line"],
     indirect=True,
 )
+@pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
 @pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
 @pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
 @pytest.mark.timeout(0)
 def test_kimi_kv_cache_table(
+    use_pretrained,
     request,
     mesh_device,
     seq_len,
     variant,
-    is_ci_env,
-    is_ci_v2_env,
     device_params,
 ):
     """
@@ -226,7 +225,13 @@ def test_kimi_kv_cache_table(
     back through the table and checks it against the gathered cache. The sequential
     gather is already position-continuous, so no chunk reorder is needed.
     """
-    config, weights = request.getfixturevalue("random_weights")
+
+    # Conditionally load fixtures - only load what we need!
+    if use_pretrained:
+        config, sd = request.getfixturevalue("pretrained_transformer_weights")
+        weights = sd["layers"][0]["mla_weights"]
+    else:
+        config, weights = request.getfixturevalue("random_weights")
 
     assert config.num_attention_heads == 64, f"Not Kimi config: {config.num_attention_heads} heads"
 
@@ -310,3 +315,110 @@ def test_kimi_kv_cache_table(
         chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
         expected_chunk = tt_kvpe_cache_torch_layer0[:, :, position : position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, :]
         assert_equal(chunk_torch, expected_chunk)
+
+
+# sp x tp
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    ids=["8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [5 * 1024, 10 * 1024, 25 * 1024], ids=["seq5k", "seq10k", "seq25k"])
+@pytest.mark.parametrize("num_users", [1, 2], ids=["1user", "2users"])
+@pytest.mark.parametrize("num_layers", [1, 2], ids=["1layer", "2layers"])
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
+@pytest.mark.timeout(0)
+def test_kimi_kv_cache_mock(
+    mesh_device,
+    seq_len,
+    num_users,
+    num_layers,
+    device_params,
+):
+    sp_axis = 0
+    mesh_shape = list(mesh_device.shape)
+    sp_factor = mesh_shape[sp_axis]
+    kvpe_cache_head_dim = 576  # qk_rope_head_dim(64) + kv_lora_rank(512); same for Kimi and DeepSeek
+    num_kvpe_cache_layers = num_users * num_layers
+
+    chunk_tokens = PREFILL_CHUNK_OUTPUT_TOKENS
+    tokens_per_chunk_per_device = chunk_tokens // sp_factor  # 640
+    num_seq_chunks = seq_len // chunk_tokens
+
+    torch.manual_seed(42)
+    reference = torch.randn(num_kvpe_cache_layers, 1, seq_len, kvpe_cache_head_dim).to(torch.bfloat16)
+
+    # For 10k, device 0 holds tokens [0-639, 5120-5759], device 1 holds [640-1279, 5760-6399], … device 7 holds [4480-5119, 9600-10239].
+    device_buffers = []
+    for d in range(sp_factor):
+        lo = d * tokens_per_chunk_per_device
+        hi = lo + tokens_per_chunk_per_device
+        slices = [reference[:, :, c * chunk_tokens + lo : c * chunk_tokens + hi, :] for c in range(num_seq_chunks)]
+        device_buffers.append(torch.cat(slices, dim=2))
+    host_stacked = torch.cat(device_buffers, dim=2)  # [num_users*num_layers, 1, seq_len, head_dim], shardable across SP
+
+    # 32-token shards round-robined over the dram banks.
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0)) for bank_id in range(BH_NUM_DRAM_BANKS)
+    ]
+    kv_mem_config = ttnn.MemoryConfig(
+        buffer_type=ttnn.BufferType.DRAM,
+        nd_shard_spec=ttnn.NdShardSpec(
+            shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim],
+            grid=ttnn.CoreRangeSet(core_ranges),
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+        ),
+    )
+
+    shard_dims = [None, None]
+    shard_dims[sp_axis] = -2
+    tt_kvpe_cache = ttnn.from_torch(
+        host_stacked,
+        dtype=ttnn.bfloat8_b,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=kv_mem_config,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+    )
+
+    CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
+    lookup_table_config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    lookup_table_config.num_layers = num_layers
+    lookup_table_config.max_sequence_length = seq_len
+    lookup_table_config.num_slots = num_users
+    lookup_table_config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
+    lookup_table = create_kv_chunk_address_table_kimi(
+        config=lookup_table_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=CHUNK_SIZE_BYTES,
+        num_users=num_users,
+    )
+
+    reference_bf8 = ttnn.to_torch(ttnn.from_torch(reference, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)).to(
+        torch.bfloat16
+    )
+
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
+    for slot in range(num_users):
+        for layer in range(num_layers):
+            batch_idx = slot * num_layers + layer  # cache batch index
+            for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                pos_end = position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                raw_bytes = lookup_table.read_device_chunk(layer=layer, position=position, slot=slot)
+                chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+                chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+                expected_chunk = reference_bf8[batch_idx : batch_idx + 1, :, position:pos_end, :]
+                assert_equal(chunk_torch, expected_chunk)

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -199,9 +199,12 @@ def test_kv_cache_table(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        }
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        },
     ],
-    ids=["line"],
+    ids=["line", "ring"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
@@ -326,8 +329,15 @@ def test_kimi_kv_cache_table(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
-    ids=["line"],
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        },
+    ],
+    ids=["line", "ring"],
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", [5 * 1024, 10 * 1024, 25 * 1024], ids=["seq5k", "seq10k", "seq25k"])

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -20,7 +20,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     PREFILL_CHUNK_OUTPUT_TOKENS,
-    create_kv_chunk_address_table,
+    create_kv_chunk_address_table_ds,
     create_kv_chunk_address_table_kimi,
     init_kvpe_cache,
 )
@@ -139,7 +139,7 @@ def test_kv_cache_table(
     lookup_table_config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
 
-    lookup_table = create_kv_chunk_address_table(
+    lookup_table = create_kv_chunk_address_table_ds(
         config=lookup_table_config,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -228,6 +228,10 @@ def test_kimi_kv_cache_table(
     """
     config, weights = request.getfixturevalue("random_weights")
 
+    assert config.num_attention_heads == 64, f"Not Kimi config: {config.num_attention_heads} heads"
+
+    logger.info(f"model={variant.name} num_heads={config.num_attention_heads} hidden={config.hidden_size}")
+
     fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
     topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
 

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -10,6 +10,7 @@ This test verifies that both modules can be created and weights are loaded corre
 import pytest
 import torch
 from loguru import logger
+from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
@@ -18,6 +19,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import reverse_reorder_tensor_chu
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     create_kv_chunk_address_table,
+    create_kv_chunk_address_table_kimi,
     init_kvpe_cache,
 )
 from tests.ttnn.utils_for_testing import assert_equal
@@ -174,6 +176,129 @@ def test_kv_cache_table(
 
     # Walk every chunk in layer 0, read it back via the address table, and
     # compare against the corresponding 32-token slice of the gathered cache.
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        expected_chunk = tt_kvpe_cache_torch_layer0[:, :, position : position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, :]
+        assert_equal(chunk_torch, expected_chunk)
+
+
+# sp x tp
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    ids=["8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+        },
+    ],
+    ids=["line", "ring"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
+@pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
+@pytest.mark.timeout(0)
+def test_kimi_kv_cache_table(
+    request,
+    mesh_device,
+    seq_len,
+    variant,
+    is_ci_env,
+    is_ci_v2_env,
+    device_params,
+):
+    """
+    Readback test for the Kimi (non-balanced / sequential) KV chunk address table.
+
+    Runs Kimi MLA (variant kimi_k2_6) to fill a sequentially laid-out KVPE cache,
+    builds the table with create_kv_chunk_address_table_kimi, then reads every chunk
+    back through the table and checks it against the gathered cache. The sequential
+    gather is already position-continuous, so no chunk reorder is needed.
+    """
+    config, weights = request.getfixturevalue("random_weights")
+
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
+    sp_axis = 0
+    tp_axis = 1
+    mesh_shape = list(mesh_device.shape)
+    config.max_seq_len = seq_len
+
+    # Test forward pass comparison
+    logger.info("=" * 80)
+    logger.info(f"Testing forward pass comparison (seq_len={seq_len})")
+    logger.info("=" * 80)
+
+    # Initialize KVPE cache
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
+
+    num_kvpe_cache_layers = 1
+    tt_kvpe_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=kvpe_cache_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_kvpe_cache_layers,
+    )
+
+    # Create and populate KV chunk address table using utility function
+    CHUNK_SIZE_BYTES = 19584  # [1, 1, 32, 576] bfp8
+    lookup_table_config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    lookup_table_config.num_layers = num_kvpe_cache_layers
+    lookup_table_config.max_sequence_length = seq_len
+    lookup_table_config.num_slots = 1
+    lookup_table_config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
+
+    lookup_table = create_kv_chunk_address_table_kimi(
+        config=lookup_table_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tt_kvpe_cache=tt_kvpe_cache,
+        chunk_size_bytes=CHUNK_SIZE_BYTES,
+    )
+
+    # Run MLA inference using utility function
+    # Fill first layer with actual kv cache
+    # Layer 1 remains zeros
+    run_mla_inference(
+        config=config,
+        weights=weights,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        topology=topology,
+        tt_kvpe_cache=tt_kvpe_cache,
+    )
+
+    tt_kvpe_cache_torch = ttnn.to_torch(
+        tt_kvpe_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)
+
+    # remember layer0 results
+    tt_kvpe_cache_torch_layer0 = tt_kvpe_cache_torch[:1, :1, :, :]
+
+    # Walk every chunk in layer 0, read it back via the address table, and compare
+    # against the corresponding 32-token slice of the gathered cache.
     chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
     for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
         raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -44,7 +44,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    create_kv_chunk_address_table,
+    create_kv_chunk_address_table_ds,
     init_kvpe_cache,
 )
 from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
@@ -432,7 +432,7 @@ def run_model(
     lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
 
     # just create atm for demo purposes, don't actually use it
-    lookup_table = create_kv_chunk_address_table(
+    lookup_table = create_kv_chunk_address_table_ds(
         config=lookup_table_config,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
@@ -26,10 +26,7 @@ import sys
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
-    NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    create_kv_chunk_address_table,
-)
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
 
 # bfp8 [1, 1, 32, 576] KV chunk: 18 tiles * 1088 B = 19584 B.
 _CHUNK_SIZE_BYTES = 19584
@@ -51,18 +48,18 @@ def _serialize_table_to_path(table, path: str) -> None:
 
 
 def build_and_serialize_kv_chunk_table(
-    *, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, path
+    *, variant, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, path
 ) -> str:
-    """Build the KV chunk address table from the device KV layout (via the shared
-    kv_cache_utils.create_kv_chunk_address_table) and serialize it to ``path`` for
-    the inference server to forward via SET_TABLE. Returns the path on success."""
+    """Build the KV chunk address table from the device KV layout (via the variant's
+    kv_cache_table_create_function) and serialize it to ``path`` for the inference
+    server to forward via SET_TABLE. Returns the path on success."""
     cfg = _disaggregation().KvChunkAddressTableConfig()
     cfg.num_layers = num_layers
     cfg.max_sequence_length = seq_len
     cfg.num_slots = 1
     cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     cfg.chunk_size_bytes = _CHUNK_SIZE_BYTES
-    table = create_kv_chunk_address_table(
+    table = variant.kv_cache_table_create_function(
         config=cfg,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -279,6 +279,7 @@ def main() -> None:
 
         table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         build_and_serialize_kv_chunk_table(
+            variant=VARIANT,
             mesh_device=mesh_device,
             kvpe_cache=pipeline.kvpe_cache,
             seq_len=MAX_SEQ_LEN,

--- a/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
@@ -11,7 +11,7 @@ live in blaze at `disaggregation/migration/python/prefill_runner_util.py`.
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 from loguru import logger
@@ -23,6 +23,10 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import create_balanced_chunk_order, reorder_tensor_chunks
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+    create_kv_chunk_address_table_ds,
+    create_kv_chunk_address_table_kimi,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +50,7 @@ class RunnerVariant:
     ttnn_cache_default: str
     default_is_balanced: bool
     default_gate_mode: str  # GateComputeMode name
+    kv_cache_table_create_function: Callable  # builds this variant's KV chunk address table
 
 
 VARIANTS = {
@@ -58,6 +63,7 @@ VARIANTS = {
         ttnn_cache_default="/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure",
         default_is_balanced=True,
         default_gate_mode="DEVICE_FP32",
+        kv_cache_table_create_function=create_kv_chunk_address_table_ds,
     ),
     "kimi_k2_6": RunnerVariant(
         name="kimi_k2_6",
@@ -74,6 +80,7 @@ VARIANTS = {
         ttnn_cache_default="/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill",
         default_is_balanced=False,  # Kimi is validated only in non_balanced layout
         default_gate_mode="HOST_ALL",  # Kimi (1 expert group) is validated only with the host gate
+        kv_cache_table_create_function=create_kv_chunk_address_table_kimi,
     ),
 }
 

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -149,7 +149,7 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
 
 
 def create_kv_chunk_address_table_kimi(
-    config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes
+    config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes, num_users=1
 ):
     """
     Create and populate a KV chunk address table for disaggregation (Kimi K2.6 model - non-balanced).
@@ -162,6 +162,7 @@ def create_kv_chunk_address_table_kimi(
         sp_axis: Sequence parallel axis
         tt_kvpe_cache: Initialized KVPE cache on device
         chunk_size_bytes: Size of each chunk in bytes
+        num_users: Number of users (slots) sharing the buffer; cache batch dim folds them as user * num_layers + layer
 
     Returns:
         lookup_table: Populated KvChunkAddressTable
@@ -193,36 +194,45 @@ def create_kv_chunk_address_table_kimi(
             f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
         )
 
-    tokens_per_chunk_per_device = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
-    num_seq_chunks = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS  # number of 5k chunks contained in the sequence length
+    tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
+    num_chunks_per_seq_len = (
+        seq_len // PREFILL_CHUNK_OUTPUT_TOKENS
+    )  # number of 5k chunks contained in the sequence length
+
     assert (
         seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
     ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
-    assert tokens_per_chunk_per_device % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
-        f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_per_device}, "
+
+    assert tokens_per_chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
+        f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
         f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
     )
 
-    slot = 0
+    assert (
+        tt_kvpe_cache.shape[0] == num_users * num_layers
+    ), f"cache batch dim {tt_kvpe_cache.shape[0]} != num_users({num_users}) * num_layers({num_layers})"
+
     dram_bank_base_addr = tt_kvpe_cache.buffer_address()
     for local_idx, global_row in enumerate(range(rank_row_start, rank_row_end)):
         group_idx = device_group_idx_per_row[local_idx]
         curr_bank_id = 0
         curr_bank_offset = 0
-        for layer in range(num_layers):
-            for seq_chunk in range(num_seq_chunks):
-                chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + global_row * tokens_per_chunk_per_device
-                chunk_token_end = chunk_token_start + tokens_per_chunk_per_device
-                for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
-                    location = ttnn.experimental.disaggregation.KvCacheLocation()
-                    location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
-                    location.size_bytes = chunk_size_bytes
-                    location.device_group_index = group_idx
-                    lookup_table.set(layer, position, slot, location)
 
-                    curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
-                    if curr_bank_id == 0:
-                        curr_bank_offset += chunk_size_bytes
+        for slot in range(num_users):
+            for layer in range(num_layers):
+                for seq_chunk in range(num_chunks_per_seq_len):
+                    chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + global_row * tokens_per_chunk_local
+                    chunk_token_end = chunk_token_start + tokens_per_chunk_local
+                    for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                        location = ttnn.experimental.disaggregation.KvCacheLocation()
+                        location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                        location.size_bytes = chunk_size_bytes
+                        location.device_group_index = group_idx
+                        lookup_table.set(layer, position, slot, location)
+
+                        curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                        if curr_bank_id == 0:
+                            curr_bank_offset += chunk_size_bytes
 
     return lookup_table
 

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -147,6 +147,81 @@ def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_a
     return lookup_table
 
 
+def create_kv_chunk_address_table_kimi(
+    config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes
+):
+    """
+    Create and populate a KV chunk address table for disaggregation (Kimi K2.6 model - non-balanced).
+
+    Args:
+        config: KvChunkAddressTableConfig
+        mesh_device: Mesh device for TT
+        mesh_shape: Shape of mesh device
+        seq_len: Sequence length
+        sp_axis: Sequence parallel axis
+        tt_kvpe_cache: Initialized KVPE cache on device
+        chunk_size_bytes: Size of each chunk in bytes
+
+    Returns:
+        lookup_table: Populated KvChunkAddressTable
+    """
+    assert seq_len % (mesh_shape[sp_axis] * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK) == 0, (
+        f"seq_len {seq_len} must be divisible by sp_factor({mesh_shape[sp_axis]}) * "
+        f"{NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK} for the sequential layout"
+    )
+
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+    host_name = socket.gethostname()
+
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+
+    num_layers = config.num_layers
+
+    # Data is replicated across each column of the mesh, so one device group per row.
+    device_group_idx_per_row = []
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = []
+        for col in range(mesh_shape[1]):
+            fabric_node_ids.append(mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(row, col)))
+        all_fabric_node_ids.extend(fabric_node_ids)
+        device_group_idx_per_row.append(lookup_table.add_device_group(fabric_node_ids))
+
+    for fid in all_fabric_node_ids:
+        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+        logger.debug(
+            f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
+        )
+
+    seq_len_local = seq_len // mesh_shape[sp_axis]
+
+    slot = 0
+    dram_bank_base_addr = tt_kvpe_cache.buffer_address()
+    for local_idx, global_row in enumerate(range(rank_row_start, rank_row_end)):
+        group_idx = device_group_idx_per_row[local_idx]
+        curr_bank_id = 0
+        curr_bank_offset = 0
+        device_token_start = global_row * seq_len_local
+        device_token_end = device_token_start + seq_len_local
+        for layer in range(num_layers):
+            for position in range(device_token_start, device_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                location = ttnn.experimental.disaggregation.KvCacheLocation()
+                location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                location.size_bytes = chunk_size_bytes
+                location.device_group_index = group_idx
+                lookup_table.set(layer, position, slot, location)
+
+                curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                if curr_bank_id == 0:
+                    curr_bank_offset += chunk_size_bytes
+
+    return lookup_table
+
+
 def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers, num_users=1):
     """
     Initialize KVPE cache for MLA.

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -18,7 +18,9 @@ BH_NUM_DRAM_BANKS = 8
 PREFILL_CHUNK_OUTPUT_TOKENS = 5 * 1024
 
 
-def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes):
+def create_kv_chunk_address_table_ds(
+    config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes
+):
     """
     Create and populate a KV chunk address table for disaggregation.
 

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -15,6 +15,7 @@ import ttnn
 # This is a predefined constant for the number of contiguous tokens in a DRAM bank
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 BH_NUM_DRAM_BANKS = 8
+PREFILL_CHUNK_OUTPUT_TOKENS = 5 * 1024
 
 
 def create_kv_chunk_address_table(config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes):
@@ -165,11 +166,6 @@ def create_kv_chunk_address_table_kimi(
     Returns:
         lookup_table: Populated KvChunkAddressTable
     """
-    assert seq_len % (mesh_shape[sp_axis] * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK) == 0, (
-        f"seq_len {seq_len} must be divisible by sp_factor({mesh_shape[sp_axis]}) * "
-        f"{NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK} for the sequential layout"
-    )
-
     lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
     host_name = socket.gethostname()
 
@@ -197,7 +193,15 @@ def create_kv_chunk_address_table_kimi(
             f"Set host name for fabric node id: mesh_id={int(fid.mesh_id)}, chip_id={int(fid.chip_id)} to {host_name}"
         )
 
-    seq_len_local = seq_len // mesh_shape[sp_axis]
+    tokens_per_chunk_per_device = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
+    num_seq_chunks = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS  # number of 5k chunks contained in the sequence length
+    assert (
+        seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
+    ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
+    assert tokens_per_chunk_per_device % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
+        f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_per_device}, "
+        f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
+    )
 
     slot = 0
     dram_bank_base_addr = tt_kvpe_cache.buffer_address()
@@ -205,19 +209,20 @@ def create_kv_chunk_address_table_kimi(
         group_idx = device_group_idx_per_row[local_idx]
         curr_bank_id = 0
         curr_bank_offset = 0
-        device_token_start = global_row * seq_len_local
-        device_token_end = device_token_start + seq_len_local
         for layer in range(num_layers):
-            for position in range(device_token_start, device_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
-                location = ttnn.experimental.disaggregation.KvCacheLocation()
-                location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
-                location.size_bytes = chunk_size_bytes
-                location.device_group_index = group_idx
-                lookup_table.set(layer, position, slot, location)
+            for seq_chunk in range(num_seq_chunks):
+                chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + global_row * tokens_per_chunk_per_device
+                chunk_token_end = chunk_token_start + tokens_per_chunk_per_device
+                for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                    location = ttnn.experimental.disaggregation.KvCacheLocation()
+                    location.noc_addr = (curr_bank_id << 32) | (dram_bank_base_addr + curr_bank_offset)
+                    location.size_bytes = chunk_size_bytes
+                    location.device_group_index = group_idx
+                    lookup_table.set(layer, position, slot, location)
 
-                curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
-                if curr_bank_id == 0:
-                    curr_bank_offset += chunk_size_bytes
+                    curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
+                    if curr_bank_id == 0:
+                        curr_bank_offset += chunk_size_bytes
 
     return lookup_table
 

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -57,6 +57,8 @@
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_table -k "line and random" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "line" -vvv --tb=short
   test_type: kv_cache_table
   test_group: module
   skus:

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -57,7 +57,6 @@
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI TT_DS_PREFILL_HOST_REF_CACHE=/tmp/deepseek_v3_transformer_ref_cache DEEPSEEK_V3_TRACE_DIR=/mnt/MLPerf/deepseek-prefill-cache MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained" -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_table -k "line and random" -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "line" -vvv --tb=short
   test_type: kv_cache_table
   test_group: module


### PR DESCRIPTION
### Summary
Issue: https://github.com/tenstorrent/tt-metal/issues/46091

Kimi K2.6 runs the non-balanced (sequential) attention layout — each SP device owns one contiguous block of seq_len / sp_factor tokens, while DeepSeek uses balanced zig-zag layout (two front/back strips per device). The existing create_kv_chunk_address_table only describes the balanced layout, so its readback can't validate a Kimi cache.

This PR adds:

- `create_kv_chunk_address_table_kimi` (utils/kv_cache_utils.py) — builds the KvChunkAddressTable for the sequential layout: one contiguous strip per SP device, reproducing init_kvpe_cache's round-robin DRAM bank/offset placement, with TP-replica device groups.
- `test_kimi_kv_cache_table` (tests/test_kv_cache_table.py) — fills a sequential KVPE cache via Kimi MLA (ISL = 5k), builds the table with the new function, reads every 32-token chunk back through read_device_chunk, and assert_equals against the gathered cache.

### DeepSeek Prefill CI

- [ ] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/kimi_kv_cache_table)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/kimi_kv_cache_table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/kimi_kv_cache_table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/kimi_kv_cache_table)