### PR TITLE
[Cleanup] Move fill_tile_utils helpers to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -30,7 +30,7 @@ FORCE_INLINE void fill_with_val(uint32_t l1_write_ptr, ScalarT scalar) {
 FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t l1_write_ptr) {
     auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_ptr);
     const uint16_t first_elem = read_ptr[0];
-    const uint32_t packed_first_elem = first_elem << 16 | first_elem;
+    const uint32_t packed_first_elem = (static_cast<uint32_t>(first_elem) << 16) | static_cast<uint32_t>(first_elem);
 
     // Since all elements in the tile are the same, we can ignore the faces and assume the entire
     // tile is contiguous in memory.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp
@@ -8,8 +8,8 @@
 
 // Fills one full tile of bfloat16 with a scalar value
 // Scalar is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void fill_with_val_bfloat16(uint32_t cb_id, uint32_t packed_scalar) {
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_with_val_bfloat16(uint32_t l1_write_ptr, uint32_t packed_scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
     // 1024 is the number of elements in a full tile, but since the scalar is packed into a u32,
     // each iteration writes 2 elements, hence the division by 2
     for (uint32_t i = 0; i < 512; ++i) {
@@ -18,8 +18,8 @@ FORCE_INLINE void fill_with_val_bfloat16(uint32_t cb_id, uint32_t packed_scalar)
 }
 
 template <uint32_t ElementsV, class ScalarT>
-FORCE_INLINE void fill_with_val(uint32_t cb_id, ScalarT scalar) {
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr ScalarT*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_with_val(uint32_t l1_write_ptr, ScalarT scalar) {
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr ScalarT*>(l1_write_ptr);
     for (uint32_t i = 0; i < ElementsV; ++i) {
         ptr[i] = scalar;
     }
@@ -27,14 +27,14 @@ FORCE_INLINE void fill_with_val(uint32_t cb_id, ScalarT scalar) {
 
 // Reads the very first element of the CB and fills the entire tile with that value.
 // Tile is assumed to have 16-bit elements
-FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t cb_id) {
-    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t l1_write_ptr) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_ptr);
     const uint16_t first_elem = read_ptr[0];
     const uint32_t packed_first_elem = first_elem << 16 | first_elem;
 
     // Since all elements in the tile are the same, we can ignore the faces and assume the entire
     // tile is contiguous in memory.
-    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
     // TODO: should I fill one face like this and then use noc to fill the rest?
     for (uint32_t i = 0; i < 512; ++i) {
         write_ptr[i] = packed_first_elem;
@@ -44,11 +44,11 @@ FORCE_INLINE void fill_tile_with_first_element_bfloat16(uint32_t cb_id) {
 // Reads the very first element of the CB and fills the entire tile with that value.
 // Tile is assumed to have 32-bit elements (float32 or int32).
 template <typename T>
-FORCE_INLINE void fill_tile_with_first_element(uint32_t cb_id) {
-    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_element(uint32_t l1_write_ptr) {
+    auto* read_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_ptr);
     const T first_elem = read_ptr[0];
 
-    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(get_write_ptr(cb_id));
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr T*>(l1_write_ptr);
     for (uint32_t i = 0; i < 1024; ++i) {
         write_ptr[i] = first_elem;
     }
@@ -61,8 +61,8 @@ FORCE_INLINE void fill_tile_with_first_element(uint32_t cb_id) {
 //                  4 faces x 16 rows/face, one exponent byte per row of 16 elements
 //   Bytes 64-1087: Data section (256 uint32_t words = 1024 bytes)
 //                  4 faces x 256 bytes/face, one byte per element
-FORCE_INLINE void fill_tile_with_first_element_bfp8(uint32_t cb_id) {
-    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_element_bfp8(uint32_t l1_write_ptr) {
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
     uint32_t packed_exp = (word_ptr[0] & 0xFF) * 0x01010101u;
     uint32_t packed_data = (word_ptr[16] & 0xFF) * 0x01010101u;
 
@@ -90,8 +90,8 @@ FORCE_INLINE void fill_tile_with_first_element_bfp8(uint32_t cb_id) {
 //   Bytes 64-575: Data section (128 uint32_t words = 512 bytes)
 //                 4 faces x 128 bytes/face, 4 bits per element (2 elements per byte)
 // BFP4 nibble packing: element[even] in low nibble (bits 0-3), element[odd] in high nibble (bits 4-7).
-FORCE_INLINE void fill_tile_with_first_element_bfp4(uint32_t cb_id) {
-    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_element_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
     uint8_t exp_val = byte_ptr[0];  // First exponent byte
 
     // Element 0 (the scalar) is in the LOW nibble of the first data byte.
@@ -105,7 +105,7 @@ FORCE_INLINE void fill_tile_with_first_element_bfp4(uint32_t cb_id) {
     uint32_t packed_data =
         (uint32_t)data_val | ((uint32_t)data_val << 8) | ((uint32_t)data_val << 16) | ((uint32_t)data_val << 24);
 
-    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    auto* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
     // Fill 64 exponent bytes = 16 uint32_t words
     for (uint32_t i = 0; i < 16; ++i) {
         write_ptr[i] = packed_exp;
@@ -125,9 +125,9 @@ FORCE_INLINE void fill_tile_with_first_element_bfp4(uint32_t cb_id) {
 // Face arrangement: 0=top-left, 1=top-right, 2=bottom-left, 3=bottom-right
 // Column broadcast: left faces (0,2) have column 0 data; right faces (1,3) are zero.
 //   -> Extract column 0 nibble, pack into both nibbles, fill row, then copy left to right face.
-FORCE_INLINE void fill_tile_with_first_column_bfp4(uint32_t cb_id) {
-    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
-    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_column_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     // Process left->right face pairs: (face0->face1) and (face2->face3)
     for (uint32_t pair = 0; pair < 2; ++pair) {
@@ -164,9 +164,9 @@ FORCE_INLINE void fill_tile_with_first_column_bfp4(uint32_t cb_id) {
 // Tile is assumed to be in BFP4 format (Bfp4 or Bfp4_b).
 // Row broadcast: top faces (0,1) have row 0 data; bottom faces (2,3) are zero.
 //   -> Replicate row 0 within top faces, then copy top faces to bottom faces.
-FORCE_INLINE void fill_tile_with_first_row_bfp4(uint32_t cb_id) {
-    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
-    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_row_bfp4(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     // Pack row-0 exponents into words and write all 4 faces at once
     uint32_t packed_exp0 = static_cast<uint32_t>(byte_ptr[0]) * 0x01010101u;
@@ -226,8 +226,8 @@ FORCE_INLINE void fill_tile_with_first_row_bfp4(uint32_t cb_id) {
 // Face arrangement: 0=top-left, 1=top-right, 2=bottom-left, 3=bottom-right
 // Column broadcast: left faces (0,2) have column 0 data; right faces (1,3) are zero.
 //   -> Replicate column 0 within left faces, then copy left faces to right faces.
-FORCE_INLINE void fill_tile_with_first_column_bfp8(uint32_t cb_id) {
-    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_column_bfp8(uint32_t l1_write_ptr) {
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     // --- Face pair 0: face0 (left) -> face1 (right) ---
     // Replicate column 0 across all 16 columns in left face data (4 words per row)
@@ -278,9 +278,9 @@ FORCE_INLINE void fill_tile_with_first_column_bfp8(uint32_t cb_id) {
 // Tile is assumed to be in BFP8 format (Bfp8 or Bfp8_b).
 // Row broadcast: top faces (0,1) have row 0 data; bottom faces (2,3) are zero.
 //   -> Replicate row 0 within top faces, then copy top faces to bottom faces.
-FORCE_INLINE void fill_tile_with_first_row_bfp8(uint32_t cb_id) {
-    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(get_write_ptr(cb_id));
-    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void fill_tile_with_first_row_bfp8(uint32_t l1_write_ptr) {
+    auto* byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_ptr);
+    auto* word_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     // Pack row-0 exponents into words and write all 4 faces at once
     uint32_t packed_exp0 = static_cast<uint32_t>(byte_ptr[0]) * 0x01010101u;
@@ -343,11 +343,11 @@ FORCE_INLINE void fill_tile_with_first_row_bfp8(uint32_t cb_id) {
 
 // Reads the very first row of the CB and fills the entire tile with the same row.
 // Tile is assumed to have 16-bit elements.
-FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t cb_id) {
+FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t l1_write_ptr) {
     // Here we have to account for the fact that a tile consists of 4 16x16 faces.
     // So we have to fill faces 0 and 2 with the first row of face 0, and faces 1 and 3
     // with the first row of face 1.
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
     uint32_t row_offset = 8;  // start at second row since first row is source
     uint32_t num_rows = 15;
 
@@ -368,9 +368,9 @@ FORCE_INLINE void fill_tile_with_first_row_bfloat16(uint32_t cb_id) {
 
 // Reads the very first row of the CB and fills the entire tile with the same row.
 // Tile is assumed to have 32-bit elements (float32/int32).
-FORCE_INLINE void fill_tile_with_first_row(uint32_t cb_id) {
+FORCE_INLINE void fill_tile_with_first_row(uint32_t l1_write_ptr) {
     // Tile with 4 faces (16x16) and 32-bit elements
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     uint32_t row_offset = 16;  // Start at the second row (offset by 16 elements)
     uint32_t num_rows = 15;    // 15 rows to fill per face
@@ -392,11 +392,11 @@ FORCE_INLINE void fill_tile_with_first_row(uint32_t cb_id) {
 
 // Reads the very first column of the CB and fills the entire tile with the same column.
 // Tile is assumed to have 16-bit elements.
-FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
+FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t l1_write_ptr) {
     // Here we have to account for the fact that a tile consists of 4 16x16 faces.
     // So we have to fill faces 0 and 1 with the first column of face 0, and faces 2 and 3
     // with the first column of face 2.
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_ptr);
 
     constexpr uint32_t num_rows = 16;
 
@@ -417,9 +417,9 @@ FORCE_INLINE void fill_tile_with_first_column_bfloat16(uint32_t cb_id) {
 
 // Reads the very first column of the CB and fills the entire tile with the same column.
 // Tile is assumed to have 32-bit elements (float32/int32).
-FORCE_INLINE void fill_tile_with_first_column(uint32_t cb_id) {
+FORCE_INLINE void fill_tile_with_first_column(uint32_t l1_write_ptr) {
     // Tile with 4 faces (16x16) and 32-bit elements
-    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_ptr);
 
     constexpr uint32_t num_rows = 16;             // Number of rows per face
     constexpr uint32_t face_row_stride = 16;      // Elements per row

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar.cpp
@@ -36,10 +36,10 @@ void kernel_main() {
     cb_src.reserve_back(onetile);
 #ifdef FILL_WITH_VALUE_FLOAT
     const auto float_ptr = reinterpret_cast<const float*>(&packed_scalar);
-    FILL_WITH_VALUE_FLOAT(cb_id_src, *float_ptr);
+    FILL_WITH_VALUE_FLOAT(cb_src.get_write_ptr(), *float_ptr);
 #endif
 #ifdef FILL_WITH_VALUE
-    FILL_WITH_VALUE(cb_id_src, packed_scalar);
+    FILL_WITH_VALUE(cb_src.get_write_ptr(), packed_scalar);
 #endif
     cb_src.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
     cb_push_back(cb_id_src, src_num_tiles);
 #endif
 #else
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if SRC_SHARDED_B
@@ -58,7 +58,7 @@ void kernel_main() {
     cb_push_back(cb_id_src_b, src_num_tiles_b);
 #endif
 #else
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -113,7 +113,7 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_src.get_write_ptr());
 #endif
                         cb_src.push_back(onetile);
 #endif
@@ -125,7 +125,7 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_src_b.get_write_ptr());
 #endif
                         cb_src_b.push_back(onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast.cpp
@@ -47,14 +47,14 @@ void kernel_main() {
     cb_src.reserve_back(src_num_tiles);
     cb_src.push_back(src_num_tiles);
 #else
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if SRC_SHARDED_B
     cb_src_b.reserve_back(src_num_tiles_b);
     cb_src_b.push_back(src_num_tiles_b);
 #else
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -63,10 +63,10 @@ void kernel_main() {
     cb_src_b.reserve_back(1);
 #ifdef FILL_WITH_VALUE_FLOAT_B
     const auto float_ptr_b = reinterpret_cast<const float*>(&packed_scalar);
-    FILL_WITH_VALUE_FLOAT_B(cb_id_src_b, *float_ptr_b);
+    FILL_WITH_VALUE_FLOAT_B(cb_src_b.get_write_ptr(), *float_ptr_b);
 #endif
 #ifdef FILL_WITH_VALUE_B
-    FILL_WITH_VALUE_B(cb_id_src_b, packed_scalar);
+    FILL_WITH_VALUE_B(cb_src_b.get_write_ptr(), packed_scalar);
 #endif
     cb_src_b.push_back(1);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -47,14 +47,14 @@ void kernel_main() {
     cb_src.reserve_back(src_num_tiles);
     cb_src.push_back(src_num_tiles);
 #else
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if SRC_SHARDED_B
     cb_src_b.reserve_back(src_num_tiles_b);
     cb_src_b.push_back(src_num_tiles_b);
 #else
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
 #if !SRC_SHARDED || !SRC_SHARDED_B

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast.cpp
@@ -124,10 +124,10 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_BCAST && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
 #endif
 #if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
 #endif
 #if !SRC_SHARDED
                             cb_src.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -98,7 +98,7 @@ void kernel_main() {
                         noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN(cb_id_src);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_src.get_write_ptr());
                         cb_src.push_back(onetile);
 #else
                         cb_src_b.reserve_back(onetile);
@@ -107,7 +107,7 @@ void kernel_main() {
                             src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_id_src_b);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_src_b.get_write_ptr());
                         cb_src_b.push_back(onetile);
 #endif
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
@@ -125,7 +125,7 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
 #endif
 #if !SRC_SHARDED_B
                             cb_src_b.push_back(onetile);
@@ -139,7 +139,7 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
 #endif
 #if !SRC_SHARDED_B
                             cb_src.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_col_mixed_bcast.cpp
@@ -44,11 +44,11 @@ void kernel_main() {
     CircularBuffer cb_src_b(cb_id_src_b);
 
 #if !SRC_SHARDED
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if !SRC_SHARDED_B
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
     cb_push_back(cb_id_src, src_num_tiles);
 #endif
 #else
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 #endif
 #if SRC_SHARDED_B
@@ -58,7 +58,7 @@ void kernel_main() {
     cb_push_back(cb_id_src_b, src_num_tiles_b);
 #endif
 #else
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src_addr_b);
 #endif
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -112,7 +112,7 @@ void kernel_main() {
                     noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                    FILL_TILE_WITH_FIRST_ELEMENT(cb_id_src);
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_src.get_write_ptr());
 #endif
                     cb_src.push_back(onetile);
 #endif
@@ -123,7 +123,7 @@ void kernel_main() {
                     noc.async_read_barrier();
 #endif
 #if !BCAST_LLK
-                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_id_src_b);
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_src_b.get_write_ptr());
 #endif
                     cb_src_b.push_back(onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
 
 #if !DST_SHARDED
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();
-    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
     const auto dst = TensorAccessor(dst_args, dst_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp
@@ -150,7 +150,7 @@ void kernel_main() {
                             s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_pred.get_write_ptr());
                         cb_pred.push_back(onetile);
 #endif
 #if SRC_BCAST_B
@@ -160,7 +160,7 @@ void kernel_main() {
                             s1, cb_true, src1_tile_bytes, {.page_id = true_tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN_B(true_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_true.get_write_ptr());
                         cb_true.push_back(onetile);
 #endif
 
@@ -172,7 +172,7 @@ void kernel_main() {
                             s2, cb_false, src2_tile_bytes, {.page_id = false_tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN_C(false_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_C(cb_false.get_write_ptr());
                         cb_false.push_back(onetile);
 #endif
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_colbcast_ttt.cpp
@@ -69,21 +69,21 @@ void kernel_main() {
     cb_pred.reserve_back(src_num_tiles);
     cb_pred.push_back(src_num_tiles);
 #else
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src_addr);
 #endif
 #if SRC_SHARDED_B
     cb_true.reserve_back(true_num_tiles);
     cb_true.push_back(true_num_tiles);
 #else
-    const uint32_t src1_tile_bytes = get_tile_size(true_cb);
+    const uint32_t src1_tile_bytes = cb_true.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, true_addr);
 #endif
 #if SRC_SHARDED_C
     cb_false.reserve_back(false_num_tiles);
     cb_false.push_back(false_num_tiles);
 #else
-    const uint32_t src2_tile_bytes = get_tile_size(false_cb);
+    const uint32_t src2_tile_bytes = cb_false.get_tile_size();
     const auto s2 = TensorAccessor(src2_args, false_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
@@ -21,16 +21,17 @@ void kernel_main() {
     constexpr auto src0_args = TensorAccessorArgs<2, 0>();
     constexpr auto src1_args =
         TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
-    const uint32_t tile_bytes_0 = get_tile_size(cb_id_in0);
-    const uint32_t tile_bytes_1 = get_tile_size(cb_id_in1);
-    const auto s0 = TensorAccessor(src0_args, src0_addr);
-    const auto s1 = TensorAccessor(src1_args, src1_addr);
-
-    constexpr uint32_t onetile = 1;
 
     Noc noc;
     CircularBuffer cb0(cb_id_in0);
     CircularBuffer cb1(cb_id_in1);
+
+    const uint32_t tile_bytes_0 = cb0.get_tile_size();
+    const uint32_t tile_bytes_1 = cb1.get_tile_size();
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+
+    constexpr uint32_t onetile = 1;
 
     for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
         cb0.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_ttt.cpp
@@ -24,18 +24,19 @@ void kernel_main() {
         TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
     constexpr auto src2_args =
         TensorAccessorArgs<src1_args.next_compile_time_args_offset(), src1_args.next_common_runtime_args_offset()>();
-    const uint32_t tile_bytes_0 = get_tile_size(cb_id_in0);
-    const uint32_t tile_bytes_1 = get_tile_size(cb_id_in1);
-    const uint32_t tile_bytes_2 = get_tile_size(cb_id_in2);
-    const auto s0 = TensorAccessor(src0_args, src0_addr);
-    const auto s1 = TensorAccessor(src1_args, src1_addr);
-    const auto s2 = TensorAccessor(src2_args, src2_addr);
-    constexpr uint32_t onetile = 1;
 
     Noc noc;
     CircularBuffer cb0(cb_id_in0);
     CircularBuffer cb1(cb_id_in1);
     CircularBuffer cb2(cb_id_in2);
+
+    const uint32_t tile_bytes_0 = cb0.get_tile_size();
+    const uint32_t tile_bytes_1 = cb1.get_tile_size();
+    const uint32_t tile_bytes_2 = cb2.get_tile_size();
+    const auto s0 = TensorAccessor(src0_args, src0_addr);
+    const auto s1 = TensorAccessor(src1_args, src1_addr);
+    const auto s2 = TensorAccessor(src2_args, src2_addr);
+    constexpr uint32_t onetile = 1;
 
     for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
         cb0.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
@@ -60,21 +60,21 @@ void kernel_main() {
     cb0.reserve_back(src0_num_tiles);
     cb0.push_back(src0_num_tiles);
 #else
-    const uint32_t src0_tile_bytes = get_tile_size(cb_id_src0);
+    const uint32_t src0_tile_bytes = cb0.get_tile_size();
     const auto src0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #if SRC_SHARDED_B
     cb1.reserve_back(src1_num_tiles);
     cb1.push_back(src1_num_tiles);
 #else
-    const uint32_t src1_tile_bytes = get_tile_size(cb_id_src1);
+    const uint32_t src1_tile_bytes = cb1.get_tile_size();
     const auto src1 = TensorAccessor(src1_args, src1_addr);
 #endif
 #if SRC_SHARDED_C
     cb2.reserve_back(src2_num_tiles);
     cb2.push_back(src2_num_tiles);
 #else
-    const uint32_t src2_tile_bytes = get_tile_size(cb_id_src2);
+    const uint32_t src2_tile_bytes = cb2.get_tile_size();
     const auto src2 = TensorAccessor(src2_args, src2_addr);
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B || !SRC_SHARDED_C

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
@@ -152,9 +152,9 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_A
-                        FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+                        FILL_TILE_WITH_FIRST_ELEMENT(cb_pred.get_write_ptr());
 #else
-                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_pred.get_write_ptr());
 #endif
                         cb_pred.push_back(onetile);
 #endif
@@ -171,9 +171,9 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_B
-                        FILL_TILE_WITH_FIRST_ELEMENT_B(true_cb);
+                        FILL_TILE_WITH_FIRST_ELEMENT_B(cb_true.get_write_ptr());
 #else
-                        FILL_TILE_WITH_FIRST_COLUMN_B(true_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_true.get_write_ptr());
 #endif
                         cb_true.push_back(onetile);
 #endif
@@ -190,9 +190,9 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif
 #if SRC_SCALAR_C
-                        FILL_TILE_WITH_FIRST_ELEMENT_C(false_cb);
+                        FILL_TILE_WITH_FIRST_ELEMENT_C(cb_false.get_write_ptr());
 #else
-                        FILL_TILE_WITH_FIRST_COLUMN_C(false_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_C(cb_false.get_write_ptr());
 #endif
                         cb_false.push_back(onetile);
 #endif
@@ -207,7 +207,7 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_A
-                            FILL_TILE_WITH_FIRST_ROW(predicate_cb);
+                            FILL_TILE_WITH_FIRST_ROW(cb_pred.get_write_ptr());
 #endif
                             cb_pred.push_back(onetile);
 #endif
@@ -220,7 +220,7 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_B
-                            FILL_TILE_WITH_FIRST_ROW_B(true_cb);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_true.get_write_ptr());
 #endif
                             cb_true.push_back(onetile);
 #endif
@@ -233,7 +233,7 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_ROW_BCAST_C
-                            FILL_TILE_WITH_FIRST_ROW_C(false_cb);
+                            FILL_TILE_WITH_FIRST_ROW_C(cb_false.get_write_ptr());
 #endif
                             cb_false.push_back(onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_row_col_bcast_ttt.cpp
@@ -64,21 +64,21 @@ void kernel_main() {
     cb_pred.reserve_back(src_num_tiles);
     cb_pred.push_back(src_num_tiles);
 #else
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
 #if SRC_SHARDED_B
     cb_true.reserve_back(src_num_tiles_b);
     cb_true.push_back(src_num_tiles_b);
 #else
-    const uint32_t src1_tile_bytes = get_tile_size(true_cb);
+    const uint32_t src1_tile_bytes = cb_true.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 #endif
 #if SRC_SHARDED_C
     cb_false.reserve_back(src_num_tiles_c);
     cb_false.push_back(src_num_tiles_c);
 #else
-    const uint32_t src2_tile_bytes = get_tile_size(false_cb);
+    const uint32_t src2_tile_bytes = cb_false.get_tile_size();
     const auto s2 = TensorAccessor(src2_args, src2_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp
@@ -76,21 +76,21 @@ void kernel_main() {
     cb_a.reserve_back(src_num_tiles);
     cb_a.push_back(src_num_tiles);
 #else
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_a.get_tile_size();
     const auto src = TensorAccessor(src0_args, src_addr);
 #endif
 #if SRC_SHARDED_B
     cb_b.reserve_back(src_num_tiles_b);
     cb_b.push_back(src_num_tiles_b);
 #else
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_b.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, src_addr_b);
 #endif
 #if SRC_SHARDED_C
     cb_c.reserve_back(src_num_tiles_c);
     cb_c.push_back(src_num_tiles_c);
 #else
-    const uint32_t src_tile_bytes_c = get_tile_size(cb_id_src_c);
+    const uint32_t src_tile_bytes_c = cb_c.get_tile_size();
     const auto src_c = TensorAccessor(src2_args, src_addr_c);
 #endif
 #if !SRC_SHARDED_A || !SRC_SHARDED_B || !SRC_SHARDED_C

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_rowbcast_ttt.cpp
@@ -172,13 +172,13 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_BCAST_A && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_a.get_write_ptr());
 #endif
 #if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_b.get_write_ptr());
 #endif
 #if SRC_BCAST_C && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW_C(cb_id_src_c);
+                            FILL_TILE_WITH_FIRST_ROW_C(cb_c.get_write_ptr());
 #endif
 #if !SRC_SHARDED_A
                             cb_a.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
@@ -69,21 +69,21 @@ void kernel_main() {
     cb_pred.reserve_back(src_num_tiles);
     cb_pred.push_back(src_num_tiles);
 #else
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src_addr);
 #endif
 #if SRC_SHARDED_B
     cb_true.reserve_back(true_num_tiles);
     cb_true.push_back(true_num_tiles);
 #else
-    const uint32_t src1_tile_bytes = get_tile_size(true_cb);
+    const uint32_t src1_tile_bytes = cb_true.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, true_addr);
 #endif
 #if SRC_SHARDED_C
     cb_false.reserve_back(false_num_tiles);
     cb_false.push_back(false_num_tiles);
 #else
-    const uint32_t src2_tile_bytes = get_tile_size(false_cb);
+    const uint32_t src2_tile_bytes = cb_false.get_tile_size();
     const auto s2 = TensorAccessor(src2_args, false_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
@@ -149,7 +149,7 @@ void kernel_main() {
                     noc.async_read(s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                     noc.async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_pred.get_write_ptr());
                     cb_pred.push_back(onetile);
 #endif
 #if SRC_BCAST_B
@@ -158,7 +158,7 @@ void kernel_main() {
                     noc.async_read(s1, cb_true, src1_tile_bytes, {.page_id = true_tile_offset}, {.offset_bytes = 0});
                     noc.async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_ELEMENT_B(true_cb);
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_true.get_write_ptr());
                     cb_true.push_back(onetile);
 #endif
 
@@ -169,7 +169,7 @@ void kernel_main() {
                     noc.async_read(s2, cb_false, src2_tile_bytes, {.page_id = false_tile_offset}, {.offset_bytes = 0});
                     noc.async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_ELEMENT_C(false_cb);
+                    FILL_TILE_WITH_FIRST_ELEMENT_C(cb_false.get_write_ptr());
                     cb_false.push_back(onetile);
 #endif
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_writer_nobcast.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
 
 #if !DST_SHARDED
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const uint32_t tile_bytes = cb_out.get_tile_size();
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     constexpr bool has_sharding = get_compile_time_arg_val(dst_args.next_compile_time_args_offset()) == 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
@@ -52,14 +52,14 @@ void kernel_main() {
     //     cb_pred.reserve_back(srcA_num_tiles);
     //     cb_pred.push_back(srcA_num_tiles);
     // #else
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
     // #endif
     // #if SRC_SHARDED_B
     //     cb_b.reserve_back(srcB_num_tiles);
     //     cb_b.push_back(srcB_num_tiles);
     // #else
-    const uint32_t src1_tile_bytes = get_tile_size(src_b_cb);
+    const uint32_t src1_tile_bytes = cb_b.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
     // #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
@@ -48,11 +48,11 @@ void kernel_main() {
     CircularBuffer cb_b(src_b_cb);
 
     // #if !SRC_SHARDED_A
-    const uint32_t src_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src_tile_bytes = cb_pred.get_tile_size();
     const auto src = TensorAccessor(src_args, src0_addr);
     // #endif
     // #if !SRC_SHARDED_B
-    const uint32_t src_tile_bytes_b = get_tile_size(src_b_cb);
+    const uint32_t src_tile_bytes_b = cb_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src1_addr);
     // #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
@@ -106,7 +106,7 @@ void kernel_main() {
                     noc.async_read(src, cb_pred, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                     noc.async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_pred.get_write_ptr());
                     cb_pred.push_back(onetile);
 #endif
 #if SRC_BCAST_B
@@ -115,7 +115,7 @@ void kernel_main() {
                     noc.async_read(src_b, cb_b, src_tile_bytes_b, {.page_id = tile_offset_b}, {.offset_bytes = 0});
                     noc.async_read_barrier();
 #endif
-                    FILL_TILE_WITH_FIRST_ELEMENT_B(src_b_cb);
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_b.get_write_ptr());
                     cb_b.push_back(onetile);
 #endif
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp
@@ -113,7 +113,7 @@ void kernel_main() {
                             s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_pred.get_write_ptr());
                         cb_pred.push_back(onetile);
 #endif
 #if SRC_BCAST_CB1
@@ -123,7 +123,7 @@ void kernel_main() {
                             s1, cb_true, src1_tile_bytes, {.page_id = true_tile_offset + th}, {.offset_bytes = 0});
                         noc.async_read_barrier();
 #endif
-                        FILL_TILE_WITH_FIRST_COLUMN_B(true_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_true.get_write_ptr());
                         cb_true.push_back(onetile);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_col_bcast.cpp
@@ -53,9 +53,9 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_true(true_cb);
 
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
-    const uint32_t src1_tile_bytes = get_tile_size(true_cb);
+    const uint32_t src1_tile_bytes = cb_true.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
@@ -49,9 +49,9 @@ void kernel_main() {
     CircularBuffer cb_src(cb_id_src);
     CircularBuffer cb_src_b(cb_id_src_b);
 
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src0_args, src0_addr);
-    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, src1_addr);
 
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_bcast.cpp
@@ -122,10 +122,10 @@ void kernel_main() {
                             noc.async_read_barrier();
 #endif
 #if SRC_BCAST_A && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW(cb_id_src);
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
 #endif
 #if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
-                            FILL_TILE_WITH_FIRST_ROW_B(cb_id_src_b);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
 #endif
 #if !SRC_SHARDED_A
                             cb_src.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
@@ -47,8 +47,8 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_tensor(tensor_cb);
 
-    const uint32_t src0_tile_bytes = get_tile_size(predicate_cb);
-    const uint32_t src1_tile_bytes = get_tile_size(tensor_cb);
+    const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
+    const uint32_t src1_tile_bytes = cb_tensor.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tts_tst_reader_row_col_bcast.cpp
@@ -105,9 +105,9 @@ void kernel_main() {
 #endif
                         noc.async_read_barrier();
 #if SRC_SCALAR_A
-                        FILL_TILE_WITH_FIRST_ELEMENT(predicate_cb);
+                        FILL_TILE_WITH_FIRST_ELEMENT(cb_pred.get_write_ptr());
 #else
-                        FILL_TILE_WITH_FIRST_COLUMN(predicate_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_pred.get_write_ptr());
 #endif
                         cb_pred.push_back(onetile);
 #endif
@@ -123,9 +123,9 @@ void kernel_main() {
 #endif
                         noc.async_read_barrier();
 #if SRC_SCALAR_CB1
-                        FILL_TILE_WITH_FIRST_ELEMENT_B(tensor_cb);
+                        FILL_TILE_WITH_FIRST_ELEMENT_B(cb_tensor.get_write_ptr());
 #else
-                        FILL_TILE_WITH_FIRST_COLUMN_B(tensor_cb);
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_tensor.get_write_ptr());
 #endif
                         cb_tensor.push_back(onetile);
 #endif
@@ -138,7 +138,7 @@ void kernel_main() {
                                 s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
                             noc.async_read_barrier();
 #if SRC_ROW_BCAST_A
-                            FILL_TILE_WITH_FIRST_ROW(predicate_cb);
+                            FILL_TILE_WITH_FIRST_ROW(cb_pred.get_write_ptr());
 #endif
                             cb_pred.push_back(onetile);
 #endif
@@ -153,7 +153,7 @@ void kernel_main() {
                                 {.offset_bytes = 0});
                             noc.async_read_barrier();
 #if SRC_ROW_BCAST_CB1
-                            FILL_TILE_WITH_FIRST_ROW_B(tensor_cb);
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_tensor.get_write_ptr());
 #endif
                             cb_tensor.push_back(onetile);
 #endif

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -31,12 +31,12 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t k_tile_face_elems = 1024;
 
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr);
-
     Noc noc;
     CircularBuffer cb_id_src_obj(cb_id_src);
     CircularBuffer cb_id_eps_obj(cb_id_eps);
+
+    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -32,10 +32,10 @@ void kernel_main() {
     constexpr uint32_t k_tile_face_elems = 1024;
 
     Noc noc;
-    CircularBuffer cb_id_src_obj(cb_id_src);
-    CircularBuffer cb_id_eps_obj(cb_id_eps);
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_eps(cb_id_eps);
 
-    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
@@ -44,15 +44,15 @@ void kernel_main() {
     uint32_t start_c = start_remaining / HtWt;
     uint32_t start_t = start_remaining % HtWt;
 
-    cb_id_eps_obj.reserve_back(onetile);
+    cb_eps.reserve_back(onetile);
     if constexpr (fill_eps_fp32) {
         float eps_f = 0;
         std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<k_tile_face_elems, float>(cb_id_eps_obj.get_write_ptr(), eps_f);
+        fill_with_val<k_tile_face_elems, float>(cb_eps.get_write_ptr(), eps_f);
     } else {
-        fill_with_val_bfloat16(cb_id_eps_obj.get_write_ptr(), eps);
+        fill_with_val_bfloat16(cb_eps.get_write_ptr(), eps);
     }
-    cb_id_eps_obj.push_back(onetile);
+    cb_eps.push_back(onetile);
 
     // Input tile offset
     uint32_t tile_offset = start_n * n_stride + start_c * c_stride + start_t;
@@ -64,10 +64,10 @@ void kernel_main() {
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
-                cb_id_src_obj.reserve_back(onetile);
-                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                cb_src.reserve_back(onetile);
+                noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_id_src_obj.push_back(onetile);
+                cb_src.push_back(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -48,9 +48,9 @@ void kernel_main() {
     if constexpr (fill_eps_fp32) {
         float eps_f = 0;
         std::memcpy(&eps_f, &eps, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<k_tile_face_elems, float>(cb_id_eps, eps_f);
+        fill_with_val<k_tile_face_elems, float>(cb_id_eps_obj.get_write_ptr(), eps_f);
     } else {
-        fill_with_val_bfloat16(cb_id_eps, eps);
+        fill_with_val_bfloat16(cb_id_eps_obj.get_write_ptr(), eps);
     }
     cb_id_eps_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -31,12 +31,12 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t k_tile_face_elems = 1024;
 
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr);
-
     Noc noc;
     CircularBuffer cb_id_src_obj(cb_id_src);
     CircularBuffer cb_id_momentum_obj(cb_id_momentum);
+
+    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -60,9 +60,9 @@ void kernel_main() {
     if constexpr (fill_momentum_fp32) {
         float momentum_f = 0;
         std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<k_tile_face_elems, float>(cb_id_momentum, momentum_f);
+        fill_with_val<k_tile_face_elems, float>(cb_id_momentum_obj.get_write_ptr(), momentum_f);
     } else {
-        fill_with_val_bfloat16(cb_id_momentum, momentum);
+        fill_with_val_bfloat16(cb_id_momentum_obj.get_write_ptr(), momentum);
     }
     cb_id_momentum_obj.push_back(onetile);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -32,10 +32,10 @@ void kernel_main() {
     constexpr uint32_t k_tile_face_elems = 1024;
 
     Noc noc;
-    CircularBuffer cb_id_src_obj(cb_id_src);
-    CircularBuffer cb_id_momentum_obj(cb_id_momentum);
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_momentum(cb_id_momentum);
 
-    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
@@ -56,24 +56,24 @@ void kernel_main() {
     fill_cb_with_value(cb_id_one, one_u);
 
     // momentum
-    cb_id_momentum_obj.reserve_back(onetile);
+    cb_momentum.reserve_back(onetile);
     if constexpr (fill_momentum_fp32) {
         float momentum_f = 0;
         std::memcpy(&momentum_f, &momentum, sizeof(float));  // Alternative for std::bit_cast
-        fill_with_val<k_tile_face_elems, float>(cb_id_momentum_obj.get_write_ptr(), momentum_f);
+        fill_with_val<k_tile_face_elems, float>(cb_momentum.get_write_ptr(), momentum_f);
     } else {
-        fill_with_val_bfloat16(cb_id_momentum_obj.get_write_ptr(), momentum);
+        fill_with_val_bfloat16(cb_momentum.get_write_ptr(), momentum);
     }
-    cb_id_momentum_obj.push_back(onetile);
+    cb_momentum.push_back(onetile);
 
     uint32_t num_tiles_read = 0;
     for (uint32_t n = start_n; n < N && num_tiles_read < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_read < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_read < num_tiles; ++t, ++num_tiles_read, ++tile_offset) {
-                cb_id_src_obj.reserve_back(onetile);
-                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                cb_src.reserve_back(onetile);
+                noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_id_src_obj.push_back(onetile);
+                cb_src.push_back(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -42,31 +42,31 @@ void kernel_main() {
     constexpr bool batch_stat_is_fp32 = get_compile_time_arg_val(bias_args.next_compile_time_args_offset()) == 1;
     constexpr bool param_is_fp32 = get_compile_time_arg_val(bias_args.next_compile_time_args_offset() + 1) == 1;
 
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr);
-
-    // output
-    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr);
-
-    // batch_var
-    const uint32_t batch_var_tile_bytes = get_tile_size(cb_id_batch_var);
-    const auto batch_var = TensorAccessor(batch_var_args, batch_var_addr);
-
-    // weight
-    const uint32_t weight_tile_bytes = get_tile_size(cb_id_weight);
-    const auto weight = TensorAccessor(weight_args, weight_addr);
-
-    // bias
-    const uint32_t bias_tile_bytes = get_tile_size(cb_id_bias);
-    const auto bias = TensorAccessor(bias_args, bias_addr);
-
     Noc noc;
     CircularBuffer cb_id_src_obj(cb_id_src);
     CircularBuffer cb_id_dst_obj(cb_id_dst);
     CircularBuffer cb_id_batch_var_obj(cb_id_batch_var);
     CircularBuffer cb_id_weight_obj(cb_id_weight);
     CircularBuffer cb_id_bias_obj(cb_id_bias);
+
+    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+
+    // output
+    const uint32_t dst_tile_bytes = cb_id_dst_obj.get_tile_size();
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+
+    // batch_var
+    const uint32_t batch_var_tile_bytes = cb_id_batch_var_obj.get_tile_size();
+    const auto batch_var = TensorAccessor(batch_var_args, batch_var_addr);
+
+    // weight
+    const uint32_t weight_tile_bytes = cb_id_weight_obj.get_tile_size();
+    const auto weight = TensorAccessor(weight_args, weight_addr);
+
+    // bias
+    const uint32_t bias_tile_bytes = cb_id_bias_obj.get_tile_size();
+    const auto bias = TensorAccessor(bias_args, bias_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -43,29 +43,29 @@ void kernel_main() {
     constexpr bool param_is_fp32 = get_compile_time_arg_val(bias_args.next_compile_time_args_offset() + 1) == 1;
 
     Noc noc;
-    CircularBuffer cb_id_src_obj(cb_id_src);
-    CircularBuffer cb_id_dst_obj(cb_id_dst);
-    CircularBuffer cb_id_batch_var_obj(cb_id_batch_var);
-    CircularBuffer cb_id_weight_obj(cb_id_weight);
-    CircularBuffer cb_id_bias_obj(cb_id_bias);
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_dst(cb_id_dst);
+    CircularBuffer cb_batch_var(cb_id_batch_var);
+    CircularBuffer cb_weight(cb_id_weight);
+    CircularBuffer cb_bias(cb_id_bias);
 
-    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 
     // output
-    const uint32_t dst_tile_bytes = cb_id_dst_obj.get_tile_size();
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
     const auto dst = TensorAccessor(dst_args, dst_addr);
 
     // batch_var
-    const uint32_t batch_var_tile_bytes = cb_id_batch_var_obj.get_tile_size();
+    const uint32_t batch_var_tile_bytes = cb_batch_var.get_tile_size();
     const auto batch_var = TensorAccessor(batch_var_args, batch_var_addr);
 
     // weight
-    const uint32_t weight_tile_bytes = cb_id_weight_obj.get_tile_size();
+    const uint32_t weight_tile_bytes = cb_weight.get_tile_size();
     const auto weight = TensorAccessor(weight_args, weight_addr);
 
     // bias
-    const uint32_t bias_tile_bytes = cb_id_bias_obj.get_tile_size();
+    const uint32_t bias_tile_bytes = cb_bias.get_tile_size();
     const auto bias = TensorAccessor(bias_args, bias_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
@@ -82,64 +82,59 @@ void kernel_main() {
     for (uint32_t n = start_n; n < N && num_tiles_written < num_tiles; ++n, start_c = 0) {
         for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
             // read a tile from src
-            cb_id_src_obj.reserve_back(onetile);
-            noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+            cb_src.reserve_back(onetile);
+            noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
             if constexpr (batch_stat_is_fp32) {
-                fill_tile_with_first_element<float>(cb_id_src_obj.get_write_ptr());
+                fill_tile_with_first_element<float>(cb_src.get_write_ptr());
             } else {
-                fill_tile_with_first_element_bfloat16(cb_id_src_obj.get_write_ptr());
+                fill_tile_with_first_element_bfloat16(cb_src.get_write_ptr());
             }
-            cb_id_src_obj.push_back(onetile);
+            cb_src.push_back(onetile);
 
             // read a tile from batch variance
-            cb_id_batch_var_obj.reserve_back(onetile);
+            cb_batch_var.reserve_back(onetile);
             noc.async_read(
-                batch_var, cb_id_batch_var_obj, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                batch_var, cb_batch_var, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
             if constexpr (batch_stat_is_fp32) {
-                fill_tile_with_first_element<float>(cb_id_batch_var_obj.get_write_ptr());
+                fill_tile_with_first_element<float>(cb_batch_var.get_write_ptr());
             } else {
-                fill_tile_with_first_element_bfloat16(cb_id_batch_var_obj.get_write_ptr());
+                fill_tile_with_first_element_bfloat16(cb_batch_var.get_write_ptr());
             }
-            cb_id_batch_var_obj.push_back(onetile);
+            cb_batch_var.push_back(onetile);
 
             if constexpr (weight_has_value) {  // read a tile from weight tensor
-                cb_id_weight_obj.reserve_back(onetile);
-                noc.async_read(
-                    weight, cb_id_weight_obj, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                cb_weight.reserve_back(onetile);
+                noc.async_read(weight, cb_weight, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if constexpr (param_is_fp32) {
-                    fill_tile_with_first_element<float>(cb_id_weight_obj.get_write_ptr());
+                    fill_tile_with_first_element<float>(cb_weight.get_write_ptr());
                 } else {
-                    fill_tile_with_first_element_bfloat16(cb_id_weight_obj.get_write_ptr());
+                    fill_tile_with_first_element_bfloat16(cb_weight.get_write_ptr());
                 }
-                cb_id_weight_obj.push_back(onetile);
+                cb_weight.push_back(onetile);
             }
 
             if constexpr (bias_has_value) {  // read a tile from bias tensor
-                cb_id_bias_obj.reserve_back(onetile);
-                noc.async_read(bias, cb_id_bias_obj, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                cb_bias.reserve_back(onetile);
+                noc.async_read(bias, cb_bias, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if constexpr (param_is_fp32) {
-                    fill_tile_with_first_element<float>(cb_id_bias_obj.get_write_ptr());
+                    fill_tile_with_first_element<float>(cb_bias.get_write_ptr());
                 } else {
-                    fill_tile_with_first_element_bfloat16(cb_id_bias_obj.get_write_ptr());
+                    fill_tile_with_first_element_bfloat16(cb_bias.get_write_ptr());
                 }
-                cb_id_bias_obj.push_back(onetile);
+                cb_bias.push_back(onetile);
             }
 
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // write a tile to dst
-                cb_id_dst_obj.wait_front(onetile);
+                cb_dst.wait_front(onetile);
                 noc.async_write(
-                    cb_id_dst_obj,
-                    dst,
-                    dst_tile_bytes,
-                    {.offset_bytes = 0},
-                    {.page_id = start_tile_id + num_tiles_written});
+                    cb_dst, dst, dst_tile_bytes, {.offset_bytes = 0}, {.page_id = start_tile_id + num_tiles_written});
                 noc.async_write_barrier();
-                cb_id_dst_obj.pop_front(onetile);
+                cb_dst.pop_front(onetile);
             }
             tile_offset += c_stride;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_batch_norm.cpp
@@ -86,9 +86,9 @@ void kernel_main() {
             noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
             if constexpr (batch_stat_is_fp32) {
-                fill_tile_with_first_element<float>(cb_id_src);
+                fill_tile_with_first_element<float>(cb_id_src_obj.get_write_ptr());
             } else {
-                fill_tile_with_first_element_bfloat16(cb_id_src);
+                fill_tile_with_first_element_bfloat16(cb_id_src_obj.get_write_ptr());
             }
             cb_id_src_obj.push_back(onetile);
 
@@ -98,9 +98,9 @@ void kernel_main() {
                 batch_var, cb_id_batch_var_obj, batch_var_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
             noc.async_read_barrier();
             if constexpr (batch_stat_is_fp32) {
-                fill_tile_with_first_element<float>(cb_id_batch_var);
+                fill_tile_with_first_element<float>(cb_id_batch_var_obj.get_write_ptr());
             } else {
-                fill_tile_with_first_element_bfloat16(cb_id_batch_var);
+                fill_tile_with_first_element_bfloat16(cb_id_batch_var_obj.get_write_ptr());
             }
             cb_id_batch_var_obj.push_back(onetile);
 
@@ -110,9 +110,9 @@ void kernel_main() {
                     weight, cb_id_weight_obj, weight_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if constexpr (param_is_fp32) {
-                    fill_tile_with_first_element<float>(cb_id_weight);
+                    fill_tile_with_first_element<float>(cb_id_weight_obj.get_write_ptr());
                 } else {
-                    fill_tile_with_first_element_bfloat16(cb_id_weight);
+                    fill_tile_with_first_element_bfloat16(cb_id_weight_obj.get_write_ptr());
                 }
                 cb_id_weight_obj.push_back(onetile);
             }
@@ -122,9 +122,9 @@ void kernel_main() {
                 noc.async_read(bias, cb_id_bias_obj, bias_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
                 if constexpr (param_is_fp32) {
-                    fill_tile_with_first_element<float>(cb_id_bias);
+                    fill_tile_with_first_element<float>(cb_id_bias_obj.get_write_ptr());
                 } else {
-                    fill_tile_with_first_element_bfloat16(cb_id_bias);
+                    fill_tile_with_first_element_bfloat16(cb_id_bias_obj.get_write_ptr());
                 }
                 cb_id_bias_obj.push_back(onetile);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -40,18 +40,6 @@ void kernel_main() {
     constexpr bool old_stat_is_fp32 =
         get_compile_time_arg_val(old_running_var_args.next_compile_time_args_offset()) == 1;
 
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const auto src = TensorAccessor(src_args, src_addr);
-
-    const uint32_t dst_tile_bytes = get_tile_size(cb_id_dst);
-    const auto dst = TensorAccessor(dst_args, dst_addr);
-
-    const uint32_t old_running_mean_tile_bytes = get_tile_size(cb_id_old_running_mean);
-    const auto old_running_mean = TensorAccessor(old_running_mean_args, old_running_mean_addr);
-
-    const uint32_t old_running_var_tile_bytes = get_tile_size(cb_id_old_running_var);
-    const auto old_running_var = TensorAccessor(old_running_var_args, old_running_var_addr);
-
     Noc noc;
     CircularBuffer cb_id_src_obj(cb_id_src);
     CircularBuffer cb_id_dst_obj(cb_id_dst);
@@ -59,6 +47,18 @@ void kernel_main() {
     CircularBuffer cb_id_old_running_var_obj(cb_id_old_running_var);
     CircularBuffer cb_id_updated_running_mean_obj(cb_id_updated_running_mean);
     CircularBuffer cb_id_updated_running_var_obj(cb_id_updated_running_var);
+
+    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const auto src = TensorAccessor(src_args, src_addr);
+
+    const uint32_t dst_tile_bytes = cb_id_dst_obj.get_tile_size();
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+
+    const uint32_t old_running_mean_tile_bytes = cb_id_old_running_mean_obj.get_tile_size();
+    const auto old_running_mean = TensorAccessor(old_running_mean_args, old_running_mean_addr);
+
+    const uint32_t old_running_var_tile_bytes = cb_id_old_running_var_obj.get_tile_size();
+    const auto old_running_var = TensorAccessor(old_running_var_args, old_running_var_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
     uint32_t start_n = start_tile_id / tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -41,23 +41,23 @@ void kernel_main() {
         get_compile_time_arg_val(old_running_var_args.next_compile_time_args_offset()) == 1;
 
     Noc noc;
-    CircularBuffer cb_id_src_obj(cb_id_src);
-    CircularBuffer cb_id_dst_obj(cb_id_dst);
-    CircularBuffer cb_id_old_running_mean_obj(cb_id_old_running_mean);
-    CircularBuffer cb_id_old_running_var_obj(cb_id_old_running_var);
-    CircularBuffer cb_id_updated_running_mean_obj(cb_id_updated_running_mean);
-    CircularBuffer cb_id_updated_running_var_obj(cb_id_updated_running_var);
+    CircularBuffer cb_src(cb_id_src);
+    CircularBuffer cb_dst(cb_id_dst);
+    CircularBuffer cb_old_mean(cb_id_old_running_mean);
+    CircularBuffer cb_old_var(cb_id_old_running_var);
+    CircularBuffer cb_new_mean(cb_id_updated_running_mean);
+    CircularBuffer cb_new_var(cb_id_updated_running_var);
 
-    const uint32_t src_tile_bytes = cb_id_src_obj.get_tile_size();
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
     const auto src = TensorAccessor(src_args, src_addr);
 
-    const uint32_t dst_tile_bytes = cb_id_dst_obj.get_tile_size();
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
     const auto dst = TensorAccessor(dst_args, dst_addr);
 
-    const uint32_t old_running_mean_tile_bytes = cb_id_old_running_mean_obj.get_tile_size();
+    const uint32_t old_running_mean_tile_bytes = cb_old_mean.get_tile_size();
     const auto old_running_mean = TensorAccessor(old_running_mean_args, old_running_mean_addr);
 
-    const uint32_t old_running_var_tile_bytes = cb_id_old_running_var_obj.get_tile_size();
+    const uint32_t old_running_var_tile_bytes = cb_old_var.get_tile_size();
     const auto old_running_var = TensorAccessor(old_running_var_args, old_running_var_addr);
 
     uint32_t tiles_per_batch = HtWt * C;
@@ -76,80 +76,76 @@ void kernel_main() {
         for (uint32_t c = start_c; c < C && num_tiles_written < num_tiles; ++c, start_t = 0) {
             for (uint32_t t = start_t; t < HtWt && num_tiles_written < num_tiles; ++t, ++num_tiles_written) {
                 // read a tile from src
-                cb_id_src_obj.reserve_back(onetile);
-                noc.async_read(src, cb_id_src_obj, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                cb_src.reserve_back(onetile);
+                noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
                 noc.async_read_barrier();
-                cb_id_src_obj.push_back(onetile);
+                cb_src.push_back(onetile);
 
                 if constexpr (old_running_mean_has_value) {
                     // read data
-                    cb_id_old_running_mean_obj.reserve_back(onetile);
+                    cb_old_mean.reserve_back(onetile);
                     noc.async_read(
                         old_running_mean,
-                        cb_id_old_running_mean_obj,
+                        cb_old_mean,
                         old_running_mean_tile_bytes,
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
                     if constexpr (old_stat_is_fp32) {
-                        fill_tile_with_first_element<float>(cb_id_old_running_mean_obj.get_write_ptr());
+                        fill_tile_with_first_element<float>(cb_old_mean.get_write_ptr());
                     } else {
-                        fill_tile_with_first_element_bfloat16(cb_id_old_running_mean_obj.get_write_ptr());
+                        fill_tile_with_first_element_bfloat16(cb_old_mean.get_write_ptr());
                     }
-                    cb_id_old_running_mean_obj.push_back(onetile);
+                    cb_old_mean.push_back(onetile);
 
                     // write data
-                    cb_id_updated_running_mean_obj.wait_front(onetile);
+                    cb_new_mean.wait_front(onetile);
                     noc.async_write(
-                        cb_id_updated_running_mean_obj,
+                        cb_new_mean,
                         old_running_mean,
                         old_running_mean_tile_bytes,
                         {.offset_bytes = 0},
                         {.page_id = tile_offset});
                     noc.async_write_barrier();
-                    cb_id_updated_running_mean_obj.pop_front(onetile);
+                    cb_new_mean.pop_front(onetile);
                 }
 
                 if constexpr (old_running_var_has_value) {
                     // read data
-                    cb_id_old_running_var_obj.reserve_back(onetile);
+                    cb_old_var.reserve_back(onetile);
                     noc.async_read(
                         old_running_var,
-                        cb_id_old_running_var_obj,
+                        cb_old_var,
                         old_running_var_tile_bytes,
                         {.page_id = tile_offset},
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
                     if constexpr (old_stat_is_fp32) {
-                        fill_tile_with_first_element<float>(cb_id_old_running_var_obj.get_write_ptr());
+                        fill_tile_with_first_element<float>(cb_old_var.get_write_ptr());
                     } else {
-                        fill_tile_with_first_element_bfloat16(cb_id_old_running_var_obj.get_write_ptr());
+                        fill_tile_with_first_element_bfloat16(cb_old_var.get_write_ptr());
                     }
-                    cb_id_old_running_var_obj.push_back(onetile);
+                    cb_old_var.push_back(onetile);
 
                     // write data
-                    cb_id_updated_running_var_obj.wait_front(onetile);
+                    cb_new_var.wait_front(onetile);
                     noc.async_write(
-                        cb_id_updated_running_var_obj,
+                        cb_new_var,
                         old_running_var,
                         old_running_var_tile_bytes,
                         {.offset_bytes = 0},
                         {.page_id = tile_offset});
                     noc.async_write_barrier();
-                    cb_id_updated_running_var_obj.pop_front(onetile);
+                    cb_new_var.pop_front(onetile);
                 }
                 ++tile_offset;
 
                 // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
-                cb_id_dst_obj.wait_front(onetile);
+                cb_dst.wait_front(onetile);
                 noc.async_write(
-                    cb_id_dst_obj,
-                    dst,
-                    dst_tile_bytes,
-                    {.offset_bytes = 0},
-                    {.page_id = start_tile_id + num_tiles_written});
+                    cb_dst, dst, dst_tile_bytes, {.offset_bytes = 0}, {.page_id = start_tile_id + num_tiles_written});
                 noc.async_write_barrier();
-                cb_id_dst_obj.pop_front(onetile);
+                cb_dst.pop_front(onetile);
             }
             tile_offset += next_channel_shift;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/writer_running_statistics.cpp
@@ -92,9 +92,9 @@ void kernel_main() {
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
                     if constexpr (old_stat_is_fp32) {
-                        fill_tile_with_first_element<float>(cb_id_old_running_mean);
+                        fill_tile_with_first_element<float>(cb_id_old_running_mean_obj.get_write_ptr());
                     } else {
-                        fill_tile_with_first_element_bfloat16(cb_id_old_running_mean);
+                        fill_tile_with_first_element_bfloat16(cb_id_old_running_mean_obj.get_write_ptr());
                     }
                     cb_id_old_running_mean_obj.push_back(onetile);
 
@@ -121,9 +121,9 @@ void kernel_main() {
                         {.offset_bytes = 0});
                     noc.async_read_barrier();
                     if constexpr (old_stat_is_fp32) {
-                        fill_tile_with_first_element<float>(cb_id_old_running_var);
+                        fill_tile_with_first_element<float>(cb_id_old_running_var_obj.get_write_ptr());
                     } else {
-                        fill_tile_with_first_element_bfloat16(cb_id_old_running_var);
+                        fill_tile_with_first_element_bfloat16(cb_id_old_running_var_obj.get_write_ptr());
                     }
                     cb_id_old_running_var_obj.push_back(onetile);
 


### PR DESCRIPTION
### PR Category
  Cleanup

### Summary
  Contributes to https://github.com/tenstorrent/tt-metal/issues/45003

  Continues the Device 2.0 data-movement migration into the `fill_tile_utils.hpp` helpers and their callers in `eltwise/binary_ng`, `eltwise/ternary`, and `normalization/batch_norm`.

  Two cleanups in `eltwise/binary_ng`, `eltwise/ternary`, and
  `normalization/batch_norm`:

  1. **Caller-side — Device 2.0 migration.** Call sites swap the CB-id-keyed free functions for the wrapper-method form:
     - `get_tile_size(cb_id)` → `cb.get_tile_size()`
     - `FILL_*(cb_id)`        → `FILL_*(cb.get_write_ptr())`

     The `CircularBuffer` wrappers were already constructed in every kernel; in a few writers (`writer_batch_norm.cpp`, `writer_running_statistics.cpp`, `ternary_reader_nobcast_*.cpp`) the CB-object declarations are moved ahead of their first use to satisfy construction order. This continues the work in #46366.

  2. **Helper-side — decouple `fill_tile_utils.hpp` from the CB abstraction.** Every `fill_*` / `fill_tile_with_first_*` helper now takes a raw L1 write pointer (`uint32_t l1_write_ptr`) instead of a CB id. The internal `get_write_ptr(cb_id)` call is dropped.

     This is the *opposite* direction from Device 2.0 (more typed → less typed) and is intentional: these helpers conceptually fill a tile-shaped region of L1; they have no business knowing about CBs. Decoupling them lets them be reused from any L1 write context — scratch regions, sharded buffers, future non-CB callers — and makes them easier to reason about in isolation.

  No behavior changes. Same memory, same writes, same fast paths.

  ### Notes for reviewers
  - The fill helpers' new signature relies on `cb.get_write_ptr()` being stable between
    `reserve_back(onetile)` / `noc.async_read_barrier()` and the subsequent `push_back(onetile)`.
    Every call site in this PR follows that invariant; note that doing a `push_back` before a fill would break this invariant.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fill_tile_utils_lift_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fill_tile_utils_lift_device_2_0)