### PR TITLE
Require full success in vllm tests

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -624,14 +624,23 @@ jobs:
             "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
             2>&1 | tee ${FILE_BENCHMARK_LOG}
 
-          # If the backend fails, the benchmark will still complete successfully but with all-zero results.
-          # It will contain a warning message, though
-          warning_message="All requests failed"
-          if grep -q "$warning_message" "${FILE_BENCHMARK_LOG}"; then
-            echo "❌ All requests failed"
+          # `vllm bench serve` exits 0 even when individual requests fail (a crashed
+          # engine surfaces as failed requests, not a non-zero exit). Gate on the saved result and
+          # require EVERY request to complete successfully.
+          RESULT_JSON="output/vllm_result.json"
+          if [ ! -f "$RESULT_JSON" ]; then
+            echo "❌ Benchmark result file not found ($RESULT_JSON) — the benchmark did not complete"
             echo "Check out the server log in a step below."
             exit 1
           fi
+          completed=$(python3 -c "import json; print(json.load(open('$RESULT_JSON'))['completed'])")
+          expected=$(python3 -c "import json; print(json.load(open('$RESULT_JSON'))['num_prompts'])")
+          if [ "$completed" != "$expected" ]; then
+            echo "❌ Only $completed/$expected requests completed successfully (require all)"
+            echo "Check out the server log in a step below."
+            exit 1
+          fi
+          echo "✅ All $expected requests completed successfully"
       - name: 📐 Run structured output benchmark
         if: ${{ matrix.test-group.structured-output }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}


### PR DESCRIPTION
### PR Category
CI fix
### Summary
vLLM missed some failures, because it only failed a step when all requests failed

### Notes for reviewers
Ci testing previously missed case: https://github.com/tenstorrent/tt-metal/actions/runs/27149052079
Ci testing regular case: https://github.com/tenstorrent/tt-metal/actions/runs/27149161757

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/vllm-nightly-fail-on-partial-success)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/vllm-nightly-fail-on-partial-success)