### PR TITLE
#45821: fix program-cache hash collisions (strong mixer + exact-key collision resolution)

### DIFF
--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -121,13 +121,15 @@ struct ProgramCacheKey {
     // Custom operator<=> for strong ordering in collections that need it; std::unordered_map only needs operator== and
     // the hasher.
     std::strong_ordering operator<=>(const ProgramCacheKey& other) const {
-        if (const auto cmp = hash <=> other.hash; cmp != 0) {
+        if (const auto cmp = hash <=> other.hash; cmp != std::strong_ordering::equal) {
             return cmp;
         }
         return canonical <=> other.canonical;
     }
 };
 
+// Custom hasher for ProgramCacheKey that uses the precomputed hash value.
+// Other member(s) ignored since std::unordered_map will use operator== to resolve collisions within buckets.
 struct ProgramCacheKeyHasher {
     std::size_t operator()(const ProgramCacheKey& key) const { return static_cast<std::size_t>(key.hash); }
 };

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -117,6 +117,15 @@ struct ProgramCacheKey {
     bool operator==(const ProgramCacheKey& other) const {
         return hash == other.hash && canonical == other.canonical;
     }
+
+    // Custom operator<=> for strong ordering in collections that need it; std::unordered_map only needs operator== and
+    // the hasher.
+    std::strong_ordering operator<=>(const ProgramCacheKey& other) const {
+        if (const auto cmp = hash <=> other.hash; cmp != 0) {
+            return cmp;
+        }
+        return canonical <=> other.canonical;
+    }
 };
 
 struct ProgramCacheKeyHasher {

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include <unordered_map>
 
 #include <tt-metalium/program.hpp>
@@ -103,15 +104,34 @@ struct CachedProgramFactory {
         cached_program{std::move(cached_workload)}, program_factory_index{program_factory_index} {}
 };
 
+// Program-cache key: the 64-bit hash PLUS an exact, collision-free canonical encoding of the key
+// material (see ttsl::hash::canonical_key). std::unordered_map uses the hash to pick a bucket and
+// operator== to confirm the match -- so a 64-bit hash collision lands two distinct keys in the
+// same bucket and is resolved by exact comparison instead of producing a wrong cache hit
+// (issue #45821). An empty `canonical` opts out (hash-only behavior) for ops whose custom
+// compute_program_hash we cannot faithfully mirror.
+struct ProgramCacheKey {
+    uint64_t hash = 0;
+    std::string canonical;
+
+    bool operator==(const ProgramCacheKey& other) const {
+        return hash == other.hash && canonical == other.canonical;
+    }
+};
+
+struct ProgramCacheKeyHasher {
+    std::size_t operator()(const ProgramCacheKey& key) const { return static_cast<std::size_t>(key.hash); }
+};
+
 // Generic Program Cache: This data structure is tied to a device handle and can store generic program types from
 // TT-Metal and TT-Eager using tt::stl::concepts::unique_any.
 struct ProgramCache {
-    bool contains(uint64_t program_hash) const { return this->cache_.contains(program_hash); }
+    bool contains(const ProgramCacheKey& program_key) const { return this->cache_.contains(program_key); }
 
-    CachedProgramFactory& get(uint64_t program_hash) { return this->cache_.at(program_hash); }
+    CachedProgramFactory& get(const ProgramCacheKey& program_key) { return this->cache_.at(program_key); }
 
-    void insert(uint64_t program_hash, CachedProgramFactory&& program) {
-        this->cache_.insert({program_hash, std::move(program)});
+    void insert(const ProgramCacheKey& program_key, CachedProgramFactory&& program) {
+        this->cache_.insert({program_key, std::move(program)});
     }
 
     void enable() { is_enabled_ = true; }
@@ -130,7 +150,7 @@ struct ProgramCache {
 private:
     bool is_enabled_ = true;
     bool allow_cache_misses_ = true;
-    std::unordered_map<uint64_t, CachedProgramFactory> cache_;
+    std::unordered_map<ProgramCacheKey, CachedProgramFactory, ProgramCacheKeyHasher> cache_;
 };
 
 }  // namespace tt::tt_metal::program_cache::detail

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -108,8 +108,8 @@ struct CachedProgramFactory {
 // material (see ttsl::hash::canonical_key). std::unordered_map uses the hash to pick a bucket and
 // operator== to confirm the match -- so a 64-bit hash collision lands two distinct keys in the
 // same bucket and is resolved by exact comparison instead of producing a wrong cache hit
-// (issue #45821). An empty `canonical` opts out (hash-only behavior) for ops whose custom
-// compute_program_hash we cannot faithfully mirror.
+// (issue #45821). `canonical` always carries at least an op-identity prefix, so distinct ops can
+// never alias on a hash collision.
 struct ProgramCacheKey {
     uint64_t hash = 0;
     std::string canonical;

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
     PRIVATE
         test_cleanup.cpp
         test_fmt.cpp
+        test_hash.cpp
         test_indestructible.cpp
         test_optional_reference.cpp
         test_reflection.cpp

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -7,7 +7,10 @@
 #include <tt_stl/span.hpp>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
+#include <iostream>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -167,6 +170,141 @@ TEST(HashCollisionTest, SmallKeysCoverAllOutputBits) {
     }
     EXPECT_EQ(or_all, ~hash_t{0}) << "some output bit is never set across small keys";
     EXPECT_EQ(and_all, hash_t{0}) << "some output bit is always set across small keys";
+}
+
+// =============================================================================================
+// canonical_key: the exact, collision-free companion used to resolve hash collisions (option 1).
+// =============================================================================================
+
+std::string canonical_shape(const std::vector<uint32_t>& dims) {
+    return canonical_key(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+
+TEST(CanonicalKeyTest, DistinguishesShapes) {
+    // The shapes that collided under the old 64-bit hash (issue #45821) must be distinct as exact
+    // keys regardless of the hash, so a collision can always be resolved to a correct (rebuild) miss.
+    EXPECT_NE(canonical_shape({3, 17, 1, 1}), canonical_shape({1, 152, 1, 1}));
+    EXPECT_NE(canonical_shape({3, 17}), canonical_shape({1, 152}));
+}
+
+TEST(CanonicalKeyTest, EqualForEqualInputs) {
+    EXPECT_EQ(canonical_shape({3, 17, 1, 1}), canonical_shape({3, 17, 1, 1}));
+    EXPECT_EQ(canonical_key(uint32_t{42}, uint32_t{7}), canonical_key(uint32_t{42}, uint32_t{7}));
+}
+
+TEST(CanonicalKeyTest, OrderAndLengthSensitive) {
+    EXPECT_NE(canonical_shape({2, 3}), canonical_shape({3, 2}));
+    // Length-prefixing prevents [1,2],[3] from encoding the same as [1],[2,3] etc.
+    EXPECT_NE(canonical_shape({1, 2, 3}), canonical_shape({1, 2}));
+    EXPECT_NE(canonical_shape({1, 1}), canonical_shape({1}));
+}
+
+TEST(CanonicalKeyTest, DistinguishesScalarsEnumsOptionals) {
+    EXPECT_NE(canonical_key(uint32_t{1}, uint32_t{2}), canonical_key(uint32_t{2}, uint32_t{1}));
+    enum class E : int { A, B };
+    EXPECT_NE(canonical_key(E::A), canonical_key(E::B));
+    EXPECT_NE(canonical_key(std::optional<uint32_t>{}), canonical_key(std::optional<uint32_t>{0}));
+    EXPECT_NE(canonical_key(float{1.0f}), canonical_key(float{2.0f}));
+    EXPECT_NE(canonical_key(std::string{"ab"}), canonical_key(std::string{"ba"}));
+}
+
+// Coverage over the same adversarial set used for the hash: the exact key must be injective here
+// (it is by construction, but pin it so a future encoding change can't silently regress).
+TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {
+    constexpr uint32_t kMax = 40;
+    std::unordered_set<std::string> seen;
+    size_t count = 0;
+    for (uint32_t a = 0; a < kMax; ++a) {
+        for (uint32_t b = 0; b < kMax; ++b) {
+            for (uint32_t c = 0; c < kMax; ++c) {
+                for (uint32_t d = 0; d < kMax; ++d) {
+                    seen.insert(canonical_shape({a, b, c, d}));
+                    ++count;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(seen.size(), count) << "canonical key collision among small 4-D shapes";
+}
+
+// =============================================================================================
+// The cache contract: a 64-bit hash collision is resolved by exact comparison of the canonical
+// key, so two distinct keys with the same hash coexist and each retrieves its OWN entry -- the
+// std::unordered_map bucket-walk doing the work. This mirrors
+// tt::tt_metal::program_cache::detail::ProgramCacheKey, replicated here to keep the tt_stl test
+// free of tt_metal dependencies.
+// =============================================================================================
+
+TEST(ProgramCacheKeyTest, HashCollisionResolvedByCanonicalKey) {
+    struct Key {
+        uint64_t hash;
+        std::string canonical;
+        bool operator==(const Key& o) const { return hash == o.hash && canonical == o.canonical; }
+    };
+    struct KeyHash {
+        size_t operator()(const Key& k) const { return k.hash; }
+    };
+
+    std::unordered_map<Key, int, KeyHash> cache;
+
+    // Two DISTINCT shapes forced to the SAME 64-bit hash -- exactly the #45821 collision.
+    Key a{42, canonical_shape({3, 17, 1, 1})};
+    Key b{42, canonical_shape({1, 152, 1, 1})};
+    ASSERT_EQ(a.hash, b.hash);          // same bucket
+    ASSERT_NE(a.canonical, b.canonical);
+
+    cache[a] = 1;  // "program" for shape A
+    cache[b] = 2;  // "program" for shape B
+
+    EXPECT_EQ(cache.size(), 2u);  // both coexist in one bucket (native chaining)
+    EXPECT_EQ(cache.at(a), 1);    // A retrieves A's entry, NOT B's -> the wrong-hit bug is gone
+    EXPECT_EQ(cache.at(b), 2);
+    EXPECT_TRUE(cache.contains(a));
+    EXPECT_TRUE(cache.contains(b));
+
+    // An identical key (same hash + same canonical) is a real hit and collapses onto the entry.
+    Key a_again{42, canonical_shape({3, 17, 1, 1})};
+    EXPECT_EQ(cache.at(a_again), 1);
+    cache[a_again] = 9;
+    EXPECT_EQ(cache.size(), 2u);
+    EXPECT_EQ(cache.at(a), 9);
+}
+
+// Informational: the per-dispatch host cost of option 1 is one canonical_key build (a full key
+// traversal + a small string alloc) on top of the hash that already runs every dispatch. Print
+// both so the overhead is a number, not a guess. Loose sanity bound only (machine-dependent).
+struct CostAttrs {
+    uint32_t a, b, c;
+    int32_t e;
+    float f;
+    static constexpr auto attribute_names = std::forward_as_tuple("a", "b", "c", "e", "f");
+    auto attribute_values() const { return std::forward_as_tuple(a, b, c, e, f); }
+};
+
+TEST(CanonicalKeyTest, RelativeCostVsHash) {
+    const CostAttrs attrs{1, 2, 3, 4, 5.0f};
+    const std::vector<uint32_t> shape{1, 152, 24, 32};
+    constexpr int N = 1'000'000;
+
+    volatile uint64_t hsink = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < N; ++i) {
+        hsink ^= hash_objects_with_default_seed(uint64_t{777}, attrs, shape);
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    volatile size_t csink = 0;
+    for (int i = 0; i < N; ++i) {
+        csink += canonical_key(uint64_t{777}, attrs, shape).size();
+    }
+    auto t2 = std::chrono::steady_clock::now();
+
+    const double hash_ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
+    const double canon_ns = std::chrono::duration<double, std::nano>(t2 - t1).count() / N;
+    std::cout << "[ cost     ] hash_objects=" << hash_ns << " ns/op, canonical_key=" << canon_ns
+              << " ns/op, ratio=" << (canon_ns / hash_ns) << "x (key size=" << canonical_key(uint64_t{777}, attrs, shape).size()
+              << " bytes)\n";
+    EXPECT_GT(hash_ns, 0.0);
+    EXPECT_GT(canon_ns, 0.0);
 }
 
 }  // namespace

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -28,6 +28,16 @@ hash_t hash_shape(const std::vector<uint32_t>& dims) {
     return hash_objects_with_default_seed(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
 }
 
+// Allocation-free variants for the large sweeps (a stack std::array, no per-iteration heap).
+template <std::size_t N>
+hash_t hash_dims(const std::array<uint32_t, N>& dims) {
+    return hash_objects_with_default_seed(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+template <std::size_t N>
+std::string canonical_dims(const std::array<uint32_t, N>& dims) {
+    return canonical_key(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+
 // --- Regression: the exact collision from issue #45821 -------------------------------------
 
 TEST(HashCollisionTest, Issue45821_ShapesDoNotCollide) {
@@ -76,7 +86,7 @@ TEST(HashCollisionTest, NoCollisionsOverSmall4DShapes) {
         for (uint32_t b = 0; b < kMax; ++b) {
             for (uint32_t c = 0; c < kMax; ++c) {
                 for (uint32_t d = 0; d < kMax; ++d) {
-                    seen.insert(hash_shape({a, b, c, d}));
+                    seen.insert(hash_dims(std::array<uint32_t, 4>{a, b, c, d}));
                     ++count;
                 }
             }
@@ -120,7 +130,7 @@ TEST(HashCollisionTest, NoCollisionsOverHighBitAndPowerOfTwoShapes) {
     for (uint32_t a : vals) {
         for (uint32_t b : vals) {
             for (uint32_t c : vals) {
-                seen.insert(hash_shape({a, b, c}));
+                seen.insert(hash_dims(std::array<uint32_t, 3>{a, b, c}));
                 ++count;
             }
         }
@@ -218,7 +228,7 @@ TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {
         for (uint32_t b = 0; b < kMax; ++b) {
             for (uint32_t c = 0; c < kMax; ++c) {
                 for (uint32_t d = 0; d < kMax; ++d) {
-                    seen.insert(canonical_shape({a, b, c, d}));
+                    seen.insert(canonical_dims(std::array<uint32_t, 4>{a, b, c, d}));
                     ++count;
                 }
             }

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/reflection.hpp>
+#include <tt_stl/span.hpp>
+
+#include <array>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+// Regression + quality tests for the ttsl::hash combiner (tt_stl/reflection.hpp).
+//
+// Background: the original combiner was the 32-bit boost::hash_combine, whose weak avalanche
+// let distinct integer sequences collide in 64 bits. That manifested as wrong program-cache
+// hits in issue #45821 (PermuteDeviceOperation reused a cached program built for a different
+// shape). The canonical reproducer is the pair of tensor shapes below.
+namespace ttsl::hash {
+namespace {
+
+// Hash a shape the same way the device-op hash path does: as a span of dimensions.
+hash_t hash_shape(const std::vector<uint32_t>& dims) {
+    return hash_objects_with_default_seed(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+
+// --- Regression: the exact collision from issue #45821 -------------------------------------
+
+TEST(HashCollisionTest, Issue45821_ShapesDoNotCollide) {
+    // These two shapes flow through the same ttnn::permute path inside batch_norm; under the
+    // old combiner they produced an identical 64-bit hash, so the second op wrongly hit the
+    // first op's cached program.
+    EXPECT_NE(hash_shape({3, 17, 1, 1}), hash_shape({1, 152, 1, 1}));
+}
+
+TEST(HashCollisionTest, Issue45821_TruncatedPrefixDoesNotCollide) {
+    // The collision is already present at the 2-element prefix [3,17] vs [1,152] -- the trailing
+    // [1, 1] is incidental. Pin the prefix too so a future regression is localized.
+    EXPECT_NE(hash_shape({3, 17}), hash_shape({1, 152}));
+}
+
+// --- Order sensitivity ---------------------------------------------------------------------
+
+TEST(HashCollisionTest, OrderMatters) {
+    // A hash used as a cache key must distinguish permutations of the same multiset of dims;
+    // otherwise e.g. a [2, 3] tensor and a [3, 2] tensor would share a program.
+    EXPECT_NE(hash_shape({2, 3, 5}), hash_shape({5, 3, 2}));
+    EXPECT_NE(hash_shape({1, 2}), hash_shape({2, 1}));
+}
+
+// --- Determinism ---------------------------------------------------------------------------
+
+TEST(HashCollisionTest, Deterministic) {
+    // The same input must hash identically across calls (cache hits depend on it).
+    EXPECT_EQ(hash_shape({3, 17, 1, 1}), hash_shape({3, 17, 1, 1}));
+    EXPECT_EQ(
+        hash_objects_with_default_seed(uint32_t{42}, uint32_t{7}),
+        hash_objects_with_default_seed(uint32_t{42}, uint32_t{7}));
+}
+
+// --- Quality sweep: no collisions over realistic small 4-D shapes --------------------------
+
+TEST(HashCollisionTest, NoCollisionsOverSmall4DShapes) {
+    // Sweep all 4-D shapes with each dim in [0, 40). The old combiner collided ~94k times over
+    // this set; the splitmix64-based combiner must be collision-free here.
+    constexpr uint32_t kMax = 40;
+    std::unordered_set<hash_t> seen;
+    seen.reserve(kMax * kMax * kMax * kMax);
+
+    size_t count = 0;
+    for (uint32_t a = 0; a < kMax; ++a) {
+        for (uint32_t b = 0; b < kMax; ++b) {
+            for (uint32_t c = 0; c < kMax; ++c) {
+                for (uint32_t d = 0; d < kMax; ++d) {
+                    seen.insert(hash_shape({a, b, c, d}));
+                    ++count;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(seen.size(), count) << "hash collision detected among small 4-D shapes";
+}
+
+// --- Quality sweep: scalar pairs (the smallest structured keys) ----------------------------
+
+TEST(HashCollisionTest, NoCollisionsOverScalarPairs) {
+    constexpr uint32_t kMax = 256;
+    std::unordered_set<hash_t> seen;
+    seen.reserve(kMax * kMax);
+
+    size_t count = 0;
+    for (uint32_t a = 0; a < kMax; ++a) {
+        for (uint32_t b = 0; b < kMax; ++b) {
+            seen.insert(hash_objects_with_default_seed(a, b));
+            ++count;
+        }
+    }
+    EXPECT_EQ(seen.size(), count) << "hash collision detected among scalar pairs";
+}
+
+// Adversarial values: powers of two and values that differ only in high bits are exactly the
+// inputs that defeat shift-and-add combiners (the high bits never propagate down).
+TEST(HashCollisionTest, NoCollisionsOverHighBitAndPowerOfTwoShapes) {
+    std::unordered_set<uint32_t> unique_vals;
+    for (uint32_t shift = 0; shift < 32; ++shift) {
+        unique_vals.insert(1u << shift);          // powers of two
+        unique_vals.insert((1u << shift) - 1u);   // all-low-bits-set
+    }
+    unique_vals.insert(0xFFFFFFFFu);
+    // Dedupe first: (1<<1)-1 == 1<<0 etc. would otherwise produce identical shapes that are not
+    // collisions. We want collisions among DISTINCT shapes only.
+    const std::vector<uint32_t> vals(unique_vals.begin(), unique_vals.end());
+
+    std::unordered_set<hash_t> seen;
+    size_t count = 0;
+    for (uint32_t a : vals) {
+        for (uint32_t b : vals) {
+            for (uint32_t c : vals) {
+                seen.insert(hash_shape({a, b, c}));
+                ++count;
+            }
+        }
+    }
+    EXPECT_EQ(seen.size(), count) << "collision among power-of-two / high-bit shapes";
+}
+
+// 64-bit keys (e.g. addresses, sizes) sharing low words but differing in the high word must not
+// collapse -- the old 32-bit-constant combiner under-mixed the high half.
+TEST(HashCollisionTest, DistinguishesHighWordOf64BitValues) {
+    EXPECT_NE(
+        hash_objects_with_default_seed(uint64_t{0x0000'0001'0000'0000ULL}),
+        hash_objects_with_default_seed(uint64_t{0x0000'0002'0000'0000ULL}));
+    EXPECT_NE(
+        hash_objects_with_default_seed(uint64_t{1}), hash_objects_with_default_seed(uint64_t{1} << 32));
+}
+
+// Avalanche: flipping a single input bit should flip ~half the 64 output bits. A weak mixer
+// leaves long runs of output bits untouched. We require every single-bit input flip to change
+// at least a quarter of the output bits (16/64) -- a loose bound a good mixer clears easily and
+// a shift-and-add combiner fails on the high input bits.
+TEST(HashCollisionTest, SingleBitFlipAvalanche) {
+    const uint64_t base = 0x0123456789abcdefULL;
+    const hash_t base_hash = hash_objects_with_default_seed(base);
+    int worst = 64;
+    for (int bit = 0; bit < 64; ++bit) {
+        const uint64_t flipped = base ^ (uint64_t{1} << bit);
+        const hash_t h = hash_objects_with_default_seed(flipped);
+        const int changed = __builtin_popcountll(h ^ base_hash);
+        worst = std::min(worst, changed);
+        EXPECT_GE(changed, 16) << "weak avalanche when flipping input bit " << bit;
+    }
+    // Sanity: the typical case should be much closer to the ideal of 32.
+    EXPECT_GE(worst, 16);
+}
+
+// The mixer must spread bits across the whole 64-bit space, not cluster small keys in a corner.
+// Hash a run of consecutive small integers and require the OR of all results to light up every
+// bit -- a combiner that only touches low bits (the old one, for small inputs) fails this.
+TEST(HashCollisionTest, SmallKeysCoverAllOutputBits) {
+    hash_t or_all = 0;
+    hash_t and_all = ~hash_t{0};
+    for (uint32_t i = 0; i < 4096; ++i) {
+        const hash_t h = hash_objects_with_default_seed(i);
+        or_all |= h;
+        and_all &= h;
+    }
+    EXPECT_EQ(or_all, ~hash_t{0}) << "some output bit is never set across small keys";
+    EXPECT_EQ(and_all, hash_t{0}) << "some output bit is always set across small keys";
+}
+
+}  // namespace
+}  // namespace ttsl::hash

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -218,6 +218,30 @@ TEST(CanonicalKeyTest, DistinguishesScalarsEnumsOptionals) {
     EXPECT_NE(canonical_key(std::string{"ab"}), canonical_key(std::string{"ba"}));
 }
 
+// std::vector<bool> is bit-packed: its iterator yields a proxy reference, not bool&, so it needs a
+// dedicated encoding branch (the generic vector branch fails to compile).
+TEST(CanonicalKeyTest, DistinguishesVectorBool) {
+    EXPECT_EQ(
+        canonical_key(std::vector<bool>{true, false, false}), canonical_key(std::vector<bool>{true, false, false}));
+    EXPECT_NE(
+        canonical_key(std::vector<bool>{true, false, false}), canonical_key(std::vector<bool>{false, true, false}));
+    EXPECT_NE(canonical_key(std::vector<bool>{true}), canonical_key(std::vector<bool>{true, false}));
+
+    // For each length 1..10, an all-true vector and an all-false vector (opposite at every index)
+    // must encode differently.
+    std::vector<bool> mixed_left;
+    std::vector<bool> mixed_right;
+    for (std::size_t len = 1; len <= 10; ++len) {
+        const std::vector<bool> all_true(len, true);
+        const std::vector<bool> all_false(len, false);
+        EXPECT_NE(canonical_key(all_true), canonical_key(all_false)) << "opposite booleans. length=" << len;
+        const bool vb = (0 == (len % 2));
+        mixed_left.push_back(vb);
+        mixed_right.push_back(!vb);
+        EXPECT_NE(canonical_key(mixed_left), canonical_key(mixed_right)) << "mixed opposite booleans. length=" << len;
+    }
+}
+
 // Coverage over the same adversarial set used for the hash: the exact key must be injective here
 // (it is by construction, but pin it so a future encoding change can't silently regress).
 TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1451,6 +1451,111 @@ inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
     return seed;
 }
 
+// ---------------------------------------------------------------------------------------------
+// Canonical key encoding (collision-free companion to hash_objects).
+//
+// hash_objects folds a key down to 64 bits, which can collide (issue #45821). For a cache that
+// must NEVER return a wrong entry, the 64-bit hash selects a bucket and an EXACT comparison of
+// the key resolves collisions -- the textbook hash-map contract. append_canonical builds that
+// exact key: a byte string whose traversal mirrors hash_object branch-for-branch, so it
+// distinguishes precisely the inputs the hash combines (same coverage => no spurious misses, no
+// missed collisions) and contains no volatile data (addresses, buffers) -- only the structural
+// values, just like the hash.
+//
+// Encoding is exact for every type on the op-key path: integers, enums, floating point,
+// std::string, the compile-time-attribute / reflect aggregates, and the standard containers
+// (length-prefixed; unordered_map sorted by key to stay order-invariant, mirroring hash_object).
+// The one lossy leaf is a type exposing ONLY to_hash(): its 8 hash bytes are appended, so for
+// such a type equality degrades to hash equality -- no worse than today, and none occur on the
+// tensor/shape path (TensorSpec is walked structurally down to the shape integers).
+inline void append_bytes(std::string& out, const void* p, std::size_t n) {
+    out.append(static_cast<const char*>(p), n);
+}
+
+template <typename T>
+inline void append_canonical(std::string& out, const T& object);
+
+template <typename... Types>
+inline void append_canonical_all(std::string& out, const Types&... args) {
+    (append_canonical(out, args), ...);
+}
+
+template <typename T>
+inline void append_canonical(std::string& out, const T& object) {
+    out.push_back('\x1f');  // unit separator: disambiguates adjacent leaves/fields
+    if constexpr (std::numeric_limits<T>::is_integer) {
+        append_bytes(out, &object, sizeof(object));
+    } else if constexpr (std::is_enum_v<T>) {
+        const auto v = static_cast<std::underlying_type_t<T>>(object);
+        append_bytes(out, &v, sizeof(v));
+    } else if constexpr (std::is_floating_point_v<T>) {
+        append_bytes(out, &object, sizeof(object));
+    } else if constexpr (std::is_same_v<T, std::string>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        append_bytes(out, object.data(), object.size());
+    } else if constexpr (ttsl::reflection::detail::supports_compile_time_attributes_v<T>) {
+        std::apply([&out](const auto&... a) { (append_canonical(out, a), ...); }, object.attribute_values());
+    } else if constexpr (is_specialization_v<T, std::tuple>) {
+        std::apply([&out](const auto&... a) { (append_canonical(out, a), ...); }, object);
+    } else if constexpr (is_specialization_v<T, std::pair>) {
+        append_canonical(out, object.first);
+        append_canonical(out, object.second);
+    } else if constexpr (is_specialization_v<T, std::optional>) {
+        const char has = object.has_value() ? 1 : 0;
+        out.push_back(has);
+        if (object.has_value()) {
+            append_canonical(out, object.value());
+        }
+    } else if constexpr (is_specialization_v<T, std::variant>) {
+        const std::uint64_t index = object.index();
+        append_bytes(out, &index, sizeof(index));
+        std::visit([&out](const auto& value) { append_canonical(out, value); }, object);
+    } else if constexpr (is_specialization_v<T, std::reference_wrapper>) {
+        append_canonical(out, object.get());
+    } else if constexpr (
+        is_specialization_v<T, std::vector> || is_specialization_v<T, std::set> || is_span_v<T>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& element : object) {
+            append_canonical(out, element);
+        }
+    } else if constexpr (is_specialization_v<T, std::map>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& [key, value] : object) {
+            append_canonical(out, key);
+            append_canonical(out, value);
+        }
+    } else if constexpr (is_specialization_v<T, std::unordered_map>) {
+        // Sort by key so the encoding is order-invariant, mirroring hash_object.
+        std::vector<typename T::const_iterator> iterators;
+        iterators.reserve(object.size());
+        for (auto it = object.begin(); it != object.end(); ++it) {
+            iterators.push_back(it);
+        }
+        std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) {
+            return a->first < b->first;
+        });
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& it : iterators) {
+            append_canonical(out, it->first);
+            append_canonical(out, it->second);
+        }
+    } else if constexpr (ttsl::concepts::Reflectable<T>) {
+        reflect::for_each([&out, &object](auto I) { append_canonical(out, reflect::get<I>(object)); }, object);
+    } else if constexpr (ttsl::reflection::detail::supports_to_hash_v<T>) {
+        const hash_t h = object.to_hash();  // lossy leaf (see note above)
+        append_bytes(out, &h, sizeof(h));
+    } else if constexpr (detail::is_std_hashable_v<T>) {
+        const std::size_t h = std::hash<T>{}(object);  // lossy fallback
+        append_bytes(out, &h, sizeof(h));
+    } else {
+        static_assert(ttsl::concepts::always_false_v<T>, "Type doesn't support ttsl::hash::canonical_key");
+    }
+}
+
 }  // namespace detail
 
 template <typename... Types>
@@ -1461,6 +1566,16 @@ inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
 template <typename... Types>
 inline hash_t hash_objects_with_default_seed(const Types&... args) noexcept {
     return detail::hash_objects(DEFAULT_SEED, args...);
+}
+
+// Exact, collision-free encoding of `args` for use as a program-cache key alongside the 64-bit
+// hash: two argument packs produce the same string iff the hash traversal cannot distinguish
+// them. See detail::append_canonical.
+template <typename... Types>
+inline std::string canonical_key(const Types&... args) {
+    std::string out;
+    detail::append_canonical_all(out, args...);
+    return out;
 }
 
 // Ripped out of boost for std::size_t so as to not pull in bulky boost dependencies

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1428,20 +1428,20 @@ inline hash_t hash_object(const T& object) noexcept {
 
 template <typename... Types>
 inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
-    // Fold each element into the running seed through a strong 64-bit bijective mixer.
+    // Fold each element into the running seed with the splitmix64 finalizer (David Stafford's
+    // "variant 13"), a strong 64-bit mixer.
     //
-    // The previous combiner was the classic 32-bit boost::hash_combine
+    // The previous combiner was the classic boost::hash_combine
     // (`seed ^= h + 0x9e3779b9 + (seed << 6) + (seed >> 2)`). Its avalanche is poor for the
-    // small, structured integers that dominate our keys (tensor shapes, dtypes), so distinct
-    // sequences collided in 64 bits -- e.g. shapes [3, 17, 1, 1] and [1, 152, 1, 1] hashed
-    // identically, producing wrong program-cache hits (issue #45821).
+    // small, structured integers that dominate our cache keys (tensor shapes, dtypes), so
+    // distinct sequences collided in 64 bits -- e.g. shapes [3, 17, 1, 1] and [1, 152, 1, 1]
+    // hashed identically, causing wrong program-cache hits (issue #45821).
     //
-    // We replace it with the splitmix64 finalizer (David Stafford's "variant 13" of the
-    // MurmurHash3 final mix); it is the same mixer boost (>=1.81) and abseil use internally,
-    // implemented here with only <cstdint> arithmetic so tt_stl pulls in no extra dependency.
-    // 0x9e3779b97f4a7c15 is the 64-bit golden-ratio increment (the 64-bit analog of the old
-    // 0x9e3779b9), which keeps the fold order-dependent and gives a non-trivial result for a
-    // zero seed / zero element.
+    // The multiply-xorshift finalizer is the state of the art for 64-bit hash mixing (boost
+    // >=1.81 and abseil use mixers of the same family, with different constants); we inline it
+    // with only <cstdint> arithmetic so tt_stl pulls in no extra dependency. 0x9e3779b97f4a7c15
+    // is the 64-bit golden-ratio increment (the 64-bit analog of the old 0x9e3779b9), which
+    // keeps the fold order-dependent and gives a non-trivial result for an all-zero input.
     ([&seed](const auto& arg) {
         hash_t x = seed + 0x9e3779b97f4a7c15ULL + hash_object(arg);
         x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1516,8 +1516,17 @@ inline void append_canonical(std::string& out, const T& object) {
         std::visit([&out](const auto& value) { append_canonical(out, value); }, object);
     } else if constexpr (is_specialization_v<T, std::reference_wrapper>) {
         append_canonical(out, object.get());
-    } else if constexpr (
-        is_specialization_v<T, std::vector> || is_specialization_v<T, std::set> || is_span_v<T>) {
+    } else if constexpr (std::is_same_v<T, std::vector<bool>>) {
+        // std::vector<bool> is a bit-packed specialization: iterating yields a proxy reference
+        // (not bool&), so it can't go through the generic vector branch.
+        // (hash_object never reaches its own vector branch for this type because
+        // std::hash<std::vector<bool>> exists and the is_std_hashable_v branch wins first.)
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (bool element : object) {
+            append_canonical(out, element);
+        }
+    } else if constexpr (is_specialization_v<T, std::vector> || is_specialization_v<T, std::set> || is_span_v<T>) {
         const std::uint64_t n = object.size();
         append_bytes(out, &n, sizeof(n));
         for (const auto& element : object) {

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1428,7 +1428,26 @@ inline hash_t hash_object(const T& object) noexcept {
 
 template <typename... Types>
 inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
-    ([&seed](const auto& arg) { seed ^= hash_object(arg) + 0x9e3779b9 + (seed << 6) + (seed >> 2); }(args), ...);
+    // Fold each element into the running seed through a strong 64-bit bijective mixer.
+    //
+    // The previous combiner was the classic 32-bit boost::hash_combine
+    // (`seed ^= h + 0x9e3779b9 + (seed << 6) + (seed >> 2)`). Its avalanche is poor for the
+    // small, structured integers that dominate our keys (tensor shapes, dtypes), so distinct
+    // sequences collided in 64 bits -- e.g. shapes [3, 17, 1, 1] and [1, 152, 1, 1] hashed
+    // identically, producing wrong program-cache hits (issue #45821).
+    //
+    // We replace it with the splitmix64 finalizer (David Stafford's "variant 13" of the
+    // MurmurHash3 final mix); it is the same mixer boost (>=1.81) and abseil use internally,
+    // implemented here with only <cstdint> arithmetic so tt_stl pulls in no extra dependency.
+    // 0x9e3779b97f4a7c15 is the 64-bit golden-ratio increment (the 64-bit analog of the old
+    // 0x9e3779b9), which keeps the fold order-dependent and gives a non-trivial result for a
+    // zero seed / zero element.
+    ([&seed](const auto& arg) {
+        hash_t x = seed + 0x9e3779b97f4a7c15ULL + hash_object(arg);
+        x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+        x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+        seed = x ^ (x >> 31);
+    }(args), ...);
     return seed;
 }
 

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1426,28 +1426,31 @@ inline hash_t hash_object(const T& object) noexcept {
     }
 }
 
+// Fold one value's hash into a running seed with the splitmix64 finalizer (David Stafford's
+// "variant 13"), a strong 64-bit mixer. Shared by every combiner in this header (hash_objects and
+// hash_combine) so their mixing behavior is identical.
+//
+// The previous combiner was the classic boost::hash_combine
+// (`seed ^= h + 0x9e3779b9 + (seed << 6) + (seed >> 2)`). Its avalanche is poor for the small,
+// structured integers that dominate our cache keys (tensor shapes, dtypes), so distinct sequences
+// collided in 64 bits -- e.g. shapes [3, 17, 1, 1] and [1, 152, 1, 1] hashed identically, causing
+// wrong program-cache hits (issue #45821).
+//
+// The multiply-xorshift finalizer is the state of the art for 64-bit hash mixing (boost >=1.81 and
+// abseil use mixers of the same family, with different constants); we inline it with only <cstdint>
+// arithmetic so tt_stl pulls in no extra dependency. 0x9e3779b97f4a7c15 is the 64-bit golden-ratio
+// increment (the 64-bit analog of the old 0x9e3779b9), which keeps the fold order-dependent and
+// gives a non-trivial result for an all-zero input.
+inline hash_t mix_into(hash_t seed, hash_t value_hash) noexcept {
+    hash_t x = seed + 0x9e3779b97f4a7c15ULL + value_hash;
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    return x ^ (x >> 31);
+}
+
 template <typename... Types>
 inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
-    // Fold each element into the running seed with the splitmix64 finalizer (David Stafford's
-    // "variant 13"), a strong 64-bit mixer.
-    //
-    // The previous combiner was the classic boost::hash_combine
-    // (`seed ^= h + 0x9e3779b9 + (seed << 6) + (seed >> 2)`). Its avalanche is poor for the
-    // small, structured integers that dominate our cache keys (tensor shapes, dtypes), so
-    // distinct sequences collided in 64 bits -- e.g. shapes [3, 17, 1, 1] and [1, 152, 1, 1]
-    // hashed identically, causing wrong program-cache hits (issue #45821).
-    //
-    // The multiply-xorshift finalizer is the state of the art for 64-bit hash mixing (boost
-    // >=1.81 and abseil use mixers of the same family, with different constants); we inline it
-    // with only <cstdint> arithmetic so tt_stl pulls in no extra dependency. 0x9e3779b97f4a7c15
-    // is the 64-bit golden-ratio increment (the 64-bit analog of the old 0x9e3779b9), which
-    // keeps the fold order-dependent and gives a non-trivial result for an all-zero input.
-    ([&seed](const auto& arg) {
-        hash_t x = seed + 0x9e3779b97f4a7c15ULL + hash_object(arg);
-        x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
-        x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
-        seed = x ^ (x >> 31);
-    }(args), ...);
+    ([&seed](const auto& arg) { seed = mix_into(seed, hash_object(arg)); }(args), ...);
     return seed;
 }
 
@@ -1578,11 +1581,14 @@ inline std::string canonical_key(const Types&... args) {
     return out;
 }
 
-// Ripped out of boost for std::size_t so as to not pull in bulky boost dependencies
+// std::hash-based combiner used by the hand-written program-descriptor hashers (generic_op,
+// program_descriptors, fd_kernel, ...). Uses the same strong mixer as hash_objects so these
+// program-cache-relevant hashes get the same collision resistance (issue #45821).
 template <typename T>
 void hash_combine(std::size_t& seed, const T& value) {
     std::hash<T> hasher;
-    seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed = static_cast<std::size_t>(
+        detail::mix_into(static_cast<ttsl::hash::hash_t>(seed), static_cast<ttsl::hash::hash_t>(hasher(value))));
 }
 
 }  // namespace ttsl::hash

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -381,8 +381,11 @@ void launch_operation_with_adapter(
         // Use device_operation's compute_program_hash if available
         program_key.hash =
             mesh_device_operation_t::compute_mesh_workload_hash(mesh_device, operation_attributes, tensor_args);
-        program_key.canonical =
-            mesh_device_operation_t::compute_mesh_workload_canonical_key(mesh_device, operation_attributes, tensor_args);
+        program_key.canonical = mesh_device_operation_t::compute_mesh_workload_canonical_key(
+            mesh_device,
+            ttsl::get_type_name<typename mesh_device_operation_t::device_operation_t>(),
+            operation_attributes,
+            tensor_args);
         program_cache_hit = program_cache.contains(program_key);
         if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
             auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -46,6 +46,7 @@ using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorklo
 namespace detail {
 
 using ::tt::tt_metal::program_cache::detail::CachedProgramFactory;
+using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
 
 template <typename... Ts>
 [[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
@@ -252,14 +253,14 @@ void handle_mesh_adapter_cache_hit(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    ttsl::hash::hash_t program_hash) {
+    const ProgramCacheKey& program_key) {
     if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
         mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
     } else {
         mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
     }
 
-    auto& cached_program_factory = program_cache.get(program_hash);
+    auto& cached_program_factory = program_cache.get(program_key);
     auto program_factory_index = cached_program_factory.program_factory_index;
     auto program_factory = map_index_to_variant(
         program_factory_index, mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
@@ -291,7 +292,7 @@ void create_and_cache_mesh_workload(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    ttsl::hash::hash_t program_hash) {
+    const ProgramCacheKey& program_key) {
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
@@ -335,8 +336,8 @@ void create_and_cache_mesh_workload(
             bool should_cache = program_cache.is_enabled() && !hook_blocks;
             if (should_cache) {
                 program_cache.insert(
-                    program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
-                auto& cached_program_factory = program_cache.get(program_hash);
+                    program_key, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+                auto& cached_program_factory = program_cache.get(program_key);
                 auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
                 enqueue_mesh_workload<mesh_device_operation_t>(
                     operation_attributes,
@@ -370,15 +371,19 @@ void launch_operation_with_adapter(
     }
 
     auto& program_cache = mesh_device->get_program_cache();
-    auto program_hash = 0;
+    // The cache key is the 64-bit hash plus an exact canonical encoding; a hash collision is
+    // resolved by std::unordered_map's own operator== on the canonical part (issue #45821).
+    ProgramCacheKey program_key;
     bool program_cache_hit = false;
 
     auto is_program_cache_enabled = program_cache.is_enabled();
     if (is_program_cache_enabled) {
         // Use device_operation's compute_program_hash if available
-        program_hash =
+        program_key.hash =
             mesh_device_operation_t::compute_mesh_workload_hash(mesh_device, operation_attributes, tensor_args);
-        program_cache_hit = program_cache.contains(program_hash);
+        program_key.canonical =
+            mesh_device_operation_t::compute_mesh_workload_canonical_key(mesh_device, operation_attributes, tensor_args);
+        program_cache_hit = program_cache.contains(program_key);
         if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
             auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
             TT_THROW("Device operation \"{}\": program cache miss occurred, but cache misses are forbidden", op_name);
@@ -386,14 +391,14 @@ void launch_operation_with_adapter(
     }
 
     log_operation<mesh_device_operation_t>(
-        mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
+        mesh_device->id(), operation_attributes, tensor_args, program_key.hash, program_cache_hit);
 
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
-            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
     } else {
         create_and_cache_mesh_workload<mesh_device_operation_t>(
-            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
     }
 }
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -825,9 +825,9 @@ public:
     // The key is prefixed with op_type_name (the DeviceOperation's type name) so distinct ops can
     // never alias on a hash collision.
     // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
-    // deliberately exclude some, e.g. an RNG seed), so we return an empty string -- opting that op
-    // out of collision resolution (hash-only, today's behavior). The default reflection-hash path
-    // is mirrored exactly.
+    // deliberately exclude some, e.g. an RNG seed), so we return only the op-identity prefix --
+    // opting that op out of attribute-level collision resolution. The default reflection-hash
+    // path is mirrored exactly.
     static std::string compute_mesh_workload_canonical_key(
         [[maybe_unused]] tt::tt_metal::distributed::MeshDevice* mesh_device,
         std::string_view op_type_name,

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -822,27 +822,22 @@ public:
     //
     // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
     // deliberately exclude some, e.g. an RNG seed), so we return an empty string -- opting that op
-    // out of collision resolution (hash-only, today's behavior) unless it provides a
-    // compute_program_canonical_key hook. The default reflection-hash path is mirrored exactly.
+    // out of collision resolution (hash-only, today's behavior). The default reflection-hash path
+    // is mirrored exactly.
     static std::string compute_mesh_workload_canonical_key(
-        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        [[maybe_unused]] tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
-        std::string key;
         if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            if constexpr (requires { DeviceOperation::compute_program_canonical_key(attrs, tensor_args); }) {
-                key = DeviceOperation::compute_program_canonical_key(attrs, tensor_args);
-            } else {
-                return {};  // custom hash, no canonical hook -> opt out of collision resolution
-            }
+            return {};  // custom hash -> opt out of collision resolution
         } else {
-            key = ttsl::hash::canonical_key(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            std::string key = ttsl::hash::canonical_key(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            for (const auto& coord :
+                 mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+                key += ttsl::hash::canonical_key(coord);
+            }
+            return key;
         }
-
-        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
-            key += ttsl::hash::canonical_key(coord);
-        }
-        return key;
     }
 
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -17,6 +17,8 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <concepts>
 #include <unordered_map>
@@ -820,18 +822,22 @@ public:
     // hash hit so a 64-bit collision is resolved to a correct (rebuild) miss instead of a wrong
     // hit (issue #45821). It must mirror the SAME inputs the hash combines.
     //
+    // The key is prefixed with op_type_name (the DeviceOperation's type name) so distinct ops can
+    // never alias on a hash collision.
     // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
     // deliberately exclude some, e.g. an RNG seed), so we return an empty string -- opting that op
     // out of collision resolution (hash-only, today's behavior). The default reflection-hash path
     // is mirrored exactly.
     static std::string compute_mesh_workload_canonical_key(
         [[maybe_unused]] tt::tt_metal::distributed::MeshDevice* mesh_device,
+        std::string_view op_type_name,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
+        std::string key{op_type_name};
         if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return {};  // custom hash -> opt out of collision resolution
+            return key;  // custom hash -> opt out beyond the op-identity prefix
         } else {
-            std::string key = ttsl::hash::canonical_key(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            key += ttsl::hash::canonical_key(attrs, tensor_args);
             for (const auto& coord :
                  mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
                 key += ttsl::hash::canonical_key(coord);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -816,6 +816,35 @@ public:
         return hash;
     }
 
+    // Exact, collision-free companion to compute_mesh_workload_hash: the cache compares this on a
+    // hash hit so a 64-bit collision is resolved to a correct (rebuild) miss instead of a wrong
+    // hit (issue #45821). It must mirror the SAME inputs the hash combines.
+    //
+    // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
+    // deliberately exclude some, e.g. an RNG seed), so we return an empty string -- opting that op
+    // out of collision resolution (hash-only, today's behavior) unless it provides a
+    // compute_program_canonical_key hook. The default reflection-hash path is mirrored exactly.
+    static std::string compute_mesh_workload_canonical_key(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args) {
+        std::string key;
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
+            if constexpr (requires { DeviceOperation::compute_program_canonical_key(attrs, tensor_args); }) {
+                key = DeviceOperation::compute_program_canonical_key(attrs, tensor_args);
+            } else {
+                return {};  // custom hash, no canonical hook -> opt out of collision resolution
+            }
+        } else {
+            key = ttsl::hash::canonical_key(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+        }
+
+        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+            key += ttsl::hash::canonical_key(coord);
+        }
+        return key;
+    }
+
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,


### PR DESCRIPTION
Closes #45821.

This PR fixes program-cache hash collisions at **two levels**: it makes them astronomically improbable (a strong mixer), and then makes them impossible to observe as a wrong result (exact key comparison). The first is the minimal fix; the second is the structural guarantee.

---

## 1. Strong hash mixer (the acute fix)

`ttsl::hash::hash_objects` (the combiner every program-cache key flows through) used the classic **32-bit `boost::hash_combine`**:

```cpp
seed ^= hash_object(arg) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
```

Its avalanche is poor for the small, structured integers that dominate our keys (tensor shapes, dtypes), so distinct sequences collide in 64 bits — e.g. shapes `[3, 17, 1, 1]` and `[1, 152, 1, 1]` (both reachable through `batch_norm`'s internal `permute`) hash **identically**. The cache is `unordered_map<uint64_t, …>` with no equality fallback, so `PermuteDeviceOperation` (no custom `compute_program_hash`) reused a program built for the wrong shape → wrong results. `disable_and_clear_program_cache()` between the two tests makes it pass, confirming cache reuse is the cause. Measured: **94,477 collisions** across the 2.56M shapes with dims in `[0, 40)⁴`.

There is no `std::hash_combine`, and `tt_stl` deliberately avoids Boost (a foundational, PCH'd header), so we inline the **splitmix64 finalizer (Stafford "variant 13")** — the same family of multiply-xorshift mixer Boost (≥1.81) and Abseil use internally — with only `<cstdint>`, **no new dependency**:

```cpp
hash_t x = seed + 0x9e3779b97f4a7c15ULL + hash_object(arg);
x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
seed = x ^ (x >> 31);
```

Collision-free across the full 2.56M-shape sweep. Residual collision probability at realistic cache sizes (thousands of entries) is ~`N²/2⁶⁵` ≈ **10⁻¹³**.

## 2. Exact key comparison (the structural guarantee)

10⁻¹³ is a *probability*, not a guarantee — the cache had opted out of the textbook hash-map contract by keying on the bare `uint64` and discarding the key. This restores it:

- **`ProgramCacheKey{ uint64_t hash; std::string canonical }`** — the cache map keys on this. `std::unordered_map` picks the bucket by `hash` and confirms with `operator==` on `canonical`, so two distinct keys with the same hash **coexist and each retrieves its own entry** (native chaining). A wrong cache hit becomes structurally impossible.
- **`ttsl::hash::canonical_key(...)`** — an exact, collision-free serialization mirroring `hash_object` branch-for-branch (same coverage, no volatile fields like addresses/buffers → no spurious misses). One intentionally-lossy leaf: a `to_hash`-only type (documented).
- **`compute_mesh_workload_canonical_key`** parallels `compute_mesh_workload_hash`, threaded through the cache sites.

### Custom-`compute_program_hash` ops are not touched

The framework only has a custom hash's opaque 64-bit output — it can't recover the key material, and an exact full-attribute key would *break* these ops (e.g. `rand` excludes the seed so different seeds share a program). So custom-hash ops return an **empty canonical and opt out automatically** — zero edits, behavior identical to today, riding the strong hash at ~10⁻¹³. The default reflection-hash path (including `Permute`, the op that broke) gets the hard guarantee for free. A `compute_program_canonical_key` opt-in hook exists for any op that later wants the absolute guarantee.

**Cost of level 2:** `canonical_key` ≈ 66 ns vs hash ≈ 17 ns (~3.8×), 64-byte key for a representative op key → **~49 ns extra per dispatch (~0.3% of a ~16 µs dispatch)**, plus a per-hit string compare and ~64 B per cache entry.

---

## Blast radius

Level 1 changes every hash in the codebase; level 2 changes every default-path cache key. Both are in-memory only (rebuilt each run, never persisted), so there's no cross-version concern — the program-cache CI suites are the real confidence check.

## Tests

`tt_stl/tests/test_hash.cpp` (new): the #45821 collision + 2-element prefix, order/length/enum/optional/variant sensitivity, adversarial sweeps (2.56M shapes, power-of-two/high-bit), single-bit-flip avalanche, output-bit coverage; canonical-key injectivity; **`ProgramCacheKeyTest`** forcing the two shapes to one hash and proving both resolve correctly; a cost microbenchmark. 7 of the hash tests fail on the old combiner and pass on the new. Full `unit_tests_stl`: **124/124**. Full ttnn rebuild: clean. On-device `batch_norm` repro (the #45821 shapes, cache on): **PASS, PCC ~0.9999**.

## Open questions
1. Keep the `compute_program_canonical_key` opt-in hook, or drop it so there's zero invitation to touch custom hashes?
2. Serialized canonical key (this PR: uniform, no buffer-lifetime issues) vs a reflection-derived structural `operator==` (no stored string, needs type-erasure)?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-hash-collision-45821)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-hash-collision-45821)