### PR TITLE
[Cleanup] Device 2.0 reduction kernels: replace get_tile_size with CB wrappers

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -54,7 +54,6 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t tile_bytes_input_values = get_tile_size(input_values_cb_index);
 
     const auto s0 = TensorAccessor(s0_args, values_addr);
 
@@ -63,6 +62,7 @@ void kernel_main() {
     Noc noc;
     CircularBuffer input_values_cb(input_values_cb_index);
     CircularBuffer input_indices_cb(input_indices_cb_index);
+    const uint32_t tile_bytes_input_values = input_values_cb.get_tile_size();
 
     uint32_t tile_id_input_values = 0;
     uint32_t tile_id_input_indices = 0;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp
@@ -27,7 +27,6 @@ void kernel_main() {
 
     // Constants
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes_in0 = get_tile_size(cb_id_in0);
 
     // DRAM tensor accessor configuration
     constexpr auto s_args = TensorAccessorArgs<5>();
@@ -36,13 +35,14 @@ void kernel_main() {
     Noc noc;
     CircularBuffer cb_in0(cb_id_in0);
     CircularBuffer cb_in1(cb_id_in1);
+    const uint32_t tile_bytes_in0 = cb_in0.get_tile_size();
 
 #if not GENERATE_INDICES
     // Precomputed indices tensor accessor
     constexpr auto indices_args = TensorAccessorArgs<s_args.next_compile_time_args_offset()>();
     const uint32_t src_indices_addr = get_arg_val<uint32_t>(4);
     const auto indices_accessor = TensorAccessor(indices_args, src_indices_addr);
-    const uint32_t tile_bytes_in1 = get_tile_size(cb_id_in1);
+    const uint32_t tile_bytes_in1 = cb_in1.get_tile_size();
 #endif  // not GENERATE_INDICES
 
     for (uint32_t i = start_ht; i < Ht; ++i) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -35,10 +35,6 @@ void kernel_main() {
 
     // Constants
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes_in0 = get_tile_size(cb_id_in0);
-#if not GENERATE_INDICES
-    const uint32_t tile_bytes_index = get_tile_size(cb_intermed_index);
-#endif
 
     // Tensor accessor
     const auto inout_tensor_accessor = TensorAccessor(inout_tensor_args, src_addr);
@@ -46,6 +42,10 @@ void kernel_main() {
     Noc noc;
     CircularBuffer cb_in0(cb_id_in0);
     CircularBuffer cb_index(cb_intermed_index);
+    const uint32_t tile_bytes_in0 = cb_in0.get_tile_size();
+#if not GENERATE_INDICES
+    const uint32_t tile_bytes_index = cb_index.get_tile_size();
+#endif
 
     // Read data and generate indices
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -25,8 +25,6 @@ void kernel_main() {
 
     // Constants
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes_val = get_tile_size(values_cb_index);
-    const uint32_t tile_bytes_idx = get_tile_size(output_ind_cb_index);
 
     // Tensor config
     const auto values_tensor_accessor = TensorAccessor(values_tensor_args, dst_addr0);
@@ -35,6 +33,8 @@ void kernel_main() {
     Noc noc;
     CircularBuffer values_cb(values_cb_index);
     CircularBuffer indices_cb(output_ind_cb_index);
+    const uint32_t tile_bytes_val = values_cb.get_tile_size();
+    const uint32_t tile_bytes_idx = indices_cb.get_tile_size();
 
     // Get Kt rows of values and then Kt rows of indices from compute kernel
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp
@@ -25,8 +25,6 @@ void kernel_main() {
 
     // Memory transfer configuration
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes_val = get_tile_size(values_cb_index);
-    const uint32_t tile_bytes_idx = get_tile_size(output_ind_cb_index);
 
     // Initialize DRAM tensor accessors for interleaved output format
     const auto interleaved_accessor0 = TensorAccessor(interleaved_accessor0_args, dst_addr0);
@@ -35,6 +33,8 @@ void kernel_main() {
     Noc noc;
     CircularBuffer values_cb(values_cb_index);
     CircularBuffer indices_cb(output_ind_cb_index);
+    const uint32_t tile_bytes_val = values_cb.get_tile_size();
+    const uint32_t tile_bytes_idx = indices_cb.get_tile_size();
 
     // Process each height row sequentially, writing Kt tiles of TopK results
     for (uint32_t j = 0; j < Ht; ++j) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -38,8 +38,8 @@ void kernel_main() {
     CircularBuffer final_indices_cb(final_indices_cb_index);
 
     // Memory transfer configuration
-    const uint32_t tile_bytes_values = get_tile_size(values_cb_index);
-    const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
+    const uint32_t tile_bytes_values = values_cb.get_tile_size();
+    const uint32_t tile_bytes_ind = indices_cb.get_tile_size();
 
     // Calculate target addresses in final core's L1 memory
     const uint32_t final_values_cb_addr = final_values_cb.get_write_ptr();


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/45003

Removes the CB-index-keyed get_tile_size(cb_id) free-function holdover from reduction/sampling and reduction/topk dataflow kernels in favor of the Device 2.0 wrapper-method form (cb.get_tile_size()). The CircularBuffer wrappers were already constructed in every kernel; this finishes Device 2.0 data-movement migration for both ops.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/reduction_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/reduction_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/reduction_device_2_0)