### PR TITLE
[Bug fix] Fix FIFO wrap handling in D2H socket

### DIFF
--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -106,7 +106,8 @@ void test_d2h_socket(
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
-    const MeshCoreCoord& sender_core = {MeshCoordinate(0, 0), CoreCoord(0, 0)}) {
+    const MeshCoreCoord& sender_core = {MeshCoordinate(0, 0), CoreCoord(0, 0)},
+    uint32_t pages_per_read = 1) {
     auto output_socket = D2HSocket(mesh_device, sender_core, socket_fifo_size);
     output_socket.set_page_size(page_size);
 
@@ -139,7 +140,7 @@ void test_d2h_socket(
                 static_cast<uint32_t>(data_size),
             }});
 
-    uint32_t num_reads = data_size / page_size;
+    uint32_t num_pages = data_size / page_size;
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::vector<uint32_t> dst_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
@@ -152,8 +153,9 @@ void test_d2h_socket(
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
 
     uint32_t page_size_words = page_size / sizeof(uint32_t);
-    for (uint32_t i = 0; i < num_reads; i++) {
-        output_socket.read(dst_vec.data() + (i * page_size_words), 1);
+    for (uint32_t page = 0; page < num_pages; page += pages_per_read) {
+        uint32_t pages = std::min<uint32_t>(pages_per_read, num_pages - page);
+        output_socket.read(dst_vec.data() + (page * page_size_words), pages);
     }
     output_socket.barrier();
     EXPECT_EQ(src_vec, dst_vec);
@@ -370,6 +372,8 @@ TEST_F(HDSocketFixture, D2HSocket) {
         // Uneven wrap with multiple pages on host allocated.
         // On most hosts, page size is 4K, so this should lead to 5 pages being allocated on the host.
         test_d2h_socket(mesh_device_, 16512, 1088, 156672, MeshCoreCoord(sender_coord, CoreCoord(0, 1)));
+        // Multi-page read whose span straddles the FIFO wrap boundary, exercising the head/tail split.
+        test_d2h_socket(mesh_device_, 4096, 1088, 79424, MeshCoreCoord(sender_coord, CoreCoord(0, 1)), 2);
     }
 }
 

--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -101,13 +101,18 @@ void test_h2d_socket(
     }
 }
 
+// Read: consume the stream with read() and verify the data. Discard: drop pages with
+// discard_pending_pages() without touching the data.
+enum class D2HConsumeMode { Read, Discard };
+
 void test_d2h_socket(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
     std::size_t socket_fifo_size,
     std::size_t page_size,
     std::size_t data_size,
     const MeshCoreCoord& sender_core = {MeshCoordinate(0, 0), CoreCoord(0, 0)},
-    uint32_t pages_per_read = 1) {
+    uint32_t pages_per_read = 1,
+    D2HConsumeMode consume_mode = D2HConsumeMode::Read) {
     auto output_socket = D2HSocket(mesh_device, sender_core, socket_fifo_size);
     output_socket.set_page_size(page_size);
 
@@ -151,6 +156,19 @@ void test_d2h_socket(
     mesh_workload.add_program(devices, std::move(send_program));
 
     EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
+
+    if (consume_mode == D2HConsumeMode::Discard) {
+        // Drop every page without reading the data region. discard_pending_pages() must
+        // advance bytes_acked exactly as read()/pop_bytes does, including the FIFO wrap
+        // gap, otherwise host bytes_acked never reconciles with device bytes_sent and the
+        // barrier deadlocks.
+        uint32_t discarded = 0;
+        while (discarded < num_pages) {
+            discarded += output_socket.discard_pending_pages();
+        }
+        output_socket.barrier(/*timeout_ms=*/5000);
+        return;
+    }
 
     uint32_t page_size_words = page_size / sizeof(uint32_t);
     for (uint32_t page = 0; page < num_pages; page += pages_per_read) {
@@ -374,6 +392,11 @@ TEST_F(HDSocketFixture, D2HSocket) {
         test_d2h_socket(mesh_device_, 16512, 1088, 156672, MeshCoreCoord(sender_coord, CoreCoord(0, 1)));
         // Multi-page read whose span straddles the FIFO wrap boundary, exercising the head/tail split.
         test_d2h_socket(mesh_device_, 4096, 1088, 79424, MeshCoreCoord(sender_coord, CoreCoord(0, 1)), 2);
+        // Drain a wrapping stream via discard_pending_pages() instead of reading. 4 pages
+        // through a 3-page FIFO forces one wrap; the discard path must credit the wrap gap
+        // or the closing barrier never reconciles with the device.
+        test_d2h_socket(
+            mesh_device_, 4096, 1088, 4352, MeshCoreCoord(sender_coord, CoreCoord(0, 1)), 1, D2HConsumeMode::Discard);
     }
 }
 

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -541,15 +541,28 @@ void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {
     uint32_t num_bytes = num_pages * page_size_;
     TT_FATAL(num_bytes <= fifo_curr_size_, "Cannot read more pages than the socket FIFO size.");
     this->wait_for_bytes(num_bytes);
-    uint32_t* src = using_hugepage_ ? hugepage_data_host_ptr_ + (read_ptr_ / sizeof(uint32_t))
-                                    : host_buffer_.get() + (read_ptr_ / sizeof(uint32_t));
+
+    uint32_t head_bytes = num_bytes;
+    if (read_ptr_ + num_bytes > fifo_curr_size_) {
+        head_bytes = fifo_curr_size_ - read_ptr_;
+    }
+    uint32_t tail_bytes = num_bytes - head_bytes;
+
+    uint32_t* base = using_hugepage_ ? hugepage_data_host_ptr_ : host_buffer_.get();
+    uint32_t* src = base + (read_ptr_ / sizeof(uint32_t));
     if (using_hugepage_) {
-        for (uint32_t i = 0; i < num_bytes; i += k_x86_clflush_line_bytes) {
+        for (uint32_t i = 0; i < head_bytes; i += k_x86_clflush_line_bytes) {
             _mm_clflush(reinterpret_cast<char*>(src) + i);
+        }
+        for (uint32_t i = 0; i < tail_bytes; i += k_x86_clflush_line_bytes) {
+            _mm_clflush(reinterpret_cast<char*>(base) + i);
         }
         _mm_lfence();
     }
-    std::memcpy(data, src, num_bytes);
+    std::memcpy(data, src, head_bytes);
+    if (tail_bytes > 0) {
+        std::memcpy(static_cast<char*>(data) + head_bytes, base, tail_bytes);
+    }
     this->pop_bytes(num_bytes);
 
     if (notify_sender) {

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -467,19 +467,8 @@ uint32_t D2HSocket::discard_pending_pages() {
     if (pages == 0) {
         return 0;
     }
-    // Rebase: ack everything currently visible without touching the data region; advance
-    // read_ptr_ as a real read() would so subsequent reads stay consistent.
     uint32_t bytes_to_discard = pages * page_size_;
-    uint32_t cursor = read_ptr_ + bytes_to_discard;
-    if (fifo_curr_size_ > 0) {
-        cursor %= fifo_curr_size_;
-    }
-    read_ptr_ = cursor;
-    bytes_acked_ += bytes_to_discard;
-    if (connector_state_) {
-        connector_state_->bytes_acked = bytes_acked_;
-        connector_state_->read_ptr = read_ptr_;
-    }
+    this->pop_bytes(bytes_to_discard);
     notify_sender();
     return pages;
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`read()` always used a single `memcpy`, so a multi-page read crossing the FIFO wrap read past the data region. It's now split into head + tail copies.
`discard_pending_pages()` advanced `bytes_acked` by only the discarded bytes, missing the unused tail bytes the device skips on wrap, so after a wrapping discard `bytes_acked` never caught up to the device's `bytes_sent`. It now uses `pop_bytes()`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/fix-d2h-read-wrap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/fix-d2h-read-wrap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/fix-d2h-read-wrap)