### PR TITLE
Fix OOM on Deepseek Prefill Combine test

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
@@ -80,10 +80,6 @@ class TorchDispatchModule(torch.nn.Module):
             self.metadata_len,
         )
 
-        # NOTE: forward() allocates fresh dispatched_buffer / dispatched_metadata each call
-        # (see below). Do NOT pre-allocate them here — for large configs the buffer is
-        # ~num_dispatch_groups*dispatch_group_size*max_dispatch_buffer_token_size*emb_dim
-        # fp32 elements (hundreds of GB), and this __init__ copy is never read.
 
     def forward(
         self,

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
@@ -80,8 +80,10 @@ class TorchDispatchModule(torch.nn.Module):
             self.metadata_len,
         )
 
-        self.dispatched_buffer = torch.zeros(self.dispatched_shape, dtype=torch.float32)
-        self.dispatched_metadata = torch.ones(self.dispatched_metadata_shape, dtype=torch.int32) * -1
+        # NOTE: forward() allocates fresh dispatched_buffer / dispatched_metadata each call
+        # (see below). Do NOT pre-allocate them here — for large configs the buffer is
+        # ~num_dispatch_groups*dispatch_group_size*max_dispatch_buffer_token_size*emb_dim
+        # fp32 elements (hundreds of GB), and this __init__ copy is never read.
 
     def forward(
         self,

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/dispatch.py
@@ -80,7 +80,6 @@ class TorchDispatchModule(torch.nn.Module):
             self.metadata_len,
         )
 
-
     def forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
## Summary
`TorchDispatchModule.__init__` pre-allocated `self.dispatched_buffer` (fp32) and
`self.dispatched_metadata`, but `forward()` always allocates its own fresh local
buffers and the `__init__` copies are never read anywhere. This removes the dead
allocation.

## Root cause
For large MoE configs the dispatch buffer is
`num_dispatch_groups * dispatch_group_size * max_dispatch_buffer_token_size * emb_dim`
fp32 elements — hundreds of GB. For the combine `perf_no_pcc` reference
(seq_len_per_chip=3200, capacity_factor=8, 64 experts on a 32-chip mesh) that is
`[4, 8, 204800, 7168]` ≈ 188 GB. Because the dead `__init__` copy and the
`forward()` copy are alive at the same time, the torch reference's host-RAM
footprint was roughly doubled, pushing it into the kernel OOM-killer.

## Impact
Measured on the combine `perf_no_pcc` reference (peak RSS via `/usr/bin/time -v`
and cgroup `memory.current`):

| | Before | After |
|---|---|---|
| peak host RAM | ~531 GB | ~382 GB |
| pytest exit | 137 (SIGKILL / OOM) | 0 (pass) |

`forward()` behavior is unchanged — it already allocates the buffers it returns.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/ds-prefill-fix-dispatch-ref-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/ds-prefill-fix-dispatch-ref-oom)