### PR TITLE
#MINFRA-762: re-host bh_qb_DeepSeek_PREFILL onto BH-QB-GE (bh_quietbox_2)

### DIFF
--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -85,7 +85,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_llmbox
+      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_llmbox,bh_quietbox_2
       model: deepseek_prefill
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[DeepSeek Prefill] "

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -307,7 +307,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check and not fabric2d' -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/cache/ -vvv --tb=short
   skus:
-    bh_llmbox:
+    bh_quietbox_2:
       timeout: 10
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
@@ -320,7 +320,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check)" || exit_code=$?
     exit $exit_code
   skus:
-    bh_quietbox_2:
+    bh_llmbox:
       timeout: 30
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -320,7 +320,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check)" || exit_code=$?
     exit $exit_code
   skus:
-    bh_llmbox:
+    bh_quietbox_2:
       timeout: 30
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -81,7 +81,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check and fabric2d' -vvv --tb=short
   model: deepseek_prefill
   skus:
-    bh_llmbox:
+    bh_quietbox_2:
       timeout: 40
   owner_id: U08E1JCMAJF
   team: models


### PR DESCRIPTION
## Summary
- Swap SKU `bh_llmbox` → `bh_quietbox_2` for `bh_qb_DeepSeek_PREFILL` in `tests/pipeline_reorg/blackhole_e2e_tests.yaml` and `tests/pipeline_reorg/demo_sp_release_tests.yaml`
- Add `bh_quietbox_2` to the `enabled-skus` allowlist for the deepseek-prefill caller in `.github/workflows/demo-sp-release.yaml` so the test isn't filtered out of the matrix
- Rebased onto latest `main` to pick up the `BH-QB-GE` → `BH-Quietbox-2` runner-label rename (PR #45620). A small fix-up commit corrects a rebase artifact where the SKU swap initially landed on Petar Milojević's `bh-qb-deepseek-prefill-op-tests` entry; that entry is restored to `bh_llmbox` and the swap is applied to Marko Bezulj's `bh-qb-deepseek-prefill` as intended.

Re-hosts Marko Bezulj's two `bh_qb_DeepSeek_PREFILL` entries onto BH-Quietbox-2 ahead of QBAE / BH-LLMBox decommissioning under MINFRA-742 (parent issue).

Follow-up PR to remove llmbox references

## Test plan

Latest validation on the rebased branch:
- [x] `(Blackhole) e2e tests` — `bh_qb_DeepSeek_PREFILL [bh_quietbox_2]` passed: https://github.com/tenstorrent/tt-metal/actions/runs/27170435334
- [ ] `(Release) Model Status for Console Deployment` — deepseek_prefill group, run in progress: https://github.com/tenstorrent/tt-metal/actions/runs/27170438317

Earlier validation history:
- Initial `(Blackhole) e2e tests` (pre-rebase, pre-enabled-skus fix) — `bh_qb_DeepSeek_PREFILL [bh_quietbox_2]` passed: https://github.com/tenstorrent/tt-metal/actions/runs/27045909579
- Initial `(Release) Model Status for Console Deployment` (pre-rebase, pre-enabled-skus fix) — test was filtered out of the matrix because `bh_quietbox_2` wasn't in `enabled-skus`: https://github.com/tenstorrent/tt-metal/actions/runs/27045912950
- Re-dispatched runs after enabled-skus fix but before the label rebase (cancelled and superseded by the rebased dispatches above): runs `27156209301` and `27156219518`

`bh_qb2_DeepSeek_PREFILL_OP_TESTS [bh_quietbox_2]` fails in the latest run as well, but that failure is **pre-existing on `main`** (was failing in the scheduled run `27027823664` before this branch existed) and the entry is not touched by this diff — owned separately by Petar Milojević.

## Dependencies / related

- Parent: [MINFRA-742](https://tenstorrent.atlassian.net/browse/MINFRA-742) (QBAE / BH-LLMBox scrub). MINFRA-742 removes `bh_llmbox` from the deepseek-prefill `enabled-skus` list as part of its scrub; this PR intentionally keeps `bh_llmbox` in place to avoid a textual conflict and lets MINFRA-742 do the cleanup.
- Picks up the label rename from #45620 via rebase (BH-QB-GE → BH-Quietbox-2).

---
**Jira:** [MINFRA-762](https://tenstorrent.atlassian.net/browse/MINFRA-762)