### PR TITLE
Fix BH PC errors due to stage size tests

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_stage_size_loopback_smoke.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_stage_size_loopback_smoke.py
@@ -91,7 +91,25 @@ def get_generic_stage_size_loopback_topology_config() -> PhysicalTopologyConfig:
     )
 
 
-GENERIC_STAGE_SIZE_LOOPBACK_CONFIG = get_generic_stage_size_loopback_topology_config()
+# These tests are a multi-rank pipeline (one MPI rank per stage) launched via tt-run on galaxy
+# stage-size hardware. Any plain-pytest CI box is a single process -- a p150 (shape (1,1)) or a BH
+# loudbox that presents as (4,2)/(2,4) -- and is NOT that deployment. Gate on rank count first so we
+# skip every single-box run regardless of shape (a (4,2) loudbox would otherwise pass the shape
+# check below and run). The build is also at import time because the parametrize decorators read its
+# attributes during collection; skip the whole module rather than let it become a collection ERROR.
+if int(ttnn.distributed_context_get_size()) <= 1:
+    pytest.skip(
+        "stage-size loopback smoke requires a multi-rank (tt-run) pipeline launch on galaxy "
+        "stage-size HW; single-process run detected",
+        allow_module_level=True,
+    )
+try:
+    GENERIC_STAGE_SIZE_LOOPBACK_CONFIG = get_generic_stage_size_loopback_topology_config()
+except ValueError as exc:
+    pytest.skip(
+        f"stage-size loopback smoke requires a 4x2/4x4/8x4 stage mesh: {exc}",
+        allow_module_level=True,
+    )
 PIPELINE_ENDPOINT_CORE_COORD = ttnn.CoreCoord(0, 0)
 
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_stage_size_loopback_smoke.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_stage_size_loopback_smoke.py
@@ -97,10 +97,17 @@ def get_generic_stage_size_loopback_topology_config() -> PhysicalTopologyConfig:
 # skip every single-box run regardless of shape (a (4,2) loudbox would otherwise pass the shape
 # check below and run). The build is also at import time because the parametrize decorators read its
 # attributes during collection; skip the whole module rather than let it become a collection ERROR.
-if int(ttnn.distributed_context_get_size()) <= 1:
+try:
+    _num_procs = int(ttnn.distributed_context_get_size())
+except RuntimeError:
+    # distributed_context_get_size() raises RuntimeError when no distributed context is
+    # initialized (plain pytest, not launched via tt-run). That alone means this isn't the
+    # multi-rank galaxy deployment, so treat it as a single process and skip below.
+    _num_procs = 1
+if _num_procs <= 1:
     pytest.skip(
         "stage-size loopback smoke requires a multi-rank (tt-run) pipeline launch on galaxy "
-        "stage-size HW; single-process run detected",
+        "stage-size HW; single-process / no distributed context detected",
         allow_module_level=True,
     )
 try:


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The stage size test on P150 errored out due to the lookup failure from mesh shape size to the stage family size. Added relevant guards. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/bh-pc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/bh-pc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/bh-pc-fix)