### PR TITLE
[Cleanup] Move transpose, binary_ng operations to device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -37,12 +37,12 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
     CircularBuffer cb(cb_id_in0);
     CircularBuffer cb_padding(tt::CBIndex::c_1);
+    const uint32_t tile_bytes = cb.get_tile_size();
 
 // read a ublock of tiles from src to CB, and then push the ublock to unpacker
 #ifdef BACKWARDS

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const uint32_t tile_bytes = cb.get_tile_size();
     const auto s = TensorAccessor(src_args, src_addr);
 
     // this reader will read a NHW tensor in NWH order

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -25,11 +25,11 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    CircularBuffer cb(cb_id_in0);
+    const uint32_t tile_bytes = cb.get_tile_size();
     const auto s = TensorAccessor(src_args, src_addr);
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
 
     uint32_t ht = start_ht;
     uint32_t wt = start_wt;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr auto src_args = TensorAccessorArgs<0, 0>();
     constexpr bool has_sharding = get_compile_time_arg_val(src_args.next_compile_time_args_offset()) == 1;
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
     const uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
 
 #if !DST_SHARDED
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();
-    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
     const auto dst = TensorAccessor(dst_args, dst_addr);
     constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/pull/46366

Removes the CB-index-keyed get_tile_size(cb_id) free-function holdover from data_movement/transpose dataflow kernels and the two legacy binary_ng dataflow kernels in favor of the Device 2.0 wrapper-method form (cb.get_tile_size()). The CircularBuffer wrappers were already in scope at every call site (two transpose kernels required relocating the wrapper declaration a few lines up).

### Notes for reviewers
Completes Device 2.0 data-movement migration for data_movement/transpose; binary_ng remains Partial pending the fill_tile_utils.hpp lift (separate effort).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/ring_1_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/ring_1_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/ring_1_device_2_0)