### PR TITLE
[skip ci] ttnn: Remove skipped Mamba-style depthwise conv1d test case from `test_conv1d_replicate_pad`

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -643,22 +643,6 @@ def run_conv1d_replicate_pad(
         (1, 64, 32, 512, 3, 1, 2, 2, 1),
         # depthwise (groups == in_channels == out_channels) with replicate pad.
         (1, 32, 32, 512, 3, 1, 1, 1, 32),
-        pytest.param(
-            # depthwise with kernel_size > 1 (Mamba-style d_conv = 4): exercises the 1d-depthwise
-            # path that was previously gated on kernel_size == 1. See PR #44490 (issue #42163)
-            1,
-            512,
-            512,
-            512,
-            4,
-            1,
-            (1, 2),
-            1,
-            512,
-            marks=pytest.mark.skip(
-                reason="Issue #45392: L1 CB allocation overflow for 512-channel depthwise conv1d with bias"
-            ),
-        ),
     ),
 )
 def test_conv1d_replicate_pad(


### PR DESCRIPTION
## Summary

Removes a `pytest.mark.skip`-marked test parameter from `test_conv1d_replicate_pad` in `tests/ttnn/unit_tests/operations/conv/test_conv1d.py`.

## Context

The removed test case exercised the 1D depthwise conv1d path with `kernel_size=4` and `groups=512` (a Mamba-style `d_conv=4` configuration), introduced as part of PR #44490 (issue #42163) to verify the path previously gated on `kernel_size==1`.

It was subsequently skipped via `pytest.mark.skip` due to issue #45392 - an L1 CB allocation overflow for 512-channel depthwise conv1d with bias - making it a debug artifact rather than a reliable regression test.

## Change

- Removes the skipped `pytest.param` entry for `(batch=1, out_ch=512, in_ch=512, length=512, kernel=4, stride=1, pad=(1,2), dilation=1, groups=512)` from the parametrize list in `test_conv1d_replicate_pad`.

## Rationale

- The test has been unconditionally skipped and provides no CI signal.
- The end-to-end tests covering the relevant conv1d paths are passing in CI.
- Keeping permanently-skipped tests adds noise to the test suite without benefit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbuticTT/remove-mamba-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbuticTT/remove-mamba-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbuticTT/remove-mamba-test)